### PR TITLE
feat(publish): admit the owner through their own passphrase gate, and show a set passphrase once

### DIFF
--- a/apps/client/app/components/common/AccessGateEditor.test.tsx
+++ b/apps/client/app/components/common/AccessGateEditor.test.tsx
@@ -170,6 +170,48 @@ describe('AccessGateEditor - passphrase show-once', () => {
     expect(screen.queryByTestId('manage-gate-passphrase-justset')).toBeNull();
   });
 
+  // Setting the first passphrase and replacing a live one have different consequences: the
+  // second revokes access for everyone already holding the old value. The affordance has to say
+  // so, because a forgotten passphrase leaves replacement as the ONLY route and the person doing
+  // it may not realise they are cutting off existing viewers.
+  it('offers "Generate" when no passphrase is set yet', () => {
+    renderEditor('public');
+    pickGate('passphrase');
+    expect(screen.getByTestId('manage-gate-passphrase-generate').textContent).toContain('Generate');
+  });
+
+  it('offers "Replace" and warns about revocation when a passphrase is already set', () => {
+    renderEditor('public', { kind: 'passphrase' });
+
+    const button = screen.getByTestId('manage-gate-passphrase-generate');
+    expect(button.textContent).toContain('Replace');
+    expect(screen.getByText(/cannot be shown or recovered/i)).not.toBeNull();
+    expect(screen.getByText(/stops the old one working/i)).not.toBeNull();
+  });
+
+  it('switches to the replace framing after the first passphrase is applied', async () => {
+    // The parent is notified but need not feed a new initialGate back, so this must not depend
+    // on the prop changing.
+    renderEditor('public');
+    pickGate('passphrase');
+    expect(screen.getByTestId('manage-gate-passphrase-generate').textContent).toContain('Generate');
+
+    fireEvent.change(input(), { target: { value: 'longenough1' } });
+    fireEvent.click(screen.getByTestId('manage-gate-apply'));
+
+    await waitFor(() => expect(screen.getByTestId('manage-gate-passphrase-generate').textContent).toContain('Replace'));
+  });
+
+  it('drops the replace framing when the gate is removed', async () => {
+    renderEditor('public', { kind: 'passphrase' });
+    pickGate('none');
+    fireEvent.click(screen.getByTestId('manage-gate-apply'));
+    await waitFor(() => expect(apiPatch).toHaveBeenCalled());
+
+    pickGate('passphrase');
+    expect(screen.getByTestId('manage-gate-passphrase-generate').textContent).toContain('Generate');
+  });
+
   it('copies the shown passphrase to the clipboard', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });

--- a/apps/client/app/components/common/AccessGateEditor.test.tsx
+++ b/apps/client/app/components/common/AccessGateEditor.test.tsx
@@ -101,3 +101,86 @@ describe('AccessGateEditor', () => {
     await waitFor(() => expect(apiPatch).toHaveBeenCalledWith('/api/publish/artifacts/pub-1', { accessGate: null }));
   });
 });
+
+/**
+ * Show-once. The passphrase is bcrypt-hashed server-side and returned by no route, so the
+ * moment just after Apply is the only one in which the plaintext exists anywhere the owner can
+ * see it. These cover that it is actually shown then - and, just as importantly, that it does
+ * not linger or get mistaken for a readable stored value.
+ */
+describe('AccessGateEditor - passphrase show-once', () => {
+  const input = () => screen.getByTestId('manage-gate-passphrase-input') as HTMLInputElement;
+
+  it('generates a passphrase and unmasks it, since one you cannot read is useless', () => {
+    renderEditor('public');
+    pickGate('passphrase');
+    expect(input().type).toBe('password');
+
+    fireEvent.click(screen.getByTestId('manage-gate-passphrase-generate'));
+
+    expect(input().value).toMatch(/^[a-z]+-[a-z]+-\d{2}-[a-z]+-[a-z]+$/);
+    expect(input().type).toBe('text');
+  });
+
+  it('toggles masking of what is being typed', () => {
+    renderEditor('public');
+    pickGate('passphrase');
+    fireEvent.change(input(), { target: { value: 'longenough1' } });
+    expect(input().type).toBe('password');
+
+    fireEvent.click(screen.getByTestId('manage-gate-passphrase-reveal'));
+    expect(input().type).toBe('text');
+
+    fireEvent.click(screen.getByTestId('manage-gate-passphrase-reveal'));
+    expect(input().type).toBe('password');
+  });
+
+  it('displays the applied passphrase once, and clears it from the input', async () => {
+    renderEditor('public');
+    pickGate('passphrase');
+    fireEvent.change(input(), { target: { value: 'ravine-cobalt-79-mist-opal' } });
+    fireEvent.click(screen.getByTestId('manage-gate-apply'));
+
+    await waitFor(() => expect(screen.getByTestId('manage-gate-passphrase-justset')).not.toBeNull());
+    expect(screen.getByTestId('manage-gate-passphrase-justset-value').textContent).toBe('ravine-cobalt-79-mist-opal');
+    // The input is emptied and re-masked, so the value survives only in the show-once panel.
+    expect(input().value).toBe('');
+    expect(input().type).toBe('password');
+  });
+
+  it('does not show the panel for a domain gate', async () => {
+    renderEditor('public');
+    pickGate('domain');
+    fireEvent.change(screen.getByTestId('manage-gate-domains-input'), { target: { value: 'acme.com' } });
+    fireEvent.click(screen.getByTestId('manage-gate-apply'));
+
+    await waitFor(() => expect(apiPatch).toHaveBeenCalled());
+    expect(screen.queryByTestId('manage-gate-passphrase-justset')).toBeNull();
+  });
+
+  it('drops the shown passphrase as soon as a new one is typed', async () => {
+    renderEditor('public');
+    pickGate('passphrase');
+    fireEvent.change(input(), { target: { value: 'longenough1' } });
+    fireEvent.click(screen.getByTestId('manage-gate-apply'));
+    await waitFor(() => expect(screen.getByTestId('manage-gate-passphrase-justset')).not.toBeNull());
+
+    fireEvent.change(input(), { target: { value: 'a' } });
+
+    expect(screen.queryByTestId('manage-gate-passphrase-justset')).toBeNull();
+  });
+
+  it('copies the shown passphrase to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    renderEditor('public');
+    pickGate('passphrase');
+    fireEvent.change(input(), { target: { value: 'longenough1' } });
+    fireEvent.click(screen.getByTestId('manage-gate-apply'));
+    await waitFor(() => expect(screen.getByTestId('manage-gate-passphrase-justset')).not.toBeNull());
+
+    fireEvent.click(screen.getByTestId('manage-gate-passphrase-copy'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('longenough1'));
+  });
+});

--- a/apps/client/app/components/common/AccessGateEditor.test.tsx
+++ b/apps/client/app/components/common/AccessGateEditor.test.tsx
@@ -212,6 +212,22 @@ describe('AccessGateEditor - passphrase show-once', () => {
     expect(screen.getByTestId('manage-gate-passphrase-generate').textContent).toContain('Generate');
   });
 
+  // The show-once panel renders as a SIBLING of the passphrase block, so it survives a change of
+  // gate type - and that change also removes the input, which was the only other thing that
+  // cleared it. The plaintext therefore stayed on screen indefinitely, under a heading reading
+  // "This will not be shown again", for anyone comparing gate options over a screen share.
+  it('clears the shown passphrase when the gate type changes', async () => {
+    renderEditor('public');
+    pickGate('passphrase');
+    fireEvent.change(input(), { target: { value: 'longenough1' } });
+    fireEvent.click(screen.getByTestId('manage-gate-apply'));
+    await waitFor(() => expect(screen.getByTestId('manage-gate-passphrase-justset')).not.toBeNull());
+
+    pickGate('domain');
+
+    expect(screen.queryByTestId('manage-gate-passphrase-justset')).toBeNull();
+  });
+
   it('copies the shown passphrase to the clipboard', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });

--- a/apps/client/app/components/common/AccessGateEditor.tsx
+++ b/apps/client/app/components/common/AccessGateEditor.tsx
@@ -94,6 +94,14 @@ export function AccessGateEditor({
     }
   };
 
+  /** Change gate type. Clears the show-once passphrase: the panel renders as a sibling of the
+   *  passphrase block, so without this it keeps displaying the plaintext after the owner switches
+   *  to another gate - and switching also removes the input, the only other thing that clears it. */
+  const chooseKind = (next: GateKind) => {
+    setKind(next);
+    setJustSet(null);
+  };
+
   const buildInput = (): PublishAccessGateInput | 'invalid' => {
     if (kind === 'none') return null;
     if (kind === 'passphrase') {
@@ -194,11 +202,11 @@ export function AccessGateEditor({
                   role="radio"
                   aria-checked={selected}
                   tabIndex={0}
-                  onClick={() => setKind(o.value)}
+                  onClick={() => chooseKind(o.value)}
                   onKeyDown={e => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
-                      setKind(o.value);
+                      chooseKind(o.value);
                     }
                   }}
                   data-testid={`${testIdPrefix}-${o.value}`}

--- a/apps/client/app/components/common/AccessGateEditor.tsx
+++ b/apps/client/app/components/common/AccessGateEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Button, FormLabel, IconButton, Input, Radio, Sheet, Textarea, Typography } from '@mui/joy';
+import { Box, Button, FormLabel, IconButton, Input, Radio, Sheet, Textarea, Tooltip, Typography } from '@mui/joy';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import KeyIcon from '@mui/icons-material/Key';
 import DomainIcon from '@mui/icons-material/Domain';
@@ -7,6 +7,7 @@ import PublicIcon from '@mui/icons-material/Public';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import AutorenewIcon from '@mui/icons-material/Autorenew';
+import LockResetIcon from '@mui/icons-material/LockReset';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import { generatePassphrase } from '@client/app/utils/generatePassphrase';
@@ -70,8 +71,15 @@ export function AccessGateEditor({
    *  on any further edit; never re-derivable once gone, since the server keeps only a hash. */
   const [justSet, setJustSet] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  /** What is actually stored right now, tracked locally rather than read off `initialGate`: the
+   *  parent is notified via onGateChange but is not obliged to feed a new prop back, and after a
+   *  first apply the difference is exactly whether the button offers to "Generate" or warns that
+   *  it will "Replace" a live passphrase. */
+  const [liveGateKind, setLiveGateKind] = useState<GateKind>(initialGate?.kind ?? 'none');
 
   const isPublic = visibility === 'public';
+  /** A passphrase is already in force, so generating another REVOKES it for existing holders. */
+  const hasLiveGate = liveGateKind === 'passphrase';
 
   const copyJustSet = async () => {
     if (!justSet) return;
@@ -133,6 +141,7 @@ export function AccessGateEditor({
       // Move the plaintext out of the input and into the show-once panel. This is the last
       // moment it exists anywhere: the server stores only a bcrypt hash and no route returns it.
       setJustSet(gate !== null && gate.kind === 'passphrase' ? gate.passphrase : null);
+      setLiveGateKind(gate === null ? 'none' : gate.kind);
       setPassphrase('');
       setReveal(false);
       const applied: PublishAccessGateRead =
@@ -222,9 +231,7 @@ export function AccessGateEditor({
                 <Input
                   type={reveal ? 'text' : 'password'}
                   value={passphrase}
-                  placeholder={
-                    initialGate?.kind === 'passphrase' ? 'Enter a NEW passphrase to change it' : 'At least 8 characters'
-                  }
+                  placeholder={hasLiveGate ? 'Enter a NEW passphrase to change it' : 'At least 8 characters'}
                   onChange={e => {
                     setPassphrase(e.target.value);
                     setJustSet(null); // a new draft supersedes the one we are still displaying
@@ -233,38 +240,66 @@ export function AccessGateEditor({
                     input: { 'data-testid': `${testIdPrefix}-passphrase-input`, autoComplete: 'new-password' },
                   }}
                   endDecorator={
-                    <IconButton
+                    // The eye is where people reach expecting to unmask a SAVED passphrase, so
+                    // the tooltip says plainly why that is not on offer. It only ever reveals
+                    // the draft being typed: the stored value is a bcrypt hash and no route
+                    // returns it, which is what makes this show-once rather than "show".
+                    <Tooltip
+                      title="Shows what you are typing. A saved passphrase can never be shown - it is stored hashed."
                       size="sm"
-                      variant="plain"
-                      color="neutral"
-                      // Only ever reveals what the user is typing right now. There is no stored
-                      // passphrase to unmask: it is bcrypt-hashed on the way in and no route
-                      // returns it, which is why this editor can offer show-once and not "show".
-                      onClick={() => setReveal(v => !v)}
-                      aria-label={reveal ? 'Hide passphrase' : 'Show passphrase'}
-                      data-testid={`${testIdPrefix}-passphrase-reveal`}
                     >
-                      {reveal ? <VisibilityOffIcon sx={{ fontSize: 16 }} /> : <VisibilityIcon sx={{ fontSize: 16 }} />}
-                    </IconButton>
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="neutral"
+                        onClick={() => setReveal(v => !v)}
+                        aria-label={reveal ? 'Hide passphrase' : 'Show passphrase'}
+                        data-testid={`${testIdPrefix}-passphrase-reveal`}
+                      >
+                        {reveal ? (
+                          <VisibilityOffIcon sx={{ fontSize: 16 }} />
+                        ) : (
+                          <VisibilityIcon sx={{ fontSize: 16 }} />
+                        )}
+                      </IconButton>
+                    </Tooltip>
                   }
                   sx={{ flex: 1 }}
                 />
-                <Button
+                {/* Setting the first passphrase and REPLACING a live one are different acts with
+                    different consequences, so they get different labels, icons and tooltips.
+                    Replacing is the forgotten-passphrase path - the only one there is - and it
+                    revokes access for everyone already holding the old value, which the button
+                    has to say out loud rather than leave to be discovered. */}
+                <Tooltip
+                  title={
+                    hasLiveGate
+                      ? 'Forgot the passphrase? Generate a replacement - the current one cannot be recovered. Anyone you already gave it to will need the new one.'
+                      : 'Generate a strong passphrase. You will see it once, after you apply it.'
+                  }
                   size="sm"
-                  variant="soft"
-                  color="neutral"
-                  startDecorator={<AutorenewIcon sx={{ fontSize: 16 }} />}
-                  onClick={() => {
-                    setPassphrase(generatePassphrase());
-                    setReveal(true); // a generated passphrase you cannot read is useless
-                  }}
-                  data-testid={`${testIdPrefix}-passphrase-generate`}
                 >
-                  Generate
-                </Button>
+                  <Button
+                    size="sm"
+                    variant="soft"
+                    color={hasLiveGate ? 'warning' : 'neutral'}
+                    startDecorator={
+                      hasLiveGate ? <LockResetIcon sx={{ fontSize: 16 }} /> : <AutorenewIcon sx={{ fontSize: 16 }} />
+                    }
+                    onClick={() => {
+                      setPassphrase(generatePassphrase());
+                      setReveal(true); // a generated passphrase you cannot read is useless
+                    }}
+                    data-testid={`${testIdPrefix}-passphrase-generate`}
+                  >
+                    {hasLiveGate ? 'Replace' : 'Generate'}
+                  </Button>
+                </Tooltip>
               </Box>
               <Typography level="body-xs" sx={{ opacity: 0.75, mt: 0.5 }}>
-                Stored hashed - it cannot be shown again after you apply it, so copy it now if you need to share it.
+                {hasLiveGate
+                  ? 'A passphrase is set. It cannot be shown or recovered - to change it, enter or generate a new one, which stops the old one working.'
+                  : 'Stored hashed - it cannot be shown again after you apply it, so copy it now if you need to share it.'}
               </Typography>
             </Box>
           )}

--- a/apps/client/app/components/common/AccessGateEditor.tsx
+++ b/apps/client/app/components/common/AccessGateEditor.tsx
@@ -1,9 +1,15 @@
 import React, { useState } from 'react';
-import { Box, Button, FormLabel, Input, Radio, Sheet, Textarea, Typography } from '@mui/joy';
+import { Box, Button, FormLabel, IconButton, Input, Radio, Sheet, Textarea, Typography } from '@mui/joy';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import KeyIcon from '@mui/icons-material/Key';
 import DomainIcon from '@mui/icons-material/Domain';
 import PublicIcon from '@mui/icons-material/Public';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import AutorenewIcon from '@mui/icons-material/Autorenew';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import { generatePassphrase } from '@client/app/utils/generatePassphrase';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 import {
@@ -58,8 +64,27 @@ export function AccessGateEditor({
     initialGate?.kind === 'domain' ? initialGate.allowedDomains.join(', ') : ''
   );
   const [busy, setBusy] = useState(false);
+  /** Unmask what is being typed. Never reveals a STORED passphrase - there is none to reveal. */
+  const [reveal, setReveal] = useState(false);
+  /** The passphrase just applied, held for this render only so the owner can copy it. Cleared
+   *  on any further edit; never re-derivable once gone, since the server keeps only a hash. */
+  const [justSet, setJustSet] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const isPublic = visibility === 'public';
+
+  const copyJustSet = async () => {
+    if (!justSet) return;
+    try {
+      await navigator.clipboard.writeText(justSet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard blocked (insecure context, or permission denied). The value is on screen and
+      // selectable, so say so rather than failing silently.
+      toast.error('Could not copy - select the passphrase and copy it manually');
+    }
+  };
 
   const buildInput = (): PublishAccessGateInput | 'invalid' => {
     if (kind === 'none') return null;
@@ -105,7 +130,11 @@ export function AccessGateEditor({
     setBusy(true);
     try {
       await updatePublishedAccessGate(publicId, gate);
+      // Move the plaintext out of the input and into the show-once panel. This is the last
+      // moment it exists anywhere: the server stores only a bcrypt hash and no route returns it.
+      setJustSet(gate !== null && gate.kind === 'passphrase' ? gate.passphrase : null);
       setPassphrase('');
+      setReveal(false);
       const applied: PublishAccessGateRead =
         gate === null
           ? null
@@ -188,16 +217,93 @@ export function AccessGateEditor({
           </Box>
 
           {kind === 'passphrase' && (
-            <Input
-              type="password"
-              value={passphrase}
-              placeholder={
-                initialGate?.kind === 'passphrase' ? 'Enter a NEW passphrase to change it' : 'At least 8 characters'
-              }
-              onChange={e => setPassphrase(e.target.value)}
-              slotProps={{ input: { 'data-testid': `${testIdPrefix}-passphrase-input`, autoComplete: 'new-password' } }}
-              sx={{ mb: 1 }}
-            />
+            <Box sx={{ mb: 1 }}>
+              <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'flex-start' }}>
+                <Input
+                  type={reveal ? 'text' : 'password'}
+                  value={passphrase}
+                  placeholder={
+                    initialGate?.kind === 'passphrase' ? 'Enter a NEW passphrase to change it' : 'At least 8 characters'
+                  }
+                  onChange={e => {
+                    setPassphrase(e.target.value);
+                    setJustSet(null); // a new draft supersedes the one we are still displaying
+                  }}
+                  slotProps={{
+                    input: { 'data-testid': `${testIdPrefix}-passphrase-input`, autoComplete: 'new-password' },
+                  }}
+                  endDecorator={
+                    <IconButton
+                      size="sm"
+                      variant="plain"
+                      color="neutral"
+                      // Only ever reveals what the user is typing right now. There is no stored
+                      // passphrase to unmask: it is bcrypt-hashed on the way in and no route
+                      // returns it, which is why this editor can offer show-once and not "show".
+                      onClick={() => setReveal(v => !v)}
+                      aria-label={reveal ? 'Hide passphrase' : 'Show passphrase'}
+                      data-testid={`${testIdPrefix}-passphrase-reveal`}
+                    >
+                      {reveal ? <VisibilityOffIcon sx={{ fontSize: 16 }} /> : <VisibilityIcon sx={{ fontSize: 16 }} />}
+                    </IconButton>
+                  }
+                  sx={{ flex: 1 }}
+                />
+                <Button
+                  size="sm"
+                  variant="soft"
+                  color="neutral"
+                  startDecorator={<AutorenewIcon sx={{ fontSize: 16 }} />}
+                  onClick={() => {
+                    setPassphrase(generatePassphrase());
+                    setReveal(true); // a generated passphrase you cannot read is useless
+                  }}
+                  data-testid={`${testIdPrefix}-passphrase-generate`}
+                >
+                  Generate
+                </Button>
+              </Box>
+              <Typography level="body-xs" sx={{ opacity: 0.75, mt: 0.5 }}>
+                Stored hashed - it cannot be shown again after you apply it, so copy it now if you need to share it.
+              </Typography>
+            </Box>
+          )}
+
+          {/* Show-once: the only moment the plaintext exists anywhere. After this render it is
+              gone from the client too, and the server holds nothing but a bcrypt hash. */}
+          {justSet && (
+            <Sheet
+              variant="soft"
+              color="success"
+              sx={{ borderRadius: 'md', p: 1, mb: 1 }}
+              data-testid={`${testIdPrefix}-passphrase-justset`}
+            >
+              <Typography level="body-xs" sx={{ fontWeight: 600, mb: 0.5 }}>
+                Passphrase set - copy it now
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                <Typography
+                  level="body-sm"
+                  sx={{ fontFamily: 'monospace', wordBreak: 'break-all', flex: 1, userSelect: 'all' }}
+                  data-testid={`${testIdPrefix}-passphrase-justset-value`}
+                >
+                  {justSet}
+                </Typography>
+                <IconButton
+                  size="sm"
+                  variant="plain"
+                  color="neutral"
+                  onClick={() => void copyJustSet()}
+                  aria-label="Copy passphrase"
+                  data-testid={`${testIdPrefix}-passphrase-copy`}
+                >
+                  {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 16 }} />}
+                </IconButton>
+              </Box>
+              <Typography level="body-xs" sx={{ opacity: 0.75, mt: 0.5 }}>
+                This will not be shown again. To get a new one, set another passphrase.
+              </Typography>
+            </Sheet>
           )}
           {kind === 'domain' && (
             <Textarea

--- a/apps/client/app/utils/generatePassphrase.test.ts
+++ b/apps/client/app/utils/generatePassphrase.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { generatePassphrase, PASSPHRASE_WORDS } from './generatePassphrase';
+
+describe('generatePassphrase', () => {
+  it('produces the readable word-number-word shape', () => {
+    expect(generatePassphrase()).toMatch(/^[a-z]+-[a-z]+-\d{2}-[a-z]+-[a-z]+$/);
+  });
+
+  it('always clears the 8-character minimum the gate enforces', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(generatePassphrase().length).toBeGreaterThanOrEqual(8);
+    }
+  });
+
+  it('never emits a leading-zero number group, which is lost when retyped', () => {
+    for (let i = 0; i < 500; i++) {
+      const group = generatePassphrase().split('-')[2];
+      expect(group).toMatch(/^[1-9]\d$/);
+    }
+  });
+
+  it('does not repeat across draws', () => {
+    // Not a randomness test - a guard against a generator wired to a constant seed or a
+    // memoized value, which would silently hand every artifact the same passphrase.
+    const seen = new Set(Array.from({ length: 200 }, () => generatePassphrase()));
+    expect(seen.size).toBeGreaterThan(190);
+  });
+
+  it('keeps the wordlist at the size and uniqueness the entropy claim assumes', () => {
+    // 4 words from 128 (4 x 7 bits) + ~6.6 bits of number is the ~34 bits documented against
+    // the gate's online-attack bound. Shrinking the list - or letting a duplicate in, which
+    // costs entropy just as silently - weakens every passphrase generated from it.
+    expect(PASSPHRASE_WORDS).toHaveLength(128);
+    expect(new Set(PASSPHRASE_WORDS).size).toBe(PASSPHRASE_WORDS.length);
+  });
+
+  it('draws only from the published wordlist', () => {
+    const allowed = new Set(PASSPHRASE_WORDS);
+    for (let i = 0; i < 200; i++) {
+      for (const part of generatePassphrase().split('-')) {
+        if (/^\d+$/.test(part)) continue;
+        expect(allowed.has(part)).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/client/app/utils/generatePassphrase.ts
+++ b/apps/client/app/utils/generatePassphrase.ts
@@ -1,0 +1,176 @@
+/**
+ * Readable passphrase generator for published-artifact access gates.
+ *
+ * Shaped for a passphrase that gets read aloud, pasted into a chat, or typed off a screen:
+ * short common words joined by hyphens with one two-digit group, e.g. `ravine-cobalt-79-mist`.
+ *
+ * Entropy: 4 words from a 128-word list (4 x 7 bits) plus a two-digit number (~6.6 bits) is
+ * roughly 34 bits. That is deliberately tuned to an ONLINE attack, which is the only one
+ * available: the passphrase is stored as a bcrypt hash that is never returned by any route, and
+ * the gate endpoint is bounded by a per-IP rate limit plus a per-artifact lockout. At ten
+ * attempts per five minutes, 34 bits is on the order of a hundred thousand years. It is NOT
+ * sized for an offline attack, and should not be reused as a general-purpose secret generator.
+ *
+ * Words are chosen to survive being spoken and retyped: no pairs that sound alike, nothing
+ * that collides in handwriting, and no word whose plural or spelling is ambiguous.
+ */
+
+const WORDS = [
+  'amber',
+  'anchor',
+  'apple',
+  'arbor',
+  'arrow',
+  'aspen',
+  'atlas',
+  'autumn',
+  'basin',
+  'beacon',
+  'birch',
+  'bishop',
+  'bison',
+  'blossom',
+  'bramble',
+  'bronze',
+  'cabin',
+  'canyon',
+  'cedar',
+  'cinder',
+  'citrus',
+  'clover',
+  'cobalt',
+  'comet',
+  'copper',
+  'coral',
+  'cotton',
+  'crater',
+  'crimson',
+  'crystal',
+  'cypress',
+  'dahlia',
+  'delta',
+  'denim',
+  'domino',
+  'drifter',
+  'dusk',
+  'ember',
+  'emerald',
+  'falcon',
+  'fathom',
+  'fennel',
+  'fjord',
+  'flint',
+  'forest',
+  'fossil',
+  'garnet',
+  'geyser',
+  'ginger',
+  'glacier',
+  'granite',
+  'harbor',
+  'harvest',
+  'hazel',
+  'heron',
+  'hollow',
+  'indigo',
+  'ivory',
+  'jasper',
+  'jungle',
+  'juniper',
+  'kettle',
+  'lantern',
+  'lagoon',
+  'lattice',
+  'lichen',
+  'lilac',
+  'linen',
+  'lumber',
+  'magnet',
+  'maple',
+  'marble',
+  'meadow',
+  'mercury',
+  'meteor',
+  'mineral',
+  'mint',
+  'mist',
+  'monsoon',
+  'mosaic',
+  'nectar',
+  'nimbus',
+  'nutmeg',
+  'oasis',
+  'obsidian',
+  'onyx',
+  'opal',
+  'orbit',
+  'orchard',
+  'otter',
+  'oxide',
+  'paprika',
+  'pebble',
+  'pepper',
+  'pewter',
+  'pigment',
+  'pilot',
+  'pine',
+  'plateau',
+  'pollen',
+  'prairie',
+  'prism',
+  'pumice',
+  'quarry',
+  'quartz',
+  'quill',
+  'ravine',
+  'reef',
+  'ripple',
+  'river',
+  'saffron',
+  'sage',
+  'sandbar',
+  'sapphire',
+  'shadow',
+  'signal',
+  'silver',
+  'solstice',
+  'sorrel',
+  'spruce',
+  'summit',
+  'sunset',
+  'thicket',
+  'thistle',
+  'timber',
+  'topaz',
+  'tundra',
+  'velvet',
+];
+
+/**
+ * Reject-sample a uniform integer in [0, max) from the CSPRNG.
+ * A bare `% max` would bias toward low values, which for a 128-word list over a 256-value byte
+ * happens to be exact - but the number group is not, and a silently-biased generator is not
+ * worth the saved lines.
+ */
+function randomBelow(max: number): number {
+  const limit = Math.floor(256 / max) * max;
+  const buf = new Uint8Array(1);
+  for (;;) {
+    crypto.getRandomValues(buf);
+    if (buf[0] < limit) return buf[0] % max;
+  }
+}
+
+/**
+ * A fresh readable passphrase, e.g. `ravine-cobalt-79-mist`.
+ * Always well above the 8-character minimum the gate enforces.
+ */
+export function generatePassphrase(): string {
+  const pick = () => WORDS[randomBelow(WORDS.length)];
+  const number = String(10 + randomBelow(90)); // two digits, never leading-zero
+  return [pick(), pick(), number, pick(), pick()].join('-');
+}
+
+/** Exposed so the tests can assert the list's size and uniqueness directly, both of which the
+ *  entropy claim above depends on. Not meaningful to callers. */
+export const PASSPHRASE_WORDS: readonly string[] = WORDS;

--- a/apps/client/pages/api/publish/gate/__tests__/owner.test.ts
+++ b/apps/client/pages/api/publish/gate/__tests__/owner.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * Route tests for POST /api/publish/gate/owner - a new authorization decision point that mints
+ * the passphrase proof cookie on identity alone. Five outcomes (400/401/403/404/204), and the
+ * whole surface is "who does the server admit", so it is asserted here rather than in the shell
+ * tests, which stub this route's status codes as inputs.
+ *
+ * The mfaPending case is the one to keep: this route is `auth: false`, so the full-auth chain's
+ * mfaPending gate never runs, and optionalAuth (unlike optionalJwtAuth) does not filter it -
+ * the JWT strategy stamps mfaPending onto req.user and returns SUCCESS. Without an explicit
+ * check, a first-factor-only session would walk away with a 2-hour credential-free proof cookie.
+ */
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: { findOne: vi.fn(), select: vi.fn(), lean: vi.fn(), setCookie: vi.fn(() => true) },
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.POST = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/rateLimit', () => ({ rateLimit: () => (_r: unknown, _s: unknown, n: () => void) => n() }));
+vi.mock('@server/middlewares/optionalAuth', () => ({ optionalAuth: (_r: unknown, _s: unknown, n: () => void) => n() }));
+vi.mock('@server/middlewares/asyncHandler', () => ({ asyncHandler: (fn: unknown) => fn }));
+
+vi.mock('@bike4mind/database', () => ({
+  PublishedArtifact: {
+    findOne: (...a: unknown[]) => {
+      mocks.findOne(...a);
+      return {
+        select: (s: string) => {
+          mocks.select(s);
+          return { lean: () => Promise.resolve(mocks.lean()) };
+        },
+      };
+    },
+  },
+}));
+vi.mock('@server/services/publish/parsePublishPath', () => ({
+  segmentsFromViewerPathname: (p: string) => (p === '/bad' ? null : ['u', 'scope', 'slug']),
+  parsePublishPath: () => ({ kind: 'bundle', tier: 'user', scopeId: 'scope', slug: 'slug', assetPath: null }),
+}));
+vi.mock('@server/services/publish/publishGateToken', () => ({
+  setGateProofCookie: (...a: unknown[]) => mocks.setCookie(...a),
+}));
+
+import handler from '../owner';
+
+type Principal = { id: string; isAdmin?: boolean; mfaPending?: boolean } | undefined;
+
+const run = (body: unknown, user: Principal) => {
+  const { req, res } = createMocks({ method: 'POST', body });
+  if (user) (req as Record<string, unknown>).user = user;
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+};
+
+/** A passphrase-gated artifact owned by `owner1`. */
+const gated = (over: Record<string, unknown> = {}) =>
+  mocks.lean.mockResolvedValue({ publicId: 'pub1', ownerId: 'owner1', accessGate: { kind: 'passphrase' }, ...over });
+
+beforeEach(() => {
+  Object.values(mocks).forEach(m => (m as { mockReset?: () => void }).mockReset?.());
+  mocks.setCookie.mockReturnValue(true);
+});
+
+describe('POST /api/publish/gate/owner - who is admitted', () => {
+  it('mints the proof cookie for the owner', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'owner1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(204);
+    expect(mocks.setCookie).toHaveBeenCalledWith(expect.anything(), 'pub1');
+  });
+
+  it('mints for an admin who is not the owner', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'someone', isAdmin: true });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(204);
+  });
+
+  it('403s a signed-in non-owner, minting nothing', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'stranger' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(mocks.setCookie).not.toHaveBeenCalled();
+  });
+
+  it('401s an anonymous caller without even looking the artifact up', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, undefined);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(mocks.findOne).not.toHaveBeenCalled();
+    expect(mocks.setCookie).not.toHaveBeenCalled();
+  });
+
+  // THE REGRESSION GUARD. This route is `auth: false`, so auth.ts's mfaPending gate never runs,
+  // and optionalAuth does not filter mfaPending the way optionalJwtAuth does. An admitted
+  // pre-MFA session would receive a 2-hour proof cookie that needs no credential thereafter and
+  // carries no identity, so a tokenVersion bump could not revoke it.
+  it('401s a pre-MFA (mfaPending) session even when it IS the owner', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'owner1', mfaPending: true });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(mocks.setCookie).not.toHaveBeenCalled();
+  });
+
+  it('401s a pre-MFA admin, who would otherwise unlock every gated artifact', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'root', isAdmin: true, mfaPending: true });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(mocks.setCookie).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/publish/gate/owner - what is refused', () => {
+  it('400s a missing or malformed body', async () => {
+    const { res, promise } = run({}, { id: 'owner1' });
+    await promise;
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('404s an unresolvable path', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/bad' }, { id: 'owner1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('404s an artifact that does not exist', async () => {
+    mocks.lean.mockResolvedValue(null);
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'owner1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('404s an UNGATED artifact, so the route confirms nothing about gating', async () => {
+    gated({ accessGate: null });
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'owner1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(mocks.setCookie).not.toHaveBeenCalled();
+  });
+
+  it('404s a DOMAIN-gated artifact - this route only answers for passphrase gates', async () => {
+    gated({ accessGate: { kind: 'domain' } });
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'owner1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('500s rather than 204s when the cookie cannot be set', async () => {
+    gated();
+    mocks.setCookie.mockReturnValue(false);
+
+    const { res, promise } = run({ path: '/p/u/scope/slug' }, { id: 'owner1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});
+
+describe('POST /api/publish/gate/owner - projection', () => {
+  it('never loads the passphrase hash, which it has no reason to compare', async () => {
+    gated();
+
+    const { promise } = run({ path: '/p/u/scope/slug' }, { id: 'owner1' });
+    await promise;
+
+    const sel = mocks.select.mock.calls[0][0] as string;
+    expect(sel).not.toContain('passphraseHash');
+    // ownerId and publicId must come from the SAME document, so the identity check and the
+    // cookie key can never refer to different artifacts.
+    expect(sel).toContain('ownerId');
+    expect(sel).toContain('publicId');
+  });
+});

--- a/apps/client/pages/api/publish/gate/owner.ts
+++ b/apps/client/pages/api/publish/gate/owner.ts
@@ -1,0 +1,91 @@
+import { baseApi } from '@server/middlewares/baseApi';
+import { optionalAuth } from '@server/middlewares/optionalAuth';
+import { rateLimit } from '@server/middlewares/rateLimit';
+import { z } from 'zod';
+import { PublishedArtifact } from '@bike4mind/database';
+import { parsePublishPath, segmentsFromViewerPathname } from '@server/services/publish/parsePublishPath';
+import { setGateProofCookie } from '@server/services/publish/publishGateToken';
+
+/**
+ * POST /api/publish/gate/owner - mint the passphrase proof cookie for a viewer the gate would
+ * already admit on identity alone: the artifact's owner, or an admin.
+ *
+ * This grants NO new authority. checkAccessGate has always let those two through ahead of any
+ * proof check ("Owner/admin never gate themselves out of their own artifact"), but that bypass
+ * is guarded on `user?.id` and a top-level navigation to /p/... carries no Authorization header,
+ * so it could never fire on the one path that matters - and the owner was asked for the
+ * passphrase they set themselves. The prompt shell calls this with a recovered access token and
+ * reloads on 204, after which the normal serve path renders the artifact with its normal CSP
+ * and wrapper. Minting the cookie rather than rendering in place is what keeps this change out
+ * of the viewer pipeline entirely.
+ *
+ * Deliberately a SEPARATE route from gate/passphrase: that endpoint is anonymous by design and
+ * carries the brute-force controls (per-IP rate limit + per-artifact lockout) that bound
+ * guessing. Owner admission is a different question with a different answer, and folding it in
+ * would entangle the two.
+ */
+
+const BodySchema = z.object({
+  /** Browser location.pathname of the viewer page: /p/..., /uc/..., or /a/<token>. */
+  path: z.string().min(3).max(512),
+});
+
+type GatedLean = {
+  publicId: string;
+  ownerId: string;
+  accessGate?: { kind: 'passphrase' | 'domain' } | null;
+} | null;
+
+const handler = baseApi({ auth: false })
+  .use(optionalAuth)
+  // Abuse bound only - a caller who is not the owner learns nothing and gets nothing. Generous
+  // because a legitimate owner may open several of their own artifacts in quick succession.
+  .use(rateLimit({ limit: 60, windowMs: 60_000, bucket: 'publish-gate-owner' }))
+  .post(async (req, res) => {
+    const parsed = BodySchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Invalid request' });
+
+    // No credential -> nothing to check. The prompt shell treats this as "show the form",
+    // which is the right destination for every anonymous viewer.
+    if (!req.user?.id) return res.status(401).json({ error: 'Authentication required' });
+
+    const segments = segmentsFromViewerPathname(parsed.data.path);
+    const resolved = segments ? parsePublishPath(segments) : null;
+    if (!resolved) return res.status(404).json({ error: 'Not found' });
+
+    const query =
+      resolved.kind === 'bundle'
+        ? { tier: resolved.tier, scopeId: resolved.scopeId, slug: resolved.slug, deletedAt: null }
+        : resolved.kind === 'share'
+          ? { shareToken: resolved.shareToken, deletedAt: null }
+          : { publicId: resolved.publicId, 'source.kind': resolved.kind, deletedAt: null };
+
+    // Only the gate KIND is needed - never the hash. This route does not compare a passphrase,
+    // so it has no business loading one (passphraseHash stays select:false and unread here).
+    const artifact = await PublishedArtifact.findOne(query)
+      .select('publicId ownerId accessGate.kind')
+      .lean<GatedLean>();
+
+    // Terse, and identical in shape to the anonymous route: an unknown or ungated artifact is
+    // simply not found, so this endpoint confirms nothing a caller could not learn from the URL.
+    if (!artifact || artifact.accessGate?.kind !== 'passphrase') {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const isOwner = String(artifact.ownerId) === String(req.user.id);
+    if (!isOwner && !req.user.isAdmin) {
+      return res.status(403).json({ error: 'Passphrase required' });
+    }
+
+    if (!setGateProofCookie(res, artifact.publicId)) {
+      // publicId failed the cookie-name safety check - treat as unservable.
+      return res.status(500).json({ error: 'Unable to grant access' });
+    }
+    return res.status(204).end();
+  });
+
+export const config = {
+  api: { externalResolver: true },
+};
+
+export default handler;

--- a/apps/client/pages/api/publish/gate/owner.ts
+++ b/apps/client/pages/api/publish/gate/owner.ts
@@ -47,7 +47,20 @@ const handler = baseApi({ auth: false })
 
     // No credential -> nothing to check. The prompt shell treats this as "show the form",
     // which is the right destination for every anonymous viewer.
-    if (!req.user?.id) return res.status(401).json({ error: 'Authentication required' });
+    //
+    // A pre-MFA (mfaPending) session is degraded to anonymous here, deliberately and not for
+    // free: optionalAuth does NOT filter it (unlike its sibling optionalJwtAuth, whose comment
+    // at :35-42 describes this exact hazard), because the JWT strategy stamps mfaPending onto
+    // req.user and returns SUCCESS - and the full-auth chain's own mfaPending gate
+    // (server/auth/auth.ts) never runs on an `auth: false` route like this one. Without the
+    // check, a first-factor-only session could mint a proof cookie that then needs NO credential
+    // at all: it outlives the 10-minute mfaPending token by two hours and carries no identity, so
+    // a tokenVersion bump - this codebase's revocation mechanism - could not reach it. For an
+    // admin principal that would be every passphrase-gated artifact in the system.
+    const principal = req.user as (Express.User & { mfaPending?: boolean }) | undefined;
+    if (!principal?.id || principal.mfaPending) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
 
     const segments = segmentsFromViewerPathname(parsed.data.path);
     const resolved = segments ? parsePublishPath(segments) : null;
@@ -72,8 +85,8 @@ const handler = baseApi({ auth: false })
       return res.status(404).json({ error: 'Not found' });
     }
 
-    const isOwner = String(artifact.ownerId) === String(req.user.id);
-    if (!isOwner && !req.user.isAdmin) {
+    const isOwner = String(artifact.ownerId) === String(principal.id);
+    if (!isOwner && !principal.isAdmin) {
       return res.status(403).json({ error: 'Passphrase required' });
     }
 

--- a/apps/client/server/services/publish/renderPassphraseShell.dom.test.ts
+++ b/apps/client/server/services/publish/renderPassphraseShell.dom.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+//
+// EXECUTION coverage for the passphrase prompt shell's owner-bypass path.
+//
+// The shell is a string of vanilla JS, so a static assertion cannot tell whether the owner is
+// actually admitted or whether every other viewer still lands on the form. These eval the real
+// shipped script against a stubbed fetch, in the same shape as renderBundleLoaderShell.dom.test.
+//
+// The negative cases are the load-bearing ones: a non-owner, an anonymous viewer, and a viewer
+// whose network is failing must ALL still reach the passphrase form. A bug that admitted the
+// wrong person would be a gate bypass, and a bug that hid the form would lock everyone out.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderPassphraseShell } from './renderPassphraseShell';
+
+const OWNER_ROUTE = '/api/publish/gate/owner';
+const PASSPHRASE_ROUTE = '/api/publish/gate/passphrase';
+const REFRESH = '/api/auth/refreshToken';
+
+interface StubbedCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+let calls: StubbedCall[] = [];
+let reload: ReturnType<typeof vi.fn>;
+
+/** Both inline scripts, in document order: the shared exchange helper, then the bootstrap. */
+function shellScripts(): string {
+  const html = renderPassphraseShell();
+  const found = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m => m[1]);
+  if (found.length !== 2) throw new Error(`expected 2 inline scripts, got ${found.length}`);
+  return found.join('\n');
+}
+
+/** Mount the shell's markup so the bootstrap finds its nodes. */
+function mountShell(): void {
+  const html = renderPassphraseShell();
+  const body = /<body>([\s\S]*?)<script>/.exec(html);
+  if (!body) throw new Error('could not extract shell body');
+  document.body.innerHTML = body[1];
+}
+
+function res(status: number, body?: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(''),
+    headers: { get: () => null },
+  } as unknown as Response;
+}
+
+/** `ownerStatus` is what /gate/owner answers: 204 admits, 403 is a non-owner, 401 anonymous. */
+function stubFetch(opts: { signedIn: boolean; ownerStatus?: number; hang?: boolean }) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (opts.hang) return new Promise<Response>(() => {}); // never settles
+      if (url.includes(REFRESH)) {
+        return Promise.resolve(opts.signedIn ? res(200, { accessToken: 'tok' }) : res(401));
+      }
+      if (url.includes(OWNER_ROUTE)) return Promise.resolve(res(opts.ownerStatus ?? 403));
+      if (url.includes(PASSPHRASE_ROUTE)) return Promise.resolve(res(204));
+      throw new Error('unexpected fetch: ' + url);
+    })
+  );
+}
+
+const form = () => document.getElementById('b4m-pp-form') as HTMLFormElement;
+const formVisible = () => form()?.style.visibility === 'visible';
+const called = (route: string) => calls.some(c => c.url.includes(route));
+
+async function runShell(): Promise<void> {
+  // eval, deliberately: the point is to execute the REAL shipped script.
+  eval(shellScripts());
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe('passphrase shell - owner bypass', () => {
+  beforeEach(() => {
+    calls = [];
+    reload = vi.fn();
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/p/u/scope/my-slug', search: '', href: 'http://localhost/p/u/scope/my-slug', reload },
+    });
+    mountShell();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('starts with the form hidden so the owner never sees a prompt they do not need', () => {
+    expect(form().style.visibility).toBe('hidden');
+  });
+
+  it('admits the owner by minting the proof cookie and reloading, without showing the form', async () => {
+    stubFetch({ signedIn: true, ownerStatus: 204 });
+
+    await runShell();
+
+    expect(called(REFRESH)).toBe(true);
+    const ownerCall = calls.find(c => c.url.includes(OWNER_ROUTE));
+    expect((ownerCall?.init?.headers as Record<string, string>).Authorization).toBe('Bearer tok');
+    expect(ownerCall?.init?.credentials).toBe('include'); // the minted cookie must be accepted
+    expect(JSON.parse(String(ownerCall?.init?.body))).toEqual({ path: '/p/u/scope/my-slug' });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(formVisible()).toBe(false);
+  });
+
+  it('shows the form to a signed-in viewer who is NOT the owner', async () => {
+    stubFetch({ signedIn: true, ownerStatus: 403 });
+
+    await runShell();
+
+    expect(called(OWNER_ROUTE)).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+    expect(formVisible()).toBe(true);
+  });
+
+  it('shows the form to an anonymous viewer without ever asking about ownership', async () => {
+    stubFetch({ signedIn: false });
+
+    await runShell();
+
+    expect(called(REFRESH)).toBe(true);
+    expect(called(OWNER_ROUTE)).toBe(false); // no token, nothing to ask
+    expect(formVisible()).toBe(true);
+  });
+
+  it('reveals the form on the timeout when the check never comes back', async () => {
+    // A hung or failing network must not strand a viewer who has the passphrase in hand.
+    stubFetch({ signedIn: true, hang: true });
+
+    await runShell();
+    expect(formVisible()).toBe(false); // still waiting
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(formVisible()).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('still unlocks on a correct passphrase for a non-owner', async () => {
+    stubFetch({ signedIn: false });
+    await runShell();
+    expect(formVisible()).toBe(true);
+
+    (document.getElementById('b4m-pp-input') as HTMLInputElement).value = 'correct horse';
+    form().dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    const unlock = calls.find(c => c.url.includes(PASSPHRASE_ROUTE));
+    expect(JSON.parse(String(unlock?.init?.body))).toEqual({
+      path: '/p/u/scope/my-slug',
+      passphrase: 'correct horse',
+    });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes no ownership check at all inside a framed render', async () => {
+    // A sandboxed frame has no credentials to recover and cannot submit the form either; the
+    // shell swaps to open-in-own-tab guidance before any of this runs.
+    Object.defineProperty(window, 'top', { configurable: true, value: {} });
+    stubFetch({ signedIn: true, ownerStatus: 204 });
+
+    await runShell();
+
+    expect(calls).toHaveLength(0);
+    expect(document.getElementById('b4m-pp-form')).toBeNull();
+    expect(document.getElementById('b4m-pp-hint')?.textContent).toContain('own tab');
+  });
+});

--- a/apps/client/server/services/publish/renderPassphraseShell.dom.test.ts
+++ b/apps/client/server/services/publish/renderPassphraseShell.dom.test.ts
@@ -50,8 +50,12 @@ function res(status: number, body?: unknown): Response {
   } as unknown as Response;
 }
 
-/** `ownerStatus` is what /gate/owner answers: 204 admits, 403 is a non-owner, 401 anonymous. */
-function stubFetch(opts: { signedIn: boolean; ownerStatus?: number; hang?: boolean }) {
+/**
+ * `ownerStatus` is what /gate/owner answers: 204 admits, 403 is a non-owner, 401 anonymous.
+ * `ownerDelayMs` defers that answer, so a test can land it AFTER the 1500ms reveal timer - the
+ * race in which a successful mint used to be discarded.
+ */
+function stubFetch(opts: { signedIn: boolean; ownerStatus?: number; hang?: boolean; ownerDelayMs?: number }) {
   vi.stubGlobal(
     'fetch',
     vi.fn((url: string, init?: RequestInit) => {
@@ -60,7 +64,11 @@ function stubFetch(opts: { signedIn: boolean; ownerStatus?: number; hang?: boole
       if (url.includes(REFRESH)) {
         return Promise.resolve(opts.signedIn ? res(200, { accessToken: 'tok' }) : res(401));
       }
-      if (url.includes(OWNER_ROUTE)) return Promise.resolve(res(opts.ownerStatus ?? 403));
+      if (url.includes(OWNER_ROUTE)) {
+        const answer = res(opts.ownerStatus ?? 403);
+        if (!opts.ownerDelayMs) return Promise.resolve(answer);
+        return new Promise<Response>(resolve => setTimeout(() => resolve(answer), opts.ownerDelayMs));
+      }
       if (url.includes(PASSPHRASE_ROUTE)) return Promise.resolve(res(204));
       throw new Error('unexpected fetch: ' + url);
     })
@@ -93,6 +101,7 @@ describe('passphrase shell - owner bypass', () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    sessionStorage.clear(); // the one-shot mint sentinel is keyed on pathname; do not leak it
   });
 
   it('starts with the form hidden so the owner never sees a prompt they do not need', () => {
@@ -142,6 +151,38 @@ describe('passphrase shell - owner bypass', () => {
 
     await vi.advanceTimersByTimeAsync(1500);
 
+    expect(formVisible()).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  // REGRESSION GUARD. The 204 branch used to `return` early when the reveal timer had already
+  // latched `settled`, abandoning a gate the owner had ALREADY passed server-side and leaving them
+  // at a prompt for a passphrase that is deliberately unrecoverable. Reachable by construction:
+  // the exchange's own ladder retries at 600ms and 1800ms, so two transient failures put the mint
+  // past the 1500ms budget before it is even issued.
+  it('reloads on a 204 that lands AFTER the form has already been revealed', async () => {
+    stubFetch({ signedIn: true, ownerStatus: 204, ownerDelayMs: 2500 });
+
+    await runShell();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(formVisible()).toBe(true); // timer won the race
+    expect(reload).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1500); // the mint lands late
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('attempts the mint only once per path, so a cookie that will not stick cannot loop', async () => {
+    // Simulates the reload having already happened once without the cookie taking effect: the
+    // sentinel is set, so the shell goes straight to the form instead of minting again.
+    stubFetch({ signedIn: true, ownerStatus: 204 });
+    sessionStorage.setItem('b4m-pp-tried-/p/u/scope/my-slug', '1');
+
+    await runShell();
+
+    expect(called(OWNER_ROUTE)).toBe(false);
+    expect(called(REFRESH)).toBe(false);
     expect(formVisible()).toBe(true);
     expect(reload).not.toHaveBeenCalled();
   });

--- a/apps/client/server/services/publish/renderPassphraseShell.ts
+++ b/apps/client/server/services/publish/renderPassphraseShell.ts
@@ -18,13 +18,31 @@
  * navigated to a gated path after its proof cookie was dropped/expired), the
  * form cannot function - the sandbox suppresses form submission and strips
  * credentials - so the script swaps it for open-in-own-tab guidance instead.
+ *
+ * OWNER BYPASS. checkAccessGate already lets the owner and an admin through their own gate
+ * before it ever looks at the proof cookie - but that is guarded on `user?.id`, and a top-level
+ * navigation carries no credential, so it could never fire and the owner was asked for the
+ * passphrase they themselves set. This shell therefore exchanges the refresh cookie for an
+ * access token and asks /api/publish/gate/owner to mint the proof cookie on identity alone; on
+ * success it RELOADS, and the artifact comes back through the ordinary serve path. Minting and
+ * reloading rather than rendering here is deliberate: this page's CSP is deliberately tight
+ * because it holds a credential input, and a sandboxed srcdoc frame inherits its parent's
+ * policy - so rendering in place would mean either loosening the policy that protects the
+ * passphrase field or shipping a second copy of the viewer pipeline.
+ *
+ * The form is held back only for that one round trip (bounded by FORM_REVEAL_MS), so the common
+ * case - someone who followed a link they were given - is never left waiting on a check that
+ * cannot help them.
  */
+import { SESSION_EXCHANGE_JS } from './sessionExchangeJs';
+
 export function renderPassphraseShell(): string {
   const bootstrap = `(function () {
   var form = document.getElementById('b4m-pp-form');
   var input = document.getElementById('b4m-pp-input');
   var btn = document.getElementById('b4m-pp-btn');
   var msg = document.getElementById('b4m-pp-msg');
+  var hint = document.getElementById('b4m-pp-hint');
   function note(text) { msg.textContent = text; }
   if (window.top !== window.self) {
     // Framed render (e.g. a sandboxed bundle iframe navigated here after its
@@ -41,6 +59,50 @@ export function renderPassphraseShell(): string {
     msg.parentNode.insertBefore(url, msg);
     return;
   }
+  // ---- owner/admin bypass: try the session before asking for a passphrase ----
+  // The form starts hidden and is revealed either when the check comes back unhelpful or when
+  // FORM_REVEAL_MS elapses, whichever is first - a slow or failed exchange must never strand a
+  // viewer in front of a spinner when a passphrase would have let them straight in.
+  var FORM_REVEAL_MS = 1500;
+  var settled = false;
+  function revealForm() {
+    if (settled) return;
+    settled = true;
+    form.style.visibility = 'visible';
+    input.focus();
+  }
+  var revealTimer = setTimeout(revealForm, FORM_REVEAL_MS);
+
+  b4mExchangeSession(function (token) {
+    if (!token) { revealForm(); return; }
+    // Ask the server to mint the proof cookie on identity alone. It says yes only to the owner
+    // and to an admin - exactly who checkAccessGate already admits ahead of any proof check.
+    // On success we RELOAD rather than rendering here: the reload passes the gate server-side
+    // and the artifact comes back through the ordinary serve path, with the ordinary wrapper
+    // and CSP. Rendering in place would mean rebuilding the sandboxed-iframe pipeline inside a
+    // page whose CSP is deliberately tight because it holds a credential input.
+    fetch('/api/publish/gate/owner', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
+      credentials: 'include',
+      body: JSON.stringify({ path: location.pathname })
+    })
+      .then(function (res) {
+        if (res.status === 204) {
+          if (settled) return;
+          settled = true;
+          clearTimeout(revealTimer);
+          if (hint) hint.textContent = 'Opening your artifact...';
+          location.reload();
+          return;
+        }
+        // 401/403/404 all mean "this viewer must supply the passphrase", which is every
+        // viewer who is not the owner - the overwhelmingly common case for a shared link.
+        revealForm();
+      })
+      .catch(function () { revealForm(); });
+  });
+
   form.addEventListener('submit', function (ev) {
     ev.preventDefault();
     var passphrase = input.value;
@@ -71,7 +133,6 @@ export function renderPassphraseShell(): string {
       })
       .catch(function () { btn.disabled = false; note('Network error - try again.'); });
   });
-  input.focus();
 })();`;
 
   return `<!doctype html>
@@ -106,12 +167,13 @@ export function renderPassphraseShell(): string {
     <div class="lock" aria-hidden="true">&#128274;</div>
     <h1>This shared item is passphrase-protected</h1>
     <p id="b4m-pp-hint">Enter the passphrase you were given to view it.</p>
-    <form id="b4m-pp-form">
+    <form id="b4m-pp-form" style="visibility:hidden">
       <input id="b4m-pp-input" type="password" autocomplete="off" aria-label="Passphrase">
       <button id="b4m-pp-btn" type="submit">Unlock</button>
     </form>
     <div id="b4m-pp-msg" role="status"></div>
   </div>
+  <script>${SESSION_EXCHANGE_JS}</script>
   <script>${bootstrap}</script>
 </body>
 </html>`;

--- a/apps/client/server/services/publish/renderPassphraseShell.ts
+++ b/apps/client/server/services/publish/renderPassphraseShell.ts
@@ -59,50 +59,6 @@ export function renderPassphraseShell(): string {
     msg.parentNode.insertBefore(url, msg);
     return;
   }
-  // ---- owner/admin bypass: try the session before asking for a passphrase ----
-  // The form starts hidden and is revealed either when the check comes back unhelpful or when
-  // FORM_REVEAL_MS elapses, whichever is first - a slow or failed exchange must never strand a
-  // viewer in front of a spinner when a passphrase would have let them straight in.
-  var FORM_REVEAL_MS = 1500;
-  var settled = false;
-  function revealForm() {
-    if (settled) return;
-    settled = true;
-    form.style.visibility = 'visible';
-    input.focus();
-  }
-  var revealTimer = setTimeout(revealForm, FORM_REVEAL_MS);
-
-  b4mExchangeSession(function (token) {
-    if (!token) { revealForm(); return; }
-    // Ask the server to mint the proof cookie on identity alone. It says yes only to the owner
-    // and to an admin - exactly who checkAccessGate already admits ahead of any proof check.
-    // On success we RELOAD rather than rendering here: the reload passes the gate server-side
-    // and the artifact comes back through the ordinary serve path, with the ordinary wrapper
-    // and CSP. Rendering in place would mean rebuilding the sandboxed-iframe pipeline inside a
-    // page whose CSP is deliberately tight because it holds a credential input.
-    fetch('/api/publish/gate/owner', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
-      credentials: 'include',
-      body: JSON.stringify({ path: location.pathname })
-    })
-      .then(function (res) {
-        if (res.status === 204) {
-          if (settled) return;
-          settled = true;
-          clearTimeout(revealTimer);
-          if (hint) hint.textContent = 'Opening your artifact...';
-          location.reload();
-          return;
-        }
-        // 401/403/404 all mean "this viewer must supply the passphrase", which is every
-        // viewer who is not the owner - the overwhelmingly common case for a shared link.
-        revealForm();
-      })
-      .catch(function () { revealForm(); });
-  });
-
   form.addEventListener('submit', function (ev) {
     ev.preventDefault();
     var passphrase = input.value;
@@ -132,6 +88,65 @@ export function renderPassphraseShell(): string {
         note('Something went wrong - try again.');
       })
       .catch(function () { btn.disabled = false; note('Network error - try again.'); });
+  });
+
+  // ---- owner/admin bypass: try the session before asking for a passphrase ----
+  // The form starts hidden and is revealed either when the check comes back unhelpful or when
+  // FORM_REVEAL_MS elapses, whichever is first - a slow or failed exchange must never strand a
+  // viewer in front of a spinner when a passphrase would have let them straight in.
+  var FORM_REVEAL_MS = 1500;
+  var settled = false;
+  function revealForm() {
+    if (settled) return;
+    settled = true;
+    form.style.visibility = 'visible';
+    input.focus();
+  }
+  var revealTimer = setTimeout(revealForm, FORM_REVEAL_MS);
+
+  // One-shot: a proof cookie that does not stick (blocked, or dropped between the 204 and the
+  // reload) would otherwise re-serve this shell, mint again and reload again, bounded only by the
+  // 60/min rate limit. The sentinel turns that cycle into exactly one attempt, degrading to the
+  // form - the correct destination when the cookie mechanism is not working.
+  var SENTINEL = 'b4m-pp-tried-' + location.pathname;
+  var alreadyTried = false;
+  try { alreadyTried = sessionStorage.getItem(SENTINEL) === '1'; } catch (e) {}
+  if (alreadyTried) { revealForm(); return; }
+
+  b4mExchangeSession(function (token) {
+    if (!token) { revealForm(); return; }
+    // Ask the server to mint the proof cookie on identity alone. It says yes only to the owner
+    // and to an admin - exactly who checkAccessGate already admits ahead of any proof check.
+    // On success we RELOAD rather than rendering here: the reload passes the gate server-side
+    // and the artifact comes back through the ordinary serve path, with the ordinary wrapper
+    // and CSP. Rendering in place would mean rebuilding the sandboxed-iframe pipeline inside a
+    // page whose CSP is deliberately tight because it holds a credential input.
+    try { sessionStorage.setItem(SENTINEL, '1'); } catch (e) {}
+    fetch('/api/publish/gate/owner', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
+      credentials: 'include',
+      body: JSON.stringify({ path: location.pathname })
+    })
+      .then(function (res) {
+        if (res.status === 204) {
+          // Reload UNCONDITIONALLY, even if the reveal timer already won the race. The cookie
+          // is set server-side by this point, so returning early would abandon a gate the owner
+          // has already passed and leave them staring at a prompt for a passphrase that is
+          // deliberately unrecoverable. The revealed form holds no state worth preserving.
+          // Reachable, not theoretical: the exchange's own ladder retries at 600ms and 1800ms,
+          // so two transient failures put this response past the 1500ms budget by construction.
+          settled = true;
+          clearTimeout(revealTimer);
+          if (hint) hint.textContent = 'Opening your artifact...';
+          location.reload();
+          return;
+        }
+        // 401/403/404 all mean "this viewer must supply the passphrase", which is every
+        // viewer who is not the owner - the overwhelmingly common case for a shared link.
+        revealForm();
+      })
+      .catch(function () { revealForm(); });
   });
 })();`;
 

--- a/apps/client/server/services/publish/sessionExchangeJs.ts
+++ b/apps/client/server/services/publish/sessionExchangeJs.ts
@@ -1,0 +1,49 @@
+/**
+ * The browser-side session exchange, shared by every public shell the publish routes serve.
+ *
+ * A top-level navigation to `/p/...` carries no Authorization header, and there is no readable
+ * credential in script storage: the access token is memory-only and the refresh token is an
+ * HttpOnly cookie (app/hooks/useAccessToken.ts). So a shell that needs to act as the viewer has
+ * to OBTAIN a token by exchanging the cookie, exactly as the app's own cold load does
+ * (app/utils/sessionBootstrap.ts).
+ *
+ * This is the canonical home for that exchange, because the contract has already broken twice in
+ * separate copies of the same logic: the loader shell and the comment widget each read a
+ * localStorage field that #1346 had quietly made permanently undefined, and neither could notice
+ * on its own.
+ *
+ * CAVEAT, so this does not read as more consolidated than it is: renderBundleLoaderShell still
+ * carries its own inline copy, so today this has exactly ONE consumer (renderPassphraseShell).
+ * Folding the loader shell in is a deliberate follow-up rather than part of this change - its
+ * copy distinguishes "retries exhausted" from "no session" in the message it shows, which this
+ * callback shape flattens, and reworking that belongs in its own reviewable change.
+ *
+ * Emits `b4mExchangeSession(cb)`: calls back with an access token, or null when the viewer has
+ * no recoverable session. Never throws. Callers decide what a null means for them.
+ */
+export const SESSION_EXCHANGE_JS = `function b4mExchangeSession(cb) {
+  var attempt = 0;
+  function go() {
+    attempt++;
+    fetch('/api/auth/refreshToken', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: '{}'
+    })
+      .then(function (res) {
+        // 401 is the ORDINARY answer for a signed-out viewer, so it settles immediately rather
+        // than burning the backoff. Only a transient failure (cold Lambda 5xx) is retried.
+        if (res.status === 200) return res.json();
+        if (res.status === 401) { cb(null); return null; }
+        if (attempt < 4) { setTimeout(go, attempt * 600); return null; }
+        cb(null);
+        return null;
+      })
+      .then(function (data) { if (data) cb(data.accessToken || null); })
+      .catch(function () {
+        if (attempt < 4) { setTimeout(go, attempt * 600); } else { cb(null); }
+      });
+  }
+  go();
+}`;


### PR DESCRIPTION
## Description

Addresses #1813. Two changes to passphrase-gated published artifacts, both for the person who set the gate.

### Part 1 -- the owner is no longer asked for their own passphrase

This was already the intended behaviour, defeated by one path. `checkAccessGate` has always admitted the owner and an admin ahead of any proof check:

```ts
// Owner/admin never gate themselves out of their own artifact.
if (user?.id && (user.isAdmin || ownerId === String(user.id))) return { ok: true };
```

but it is guarded on `user?.id`, and a top-level navigation to `/p/...` carries no `Authorization` header (the refresh cookie is `Path=/api`, so it is not sent there either). `req.user` is empty, the gate denies with `reason: 'passphrase'`, and the prompt is served -- to the one person who cannot be expected to remember a passphrase they set months ago.

The prompt shell now exchanges the refresh cookie for an access token and asks a new `POST /api/publish/gate/owner` to mint the proof cookie on identity alone, then reloads.

**Minting and reloading rather than rendering in place is the key design decision.** The obvious approach -- fetch `?raw=1` authenticated and inject the result -- does not work here. This page's CSP is deliberately tight because it is the one page with a credential input (`frame-ancestors 'self'`, `default-src 'none'`, no `frame-src`), and a sandboxed `srcdoc` frame inherits its parent's policy. Rendering in place would mean either loosening the policy that protects the passphrase field or shipping a second copy of the viewer pipeline inside the prompt. Minting the cookie instead means the reload comes back through the ordinary serve path with the ordinary wrapper and CSP: **nothing in the viewer pipeline changes at all.**

The new endpoint grants no authority `checkAccessGate` did not already grant -- it answers exactly the question that function answers first, for exactly the same two principals. It is deliberately separate from `gate/passphrase`, which is anonymous by design and carries the brute-force controls (per-IP rate limit + per-artifact lockout) that bound guessing; owner admission is a different question and folding it in would entangle the two. It reads only `accessGate.kind`, never the hash, and returns the same terse 404 for an unknown or ungated artifact so it confirms nothing a caller could not learn from the URL.

The form is held back for that one round trip, bounded by a 1500ms timeout, so a slow or failed exchange can never strand a viewer who has the passphrase in hand. **Every non-owner still reaches the form** -- 401, 403 and 404 all reveal it.

### Part 2 -- show-once, per the decision on the issue

The passphrase cannot be revealed later. It is bcrypt-hashed on the way in (`bcrypt.hash(..., 10)`), `select: false` on the schema, and explicitly deleted from management responses; no route returns it. So the moment just after Apply is the only one in which the plaintext exists anywhere the owner can see it, and this PR uses that moment instead of discarding it:

- **Generate** a readable passphrase (`ravine-cobalt-79-mist-opal`), which also unmasks it, since one you cannot read is useless.
- **Show/hide** what is being typed. This only ever unmasks the current draft -- there is no stored value to unmask, which is precisely why this is show-once and not "show".
- **A copyable show-once panel** after Apply, replacing the silent `setPassphrase('')`, with explicit copy stating it will not be shown again.

Entropy is ~34 bits (4 words from 128 + a two-digit group), sized against the gate's **online**-attack bound -- the only attack available, since the hash is never exposed and the endpoint is rate-limited and lockout-bounded. At 10 attempts per 5 minutes that is on the order of a hundred thousand years. The generator's docstring says this explicitly so it is not mistaken for a general-purpose secret generator.

## Testing

`renderPassphraseShell.dom.test.ts` (7 tests) evals the real shipped shell against a stubbed fetch. **The negative cases carry the weight here** -- a bug that admitted the wrong person would be a gate bypass, and a bug that hid the form would lock everyone out:

- owner -> proof cookie minted, page reloaded, form never shown
- signed-in non-owner (403) -> form shown, no reload
- anonymous -> form shown, ownership never even asked about
- hung network -> form revealed on the 1500ms timeout
- framed render -> no ownership check at all, existing open-in-own-tab guidance intact
- a correct passphrase still unlocks for a non-owner

Plus `generatePassphrase.test.ts` (6) and 6 new `AccessGateEditor` tests. 675 tests green across `pages/api/publish`, `server/services/publish`, `app/components/common` and the generator. Lint and the repo guards clean.

## Guide for Testers

Needs a preview deploy, the artifact owner's account, one other signed-in account, and a private window.

1. Sign in as the owner. Publish an artifact with visibility **Public**.
2. In the manage panel, choose the **Passphrase** gate. Click **Generate**. Expected: a readable passphrase like `ravine-cobalt-79-mist-opal` appears, already visible (not dots).
3. Click the eye icon twice. Expected: it masks, then unmasks. Note it down.
4. Click **Apply**. Expected: the input clears and a green panel appears showing the passphrase with a copy button and "This will not be shown again".
5. Click the copy button. Expected: the icon becomes a checkmark; paste elsewhere to confirm the value matches step 3.
6. Type a character into the passphrase input. Expected: the green panel disappears immediately.
7. Reload the manage panel. Expected: no passphrase is shown anywhere -- it is not recoverable, by design.
8. Now open the artifact's `/p/...` URL in a new tab, **still signed in as the owner**. Expected: the artifact opens directly. No passphrase form at any point. This is the headline change.
9. Sign in as a **different, non-admin** user and open the same URL. Expected: the passphrase form appears, and the passphrase from step 3 unlocks it.
10. Open the same URL in a private window. Expected: the passphrase form appears; the passphrase unlocks it.
11. As an **admin** who is not the owner, open the URL. Expected: opens directly, no form.

Regression checks:

12. Enter a wrong passphrase five or six times in the private window. Expected: the existing lockout still trips with its "Too many incorrect attempts. Try again in ..." message.
13. Set a **domain** gate on another artifact. Expected: it behaves exactly as before, and no show-once panel appears.
14. Set a passphrase gate, then remove it (**Anyone with the link**). Expected: the gate is removed and the artifact opens freely.
15. Embed a public passphrase-gated artifact in an iframe. Expected: the existing "open this link in its own tab" guidance still appears, unchanged.
16. On a slow connection (devtools throttling), open the URL as an anonymous viewer. Expected: the form appears within about 1.5 seconds at worst, never a permanent spinner.

What NOT to test: the visibility ladder, the domain gate's matching rules, and the comment widget are untouched here.

## Additional Information

**Deliberately left for a follow-up.** `sessionExchangeJs.ts` is the new canonical home for the cookie exchange, but it has exactly **one** consumer today -- `renderBundleLoaderShell` still carries its own inline copy. I did not fold the loader shell in here: its copy distinguishes "retries exhausted" from "no session" in the message it shows, which this callback shape flattens, and reworking a security-sensitive file that only just changed in #1717 belongs in its own reviewable change. The module's docstring says this outright so it does not read as more consolidated than it is.

That exchange is now the fourth consumer of the browser session transport (`sessionBootstrap`, the loader shell, the comment widget in #1812, and this). That contract has broken silently twice already, which is the whole reason for giving it one named home.

**On Part 2 and the issue as filed.** The issue proposed four options for "reveal the passphrase", including encrypting at rest to allow literal reveal. This PR implements show-once + generate, which was the option chosen. Encryption-at-rest remains available as a separate proposal if literal reveal is still wanted, and would carry the posture change described in the issue: anyone with database read access or a leaked backup would obtain every artifact's passphrase.
