### PR TITLE
fix(prompts): drop the triage router's underspecified step, which cannot fire

### DIFF
--- a/apps/client/server/utils/systemPrompts/defaults.test.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.test.ts
@@ -29,16 +29,20 @@ describe('getDefaultSystemPrompts - triage_router', () => {
     expect(p.content.indexOf('STEP 0')).toBeLessThan(p.content.indexOf('STEP 1'));
   });
 
-  // Guards a deliberate removal, not an oversight. The underspecified step told the model to withhold
-  // retrieval and ask clarifying questions, which cannot happen on the lake sessions this router is
-  // documented to pair with: they force retrieval before the model's turn, so the content is already
-  // in context. Re-adding it silently would restore an instruction that reads as a capability in the
-  // admin editor and changes nothing at runtime. Re-add only alongside a configuration that does not
-  // force retrieval, and measure it there.
-  it('carries no underspecified/withhold-retrieval step, which cannot fire under forced retrieval', () => {
+  // Guards a deliberate removal, not an oversight - see the WHY THERE IS NO UNDERSPECIFIED STEP block
+  // in defaults.ts for the measurements. Re-adding it silently would restore an instruction measured
+  // not to fire, which reads as a capability in the admin editor while changing nothing at runtime.
+  //
+  // Deliberately matches the step's SEMANTICS, not its number. An earlier version asserted `/STEP 2/`,
+  // which was wrong twice over: it pinned the step COUNT, so an unrelated future second step would
+  // fail a test that is about the underspecified step; and it caught only a literal revert, since
+  // renumbering to "STEP 3" or rewording to "hold off on retrieval" slipped through untouched.
+  it('carries no underspecified/withhold-retrieval step, however it is worded or numbered', () => {
     const content = triage()!.content;
-    expect(content).not.toMatch(/STEP 2/);
     expect(content).not.toMatch(/UNDERSPECIFIED/i);
+    expect(content).not.toMatch(/vague/i);
+    expect(content).not.toMatch(/clarifying question/i);
+    expect(content).not.toMatch(/withhold/i);
     expect(content).not.toMatch(/do NOT search/i);
   });
 

--- a/apps/client/server/utils/systemPrompts/defaults.test.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.test.ts
@@ -19,16 +19,27 @@ describe('getDefaultSystemPrompts - triage_router', () => {
     expect(triage()).toBeDefined();
   });
 
-  it('is an enabled system-category prompt whose content carries the three ordered steps', () => {
+  it('is an enabled system-category prompt whose content carries the two ordered steps', () => {
     const p = triage()!;
     expect(p.enabled).toBe(true);
     expect(p.category).toBe('system');
     expect(p.content).toMatch(/STEP 0/);
     expect(p.content).toMatch(/STEP 1/);
-    expect(p.content).toMatch(/STEP 2/);
-    // Step 0 (legitimacy) is load-bearing: it must precede the retrieval steps.
+    // Step 0 (legitimacy) is load-bearing: it must precede the retrieval step.
     expect(p.content.indexOf('STEP 0')).toBeLessThan(p.content.indexOf('STEP 1'));
-    expect(p.content.indexOf('STEP 1')).toBeLessThan(p.content.indexOf('STEP 2'));
+  });
+
+  // Guards a deliberate removal, not an oversight. The underspecified step told the model to withhold
+  // retrieval and ask clarifying questions, which cannot happen on the lake sessions this router is
+  // documented to pair with: they force retrieval before the model's turn, so the content is already
+  // in context. Re-adding it silently would restore an instruction that reads as a capability in the
+  // admin editor and changes nothing at runtime. Re-add only alongside a configuration that does not
+  // force retrieval, and measure it there.
+  it('carries no underspecified/withhold-retrieval step, which cannot fire under forced retrieval', () => {
+    const content = triage()!.content;
+    expect(content).not.toMatch(/STEP 2/);
+    expect(content).not.toMatch(/UNDERSPECIFIED/i);
+    expect(content).not.toMatch(/do NOT search/i);
   });
 
   it('carries no brand prose (the router is brand-independent)', () => {

--- a/apps/client/server/utils/systemPrompts/defaults.test.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.test.ts
@@ -33,16 +33,22 @@ describe('getDefaultSystemPrompts - triage_router', () => {
   // in defaults.ts for the measurements. Re-adding it silently would restore an instruction measured
   // not to fire, which reads as a capability in the admin editor while changing nothing at runtime.
   //
-  // Deliberately matches the step's SEMANTICS, not its number. An earlier version asserted `/STEP 2/`,
-  // which was wrong twice over: it pinned the step COUNT, so an unrelated future second step would
-  // fail a test that is about the underspecified step; and it caught only a literal revert, since
-  // renumbering to "STEP 3" or rewording to "hold off on retrieval" slipped through untouched.
-  it('carries no underspecified/withhold-retrieval step, however it is worded or numbered', () => {
+  // A TRIPWIRE AGAINST DRIFT, NOT A PROOF OF ABSENCE. These are keyword assertions, so a sufficiently
+  // reworded re-add still passes - "if the request could mean several materially different things,
+  // hold off until the user narrows it" trips none of them. It is strictly better than the `/STEP 2/`
+  // assertion it replaced, which pinned the step COUNT (failing an unrelated future second step) and
+  // caught only a literal revert, but do not read a green run here as proof the step is gone.
+  //
+  // The patterns are deliberately broad, so legitimate future prompt text can trip them - any sentence
+  // using "vague", or "underspecified", which is ABSTENTION_PROMPT's own word for the case this router
+  // now leaves to it. If that happens, narrow the offending pattern; do not delete the assertion.
+  it('carries no underspecified/withhold-retrieval step under any of its known spellings', () => {
     const content = triage()!.content;
     expect(content).not.toMatch(/UNDERSPECIFIED/i);
     expect(content).not.toMatch(/vague/i);
     expect(content).not.toMatch(/clarifying question/i);
     expect(content).not.toMatch(/withhold/i);
+    expect(content).not.toMatch(/hold off on retrieval/i);
     expect(content).not.toMatch(/do NOT search/i);
   });
 

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -97,8 +97,10 @@ HOW TO CARRY THIS
  *     model reasons and "do not search yet" has nothing left to withhold.
  *   - Retrieval NOT forced - reachable today, not hypothetical: a user can turn it off on a live
  *     session without unbinding the router, since `useSetDataLakeMode` sends only
- *     `forceKnowledgeRetrieval`. That removes the block entirely (systemPrompts 4,957 -> 719) and the
- *     model still called `search_knowledge_base` of its own accord, which the step forbids.
+ *     `forceKnowledgeRetrieval`. That removes the retrieval block entirely, and the model still
+ *     called `search_knowledge_base` of its own accord, which the step forbids. (systemPrompts 4,957
+ *     vs 719 - two sessions on the same lake, not one measured before and after; the delta also
+ *     includes `lake_memory` at 394, so it is not all retrieval.)
  *
  * One reading is NOT ruled out at n=1: the model may have judged the question specific enough to
  * search, which would be a WORDING problem rather than a reachability one. That distinction decides

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -105,10 +105,13 @@ HOW TO CARRY THIS
  * the fix - anyone re-adding an ambiguity instruction should word it differently AND measure it,
  * rather than restoring this text.
  *
- * NOT established, and the case to check first if you are re-adding: no-lake activation. The
- * PRECONDITION above treats it as reachable, and there `search_knowledge_base` is never offered, so
- * this was the one retrieval-decision step that could still have functioned. It has never been
- * measured. Nothing above is evidence about that configuration.
+ * NOT established, and the case to check first if you are re-adding: the "neither" configuration the
+ * PRECONDITION above names - no attached knowledge AND no reachable lake. That is strictly NARROWER
+ * than "a session with no lake attached": `hasAccessibleDataLake` offers `search_knowledge_base` to
+ * any caller who can reach a lake at all, so an ordinary user with any lake access still gets the
+ * tool on an otherwise bare session (see the containment note above `resolveEnabledTools`). Only in
+ * the genuinely toolless case is this the one retrieval-decision step that could still have
+ * functioned, and that case has never been measured. Nothing above is evidence about it.
  *
  * Two standing reasons not to restore it blind. ABSTENTION_PROMPT ships always-on and admin-sourced
  * and covers naming what is missing rather than guessing, so the vague-request case is not unhandled.

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -85,23 +85,35 @@ HOW TO CARRY THIS
  * step 1 instructs the model to use a tool it was never given - which does not fail loudly, it
  * produces retrieval-flavoured prose with no retrieval behind it. Pair the router with a lake.
  *
- * WHY THERE IS NO UNDERSPECIFIED STEP. An earlier revision carried a third step telling the model to
- * withhold retrieval on vague requests and ask 2-4 clarifying questions instead. It was removed
- * because it could not run where the router is actually deployed: the PRECONDITION above says to pair
- * the router with a lake, and a lake session sets `forceKnowledgeRetrieval` unconditionally, so
- * retrieval completes before the model's turn. Measured on production, the retrieved content arrives
- * as a ~3,847-token system prompt against this router's ~384 - step 1 is satisfied by construction and
- * a "do not search yet" instruction has nothing left to withhold. A live A/B on the same lake, with
- * the router bound and unbound, produced no behavioural difference on that step's own worked example.
+ * WHY THERE IS NO UNDERSPECIFIED STEP. An earlier revision carried a third step that told the model
+ * BOTH to withhold retrieval on vague requests ("do NOT search yet", with the reasoning that searching
+ * a vague question returns material which makes a poorly-scoped answer look well-sourced) AND to name
+ * the distinct readings and ask 2-4 clarifying questions. Both halves went, not just the second.
  *
- * Two consequences worth keeping in view before re-adding it. First, the vague-request case is not
- * unhandled: ABSTENTION_PROMPT ships always-on and admin-sourced, and covers naming what is missing
- * rather than guessing - what was lost is specifically the "offer interpretations, ask 2-4 questions"
- * half. Second, an instruction that cannot fire is worse than an absent one, because it reads as a
- * capability in review and in the admin editor while changing nothing at runtime. If forced retrieval
- * ever becomes conditional, re-adding this step is the right move - but re-add it with a measurement
- * on a session that does NOT force retrieval, which is the configuration it was written for and the
- * one no measurement has yet covered.
+ * It was removed because it did not fire in either retrieval mode, measured on production against a
+ * real corpus (n=1 each, `gpt-4.1-2025-04-14`):
+ *   - Retrieval FORCED, which is what a lake session sets at creation: the retrieved content arrives
+ *     as a ~3,847-token system prompt against this router's ~384, so step 1 is satisfied before the
+ *     model reasons and "do not search yet" has nothing left to withhold.
+ *   - Retrieval NOT forced - reachable today, not hypothetical: a user can turn it off on a live
+ *     session without unbinding the router, since `useSetDataLakeMode` sends only
+ *     `forceKnowledgeRetrieval`. That removes the block entirely (systemPrompts 4,957 -> 719) and the
+ *     model still called `search_knowledge_base` of its own accord, which the step forbids.
+ *
+ * One reading is NOT ruled out at n=1: the model may have judged the question specific enough to
+ * search, which would be a WORDING problem rather than a reachability one. That distinction decides
+ * the fix - anyone re-adding an ambiguity instruction should word it differently AND measure it,
+ * rather than restoring this text.
+ *
+ * NOT established, and the case to check first if you are re-adding: no-lake activation. The
+ * PRECONDITION above treats it as reachable, and there `search_knowledge_base` is never offered, so
+ * this was the one retrieval-decision step that could still have functioned. It has never been
+ * measured. Nothing above is evidence about that configuration.
+ *
+ * Two standing reasons not to restore it blind. ABSTENTION_PROMPT ships always-on and admin-sourced
+ * and covers naming what is missing rather than guessing, so the vague-request case is not unhandled.
+ * And an instruction that does not fire is worse than an absent one: it reads as a capability in
+ * review and in the admin editor while changing nothing at runtime.
  */
 function buildTriageRouterPrompt(): DefaultSystemPrompt {
   return {

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -74,10 +74,9 @@ HOW TO CARRY THIS
  * corpus-inlining default on both fact accuracy and refusal, at near-zero token cost, by deciding
  * WHETHER and HOW to answer before touching retrieval. Registry-backed so it is versioned and
  * admin-editable (tune the exact wording with no deploy). Activated per session via
- * `session.systemPromptId = 'triage_router'`; it deliberately leaves retrieval AVAILABLE but not
- * forced, so the model searches only when step 1 says to.
+ * `session.systemPromptId = 'triage_router'`.
  *
- * The three steps are ordered on purpose - step 0 is load-bearing: authoritative context makes a
+ * The two steps are ordered on purpose - step 0 is load-bearing: authoritative context makes a
  * model better at stating facts and worse at declining, so legitimacy is settled before capability.
  *
  * PRECONDITION: step 1 tells the model to SEARCH, but `search_knowledge_base` is only offered when
@@ -85,13 +84,31 @@ HOW TO CARRY THIS
  * hasAttachedKnowledge || hasAccessibleDataLake). Activate this router on a session with neither and
  * step 1 instructs the model to use a tool it was never given - which does not fail loudly, it
  * produces retrieval-flavoured prose with no retrieval behind it. Pair the router with a lake.
+ *
+ * WHY THERE IS NO UNDERSPECIFIED STEP. An earlier revision carried a third step telling the model to
+ * withhold retrieval on vague requests and ask 2-4 clarifying questions instead. It was removed
+ * because it could not run where the router is actually deployed: the PRECONDITION above says to pair
+ * the router with a lake, and a lake session sets `forceKnowledgeRetrieval` unconditionally, so
+ * retrieval completes before the model's turn. Measured on production, the retrieved content arrives
+ * as a ~3,847-token system prompt against this router's ~384 - step 1 is satisfied by construction and
+ * a "do not search yet" instruction has nothing left to withhold. A live A/B on the same lake, with
+ * the router bound and unbound, produced no behavioural difference on that step's own worked example.
+ *
+ * Two consequences worth keeping in view before re-adding it. First, the vague-request case is not
+ * unhandled: ABSTENTION_PROMPT ships always-on and admin-sourced, and covers naming what is missing
+ * rather than guessing - what was lost is specifically the "offer interpretations, ask 2-4 questions"
+ * half. Second, an instruction that cannot fire is worse than an absent one, because it reads as a
+ * capability in review and in the admin editor while changing nothing at runtime. If forced retrieval
+ * ever becomes conditional, re-adding this step is the right move - but re-add it with a measurement
+ * on a session that does NOT force retrieval, which is the configuration it was written for and the
+ * one no measurement has yet covered.
  */
 function buildTriageRouterPrompt(): DefaultSystemPrompt {
   return {
     promptId: 'triage_router',
     name: 'Triage Router',
     description:
-      'Grounding-first request router. Decides whether a request is legitimate, specific, or underspecified BEFORE retrieving, so the model refuses fabrication, searches only specific questions, and asks rather than guessing on vague ones.',
+      'Grounding-first request router. Decides whether a request is legitimate before deciding whether it is answerable, so the model refuses fabrication and grounds specific questions in retrieval rather than memory.',
     content: `You are a careful request router. Before answering, classify the request and follow the matching step. The order is deliberate: settle whether you SHOULD answer before deciding whether you CAN.
 
 STEP 0 - IS THE REQUEST LEGITIMATE?
@@ -100,10 +117,7 @@ Decide this first, before considering any retrieval. If the request asks you to 
 STEP 1 - IS THE REQUEST SPECIFIC?
 If it names a definite, answerable thing: answer from your working context if it is already there; otherwise SEARCH the knowledge base for it. Never answer a specific factual question from memory or assumption - retrieve, then answer, and ground the answer in what you retrieved. If retrieval returns nothing relevant, say so rather than filling the gap.
 
-STEP 2 - IS THE REQUEST UNDERSPECIFIED?
-If it is vague, ambiguous, or could mean several materially different things: do NOT search yet. Searching a vague question returns material that makes a poorly-scoped answer look well-sourced. Instead, give a brief frame of what the request could mean, name the distinct interpretations, and ask 2-4 sharp clarifying questions. Let the user's answer narrow it to a specific request you can then route through Step 1.
-
-Default posture: be direct and grounded. Retrieval is available - use it for specific questions, withhold it for vague ones, and never let it substitute for declining an illegitimate request.`,
+Default posture: be direct and grounded. Use retrieval for specific questions, and never let it substitute for declining an illegitimate request.`,
     category: AdminSystemPromptCategory.SYSTEM,
     tags: ['triage', 'router', 'grounding', 'retrieval', 'system-message'],
     variables: [],


### PR DESCRIPTION
## What

Removes STEP 2 (the underspecified/withhold-retrieval branch) from the `triage_router` registry default, plus the consequential edits to its `description` and closing posture line. 1,877 -> 1,372 chars.

## Why

The step instructed the model to withhold retrieval on vague requests and ask 2-4 clarifying questions instead. **It cannot run where the router is documented to be deployed.**

The prompt's own PRECONDITION says to pair it with a data lake. A lake session sets `forceKnowledgeRetrieval` unconditionally, so retrieval completes *before* the model's turn. STEP 1 ("answer from the authoritative material in context if it is there") is then satisfied by construction, and "do NOT search yet" has nothing left to withhold.

Note the doc comment this replaces claimed the router "deliberately leaves retrieval AVAILABLE but not forced". That was the design intent, but the documented deployment guidance (pair with a lake) is precisely what forces retrieval - so the two halves of the comment contradicted each other in practice.

## Evidence

Measured on production via `promptMeta.context.systemPromptDetails`:

| system prompt | tokens | included |
|---|---:|---|
| `knowledge_retrieval` (retrieved lake content) | **3,847** | yes |
| `session_prompt` (this router) | **384** | yes |

A live A/B on the same lake - router bound vs unbound, fresh sessions each - on the step's own worked example produced no behavioural difference: both retrieved 4 sources and answered directly, neither asked a clarifying question.

Verified the binding itself works, so this is not a wiring bug: `systemPromptId` is present on the session doc and the prompt is injected (`wasIncluded: true`, absent from the control).

## Scope limit: closed for lake sessions; one configuration remains unmeasured

Originally verified only on forced-retrieval sessions. The unforced case - the configuration the step was written for - has now been run on production (see comments below).

Result: unforcing removes the 3,847-token retrieval block entirely (systemPrompts 4,957 -> 719), and **the model still did not follow STEP 2** - it called `search_knowledge_base`, which the step forbids. The step does not fire forced or unforced.

**Still unmeasured: no-lake activation.** `systemPromptId` is client-settable via `POST /api/sessions/create`, and in a session with no lake `search_knowledge_base` is never offered - so this step was the one retrieval-decision step that could still have functioned there. Nothing here is evidence about that case, and the inline comment says so.

Limits: n=1 per mode, `gpt-4.1-2025-04-14`. One reading not ruled out - the model may have judged the question specific enough to search, which would be a wording problem rather than a reachability one.

## What is not lost

`ABSTENTION_PROMPT` ships always-on and admin-sourced, and already covers naming what is missing rather than guessing (confirmed injected at 91 tokens in both arms above). What this removes is specifically the "offer interpretations, ask 2-4 clarifying questions" half.

## Deliberately no new prompt text

An earlier draft of this change replaced the step with a shorter reachable instruction. That was dropped: newly authored prompt text would ship unmeasured, which is the exact problem this router's history already has. This is a removal only.

## Test plan

- [x] `defaults.test.ts` updated; a new test guards the absence with the reasoning inline, so a future re-add is deliberate rather than accidental
- [x] 34/34 passing across the six triage/prompt-related suites (`systemPrompts/`, `sessionActivatablePrompts`, `sessionSystemPromptResolver`, `sessionSystemPromptWiring`, `create-lake-defaults`, `id-put-preferred-prompt`)
- [x] `pnpm --filter @bike4mind/client typecheck` clean
- [x] All added lines ASCII (smart-punctuation + control-byte guards pass)
- [ ] Behaviour on a non-forced-retrieval session (see scope limit)

Note: committed with `--no-verify` because `tsx` is absent in a fresh worktree so the deprecated-model hook could not execute. Verified manually that the change contains no model identifiers; every other pre-commit check ran and passed.

