### PR TITLE
test(database): size the confirmChunkClaim concurrency timeout for a contended runner

### DIFF
--- a/packages/database/src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts
+++ b/packages/database/src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts
@@ -30,6 +30,28 @@ afterAll(async () => {
   await server.stop();
 });
 
+/**
+ * Fail a handshake wait with a message naming WHICH side hung, instead of letting the whole test
+ * die on vitest's timeout with no indication of where.
+ *
+ * Deliberately generous: this must never fire on a merely slow runner (the waits it guards are one
+ * transaction-start-plus-read and one non-transactional write), only on a genuine deadlock. It
+ * exists because a previous CI failure was an unexplained 30s timeout whose cause - slow vs stuck -
+ * could not be told apart from the log.
+ */
+const HANDSHAKE_DEADLINE_MS = 20_000;
+function withDeadline<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} did not settle within ${HANDSHAKE_DEADLINE_MS}ms - handshake deadlock`)),
+      HANDSHAKE_DEADLINE_MS
+    );
+  });
+  // clearTimeout on settle, or the pending timer keeps the worker's event loop alive after the test.
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
 describe('FabFileRepository.confirmChunkClaim - genuine concurrent takeover', () => {
   it("detects a stale-claim takeover that commits WHILE the guard's own transaction is still open", async () => {
     const file = await FabFile.create({
@@ -61,11 +83,11 @@ describe('FabFileRepository.confirmChunkClaim - genuine concurrent takeover', ()
     const guardPromise = withTransaction(async () => {
       await FabFile.findById(fabFileId);
       releaseTakeover();
-      await takeoverCommitted;
+      await withDeadline(takeoverCommitted, 'takeoverCommitted');
       return fabFileRepository.confirmChunkClaim(fabFileId, originalStamp);
     });
 
-    await takeoverReady;
+    await withDeadline(takeoverReady, 'takeoverReady');
     try {
       // The real mechanism this simulates: fabFileChunk.ts's stale-arm CAS, a plain
       // findOneAndUpdate with no session, via a wholly separate client - genuinely concurrent,
@@ -90,5 +112,13 @@ describe('FabFileRepository.confirmChunkClaim - genuine concurrent takeover', ()
 
     const finalFile = await FabFile.findById(fabFileId).lean();
     expect(finalFile?.chunkClaimedAt?.toISOString()).toBe(successorStamp.toISOString());
-  }, 30000);
+    // 30s was too tight and timed out on CI twice, blocking a production promotion. This test is
+    // heavier than its ~2s local runtime suggests: a single-node replica set (so every transaction
+    // commit needs majority acknowledgement) plus a guarded write that can raise a WriteConflict and
+    // send withTransaction through up to two more full attempts with backoff. Under the shard's
+    // parallelism the database package logs ~2470s of test-time in ~221s of wall clock locally, and
+    // a 2-core CI runner is slower again - so the ceiling has to be sized for a contended runner,
+    // not for an idle laptop. Nothing here should take a minute; if it does, the deadlines above
+    // fire first and name the side that hung.
+  }, 90_000);
 });

--- a/packages/database/src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts
+++ b/packages/database/src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts
@@ -44,12 +44,18 @@ function withDeadline<T>(promise: Promise<T>, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(
-      () => reject(new Error(`${label} did not settle within ${HANDSHAKE_DEADLINE_MS}ms - handshake deadlock`)),
+      // "stalled", not "deadlock": this cannot tell a true deadlock from extreme contention, and
+      // naming the wrong cause in a diagnostic is worse than naming neither.
+      () =>
+        reject(
+          new Error(
+            `${label} did not settle within ${HANDSHAKE_DEADLINE_MS}ms - handshake stalled (deadlock or extreme contention)`
+          )
+        ),
       HANDSHAKE_DEADLINE_MS
     );
   });
-  // clearTimeout on settle, or the pending timer keeps the worker's event loop alive after the test.
-  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer)) as Promise<T>;
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
 }
 
 describe('FabFileRepository.confirmChunkClaim - genuine concurrent takeover', () => {
@@ -87,8 +93,12 @@ describe('FabFileRepository.confirmChunkClaim - genuine concurrent takeover', ()
       return fabFileRepository.confirmChunkClaim(fabFileId, originalStamp);
     });
 
-    await withDeadline(takeoverReady, 'takeoverReady');
     try {
+      // Inside the try: withDeadline can REJECT (a bare `await takeoverReady` could only hang), so
+      // leaving it outside would skip the finally below and strand guardPromise unresolved into
+      // teardown - resurfacing the MongoClientClosedError noise that made the original failure hard
+      // to read. Signalling on this path is harmless: the transaction is still before its own await.
+      await withDeadline(takeoverReady, 'takeoverReady');
       // The real mechanism this simulates: fabFileChunk.ts's stale-arm CAS, a plain
       // findOneAndUpdate with no session, via a wholly separate client - genuinely concurrent,
       // genuinely external.
@@ -118,7 +128,18 @@ describe('FabFileRepository.confirmChunkClaim - genuine concurrent takeover', ()
     // send withTransaction through up to two more full attempts with backoff. Under the shard's
     // parallelism the database package logs ~2470s of test-time in ~221s of wall clock locally, and
     // a 2-core CI runner is slower again - so the ceiling has to be sized for a contended runner,
-    // not for an idle laptop. Nothing here should take a minute; if it does, the deadlines above
-    // fire first and name the side that hung.
+    // not for an idle laptop.
+    //
+    // The deadlines above cover the HANDSHAKE only. So a bare 90s timeout with no deadline message
+    // means the handshake was fine and the time went somewhere unguarded - most likely the first
+    // write's cold start (vitest.config.ts explains why: Mongoose builds every model's indexes on
+    // connect and autoIndex cannot be disabled) or confirmChunkClaim's WriteConflict re-attempts.
+    // Look there, not at the handshake.
+    //
+    // Only one other test in this package shares the expensive shape - a replica set plus real
+    // transactions - and that is deleteTransaction.integration.test.ts, whose cases still sit at the
+    // 30s default. It has never blown it (it aborts deliberately, so it pays no retry cost), but it
+    // is the one place to check first if this class of timeout shows up again. The other ~50 suites
+    // here use a standalone server and never pay the transaction cost at all.
   }, 90_000);
 });


### PR DESCRIPTION
## Summary

`FabFileModel.confirmChunkClaim.concurrency.test.ts` timed out at 30s on CI twice, **blocking a
production promotion**, while completing in ~2.1s locally.

This PR started out as a quarantine (`it.skip`). Since a skip costs the same review-and-merge cycle
as a fix, it now **fixes the cause and keeps the coverage**.

Closes #1820.

## Diagnosis: slowness, not deadlock

Four pieces of evidence converge:

1. It **passed** on CI at `8dd55e72` — so there is no deterministic deadlock.
2. Every post-#1818 failure is a **timeout**, never an assertion — the ordering fix in #1818 worked;
   only the budget was wrong.
3. It still **passes locally under the real CI shard conditions**
   (`VITEST_MAX_WORKERS=25%` across all four data-shard packages) — no structural deadlock reachable.
4. Under that parallelism the database package logs **~2470s of test-time in ~221s of wall clock**
   locally. Individual tests slow down enormously under contention, and a 2-core CI runner is slower
   again.

The test is heavier than its local runtime suggests: a single-node replica set (so every transaction
commit needs majority acknowledgement) plus a guarded write that can raise a `WriteConflict` and send
`withTransaction` through up to two more full attempts with backoff. 30s was simply sized for an idle
laptop.

## Changes

- **Timeout 30s → 90s**, with the reasoning recorded in-file so the next person doesn't re-derive it.
- **A 20s deadline on each side of the handshake.** If it ever *is* a deadlock, it now fails fast
  naming the side that hung (`takeoverCommitted did not settle within 20000ms - handshake deadlock`)
  instead of dying on an unexplained timeout — which is exactly what made the original failure hard
  to diagnose. Deliberately generous: it guards one transaction-start-plus-read and one
  non-transactional write, so it cannot fire on mere slowness.

## Test plan

- [x] Passes locally (2.2s).
- [x] Passes under the real CI shard command — the condition that was failing.
- [x] **Ordering mutation still caught**: replacing the signal with `await Promise.resolve()` fails
      with `expected true to be false`. The test still proves the ordering is load-bearing.
- [x] **Deadlock guard verified**: never signalling fails at 22s with
      `takeoverCommitted did not settle within 20000ms - handshake deadlock`, ahead of the 90s
      ceiling — so the diagnostic works rather than being decorative.
- [x] `typecheck`, `lint:check`, ASCII guards all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review fold-ins (round 1, adjudicated)

- **Moved the `takeoverReady` deadline inside the `try`.** `withDeadline` can *reject* where the
  previous bare `await` could only hang, so leaving it outside skipped the `finally` and stranded
  `guardPromise` into teardown — resurfacing the exact `MongoClientClosedError` noise this PR removes.
  The review filed this as pre-existing; it isn't — adding the deadline created that path.
- **Reworded the deadline message** to `handshake stalled (deadlock or extreme contention)`. It cannot
  distinguish the two, and the diagnosis here is contention.
- **Dropped an unnecessary `as Promise<T>`** — `Promise.race` already infers it (typecheck confirms).
- **Documented that the deadlines cover the handshake only**, so a bare 90s timeout with no deadline
  message points at the unguarded segments instead.

**Deliberately not done:** a package-wide timeout sweep. 33 other tests sit at `}, 30000)`, but only
**2 of 56 test files use `createMongoReplSet`** — the rest use a standalone server and never pay the
transaction cost that blew this budget. The one real peer (`deleteTransaction.integration.test.ts`,
still at 30s, never failed) is named in-file rather than bumped speculatively.

Re-verified after the fold-ins: typecheck clean, test green, lint + ASCII guards clean, and **both
mutations still caught** — the ordering signal still fails `expected true to be false`, and never
signalling still fails at 22.0s with the reworded message, proving the `finally` still fires through
the new `try` placement.
