### PR TITLE
fix(data-lakes): reject an unbounded chunkSize in POST /api/files/chunk

### DIFF
--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
@@ -115,4 +115,23 @@ describe('KnowledgeChunkControls - chunk-size ceiling', () => {
 
     await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 512));
   });
+
+  it('rounds a fractional chunk size instead of submitting it as-is', async () => {
+    render(
+      <TestWrapper>
+        <KnowledgeChunkControls fabFile={FAB_FILE} />
+      </TestWrapper>
+    );
+
+    const input = screen.getByTestId('knowledge-chunk-controls-size-input').querySelector('input')!;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '800.5' } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('801 tokens');
+
+    fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
+
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 801));
+  });
 });

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
@@ -7,6 +7,7 @@ import { getThemeConfig } from '@client/app/utils/themes';
 import { KnowledgeChunkControls } from './KnowledgeChunkControls';
 
 const chunkFileUtility = vi.fn().mockResolvedValue(undefined);
+let configuredChunkSize: number | undefined;
 
 vi.mock('@client/app/utils/filesAPICalls', () => ({
   chunkFileUtility: (...args: unknown[]) => chunkFileUtility(...args),
@@ -14,7 +15,7 @@ vi.mock('@client/app/utils/filesAPICalls', () => ({
 }));
 
 vi.mock('@client/app/hooks/data/settings', () => ({
-  useGetSettingsValue: () => undefined,
+  useGetSettingsValue: () => configuredChunkSize,
 }));
 
 vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }));
@@ -38,6 +39,7 @@ const FAB_FILE = {
 describe('KnowledgeChunkControls - chunk-size ceiling', () => {
   beforeEach(() => {
     chunkFileUtility.mockClear();
+    configuredChunkSize = undefined;
   });
 
   it('clamps a chunk size above the detection threshold before sending it', async () => {
@@ -116,7 +118,7 @@ describe('KnowledgeChunkControls - chunk-size ceiling', () => {
     await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 512));
   });
 
-  it('rounds a fractional chunk size instead of submitting it as-is', async () => {
+  it('floors a fractional chunk size instead of submitting it as-is', async () => {
     render(
       <TestWrapper>
         <KnowledgeChunkControls fabFile={FAB_FILE} />
@@ -128,10 +130,46 @@ describe('KnowledgeChunkControls - chunk-size ceiling', () => {
     fireEvent.change(input, { target: { value: '800.5' } });
     fireEvent.blur(input);
 
-    expect(input).toHaveValue('801 tokens');
+    expect(input).toHaveValue('800 tokens');
 
     fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
 
-    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 801));
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 800));
+  });
+
+  it('raises a below-floor chunk size to the shared minimum', async () => {
+    render(
+      <TestWrapper>
+        <KnowledgeChunkControls fabFile={FAB_FILE} />
+      </TestWrapper>
+    );
+
+    const input = screen.getByTestId('knowledge-chunk-controls-size-input').querySelector('input')!;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '5' } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('64 tokens');
+
+    fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
+
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 64));
+  });
+
+  it('clamps a legacy above-ceiling DefaultChunkSize prefill even if the input is never touched', async () => {
+    configuredChunkSize = 5000;
+
+    render(
+      <TestWrapper>
+        <KnowledgeChunkControls fabFile={FAB_FILE} />
+      </TestWrapper>
+    );
+
+    const input = screen.getByTestId('knowledge-chunk-controls-size-input').querySelector('input')!;
+    expect(input).toHaveValue('1500 tokens');
+
+    fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
+
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 1500));
   });
 });

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
@@ -78,7 +78,7 @@ describe('KnowledgeChunkControls - chunk-size ceiling', () => {
     await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 800));
   });
 
-  it('falls back to the last valid size on a blank blur instead of committing NaN', async () => {
+  it('falls back to the last valid size on a blank blur instead of submitting 0', async () => {
     render(
       <TestWrapper>
         <KnowledgeChunkControls fabFile={FAB_FILE} />
@@ -90,12 +90,29 @@ describe('KnowledgeChunkControls - chunk-size ceiling', () => {
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.blur(input);
 
-    expect(input).not.toHaveValue('NaN tokens');
+    expect(input).toHaveValue('512 tokens');
 
     fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
 
-    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalled());
-    const [, sentChunkSize] = chunkFileUtility.mock.calls[0];
-    expect(Number.isNaN(sentChunkSize)).toBe(false);
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 512));
+  });
+
+  it('falls back to the last valid size on a negative blur', async () => {
+    render(
+      <TestWrapper>
+        <KnowledgeChunkControls fabFile={FAB_FILE} />
+      </TestWrapper>
+    );
+
+    const input = screen.getByTestId('knowledge-chunk-controls-size-input').querySelector('input')!;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '-5' } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('512 tokens');
+
+    fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
+
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 512));
   });
 });

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { KnowledgeChunkControls } from './KnowledgeChunkControls';
+
+const chunkFileUtility = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@client/app/utils/filesAPICalls', () => ({
+  chunkFileUtility: (...args: unknown[]) => chunkFileUtility(...args),
+  updateFileUtility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@client/app/hooks/data/settings', () => ({
+  useGetSettingsValue: () => undefined,
+}));
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+  </QueryClientProvider>
+);
+
+const FAB_FILE = {
+  id: 'f1',
+  fileName: 'doc.txt',
+  isChunking: false,
+  isVectorizing: false,
+  chunked: false,
+  vectorized: false,
+} as never;
+
+describe('KnowledgeChunkControls - chunk-size ceiling', () => {
+  beforeEach(() => {
+    chunkFileUtility.mockClear();
+  });
+
+  it('clamps a chunk size above the detection threshold before sending it', async () => {
+    render(
+      <TestWrapper>
+        <KnowledgeChunkControls fabFile={FAB_FILE} />
+      </TestWrapper>
+    );
+
+    const input = screen.getByTestId('knowledge-chunk-controls-size-input').querySelector('input')!;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '5000' } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('1500 tokens');
+
+    fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
+
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 1500));
+  });
+
+  it('leaves an in-range chunk size unchanged', async () => {
+    render(
+      <TestWrapper>
+        <KnowledgeChunkControls fabFile={FAB_FILE} />
+      </TestWrapper>
+    );
+
+    const input = screen.getByTestId('knowledge-chunk-controls-size-input').querySelector('input')!;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '800' } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('800 tokens');
+
+    fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
+
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 800));
+  });
+});

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.test.tsx
@@ -77,4 +77,25 @@ describe('KnowledgeChunkControls - chunk-size ceiling', () => {
 
     await waitFor(() => expect(chunkFileUtility).toHaveBeenCalledWith('f1', 800));
   });
+
+  it('falls back to the last valid size on a blank blur instead of committing NaN', async () => {
+    render(
+      <TestWrapper>
+        <KnowledgeChunkControls fabFile={FAB_FILE} />
+      </TestWrapper>
+    );
+
+    const input = screen.getByTestId('knowledge-chunk-controls-size-input').querySelector('input')!;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(input).not.toHaveValue('NaN tokens');
+
+    fireEvent.click(screen.getByTestId('knowledge-chunk-controls-chunk-btn'));
+
+    await waitFor(() => expect(chunkFileUtility).toHaveBeenCalled());
+    const [, sentChunkSize] = chunkFileUtility.mock.calls[0];
+    expect(Number.isNaN(sentChunkSize)).toBe(false);
+  });
 });

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -67,10 +67,12 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
             onBlur={e => {
               // Ceiling matches the route's own limit (POST /api/files/chunk rejects above
               // OVERSIZED_PASSAGE_TOKEN_THRESHOLD), so this input can't suggest a value the
-              // policy will not honor. Falls back to the last valid size on a blank/non-numeric
-              // blur, rather than committing NaN.
+              // policy will not honor. Falls back to the last valid size on a blank, negative, or
+              // non-numeric blur - Number('') is 0, not NaN, so that case must be checked
+              // explicitly rather than relying on Number.isFinite alone.
               const parsed = Number(e.target.value);
-              const next = Number.isFinite(parsed) ? Math.min(parsed, OVERSIZED_PASSAGE_TOKEN_THRESHOLD) : chunkSize;
+              const next =
+                Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, OVERSIZED_PASSAGE_TOKEN_THRESHOLD) : chunkSize;
               setChunkSizeDisplay(`${next} tokens`);
               setChunkSize(next);
             }}

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Button, CircularProgress, Input, Stack, Tooltip, Typography } from '@mui/joy';
 import SegmentIcon from '@mui/icons-material/Segment';
 import CheckIcon from '@mui/icons-material/Check';
-import { DEFAULT_PASSAGE_TOKEN_TARGET, IFabFileDocument } from '@bike4mind/common';
+import { DEFAULT_PASSAGE_TOKEN_TARGET, IFabFileDocument, OVERSIZED_PASSAGE_TOKEN_THRESHOLD } from '@bike4mind/common';
 import { useChunkFile } from '@client/app/hooks/data/fabFiles';
 import { useGetSettingsValue } from '@client/app/hooks/data/settings';
 import { toast } from 'sonner';
@@ -59,13 +59,18 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
         <Typography>Chunks &amp; Vectorize</Typography>
         <Tooltip title="Chunking breaks your file into smaller pieces.">
           <Input
+            data-testid="knowledge-chunk-controls-size-input"
             type="string"
             color="success"
             value={chunkSizeDisplay}
             onChange={e => setChunkSizeDisplay(e.target.value)}
             onBlur={e => {
-              setChunkSizeDisplay(`${chunkSize} tokens`);
-              setChunkSize(Number(e.target.value));
+              // Ceiling matches the route's own limit (POST /api/files/chunk rejects above
+              // OVERSIZED_PASSAGE_TOKEN_THRESHOLD), so this input can't suggest a value the
+              // policy will not honor.
+              const next = Math.min(Number(e.target.value), OVERSIZED_PASSAGE_TOKEN_THRESHOLD);
+              setChunkSizeDisplay(`${next} tokens`);
+              setChunkSize(next);
             }}
             onFocus={() => {
               setChunkSizeDisplay(chunkSizeDisplay.replace(' tokens', ''));
@@ -87,6 +92,7 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
       <Stack direction="row" spacing={2} justifyContent="space-between">
         <Tooltip title="Chunking breaks your file into smaller pieces, while vectorizing creates a vector representation of your chunks.">
           <Button
+            data-testid="knowledge-chunk-controls-chunk-btn"
             color="success"
             variant="solid"
             fullWidth

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { Box, Button, CircularProgress, Input, Stack, Tooltip, Typography } from '@mui/joy';
 import SegmentIcon from '@mui/icons-material/Segment';
 import CheckIcon from '@mui/icons-material/Check';
-import { DEFAULT_PASSAGE_TOKEN_TARGET, IFabFileDocument, OVERSIZED_PASSAGE_TOKEN_THRESHOLD } from '@bike4mind/common';
+import { DEFAULT_PASSAGE_TOKEN_TARGET, IFabFileDocument } from '@bike4mind/common';
 import { useChunkFile } from '@client/app/hooks/data/fabFiles';
 import { useGetSettingsValue } from '@client/app/hooks/data/settings';
 import { toast } from 'sonner';
+import { clampChunkSize } from '@client/app/utils/chunkSize';
 import { updateFileUtility } from '@client/app/utils/filesAPICalls';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -20,8 +21,12 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
   // stored value loads the fallback applies, and the two answers now differ by ~4x (512 vs a stored
   // 2100) where they used to differ by 5% - so a cold mount would silently chunk at a different
   // granularity than a warm one. The effect below resyncs if the setting arrives after mount.
+  // `clampChunkSize` matters here too: a legacy stored value above the ceiling reaches this raw
+  // (the settings-fetch route has no clamp of its own), and submitting it unclamped now hard-400s.
   const configuredChunkSize = useGetSettingsValue('DefaultChunkSize');
-  const [chunkSize, setChunkSize] = useState<number>(Number(configuredChunkSize) || DEFAULT_PASSAGE_TOKEN_TARGET);
+  const [chunkSize, setChunkSize] = useState<number>(
+    clampChunkSize(Number(configuredChunkSize) || DEFAULT_PASSAGE_TOKEN_TARGET)
+  );
   const [chunkSizeDisplay, setChunkSizeDisplay] = useState<string>(`${chunkSize} tokens`);
   const queryClient = useQueryClient();
   const [recheckingVectorization, setRecheckingVectorization] = useState<boolean>(false);
@@ -36,7 +41,7 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
   // rather than on `chunkSize` so a user's manual edit is not stomped on a later settings refetch.
   useEffect(() => {
     const resolved = Number(configuredChunkSize);
-    if (resolved) setChunkSize(resolved);
+    if (resolved) setChunkSize(clampChunkSize(resolved));
   }, [configuredChunkSize]);
 
   return (
@@ -65,17 +70,11 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
             value={chunkSizeDisplay}
             onChange={e => setChunkSizeDisplay(e.target.value)}
             onBlur={e => {
-              // Ceiling matches the route's own limit (POST /api/files/chunk rejects above
-              // OVERSIZED_PASSAGE_TOKEN_THRESHOLD), so this input can't suggest a value the
-              // policy will not honor. Falls back to the last valid size on a blank, negative, or
-              // non-numeric blur - Number('') is 0, not NaN, so that case must be checked
-              // explicitly rather than relying on Number.isFinite alone. Rounds a fractional entry
-              // (the route requires an integer) rather than letting it through to a submit-time error.
+              // Number('') is 0, not NaN, so a blank blur must be checked explicitly rather than
+              // relying on Number.isFinite alone - otherwise it clamps to a bogus 0 instead of
+              // falling back below.
               const parsed = Number(e.target.value);
-              const next =
-                Number.isFinite(parsed) && parsed > 0
-                  ? Math.min(Math.round(parsed), OVERSIZED_PASSAGE_TOKEN_THRESHOLD)
-                  : chunkSize;
+              const next = Number.isFinite(parsed) && parsed > 0 ? clampChunkSize(parsed) : chunkSize;
               setChunkSizeDisplay(`${next} tokens`);
               setChunkSize(next);
             }}

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -67,8 +67,10 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
             onBlur={e => {
               // Ceiling matches the route's own limit (POST /api/files/chunk rejects above
               // OVERSIZED_PASSAGE_TOKEN_THRESHOLD), so this input can't suggest a value the
-              // policy will not honor.
-              const next = Math.min(Number(e.target.value), OVERSIZED_PASSAGE_TOKEN_THRESHOLD);
+              // policy will not honor. Falls back to the last valid size on a blank/non-numeric
+              // blur, rather than committing NaN.
+              const parsed = Number(e.target.value);
+              const next = Number.isFinite(parsed) ? Math.min(parsed, OVERSIZED_PASSAGE_TOKEN_THRESHOLD) : chunkSize;
               setChunkSizeDisplay(`${next} tokens`);
               setChunkSize(next);
             }}

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -69,10 +69,13 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
               // OVERSIZED_PASSAGE_TOKEN_THRESHOLD), so this input can't suggest a value the
               // policy will not honor. Falls back to the last valid size on a blank, negative, or
               // non-numeric blur - Number('') is 0, not NaN, so that case must be checked
-              // explicitly rather than relying on Number.isFinite alone.
+              // explicitly rather than relying on Number.isFinite alone. Rounds a fractional entry
+              // (the route requires an integer) rather than letting it through to a submit-time error.
               const parsed = Number(e.target.value);
               const next =
-                Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, OVERSIZED_PASSAGE_TOKEN_THRESHOLD) : chunkSize;
+                Number.isFinite(parsed) && parsed > 0
+                  ? Math.min(Math.round(parsed), OVERSIZED_PASSAGE_TOKEN_THRESHOLD)
+                  : chunkSize;
               setChunkSizeDisplay(`${next} tokens`);
               setChunkSize(next);
             }}

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -22,7 +22,9 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
   // 2100) where they used to differ by 5% - so a cold mount would silently chunk at a different
   // granularity than a warm one. The effect below resyncs if the setting arrives after mount.
   // `clampChunkSize` matters here too: a legacy stored value above the ceiling reaches this raw
-  // (the settings-fetch route has no clamp of its own), and submitting it unclamped now hard-400s.
+  // (the settings-fetch route has no clamp of its own), and submitting it unclamped would resolve
+  // as a silent false "success" here (chunkFileUtility swallows the route's rejection) rather than
+  // a visible error.
   const configuredChunkSize = useGetSettingsValue('DefaultChunkSize');
   const [chunkSize, setChunkSize] = useState<number>(
     clampChunkSize(Number(configuredChunkSize) || DEFAULT_PASSAGE_TOKEN_TARGET)

--- a/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
@@ -8,11 +8,15 @@ import type { IFabFileDocument } from '@bike4mind/common';
 const mockAdd = vi.fn().mockResolvedValue(undefined);
 const mockRemove = vi.fn().mockResolvedValue(undefined);
 const mockIsPending = vi.fn().mockReturnValue(false);
+const mockChunkMutate = vi.fn();
 
 let messageFiles: IFabFileDocument[] = [];
 let workBenchFiles: IFabFileDocument[] = [];
 let currentUserId = 'me';
 let sessionUserId = 'me';
+// Keyed so a test can set only the setting it cares about; other keys stay undefined,
+// matching the real useGetSettingsValue's per-key resolution.
+let settingsValues: Record<string, unknown> = {};
 
 vi.mock('@client/app/hooks/useNotebookContextFiles', () => ({
   useNotebookContextFiles: () => ({
@@ -32,8 +36,8 @@ vi.mock('@client/app/contexts/SessionsContext', () => ({
 vi.mock('@client/app/contexts/UserContext', () => ({ useUser: () => ({ currentUser: { id: currentUserId } }) }));
 vi.mock('@client/app/hooks/useMessageFiles', () => ({ useMessageFiles: () => messageFiles }));
 vi.mock('@client/app/hooks/data/useModelInfo', () => ({ useModelInfo: () => ({ data: undefined }) }));
-vi.mock('@client/app/hooks/data/settings', () => ({ useGetSettingsValue: () => undefined }));
-vi.mock('@client/app/hooks/data/fabFiles', () => ({ useChunkFile: () => ({ mutateAsync: vi.fn() }) }));
+vi.mock('@client/app/hooks/data/settings', () => ({ useGetSettingsValue: (key: string) => settingsValues[key] }));
+vi.mock('@client/app/hooks/data/fabFiles', () => ({ useChunkFile: () => ({ mutate: mockChunkMutate }) }));
 vi.mock('@client/app/hooks/useEmbeddingMismatchStatus', () => ({
   useEmbeddingMismatchStatus: () => ({ hasEmbeddingMismatch: () => false }),
 }));
@@ -65,6 +69,7 @@ describe('FilesSection message-scoped files', () => {
     workBenchFiles = [];
     currentUserId = 'me';
     sessionUserId = 'me';
+    settingsValues = {};
   });
 
   it('renders when the notebook has ONLY message-scoped files', () => {
@@ -139,5 +144,19 @@ describe('FilesSection message-scoped files', () => {
   it('renders nothing when there are no files of any kind', () => {
     const { container } = renderPanel();
     expect(container.firstChild).toBeNull();
+  });
+
+  it('clamps a legacy above-ceiling DefaultChunkSize before reprocessing a mismatched file', () => {
+    // Reachable state settings.ts documents explicitly: a value stored before the ceiling shipped
+    // resolves at its stored size on this raw settings-fetch read, with no clamp of its own.
+    settingsValues.DefaultChunkSize = 5000;
+    settingsValues.defaultEmbeddingModel = 'model-b';
+    workBenchFiles = [{ ...fab('w1', 'roster.pdf'), embeddingModel: 'model-a' } as IFabFileDocument];
+
+    renderPanel();
+    fireEvent.click(screen.getByTestId('files-section-reprocess-btn-w1'));
+
+    expect(mockChunkMutate).toHaveBeenCalledOnce();
+    expect(mockChunkMutate.mock.calls[0][0]).toMatchObject({ fabFileId: 'w1', chunkSize: 1500 });
   });
 });

--- a/apps/client/app/components/Session/AISettings/FilesSection.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.tsx
@@ -26,6 +26,7 @@ import { useChunkFile } from '@client/app/hooks/data/fabFiles';
 import { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 import useSessionLayout from '@client/app/hooks/useSessionLayout';
 import { useMessageFiles } from '@client/app/hooks/useMessageFiles';
+import { clampChunkSize } from '@client/app/utils/chunkSize';
 import { renameDuplicateFiles } from '@client/app/utils/fabFileUtils';
 import { buildSortedKnowledgeItems } from '@client/app/utils/knowledgeViewerSorting';
 import { useQueryClient } from '@tanstack/react-query';
@@ -161,8 +162,12 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
   const { currentUser } = useUser();
   const modelInfo = useModelInfo()?.data?.find(m => m.id === model);
   const currentEmbeddingModel = useGetSettingsValue('defaultEmbeddingModel');
-  // Fall back to the canonical chunker default, not a third hand-copied number.
-  const defaultChunkSize = useGetSettingsValue('DefaultChunkSize') || DEFAULT_PASSAGE_TOKEN_TARGET;
+  // Fall back to the canonical chunker default, not a third hand-copied number. Clamped: a legacy
+  // stored value above the ceiling reaches this raw (the settings-fetch route applies no clamp of
+  // its own), and submitting it unclamped now hard-400s at the route.
+  const defaultChunkSize = clampChunkSize(
+    Number(useGetSettingsValue('DefaultChunkSize')) || DEFAULT_PASSAGE_TOKEN_TARGET
+  );
   const chunkFile = useChunkFile();
   const queryClient = useQueryClient();
 
@@ -455,6 +460,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
                       arrow
                     >
                       <IconButton
+                        data-testid={`files-section-reprocess-btn-${file.id}`}
                         size="sm"
                         variant="plain"
                         color="danger"
@@ -558,6 +564,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
                       arrow
                     >
                       <IconButton
+                        data-testid={`files-section-reprocess-btn-${file.id}`}
                         size="sm"
                         variant="plain"
                         color="danger"

--- a/apps/client/app/components/Session/AISettings/FilesSection.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.tsx
@@ -164,7 +164,8 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
   const currentEmbeddingModel = useGetSettingsValue('defaultEmbeddingModel');
   // Fall back to the canonical chunker default, not a third hand-copied number. Clamped: a legacy
   // stored value above the ceiling reaches this raw (the settings-fetch route applies no clamp of
-  // its own), and submitting it unclamped now hard-400s at the route.
+  // its own), and submitting it unclamped would resolve as a silent false "success" here
+  // (chunkFileUtility swallows the route's rejection) rather than a visible error.
   const defaultChunkSize = clampChunkSize(
     Number(useGetSettingsValue('DefaultChunkSize')) || DEFAULT_PASSAGE_TOKEN_TARGET
   );

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -263,8 +263,8 @@ Initiates the chunking and embedding pipeline for a file.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| fileId | string | Yes | File ID to chunk |
-| chunkSize | integer | No | Passage target in tokens. Must be a positive integer, capped at ${OVERSIZED_PASSAGE_TOKEN_THRESHOLD}. |
+| fabFileId | string | Yes | File ID to chunk |
+| chunkSize | integer | Yes | Passage target in tokens. Must be a positive integer, capped at ${OVERSIZED_PASSAGE_TOKEN_THRESHOLD}. |
 
 #### File Endpoints Summary
 

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -1,5 +1,6 @@
 // brand externalized
 import { getBrandName } from '@client/config/general';
+import { OVERSIZED_PASSAGE_TOKEN_THRESHOLD } from '@bike4mind/common';
 
 export const API_REFERENCE_CONTENT = `
 # ${getBrandName()} API Reference
@@ -263,6 +264,7 @@ Initiates the chunking and embedding pipeline for a file.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | fileId | string | Yes | File ID to chunk |
+| chunkSize | integer | No | Passage target in tokens. Must be a positive integer, capped at ${OVERSIZED_PASSAGE_TOKEN_THRESHOLD}. |
 
 #### File Endpoints Summary
 

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -1,6 +1,6 @@
 // brand externalized
 import { getBrandName } from '@client/config/general';
-import { OVERSIZED_PASSAGE_TOKEN_THRESHOLD } from '@bike4mind/common';
+import { MIN_PASSAGE_TOKEN_TARGET, OVERSIZED_PASSAGE_TOKEN_THRESHOLD } from '@bike4mind/common';
 
 export const API_REFERENCE_CONTENT = `
 # ${getBrandName()} API Reference
@@ -264,7 +264,7 @@ Initiates the chunking and embedding pipeline for a file.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | fabFileId | string | Yes | File ID to chunk |
-| chunkSize | integer | Yes | Passage target in tokens. Must be a positive integer, capped at ${OVERSIZED_PASSAGE_TOKEN_THRESHOLD}. |
+| chunkSize | integer | Yes | Passage target in tokens. Must be an integer between ${MIN_PASSAGE_TOKEN_TARGET} and ${OVERSIZED_PASSAGE_TOKEN_THRESHOLD}, inclusive. |
 
 #### File Endpoints Summary
 

--- a/apps/client/app/utils/chunkSize.ts
+++ b/apps/client/app/utils/chunkSize.ts
@@ -6,7 +6,8 @@ import { settingsMap } from '@bike4mind/common';
  * above the ceiling (settings.ts documents this as a real, reachable state) or a hand-typed number
  * can never bypass the same bound the resolver enforces server-side
  * (`settingsMap.DefaultChunkSize.scope.clamp`) - only POST /api/files/chunk's own check catches it
- * otherwise, which now hard-rejects instead of silently reprocessing.
+ * otherwise, and chunkFileUtility swallows a rejected request (filesAPICalls.ts), so an unclamped
+ * value here would resolve as a silent false "success" with nothing queued, not a visible error.
  */
 export function clampChunkSize(value: number): number {
   return settingsMap.DefaultChunkSize.scope?.clamp?.(value, {}) ?? value;

--- a/apps/client/app/utils/chunkSize.ts
+++ b/apps/client/app/utils/chunkSize.ts
@@ -1,0 +1,13 @@
+import { settingsMap } from '@bike4mind/common';
+
+/**
+ * Applies the DefaultChunkSize setting's own scope clamp (floor + ceiling) to a chunk-size value.
+ * Use this at every client-side read/prefill/submit site for a chunk size, so a legacy stored value
+ * above the ceiling (settings.ts documents this as a real, reachable state) or a hand-typed number
+ * can never bypass the same bound the resolver enforces server-side
+ * (`settingsMap.DefaultChunkSize.scope.clamp`) - only POST /api/files/chunk's own check catches it
+ * otherwise, which now hard-rejects instead of silently reprocessing.
+ */
+export function clampChunkSize(value: number): number {
+  return settingsMap.DefaultChunkSize.scope?.clamp?.(value, {}) ?? value;
+}

--- a/apps/client/pages/api/files/__tests__/chunk.test.ts
+++ b/apps/client/pages/api/files/__tests__/chunk.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getFabFileById: vi.fn(),
+  sendToQueue: vi.fn(),
+  sendToClient: vi.fn(),
+  getSourceQueueUrl: vi.fn(),
+}));
+
+// Single-method chain: the route only calls `.post(...)`.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => ({ post: (fn: unknown) => fn }),
+}));
+
+vi.mock('sst', () => ({ Resource: { websocket: { managementEndpoint: 'wss://test' } } }));
+
+vi.mock('@server/managers/fabFileManager', () => ({ getFabFileById: h.getFabFileById }));
+vi.mock('@server/utils/sqs', () => ({ sendToQueue: h.sendToQueue }));
+vi.mock('@server/websocket/utils', () => ({ sendToClient: h.sendToClient }));
+vi.mock('@server/utils/dlqRegistry', () => ({ getSourceQueueUrl: h.getSourceQueueUrl }));
+
+import handler from '../chunk';
+
+const FILE = { _id: 'f1', id: 'f1', userId: 'u1', isChunking: false };
+
+const makeRes = () => {
+  const json = vi.fn();
+  return { res: { json } as never, json };
+};
+
+const req = (body: unknown) =>
+  ({
+    method: 'POST',
+    user: { id: 'u1' },
+    ability: { can: () => true },
+    body,
+  }) as never;
+
+const run = (body: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(req(body), res);
+
+describe('POST /api/files/chunk - chunkSize ceiling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.getFabFileById.mockResolvedValue(FILE);
+    h.getSourceQueueUrl.mockReturnValue('http://sqs/chunk');
+    h.sendToQueue.mockResolvedValue('msg-1');
+    h.sendToClient.mockResolvedValue(undefined);
+  });
+
+  it('rejects a chunkSize above the detection threshold', async () => {
+    const { res } = makeRes();
+    await expect(run({ fabFileId: 'f1', chunkSize: '1501' }, res)).rejects.toThrow(/must not exceed 1500/i);
+    expect(h.sendToQueue).not.toHaveBeenCalled();
+  });
+
+  it('accepts a chunkSize exactly at the detection threshold (detection is $gt)', async () => {
+    const { res, json } = makeRes();
+    await run({ fabFileId: 'f1', chunkSize: '1500' }, res);
+    expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/chunk', expect.objectContaining({ chunkSize: '1500' }));
+    expect(json).toHaveBeenCalledWith({ messageId: 'msg-1' });
+  });
+
+  it('accepts a typical chunkSize', async () => {
+    const { res, json } = makeRes();
+    await run({ fabFileId: 'f1', chunkSize: '300' }, res);
+    expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/chunk', expect.objectContaining({ chunkSize: '300' }));
+    expect(json).toHaveBeenCalledWith({ messageId: 'msg-1' });
+  });
+});

--- a/apps/client/pages/api/files/__tests__/chunk.test.ts
+++ b/apps/client/pages/api/files/__tests__/chunk.test.ts
@@ -41,7 +41,7 @@ const run = (body: unknown, res: unknown) => (handler as (req: unknown, res: unk
 
 // Unit-level: baseApi is stubbed to a bare pass-through above, so this exercises the handler's own
 // logic, not the throw-to-400 mapping (that lives in the real baseApi/asyncHandler chain).
-describe('chunk handler (unit) - chunkSize ceiling', () => {
+describe('chunk handler (unit) - chunkSize bounds', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.getFabFileById.mockResolvedValue(FILE);
@@ -72,6 +72,19 @@ describe('chunk handler (unit) - chunkSize ceiling', () => {
     const { res, json } = makeRes();
     await run({ fabFileId: 'f1', chunkSize: '1500' }, res);
     expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/chunk', expect.objectContaining({ chunkSize: '1500' }));
+    expect(json).toHaveBeenCalledWith({ messageId: 'msg-1' });
+  });
+
+  it('rejects a chunkSize below the chunker floor instead of silently raising it', async () => {
+    const { res } = makeRes();
+    await expect(run({ fabFileId: 'f1', chunkSize: '10' }, res)).rejects.toThrow(/at least 64/i);
+    expect(h.sendToQueue).not.toHaveBeenCalled();
+  });
+
+  it('accepts a chunkSize exactly at the chunker floor', async () => {
+    const { res, json } = makeRes();
+    await run({ fabFileId: 'f1', chunkSize: '64' }, res);
+    expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/chunk', expect.objectContaining({ chunkSize: '64' }));
     expect(json).toHaveBeenCalledWith({ messageId: 'msg-1' });
   });
 

--- a/apps/client/pages/api/files/__tests__/chunk.test.ts
+++ b/apps/client/pages/api/files/__tests__/chunk.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestError } from '@server/utils/errors';
 
 const h = vi.hoisted(() => ({
   getFabFileById: vi.fn(),
@@ -38,7 +39,9 @@ const req = (body: unknown) =>
 
 const run = (body: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(req(body), res);
 
-describe('POST /api/files/chunk - chunkSize ceiling', () => {
+// Unit-level: baseApi is stubbed to a bare pass-through above, so this exercises the handler's own
+// logic, not the throw-to-400 mapping (that lives in the real baseApi/asyncHandler chain).
+describe('chunk handler (unit) - chunkSize ceiling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.getFabFileById.mockResolvedValue(FILE);
@@ -51,6 +54,18 @@ describe('POST /api/files/chunk - chunkSize ceiling', () => {
     const { res } = makeRes();
     await expect(run({ fabFileId: 'f1', chunkSize: '1501' }, res)).rejects.toThrow(/must not exceed 1500/i);
     expect(h.sendToQueue).not.toHaveBeenCalled();
+  });
+
+  it('throws a BadRequestError (400) for an over-ceiling chunkSize', async () => {
+    const { res } = makeRes();
+    let caught: unknown;
+    try {
+      await run({ fabFileId: 'f1', chunkSize: '1501' }, res);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BadRequestError);
+    expect((caught as BadRequestError).statusCode).toBe(400);
   });
 
   it('accepts a chunkSize exactly at the detection threshold (detection is $gt)', async () => {

--- a/apps/client/pages/api/files/chunk.ts
+++ b/apps/client/pages/api/files/chunk.ts
@@ -1,4 +1,4 @@
-import { Permission } from '@bike4mind/common';
+import { OVERSIZED_PASSAGE_TOKEN_THRESHOLD, Permission } from '@bike4mind/common';
 import { getFabFileById } from '@server/managers/fabFileManager';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -18,6 +18,14 @@ const handler = baseApi().post(
     // chunk at the default instead of what the caller asked for.
     if (!/^\d+$/.test(String(chunkSize)) || Number(chunkSize) < 1) {
       throw new BadRequestError('chunkSize must be a positive integer (tokens)');
+    }
+    // This payload value overrides the resolved chunk-size policy entirely (fabFileChunk.ts:
+    // requestedPassageTokenTarget = chunkSize ?? resolvedChunkPolicy.value), so it is the one
+    // door the policy's own ceiling (DefaultChunkSize's max) cannot reach. Enforce the same
+    // detection-threshold ceiling here, or a caller can still make "Rebuild passages"
+    // non-convergent for this file. Detection is `$gt`, so the threshold itself is accepted.
+    if (Number(chunkSize) > OVERSIZED_PASSAGE_TOKEN_THRESHOLD) {
+      throw new BadRequestError(`chunkSize must not exceed ${OVERSIZED_PASSAGE_TOKEN_THRESHOLD} tokens`);
     }
 
     const fabFile = await getFabFileById(fabFileId, req.ability!, Permission.update);

--- a/apps/client/pages/api/files/chunk.ts
+++ b/apps/client/pages/api/files/chunk.ts
@@ -1,4 +1,4 @@
-import { OVERSIZED_PASSAGE_TOKEN_THRESHOLD, Permission } from '@bike4mind/common';
+import { MIN_PASSAGE_TOKEN_TARGET, OVERSIZED_PASSAGE_TOKEN_THRESHOLD, Permission } from '@bike4mind/common';
 import { getFabFileById } from '@server/managers/fabFileManager';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -26,6 +26,12 @@ const handler = baseApi().post(
     // non-convergent for this file. Detection is `$gt`, so the threshold itself is accepted.
     if (Number(chunkSize) > OVERSIZED_PASSAGE_TOKEN_THRESHOLD) {
       throw new BadRequestError(`chunkSize must not exceed ${OVERSIZED_PASSAGE_TOKEN_THRESHOLD} tokens`);
+    }
+    // Below MIN_PASSAGE_TOKEN_TARGET, the chunker (effectiveChunkTokenLimit) silently raises the
+    // value instead of honoring it - reject here rather than letting a caller's request get
+    // ignored with no signal, same reasoning as the ceiling above.
+    if (Number(chunkSize) < MIN_PASSAGE_TOKEN_TARGET) {
+      throw new BadRequestError(`chunkSize must be at least ${MIN_PASSAGE_TOKEN_TARGET} tokens`);
     }
 
     const fabFile = await getFabFileById(fabFileId, req.ability!, Permission.update);


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1498" height="530" alt="knowledge-chunk-ceiling-live" src="https://github.com/user-attachments/assets/aa52fd99-4b65-4edf-9ec1-17e1e7b4bfae" />

Typed `5000` into the chunk-size field on a real file's Vectorize modal; it snapped to `1500 tokens` on blur.

## Description
Closes #1809.

A previous fix bounded the resolved chunk-size policy (the `DefaultChunkSize` setting and a lake's required target) at the under-chunked detection threshold, but `POST /api/files/chunk` still let a caller pass a raw `chunkSize` that overrides that policy entirely. That value was the one door the policy's own ceiling could not reach, so a caller could still create chunks large enough to make "Rebuild passages" non-convergent for a file.

## Changes
- Reject a `chunkSize` above the detection threshold, and below the chunker's own minimum, in `POST /api/files/chunk` with a clear 400. Below the minimum previously returned 200 and silently chunked at the floor instead of the requested size.
- Clamp the chunk-size value (floor and ceiling) at every client read site - `KnowledgeChunkControls`' prefill/resync/blur and `FilesSection`'s reprocess default - via the setting's own `scope.clamp`, so the UI never submits a value the route will now reject.
- Document `chunkSize` and its bounds in the public API reference for this route.

## Guide for Testers
1. Authenticate to the API (bearer token or API key) and pick an existing file's `fabFileId` you own.
2. Send `POST /api/files/chunk` with body `{"fabFileId": "<id>", "chunkSize": 1501}`.
   Expected: HTTP 400 with a message naming the 1500-token limit; no chunk job is queued.
3. Send the same request with `chunkSize: 10`.
   Expected: HTTP 400 with a message naming the 64-token minimum; no chunk job is queued.
4. Send the same request with `chunkSize: 1500`.
   Expected: HTTP 200 with a `messageId`; the file starts chunking.
5. In the app, open the Files Manager (left sidenav), find any file, open its actions menu, and click "Vectorize".
6. In the modal that opens, type `5000` into the chunk-size field (top right), then click away (blur).
   Expected: the field snaps to `1500 tokens` before you can click "Chunk & Vectorize".

## Additional Information
N/A

## Developer Notes (Optional)
N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

