### PR TITLE
test(database): raise the confirmChunkClaim handshake deadline above CI contention

### DIFF
--- a/packages/database/src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts
+++ b/packages/database/src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts
@@ -38,8 +38,20 @@ afterAll(async () => {
  * transaction-start-plus-read and one non-transactional write), only on a genuine deadlock. It
  * exists because a previous CI failure was an unexplained 30s timeout whose cause - slow vs stuck -
  * could not be told apart from the log.
+ *
+ * Raised 20s -> 90s (#1098): the 20s ceiling DID fire on the sharded CI matrix - "takeoverCommitted
+ * did not settle within 20000ms" - which is the exact slow-runner false positive this deadline is
+ * supposed to tolerate, not a real deadlock. The data shard runs ~54 real-Mongo suites in parallel on
+ * a 2-core runner with no worker cap, so a single external write can be CPU-starved for far longer than
+ * 20s (it still tripped at 60s on a cold local run). #1821 raised the OUTER test timeout but not this
+ * INNER deadline, so this deadline stayed the binding constraint on the observed failures.
+ *
+ * This deadline is diagnostics only - it exists to LABEL which handshake wait hung, which a bare vitest
+ * timeout cannot. So it is sized just under the outer 120s test timeout: on a genuine hang it still
+ * surfaces the labelled error ~30s before the unlabelled timeout, but it never pre-empts a handshake
+ * that is merely slow and would otherwise complete.
  */
-const HANDSHAKE_DEADLINE_MS = 20_000;
+const HANDSHAKE_DEADLINE_MS = 90_000;
 function withDeadline<T>(promise: Promise<T>, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   const deadline = new Promise<never>((_, reject) => {
@@ -130,16 +142,21 @@ describe('FabFileRepository.confirmChunkClaim - genuine concurrent takeover', ()
     // a 2-core CI runner is slower again - so the ceiling has to be sized for a contended runner,
     // not for an idle laptop.
     //
-    // The deadlines above cover the HANDSHAKE only. So a bare 90s timeout with no deadline message
+    // The deadlines above cover the HANDSHAKE only. So a bare 120s timeout with no deadline message
     // means the handshake was fine and the time went somewhere unguarded - most likely the first
     // write's cold start (vitest.config.ts explains why: Mongoose builds every model's indexes on
     // connect and autoIndex cannot be disabled) or confirmChunkClaim's WriteConflict re-attempts.
     // Look there, not at the handshake.
+    //
+    // Raised 90s -> 120s (#1098) alongside the inner handshake deadline (20s -> 90s): the real CI
+    // failures were the inner deadline tripping under the shard's contention, so the outer ceiling
+    // sits above it with headroom for the post-handshake retries on the same starved runner. A passing
+    // run finishes in ~2s and never approaches either ceiling.
     //
     // Only one other test in this package shares the expensive shape - a replica set plus real
     // transactions - and that is deleteTransaction.integration.test.ts, whose cases still sit at the
     // 30s default. It has never blown it (it aborts deliberately, so it pays no retry cost), but it
     // is the one place to check first if this class of timeout shows up again. The other ~50 suites
     // here use a standalone server and never pay the transaction cost at all.
-  }, 90_000);
+  }, 120_000);
 });


### PR DESCRIPTION
## Optional Screenshot/Video

N/A - test-only timing change.

## Description

Contributes to #1098 (flaky CI in the sharded test matrix).

`FabFileModel.confirmChunkClaim.concurrency.test.ts` keeps flaking the **`Run Tests (data)`** shard with:

```
takeoverCommitted did not settle within 20000ms - handshake stalled (deadlock or extreme contention)
```

That is the test's **inner `HANDSHAKE_DEADLINE_MS` (20s)** firing - not the outer vitest test timeout. The inner deadline is a **diagnostics-only** guard: it exists solely to label *which* of the two handshake waits hung, which a bare vitest timeout cannot. Its own doc says it "must never fire on a merely slow runner, only on a genuine deadlock" - but 20s is below what a CPU-starved 2-core data-shard runner (~54 real-Mongo suites in parallel, no worker cap, plus a single-node replica set with majority-ack commits) can take for a single external write. So it was false-positiving on contention, exactly the case it is meant to tolerate.

**Why #1821 did not fix it:** #1821 raised the *outer* test timeout (30s -> 90s) but left this *inner* deadline at 20s, so the inner deadline stayed the binding constraint on the observed failures.

## Changes

- `packages/database/src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts`
  - `HANDSHAKE_DEADLINE_MS` 20s -> **90s**, and the outer test timeout 90s -> **120s**.
  - The inner deadline is now sized just under the outer timeout: on a genuine hang it still surfaces the labelled diagnostic ~30s before the unlabelled bare timeout, but it never pre-empts a handshake that is merely slow and would otherwise complete.
  - Comments updated to record the actual failure mode and the deadline's diagnostics-only intent.

No product code changes; no assertion or logic changes - only the two timing ceilings.

## Guide for Testers

This is a CI-timing flake fix; the observable is "the data shard stops intermittently failing on this suite." To sanity-check locally:

```
cd packages/database && VITEST_MAX_WORKERS=2 node_modules/.bin/vitest run \
  src/models/content/FabFileModel.confirmChunkClaim.concurrency.test.ts
```

Expected: passes (warm run ~2s). The change only widens two timing ceilings, so the assertions are unchanged.

## Additional Information

- **Honesty on verification:** the flake is CI-contention-dependent and cannot be reproduced deterministically on an idle machine (the suite passes in ~2s warm), so this cannot be *proven* to eliminate the flake - it removes the specific 20s inner-deadline failure mode seen in CI and makes that deadline purely diagnostic. During investigation the suite tripped even at a 60s inner deadline on a cold local run, which is why the deadline is sized just under the outer timeout rather than to a fixed larger constant.
- The deeper root cause is the data shard running ~54 real-Mongo suites with no worker cap on a 2-core runner (CPU oversubscription). A worker cap or isolating the two replica-set suites would address the class of flake in #1098 more broadly, but that is a CI/infra change beyond this suite - noted for the #1098 owners.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, test-only
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings