### PR TITLE
docs(billing): record the per-member cap exemption for operational usage (#1651)

### DIFF
--- a/b4m-core/services/src/billing/recordOperationalUsage.ts
+++ b/b4m-core/services/src/billing/recordOperationalUsage.ts
@@ -70,10 +70,18 @@ export interface RecordOperationalUsageAdapters {
  *
  * PER-MEMBER CAP: deliberately EXEMPT (#1651). `maxCreditsPerMember` is enforced at the
  * reservation pre-flight of the paths that trigger this spend, never here - this helper must not
- * throw, so a cap check could only skip the debit (already what an unbilled call does) or break
- * the operational call it measures. The bound is indirect: callers sit downstream of a primary
- * action that is itself gated. The exception is `pages/api/data-lakes/semantic-search`, which has
- * no pre-flight of its own; gating belongs at that endpoint, not here.
+ * throw, so a cap check could only skip the debit (already what an unbilled call does), break the
+ * operational call it measures, or mark the UsageEvent over-cap (observability, not enforcement).
+ *
+ * The bound is uneven, so do not read this as "every caller is gated upstream". The LLM-tool and
+ * knowledge-base callers pass a narrowed db with no billing repos, so they can never reach the
+ * deduct path at all - their safety comes from the adapter shape, not from a gated caller. The two
+ * debit-capable callers are `server/events/recordSessionOperationalUsage` and
+ * `pages/api/data-lakes/semantic-search`, and both are reachable with no pre-flight: session ops
+ * are queued directly by `POST /api/sessions/[id]/tag`, `POST /api/sessions/[id]/summary`, the
+ * project-attach fan-out (`pages/api/projects/[id]/sessions.ts`) and the admin spider, and
+ * semantic-search has no credit check of its own (#1843). Gating belongs at those entry points,
+ * not in a measurement helper.
  */
 export async function recordOperationalUsage(
   params: RecordOperationalUsageParams,

--- a/b4m-core/services/src/billing/recordOperationalUsage.ts
+++ b/b4m-core/services/src/billing/recordOperationalUsage.ts
@@ -68,20 +68,22 @@ export interface RecordOperationalUsageAdapters {
  * for both features - the precise feature ('operations' | 'embedding') lives on the UsageEvent;
  * the ledger row (opt-in, off by default) does not distinguish embeddings from operational text.
  *
- * PER-MEMBER CAP: deliberately EXEMPT (#1651). `maxCreditsPerMember` is enforced at the
- * reservation pre-flight of the paths that trigger this spend, never here - this helper must not
- * throw, so a cap check could only skip the debit (already what an unbilled call does), break the
- * operational call it measures, or mark the UsageEvent over-cap (observability, not enforcement).
+ * PER-MEMBER CAP: deliberately EXEMPT (#1651). `maxCreditsPerMember` BELONGS at the reservation
+ * pre-flight of the paths that trigger this spend, never here - this helper must not throw, so a
+ * cap check could only skip the debit (already what an unbilled call does), break the operational
+ * call it measures, or mark the UsageEvent over-cap (observability, not enforcement). That is
+ * where the cap belongs, not a claim that it is there today: see below for where it is missing.
  *
  * The bound is uneven, so do not read this as "every caller is gated upstream". The LLM-tool and
  * knowledge-base callers pass a narrowed db with no billing repos, so they can never reach the
  * deduct path at all - their safety comes from the adapter shape, not from a gated caller. The two
  * debit-capable callers are `server/events/recordSessionOperationalUsage` and
- * `pages/api/data-lakes/semantic-search`, and both are reachable with no pre-flight: session ops
- * are queued directly by `POST /api/sessions/[id]/tag`, `POST /api/sessions/[id]/summary`, the
- * project-attach fan-out (`pages/api/projects/[id]/sessions.ts`) and the admin spider, and
- * semantic-search has no credit check of its own (#1843). Gating belongs at those entry points,
- * not in a measurement helper.
+ * `pages/api/data-lakes/semantic-search`, and NEITHER is gated today: session ops are queued with
+ * no pre-flight by at least `POST /api/sessions/[id]/tag`, `POST /api/sessions/[id]/summary`, the
+ * project-attach fan-out (`pages/api/projects/[id]/sessions.ts`) and the admin spider (#1852;
+ * other `SessionEvents` publishers do sit behind gated primary actions), and semantic-search has
+ * no credit check of its own (#1843). Gating belongs at those entry points, not in a measurement
+ * helper.
  */
 export async function recordOperationalUsage(
   params: RecordOperationalUsageParams,

--- a/b4m-core/services/src/billing/recordOperationalUsage.ts
+++ b/b4m-core/services/src/billing/recordOperationalUsage.ts
@@ -67,6 +67,13 @@ export interface RecordOperationalUsageAdapters {
  * is measuring. The billing (deduct) path reuses the `text_generation_usage` ledger machinery
  * for both features - the precise feature ('operations' | 'embedding') lives on the UsageEvent;
  * the ledger row (opt-in, off by default) does not distinguish embeddings from operational text.
+ *
+ * PER-MEMBER CAP: deliberately EXEMPT (#1651). `maxCreditsPerMember` is enforced at the
+ * reservation pre-flight of the paths that trigger this spend, never here - this helper must not
+ * throw, so a cap check could only skip the debit (already what an unbilled call does) or break
+ * the operational call it measures. The bound is indirect: callers sit downstream of a primary
+ * action that is itself gated. The exception is `pages/api/data-lakes/semantic-search`, which has
+ * no pre-flight of its own; gating belongs at that endpoint, not here.
  */
 export async function recordOperationalUsage(
   params: RecordOperationalUsageParams,


### PR DESCRIPTION
# Pull Request

## Description

Comment-only. Records a decision, changes no behavior.

#1651 asked for an `isMemberCreditCapExceeded` reservation pre-flight on five org-billed settlement callers, and flagged two of them as needing a product decision first. #1625 has since landed the gate on four of the five (`ImageGeneration`, `ImageEdit`, `VideoGeneration`, and `agentExecutor` - the last via `isMemberAtOrOverCap`, since an agent run has no single upfront estimate). The fifth, `recordOperationalUsage`, is the decision item, and this PR encodes the answer: **exempt**.

The reasoning is forced by the function's own contract rather than being a preference:

- It must never throw, so that a billing or analytics failure cannot break the operational call it is measuring. A cap check there could only skip the debit - which is already exactly what an unbilled call does - break the call it measures, or mark the UsageEvent over-cap, which is observability rather than enforcement.
- It debits only when `billOperationalUsage` AND `enforceCredits` are both on, and the former defaults to off.

So the cap belongs at the reservation pre-flight of the paths that trigger this spend. The second half of the comment records where that is **not** true today, because the honest version of this decision is the useful one:

- Of the four production callers, two cannot debit at all. `recordToolOperationalUsage` and `knowledgeBaseSearch` pass a narrowed db with no billing repos, and the deduct path requires all three. Their safety comes from the adapter shape, not from a gated caller upstream.
- The two that can debit are `server/events/recordSessionOperationalUsage` and `pages/api/data-lakes/semantic-search`, and **neither is gated today**. Session ops are queued with no pre-flight by `POST /api/sessions/[id]/tag`, `POST /api/sessions/[id]/summary`, the project-attach fan-out and the admin spider (#1852). Semantic-search has no credit check of its own (#1843).

Gating belongs at those entry points, not in a measurement helper, so both gaps are tracked rather than fixed here. The exposure is latent: `billOperationalUsage` defaults off, which is exactly why the comment needs to be accurate - it is what someone consults at the moment they flip that toggle.

## Changes

- `b4m-core/services/src/billing/recordOperationalUsage.ts` - added a `PER-MEMBER CAP: deliberately EXEMPT` block (15 lines) to the function docstring: the decision, why the never-throw contract forces it, where the cap belongs, and which callers can actually debit and whether they are gated.

## Guide for Testers

**Nothing to exercise at runtime.** This PR adds comment lines to one docstring. There is no code path, endpoint, UI, setting, or migration to test, and no behavior differs before and after.

Verify by reading instead:

1. Open `b4m-core/services/src/billing/recordOperationalUsage.ts` and read the new `PER-MEMBER CAP` block in the `recordOperationalUsage` docstring. Confirm the header states where the cap *belongs* and does not assert that it is enforced there today.
2. Confirm the "cannot debit" claim: the deduct path at `:88` requires `db.creditTransactions && db.users && db.organizations`, and both `b4m-core/services/src/llm/tools/base/recordToolOperationalUsage.ts:94` and `llm/tools/implementation/knowledgeBaseSearch/index.ts:245` pass `{ usageEvents, adminSettings }` only.
3. Confirm the "can debit, not gated" claim for session ops: `apps/client/server/events/recordSessionOperationalUsage.ts:82-89` passes the full repo set, and the four entry points that queue session ops - `pages/api/sessions/[id]/tag.ts:18`, `pages/api/sessions/[id]/summary.ts:18`, `pages/api/projects/[id]/sessions.ts:90`, and the admin spider via `server/events/spider.ts:566-567` - contain no `isMemberCreditCapExceeded` / `isMemberAtOrOverCap` / `enforceCredits` check.
4. Confirm the same for `apps/client/pages/api/data-lakes/semantic-search.ts`: it passes the full repo set at `:344-351` and contains no cap or credit pre-flight anywhere in the file.
5. Expected result: every claim in the comment matches the code as it stands on this branch.

### Regression Checks

- `git diff origin/main` must show additions inside a block comment only - no executable line changed. Any behavior difference would mean the wrong thing shipped.

### What NOT to test

- Do not try to trigger a per-member cap rejection through operational or embedding spend. That is precisely what this PR documents as NOT happening, by design.
- Do not test `billOperationalUsage`, credit deduction, or usage-event recording. None of it is touched.

## Additional Information

Records the decision from #1651, which is closed with the full evidence. Part of epic #1172.

The two gaps the comment names are tracked separately and are not fixed here: #1852 (session-event ops) and #1843 (semantic-search). #1843's body was corrected alongside this PR - its original "Why this is the odd one out" section asserted the pre-correction claim that this PR overturns.

Verified: prettier, the smart-punctuation guard and the control-byte guard all pass on the touched file. No tests were run - the change is inside a block comment and cannot affect any.
