### PR TITLE
fix(e2e): raise the credits ceiling above cold-turn and OpenAI baselines

### DIFF
--- a/apps/client/e2e/helpers/slack.ts
+++ b/apps/client/e2e/helpers/slack.ts
@@ -4,7 +4,32 @@ import path from 'path';
 dotenv.config({ path: path.resolve(__dirname, '../../.env.e2e') });
 
 const WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL_SLOW_RESPONSES || '';
-export const CREDITS_THRESHOLD = 30;
+/**
+ * Ceiling for a model's AVERAGE credits on the fixed CREDITS_PROMPT turn
+ * (see notebook.spec.ts). Deliberately loose, and temporary at this value.
+ *
+ * 30 was failing daily for two unrelated reasons, neither of them a regression:
+ *
+ * - GPT-5.5 settles at 39-40 on every run, warm or cold. OpenAI cached tokens
+ *   are not passed through to billing (see openaiBackend.ts, where
+ *   prompt_tokens_details.cached_tokens is captured but deliberately not
+ *   forwarded), so every turn bills the full input rate. Whether that is
+ *   correct COGS or an overcharge is still open.
+ * - Claude 4.7 Opus averages ~50 whenever warmup.setup.ts's warm has aged past
+ *   the 5m prompt-cache TTL: run 1 re-pays the 1.25x cache write (~91 credits)
+ *   and run 2 reads it back (~8). Cold/warm differ by ~12.5x, which is the
+ *   cache multipliers, not prompt growth.
+ *
+ * 60 clears both. It deliberately does NOT clear a both-runs-cold average
+ * (~91): that stays a failure, because it means warmup is not working at all,
+ * which is worth being told about.
+ *
+ * Do not raise this again to accommodate a new number. A credit figure mixes
+ * prompt size with cache state, provider pricing and stochastic rounding, so it
+ * cannot isolate a regression. Prompt-size guarding belongs in a token budget -
+ * see #1844, which owns replacing this constant.
+ */
+export const CREDITS_THRESHOLD = 60;
 
 export interface ModelCreditsData {
   model: string;


### PR DESCRIPTION
# Pull Request

## Description

The daily Playwright credits check has been failing, and QA is blocked. Neither cause is a regression.

`notebook.spec.ts` sends a fixed prompt ("What is the capital of France?") to each model in `MONITORED_MODELS`, averages the runs, and `global-teardown.ts` compares that average to `CREDITS_THRESHOLD` (was 30). Two separate things push it over:

**GPT-5.5 settles at 39-40 on every run, warm or cold.** OpenAI reports `prompt_tokens_details.cached_tokens`, but the adapter captures it and deliberately does not forward it to billing (the reasoning is sound - OpenAI's `prompt_tokens` is cache-inclusive, so forwarding without subtracting would double-bill). The consequence is that every OpenAI turn settles at the full input rate with no cache discount, giving a flat baseline already above 30. **Whether that is correct COGS or an overcharge is unresolved** and is not addressed here.

**Claude 4.7 Opus averages ~50 when the warm has gone stale.** `warmup.setup.ts` warms each monitored model, but `cacheTTL` is `5m` and the credits suite runs after other projects. Once the warm ages out, run 1 re-pays the 1.25x prompt-cache write (~91 credits) and run 2 reads it back (~8). Cold and warm differ by ~12.5x purely from the cache multipliers (1.25x write vs 0.1x read) - not from prompt growth.

Confirmed unchanged, not a regression: a cold Opus turn was measured at ~94 credits on Opus 4.8 before 2026-08-13 under earlier prompt-footprint work. The number has been flat; only the threshold's tolerance for it changed.

## Changes

- `apps/client/e2e/helpers/slack.ts`: `CREDITS_THRESHOLD` 30 -> 60, with a comment recording both causes, why 60 specifically, and the norm against raising it again.

60 clears both baselines. It deliberately does **not** clear a both-runs-cold average (~91), which stays a failure on purpose - that state means warmup is not working at all, which is worth being told about.

## Guide for Testers

This is an E2E-harness constant. There is no product behaviour to click through; the verification is that the daily job stops failing for the wrong reason.

1. Open the repository at `apps/client/e2e/helpers/slack.ts`.
2. Confirm `CREDITS_THRESHOLD` is `60` and carries the explanatory comment. Expected: both present.
3. Trigger the AI latency/credits workflow (Actions -> `e2e-ai-latency`), or wait for the next scheduled daily run.
4. When it completes, open the Slack credits report posted by `notifyCreditsReport`. Expected: a line per monitored model, `Claude 4.7 Opus` and `GPT-5.5`, each with a green check.
5. Confirm the reported figures are unchanged from before this PR - roughly 8-9 for a warm `Claude 4.7 Opus`, 39-40 for `GPT-5.5`. Expected: **the numbers do not move**. Only the pass/fail verdict changes. If a credit figure itself changed, this PR is not the cause and something else moved.
6. If the run happens to catch a cold Opus first turn, expected: the average lands near 50 and still passes.

### Regression Checks

1. Confirm the credits report is still posted at all - the constant is imported by `notifyCreditsReport` and `global-teardown.ts`. Expected: the Slack message arrives as before.
2. Confirm a genuinely missing Used Credit chip still fails. `notebook.spec.ts`'s `afterAll` asserts `avgCredits` is not null independently of the threshold. Expected: a null credits value still fails regardless of this change.
3. Confirm no other test reads `CREDITS_THRESHOLD` and inherits an unintended tolerance change: `grep -rn "CREDITS_THRESHOLD" apps/client/e2e`. Expected: only `helpers/slack.ts` and `global-teardown.ts`.

### What NOT to test

- Do not test chat, billing, or credit deduction behaviour. No product or billing code is touched; this changes only an assertion ceiling in the E2E harness.
- Do not treat this as a cost fix. Cold-turn cost is unchanged by design here.
- Do not re-tune the threshold to make a future failure pass. See below.

## Additional Information

This is an unblock, not a fix. The underlying cost work is tracked separately:

- #1844 - replace this credit ceiling with a token budget over the always-on prompt footprint. **Owns deleting this constant.**
- #1829 - stop attaching `delegate_to_agent` to chats that cannot use it (the largest prefix lever).
- #1830 - measure and decide on the artifact-emission prompt (~39% of the cold-turn prefix).

Deliberately out of scope here, and worth filing on their own:

- The OpenAI cached-token pass-through described above. If `cached_tokens` is non-zero in production, customers are being billed the full rate on tokens the provider discounts, which is a billing-correctness problem rather than a cost-optimisation one.
- `enableCaching: messageCount >= 2` is true on the first turn of a conversation, because system blocks are already in `messages`. Every new chat therefore pays the 1.25x cache write for a cache nothing will read - 25% worse than not caching.

## Developer Notes

The comment on the constant is the deliverable as much as the number is. A credit figure is a product of prompt size, cache state, provider pricing, output length and stochastic settlement rounding; raising the ceiling whenever any of those moves is why it went 20 -> 30 -> 60. The comment names that explicitly and points at #1844 so the next person to see a red build reaches for the token budget instead of a bigger number.
