### PR TITLE
chore(waf): shadow the production rate limits on staging in Count mode

### DIFF
--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -170,6 +170,23 @@ describe('wafPolicy', () => {
       expect(new Set(priorities).size).toBe(priorities.length);
     });
 
+    // The *-prod-shadow rules exist only to measure how often production's tighter thresholds
+    // would be crossed by staging traffic. Count is what keeps them measurement-only: flip one to
+    // Block and staging starts enforcing a limit nobody has validated, which would take the e2e
+    // gate (and therefore prod promotion) down with it. Pin the action so that cannot happen quietly.
+    it('keeps every prod-shadow rule on Count so staging enforcement is unchanged', () => {
+      const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'dev' });
+      const parsed = JSON.parse(ruleJson);
+
+      const shadows = (parsed as WafRule[]).filter(rule => rule.Name.endsWith('-prod-shadow'));
+      expect(shadows.length).toBeGreaterThan(0);
+
+      for (const rule of shadows) {
+        expect(rule.Action).toEqual({ Count: {} });
+        expect(rule.OverrideAction).toBeUndefined();
+      }
+    });
+
     it('gives every rule a visibility config', () => {
       const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'dev' });
       const parsed = JSON.parse(ruleJson);

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -509,6 +509,101 @@
         "CloudWatchMetricsEnabled": true,
         "MetricName": "register-rate-limit"
       }
+    },
+    {
+      "Name": "api-rate-limit-prod-shadow",
+      "Priority": 12,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 2000,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP"
+        }
+      },
+      "Action": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "api-rate-limit-prod-shadow"
+      }
+    },
+    {
+      "Name": "ai-route-rate-limit-prod-shadow",
+      "Priority": 13,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 300,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/api/ai/",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "LOWERCASE"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
+        }
+      },
+      "Action": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "ai-route-rate-limit-prod-shadow"
+      }
+    },
+    {
+      "Name": "register-rate-limit-prod-shadow",
+      "Priority": 14,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 100,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/api/otc/send",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "LOWERCASE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
+        }
+      },
+      "Action": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "register-rate-limit-prod-shadow"
+      }
     }
   ],
   "VisibilityConfig": {


### PR DESCRIPTION
## Why

The staging and production WAF policies have quietly diverged on exactly the rules that carry blast radius, so staging traffic has never exercised the thresholds production would enforce. Ahead of re-enabling the WAF on the production distribution, this gives us a real measurement instead of a guess.

| rule | staging today | production policy |
| --- | --- | --- |
| `api-rate-limit` | 10000/5min **with** a `/api/` scope-down | 2000/5min **blanket** |
| `register-rate-limit` | 1000/5min | 100/5min |
| `ai-route-rate-limit` | absent | 300/5min on `/api/ai/` |

The blanket 2000 is the one worth measuring. Staging carves static assets out into a separate 50000 rule; the production policy has no such carve-out, so every request from an IP counts against one bucket. The last time that rule was live in production it blocked a non-trivial number of requests, and the log group has since aged out to zero bytes, so there is no way to go back and check whether those were attackers or one office behind a NAT.

## What

Three Count-action shadow rules appended to the staging policy, cloned verbatim from the production policy so the comparison is faithful. Nothing existing is modified.

Count means they evaluate and emit CloudWatch metrics but never block, so staging keeps its current enforcement exactly as-is and the e2e gate cannot be wedged by a threshold we have not validated yet.

They sit after the existing rules, so they do not observe the small fraction of requests a managed rule group terminates first (~0.16% of traffic over the last 30 days). That is acceptable for a threshold read, and it mirrors production's own ordering, where these rules also sit behind the terminating Allow rules.

## Reading the result

After this is on staging, per-rule `CountedRequests` in the `AWS/WAFV2` namespace answers the question directly: a flat zero on `api-rate-limit-prod-shadow` means the production threshold is safe to enable in Block, and a non-zero count means we need to raise it or restore the static-asset carve-out before it ever reaches production.

## Note

These rules are temporary and should be removed once the production thresholds are settled. The `-prod-shadow` suffix is there to make that obvious.

## Verification

- `infra/__tests__/wafPolicy.test.ts` passes, 22/22, including the no-duplicate-priorities assertion
- `aws wafv2 check-capacity` accepts the full ruleset: 1296 to 1326 WCU against a 5000 ceiling
- Purely additive, 95 insertions, no deletions


---

# Results so far, and what they change

**Phase 1 answered the main question on its own, on 18 Aug.** The shadow rules went live on staging and one day of passive traffic was enough. Recording it here so nobody drives phases that have already been settled.

| shadow rule | counted in one day | verdict |
| --- | --- | --- |
| `api-rate-limit-prod-shadow` (2000, blanket) | **331,374** of 517,542 allowed | production's rule is the wrong shape |
| `ai-route-rate-limit-prod-shadow` (300) | 0 | untested, needs driving |
| `register-rate-limit-prod-shadow` (100) | 0 | untested, needs driving |

Single IPs reached **18,335** requests in one 5-minute window against a 2,000 budget, and about **56%** of staging traffic is `/_next/static/`. Staging's own `api-rate-limit`, which is scoped to `/api/` and has a separate asset ceiling, blocked nothing in the same period. So the limit was never the problem; applying it to every request was.

Honest limit on that evidence: staging is CI-heavy, and the same rule blocked only **2,021 of 279,554** requests on real production traffic in January. Read it as a demonstrated design fault rather than a predicted outage.

**Consequence for the phases below.** Bike4Mind/bike4mind#1959 scopes production's rule to `/api/` and adds the asset ceiling, and re-points `api-rate-limit-prod-shadow` at that new statement.

- **Phase 3 as written is obsolete** and should not be run. It drives the blanket 2000, which is being removed. Once 1959 lands, the same phase is worth re-running against the new scoped shape, where the interesting number is whether real `/api/` traffic ever approaches 2000.
- **Phases 4 and 5 stand unchanged.** Both those shadows counted zero passively, so driving them is still the only way to learn whether they fire at all, which is the failure mode this whole exercise exists to catch.
- **Phase 6 stands** and matters more now, since an E2E run is the closest analogue to many users behind one address.

# Simulation plan

Merging this only proves the rules deploy. It does not prove they fire, and organic staging traffic has never come close to a 2000/5min per-IP ceiling, so passive waiting would tell us nothing. This is the active plan to run against staging before any of it reaches production.

## The trick that makes this safe

WAF evaluates on the viewer request, before CloudFront's cache and before the origin ever sees anything. So a probe does not need to reach working functionality to be counted. Every path below is deliberately chosen to 404 at the origin while still matching its rule's scope-down, which means no authentication, no LLM spend, and no one-time-code emails are involved at any point.

| target rule | probe path | why it is inert |
| --- | --- | --- |
| `api-rate-limit-prod-shadow` (2000, blanket) | `/waf-sim/blanket` | no scope-down at all, so any path counts |
| `ai-route-rate-limit-prod-shadow` (300) | `/api/ai/waf-sim` | matches `STARTS_WITH /api/ai/`, no such route exists |
| `register-rate-limit-prod-shadow` (100) | `/api/otc/sendwafsim` | matches `STARTS_WITH /api/otc/send`, no such route exists, so the real handler and its mailer are never entered |

Worth stating explicitly for the last one: the live `/api/otc/send` handler dispatches a real sign-in code, and on staging its app-level per-IP cap is lifted to `Infinity` under E2E, so WAF is the only backstop there. The probe path never enters that handler.

## Ordering constraints that will otherwise corrupt the read

Three real rules sit at lower priorities than the shadows and would swallow probe traffic before it arrives:

- Do not send the ZAP scanner header. `Allow-ZAP-Scanner` is a terminating Allow at priority 1 and evaluation stops there.
- Do not use the overwatch ingest path with a live-prefixed API key. `allow-overwatch-ingest` is a terminating Allow at priority 3.
- Keep the register probe between 100 and roughly 900 requests. Staging's real `register-rate-limit` is a Block at 1000 sitting at priority 11, ahead of the shadow at 14, so exceeding 1000 makes the shadow stop seeing traffic.

Also keep total `/api/` probe volume under 10000 per window so staging's own `api-rate-limit` Block never trips, and run each phase in its own 5-minute window with a gap between them. The blanket shadow has no scope-down, so every probe from every phase counts toward it, and overlapping phases would make the numbers unattributable.

## Known fidelity gap: admin traffic

Raised in review, and it is real. Production has a terminating `allow-admin-endpoints` Allow at priority 1, so `/api/admin/` requests never reach production's `api-rate-limit` at all. Staging has no such rule, so those requests do reach the blanket shadow and get counted, which means the shadow can over-count relative to production's rule as it stands today.

Measured rather than assumed, over the last 7 days of staging WAF logs: 7,055 `/api/admin/` requests out of 3,291,007 total, so 0.21% of traffic, and the worst single-IP burst in any 5-minute window was 55 requests against a 2000 budget, or 2.75%. Too small to change a go/no-go decision, so the shadow stays a verbatim clone rather than growing a staging-only scope-down that would make it less faithful in a different way.

Worth noting the direction of the error too. The intended production policy drops that terminating Allow in favour of the surgical pattern staging already uses, a CommonRuleSet scope-down for the specific ingest paths plus the AdminProtection rule override, because a terminating Allow on `/api/admin/` also skips the emergency IP block and every managed rule group. Against that target policy the shadow is the faithful model and today's production rule is the outlier. Either way the over-count is bounded at roughly 3% and biases toward caution.

To separate the two numbers when reading results:

```bash
aws logs start-query --log-group-name aws-waf-logs-bike4mind-dev --region us-east-1 --start-time "$(date -u -v-1d +%s)" --end-time "$(date -u +%s)" --query-string 'fields httpRequest.clientIp as ip, httpRequest.uri as uri | stats count(*) as total, sum(uri like /^\/api\/admin\//) as admin by ip, bin(5m) as w | sort total desc | limit 20'
```

## Two more reading caveats

**Pin the WebACL dimension, never use a bare metric search.** `wafPolicy.ts` loads this policy file for dev, staging and every PR preview stage, so in principle each preview WebACL would carry these three rules and a `SEARCH` on `Rule="api-rate-limit-prod-shadow"` alone would fold short-lived preview stacks into the reading. That is exactly the traffic shape most likely to produce a spurious non-zero against a 2000/5min bucket, because preview traffic is CI rather than users.

In practice it does not bite today, and it is worth recording why rather than relying on it. The preview environment has no `ENABLE_WAF` set, so preview deploys compute `false` and create no WAF resources at all: the dev account currently holds exactly two CloudFront-scope WebACLs, neither of them a preview stack, and `CountedRequests` metrics exist for exactly one WebACL name. So there is nothing to fold in. But that is a property of an unset variable, not of the policy, and it flips the moment anyone enables the WAF for previews. Every read command in this plan therefore pins explicit `Name=WebACL` and `Name=Rule` dimensions rather than a search expression, and it should stay that way.

**The staging security dashboard's counted bucket will move, by design.** `getTrafficMetricsForWebAcl` sums the `Rule="ALL"` aggregate for `CountedRequests`, so these shadow rules land in the same bucket as the existing `AdminProtection_URIPATH` override and the staging dashboard's counted total will step up with no attack behind it. Nothing is wrong and no code change is wanted; it is a read-interpretation trap.

It matters most during the active phases below, which deliberately drive several thousand counted requests through staging in a few minutes. Anyone glancing at the staging dashboard mid-simulation would see a spike that looks like an attack. Worth a heads-up in the deploys channel before running phases 3 through 5, and worth knowing that the metric is scoped per WebACL, so production's dashboard is unaffected either way.

## Making the simulation unmistakably ours

The counted-requests spike this produces on staging is indistinguishable from an attack if you only look at the number, and it lands in a dashboard two other workstreams are currently using to build an evidence trail. So the probes are built to identify themselves three ways over, and every phase should preserve all three.

- The rules are named `*-prod-shadow`, so the rule dimension on the metric says what it is.
- The probe paths read `/waf-sim/blanket`, `/api/ai/waf-sim` and `/api/otc/sendwafsim`, so a glance at the sampled requests or the logs shows intent rather than a plausible attack path.
- Every probe request must carry `User-Agent: b4m-waf-simulation`, which makes attribution a single unambiguous filter after the fact rather than an inference from timing.

That last one is what turns "was this us?" into a query:

```bash
aws logs start-query --log-group-name aws-waf-logs-bike4mind-dev --region us-east-1 --start-time "$(date -u -v-1d +%s)" --end-time "$(date -u +%s)" --query-string 'fields @timestamp, httpRequest.uri as uri, httpRequest.clientIp as ip | filter httpRequest.headers.0.value like /b4m-waf-simulation/ or uri like /waf-sim/ | stats count(*) as probes, earliest(@timestamp) as started, latest(@timestamp) as ended by uri'
```

Operationally: post the window in the deploys channel before running phases 3 through 5, and record the exact start and end timestamps with the results so any later review of the staging dashboard can exclude them rather than re-investigate them.

## Phases

1. Baseline, passive, 24 to 48 hours after merge. Read `CountedRequests` on all three shadows and expect flat zero. This is the first real finding either way: zero confirms organic staging traffic sits inside production's thresholds, and non-zero means production's config is already too tight and the enablement plan changes before we go any further.
2. Session cost. Drive a normal browser session against staging (sign in, open a chat, send a few prompts, move around) from one known IP, then count that IP's requests over the following 5 minutes. This converts the abstract 2000 budget into the number that actually matters: how many concurrent people behind one shared address before production starts refusing them.
3. Blanket ceiling. About 2500 requests to the blanket probe path from a single IP over roughly 4 minutes, concurrency 10, which is about 7 requests per second and negligible load on staging. Success is `api-rate-limit-prod-shadow` going non-zero while `BlockedRequests` stays zero on every rule, which simultaneously proves the rule fires and proves Count did not terminate anything.
4. AI route. About 400 requests to the AI probe path, confirming the scope-down matches. Then, in a separate window, about 400 requests to a path prefixed `/api/ai/v1/completions` and confirm the AI shadow stays at zero. That second half documents empirically that the priority-0 terminating Allow exempts the completions prefix from this rate limit, which is asserted by a unit test as intentional and is worth having as evidence rather than folklore.
5. Register route. About 300 requests to the register probe path, staying under the 1000 ceiling described above.
6. E2E. Trigger the core suite against staging and read the shadows afterward. This is the highest-value phase and the one thing staging can genuinely settle: CI drives heavy traffic from a small set of runner addresses, which is the closest available analogue to a busy office behind one NAT. If the blanket 2000 survives an E2E run it is defensible in production; if it does not, we have found the problem in the only place it is free to find.

## Reading it

Per-rule counts, swapping in each shadow rule name:

```bash
aws cloudwatch get-metric-statistics --namespace AWS/WAFV2 --metric-name CountedRequests --region us-east-1 --dimensions Name=WebACL,Value=bike4mind-api-protection-dev Name=Rule,Value=api-rate-limit-prod-shadow --start-time "$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --period 300 --statistics Sum --output table
```

And the organic distribution, which is what tells us the real headroom rather than just whether a probe worked:

```bash
aws logs start-query --log-group-name aws-waf-logs-bike4mind-dev --region us-east-1 --start-time "$(date -u -v-7d +%s)" --end-time "$(date -u +%s)" --query-string 'fields httpRequest.clientIp as ip | stats count(*) as reqs by ip, bin(5m) as window | sort reqs desc | limit 20'
```

Rate-based rules use a sliding 5-minute window refreshed roughly every 30 seconds, so expect up to a couple of minutes of lag between the last probe request and the metric moving. Read after waiting, not during.

## Go / no-go for production

- Blanket shadow flat zero through both organic traffic and an E2E run: production's 2000 is safe to enable directly in Block.
- Non-zero during E2E only: port staging's static-asset carve-out to the production policy first, since the blanket rule counts asset requests that staging currently budgets separately.
- Non-zero during organic traffic: the limit is wrong for real usage and needs raising before enablement, not after.
- Any shadow that stays at zero even when deliberately driven past its threshold: the rule does not work as written and must be fixed before it reaches production, which is exactly the failure mode of shipping a control that looks correct in config and produces nothing.

One check that is deliberately a human step rather than a test, raised in review on the parity-guard follow-up: before promoting any threshold to Block, confirm every production rate limit actually has a measurement behind it. The parity test pins each shadow to its production original, but nothing can pin the reverse without asserting a policy decision, and an invariant demanding a shadow for every production rate limit would fail the cleanup change whose whole purpose is deleting these rules. So it belongs here, at the decision point, where a new production rate limit arriving without a shadow is caught by a person reading this list.

Whatever the outcome, the production rate limits still land in Count for their first week rather than Block, because staging traffic is not production traffic and this plan is directional evidence rather than proof.

## Cleanup

These shadows come out once the production thresholds are settled. Removing them is the last step of the enablement work, not a follow-up to be forgotten.





