### PR TITLE
fix(api): add Zod validation at API layer for 8 unvalidated req.body endpoints

### DIFF
--- a/apps/client/pages/api/[type]/[id]/__tests__/revokeSharing.zod-validation.test.ts
+++ b/apps/client/pages/api/[type]/[id]/__tests__/revokeSharing.zod-validation.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ZodError } from 'zod';
+
+const mockRefs = vi.hoisted(() => ({
+  useHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: (fn: any) => {
+      mockRefs.useHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const revoke = vi.hoisted(() => vi.fn(async () => ({ id: 'doc1' })));
+vi.mock('@bike4mind/services', () => ({ sharingService: { revoke } }));
+vi.mock('@bike4mind/database', () => ({
+  fabFileRepository: {},
+  projectRepository: {},
+  sessionRepository: {},
+  userRepository: {},
+}));
+
+import '@pages/api/[type]/[id]/revokeSharing';
+
+function makeReq(body: unknown, type = 'files', id = 'doc-123') {
+  const { req, res } = createMocks({ method: 'POST', query: { type, id } });
+  (req as any).user = { id: 'u1' };
+  (req as any).body = body;
+  return { req, res };
+}
+
+describe('POST /api/[type]/[id]/revokeSharing -- Zod validation', () => {
+  beforeEach(() => revoke.mockClear());
+
+  it('accepts the real client payload (userId)', async () => {
+    const { req, res } = makeReq({ userId: 'target-user' });
+    await mockRefs.useHandler!(req, res);
+    expect(revoke).toHaveBeenCalledOnce();
+  });
+
+  it('accepts optional projectId alongside userId', async () => {
+    const { req, res } = makeReq({ userId: 'target-user', projectId: 'proj-abc' });
+    await mockRefs.useHandler!(req, res);
+    expect(revoke).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a missing userId with ZodError', async () => {
+    const { req, res } = makeReq({ projectId: 'proj-abc' });
+    await expect(mockRefs.useHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(revoke).not.toHaveBeenCalled();
+  });
+
+  it('strips unknown keys before they reach the service', async () => {
+    const { req, res } = makeReq({ userId: 'target-user', $where: 'sleep(1000)' });
+    await mockRefs.useHandler!(req, res);
+    const calledBody = revoke.mock.calls[0][1] as any;
+    expect(calledBody).not.toHaveProperty('$where');
+  });
+});

--- a/apps/client/pages/api/[type]/[id]/revokeSharing.ts
+++ b/apps/client/pages/api/[type]/[id]/revokeSharing.ts
@@ -1,8 +1,14 @@
+import { z } from 'zod';
 import { IShareableDocument } from '@bike4mind/common';
 import { fabFileRepository, projectRepository, sessionRepository, userRepository } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
 import { baseApi } from '@server/middlewares/baseApi';
 import { Request, Response } from 'express';
+
+const revokeBodySchema = z.object({
+  userId: z.string(),
+  projectId: z.string().optional(),
+});
 
 interface SharingParams {
   id: string;
@@ -13,10 +19,11 @@ interface SharingParams {
 const handler = baseApi().use(
   async (req: Request<unknown, {}, IShareableDocument, SharingParams>, res: Response<IShareableDocument>) => {
     const { type, id } = req.query;
+    const body = revokeBodySchema.parse(req.body);
 
     const document = await sharingService.revoke(
       req.user.id,
-      { id, type: type as 'files' | 'sessions', ...(req.body as any) },
+      { id, type: type as 'files' | 'sessions', ...body },
       {
         db: {
           sessions: sessionRepository,

--- a/apps/client/pages/api/files/tags/__tests__/zod-validation.test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/zod-validation.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ZodError } from 'zod';
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: any) => fn,
+}));
+
+const create = vi.hoisted(() => vi.fn(async () => ({ id: 'tag1', name: 'bug' })));
+vi.mock('@bike4mind/services', () => ({ tagService: { create, listFileTags: vi.fn() } }));
+vi.mock('@bike4mind/database', () => ({ fabFileRepository: {}, fileTagRepository: {} }));
+vi.mock('@bike4mind/common', () => ({ TagType: { FILE: 'file' } }));
+vi.mock('@server/utils/errors', () => ({
+  ForbiddenError: class extends Error {},
+}));
+vi.mock('@server/utils/userFileScope', () => ({ buildUserFileScope: vi.fn(() => ({})) }));
+
+import '@pages/api/files/tags/index';
+
+function makeReq(body: unknown) {
+  const { req, res } = createMocks({ method: 'POST' });
+  (req as any).user = { id: 'u1' };
+  (req as any).body = body;
+  return { req, res };
+}
+
+describe('POST /api/files/tags -- Zod validation', () => {
+  beforeEach(() => create.mockClear());
+
+  it('accepts the real client payload (name only, trimmed)', async () => {
+    const { req, res } = makeReq({ name: 'bug' });
+    await mockRefs.postHandler!(req, res);
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it('accepts all optional fields alongside name', async () => {
+    const { req, res } = makeReq({ name: 'bug', icon: '🐛', description: 'a bug tag', color: '#ff0000' });
+    await mockRefs.postHandler!(req, res);
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it('trims leading/trailing whitespace from name', async () => {
+    const { req, res } = makeReq({ name: '  bug  ' });
+    await mockRefs.postHandler!(req, res);
+    const calledBody = create.mock.calls[0][1] as any;
+    expect(calledBody.name).toBe('bug');
+  });
+
+  it('rejects a missing name with ZodError', async () => {
+    const { req, res } = makeReq({ icon: 'x' });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty name (whitespace-only) with ZodError', async () => {
+    const { req, res } = makeReq({ name: '   ' });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('strips unknown keys before they reach the service', async () => {
+    const { req, res } = makeReq({ name: 'bug', type: 'custom-override' });
+    await mockRefs.postHandler!(req, res);
+    // type is fixed to TagType.FILE in the handler, not read from body
+    const calledBody = create.mock.calls[0][1] as any;
+    expect(calledBody.type).toBe('file');
+  });
+});

--- a/apps/client/pages/api/files/tags/index.ts
+++ b/apps/client/pages/api/files/tags/index.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { TagType } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -6,6 +7,13 @@ import { buildUserFileScope } from '@server/utils/userFileScope';
 import { tagService } from '@bike4mind/services';
 import { fabFileRepository, fileTagRepository } from '@bike4mind/database';
 
+const tagCreateBodySchema = z.object({
+  name: z.string().trim().min(1),
+  icon: z.string().optional(),
+  description: z.string().optional(),
+  color: z.string().optional(),
+});
+
 const handler = baseApi()
   .post(
     asyncHandler<{}, unknown, unknown>(async (req, res) => {
@@ -13,15 +21,10 @@ const handler = baseApi()
         throw new ForbiddenError('Unauthorized');
       }
 
+      const body = tagCreateBodySchema.parse(req.body);
       const result = await tagService.create(
         req.user.id,
-        {
-          // any: the request body is unknown at this layer; tagService/create re-parses it.
-          ...(req.body as any),
-          // After the spread, not before: this route only ever creates FILE tags, and a body
-          // claiming another type would otherwise reach the service and be refused as a 500.
-          type: TagType.FILE,
-        },
+        { ...body, type: TagType.FILE },
         {
           db: {
             fileTags: fileTagRepository,

--- a/apps/client/pages/api/organizations/[id]/__tests__/members.zod-validation.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/members.zod-validation.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+    delete: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+const addMember = vi.hoisted(() =>
+  vi.fn(async () => ({
+    user: { id: 'new-u', email: 'new@example.com', level: 'member' },
+  }))
+);
+vi.mock('@bike4mind/services', () => ({
+  organizationService: { addMember, getUsers: vi.fn() },
+}));
+vi.mock('@bike4mind/database', () => ({
+  withTransaction: (fn: any) => fn(),
+  organizationRepository: {},
+  userRepository: {},
+}));
+vi.mock('@bike4mind/database/social', () => ({ groupRepository: {} }));
+vi.mock('@bike4mind/common', async importOriginal => {
+  const actual = await importOriginal<typeof import('@bike4mind/common')>();
+  return {
+    ...actual,
+    toSafeUser: (u: any) => u,
+    toSafeUsers: (u: any) => u,
+    safeUserResponseSchema: { parse: (x: any) => x },
+    safeUsersResponseSchema: { parse: (x: any) => x },
+  };
+});
+vi.mock('@server/utils/respond', () => ({ respond: (_res: any, _schema: any, data: any) => data }));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn(async () => {}) }));
+vi.mock('@server/utils/errors', () => ({
+  BadRequestError: class extends Error {},
+}));
+
+import '@pages/api/organizations/[id]/members/index';
+
+function makeReq(body: unknown) {
+  const { req, res } = createMocks({ method: 'POST', query: { id: 'org-123' } });
+  (req as any).user = { id: 'u1' };
+  (req as any).ability = null;
+  (req as any).body = body;
+  (req as any).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { req, res };
+}
+
+describe('POST /api/organizations/[id]/members -- Zod validation', () => {
+  beforeEach(() => addMember.mockClear());
+
+  it('accepts a real client payload with email (invite by email)', async () => {
+    const { req, res } = makeReq({ email: 'new@example.com' });
+    await mockRefs.postHandler!(req, res);
+    expect(addMember).toHaveBeenCalledOnce();
+    const body = addMember.mock.calls[0][1] as any;
+    expect(body.email).toBe('new@example.com');
+  });
+
+  it('accepts a payload with userId (invite by id)', async () => {
+    const { req, res } = makeReq({ userId: 'uid-abc' });
+    await mockRefs.postHandler!(req, res);
+    expect(addMember).toHaveBeenCalledOnce();
+  });
+
+  it('accepts force flag alongside email', async () => {
+    const { req, res } = makeReq({ email: 'new@example.com', force: true });
+    await mockRefs.postHandler!(req, res);
+    expect(addMember).toHaveBeenCalledOnce();
+  });
+
+  it('strips unknown keys -- organizationId in body cannot override the path param', async () => {
+    const { req, res } = makeReq({ email: 'new@example.com', organizationId: 'attacker-org' });
+    await mockRefs.postHandler!(req, res);
+    // body schema only allows userId, email, force -- organizationId stripped
+    const calledBody = addMember.mock.calls[0][1] as any;
+    // service is called with organizationId from req.query, not from body
+    expect(calledBody.organizationId).toBe('org-123');
+  });
+});

--- a/apps/client/pages/api/organizations/[id]/__tests__/zod-validation.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/zod-validation.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ZodError } from 'zod';
+
+const mockRefs = vi.hoisted(() => ({
+  putHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    put: (fn: any) => {
+      mockRefs.putHandler = fn;
+      return chain;
+    },
+    delete: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: any) => fn,
+}));
+
+const update = vi.hoisted(() => vi.fn(async () => ({ id: 'org1', userId: 'u1', name: 'Acme' })));
+vi.mock('@bike4mind/services', () => ({
+  organizationService: { update, get: vi.fn() },
+}));
+vi.mock('@bike4mind/database/infra', () => ({ organizationRepository: {} }));
+vi.mock('@bike4mind/database', () => ({
+  partnerSignupRuleRepository: {},
+  userRepository: {},
+  withTransaction: (fn: any) => fn(),
+}));
+vi.mock('@bike4mind/database/social', () => ({ groupRepository: {} }));
+vi.mock('@bike4mind/common', () => ({ toSafeOrganization: (org: any) => org }));
+vi.mock('@server/entitlements/partnerRules', () => ({ invalidatePartnerRuleCache: vi.fn() }));
+vi.mock('@server/models/Subscription', () => ({ subscriptionRepository: {} }));
+vi.mock('@client/lib/subscriptions/types', () => ({ SubscriptionOwnerType: {} }));
+
+import '@pages/api/organizations/[id]/index';
+
+function makeReq(body: unknown, queryId = 'org-123') {
+  const { req, res } = createMocks({ method: 'PUT', query: { id: queryId } });
+  (req as any).user = { id: 'u1', isAdmin: false };
+  (req as any).ability = null;
+  (req as any).body = body;
+  return { req, res };
+}
+
+describe('PUT /api/organizations/[id] -- Zod validation', () => {
+  beforeEach(() => update.mockClear());
+
+  it('accepts a real client payload (name + description)', async () => {
+    const { req, res } = makeReq({ name: 'Acme Corp', description: 'We build things' });
+    await mockRefs.putHandler!(req, res);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('accepts systemPrompt up to 10000 chars', async () => {
+    const { req, res } = makeReq({ systemPrompt: 'a'.repeat(100) });
+    await mockRefs.putHandler!(req, res);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('rejects systemPrompt over 10000 chars', async () => {
+    const { req, res } = makeReq({ systemPrompt: 'a'.repeat(10001) });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('coerces numeric string currentCredits to a number', async () => {
+    const { req, res } = makeReq({ currentCredits: '500' });
+    await mockRefs.putHandler!(req, res);
+    expect(update).toHaveBeenCalledOnce();
+    const calledBody = update.mock.calls[0][1] as any;
+    expect(typeof calledBody.currentCredits).toBe('number');
+  });
+
+  it('rejects non-numeric currentCredits that coerce to NaN', async () => {
+    const { req, res } = makeReq({ currentCredits: 'not-a-number' });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('strips unknown keys before they reach the service', async () => {
+    const { req, res } = makeReq({ name: 'n', stripeCustomerId: 'cus_EVIL' });
+    await mockRefs.putHandler!(req, res);
+    const calledBody = update.mock.calls[0][1] as any;
+    expect(calledBody).not.toHaveProperty('stripeCustomerId');
+  });
+});

--- a/apps/client/pages/api/organizations/[id]/index.ts
+++ b/apps/client/pages/api/organizations/[id]/index.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { organizationRepository } from '@bike4mind/database/infra';
@@ -9,6 +10,15 @@ import { toSafeOrganization } from '@bike4mind/common';
 import { Request } from 'express';
 import { subscriptionRepository } from '@server/models/Subscription';
 import { SubscriptionOwnerType } from '@client/lib/subscriptions/types';
+
+const updateOrgBodySchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  billingContact: z.string().optional(),
+  currentCredits: z.coerce.number().optional(),
+  systemPrompt: z.string().max(10000).optional(),
+  maxCreditsPerMember: z.number().positive().nullable().optional(),
+});
 
 const handler = baseApi()
   .get(
@@ -32,11 +42,12 @@ const handler = baseApi()
   )
   .put(
     asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
-      const orgId = req.query.id;
+      const orgId = req.query.id!;
 
+      const body = updateOrgBodySchema.parse(req.body);
       const updatedOrganization = await organizationService.update(
         req.user!,
-        { id: orgId, ...(req.body as any) },
+        { id: orgId, ...body },
         {
           db: {
             organizations: organizationRepository,

--- a/apps/client/pages/api/organizations/[id]/members/index.ts
+++ b/apps/client/pages/api/organizations/[id]/members/index.ts
@@ -1,12 +1,6 @@
 import { z } from 'zod';
 import { organizationService } from '@bike4mind/services';
 import { baseApi } from '@server/middlewares/baseApi';
-
-const addMemberBodySchema = z.object({
-  userId: z.string().optional(),
-  email: z.string().optional(),
-  force: z.boolean().optional(),
-});
 import { withTransaction } from '@bike4mind/database';
 import { BadRequestError } from '@server/utils/errors';
 import { logEvent } from '@server/utils/analyticsLog';
@@ -23,6 +17,12 @@ import { Request } from 'express';
 import { organizationRepository } from '@bike4mind/database/infra';
 import { userRepository } from '@bike4mind/database/auth';
 import { groupRepository } from '@bike4mind/database/social';
+
+const addMemberBodySchema = z.object({
+  userId: z.string().optional(),
+  email: z.string().optional(),
+  force: z.boolean().optional(),
+});
 
 const handler = baseApi()
   .get(async (req, res) => {

--- a/apps/client/pages/api/organizations/[id]/members/index.ts
+++ b/apps/client/pages/api/organizations/[id]/members/index.ts
@@ -1,5 +1,12 @@
+import { z } from 'zod';
 import { organizationService } from '@bike4mind/services';
 import { baseApi } from '@server/middlewares/baseApi';
+
+const addMemberBodySchema = z.object({
+  userId: z.string().optional(),
+  email: z.string().optional(),
+  force: z.boolean().optional(),
+});
 import { withTransaction } from '@bike4mind/database';
 import { BadRequestError } from '@server/utils/errors';
 import { logEvent } from '@server/utils/analyticsLog';
@@ -37,10 +44,11 @@ const handler = baseApi()
       throw new BadRequestError('Organization ID is required');
     }
 
+    const body = addMemberBodySchema.parse(req.body);
     const { user: newMember } = await withTransaction(async () =>
       organizationService.addMember(
         req.user,
-        { organizationId, ...(req.body as any) },
+        { organizationId, ...body },
         {
           db: {
             organizations: organizationRepository,

--- a/apps/client/pages/api/projects/[id]/__tests__/files.zod-validation.test.ts
+++ b/apps/client/pages/api/projects/[id]/__tests__/files.zod-validation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ZodError } from 'zod';
+
+// POST /api/projects/[id]/files enforces fileIds.min(1).
+// DELETE /api/projects/[id]/files accepts an empty array (no-op preserved).
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+    delete: (fn: any) => {
+      mockRefs.deleteHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: any) => fn,
+}));
+
+const addFiles = vi.hoisted(() => vi.fn(async () => ({ id: 'p1', name: 'n', description: 'd' })));
+const removeFiles = vi.hoisted(() => vi.fn(async () => ({ id: 'p1', name: 'n', description: 'd' })));
+vi.mock('@bike4mind/services', () => ({
+  projectService: { addFiles, removeFiles },
+}));
+vi.mock('@bike4mind/database', () => ({
+  withTransaction: (fn: any) => fn(),
+  projectRepository: {},
+  fabFileRepository: {},
+  userRepository: {},
+  inviteRepository: {},
+}));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn(async () => {}) }));
+vi.mock('@server/utils/storage', () => ({ getFilesStorage: () => ({}) }));
+
+import '@pages/api/projects/[id]/files';
+
+function makeReq(method: 'POST' | 'DELETE', body: unknown) {
+  const { req, res } = createMocks({ method, query: { id: 'proj-123' } });
+  (req as any).user = { id: 'u1' };
+  (req as any).ability = null;
+  (req as any).body = body;
+  return { req, res };
+}
+
+describe('POST /api/projects/[id]/files -- Zod validation', () => {
+  beforeEach(() => addFiles.mockClear());
+
+  it('accepts the real client payload (fileIds with one entry)', async () => {
+    const { req, res } = makeReq('POST', { fileIds: ['file-abc'] });
+    await mockRefs.postHandler!(req, res);
+    expect(addFiles).toHaveBeenCalledOnce();
+  });
+
+  it('accepts multiple fileIds', async () => {
+    const { req, res } = makeReq('POST', { fileIds: ['f1', 'f2', 'f3'] });
+    await mockRefs.postHandler!(req, res);
+    expect(addFiles).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an empty fileIds array (min(1) matches service contract)', async () => {
+    const { req, res } = makeReq('POST', { fileIds: [] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(addFiles).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing fileIds field', async () => {
+    const { req, res } = makeReq('POST', {});
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(addFiles).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/projects/[id]/files -- Zod validation', () => {
+  beforeEach(() => removeFiles.mockClear());
+
+  it('accepts the real client payload (fileIds with entries)', async () => {
+    const { req, res } = makeReq('DELETE', { fileIds: ['file-abc'] });
+    await mockRefs.deleteHandler!(req, res);
+    expect(removeFiles).toHaveBeenCalledOnce();
+  });
+
+  it('accepts an empty fileIds array -- DELETE empty is a 200 no-op (regression guard)', async () => {
+    const { req, res } = makeReq('DELETE', { fileIds: [] });
+    await mockRefs.deleteHandler!(req, res);
+    expect(removeFiles).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/client/pages/api/projects/[id]/__tests__/zod-validation.test.ts
+++ b/apps/client/pages/api/projects/[id]/__tests__/zod-validation.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ZodError } from 'zod';
+
+const mockRefs = vi.hoisted(() => ({
+  putHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    put: (fn: any) => {
+      mockRefs.putHandler = fn;
+      return chain;
+    },
+    delete: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+const update = vi.hoisted(() => vi.fn(async () => ({ id: 'p1', name: 'n', description: 'd' })));
+vi.mock('@bike4mind/services', () => ({ projectService: { update, get: vi.fn() } }));
+vi.mock('@bike4mind/database', () => ({ projectRepository: {}, userRepository: {} }));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn(async () => {}) }));
+vi.mock('@server/utils/isDuplicateKeyError', () => ({ isDuplicateKeyError: () => false }));
+
+import '@pages/api/projects/[id]/index';
+
+function makeReq(body: unknown, queryId = 'path-project-id') {
+  const { req, res } = createMocks({ method: 'PUT', query: { id: queryId } });
+  (req as any).user = { id: 'u1' };
+  (req as any).ability = null;
+  (req as any).body = body;
+  return { req, res };
+}
+
+describe('PUT /api/projects/[id] -- Zod validation', () => {
+  beforeEach(() => update.mockClear());
+
+  it('accepts the real client payload (name + description from IProjectDocument)', async () => {
+    const { req, res } = makeReq({ name: 'Renamed Project', description: 'New desc' });
+    await mockRefs.putHandler!(req, res);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('accepts a partial update (only name)', async () => {
+    const { req, res } = makeReq({ name: 'Renamed' });
+    await mockRefs.putHandler!(req, res);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('strips an attacker-supplied id from the body -- path param wins', async () => {
+    const { req, res } = makeReq({ name: 'n', id: 'attacker-project-id' }, 'path-project-id');
+    await mockRefs.putHandler!(req, res);
+    // The body schema only allows name and description; id is stripped by Zod.
+    // The service is called with the path param id from req.query, not body.id.
+    const serviceArgs = update.mock.calls[0][1] as any;
+    expect(serviceArgs.id).toBe('path-project-id');
+  });
+
+  it('strips unknown operator-injection keys before they reach the service', async () => {
+    const { req, res } = makeReq({ name: 'n', $where: 'sleep(1000)' });
+    await mockRefs.putHandler!(req, res);
+    const body = update.mock.calls[0][1] as any;
+    expect(body).not.toHaveProperty('$where');
+  });
+
+  it('rejects a non-string name', async () => {
+    const { req, res } = makeReq({ name: 42 });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/projects/[id]/files.ts
+++ b/apps/client/pages/api/projects/[id]/files.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import {
   withTransaction,
   projectRepository,
@@ -11,6 +12,10 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { logEvent } from '@server/utils/analyticsLog';
 import { ProjectEvents } from '@bike4mind/common';
 import { getFilesStorage } from '@server/utils/storage';
+
+const fileIdsBodySchema = z.object({
+  fileIds: z.array(z.string()).min(1),
+});
 
 const handler = baseApi()
   .get(
@@ -37,14 +42,14 @@ const handler = baseApi()
   .post(
     asyncHandler<{ id: string }>(async (req, res) => {
       const { id } = req.query as { id: string };
-      const { fileIds } = req.body as any;
+      const { fileIds } = fileIdsBodySchema.parse(req.body);
 
       const project = await withTransaction(() =>
         projectService.addFiles(
           req.user,
           {
             projectId: id,
-            fileIds,
+            fileIds: fileIds as [string, ...string[]],
           },
           {
             db: {
@@ -79,7 +84,7 @@ const handler = baseApi()
   .delete(
     asyncHandler<{ id: string }>(async (req, res) => {
       const { id } = req.query as { id: string };
-      const { fileIds } = req.body as any;
+      const { fileIds } = fileIdsBodySchema.parse(req.body);
 
       const project = await withTransaction(() =>
         projectService.removeFiles(

--- a/apps/client/pages/api/projects/[id]/files.ts
+++ b/apps/client/pages/api/projects/[id]/files.ts
@@ -13,8 +13,12 @@ import { logEvent } from '@server/utils/analyticsLog';
 import { ProjectEvents } from '@bike4mind/common';
 import { getFilesStorage } from '@server/utils/storage';
 
-const fileIdsBodySchema = z.object({
+const addFileIdsBodySchema = z.object({
   fileIds: z.array(z.string()).min(1),
+});
+
+const removeFileIdsBodySchema = z.object({
+  fileIds: z.array(z.string()),
 });
 
 const handler = baseApi()
@@ -42,7 +46,7 @@ const handler = baseApi()
   .post(
     asyncHandler<{ id: string }>(async (req, res) => {
       const { id } = req.query as { id: string };
-      const { fileIds } = fileIdsBodySchema.parse(req.body);
+      const { fileIds } = addFileIdsBodySchema.parse(req.body);
 
       const project = await withTransaction(() =>
         projectService.addFiles(
@@ -84,7 +88,7 @@ const handler = baseApi()
   .delete(
     asyncHandler<{ id: string }>(async (req, res) => {
       const { id } = req.query as { id: string };
-      const { fileIds } = fileIdsBodySchema.parse(req.body);
+      const { fileIds } = removeFileIdsBodySchema.parse(req.body);
 
       const project = await withTransaction(() =>
         projectService.removeFiles(

--- a/apps/client/pages/api/projects/[id]/index.ts
+++ b/apps/client/pages/api/projects/[id]/index.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { ProjectEvents } from '@bike4mind/common';
 import { projectRepository, userRepository } from '@bike4mind/database';
 import { projectService } from '@bike4mind/services';
@@ -5,6 +6,11 @@ import { UnprocessableEntityError } from '@bike4mind/utils';
 import { baseApi } from '@server/middlewares/baseApi';
 import { isDuplicateKeyError } from '@server/utils/isDuplicateKeyError';
 import { logEvent } from '@server/utils/analyticsLog';
+
+const updateProjectBodySchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+});
 
 const handler = baseApi()
   .get(async (req, res) => {
@@ -18,12 +24,13 @@ const handler = baseApi()
   })
   .put(async (req, res) => {
     let project;
+    const body = updateProjectBodySchema.parse(req.body);
     try {
       project = await projectService.update(
         req.user.id,
         {
           ...(req.query as any),
-          ...(req.body as any),
+          ...body,
         },
         {
           db: {
@@ -48,7 +55,7 @@ const handler = baseApi()
         metadata: {
           projectId: project.id,
           projectName: project.name,
-          updatedFields: Object.keys(req.body),
+          updatedFields: Object.keys(body),
         },
       },
       { ability: req.ability }

--- a/apps/client/pages/api/projects/__tests__/zod-validation.test.ts
+++ b/apps/client/pages/api/projects/__tests__/zod-validation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ZodError } from 'zod';
+
+// ZodError must escape the try block now that parse is above it.
+// This file pins that: a bad POST /api/projects body throws ZodError
+// (previously it was swallowed into InternalServerError).
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const createProject = vi.hoisted(() => vi.fn(async () => ({ id: 'p1', name: 'n', description: 'd' })));
+vi.mock('@bike4mind/services', () => ({ projectService: { createProject } }));
+vi.mock('@bike4mind/database', () => ({ projectRepository: {} }));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn(async () => {}) }));
+
+import '@pages/api/projects/index';
+
+function makeReq(body: unknown) {
+  const { req, res } = createMocks({ method: 'POST' });
+  (req as any).user = { id: 'u1' };
+  (req as any).ability = null;
+  (req as any).body = body;
+  return { req, res };
+}
+
+describe('POST /api/projects -- Zod validation', () => {
+  beforeEach(() => createProject.mockClear());
+
+  it('accepts the real client payload (name + description)', async () => {
+    const { req, res } = makeReq({ name: 'My Project', description: 'A project' });
+    await mockRefs.postHandler!(req, res);
+    expect(createProject).toHaveBeenCalledOnce();
+  });
+
+  it('accepts optional sessionIds and fileIds alongside required fields', async () => {
+    const { req, res } = makeReq({
+      name: 'Project B',
+      description: 'desc',
+      sessionIds: ['s1'],
+      fileIds: ['f1'],
+    });
+    await mockRefs.postHandler!(req, res);
+    expect(createProject).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a missing name with ZodError -- no longer swallowed as 500', async () => {
+    const { req, res } = makeReq({ description: 'A project' });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(createProject).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing description with ZodError', async () => {
+    const { req, res } = makeReq({ name: 'My Project' });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(createProject).not.toHaveBeenCalled();
+  });
+
+  it('strips unknown keys before they reach the service', async () => {
+    const { req, res } = makeReq({ name: 'n', description: 'd', _injected: { $gt: '' } });
+    await mockRefs.postHandler!(req, res);
+    const calledWith = createProject.mock.calls[0][1];
+    expect(calledWith).not.toHaveProperty('_injected');
+  });
+});

--- a/apps/client/pages/api/projects/index.ts
+++ b/apps/client/pages/api/projects/index.ts
@@ -1,12 +1,19 @@
+import { z } from 'zod';
 import { Permission, ProjectEvents } from '@bike4mind/common';
 import { Project, projectRepository } from '@bike4mind/database';
 import { projectService } from '@bike4mind/services';
-
 import { baseApi } from '@server/middlewares/baseApi';
 import qs from 'qs';
 import { accessibleBy } from '@casl/mongoose';
 import { InternalServerError, UnprocessableEntityError } from '@bike4mind/utils';
 import { logEvent } from '@server/utils/analyticsLog';
+
+const createProjectBodySchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  sessionIds: z.array(z.string()).optional(),
+  fileIds: z.array(z.string()).optional(),
+});
 
 const handler = baseApi()
   .get(async (req, res) => {
@@ -27,7 +34,8 @@ const handler = baseApi()
   })
   .post(async (req, res) => {
     try {
-      const project = await projectService.createProject(req.user.id, req.body as any, {
+      const body = createProjectBodySchema.parse(req.body);
+      const project = await projectService.createProject(req.user.id, body, {
         db: {
           projects: projectRepository,
         },
@@ -45,9 +53,9 @@ const handler = baseApi()
         { ability: req.ability }
       );
 
-      if (req.body.sessionIds?.length) {
+      if (body.sessionIds?.length) {
         await Promise.all(
-          req.body.sessionIds.map((sessionId: string) =>
+          body.sessionIds.map((sessionId: string) =>
             logEvent(
               {
                 userId: req.user.id,
@@ -65,9 +73,9 @@ const handler = baseApi()
         );
       }
 
-      if (req.body.fileIds?.length) {
+      if (body.fileIds?.length) {
         await Promise.all(
-          req.body.fileIds.map((fileId: string) =>
+          body.fileIds.map((fileId: string) =>
             logEvent(
               {
                 userId: req.user.id,

--- a/apps/client/pages/api/projects/index.ts
+++ b/apps/client/pages/api/projects/index.ts
@@ -33,8 +33,8 @@ const handler = baseApi()
     return res.json(projects);
   })
   .post(async (req, res) => {
+    const body = createProjectBodySchema.parse(req.body);
     try {
-      const body = createProjectBodySchema.parse(req.body);
       const project = await projectService.createProject(req.user.id, body, {
         db: {
           projects: projectRepository,

--- a/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/__tests__/zod-validation.test.ts
+++ b/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/__tests__/zod-validation.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ZodError } from 'zod';
+
+// ResearchTaskType must stay real so z.enum(ResearchTaskType) uses actual values.
+// Only the service / DB / middleware seams are mocked.
+
+const mockRefs = vi.hoisted(() => ({
+  putHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    put: (fn: any) => {
+      mockRefs.putHandler = fn;
+      return chain;
+    },
+    delete: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: any) => fn,
+}));
+
+const update = vi.hoisted(() => vi.fn(async () => ({ id: 'task1', title: 't' })));
+vi.mock('@bike4mind/services', () => ({ researchTaskService: { update, get: vi.fn(), remove: vi.fn() } }));
+vi.mock('@bike4mind/database', () => ({
+  researchDataRepository: {},
+  researchTaskRepository: {},
+}));
+
+import '@pages/api/research/agents/[id]/tasks/[taskId]/index';
+
+function makeReq(body: unknown, taskId = 'task-123') {
+  const { req, res } = createMocks({ method: 'PUT', query: { id: 'agent-abc', taskId } });
+  (req as any).user = { id: 'u1' };
+  (req as any).body = body;
+  return { req, res };
+}
+
+describe('PUT /api/research/agents/[id]/tasks/[taskId] -- Zod validation', () => {
+  beforeEach(() => update.mockClear());
+
+  it('accepts a scrape task -- real client payload with urls', async () => {
+    const { req, res } = makeReq({
+      title: 'Scrape example.com',
+      description: 'Get content',
+      type: 'scrape',
+      urls: ['https://example.com'],
+      canDiscoverLinks: false,
+    });
+    await mockRefs.putHandler!(req, res);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('accepts a deep research task (no urls required)', async () => {
+    const { req, res } = makeReq({
+      title: 'Research topic',
+      description: 'Deep dive',
+      type: 'deepResearch',
+    });
+    await mockRefs.putHandler!(req, res);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('validates the taskId path param via z.string()', async () => {
+    const { req, res } = makeReq({ title: 't', description: 'd', type: 'deepResearch' }, 'task-abc');
+    await mockRefs.putHandler!(req, res);
+    const calledWith = update.mock.calls[0][1] as any;
+    expect(calledWith.id).toBe('task-abc');
+  });
+
+  it('rejects an invalid type string', async () => {
+    const { req, res } = makeReq({ title: 't', description: 'd', type: 'invalid-type' });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a scrape task with a non-URL in urls (z.url() not z.string())', async () => {
+    const { req, res } = makeReq({
+      title: 't',
+      description: 'd',
+      type: 'scrape',
+      urls: ['not-a-url'],
+    });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a scrape task with an empty urls array (min(1))', async () => {
+    const { req, res } = makeReq({
+      title: 't',
+      description: 'd',
+      type: 'scrape',
+      urls: [],
+    });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(ZodError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('strips unknown keys before they reach the service', async () => {
+    const { req, res } = makeReq({
+      title: 't',
+      description: 'd',
+      type: 'deepResearch',
+      userId: 'attacker-uid',
+    });
+    await mockRefs.putHandler!(req, res);
+    const calledWith = update.mock.calls[0][1] as any;
+    expect(calledWith).not.toHaveProperty('userId');
+  });
+});

--- a/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/index.ts
+++ b/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/index.ts
@@ -10,8 +10,8 @@ const taskIdParamSchema = z.object({ taskId: z.string() });
 const taskUpdateBodySchema = z.object({
   title: z.string(),
   description: z.string(),
-  type: z.nativeEnum(ResearchTaskType),
-  urls: z.array(z.string().url()).min(1).optional(),
+  type: z.enum(ResearchTaskType),
+  urls: z.array(z.url()).min(1).optional(),
   canDiscoverLinks: z.boolean().optional(),
 });
 

--- a/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/index.ts
+++ b/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/index.ts
@@ -1,15 +1,27 @@
+import * as z from 'zod';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { researchTaskService } from '@bike4mind/services';
 import { researchDataRepository, researchTaskRepository } from '@bike4mind/database';
+import { ResearchTaskType } from '@bike4mind/common';
+
+const taskIdParamSchema = z.object({ taskId: z.string() });
+
+const taskUpdateBodySchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  type: z.nativeEnum(ResearchTaskType),
+  urls: z.array(z.string().url()).min(1).optional(),
+  canDiscoverLinks: z.boolean().optional(),
+});
 
 const handler = baseApi({ auth: true })
   .get(
     asyncHandler(async (req, res) => {
-      const { taskId } = req.query as any;
+      const { taskId } = taskIdParamSchema.parse(req.query);
       const result = await researchTaskService.get(
         req.user as any,
-        { id: taskId as any },
+        { id: taskId },
         {
           db: {
             researchTasks: researchTaskRepository,
@@ -23,13 +35,11 @@ const handler = baseApi({ auth: true })
   )
   .put(
     asyncHandler(async (req, res) => {
-      const { taskId } = req.query as any;
+      const { taskId } = taskIdParamSchema.parse(req.query);
+      const body = taskUpdateBodySchema.parse(req.body);
       const result = await researchTaskService.update(
         req.user as any,
-        {
-          id: taskId as any,
-          ...(req.body as any),
-        },
+        { id: taskId, ...body },
         {
           db: {
             researchTasks: researchTaskRepository,
@@ -42,10 +52,10 @@ const handler = baseApi({ auth: true })
   )
   .delete(
     asyncHandler(async (req, res) => {
-      const { taskId } = req.query as any;
+      const { taskId } = taskIdParamSchema.parse(req.query);
       const result = await researchTaskService.remove(
         req.user as any,
-        { id: taskId as any },
+        { id: taskId },
         {
           db: {
             researchTasks: researchTaskRepository,


### PR DESCRIPTION
## Summary

- Adds API-layer Zod schemas to 8 endpoints that previously relied solely on service-layer `secureParameters()` for input validation
- Closes the defense-in-depth gap identified in the follow-up audit on #930 (the three originally named endpoints were already fixed; this covers the remaining files)
- All schemas mirror the service-layer schemas; see **Behavior changes** below for two observable differences

## Behavior changes

**1. Unknown keys are stripped at the API layer, not just the service layer.**
Previously, any extra fields in `req.body` passed through to the service, which stripped them via `secureParameters()`. Now they are stripped at the API boundary. The practical effect: a `body.id` field can no longer shadow a `req.query.id` path param in any of these handlers -- the path param is always authoritative.

**2. `POST /api/projects` now returns 422 on bad input instead of 500.**
The original commit placed `createProjectBodySchema.parse(req.body)` inside the `try` block whose `catch` re-throws anything without `code === 11000` as `InternalServerError`. The parse is now above the `try` block so ZodErrors reach `errorHandler` and return 422 as expected.

**`DELETE /api/projects/[id]/files` with an empty array is still a 200 no-op.**
The original commit used a single schema with `.min(1)` for both POST and DELETE. Corrected to separate schemas: POST enforces `.min(1)` (matching the service tuple contract), DELETE has no minimum (preserving the existing no-op behavior).

## Files changed

| File | Schema(s) added |
|---|---|
| `pages/api/research/agents/[id]/tasks/[taskId]/index.ts` | `taskIdParamSchema` + `taskUpdateBodySchema` |
| `pages/api/projects/index.ts` | `createProjectBodySchema` |
| `pages/api/projects/[id]/index.ts` | `updateProjectBodySchema` |
| `pages/api/projects/[id]/files.ts` | `addFileIdsBodySchema` + `removeFileIdsBodySchema` |
| `pages/api/organizations/[id]/index.ts` | `updateOrgBodySchema` |
| `pages/api/organizations/[id]/members/index.ts` | `addMemberBodySchema` |
| `pages/api/[type]/[id]/revokeSharing.ts` | `revokeBodySchema` |
| `pages/api/files/tags/index.ts` | `tagCreateBodySchema` |

## Test plan

- [ ] Typecheck passes on changed files (`pnpm --filter @bike4mind/client typecheck` -- pre-existing premium overlay errors unrelated to this PR)
- [ ] POST `/api/projects` with missing `name` returns 422 (not 500)
- [ ] PUT `/api/projects/[id]` with extra unknown keys -- keys are stripped, real owner intact
- [ ] POST `/api/projects/[id]/files` with empty `fileIds` returns 422
- [ ] DELETE `/api/projects/[id]/files` with empty `fileIds` returns 200 (no-op preserved)
- [ ] PUT `/api/organizations/[id]` with invalid `currentCredits` (non-numeric) returns 422
- [ ] POST `/api/organizations/[id]/members` with neither `userId` nor `email` -- service validation still applies
- [ ] POST `/api/files/tags` with missing `name` returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
