### PR TITLE
fix(data-lake): refresh the lake list when ingestion completes, not only its health

### DIFF
--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -675,3 +675,71 @@ describe('useBatchProgressListener - processingFailedFiles (#1412)', () => {
     expect(useDataLakeWizardStore.getState().uploadProgress.processingFailedFiles).toBe(0);
   });
 });
+
+/**
+ * `fileCount` is a cached rollup on the lake DOCUMENT. The server recomputes it in
+ * `finalizeBatchIfComplete` BEFORE emitting the completion message, so by the time this listener
+ * fires the DB is already correct and only the client cache is stale. The upload doors invalidate
+ * the lake list at SUBMIT time - too early, since ingestion has not run - so completion is the only
+ * moment that can refresh it. Without this the count sits stale until a hard refresh.
+ */
+describe('useBatchProgressListener - refreshes the lake list on completion', () => {
+  const seedActiveBatch = () =>
+    useDataLakeWizardStore.setState({
+      uploadProgress: {
+        totalFiles: 1,
+        uploadedFiles: 1,
+        chunkedFiles: 0,
+        vectorizedFiles: 0,
+        failedFiles: 0,
+        failedFileNames: [],
+        processingFailedFiles: 0,
+        status: 'uploading',
+        currentBatchId: 'batch1',
+      },
+    });
+
+  // Spy on the prototype rather than reshaping mountHook, which owns its QueryClient internally.
+  const spyInvalidate = () => vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue(undefined);
+
+  const invalidatedKeys = (spy: ReturnType<typeof spyInvalidate>) =>
+    spy.mock.calls.map(([arg]) => JSON.stringify((arg as { queryKey?: unknown })?.queryKey));
+
+  beforeEach(() => {
+    subscribeToAction.mockClear();
+    seedActiveBatch();
+  });
+
+  it.each(['completed', 'completed_with_errors'] as const)(
+    'invalidates the lake list when the batch reports %s',
+    status => {
+      const spy = spyInvalidate();
+      mountHook(useBatchProgressListener);
+      const [, onMessage] = subscribeToAction.mock.calls.at(-1)!;
+
+      act(() => {
+        onMessage({ action: 'data_lake_batch_progress', batchId: 'batch1', status });
+      });
+
+      // `['data-lakes']` is dataLakeKeys.list - asserted as a literal so a rename of the key's VALUE
+      // (not just its name) still fails here rather than silently agreeing with itself.
+      expect(invalidatedKeys(spy)).toContain(JSON.stringify(['data-lakes']));
+      spy.mockRestore();
+    }
+  );
+
+  it('does NOT invalidate the lake list on an ordinary progress tick', () => {
+    // The guard against "just invalidate on every message": mid-ingest the server rollup has not
+    // run yet, so refetching then would re-cache the stale count and cost a request per tick.
+    const spy = spyInvalidate();
+    mountHook(useBatchProgressListener);
+    const [, onMessage] = subscribeToAction.mock.calls.at(-1)!;
+
+    act(() => {
+      onMessage({ action: 'data_lake_batch_progress', batchId: 'batch1', chunkedFiles: 1 });
+    });
+
+    expect(invalidatedKeys(spy)).not.toContain(JSON.stringify(['data-lakes']));
+    spy.mockRestore();
+  });
+});

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -700,20 +700,27 @@ describe('useBatchProgressListener - refreshes the lake list on completion', () 
     });
 
   // Spy on the prototype rather than reshaping mountHook, which owns its QueryClient internally.
-  const spyInvalidate = () => vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue(undefined);
+  // Restored in afterEach, NOT at the end of each test body: this file sets no `restoreMocks` in
+  // its vitest config, so a thrown assertion would otherwise leave invalidateQueries mocked for
+  // every test that runs after it.
+  let spy: ReturnType<typeof vi.spyOn>;
 
-  const invalidatedKeys = (spy: ReturnType<typeof spyInvalidate>) =>
+  const invalidatedKeys = () =>
     spy.mock.calls.map(([arg]) => JSON.stringify((arg as { queryKey?: unknown })?.queryKey));
 
   beforeEach(() => {
     subscribeToAction.mockClear();
     seedActiveBatch();
+    spy = vi.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
   });
 
   it.each(['completed', 'completed_with_errors'] as const)(
     'invalidates the lake list when the batch reports %s',
     status => {
-      const spy = spyInvalidate();
       mountHook(useBatchProgressListener);
       const [, onMessage] = subscribeToAction.mock.calls.at(-1)!;
 
@@ -723,15 +730,13 @@ describe('useBatchProgressListener - refreshes the lake list on completion', () 
 
       // `['data-lakes']` is dataLakeKeys.list - asserted as a literal so a rename of the key's VALUE
       // (not just its name) still fails here rather than silently agreeing with itself.
-      expect(invalidatedKeys(spy)).toContain(JSON.stringify(['data-lakes']));
-      spy.mockRestore();
+      expect(invalidatedKeys()).toContain(JSON.stringify(['data-lakes']));
     }
   );
 
   it('does NOT invalidate the lake list on an ordinary progress tick', () => {
     // The guard against "just invalidate on every message": mid-ingest the server rollup has not
     // run yet, so refetching then would re-cache the stale count and cost a request per tick.
-    const spy = spyInvalidate();
     mountHook(useBatchProgressListener);
     const [, onMessage] = subscribeToAction.mock.calls.at(-1)!;
 
@@ -739,7 +744,6 @@ describe('useBatchProgressListener - refreshes the lake list on completion', () 
       onMessage({ action: 'data_lake_batch_progress', batchId: 'batch1', chunkedFiles: 1 });
     });
 
-    expect(invalidatedKeys(spy)).not.toContain(JSON.stringify(['data-lakes']));
-    spy.mockRestore();
+    expect(invalidatedKeys()).not.toContain(JSON.stringify(['data-lakes']));
   });
 });

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -678,6 +678,13 @@ export function useBatchProgressListener() {
         // the active lake-detail view mounts one, so this is a single cheap refetch at most. Without
         // it the badge keeps its pending chip until staleTime (2 min) or a remount. (#1666)
         queryClient.invalidateQueries({ queryKey: dataLakeKeys.healthRoot });
+        // Same reason, different surface: `fileCount`/`totalSizeBytes` are cached rollups on the lake
+        // DOCUMENT, and `finalizeBatchIfComplete` calls recomputeLakeStats BEFORE emitting this
+        // message - so the server value is already fresh here and only the client cache is stale.
+        // The upload doors invalidate `list` at SUBMIT time, which is too early: ingestion has not
+        // run yet, so that refetch returns the pre-upload count and nothing asks again. Without this
+        // the count sits stale until a hard refresh.
+        queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
       }
       if (message.taxonomyStatus !== undefined) {
         updates.taxonomyStatus = message.taxonomyStatus;

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -681,9 +681,19 @@ export function useBatchProgressListener() {
         // Same reason, different surface: `fileCount`/`totalSizeBytes` are cached rollups on the lake
         // DOCUMENT, and `finalizeBatchIfComplete` calls recomputeLakeStats BEFORE emitting this
         // message - so the server value is already fresh here and only the client cache is stale.
-        // The upload doors invalidate `list` at SUBMIT time, which is too early: ingestion has not
-        // run yet, so that refetch returns the pre-upload count and nothing asks again. Without this
-        // the count sits stale until a hard refresh.
+        // The batch upload door invalidates `list` at SUBMIT time (see useBatchUpload), which is too
+        // early: ingestion has not run yet, so that refetch returns the pre-upload count.
+        //
+        // PARTIAL BY CONSTRUCTION - this only fires while the wizard is open. This listener is
+        // mounted solely by UploadStep, and DataLakeWizardModal renders <Modal> without
+        // `keepMounted`, so both exits ("Close and continue in background", "Done") tear the
+        // subscription down. Worse, `status: 'complete'` is set the moment browser uploads finish -
+        // before chunk/vectorize - so the Complete screen invites the user to leave BEFORE this
+        // message ever arrives. A user who takes either exit still sees the stale count until a
+        // refresh, exactly as before; nothing regresses, but this is not a whole-product fix.
+        // Making it unconditional means hosting the listener somewhere always-mounted (e.g.
+        // DataLakeUploadIndicator in the Notebook layout) - a separate change, and one that needs
+        // the double-subscribe interaction checked rather than assumed.
         queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
       }
       if (message.taxonomyStatus !== undefined) {


### PR DESCRIPTION
## Summary

A lake's file count sat stale after an upload until a hard refresh (`datalake-followups.md` item 3).

**The database was never wrong.** `fileCount`/`totalSizeBytes` are cached rollups on the lake document, and the server recomputes them in `finalizeBatchIfComplete` **before** emitting the batch-completion message. Measured `stored fileCount` against the exact `computeDataLakeStats` query across all six active prod lakes: **zero drift**.

The gap is client-side, and it is a timing gap rather than a missing call. `useBatchUpload` invalidates `dataLakeKeys.list` at **submit** time — too early, since ingestion has not run, so the refetch re-caches the *pre-upload* count. The batch-completion handler, the one moment the fresh value exists, invalidated only `dataLakeKeys.healthRoot` (added for exactly this class of bug on the health badge in #1666). So nothing ever asked for the new count. This adds the sibling `list` invalidation in that same completion branch.

## Scope — this is a partial fix, deliberately

It only fires **while the wizard is open**. `useBatchProgressListener` is mounted solely by `UploadStep`, and `DataLakeWizardModal` renders `<Modal>` without `keepMounted`, so both exits ("Close and continue in background", "Done") tear the subscription down.

That matters more than it sounds: `status: 'complete'` is set the moment browser uploads finish — *before* chunk/vectorize — so the Complete screen appears at the same instant as the too-early submit-time invalidation, and invites the user to leave before the useful message arrives. A user taking either exit still sees the stale count until a refresh, exactly as before.

Nothing regresses, and the flow this does cover is real. But making it unconditional means hosting the listener somewhere always-mounted (`DataLakeUploadIndicator` in the Notebook layout is the natural candidate) — a separate change, and one that needs the double-subscribe interaction verified rather than assumed. Recorded in the code comment beside the fix.

Note `SendToDataLakeModal` also invalidates `list` at submit time, but it is **not** affected either way: it never mounts this listener and produces no `data_lake_batch_progress` message, so it cannot reach this branch.

## Verification

- Both terminal statuses covered (`completed`, `completed_with_errors`).
- **Negative case asserted**: an ordinary progress tick must *not* invalidate the list — mid-ingest the server rollup has not run, so refetching then would re-cache the stale value at a cost of one request per tick.
- **Mutation-tested**: reverting the one-line fix fails exactly the two new tests and nothing else. Restored, 25/25 pass.
- `pnpm turbo:typecheck` 40/40, `pnpm lint:check` clean, hygiene checks clean.

## Diagnosis notes for anyone re-measuring this

Reproducing the count requires the query `computeDataLakeStats` actually runs (`FabFileModel.ts:1080`) — membership filter AND `deletedAt: null` AND `archivedAt: null` AND **`status: { $ne: 'pending' }`**. Omitting a condition produces a convincing false drift; three separate ones showed up while diagnosing this, including a coincidence that matched the bogus delta exactly. The traps are written up in `datalake-followups.md` item 3.
