### PR TITLE
fix(client): stop chunkFileUtility swallowing a rejected chunk request as false success

### DIFF
--- a/apps/client/app/utils/filesAPICalls.test.ts
+++ b/apps/client/app/utils/filesAPICalls.test.ts
@@ -57,9 +57,11 @@ describe('chunkFileUtility', () => {
   });
 
   it('rejects when the chunk request fails so the mutation onError can fire', async () => {
-    apiPost.mockRejectedValue(new Error('Request failed with status code 400'));
+    // A realistic rejection: the workbench holds a file that was deleted server-side, so the
+    // route returns 404. (chunkSize 1000 is a normal valid value - the route has no upper ceiling.)
+    apiPost.mockRejectedValue(new Error('Request failed with status code 404'));
 
-    await expect(chunkFileUtility('ff1', 999999)).rejects.toThrow('status code 400');
+    await expect(chunkFileUtility('ff1', 1000)).rejects.toThrow('status code 404');
   });
 
   it('resolves with the server payload on success', async () => {

--- a/apps/client/app/utils/filesAPICalls.test.ts
+++ b/apps/client/app/utils/filesAPICalls.test.ts
@@ -15,7 +15,7 @@ vi.mock('@client/app/contexts/ApiContext', () => ({
 vi.mock('axios', () => ({ default: { put: axiosPut, isCancel: () => false } }));
 vi.mock('./imageResizer', () => ({ resizeImageFile: vi.fn(), isImageFile: () => false }));
 
-const { createFabFileOnServerWithUpload } = await import('./filesAPICalls');
+const { createFabFileOnServerWithUpload, chunkFileUtility } = await import('./filesAPICalls');
 
 const formData = {} as unknown as CreateFabFileRequestInputType;
 const fakeFile = { type: 'text/plain', size: 11 } as unknown as File;
@@ -48,5 +48,24 @@ describe('createFabFileOnServerWithUpload PUT routing', () => {
 
     expect(axiosPut).toHaveBeenCalledWith('https://s3.amazonaws.com/b/x?X-Amz=1', fakeFile, expect.anything());
     expect(apiPut).not.toHaveBeenCalled();
+  });
+});
+
+describe('chunkFileUtility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects when the chunk request fails so the mutation onError can fire', async () => {
+    apiPost.mockRejectedValue(new Error('Request failed with status code 400'));
+
+    await expect(chunkFileUtility('ff1', 999999)).rejects.toThrow('status code 400');
+  });
+
+  it('resolves with the server payload on success', async () => {
+    apiPost.mockResolvedValue({ data: { queued: true } });
+
+    await expect(chunkFileUtility('ff1', 1000)).resolves.toEqual({ queued: true });
+    expect(apiPost).toHaveBeenCalledWith('/api/files/chunk', { fabFileId: 'ff1', chunkSize: 1000 });
   });
 });

--- a/apps/client/app/utils/filesAPICalls.ts
+++ b/apps/client/app/utils/filesAPICalls.ts
@@ -24,7 +24,9 @@ export const getFabFilesFromServerByIds = async (ids: string[]) => {
 };
 
 export const chunkFabFileFromServer = async (fabFileId: string, chunkSize: number) => {
-  const response = await api.post(`/api/files/chunk`, {
+  // `unknown` not the api client's default `any`: no caller reads the ack body (useChunkFile's
+  // onSuccess ignores it), so keep the return un-narrowed rather than leaking `any` to the mutation.
+  const response = await api.post<unknown>(`/api/files/chunk`, {
     fabFileId,
     chunkSize,
   });
@@ -245,8 +247,9 @@ export const deleteFileUtility = async (fileId: string): Promise<boolean> => {
 };
 
 export const chunkFileUtility = async (fabFileId: string, chunkSize: number) => {
-  // Do not swallow: a rejected request (e.g. an over-ceiling chunkSize 400) must
-  // reject the mutation so useChunkFile's onError fires instead of a false success toast.
+  // Do not swallow: a rejected request (e.g. a 404 when the workbench still holds a file
+  // deleted server-side, or the route's positive-integer 400) must reject the mutation so
+  // useChunkFile's onError fires instead of onSuccess running on a request that never landed.
   return await chunkFabFileFromServer(fabFileId, chunkSize);
 };
 

--- a/apps/client/app/utils/filesAPICalls.ts
+++ b/apps/client/app/utils/filesAPICalls.ts
@@ -245,11 +245,9 @@ export const deleteFileUtility = async (fileId: string): Promise<boolean> => {
 };
 
 export const chunkFileUtility = async (fabFileId: string, chunkSize: number) => {
-  try {
-    await chunkFabFileFromServer(fabFileId, chunkSize);
-  } catch (err: any) {
-    console.error('Failed to chunk the file:', err);
-  }
+  // Do not swallow: a rejected request (e.g. an over-ceiling chunkSize 400) must
+  // reject the mutation so useChunkFile's onError fires instead of a false success toast.
+  return await chunkFabFileFromServer(fabFileId, chunkSize);
 };
 
 export const getFabFileByIdFromServer = async (fabFileId: string): Promise<IFabFileDocument> => {


### PR DESCRIPTION
## Description

`chunkFileUtility` (`apps/client/app/utils/filesAPICalls.ts`) wrapped its `POST /api/files/chunk` in a try/catch that only `console.error`'d on failure and returned `undefined`. Its sole consumer, `useChunkFile`, awaits that utility in its `mutationFn`, so a rejected request (any 4xx/5xx) still resolved the mutation successfully: `onSuccess` fired and `onError` never did, at all three call sites (`KnowledgeChunkControls`, `FilesSection`'s "reprocess with current embedding model", `ResearchTasks/File`).

**This is bigger than a misleading toast** (thanks @onoya for driving the `FilesSection` path live and pinning this down). On a rejected reprocess the mutation still ran `onSuccess` at `FilesSection.tsx:237-248`, which writes `embeddingModel`/`vectorized`/`chunked` into the workbench Zustand store. Three surfaces derive from that field and were silently cleared even though nothing was queued: the red embedding-mismatch badge on the Session Files button (`useEmbeddingMismatchStatus.ts` -> `SessionToolbar.tsx`), the per-file reprocess IconButton (`FilesSection.tsx`), and the mismatch tooltip. `invalidateQueries(['fabFiles'])` cannot correct them because they read `sessionStates[sessionId]` (`SessionsContext.tsx`), which React Query never touches. So pre-fix, a rejected reprocess took the retry affordance away with no error, no red badge, no button. Scoped to SAVED notebooks only (the write is gated on `currentSessionId`), so `/new` was never affected.

The fix drops the swallow and returns the server result, so a real failure rejects the mutation and reaches the existing `onError` handling at every call site.

## Changes

- `apps/client/app/utils/filesAPICalls.ts`: `chunkFileUtility` no longer catches-and-swallows; it returns `await chunkFabFileFromServer(...)` so a rejection propagates. Typed `chunkFabFileFromServer`'s `api.post<unknown>` (was the client's default `any`) so the un-read ack body no longer leaks `any` into the mutation.
- `apps/client/app/utils/filesAPICalls.test.ts`: added a `chunkFileUtility` describe block covering the reject path (a 404, which rejects the mutation so `onError` can fire) and the success path (resolves with the server payload).

## Guide for Testers

Fix is client-only; verified by unit test + mutation. To exercise the behavior manually (in a SAVED notebook - `/new` is unaffected):

1. Chunk/vectorize a probe file so it is current, then delete that file server-side (or open a second tab and delete it there) so the workbench holds stale state. Trigger "reprocess with current embedding model" on it - the request rejects with a real 404. (Note: there is no over-ceiling 400 to trigger from the route; the route's only size guard is a positive-integer check, and the `DefaultChunkSize` ceiling lives in the setting schema, which blocks *storing* an out-of-range value rather than 400-ing the chunk request.)
2. **Before:** a green "Successfully..." toast appears, and the red mismatch badge + reprocess button silently disappear even though nothing was queued.
3. **After:** the error toast fires and the retry affordance (badge + button) stays put. Note the toast text is axios's generic `Request failed with status code 404`, not the response payload's message - `FilesSection` interpolates `error?.message`; surfacing `error.response?.data?.message` would be a fair follow-up, out of scope here.
4. Confirm a normal, valid reprocess still succeeds and toasts success as before.

Unit: `cd apps/client && npx vitest run app/utils/filesAPICalls.test.ts` (4 passing; the new tests fail if the swallow is reintroduced).

## Additional Information

Scope was verified against every caller of the changed function: the only consumer is `useChunkFile`, used by `KnowledgeChunkControls`, `FilesSection` (reprocess with current embedding model), and `ResearchTasks/File` - all route through the mutation's `onSuccess`/`onError`, none relied on the swallowed `undefined` return. The two sibling utilities in the same file are intentionally different contracts and were left alone: `updateFileUtility` already re-throws, and `deleteFileUtility` returns a `Promise<boolean>` its callers branch on.

Explicitly out of scope, worth their own issues (raised by @onoya / @cgtorniado in review): the 200 path is a server-side no-op on an already-chunked file (`fabFileChunk.ts` early-returns) yet still clears the three surfaces; the double-toast; and `useDeleteFile` ignoring `deleteFileUtility`'s `false` return and toasting success anyway.

## Developer Notes (Optional)

N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings

Closes #1849
