### PR TITLE
test(subscriptions): cover the org-subscribe callbackUrl origin guard

### DIFF
--- a/apps/client/lib/subscriptions/schema.test.ts
+++ b/apps/client/lib/subscriptions/schema.test.ts
@@ -52,13 +52,16 @@ describe('OrgSubscriptionSubscribeSchema.quantity', () => {
 describe('OrgSubscriptionSubscribeSchema.callbackUrl', () => {
   const baseSeats = { ...baseRequest, quantity: ORGANIZATION_SUBSCRIPTION_MIN_SEATS };
 
-  it('accepts an absolute https callbackUrl', () => {
+  it('accepts an absolute https callbackUrl and passes it through unchanged', () => {
     const result = OrgSubscriptionSubscribeSchema.safeParse({
       ...baseSeats,
       callbackUrl: 'https://app.example.com/settings/billing',
     });
 
     expect(result.success).toBe(true);
+    // The value must survive parsing verbatim - appendSuccessParams and the origin guard
+    // both operate on exactly what the caller sent, so any normalization would matter.
+    expect(result.data?.callbackUrl).toBe('https://app.example.com/settings/billing');
   });
 
   it('accepts an origin-only callbackUrl with no trailing path', () => {
@@ -71,6 +74,7 @@ describe('OrgSubscriptionSubscribeSchema.callbackUrl', () => {
     });
 
     expect(result.success).toBe(true);
+    expect(result.data?.callbackUrl).toBe('https://app.example.com');
   });
 
   it('rejects a relative path', () => {

--- a/apps/client/lib/subscriptions/schema.test.ts
+++ b/apps/client/lib/subscriptions/schema.test.ts
@@ -48,3 +48,40 @@ describe('OrgSubscriptionSubscribeSchema.quantity', () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe('OrgSubscriptionSubscribeSchema.callbackUrl', () => {
+  const baseSeats = { ...baseRequest, quantity: ORGANIZATION_SUBSCRIPTION_MIN_SEATS };
+
+  it('accepts an absolute https callbackUrl', () => {
+    const result = OrgSubscriptionSubscribeSchema.safeParse({
+      ...baseSeats,
+      callbackUrl: 'https://app.example.com/settings/billing',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an origin-only callbackUrl with no trailing path', () => {
+    // OrganizationBillingSection sends window.location.origin on purpose (CloudFront 403s
+    // deep paths, so the real destination is stashed in sessionStorage) - requiring a path
+    // here would break that flow.
+    const result = OrgSubscriptionSubscribeSchema.safeParse({
+      ...baseSeats,
+      callbackUrl: 'https://app.example.com',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a relative path', () => {
+    const result = OrgSubscriptionSubscribeSchema.safeParse({ ...baseSeats, callbackUrl: '/settings/billing' });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a string that is not a URL', () => {
+    const result = OrgSubscriptionSubscribeSchema.safeParse({ ...baseSeats, callbackUrl: 'not a url' });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/client/lib/subscriptions/schema.ts
+++ b/apps/client/lib/subscriptions/schema.ts
@@ -49,9 +49,12 @@ export const OrgSubscriptionSubscribeSchema = z
     organizationId: z.string().optional(),
 
     /**
-     * The URL to redirect to after the subscription is created.
+     * The URL to redirect to after the subscription is created. Must be a real URL -
+     * origin is further restricted to the deployed app in the subscribe handler
+     * (isAllowedCallbackOrigin) to prevent an open-redirect through Stripe's hosted
+     * checkout success/cancel pages.
      */
-    callbackUrl: z.string(),
+    callbackUrl: z.string().url(),
 
     /**
      * If organizationId is not provided, this is the data of the organization to create.

--- a/apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts
+++ b/apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import {
+  ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
+  ORGANIZATION_SUBSCRIPTION_PRICE_ID,
+} from '@client/lib/subscriptions/constants';
+
+// baseApi: unwrap the chain so handler.post(fn) just returns fn, and .use() is a no-op.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => ({
+    use: function () {
+      return this;
+    },
+    post: (fn: unknown) => fn,
+  }),
+}));
+
+// requireStripeWebhook is applied via .use() (dropped by the baseApi mock); stub the
+// factory so importing the handler doesn't touch real webhook config.
+vi.mock('@server/middlewares/requireStripeWebhook', () => ({
+  requireStripeWebhook: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('@bike4mind/utils', () => ({
+  BadRequestError: class BadRequestError extends Error {},
+  NotFoundError: class NotFoundError extends Error {},
+}));
+
+const mockOrgFindById = vi.fn();
+const mockOrgUpdate = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  organizationRepository: {
+    findById: (...args: unknown[]) => mockOrgFindById(...args),
+    update: (...args: unknown[]) => mockOrgUpdate(...args),
+  },
+}));
+
+const mockFindByPriceIdAndOwner = vi.fn();
+vi.mock('@server/models/Subscription', () => ({
+  subscriptionRepository: {
+    findByPriceIdAndOwner: (...args: unknown[]) => mockFindByPriceIdAndOwner(...args),
+  },
+}));
+
+// Drive the origin verdict per test. Keep the REAL appendSuccessParams so the success_url
+// this route builds is actually asserted rather than mocked into agreement.
+const mockIsAllowedCallbackOrigin = vi.fn();
+vi.mock('@server/integrations/stripe/callbackUrl', async importOriginal => {
+  const actual = await importOriginal<typeof import('@server/integrations/stripe/callbackUrl')>();
+  return { ...actual, isAllowedCallbackOrigin: (...args: unknown[]) => mockIsAllowedCallbackOrigin(...args) };
+});
+vi.mock('@server/utils/config', () => ({ Config: { STAGE: 'test' } }));
+
+const mockSessionsCreate = vi.fn();
+const mockCreateCustomer = vi.fn();
+vi.mock('@server/integrations/stripe/stripe', () => ({
+  createCustomer: (...args: unknown[]) => mockCreateCustomer(...args),
+  CustomerType: { User: 'User', Organization: 'Organization' },
+  stripe: {
+    checkout: { sessions: { create: (...args: unknown[]) => mockSessionsCreate(...args) } },
+  },
+}));
+
+import handler from '../subscribe';
+
+type HandlerFn = (req: unknown, res: unknown) => Promise<unknown>;
+
+const CALLBACK_URL = 'https://app.example.com/cb';
+
+function makeReq(callbackUrl = CALLBACK_URL) {
+  const { req, res } = createMocks({ method: 'POST' });
+  (req as Record<string, unknown>).body = {
+    priceId: ORGANIZATION_SUBSCRIPTION_PRICE_ID,
+    quantity: ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
+    organizationId: 'org_1',
+    callbackUrl,
+  };
+  (req as Record<string, unknown>).user = { id: 'user_1', email: 'buyer@example.com', name: 'Buyer' };
+  return { req, res };
+}
+
+describe('POST /api/organizations/subscriptions/subscribe - callbackUrl origin guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowedCallbackOrigin.mockReturnValue(true);
+    mockFindByPriceIdAndOwner.mockResolvedValue(null); // no active org subscription
+    mockOrgFindById.mockResolvedValue({
+      id: 'org_1',
+      name: 'Org One',
+      billingContact: 'billing@example.com',
+      stripeCustomerId: 'cus_existing',
+      users: [{ userId: 'user_1' }],
+    });
+    mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe/session' });
+  });
+
+  it('rejects a callbackUrl on a disallowed origin', async () => {
+    // The guard is the only thing between an org callbackUrl and an open redirect off
+    // Stripe's hosted checkout page, where the redirect wears Stripe's brand.
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('https://attacker.example.net/phish');
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toThrow(
+      'callbackUrl must point to the deployed application origin'
+    );
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith('https://attacker.example.net/phish');
+  });
+
+  it('runs the guard before any lookup or Stripe side effect', async () => {
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('https://attacker.example.net/phish');
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toThrow();
+
+    expect(mockFindByPriceIdAndOwner).not.toHaveBeenCalled();
+    expect(mockOrgFindById).not.toHaveBeenCalled();
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('passes an allowed-origin callbackUrl through to the checkout session', async () => {
+    const { req, res } = makeReq();
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(mockSessionsCreate).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res._getJSONData()).toEqual({ sessionUrl: 'https://checkout.stripe/session' });
+  });
+
+  it('marks the org success_url and leaves cancel_url bare', async () => {
+    // The {CHECKOUT_SESSION_ID} template must stay literal for Stripe to substitute it;
+    // encoded braces would hand the client the placeholder instead of a session id.
+    const { req, res } = makeReq();
+
+    await (handler as HandlerFn)(req, res);
+
+    const args = mockSessionsCreate.mock.calls[0][0] as { success_url: string; cancel_url: string };
+    expect(args.success_url).toBe(
+      'https://app.example.com/cb?subscription_success=true&checkout_session_id={CHECKOUT_SESSION_ID}'
+    );
+    expect(args.success_url).not.toContain('%7B');
+    expect(args.cancel_url).toBe(CALLBACK_URL);
+  });
+});

--- a/apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts
+++ b/apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts
@@ -22,10 +22,11 @@ vi.mock('@server/middlewares/requireStripeWebhook', () => ({
   requireStripeWebhook: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
-vi.mock('@bike4mind/utils', () => ({
-  BadRequestError: class BadRequestError extends Error {},
-  NotFoundError: class NotFoundError extends Error {},
-}));
+// Deliberately NOT mocking @bike4mind/utils: the real BadRequestError carries
+// statusCode 400, which lets the rejection test assert the status the client would
+// actually receive rather than only the message.
+import { BadRequestError } from '@bike4mind/utils';
+import { HttpStatus } from '@bike4mind/common';
 
 const mockOrgFindById = vi.fn();
 const mockOrgUpdate = vi.fn();
@@ -104,6 +105,12 @@ describe('POST /api/organizations/subscriptions/subscribe - callbackUrl origin g
     await expect((handler as HandlerFn)(req, res)).rejects.toThrow(
       'callbackUrl must point to the deployed application origin'
     );
+    // Assert the status the caller actually gets, not just the message: a regression in
+    // which error class is thrown would keep the message and silently change the response.
+    await expect((handler as HandlerFn)(req, res)).rejects.toMatchObject({
+      constructor: BadRequestError,
+      statusCode: HttpStatus.BadRequest,
+    });
 
     expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith('https://attacker.example.net/phish');
   });

--- a/apps/client/pages/api/organizations/subscriptions/subscribe.ts
+++ b/apps/client/pages/api/organizations/subscriptions/subscribe.ts
@@ -30,10 +30,11 @@ const handler = baseApi()
 
     // Restrict the Stripe success/cancel redirect to the deployed app origin. An
     // external callbackUrl is an open-redirect/phishing vector off Stripe's hosted
-    // checkout page, and this route's schema types callbackUrl as a bare string, so
-    // this is the only guard. The individual path and pages/api/stripe/portal.ts
-    // already do this; the omission here matters more now that the success redirect
-    // carries the completed checkout session id.
+    // checkout page. The schema only guarantees a parseable URL, so this origin check
+    // is what actually confines the redirect - and it matters more now that the
+    // success redirect carries the completed checkout session id. Same pairing in
+    // pages/api/subscriptions/subscribe.ts, pages/api/stripe/portal.ts and
+    // pages/api/admin/organizations/[id]/convert-to-paid.ts - keep them in sync.
     if (!isAllowedCallbackOrigin(callbackUrl)) {
       throw new BadRequestError('callbackUrl must point to the deployed application origin');
     }

--- a/apps/client/pages/api/subscriptions/__tests__/subscribe.test.ts
+++ b/apps/client/pages/api/subscriptions/__tests__/subscribe.test.ts
@@ -66,7 +66,7 @@ const mockCustomersRetrieve = vi.fn();
 const mockCreateCustomer = vi.fn();
 vi.mock('@server/integrations/stripe/stripe', () => ({
   createCustomer: (...args: unknown[]) => mockCreateCustomer(...args),
-  CustomerType: { User: 'user' },
+  CustomerType: { User: 'User' },
   stripe: {
     customers: { retrieve: (...args: unknown[]) => mockCustomersRetrieve(...args) },
     prices: { retrieve: (...args: unknown[]) => mockPricesRetrieve(...args) },

--- a/apps/client/server/integrations/stripe/callbackUrl.test.ts
+++ b/apps/client/server/integrations/stripe/callbackUrl.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { appendSuccessParams } from './callbackUrl';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { appendSuccessParams, isAllowedCallbackOrigin } from './callbackUrl';
 
 describe('appendSuccessParams', () => {
   it('adds the success marker and session template to a bare url', () => {
@@ -32,5 +32,51 @@ describe('appendSuccessParams', () => {
     const url = appendSuccessParams('https://app.example.com');
     expect(url).toContain('{CHECKOUT_SESSION_ID}');
     expect(url).not.toContain('%7B');
+  });
+});
+
+describe('isAllowedCallbackOrigin', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('accepts any path on the configured app origin', () => {
+    vi.stubEnv('APP_URL', 'https://app.example.com');
+
+    expect(isAllowedCallbackOrigin('https://app.example.com')).toBe(true);
+    expect(isAllowedCallbackOrigin('https://app.example.com/settings/billing?x=1#frag')).toBe(true);
+  });
+
+  it('rejects a different host, which is the open-redirect this guard exists to stop', () => {
+    vi.stubEnv('APP_URL', 'https://app.example.com');
+
+    expect(isAllowedCallbackOrigin('https://attacker.example.net/phish')).toBe(false);
+    // Origin is scheme + host + port, so a lookalike subdomain and a scheme downgrade both fail.
+    expect(isAllowedCallbackOrigin('https://app.example.com.attacker.net/')).toBe(false);
+    expect(isAllowedCallbackOrigin('http://app.example.com/')).toBe(false);
+  });
+
+  it('rejects anything the URL parser cannot resolve to an origin', () => {
+    vi.stubEnv('APP_URL', 'https://app.example.com');
+
+    expect(isAllowedCallbackOrigin('/settings/billing')).toBe(false);
+    expect(isAllowedCallbackOrigin('not a url')).toBe(false);
+    expect(isAllowedCallbackOrigin('')).toBe(false);
+  });
+
+  it('fails closed when APP_URL is missing in production', () => {
+    // The branch that matters: a stage that lost APP_URL must reject every callback
+    // rather than wave all origins through.
+    vi.stubEnv('APP_URL', '');
+    vi.stubEnv('NODE_ENV', 'production');
+
+    expect(isAllowedCallbackOrigin('https://attacker.example.net/phish')).toBe(false);
+  });
+
+  it('passes through when APP_URL is missing outside production (documented dev convenience)', () => {
+    vi.stubEnv('APP_URL', '');
+    vi.stubEnv('NODE_ENV', 'development');
+
+    expect(isAllowedCallbackOrigin('https://anything.example.net')).toBe(true);
   });
 });

--- a/apps/client/server/integrations/stripe/callbackUrl.test.ts
+++ b/apps/client/server/integrations/stripe/callbackUrl.test.ts
@@ -54,6 +54,10 @@ describe('isAllowedCallbackOrigin', () => {
     // Origin is scheme + host + port, so a lookalike subdomain and a scheme downgrade both fail.
     expect(isAllowedCallbackOrigin('https://app.example.com.attacker.net/')).toBe(false);
     expect(isAllowedCallbackOrigin('http://app.example.com/')).toBe(false);
+    // Userinfo: the allowed host sits before the `@`, so it reads as the app origin to a
+    // human but parses to an origin of https://attacker.net. Comparing origins is what
+    // defeats it - a prefix or substring check on the URL would not.
+    expect(isAllowedCallbackOrigin('https://app.example.com@attacker.net')).toBe(false);
   });
 
   it('rejects anything the URL parser cannot resolve to an origin', () => {
@@ -62,6 +66,9 @@ describe('isAllowedCallbackOrigin', () => {
     expect(isAllowedCallbackOrigin('/settings/billing')).toBe(false);
     expect(isAllowedCallbackOrigin('not a url')).toBe(false);
     expect(isAllowedCallbackOrigin('')).toBe(false);
+    // Protocol-relative: a browser would resolve this against the current page, but the
+    // guard has no base URL, so `new URL()` throws and the catch rejects it.
+    expect(isAllowedCallbackOrigin('//attacker.net')).toBe(false);
   });
 
   it('fails closed when APP_URL is missing in production', () => {


### PR DESCRIPTION
# Pull Request

Closes #1565

## Optional Screenshot/Video

**Test suite run** - the three files this PR touches, all green. 22 tests, 13 of them new.

<!-- Attach a terminal screenshot of the run here. Command that produced the output below:
pnpm --filter @bike4mind/client exec vitest run --reporter=verbose \
  pages/api/organizations/subscriptions/__tests__/subscribe.test.ts \
  server/integrations/stripe/callbackUrl.test.ts \
  lib/subscriptions/schema.test.ts
-->

```
 RUN  v4.1.10 <repo>/apps/client
 ✓ server/integrations/stripe/callbackUrl.test.ts > appendSuccessParams > adds the success marker and session template to a bare url 1ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > appendSuccessParams > joins with & when the callback already carries a query 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > appendSuccessParams > splices params before a fragment rather than into it 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > appendSuccessParams > preserves an existing query alongside a fragment 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > appendSuccessParams > leaves the Stripe template literal - encoded braces would never be substituted 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > isAllowedCallbackOrigin > accepts any path on the configured app origin 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > isAllowedCallbackOrigin > rejects a different host, which is the open-redirect this guard exists to stop 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > isAllowedCallbackOrigin > rejects anything the URL parser cannot resolve to an origin 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > isAllowedCallbackOrigin > fails closed when APP_URL is missing in production 0ms
 ✓ server/integrations/stripe/callbackUrl.test.ts > isAllowedCallbackOrigin > passes through when APP_URL is missing outside production (documented dev convenience) 0ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.quantity > accepts an in-range integer seat count 1ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.quantity > rejects a non-integer seat count 0ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.quantity > rejects a seat count below the platform minimum 0ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.quantity > rejects a seat count above the platform maximum 0ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.callbackUrl > accepts an absolute https callbackUrl and passes it through unchanged 0ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.callbackUrl > accepts an origin-only callbackUrl with no trailing path 0ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.callbackUrl > rejects a relative path 0ms
 ✓ lib/subscriptions/schema.test.ts > OrgSubscriptionSubscribeSchema.callbackUrl > rejects a string that is not a URL 0ms
 ✓ pages/api/organizations/subscriptions/__tests__/subscribe.test.ts > POST /api/organizations/subscriptions/subscribe - callbackUrl origin guard > rejects a callbackUrl on a disallowed origin 2ms
 ✓ pages/api/organizations/subscriptions/__tests__/subscribe.test.ts > POST /api/organizations/subscriptions/subscribe - callbackUrl origin guard > runs the guard before any lookup or Stripe side effect 0ms
 ✓ pages/api/organizations/subscriptions/__tests__/subscribe.test.ts > POST /api/organizations/subscriptions/subscribe - callbackUrl origin guard > passes an allowed-origin callbackUrl through to the checkout session 1ms
 ✓ pages/api/organizations/subscriptions/__tests__/subscribe.test.ts > POST /api/organizations/subscriptions/subscribe - callbackUrl origin guard > marks the org success_url and leaves cancel_url bare 0ms
 Test Files  3 passed (3)
      Tests  22 passed (22)
```

No UI screenshot: this PR changes no rendered surface.

## Description

`isAllowedCallbackOrigin` (`apps/client/server/integrations/stripe/callbackUrl.ts:12`) is what confines a caller-supplied `callbackUrl` to the deployed app's origin. Stripe lands the customer on that URL after checkout, so an external origin is an open redirect that arrives wearing Stripe's brand.

Four routes call that guard. Before this PR the helper had **no unit test at all** - `callbackUrl.test.ts` covered only `appendSuccessParams` - and no route had a test that asserted what happens when the guard rejects. Issue #1565 asked for coverage on the org-subscribe route, which had no test file whatsoever.

Two corrections worth flagging, since #1565 frames it differently. First, the issue says the new test should "mirror the individual-path test", but that test stubs `isAllowedCallbackOrigin` to a hard-coded `true` (`apps/client/pages/api/subscriptions/__tests__/subscribe.test.ts:57-60`) - there was no rejection test to mirror. Second, the issue credits PR #1425 with adding the guard to the *individual* route; the diff shows #1425 added it to the *org* route, which is the one that had no validation at all - the individual path and the billing portal already had it. This PR therefore also gives the guard its own unit tests, which pins the shared logic once for all four call sites instead of only for the org route.

The optional half of #1565 is included: `OrgSubscriptionSubscribeSchema.callbackUrl` was the last bare `z.string()` among the four `callbackUrl` schemas in the repo, and the org route's comment cited exactly that as the reason the runtime guard was "the only guard" there.

**No behavior changes for any existing caller.** Two caveats are stated explicitly under Additional Information rather than left for a reviewer to discover.

## Changes

- **`apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts`** (new, 4 tests) - route-level coverage for the org-subscribe guard. The guard is replaced with a test-controlled `vi.fn()`, so these assert the route's handling of its verdict, not the guard's own logic (that is the unit tests' job): when the guard returns `false` the handler throws `callbackUrl must point to the deployed application origin`, and the thrown error is asserted to be a real `BadRequestError` carrying `statusCode` 400, so a regression in *which* error class is thrown cannot slip through by keeping the message; on that path the subscription lookup, the org lookup, customer creation and the Stripe call are all confirmed uncalled, so the guard cannot drift below a side effect; when it returns `true` the route reaches `checkout.sessions.create` and returns 200 with `{ sessionUrl }`; and the org `success_url` carries the success marker plus a literal `{CHECKOUT_SESSION_ID}` while `cancel_url` stays bare. The real `appendSuccessParams` is kept unmocked so the URL the route actually builds is asserted rather than mocked into agreement.
- **`apps/client/server/integrations/stripe/callbackUrl.test.ts`** (+5 tests, 10 total) - first unit tests for `isAllowedCallbackOrigin`, driving `APP_URL` and `NODE_ENV` through `vi.stubEnv`: a matching origin with a differing path passes; a different host, a lookalike subdomain (`app.example.com.attacker.net`) and a scheme downgrade all fail; unparseable, relative and protocol-relative (`//attacker.net`) inputs fail through the `catch`; a userinfo URL (`https://app.example.com@attacker.net`) fails because it parses to an origin of `https://attacker.net`, which is exactly why the guard compares origins instead of prefixes; `APP_URL` unset with `NODE_ENV=production` fails closed (`callbackUrl.ts:15`); `APP_URL` unset outside production keeps the documented dev pass-through.
- **`apps/client/lib/subscriptions/schema.ts:57`** - `callbackUrl` tightened from `z.string()` to `z.string().url()`, with a docblock matching the wording already at `apps/client/lib/userSubscriptions/schemas.ts:5-7`.
- **`apps/client/lib/subscriptions/schema.test.ts`** (+4 tests, 8 total) - accepts an absolute https URL; accepts an origin-only URL with no trailing path; rejects a relative path; rejects a non-URL string. The accepting cases assert `result.data.callbackUrl` verbatim rather than merely `result.success`, since `appendSuccessParams` and the origin guard both operate on exactly what the caller sent.
- **`apps/client/pages/api/subscriptions/__tests__/subscribe.test.ts`** - one mock value. `CustomerType` was stubbed with lowercase strings that do not match the real enum (`server/integrations/stripe/stripe.ts:42-45`). Inert today, because that test never reaches `createCustomer`, but it would have silently validated a future assertion against a fiction.
- **`apps/client/pages/api/organizations/subscriptions/subscribe.ts:31-37`** - comment only. Its claim that "this route's schema types callbackUrl as a bare string, so this is the only guard" became false with the schema change; the replacement keeps the open-redirect rationale and cross-references the other three call sites with a keep-in-sync note.

## Guide for Testers

Backend test-coverage PR with no new UI and no new user-facing behavior. The only thing worth a human pass is confirming the existing team-checkout flow is untouched.

### Regression Checks

1. Open the preview link and sign in as a user who can create or manage an organization.
2. Navigate to the organization billing area (`Sidebar -> Organizations -> your org -> Billing` tab).
3. Click the button to subscribe to the team plan and choose a seat count of `4`.
   - **Expected:** the browser redirects to Stripe's hosted checkout page. No error appears and you do not stay on the billing page.
4. On the Stripe checkout page, inspect the seat quantity control.
   - **Expected:** it allows adjusting between a minimum of `4` and a maximum of `100`.
5. Use Stripe's back or cancel control to abandon checkout.
   - **Expected:** you land back on the application and the URL does **not** contain `subscription_success=true`.
6. Repeat step 3, complete checkout with a Stripe test card, and wait for the redirect back.
   - **Expected:** you land back on the application and the URL contains `subscription_success=true` plus a `checkout_session_id` whose value is a real `cs_...` id - not the literal text `{CHECKOUT_SESSION_ID}` and not a percent-encoded `%7B`.
7. Create a team from the team-creation modal (the new-organization path, which sends a different callback URL).
   - **Expected:** it reaches Stripe checkout the same way as step 3.

### What NOT to test

- Do not try to trigger the origin-guard rejection through the UI. Every client caller builds its `callbackUrl` from `window.location.origin` or `window.location.href`, so a browser cannot produce a rejected value. That path is reachable only by calling the API directly and is covered by the automated tests instead.
- No typecheck or test-suite runs are needed from a tester; the automated coverage is shown above.

## Additional Information

**Two caveats stated plainly rather than left to be discovered:**

1. **`z.string().url()` is not itself a security fix.** Zod's URL check only runs `new URL(value)`, so `javascript:` and `mailto:` still parse successfully. The protection is and remains `isAllowedCallbackOrigin`, which compares origins. The schema change is a consistency fix: it moves the "must be a URL" contract into the schema and makes the org route match its three siblings (`lib/userSubscriptions/schemas.ts:8`, `pages/api/stripe/portal.ts:14`, `pages/api/admin/organizations/[id]/convert-to-paid.ts:21`).
2. **One status code moves, on a path no caller reaches.** A non-URL `callbackUrl` is already rejected today: `isAllowedCallbackOrigin` calls `new URL()`, it throws, the catch returns `false`, and the handler responds 400. After this change the same input is rejected one step earlier at schema parse, which `errorHandler` maps to 422. Same rejection, different status. Both producers of an org `callbackUrl` send an absolute URL - `OrganizationBillingSection.tsx:324` (`window.location.origin`) and `CreateTeamModal.tsx:89` (`window.location.href`), the only two components wired to `useSubscribeTeamPlan` - so nothing that succeeds today changes.

**Not a security-labeled PR, and the gap it relates to is already closed.** `isAllowedCallbackOrigin` predates PR #1425 - it is present as of the initial open-core release. What #1425 added was the guard's *call site on this org route*, which until then validated nothing; that was a P1 raised in its review, not something reopened here. This PR changes no guard behavior, it only pins it. Issue #1565 carries no security label, so the Security Testing section is omitted rather than shipped as unchecked boxes.

**These tests were confirmed to bite.** A passing test proves nothing if it would also pass against broken code, so each new assertion was checked against a deliberately broken tree, reverted immediately after:

- Dropping the `!` from the org route's guard fails all 4 route tests.
- Restoring `z.string()` in the schema fails exactly the relative-path and non-URL cases, and nothing else.
- Flipping the fail-closed branch at `callbackUrl.ts:15` to `return true` fails exactly 1 test: the production case, which is the branch that had no coverage at all before this PR.

Each test therefore fails for the reason claimed rather than incidentally.

**Known gap, deliberately left for a follow-up - tracked in #1892.** Three of the four guard call sites still have no route-level test of the rejection path: `pages/api/subscriptions/subscribe.ts` (its existing test stubs the guard to `true`), `pages/api/stripe/portal.ts`, and `pages/api/admin/organizations/[id]/convert-to-paid.ts`. The new unit tests pin the shared fail-closed logic for all four, which is why this was scoped out rather than folded in. #1892 also carries the review's observation that `callbackUrl.ts:15` fails closed only on `NODE_ENV === 'production'`, with the evidence that the branch is unreachable on every deployed stage today.

## Developer Notes (Optional)

- **The guard is now pinned once for every caller.** `isAllowedCallbackOrigin` had no unit test before this PR, so its fail-closed branch - the one that rejects everything when `APP_URL` goes missing on a deployed stage - could have regressed silently across all four Stripe redirect routes. Any future call site inherits that coverage.
- **Pattern for route tests that assert a built URL.** Partial-mock the module with `importOriginal`, replace only the environment-reading function (`isAllowedCallbackOrigin`) with a `vi.fn()` the test drives, and keep the pure builder (`appendSuccessParams`) real. Mocking the builder away is what let the individual path ship an unmarked success redirect in the first place; this shape keeps the assertion honest while still controlling the environment-dependent branch.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
