### PR TITLE
test(waf): pin each prod-shadow statement to the rule it shadows

### DIFF
--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -19,6 +19,9 @@ interface WafRule {
 
 const mockEmergencyIpSetArn = 'arn:aws:wafv2:us-east-1:123456789012:global/ipset/test-ipset/abc123';
 
+/** Suffix marking a rule as a Count-only clone of the production rule of the same base name. */
+const SHADOW_SUFFIX = '-prod-shadow';
+
 // any: deeply nested AWS WAF statement shapes - a bare ByteMatch or an OrStatement of them
 /** The CommonRuleSet scope-down statement for a stage, exactly as WAF receives it. */
 function commonRuleSetScopeDown(stage: string): any {
@@ -178,12 +181,38 @@ describe('wafPolicy', () => {
       const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'dev' });
       const parsed = JSON.parse(ruleJson);
 
-      const shadows = (parsed as WafRule[]).filter(rule => rule.Name.endsWith('-prod-shadow'));
+      const shadows = (parsed as WafRule[]).filter(rule => rule.Name.endsWith(SHADOW_SUFFIX));
       expect(shadows.length).toBeGreaterThan(0);
 
       for (const rule of shadows) {
         expect(rule.Action).toEqual({ Count: {} });
         expect(rule.OverrideAction).toBeUndefined();
+      }
+    });
+    // A shadow rule is only worth reading if it still mirrors the production rule it stands in for.
+    // Nothing but a naming convention links the two, and they live in separate files, so a later
+    // retune of production's limits would leave the shadow counting against a threshold nobody
+    // enforces. That failure is invisible in the worst way: the metric still populates and the
+    // number still looks meaningful, so it would be used to make the promotion call. Compare the
+    // statements directly rather than trusting the copy.
+    it('keeps every prod-shadow statement identical to the production rule it shadows', () => {
+      const devRules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'dev' })
+      );
+      const prodRules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      const shadows = devRules.filter(rule => rule.Name.endsWith(SHADOW_SUFFIX));
+      expect(shadows.length).toBeGreaterThan(0);
+
+      for (const shadow of shadows) {
+        const originName = shadow.Name.slice(0, -SHADOW_SUFFIX.length);
+        const origin = prodRules.find(rule => rule.Name === originName);
+
+        // A shadow whose origin has been renamed or removed is the same drift, caught earlier.
+        expect(origin, `no production rule named ${originName} for ${shadow.Name}`).toBeDefined();
+        expect(shadow.Statement).toEqual(origin!.Statement);
       }
     });
 

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -189,32 +189,6 @@ describe('wafPolicy', () => {
         expect(rule.OverrideAction).toBeUndefined();
       }
     });
-    // A shadow rule is only worth reading if it still mirrors the production rule it stands in for.
-    // Nothing but a naming convention links the two, and they live in separate files, so a later
-    // retune of production's limits would leave the shadow counting against a threshold nobody
-    // enforces. That failure is invisible in the worst way: the metric still populates and the
-    // number still looks meaningful, so it would be used to make the promotion call. Compare the
-    // statements directly rather than trusting the copy.
-    it('keeps every prod-shadow statement identical to the production rule it shadows', () => {
-      const devRules: WafRule[] = JSON.parse(
-        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'dev' })
-      );
-      const prodRules: WafRule[] = JSON.parse(
-        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
-      );
-
-      const shadows = devRules.filter(rule => rule.Name.endsWith(SHADOW_SUFFIX));
-      expect(shadows.length).toBeGreaterThan(0);
-
-      for (const shadow of shadows) {
-        const originName = shadow.Name.slice(0, -SHADOW_SUFFIX.length);
-        const origin = prodRules.find(rule => rule.Name === originName);
-
-        // A shadow whose origin has been renamed or removed is the same drift, caught earlier.
-        expect(origin, `no production rule named ${originName} for ${shadow.Name}`).toBeDefined();
-        expect(shadow.Statement).toEqual(origin!.Statement);
-      }
-    });
 
     it('gives every rule a visibility config', () => {
       const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'dev' });
@@ -258,6 +232,37 @@ describe('wafPolicy', () => {
         positionalConstraint: 'EXACTLY',
         textTransformations: ['LOWERCASE'],
       });
+    });
+  });
+
+  // Deliberately its own block: this invariant spans both stages, so it belongs in neither
+  // the dev-stage nor the production-stage describe.
+  describe('shadow parity between the dev and production policies', () => {
+    // A shadow rule is only worth reading if it still mirrors the production rule it stands in for.
+    // Nothing but a naming convention links the two, and they live in separate files, so a later
+    // retune of production's limits would leave the shadow counting against a threshold nobody
+    // enforces. That failure is invisible in the worst way: the metric still populates and the
+    // number still looks meaningful, so it would be used to make the promotion call. Compare the
+    // statements directly rather than trusting the copy.
+    it('keeps every prod-shadow statement identical to the production rule it shadows', () => {
+      const devRules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'dev' })
+      );
+      const prodRules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      const shadows = devRules.filter(rule => rule.Name.endsWith(SHADOW_SUFFIX));
+      expect(shadows.length).toBeGreaterThan(0);
+
+      for (const shadow of shadows) {
+        const originName = shadow.Name.slice(0, -SHADOW_SUFFIX.length);
+        const origin = prodRules.find(rule => rule.Name === originName);
+
+        // A shadow whose origin has been renamed or removed is the same drift, caught earlier.
+        expect(origin, `no production rule named ${originName} for ${shadow.Name}`).toBeDefined();
+        expect(shadow.Statement).toEqual(origin!.Statement);
+      }
     });
   });
 


### PR DESCRIPTION
Follow-up to the shadow-rules PR, closing the one P3 raised in review there. Test-only, no policy or infrastructure change.

## Why

The three `*-prod-shadow` rules on staging are verbatim copies of production's rate limits, and their entire value rests on staying that way. Nothing enforced it. They live in a different file from the rules they mirror, and only a naming convention connects the two.

That matters because the drift is scheduled rather than hypothetical. The production policy is due to change on the way to enabling the WAF: dropping the terminating `allow-admin-endpoints` in favour of the scope-down pattern staging already runs, then flipping the rate limits from Count to Block after a week of observation. Any of those edits could retune a limit and leave the shadow measuring something nobody enforces.

The failure mode is the bad kind. The metric keeps populating, the dashboard still looks meaningful, and the number still gets used to make the promotion call. It would be strictly worse than having no measurement, because nothing about it looks wrong.

## What

For every rule whose name ends in the shadow suffix, assert its `Statement` deep-equals the production rule of the same base name.

Two details worth noting. The comparison runs through `buildDevWafRuleJson` for both `dev` and `production` rather than reading the JSON files directly, so it asserts on the artifact that actually deploys, including the emergency-IPSet substitution. And a missing origin fails with the rule name in the message, because a rename or deletion is the same drift caught one step earlier rather than a separate concern.

Also lifted the suffix into a named constant so this test and the existing Count guard cannot disagree about what a shadow rule is.

## Verification

Mutation-tested both drift shapes rather than trusting a green run:

- Retuning production's `api-rate-limit` from 2000 to 1000 while the shadow stays at 2000 fails the new assertion.
- Renaming production's `register-rate-limit` fails with `no production rule named register-rate-limit for register-rate-limit-prod-shadow`.
- Reverting both returns the suite to 24 passing, and the production policy file is byte-identical to main.
