### PR TITLE
fix(ci): stop the preview gate demanding a deploy for infra test changes

### DIFF
--- a/.github/workflows/sst-infra-preview-gate.yml
+++ b/.github/workflows/sst-infra-preview-gate.yml
@@ -69,6 +69,20 @@ jobs:
           fi
           echo "Changed files considered:"; sed 's/^/  /' /tmp/files.txt || true
 
+          # Tests under the gated paths have no deploy surface: sst.config.ts and the infra
+          # modules never import them (only comments reference them), and they already run in
+          # `Run Tests`. Left in the glob they make a test-only change demand a throwaway
+          # preview deploy that cannot tell anyone anything, which is what happened to the WAF
+          # shadow-rule test. Filtered out of the path-glob input ONLY, so the package.json
+          # sst-pin patch inspection below still sees every file. Kept to test dirs and
+          # *.test/*.spec files so all 51 real files under these paths still redden the gate.
+          # An empty result is correct, not a failure: a tests-only PR is not applicable.
+          grep -vE '(^|/)__tests__/|\.(test|spec)\.[cm]?[jt]sx?$' /tmp/files.txt > /tmp/files_glob.txt || true
+          if ! cmp -s /tmp/files.txt /tmp/files_glob.txt; then
+            echo "Excluded from the path glob as non-deploy-surface tests:"
+            comm -23 <(sort /tmp/files.txt) <(sort /tmp/files_glob.txt) | sed 's/^/  /'
+          fi
+
           applicable=0
           reason=""
 
@@ -77,7 +91,7 @@ jobs:
           # by the deploy layer), and sst.config.ts.
           # Anchored so it does NOT match data-model dirs like
           # packages/database/src/models/infra/.
-          if grep -qE '^(infra/|b4m-core/infra/|sst\.config\.ts$)' /tmp/files.txt; then
+          if grep -qE '^(infra/|b4m-core/infra/|sst\.config\.ts$)' /tmp/files_glob.txt; then
             applicable=1
             reason="infra/, b4m-core/infra/, or sst.config.ts changed"
           fi


### PR DESCRIPTION
## The problem

The preview gate globs `^infra/` and `^b4m-core/infra/`, and those globs match the test files that live under those paths. So a PR touching only `infra/__tests__/wafPolicy.test.ts` gets blocked pending a preview deploy.

That happened on Bike4Mind/bike4mind#1893, which changes one vitest file and nothing else. Every other check passed; the gate was the only thing holding it, and the only way to satisfy it was a full preview deploy of the whole app to a throwaway stage, roughly 25 minutes of infrastructure, to prove a test file is safe.

## Why a test file cannot need a preview

The gate's own header explains what it is for: catching an sst pin or overlay mismatch that is invisible until a real deploy runs. A vitest file cannot produce that class of failure.

Checked rather than assumed: nothing on the deploy path imports the test directories. The only references from `infra/*.ts` or `sst.config.ts` to any test file are two comments in `infra/dlqAlarms.ts` pointing at a parity test. And those tests already run in `Run Tests`, which is a separate required check, so the coverage the gate would be standing in for is already enforced.

## The change

Filter test directories and `*.test` / `*.spec` files out of the path-glob input only.

The `package.json` sst-pin patch inspection deliberately still reads every changed file, so a pin change riding along on an otherwise test-only PR still reddens the gate. Nothing about the fail-closed behaviour changes: the oversized-diff fail-closed branch, the release-PR CHANGELOG handling, and the "no `|| true` on the file fetch" rule are all untouched.

Kept deliberately narrow, because this gate is fail-closed on purpose. Of the 65 tracked files under the gated globs, the filter excludes exactly the 14 test files and keeps all 51 others, including the two near-misses worth calling out: `b4m-core/infra/src/dlqAlarmSpecs.ts`, a real deploy-surface module whose name contains "Spec", and `b4m-core/infra/vitest.config.ts`, which is test configuration rather than a test and still requires a preview.

## Verification

Extracted the patched decision logic and ran it over 14 file sets. All correct:

- Pass: infra test only, `b4m-core` infra test only, two tests together, app-only change, and the `packages/database/src/models/infra/` decoy the existing anchoring was written to avoid.
- Still applicable: `infra/waf.ts`, `infra/waf/*.json`, `sst.config.ts`, `b4m-core/infra/src/index.ts`, and both near-miss filenames above.
- Still applicable when mixed: a test change plus `infra/waf.ts`, plus `sst.config.ts`, or plus `b4m-core/infra/src/index.ts`. A real infra change cannot hide behind a test file in the same PR, which was the case I most wanted to be sure of.

YAML parses and the embedded script passes `bash -n`.

Worth noting one adjacent case left alone on purpose: `b4m-core/infra/CHANGELOG.md` is also non-deploy-surface but still trips the glob on a non-release PR. The release PR already exempts CHANGELOGs, so this is rare in practice, and widening a fail-closed gate further than the reported problem did not seem worth it here.
