### PR TITLE
fix(api-keys): enforce server-side scope allowlist on key creation

### DIFF
--- a/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * Scope allowlist guard for the admin key-minting endpoint. The admin endpoint
+ * may mint overwatch-ingest:write (admin-provisioned) but not admin:* or
+ * cc-bridge:connect - those still have no minting path. All standard user
+ * scopes remain mintable here too.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: any = {
+      use: () => chain,
+      post: (fn: any) => {
+        mockRefs.postHandler = fn;
+        return chain;
+      },
+    };
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: any) => fn,
+}));
+
+vi.mock('@server/middlewares/csrfProtection', () => ({
+  csrfProtection: () => vi.fn(),
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+}));
+
+vi.mock('@bike4mind/utils', () => ({
+  BadRequestError: class BadRequestError extends Error {},
+}));
+
+const mockUserFind = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ id: 'target-user', username: 'targetUser' })
+);
+vi.mock('@bike4mind/database', () => ({
+  userRepository: { findById: (...a: unknown[]) => mockUserFind(...a) },
+}));
+
+vi.mock('@bike4mind/database/auth', () => ({
+  userApiKeyRepository: {},
+}));
+
+const mockCreateKey = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ id: 'k1', name: 'key', scopes: ['notebooks:read'] })
+);
+vi.mock('@bike4mind/services', () => ({
+  userApiKeyService: { createUserApiKey: (...a: unknown[]) => mockCreateKey(...a) },
+}));
+
+vi.mock('@server/utils/analyticsLog', () => ({
+  logEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import '../generate-api-key';
+import { ForbiddenError } from '@server/utils/errors';
+import { BadRequestError } from '@bike4mind/utils';
+
+function post(body: unknown, opts: { isAdmin?: boolean; userId?: string } = {}) {
+  const { req, res } = createMocks({
+    method: 'POST',
+    query: { userId: opts.userId ?? 'target-user' },
+    body,
+  });
+  (req as any).user = {
+    id: 'caller',
+    isAdmin: opts.isAdmin ?? true,
+    username: 'admin-user',
+  };
+  (req as any).ability = {};
+  (req as any).ip = '127.0.0.1';
+  (req as any).headers = { 'user-agent': 'test' };
+  (req as any).logger = { info: vi.fn() };
+  return { req, res };
+}
+
+describe('POST /api/admin/users/:userId/generate-api-key - scope allowlist guard', () => {
+  beforeEach(() => {
+    mockCreateKey.mockClear();
+    mockUserFind.mockResolvedValue({ id: 'target-user', username: 'targetUser' });
+  });
+
+  it('rejects non-admin callers with ForbiddenError before touching the service', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] }, { isAdmin: false });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(ForbiddenError);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects admin:* even from an admin caller with Scope not allowed', async () => {
+    const { req, res } = post({ name: 'test', scopes: ['admin:*'] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Scope not allowed/i);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects admin:* even when mixed with valid scopes', async () => {
+    const { req, res } = post({ name: 'test', scopes: ['notebooks:read', 'admin:*'] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Scope not allowed/i);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects cc-bridge:connect with Scope not allowed', async () => {
+    const { req, res } = post({ name: 'bridge', scopes: ['cc-bridge:connect'] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Scope not allowed/i);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('allows overwatch-ingest:write (admin-provisioned scope) and calls the service', async () => {
+    const { req, res } = post({ name: 'ingest', scopes: ['overwatch-ingest:write'] });
+    await mockRefs.postHandler!(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      'target-user',
+      expect.objectContaining({ scopes: ['overwatch-ingest:write'] }),
+      expect.anything()
+    );
+  });
+
+  it('allows standard user scopes (notebooks:read) through the admin endpoint', async () => {
+    const { req, res } = post({ name: 'plain', scopes: ['notebooks:read'] });
+    await mockRefs.postHandler!(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(mockCreateKey).toHaveBeenCalled();
+  });
+
+  it('rejects with BadRequestError when the target user does not exist', async () => {
+    mockUserFind.mockResolvedValueOnce(null);
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
+++ b/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
@@ -7,11 +7,11 @@ import { csrfProtection } from '@server/middlewares/csrfProtection';
 import { ForbiddenError } from '@server/utils/errors';
 import { BadRequestError } from '@bike4mind/utils';
 import { logEvent } from '@server/utils/analyticsLog';
-import { ApiKeyScope, UserApiKeyEvents } from '@bike4mind/common';
+import { UserApiKeyEvents } from '@bike4mind/common';
 import { ADMIN_ONLY_API_KEY_SCOPES, USER_API_KEY_SCOPE_VALUES } from '@client/app/constants/apiKeyScopes';
 
 // Scopes this admin endpoint may mint: the standard self-service set plus the
-// admin-provisioned ingest scopes. ADMIN and CC_BRIDGE are still excluded —
+// admin-provisioned ingest scopes. ADMIN and CC_BRIDGE are still excluded -
 // those must come through their own dedicated flows.
 const ADMIN_ENDPOINT_MINTABLE_SCOPES = new Set<string>([
   ...USER_API_KEY_SCOPE_VALUES,

--- a/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
+++ b/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
@@ -7,7 +7,16 @@ import { csrfProtection } from '@server/middlewares/csrfProtection';
 import { ForbiddenError } from '@server/utils/errors';
 import { BadRequestError } from '@bike4mind/utils';
 import { logEvent } from '@server/utils/analyticsLog';
-import { UserApiKeyEvents } from '@bike4mind/common';
+import { ApiKeyScope, UserApiKeyEvents } from '@bike4mind/common';
+import { ADMIN_ONLY_API_KEY_SCOPES, USER_API_KEY_SCOPE_VALUES } from '@client/app/constants/apiKeyScopes';
+
+// Scopes this admin endpoint may mint: the standard self-service set plus the
+// admin-provisioned ingest scopes. ADMIN and CC_BRIDGE are still excluded —
+// those must come through their own dedicated flows.
+const ADMIN_ENDPOINT_MINTABLE_SCOPES = new Set<string>([
+  ...USER_API_KEY_SCOPE_VALUES,
+  ...ADMIN_ONLY_API_KEY_SCOPES.map(s => s.value),
+]);
 
 interface RequestQuery {
   userId: string;
@@ -49,6 +58,13 @@ const handler = baseApi({ auth: true })
       }
 
       const { name, scopes, expiresAt, rateLimit } = req.body as CreateApiKeyBody;
+
+      // Reject any scope outside the mintable allowlist, including admin:* and cc-bridge:connect.
+      const requestedScopes = Array.isArray(scopes) ? scopes : [];
+      const invalidScopes = requestedScopes.filter(s => !ADMIN_ENDPOINT_MINTABLE_SCOPES.has(s));
+      if (invalidScopes.length > 0) {
+        throw new BadRequestError(`Scope not allowed: ${invalidScopes.join(', ')}`);
+      }
 
       const newApiKey = await userApiKeyService.createUserApiKey(
         userId,

--- a/apps/client/pages/api/user-api-keys/__tests__/index.test.ts
+++ b/apps/client/pages/api/user-api-keys/__tests__/index.test.ts
@@ -371,6 +371,47 @@ describe('GET /api/user-api-keys - revoked-key visibility', () => {
 });
 
 /**
+ * Scope allowlist guard: the server rejects any scope outside USER_API_KEY_SCOPE_VALUES
+ * regardless of the caller's admin status, so privileged scopes (admin:*, cc-bridge:connect,
+ * overwatch-ingest:write) cannot be self-minted through this endpoint.
+ */
+describe('POST /api/user-api-keys - scope allowlist guard', () => {
+  beforeEach(() => createUserApiKey.mockClear());
+
+  it('rejects admin:* for a non-admin user with Scope not allowed', async () => {
+    const { req, res } = post({ name: 'test', scopes: ['admin:*'] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Scope not allowed/i);
+    expect(createUserApiKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects admin:* even for a platform admin user', async () => {
+    const { req, res } = post({ name: 'test', scopes: ['admin:*'] }, { isAdmin: true });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Scope not allowed/i);
+    expect(createUserApiKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects overwatch-ingest:write (admin-provisioned only) from the user endpoint', async () => {
+    const { req, res } = post({ name: 'ingest', scopes: ['overwatch-ingest:write'] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Scope not allowed/i);
+    expect(createUserApiKey).not.toHaveBeenCalled();
+  });
+
+  it('allows a valid self-service scope through (notebooks:read)', async () => {
+    const { req, res } = post({ name: 'plain', scopes: ['notebooks:read'] });
+    await mockRefs.postHandler!(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(createUserApiKey).toHaveBeenCalled();
+  });
+
+  it('allows embed:chat through the user endpoint', async () => {
+    const { req, res } = post({ name: 'widget', scopes: ['embed:chat'], agentId: 'a1' });
+    await mockRefs.postHandler!(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(createUserApiKey).toHaveBeenCalled();
+  });
+});
+
+/**
  * List route computes `ownerHasWhitelabel` per embed key (#891) so the Configure
  * UI gates the toggle on the OWNER's plan, not the viewer's. The finders return
  * hydrated Mongoose docs whose toJSON emits only schema paths, so the handler

--- a/apps/client/pages/api/user-api-keys/index.ts
+++ b/apps/client/pages/api/user-api-keys/index.ts
@@ -19,6 +19,7 @@ import {
   UserApiKeyEvents,
 } from '@bike4mind/common';
 import { BadRequestError, ForbiddenError } from '@server/utils/errors';
+import { USER_API_KEY_SCOPE_VALUES } from '@client/app/constants/apiKeyScopes';
 import { Request } from 'express';
 
 interface CreateApiKeyRequest {
@@ -125,6 +126,15 @@ const handler = baseApi()
     const userId = req.user?.id;
     const { name, scopes, expiresAt, rateLimit, organizationId, agentId, allowedOrigins, branding, spendCap } =
       req.body;
+
+    // Reject any scope outside the self-service allowlist. ADMIN, CC_BRIDGE, and
+    // other dedicated-flow scopes are intentionally absent from USER_API_KEY_SCOPE_VALUES
+    // and must never be reachable here, regardless of what the request body contains.
+    const requestedScopes = Array.isArray(scopes) ? scopes : [];
+    const invalidScopes = requestedScopes.filter(s => !USER_API_KEY_SCOPE_VALUES.includes(s as ApiKeyScope));
+    if (invalidScopes.length > 0) {
+      throw new BadRequestError(`Scope not allowed: ${invalidScopes.join(', ')}`);
+    }
 
     // Authorize org-billed minting: caller must administer the org (owner or
     // manager) or be a platform admin. Fail closed on anything else.


### PR DESCRIPTION
## Summary

- Any authenticated user could self-mint an API key carrying `admin:*` scope by POSTing directly to `/api/user-api-keys` or `/api/admin/users/[userId]/generate-api-key`, bypassing the UI-only restriction
- Root cause: the service-layer validation only checked that scopes were valid enum values (`z.enum(ApiKeyScope)`), not that they were self-service eligible
- Both creation handlers now validate the requested scopes against an explicit server-side allowlist before the service call

**Changes:**
- `apps/client/pages/api/user-api-keys/index.ts` — rejects any scope not in `USER_API_KEY_SCOPE_VALUES`
- `apps/client/pages/api/admin/users/[userId]/generate-api-key.ts` — rejects any scope not in `USER_API_KEY_SCOPE_VALUES` + `ADMIN_ONLY_API_KEY_SCOPES`; `admin:*` and `cc-bridge:connect` remain blocked even from the admin endpoint

## Test plan

- [ ] `POST /api/user-api-keys` with `"scopes": ["admin:*"]` as a non-admin user returns 400 `Scope not allowed`
- [ ] `POST /api/user-api-keys` with `"scopes": ["admin:*"]` as an admin user returns 400 `Scope not allowed`
- [ ] `POST /api/admin/users/:id/generate-api-key` with `"scopes": ["admin:*"]` returns 400 `Scope not allowed`
- [ ] Normal key creation with valid scopes (e.g. `read:notebooks`, `ai:chat`) still works for both endpoints
- [ ] Admin endpoint can still mint `overwatch-ingest:write` keys for service accounts
- [ ] Embed key creation flow (`embed:chat`) still works through the user endpoint
