### PR TITLE
feat(data-lakes): surface lakes on the page and stop the empty state guessing

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -18,6 +18,17 @@ const useActiveDataLakeBatches = vi.fn(() => ({ data: [] as unknown[] }));
 // empty-section rendering.
 const useGetArchivedDataLakes = vi.fn(() => ({ data: undefined as unknown[] | undefined }));
 const useGetDeletedDataLakes = vi.fn(() => ({ data: undefined as unknown[] | undefined }));
+// LakeInfoPanel's Drive chip and the purge dialog's warning both read the connection. Default to
+// "no connection" so existing cases are unaffected; the Drive-specific cases override it.
+const useLakeDriveConnection = vi.fn(() => ({ data: null as unknown }));
+vi.mock('@client/app/hooks/data/googleDrive', () => ({
+  useLakeDriveConnection: () => useLakeDriveConnection(),
+  DRIVE_STATUS_BADGE: {
+    connected: { label: 'Connected', color: 'success' },
+    needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
+    credential_error: { label: 'Credential error', color: 'danger' },
+  },
+}));
 vi.mock('@client/app/hooks/data/dataLakes', () => {
   const mutation = () => ({ mutate: vi.fn(), isPending: false });
   return {

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -20,7 +20,7 @@ const useGetArchivedDataLakes = vi.fn(() => ({ data: undefined as unknown[] | un
 const useGetDeletedDataLakes = vi.fn(() => ({ data: undefined as unknown[] | undefined }));
 // LakeInfoPanel's Drive chip and the purge dialog's warning both read the connection. Default to
 // "no connection" so existing cases are unaffected; the Drive-specific cases override it.
-const useLakeDriveConnection = vi.fn(() => ({ data: null as unknown }));
+const useLakeDriveConnection = vi.fn(() => ({ data: null as unknown, isError: false, isLoading: false }));
 vi.mock('@client/app/hooks/data/googleDrive', () => ({
   useLakeDriveConnection: () => useLakeDriveConnection(),
   DRIVE_STATUS_BADGE: {
@@ -217,6 +217,11 @@ beforeEach(() => {
   useGetDeletedDataLakes.mockReturnValue({ data: undefined });
   useActiveDataLakeBatches.mockReset();
   useActiveDataLakeBatches.mockReturnValue({ data: [] });
+  // Reset here as well as at the point of use: the purge cases below set this persistently, and
+  // without a reset the next test added after them would silently inherit a connected/erroring
+  // Drive mock.
+  useLakeDriveConnection.mockReset();
+  useLakeDriveConnection.mockReturnValue({ data: null, isError: false, isLoading: false });
   useGetArchivedDataLakes.mockReset();
   useGetArchivedDataLakes.mockReturnValue({ data: undefined });
   useGetDeletedDataLakes.mockReset();
@@ -823,5 +828,56 @@ describe('DataLakeManagerPanel - purge confirmation', () => {
     // this argument rather than refetching (see dataLakes.test.ts).
     expect(cleanupMutate).toHaveBeenCalledWith('gone', expect.objectContaining({ onSuccess: expect.any(Function) }));
     await waitFor(() => expect(screen.queryByTestId('datalake-purge-confirm')).not.toBeInTheDocument());
+  });
+
+  /** Opens the purge dialog for `deletedLake`, whatever the Drive-connection mock is set to. */
+  const openPurgeDialog = async () => {
+    useGetDeletedDataLakes.mockReturnValue({ data: [deletedLake] });
+    const user = userEvent.setup();
+    renderPanel();
+    await user.click(screen.getByTestId('datalake-deleted-section-toggle'));
+    await user.click(screen.getByTestId('datalake-deleted-section-menu-btn-gone'));
+    await user.click(screen.getByTestId('datalake-purge-btn-gone'));
+    expect(screen.getByTestId('datalake-purge-confirm')).toBeInTheDocument();
+  };
+
+  it('names the attached Drive folder, so the stranding hazard is visible before an irreversible purge', async () => {
+    useLakeDriveConnection.mockReturnValue({
+      data: { folderName: 'Q3-Reports', driveFolderId: 'fld_1', status: 'connected' },
+      isError: false,
+      isLoading: false,
+    });
+    await openPurgeDialog();
+
+    expect(screen.getByTestId('datalake-purge-drive-warning')).toHaveTextContent('Q3-Reports');
+    expect(screen.queryByTestId('datalake-purge-drive-unknown')).not.toBeInTheDocument();
+  });
+
+  it('warns when the connection could not be READ, instead of silently omitting the warning', async () => {
+    // The dangerous collapse: a failed read is not "no connection". Staying silent here would let
+    // the user purge and permanently strand the Drive claim on that folder (#1807) - the exact
+    // outcome this warning exists to prevent, hidden by a transient error.
+    useLakeDriveConnection.mockReturnValue({ data: undefined, isError: true, isLoading: false });
+    await openPurgeDialog();
+
+    expect(screen.getByTestId('datalake-purge-drive-unknown')).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-purge-drive-warning')).not.toBeInTheDocument();
+  });
+
+  it('stays quiet for a lake with no connection, so an ordinary purge is not nagged', async () => {
+    // A 404 (personal lake, or genuinely no connection) resolves to null and must NOT read as an error.
+    useLakeDriveConnection.mockReturnValue({ data: null, isError: false, isLoading: false });
+    await openPurgeDialog();
+
+    expect(screen.queryByTestId('datalake-purge-drive-warning')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-purge-drive-unknown')).not.toBeInTheDocument();
+  });
+
+  it('stays quiet while the connection read is still in flight', async () => {
+    useLakeDriveConnection.mockReturnValue({ data: undefined, isError: false, isLoading: true });
+    await openPurgeDialog();
+
+    expect(screen.queryByTestId('datalake-purge-drive-warning')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-purge-drive-unknown')).not.toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
@@ -81,6 +81,9 @@ import useStartChatWithLake from '@client/app/hooks/useStartChatWithLake';
 import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import DataLakeEmptyState from '@client/app/components/datalake/DataLakeEmptyState';
 import LakeHealthBadge from '@client/app/components/datalake/LakeHealthBadge';
+import LakeDriveStatusChip from '@client/app/components/datalake/LakeDriveStatusChip';
+import { lakeVisibilityLabel } from '@client/app/components/datalake/lakeVisibility';
+import { useLakeDriveConnection } from '@client/app/hooks/data/googleDrive';
 import { RowActionsMenu, RowMenuItem } from '@client/app/components/datalake/rowActionsMenu';
 import DataLakeArticlePanel from './DataLakeArticlePanel';
 import DataLakeDiscoverPanel from './DataLakeDiscoverPanel';
@@ -153,6 +156,7 @@ export default function DataLakeManagerPanel() {
   // sidebar footer's Discover button flips it the same way.
   const managerTab = useDataLakeWizardStore(s => s.managerTab);
   const openManager = useDataLakeWizardStore(s => s.openManager);
+  const managerLakeId = useDataLakeWizardStore(s => s.managerLakeId);
   const { isFeatureEnabled } = useAdminSettingsCache();
 
   // The lakes list projection carries no per-lake file counts. Size a lake by MEMBERSHIP, not
@@ -169,6 +173,16 @@ export default function DataLakeManagerPanel() {
   const [path, setPath] = useState<string[]>([]);
   const [selectedFile, setSelectedFile] = useState<IFabFileDocument | null>(null);
   const [editingLakeId, setEditingLakeId] = useState<string | null>(null);
+
+  // Deep-link: a per-lake action elsewhere (the page rail's header) opens the manager already
+  // pointed at that lake. Only a non-null id steers; null is the plain "open at root" case and
+  // must not wipe a selection the user made inside the panel.
+  useEffect(() => {
+    if (!managerLakeId) return;
+    setLakeId(managerLakeId);
+    setPath([]);
+    setSelectedFile(null);
+  }, [managerLakeId]);
 
   // Derived, not effect-synced: when the active lake vanishes from the list (archived or
   // deleted), this goes null and the panel falls back to the root view on its own. The stale
@@ -746,6 +760,7 @@ function ManagerNav({
                 <DialogContent>
                   This irreversibly deletes “{purgeTarget?.name}” and all its files, chunks, and batches. This cannot be
                   undone.
+                  {purgeTarget && <PurgeDriveWarning lakeId={purgeTarget.id} />}
                 </DialogContent>
                 <DialogActions>
                   <Button
@@ -1091,6 +1106,34 @@ function NavLifecycleSection({
 
 // Right pane: selected lake's details + management actions
 
+/**
+ * Purge-time warning that the lake still has a Drive folder attached. Renders nothing when there is
+ * no connection (or it is not visible to this caller - the endpoint 404s on a personal lake and
+ * 403s for a non-manager).
+ *
+ * It deliberately does NOT promise that purging releases the connection, because today it does not:
+ * the row survives its lake and its globally-unique driveFolderId then blocks re-claiming that
+ * folder app-wide, with no UI or API path back (#1807). So the copy tells the user to disconnect
+ * FIRST. When #1807 lands and teardown releases the connection itself, this wording must change
+ * with it - it describes a defect, not a design.
+ */
+function PurgeDriveWarning({ lakeId }: { lakeId: string }) {
+  // Deliberately NOT gated on org scope, unlike LakeDriveStatusChip. The chip renders on every lake
+  // the user opens, so skipping a personal lake's guaranteed 404 there is worth it. This warning
+  // guards an IRREVERSIBLE action, and gating it on a field this projection is not proven to
+  // populate would trade one wasted request for silently withholding the warning on a lake that
+  // does have a connection. A rare 404 on a purge dialog is the cheaper failure.
+  const { data: connection } = useLakeDriveConnection(lakeId);
+  if (!connection) return null;
+  const folder = connection.folderName || connection.driveFolderId;
+  return (
+    <Typography level="body-sm" color="warning" sx={{ mt: 1.5 }} data-testid="datalake-purge-drive-warning">
+      This lake still syncs the Google Drive folder &ldquo;{folder}&rdquo;. Purging leaves that connection behind, and
+      the folder cannot be connected to another lake afterwards. Restore the lake and disconnect Drive first.
+    </Typography>
+  );
+}
+
 function LakeInfoPanel({
   lake,
   fileCount,
@@ -1121,7 +1164,7 @@ function LakeInfoPanel({
   const deleteLake = usePermanentDeleteDataLake();
   const startChatWithLake = useStartChatWithLake();
   const [startingChat, setStartingChat] = useState(false);
-  const visibility = lake.isPublic ? 'Public' : lake.organizationId ? 'Organization' : 'Private';
+  const visibility = lakeVisibilityLabel(lake);
   // "Rebuild passages": gated on canRebuild, NOT canManage - a fallback (built-in) lake has no
   // document to manage but can still be rebuilt by an admin (see assertLakeRebuildAccess). Only
   // surfaced when the lake actually has legacy oversized-chunk files to repair (the count
@@ -1281,6 +1324,9 @@ function LakeInfoPanel({
               {fileCount} {fileCount === 1 ? 'file' : 'files'}
             </Chip>
           )}
+          {/* Attached-source marker: this panel is where a user comes to inspect or delete a lake,
+              and it previously gave no sign a Drive folder was feeding it (#1645). */}
+          <LakeDriveStatusChip lakeId={lake.id} organizationId={lake.organizationId} />
           {/* Derived retrievability health (#1666): reachable-content share + affected-file drill-down.
               Advisory only. Fetched lazily for the lake in view; renders nothing for an empty lake. */}
           <LakeHealthBadge lakeId={lake.id} failedFileCount={failedCount} />

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -1123,8 +1123,25 @@ function PurgeDriveWarning({ lakeId }: { lakeId: string }) {
   // guards an IRREVERSIBLE action, and gating it on a field this projection is not proven to
   // populate would trade one wasted request for silently withholding the warning on a lake that
   // does have a connection. A rare 404 on a purge dialog is the cheaper failure.
-  const { data: connection } = useLakeDriveConnection(lakeId);
-  if (!connection) return null;
+  const { data: connection, isError, isLoading } = useLakeDriveConnection(lakeId);
+
+  // A FAILED read is not "no connection". Collapsing it into the silent case would borrow the
+  // benign default's meaning for an unknown, and the cost lands on the one action that cannot be
+  // undone: the user purges, the row survives, and its globally-unique driveFolderId blocks
+  // re-claiming that folder app-wide with no path back (#1807). A 404 (personal lake / no
+  // connection) resolves to `connection: null` and is NOT an error, so this only fires on a real
+  // failure - it does not nag on every ordinary purge.
+  if (isError) {
+    return (
+      <Typography level="body-sm" color="warning" sx={{ mt: 1.5 }} data-testid="datalake-purge-drive-unknown">
+        Couldn&rsquo;t check whether a Google Drive folder is connected to this lake. If one is, purging leaves the
+        connection behind and that folder cannot be connected to another lake afterwards - restore the lake and
+        disconnect Drive first to be safe.
+      </Typography>
+    );
+  }
+  if (isLoading || !connection) return null;
+
   const folder = connection.folderName || connection.driveFolderId;
   return (
     <Typography level="body-sm" color="warning" sx={{ mt: 1.5 }} data-testid="datalake-purge-drive-warning">

--- a/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.test.tsx
@@ -18,6 +18,12 @@ vi.mock('@client/app/hooks/data/googleDrive', () => ({
   useLakeDriveConnection: () => ({ data: h.connection.current, isLoading: false, isError: h.isError.current }),
   useConnectDriveFolderToLake: () => ({ mutate: h.connectMutate, isPending: false }),
   useDisconnectLakeDrive: () => ({ mutate: h.disconnectMutate, isPending: false }),
+  // Real map, not a stub: the status wording is the thing under test in the connected case.
+  DRIVE_STATUS_BADGE: {
+    connected: { label: 'Connected', color: 'success' },
+    needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
+    credential_error: { label: 'Credential error', color: 'danger' },
+  },
 }));
 vi.mock('react-google-drive-picker', () => ({ default: () => [h.openPicker] }));
 vi.mock('@client/app/contexts/ApiContext', () => ({ api: { get: vi.fn(), post: vi.fn() } }));

--- a/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.tsx
@@ -12,15 +12,8 @@ import {
   useLakeDriveConnection,
   useConnectDriveFolderToLake,
   useDisconnectLakeDrive,
-  type LakeDriveConnection,
+  DRIVE_STATUS_BADGE,
 } from '@client/app/hooks/data/googleDrive';
-
-const STATUS_LABEL: Record<LakeDriveConnection['status'], { label: string; color: 'success' | 'warning' | 'danger' }> =
-  {
-    connected: { label: 'Connected', color: 'success' },
-    needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
-    credential_error: { label: 'Credential error', color: 'danger' },
-  };
 
 /** The specific server `error` message off an axios failure, if the response carried one. */
 function serverError(e: unknown): string | undefined {
@@ -163,7 +156,7 @@ export default function DriveConnectAction({ lake }: { lake: { id: string } | nu
   }
 
   if (connection) {
-    const badge = STATUS_LABEL[connection.status];
+    const badge = DRIVE_STATUS_BADGE[connection.status];
     return (
       <Stack direction="row" gap={1} alignItems="center" flexWrap="wrap" data-testid="drive-connection-status">
         <CloudIcon color="primary" />

--- a/apps/client/app/components/datalake/DataLakeArticle.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeArticle.test.tsx
@@ -15,24 +15,24 @@ const appTheme = extendTheme({ ...getThemeConfig() });
 const Wrapper = ({ children }: { children: ReactNode }) => (
   <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
 );
+const { copy } = DEFAULT_DATA_LAKE_SURFACE_TOKENS;
 
 describe('DataLakeArticle - create-first empty state (#837)', () => {
-  it('renders a create CTA in the empty state when onCreate is provided and invokes it', () => {
+  it('renders a create CTA in the true zero-lake state and invokes it', () => {
     const onCreate = vi.fn();
     render(
       <Wrapper>
-        <DataLakeArticle file={null} onAskAbout={vi.fn()} onCreate={onCreate} />
+        <DataLakeArticle file={null} onAskAbout={vi.fn()} emptyVariant="no-lakes" onCreate={onCreate} />
       </Wrapper>
     );
 
+    expect(screen.getByText(copy.zeroTitle)).toBeInTheDocument();
     const cta = screen.getByTestId('datalake-empty-create-btn');
-    expect(cta).toBeInTheDocument();
-
     fireEvent.click(cta);
     expect(onCreate).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the default idle copy and no CTA when onCreate is absent', () => {
+  it('shows the default idle copy and no CTA when no variant is given', () => {
     render(
       <Wrapper>
         <DataLakeArticle file={null} onAskAbout={vi.fn()} />
@@ -40,6 +40,95 @@ describe('DataLakeArticle - create-first empty state (#837)', () => {
     );
 
     expect(screen.queryByTestId('datalake-empty-create-btn')).not.toBeInTheDocument();
-    expect(screen.getByText(DEFAULT_DATA_LAKE_SURFACE_TOKENS.copy.emptyTitle)).toBeInTheDocument();
+    expect(screen.getByText(copy.emptyTitle)).toBeInTheDocument();
+  });
+});
+
+describe('DataLakeArticle - the empty state cannot claim a zero-lake state it was not told about (#1645)', () => {
+  it('withholds the create CTA when onCreate is set but the variant is not the zero-lake one', () => {
+    // The regression pin. The CTA used to key off onCreate's mere presence, and the page passed it
+    // whenever the file scope was empty - so a user with lakes was invited to create their first.
+    render(
+      <Wrapper>
+        <DataLakeArticle file={null} onAskAbout={vi.fn()} emptyVariant="no-selection" onCreate={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('datalake-empty-create-btn')).not.toBeInTheDocument();
+    expect(screen.queryByText(copy.zeroTitle)).not.toBeInTheDocument();
+    expect(screen.getByText(copy.emptyTitle)).toBeInTheDocument();
+  });
+
+  it('offers a retry (and never the create CTA) when the lake list could not be read', () => {
+    const onRetryLakes = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeArticle
+          file={null}
+          onAskAbout={vi.fn()}
+          emptyVariant="lakes-error"
+          onCreate={vi.fn()}
+          onRetryLakes={onRetryLakes}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByText(copy.lakesErrorTitle)).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-empty-create-btn')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('datalake-empty-retry-btn'));
+    expect(onRetryLakes).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers add-files for an empty selected lake, rather than creating another one', () => {
+    const onAddFiles = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeArticle
+          file={null}
+          onAskAbout={vi.fn()}
+          emptyVariant="lake-empty"
+          onCreate={vi.fn()}
+          onAddFiles={onAddFiles}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByText(copy.lakeEmptyTitle)).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-empty-create-btn')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('datalake-empty-addfiles-btn'));
+    expect(onAddFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the browse shortcuts in every state that has nothing to browse', () => {
+    // Category chips beside "you have no lakes" is the same contradiction in a different place.
+    const dives = [{ path: ['legal', 'contracts'], segment: 'contracts', count: 4 }];
+    for (const variant of ['no-lakes', 'lakes-error', 'lake-empty', 'all-lakes-empty'] as const) {
+      const { unmount } = render(
+        <Wrapper>
+          <DataLakeArticle
+            file={null}
+            onAskAbout={vi.fn()}
+            emptyVariant={variant}
+            quickDives={dives}
+            onDive={vi.fn()}
+          />
+        </Wrapper>
+      );
+      expect(screen.queryByTestId('datalake-dive-legal-contracts')).not.toBeInTheDocument();
+      unmount();
+    }
+
+    render(
+      <Wrapper>
+        <DataLakeArticle
+          file={null}
+          onAskAbout={vi.fn()}
+          emptyVariant="no-selection"
+          quickDives={dives}
+          onDive={vi.fn()}
+        />
+      </Wrapper>
+    );
+    expect(screen.getByTestId('datalake-dive-legal-contracts')).toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/datalake/DataLakeArticle.tsx
+++ b/apps/client/app/components/datalake/DataLakeArticle.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Chip, Skeleton, Typography, useTheme } from '@mui/joy';
 import { alpha } from '@mui/system';
 import AddIcon from '@mui/icons-material/Add';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import ChatIcon from '@mui/icons-material/Chat';
 import MarkdownViewer from '@client/app/components/Knowledge/MarkdownViewer';
 import { REDUCED_MOTION_OFF, driftFloat, inkFor, ringPing } from '@client/app/components/datalake/surfaceChrome';
@@ -19,15 +20,31 @@ interface QuickDive {
   count: number;
 }
 
+/**
+ * Which "nothing to read" situation the pane is in. Passed explicitly rather than inferred from
+ * which callbacks happen to be set: the create-first CTA used to key off `onCreate`'s presence,
+ * which the caller derived from an EMPTY-SCOPE test, so a user with lakes was told to create their
+ * first one (#1645). The distinction the caller cannot fudge is now in the type.
+ *
+ * `lakes-error` is separate from `no-lakes` on purpose - a failed read must never render as a
+ * confident zero.
+ */
+export type DataLakeEmptyVariant = 'no-selection' | 'no-lakes' | 'lakes-error' | 'lake-empty' | 'all-lakes-empty';
+
 interface DataLakeArticleProps {
   file: IFabFileDocument | null;
   onAskAbout: (prompt: string) => void;
   /** Richest categories, surfaced as one-click dives in the empty state. */
   quickDives?: QuickDive[];
   onDive?: (path: string[]) => void;
-  /** When set, the empty state offers a create-first CTA (zero-lake bootstrap, #837).
-   *  The caller only passes this in the true zero-state, so its presence is the signal. */
+  /** Defaults to `no-selection`, the pick-a-branch state chat mode has always shown. */
+  emptyVariant?: DataLakeEmptyVariant;
+  /** Create a lake - offered only in `no-lakes`. */
   onCreate?: () => void;
+  /** Re-read the lake list - offered only in `lakes-error`. */
+  onRetryLakes?: () => void;
+  /** Add files to the selected lake - offered only in `lake-empty`. */
+  onAddFiles?: () => void;
 }
 
 function cleanFileName(fileName: string): string {
@@ -59,11 +76,30 @@ const MOTES: {
   { left: '48%', top: '18%', size: 3, hue: 'accent', duration: 9.5, delay: 2.4 },
 ];
 
+/** Title/hint per variant, so the copy choice is a lookup rather than nested ternaries. */
+function emptyCopyFor(variant: DataLakeEmptyVariant, copy: DataLakeSurfaceCopy): { title: string; hint: string } {
+  switch (variant) {
+    case 'no-lakes':
+      return { title: copy.zeroTitle, hint: copy.zeroHint };
+    case 'lakes-error':
+      return { title: copy.lakesErrorTitle, hint: copy.lakesErrorHint };
+    case 'lake-empty':
+      return { title: copy.lakeEmptyTitle, hint: copy.lakeEmptyHint };
+    case 'all-lakes-empty':
+      return { title: copy.allLakesEmptyTitle, hint: copy.allLakesEmptyHint };
+    case 'no-selection':
+      return { title: copy.emptyTitle, hint: copy.emptyHint };
+  }
+}
+
 function EmptyState({
   isDark,
   quickDives,
   onDive,
+  variant,
   onCreate,
+  onRetryLakes,
+  onAddFiles,
   theme,
   copy,
   taxonomy,
@@ -71,12 +107,20 @@ function EmptyState({
   isDark: boolean;
   quickDives: QuickDive[];
   onDive?: (path: string[]) => void;
+  variant: DataLakeEmptyVariant;
   onCreate?: () => void;
+  onRetryLakes?: () => void;
+  onAddFiles?: () => void;
   theme: DataLakeSurfaceTheme;
   copy: DataLakeSurfaceCopy;
   taxonomy: DataLakeSurfaceTaxonomy;
 }) {
   const accent = inkFor(theme.accent, isDark);
+  const { title, hint } = emptyCopyFor(variant, copy);
+  // Quick dives are a browse shortcut, so they only make sense when there IS something to browse.
+  // In the zero/error/empty-lake states the tree is empty anyway, and showing category chips
+  // beside "you have no lakes" is the same kind of contradiction this variant split removes.
+  const showQuickDives = variant === 'no-selection' && quickDives.length > 0 && !!onDive;
   return (
     <Box
       data-testid="datalake-article-empty"
@@ -152,15 +196,15 @@ function EmptyState({
           level="title-lg"
           sx={{ fontWeight: 700, letterSpacing: '0.02em', color: 'text.secondary', mb: 0.5 }}
         >
-          {onCreate ? copy.zeroTitle : copy.emptyTitle}
+          {title}
         </Typography>
         <Typography level="body-sm" sx={{ color: 'text.tertiary', maxWidth: 380 }}>
-          {onCreate ? copy.zeroHint : copy.emptyHint}
+          {hint}
         </Typography>
       </Box>
 
-      {/* Create-first CTA: only shown in the true zero-lake state (caller passes onCreate). */}
-      {onCreate && (
+      {/* One action per variant, so the offer always matches what the copy just said. */}
+      {variant === 'no-lakes' && onCreate && (
         <Button
           data-testid="datalake-empty-create-btn"
           variant="solid"
@@ -172,9 +216,33 @@ function EmptyState({
           {copy.createLabel}
         </Button>
       )}
+      {variant === 'lakes-error' && onRetryLakes && (
+        <Button
+          data-testid="datalake-empty-retry-btn"
+          variant="outlined"
+          color="neutral"
+          startDecorator={<RefreshIcon />}
+          onClick={onRetryLakes}
+          sx={{ zIndex: 1 }}
+        >
+          Retry
+        </Button>
+      )}
+      {variant === 'lake-empty' && onAddFiles && (
+        <Button
+          data-testid="datalake-empty-addfiles-btn"
+          variant="solid"
+          color="primary"
+          startDecorator={<AddIcon />}
+          onClick={onAddFiles}
+          sx={{ zIndex: 1 }}
+        >
+          Add files
+        </Button>
+      )}
 
       {/* Quick dives */}
-      {quickDives.length > 0 && onDive && (
+      {showQuickDives && (
         <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', justifyContent: 'center', zIndex: 1, maxWidth: 520 }}>
           {quickDives.map(dive => (
             <Chip
@@ -209,7 +277,16 @@ function EmptyState({
   );
 }
 
-export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onDive, onCreate }: DataLakeArticleProps) {
+export default function DataLakeArticle({
+  file,
+  onAskAbout,
+  quickDives = [],
+  onDive,
+  emptyVariant = 'no-selection',
+  onCreate,
+  onRetryLakes,
+  onAddFiles,
+}: DataLakeArticleProps) {
   const muiTheme = useTheme();
   const isDark = muiTheme.palette.mode === 'dark';
   const { theme, copy, icons, taxonomy } = useDataLakeSurface();
@@ -223,7 +300,10 @@ export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onD
         isDark={isDark}
         quickDives={quickDives}
         onDive={onDive}
+        variant={emptyVariant}
         onCreate={onCreate}
+        onRetryLakes={onRetryLakes}
+        onAddFiles={onAddFiles}
         theme={theme}
         copy={copy}
         taxonomy={taxonomy}

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -18,6 +18,9 @@ import { SurfaceBreadcrumb } from '@client/app/components/datalake/SurfaceBreadc
 import DataLakeTree from './DataLakeTree';
 import DataLakeChatTree from './DataLakeChatTree';
 import DataLakeArticle from './DataLakeArticle';
+import { resolveEmptyVariant } from './resolveEmptyVariant';
+import DataLakeRail from './DataLakeRail';
+import SelectedLakeHeader from './SelectedLakeHeader';
 import DataLakeRailViewer from './DataLakeRailViewer';
 import { resolveManageableLake } from './resolveManageableLake';
 import { DataLakeNavProvider } from './dataLakeNavContext';
@@ -42,6 +45,7 @@ import {
   getNodesAtPath,
 } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import DataLakeIngestPickerModal from '@client/app/components/DataLakeWizard/DataLakeIngestPickerModal';
+import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { readDroppedItems } from '@client/app/utils/dropReader';
 import { DATA_LAKES } from '@client/app/components/datalake/dataLakeBranding';
 import { toast } from 'sonner';
@@ -145,6 +149,8 @@ export default function DataLakeExplorer({
   const acceptedHint = copy.dropAcceptedHint;
   const accentInk = inkFor(theme.accent, isDark);
   const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+  /** Page-mode lake scope; null is the explicit all-lakes view. Chat mode never sets it. */
+  const [selectedLakeId, setSelectedLakeId] = useState<string | null>(null);
   // Page mode: file shown in the inline article reader.
   const [userSelectedFile, setUserSelectedFile] = useState<IFabFileDocument | null>(null);
   // External-chat hosts only: our own KnowledgeViewer is open beside the tree (View action).
@@ -170,6 +176,7 @@ export default function DataLakeExplorer({
   const workBenchFiles = useWorkBenchFiles(currentSessionId);
   const attachedFileIds = useMemo(() => new Set(workBenchFiles.map(f => f.id)), [workBenchFiles]);
   const setDataLakeMode = useSetDataLakeMode();
+  const openWizardForLake = useDataLakeWizardStore(s => s.openWizardForLake);
   // When the sidenav is collapsed its floating expand control overlaps the top-left, so the
   // chat tree needs extra left clearance past it (same 48px the deck top bar uses).
   const sidenavOpen = useNotebookLayout(s => s.openSideNav);
@@ -254,8 +261,10 @@ export default function DataLakeExplorer({
     [chatEmbedded, setRailViewerOpen]
   );
 
-  // Delete gating: the lake list is only needed in chat mode (page mode has no row actions).
-  const { data: lakes } = useGetDataLakes(chatMode);
+  // Enabled on BOTH surfaces now. Chat mode needs it to gate row deletes; page mode needs it to
+  // answer "do I have any lakes?" - a question the page could not previously ask, which is why its
+  // empty state answered it from the file scope instead and got it wrong (#1645).
+  const { data: lakes, isLoading: lakesLoading, isError: lakesError, refetch: refetchLakes } = useGetDataLakes();
   const removeFile = useRemoveFileFromDataLake(deleteTarget?.lake.id ?? null);
   const canDeleteFile = useCallback((file: IFabFileDocument) => resolveManageableLake(file, lakes) != null, [lakes]);
   const handleDeleteFile = useCallback(
@@ -313,7 +322,21 @@ export default function DataLakeExplorer({
 
   // Phase 1: Lightweight counts for the tree (server-side aggregation, ~50 entries)
   const { data: tagCountsData, isLoading: tagCountsLoading, isError: tagCountsError } = useGetDataLakeTagCounts(source);
-  const tree = useMemo(() => buildTagTree(tagCountsData?.tagCounts ?? []), [tagCountsData]);
+
+  const selectedLake = useMemo(
+    () => (selectedLakeId ? (lakes?.find(l => l.id === selectedLakeId) ?? null) : null),
+    [lakes, selectedLakeId]
+  );
+
+  // Lake scoping is a client-side filter on the SAME tag-counts payload the unscoped tree uses -
+  // every taxonomy tag in a lake is namespaced under its fileTagPrefix, so no extra request is
+  // needed and switching lakes costs nothing.
+  const scopedTagCounts = useMemo(() => {
+    const all = tagCountsData?.tagCounts ?? [];
+    if (!selectedLake) return all;
+    return all.filter(tc => tc.tag.startsWith(selectedLake.fileTagPrefix));
+  }, [tagCountsData, selectedLake]);
+  const tree = useMemo(() => buildTagTree(scopedTagCounts), [scopedTagCounts]);
 
   // Derive the current leaf tag from breadcrumb + tree state. A branch node (has children) can
   // ALSO carry files tagged with its own exact path, which DataLakeTreeView renders mixed into
@@ -400,13 +423,48 @@ export default function DataLakeExplorer({
   const handleSelectFile = useCallback((file: IFabFileDocument) => setUserSelectedFile(file), []);
 
   // Truthful distinct-file count (the tree's fileCounts are tag-occurrence sums, which
-  // overcount multi-tagged articles ~2x); branch count stays tree-derived.
-  const totalArticles = tagCountsData?.uniqueArticleCounts?.total ?? 0;
+  // overcount multi-tagged articles ~2x); branch count stays tree-derived. Follows the lake scope
+  // so the ticker describes what is actually on screen.
+  const totalArticles = selectedLake
+    ? (tagCountsData?.uniqueArticleCounts?.byPrefix?.[selectedLake.fileTagPrefix] ?? 0)
+    : (tagCountsData?.uniqueArticleCounts?.total ?? 0);
   const branchCount = useMemo(() => tree.reduce((sum, node) => sum + Math.max(node.children.length, 1), 0), [tree]);
 
-  // Zero-state: nothing to browse yet. Drives the create-first affordance so the first
-  // lake can be created in place instead of dead-ending on an empty scope (#837).
-  const isEmpty = !tagCountsLoading && !tagCountsError && totalArticles === 0 && tree.length === 0;
+  /** Nothing to browse in the CURRENT scope. Says nothing about how many lakes exist. */
+  const isScopeEmpty = !tagCountsLoading && !tagCountsError && totalArticles === 0 && tree.length === 0;
+
+  // Precedence lives in resolveEmptyVariant (pure + unit-tested) rather than inline here, because
+  // the ORDER of its checks is the whole fix - see that module's contract.
+  const emptyVariant = resolveEmptyVariant({
+    chatMode,
+    lakesError,
+    lakesLoading,
+    lakeCount: lakes?.length ?? 0,
+    manageableLakeCount: lakes?.filter(l => l.canManage).length ?? 0,
+    hasSelectedLake: !!selectedLake,
+    isScopeEmpty,
+  });
+
+  const addFilesToSelectedLake = useCallback(() => {
+    if (!selectedLake) return;
+    openWizardForLake({
+      id: selectedLake.id,
+      slug: selectedLake.slug,
+      name: selectedLake.name,
+      fileTagPrefix: selectedLake.fileTagPrefix,
+      requiredUserTag: selectedLake.requiredUserTag,
+      requiredEntitlement: selectedLake.requiredEntitlement,
+    });
+  }, [selectedLake, openWizardForLake]);
+
+  // Switching lake scope invalidates the breadcrumb: it names a path in the OUTGOING lake's tree,
+  // so keeping it would leave the new lake showing an empty node (and the stale leafTag would
+  // fetch the old lake's files).
+  const handleSelectLake = useCallback((lakeId: string | null) => {
+    setSelectedLakeId(lakeId);
+    setBreadcrumb([]);
+    setUserSelectedFile(null);
+  }, []);
 
   // Richest second-level branches (top 6): the page empty-state's quick dives AND, in chat mode,
   // exposed to a host idle pane via context so its quick-dive chips can drive the tree.
@@ -570,7 +628,7 @@ export default function DataLakeExplorer({
       {/* Zero-state gets a full-width version of the same invitation - a first-time user
           has no tree to scan, so the small header hint alone reads as chrome. Page mode
           only; chat mode's tree carries its own header affordances. */}
-      {!chatMode && isEmpty && !isDragging && (
+      {!chatMode && isScopeEmpty && emptyVariant !== 'lakes-error' && !isDragging && (
         <Box
           data-testid="datalake-drop-prompt"
           sx={{
@@ -653,25 +711,52 @@ export default function DataLakeExplorer({
           </Box>
         </Box>
       ) : (
+        /* Master/detail: the lake rail owns the choice of lake, and everything to its right is
+           that lake's content. The rail is page-mode only - chat mode's host already spends its
+           width on the chat, and adding a third column there would squeeze both. */
         <Box sx={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
-          <DataLakeTree
-            tree={tree}
-            articles={leafArticles}
-            breadcrumb={breadcrumb}
-            onNavigate={handleNavigate}
-            source={source}
-            selectedFileIds={pageSelectedFileIds}
-            onSelectFile={handleSelectFile}
-            isLoading={tagCountsLoading || (!!leafTag && leafLoading && currentNodes.length === 0)}
-            isError={tagCountsError}
+          <DataLakeRail
+            lakes={lakes}
+            isLoading={lakesLoading}
+            isError={lakesError}
+            onRetry={() => void refetchLakes()}
+            selectedLakeId={selectedLakeId}
+            onSelect={handleSelectLake}
+            lakeFileCounts={tagCountsData?.lakeFileCounts}
+            totalFileCount={tagCountsData?.uniqueArticleCounts?.total ?? 0}
+            onCreate={onCreate}
           />
-          <DataLakeArticle
-            file={selectedFile}
-            onAskAbout={onAskAbout ?? (() => {})}
-            quickDives={quickDives}
-            onDive={handleNavigate}
-            onCreate={isEmpty ? onCreate : undefined}
-          />
+          <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, minHeight: 0 }}>
+            {selectedLake && (
+              <SelectedLakeHeader
+                lake={selectedLake}
+                fileCount={tagCountsData?.lakeFileCounts?.[selectedLake.datalakeTag]}
+              />
+            )}
+            <Box sx={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
+              <DataLakeTree
+                tree={tree}
+                articles={leafArticles}
+                breadcrumb={breadcrumb}
+                onNavigate={handleNavigate}
+                source={source}
+                selectedFileIds={pageSelectedFileIds}
+                onSelectFile={handleSelectFile}
+                isLoading={tagCountsLoading || (!!leafTag && leafLoading && currentNodes.length === 0)}
+                isError={tagCountsError}
+              />
+              <DataLakeArticle
+                file={selectedFile}
+                onAskAbout={onAskAbout ?? (() => {})}
+                quickDives={quickDives}
+                onDive={handleNavigate}
+                emptyVariant={emptyVariant}
+                onCreate={onCreate}
+                onRetryLakes={() => void refetchLakes()}
+                onAddFiles={selectedLake?.canManage ? addFilesToSelectedLake : undefined}
+              />
+            </Box>
+          </Box>
         </Box>
       )}
 

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -19,6 +19,7 @@ import DataLakeTree from './DataLakeTree';
 import DataLakeChatTree from './DataLakeChatTree';
 import DataLakeArticle from './DataLakeArticle';
 import { resolveEmptyVariant } from './resolveEmptyVariant';
+import { scopeTagCountsToLake } from './scopeTagCountsToLake';
 import DataLakeRail from './DataLakeRail';
 import SelectedLakeHeader from './SelectedLakeHeader';
 import DataLakeRailViewer from './DataLakeRailViewer';
@@ -328,14 +329,12 @@ export default function DataLakeExplorer({
     [lakes, selectedLakeId]
   );
 
-  // Lake scoping is a client-side filter on the SAME tag-counts payload the unscoped tree uses -
-  // every taxonomy tag in a lake is namespaced under its fileTagPrefix, so no extra request is
-  // needed and switching lakes costs nothing.
-  const scopedTagCounts = useMemo(() => {
-    const all = tagCountsData?.tagCounts ?? [];
-    if (!selectedLake) return all;
-    return all.filter(tc => tc.tag.startsWith(selectedLake.fileTagPrefix));
-  }, [tagCountsData, selectedLake]);
+  // Scoping lives in scopeTagCountsToLake (pure + unit-tested, including the prefix-containment
+  // assumption it rests on) rather than inline here.
+  const scopedTagCounts = useMemo(
+    () => scopeTagCountsToLake(tagCountsData?.tagCounts ?? [], selectedLake),
+    [tagCountsData, selectedLake]
+  );
   const tree = useMemo(() => buildTagTree(scopedTagCounts), [scopedTagCounts]);
 
   // Derive the current leaf tag from breadcrumb + tree state. A branch node (has children) can

--- a/apps/client/app/components/datalake/DataLakeRail.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeRail.test.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import DataLakeRail from './DataLakeRail';
+import type { ManageableDataLakeConfig } from '@bike4mind/common';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const lake = (over: Partial<ManageableDataLakeConfig> & { id: string; name: string }): ManageableDataLakeConfig =>
+  ({
+    slug: over.id,
+    fileTagPrefix: `${over.id}:`,
+    datalakeTag: `datalake:${over.id}`,
+    isOwn: true,
+    canRebuild: false,
+    canManage: true,
+    ...over,
+  }) as ManageableDataLakeConfig;
+
+const baseProps = {
+  isLoading: false,
+  isError: false,
+  onRetry: vi.fn(),
+  selectedLakeId: null as string | null,
+  onSelect: vi.fn(),
+  lakeFileCounts: {} as Record<string, number>,
+  totalFileCount: 0,
+};
+
+describe('DataLakeRail', () => {
+  it('lists the caller lakes with an honest count, so the page can answer "do I have any?"', () => {
+    render(
+      <Wrapper>
+        <DataLakeRail
+          {...baseProps}
+          lakes={[lake({ id: 'a', name: 'Research Corpus' }), lake({ id: 'b', name: 'Design Docs' })]}
+          lakeFileCounts={{ 'datalake:a': 128 }}
+          totalFileCount={170}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-rail-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('datalake-rail-lake-a')).toHaveTextContent('Research Corpus');
+    expect(screen.getByTestId('datalake-rail-lake-a')).toHaveTextContent('128');
+    expect(screen.getByTestId('datalake-rail-all')).toHaveTextContent('170');
+  });
+
+  it('selects a lake, and clears the scope from the all-lakes row', () => {
+    const onSelect = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeRail {...baseProps} onSelect={onSelect} lakes={[lake({ id: 'a', name: 'Research Corpus' })]} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('datalake-rail-lake-a'));
+    expect(onSelect).toHaveBeenCalledWith('a');
+
+    fireEvent.click(screen.getByTestId('datalake-rail-all'));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('renders a retry instead of an empty list when the read failed, and withholds the count', () => {
+    // An empty rail would read as "you have no lakes", which is the lie this whole change removes.
+    const onRetry = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeRail {...baseProps} isError onRetry={onRetry} lakes={undefined} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-rail-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-rail-count')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-rail-all')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('datalake-rail-retry-btn'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('withholds the count while loading, so it never reads as a confident zero', () => {
+    render(
+      <Wrapper>
+        <DataLakeRail {...baseProps} isLoading lakes={undefined} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-rail-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-rail-count')).not.toBeInTheDocument();
+  });
+
+  it('marks a lake owned by someone else, so an admin cannot mistake it for their own', () => {
+    render(
+      <Wrapper>
+        <DataLakeRail
+          {...baseProps}
+          lakes={[lake({ id: 'a', name: 'Someone Elses', isOwn: false, ownerDisplayName: 'Ada' })]}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-rail-owner-icon-a')).toBeInTheDocument();
+  });
+
+  it('only offers the filter box once the list is long enough to need one', () => {
+    const many = Array.from({ length: 8 }, (_, i) => lake({ id: `l${i}`, name: `Lake ${i}` }));
+    const { unmount } = render(
+      <Wrapper>
+        <DataLakeRail {...baseProps} lakes={many.slice(0, 3)} />
+      </Wrapper>
+    );
+    expect(screen.queryByTestId('datalake-rail-search')).not.toBeInTheDocument();
+    unmount();
+
+    render(
+      <Wrapper>
+        <DataLakeRail {...baseProps} lakes={many} />
+      </Wrapper>
+    );
+    const search = screen.getByTestId('datalake-rail-search');
+    fireEvent.change(search, { target: { value: 'Lake 5' } });
+    expect(screen.getByTestId('datalake-rail-lake-l5')).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-rail-lake-l4')).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/datalake/DataLakeRail.tsx
+++ b/apps/client/app/components/datalake/DataLakeRail.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  Input,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemContent,
+  Skeleton,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/joy';
+import AddIcon from '@mui/icons-material/Add';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import LayersOutlinedIcon from '@mui/icons-material/LayersOutlined';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import SearchIcon from '@mui/icons-material/Search';
+import { useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
+import { lakeVisibilityLabelShort } from '@client/app/components/datalake/lakeVisibility';
+import type { ManageableDataLakeConfig } from '@bike4mind/common';
+
+/**
+ * The page surface's lake list: the primary object, visible without opening a modal (#1645).
+ *
+ * Read-only navigation - it selects which lake the browse panes are scoped to and nothing else.
+ * Lake-level MUTATIONS live on the header beside it, so this stays a list and the actions have a
+ * single home. `null` selection is the explicit all-lakes scope, not an absence of choice.
+ *
+ * No Drive/source indicator per row on purpose: the manager list projection
+ * (`ManageableDataLakeConfig`) carries no connection field, so a per-row badge would cost one
+ * request per lake. The selected lake's source state is shown on the header instead, which needs
+ * exactly one. Surfacing it per row wants a `driveConnected` flag on the list projection first.
+ */
+export interface DataLakeRailProps {
+  lakes: ManageableDataLakeConfig[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  /** null = the all-lakes scope. */
+  selectedLakeId: string | null;
+  onSelect: (lakeId: string | null) => void;
+  /** Distinct live files per lake, keyed by `datalakeTag` (see DataLakeTagCountsResponse). */
+  lakeFileCounts: Record<string, number> | undefined;
+  /** Combined distinct-file count across every reachable lake, for the all-lakes row. */
+  totalFileCount: number;
+  onCreate?: () => void;
+}
+
+/** Below this many lakes a filter box is noise rather than help. */
+const SEARCH_THRESHOLD = 8;
+
+export default function DataLakeRail({
+  lakes,
+  isLoading,
+  isError,
+  onRetry,
+  selectedLakeId,
+  onSelect,
+  lakeFileCounts,
+  totalFileCount,
+  onCreate,
+}: DataLakeRailProps) {
+  const muiTheme = useTheme();
+  const isDark = muiTheme.palette.mode === 'dark';
+  const { copy } = useDataLakeSurface();
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!lakes) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return lakes;
+    return lakes.filter(l => l.name.toLowerCase().includes(q) || l.fileTagPrefix.toLowerCase().includes(q));
+  }, [lakes, query]);
+
+  const showSearch = (lakes?.length ?? 0) >= SEARCH_THRESHOLD;
+
+  return (
+    <Box
+      data-testid="datalake-rail"
+      sx={{
+        width: 248,
+        flexShrink: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0,
+        borderRight: '1px solid',
+        borderColor: 'divider',
+        bgcolor: isDark ? 'rgba(0,0,0,0.16)' : 'rgba(255,255,255,0.5)',
+      }}
+    >
+      <Box sx={{ px: 2, pt: 2, pb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="title-sm" sx={{ color: 'text.secondary', flex: 1 }}>
+          {copy.railTitle}
+        </Typography>
+        {/* The count is the honest answer to "do I have lakes?" - the question the old
+            file-scoped empty state answered wrongly. Withheld while loading/erroring so it
+            never reads as a confident zero. */}
+        {!isLoading && !isError && (
+          <Chip size="sm" variant="soft" color="neutral" data-testid="datalake-rail-count" sx={{ fontSize: '11px' }}>
+            {lakes?.length ?? 0}
+          </Chip>
+        )}
+        {onCreate && (
+          <Tooltip title={copy.createLabel} size="sm">
+            <IconButton
+              size="sm"
+              variant="plain"
+              color="primary"
+              data-testid="datalake-rail-create-btn"
+              onClick={onCreate}
+            >
+              <AddIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+
+      {showSearch && (
+        <Box sx={{ px: 2, pb: 1 }}>
+          <Input
+            size="sm"
+            placeholder="Filter lakes"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            startDecorator={<SearchIcon sx={{ fontSize: 16 }} />}
+            slotProps={{ input: { 'data-testid': 'datalake-rail-search' } }}
+          />
+        </Box>
+      )}
+
+      <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', px: 1, pb: 1 }}>
+        {isLoading ? (
+          <Box data-testid="datalake-rail-loading" sx={{ px: 1, py: 0.5 }}>
+            {[0, 1, 2].map(i => (
+              <Skeleton key={i} variant="text" level="body-sm" sx={{ my: 1.25 }} />
+            ))}
+          </Box>
+        ) : isError ? (
+          // A failed read must not render as an empty list: an empty rail beside a
+          // "create your first lake" pane is exactly the lie this issue is about.
+          <Box data-testid="datalake-rail-error" sx={{ px: 1.5, py: 1.5 }}>
+            <Typography level="body-sm" sx={{ color: 'danger.400', mb: 1 }}>
+              {copy.lakesErrorTitle}
+            </Typography>
+            <Button
+              size="sm"
+              variant="outlined"
+              color="neutral"
+              startDecorator={<RefreshIcon sx={{ fontSize: 16 }} />}
+              onClick={onRetry}
+              data-testid="datalake-rail-retry-btn"
+            >
+              Retry
+            </Button>
+          </Box>
+        ) : (
+          <List size="sm" sx={{ '--ListItem-radius': '8px', '--List-gap': '2px' }}>
+            {/* All-lakes stays an explicit ROW rather than the unlabelled default the page used
+                to open in, so cross-lake browse is something the user chose. */}
+            <ListItem>
+              <ListItemButton
+                selected={selectedLakeId === null}
+                onClick={() => onSelect(null)}
+                data-testid="datalake-rail-all"
+              >
+                <LayersOutlinedIcon sx={{ fontSize: 16, flexShrink: 0, color: 'text.tertiary' }} />
+                <ListItemContent>
+                  <Typography noWrap level="body-sm">
+                    {copy.allLakesLabel}
+                  </Typography>
+                </ListItemContent>
+                <Typography level="body-xs" sx={{ fontFamily: 'monospace', color: 'text.tertiary' }}>
+                  {totalFileCount || '-'}
+                </Typography>
+              </ListItemButton>
+            </ListItem>
+
+            {filtered.length === 0 ? (
+              <ListItem>
+                <Typography level="body-xs" sx={{ px: 1, py: 1, color: 'text.tertiary' }}>
+                  {query ? 'No matches' : `No ${copy.allLakesLabel.toLowerCase()} yet`}
+                </Typography>
+              </ListItem>
+            ) : (
+              filtered.map(lake => {
+                const count = lakeFileCounts?.[lake.datalakeTag];
+                return (
+                  <ListItem key={lake.id}>
+                    <ListItemButton
+                      selected={selectedLakeId === lake.id}
+                      onClick={() => onSelect(lake.id)}
+                      data-testid={`datalake-rail-lake-${lake.id}`}
+                    >
+                      <FolderOutlinedIcon sx={{ fontSize: 16, flexShrink: 0, color: 'text.tertiary' }} />
+                      <ListItemContent sx={{ minWidth: 0 }}>
+                        <Typography noWrap level="body-sm">
+                          {lake.name}
+                        </Typography>
+                        <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                          {lakeVisibilityLabelShort(lake)}
+                        </Typography>
+                      </ListItemContent>
+                      {/* Mirrors the manager list's marker: an admin sees every tenant's lakes,
+                          so an unmarked row would read as their own. */}
+                      {lake.isOwn === false && (
+                        <Tooltip
+                          size="sm"
+                          title={lake.ownerDisplayName ? `Owned by ${lake.ownerDisplayName}` : 'Owned by another user'}
+                        >
+                          <PersonOutlineIcon
+                            data-testid={`datalake-rail-owner-icon-${lake.id}`}
+                            sx={{ fontSize: 14, color: 'warning.400', flexShrink: 0 }}
+                          />
+                        </Tooltip>
+                      )}
+                      {typeof count === 'number' && (
+                        <Typography level="body-xs" sx={{ fontFamily: 'monospace', color: 'text.tertiary' }}>
+                          {count}
+                        </Typography>
+                      )}
+                    </ListItemButton>
+                  </ListItem>
+                );
+              })
+            )}
+          </List>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/client/app/components/datalake/LakeDriveStatusChip.tsx
+++ b/apps/client/app/components/datalake/LakeDriveStatusChip.tsx
@@ -1,0 +1,55 @@
+import { Chip, Tooltip } from '@mui/joy';
+import CloudIcon from '@mui/icons-material/Cloud';
+import { DRIVE_STATUS_BADGE, useLakeDriveConnection } from '@client/app/hooks/data/googleDrive';
+
+/**
+ * Read-only "this lake has a Drive folder attached" marker, for the surfaces a user reaches when
+ * they want to inspect or REMOVE a lake (#1645). Until this existed, a lake's detail panel showed
+ * tag/scope/file-count/Delete and gave no sign a source was attached at all, so there was no way
+ * to know something needed releasing before teardown - and purging strands the connection
+ * permanently (#1807).
+ *
+ * A Drive connection is an ORG-lake concept, so a personal lake is not read at all - the route would
+ * only ever 404. Beyond that, renders NOTHING when there is no connection, while the read is in
+ * flight, or when the read fails (403 for a non-manager). Absence therefore means "no connection OR
+ * not visible to you" - it is not a guarantee that none exists. Any surface making an irreversible
+ * promise about the connection must consult the query itself rather than infer from this chip.
+ */
+export default function LakeDriveStatusChip({
+  lakeId,
+  organizationId,
+}: {
+  lakeId: string;
+  /** The lake's org scope. Absent (personal lake) means no connection is possible, so none is read. */
+  organizationId?: string;
+}) {
+  const { data: connection } = useLakeDriveConnection(lakeId, !!organizationId);
+  if (!connection) return null;
+
+  const badge = DRIVE_STATUS_BADGE[connection.status];
+  const folder = connection.folderName || connection.driveFolderId;
+
+  return (
+    <Tooltip
+      size="sm"
+      title={
+        connection.status === 'connected'
+          ? `Syncing the Google Drive folder "${folder}"`
+          : `Google Drive folder "${folder}": ${badge.label.toLowerCase()}${
+              connection.lastError ? ` - ${connection.lastError}` : ''
+            }`
+      }
+    >
+      <Chip
+        size="sm"
+        variant="soft"
+        color={badge.color}
+        startDecorator={<CloudIcon sx={{ fontSize: 12 }} />}
+        sx={{ fontSize: '11px', maxWidth: 220 }}
+        data-testid={`datalake-drive-status-chip-${lakeId}`}
+      >
+        {folder}
+      </Chip>
+    </Tooltip>
+  );
+}

--- a/apps/client/app/components/datalake/SelectedLakeHeader.tsx
+++ b/apps/client/app/components/datalake/SelectedLakeHeader.tsx
@@ -1,0 +1,118 @@
+import { Box, Button, Chip, Stack, Tooltip, Typography } from '@mui/joy';
+import AddIcon from '@mui/icons-material/Add';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import DriveConnectAction from '@client/app/components/DataLakeWizard/steps/DriveConnectAction';
+import { lakeVisibilityLabel } from '@client/app/components/datalake/lakeVisibility';
+import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import type { ManageableDataLakeConfig } from '@bike4mind/common';
+
+/**
+ * Header for the lake the page is scoped to: what it is, what feeds it, and the lake-level
+ * actions - the home those actions never had (#1645). Lake-level work previously required
+ * Manage lakes -> pick a lake -> Add files, which put "connect a Drive folder" three
+ * navigations deep and made an attached source invisible from every surface but the wizard.
+ *
+ * Lifecycle (archive / delete / purge / settings) is deliberately NOT duplicated here - it stays
+ * in the manager panel, and Configure deep-links there with this lake preselected. A second set
+ * of destructive controls on a second surface is how the two drift apart.
+ */
+export default function SelectedLakeHeader({
+  lake,
+  fileCount,
+}: {
+  lake: ManageableDataLakeConfig;
+  /** Distinct live files in this lake; undefined while the counts query is in flight. */
+  fileCount: number | undefined;
+}) {
+  const openWizardForLake = useDataLakeWizardStore(s => s.openWizardForLake);
+  const openManager = useDataLakeWizardStore(s => s.openManager);
+
+  const visibility = lakeVisibilityLabel(lake);
+  // Drive connect is an org-lake, owner/manager capability server-side (the status route 404s on a
+  // personal lake and 403s for a non-manager). Gating on the same condition keeps a permanently
+  // disabled button off every personal lake's header, rather than offering an action that can only
+  // ever fail.
+  const canConnectDrive = !!lake.organizationId && !!lake.canManage;
+
+  return (
+    <Box
+      data-testid="datalake-selected-lake-header"
+      sx={{
+        px: 3,
+        py: 1.5,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+      }}
+    >
+      <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+        <Typography level="title-md" data-testid="datalake-selected-lake-name">
+          {lake.name}
+        </Typography>
+        <Chip size="sm" variant="outlined" color="neutral" sx={{ fontSize: '11px' }}>
+          {visibility}
+        </Chip>
+        <Chip size="sm" variant="soft" color="neutral" sx={{ fontSize: '11px' }}>
+          {lake.fileTagPrefix}
+        </Chip>
+        {typeof fileCount === 'number' && (
+          <Chip
+            size="sm"
+            variant="outlined"
+            color="neutral"
+            sx={{ fontSize: '11px' }}
+            data-testid="datalake-selected-lake-filecount"
+          >
+            {fileCount} {fileCount === 1 ? 'file' : 'files'}
+          </Chip>
+        )}
+
+        <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
+          {lake.canManage && (
+            <Button
+              size="sm"
+              variant="outlined"
+              color="neutral"
+              startDecorator={<AddIcon sx={{ fontSize: 16 }} />}
+              data-testid="datalake-selected-lake-addfiles-btn"
+              onClick={() =>
+                openWizardForLake({
+                  id: lake.id,
+                  slug: lake.slug,
+                  name: lake.name,
+                  fileTagPrefix: lake.fileTagPrefix,
+                  requiredUserTag: lake.requiredUserTag,
+                  requiredEntitlement: lake.requiredEntitlement,
+                })
+              }
+            >
+              Add files
+            </Button>
+          )}
+          <Tooltip title="Settings, archive and delete live in the manager" size="sm">
+            <Button
+              size="sm"
+              variant="plain"
+              color="neutral"
+              startDecorator={<SettingsOutlinedIcon sx={{ fontSize: 16 }} />}
+              data-testid="datalake-selected-lake-manage-btn"
+              onClick={() => openManager('mine', lake.id)}
+            >
+              Configure
+            </Button>
+          </Tooltip>
+        </Box>
+      </Stack>
+
+      {/* The source row: for an org lake this is the whole connect/re-sync/disconnect control, so
+          attaching a Drive folder is one step from the page instead of three. */}
+      {canConnectDrive && (
+        <Box data-testid="datalake-selected-lake-source">
+          <DriveConnectAction lake={{ id: lake.id }} />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/client/app/components/datalake/lakeVisibility.test.ts
+++ b/apps/client/app/components/datalake/lakeVisibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { DATA_LAKES } from '@bike4mind/common';
+import { isBuiltInLake, lakeVisibilityLabel, lakeVisibilityLabelShort } from './lakeVisibility';
+
+/** A real registry id, so the test cannot drift from the registry it is asserting about. */
+const builtInId = DATA_LAKES[0]?.id;
+
+describe('lakeVisibilityLabel', () => {
+  it('labels a personal lake Private', () => {
+    expect(lakeVisibilityLabel({ id: 'own-lake' })).toBe('Private');
+  });
+
+  it('labels an org lake Organization, abbreviated in the compact form', () => {
+    expect(lakeVisibilityLabel({ id: 'x', organizationId: 'org1' })).toBe('Organization');
+    expect(lakeVisibilityLabelShort({ id: 'x', organizationId: 'org1' })).toBe('Org');
+  });
+
+  it('lets public win over org', () => {
+    expect(lakeVisibilityLabel({ id: 'x', organizationId: 'org1', isPublic: true })).toBe('Public');
+  });
+
+  it('labels a static registry lake Built-in, not Private', () => {
+    // The registry lake has no owner, no org and is not a public opt-in, so every other arm would
+    // call it "Private" - which is wrong: nobody owns it and it is not the viewer's own lake.
+    expect(builtInId).toBeTruthy();
+    expect(lakeVisibilityLabel({ id: builtInId })).toBe('Built-in');
+    expect(lakeVisibilityLabelShort({ id: builtInId })).toBe('Built-in');
+  });
+
+  it('does NOT mistake a stranger private lake for a built-in one', () => {
+    // Same field shape as a registry lake (no org, not public) - the distinction is registry
+    // membership, which is why the label cannot be inferred from isOwn/organizationId alone.
+    expect(isBuiltInLake({ id: 'someone-elses-private-lake' })).toBe(false);
+    expect(lakeVisibilityLabel({ id: 'someone-elses-private-lake' })).toBe('Private');
+  });
+
+  it('treats a missing id as not built-in rather than throwing', () => {
+    expect(isBuiltInLake({})).toBe(false);
+    expect(lakeVisibilityLabel({})).toBe('Private');
+  });
+});

--- a/apps/client/app/components/datalake/lakeVisibility.ts
+++ b/apps/client/app/components/datalake/lakeVisibility.ts
@@ -1,0 +1,24 @@
+/**
+ * The single derivation of a lake's visibility label.
+ *
+ * Three surfaces render this (the manager's detail panel, the page's lake header, and the page's
+ * lake rail) and they must agree: the rail and the header can show the same lake side by side, so
+ * two independent ternaries would eventually disagree about the same document. The rail wants a
+ * compact form, which is why the short label lives here too rather than becoming a fourth rule.
+ *
+ * Precedence matches the tri-state the settings form writes: public wins over org, org over
+ * personal. Note this describes the lake's SCOPE, not who owns it - a stranger's private lake seen
+ * by an admin still reads "Private"; ownership is marked separately (see `isOwn`).
+ */
+export type LakeVisibilityScope = { organizationId?: string; isPublic?: boolean };
+
+export function lakeVisibilityLabel(lake: LakeVisibilityScope): string {
+  if (lake.isPublic) return 'Public';
+  return lake.organizationId ? 'Organization' : 'Private';
+}
+
+/** Compact form for dense rows. Same precedence, shorter words. */
+export function lakeVisibilityLabelShort(lake: LakeVisibilityScope): string {
+  if (lake.isPublic) return 'Public';
+  return lake.organizationId ? 'Org' : 'Private';
+}

--- a/apps/client/app/components/datalake/lakeVisibility.ts
+++ b/apps/client/app/components/datalake/lakeVisibility.ts
@@ -1,3 +1,5 @@
+import { DATA_LAKES as BUILT_IN_LAKES } from '@bike4mind/common';
+
 /**
  * The single derivation of a lake's visibility label.
  *
@@ -6,19 +8,36 @@
  * two independent ternaries would eventually disagree about the same document. The rail wants a
  * compact form, which is why the short label lives here too rather than becoming a fourth rule.
  *
- * Precedence matches the tri-state the settings form writes: public wins over org, org over
- * personal. Note this describes the lake's SCOPE, not who owns it - a stranger's private lake seen
- * by an admin still reads "Private"; ownership is marked separately (see `isOwn`).
+ * Precedence: built-in wins, then public, then org, then personal. Note this describes the lake's
+ * SCOPE, not who owns it - a stranger's private lake seen by an admin still reads "Private";
+ * ownership is marked separately (see `isOwn`).
  */
-export type LakeVisibilityScope = { organizationId?: string; isPublic?: boolean };
+export type LakeVisibilityScope = { id?: string; organizationId?: string; isPublic?: boolean };
+
+/**
+ * A static registry lake (`DATA_LAKES`) rather than a user-created document. These have no owner,
+ * no org, and are not public opt-ins, so every other arm of the label would call them "Private" -
+ * which they are not: they are entitlement-gated shared content nobody owns.
+ *
+ * Identified by registry membership rather than by inferring from `isOwn`/`organizationId`, because
+ * those same values also describe a STRANGER'S private lake as seen by a global admin (whose list
+ * is unscoped). Those two cases must not collapse: one is built-in, the other really is private.
+ *
+ * The registry is extended by premium overlays, so this correctly covers overlay-contributed lakes
+ * in a build that has them and silently covers none in the open-core fork.
+ */
+export const isBuiltInLake = (lake: LakeVisibilityScope): boolean =>
+  !!lake.id && BUILT_IN_LAKES.some(registered => registered.id === lake.id);
 
 export function lakeVisibilityLabel(lake: LakeVisibilityScope): string {
+  if (isBuiltInLake(lake)) return 'Built-in';
   if (lake.isPublic) return 'Public';
   return lake.organizationId ? 'Organization' : 'Private';
 }
 
 /** Compact form for dense rows. Same precedence, shorter words. */
 export function lakeVisibilityLabelShort(lake: LakeVisibilityScope): string {
+  if (isBuiltInLake(lake)) return 'Built-in';
   if (lake.isPublic) return 'Public';
   return lake.organizationId ? 'Org' : 'Private';
 }

--- a/apps/client/app/components/datalake/resolveEmptyVariant.test.ts
+++ b/apps/client/app/components/datalake/resolveEmptyVariant.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEmptyVariant, type EmptyVariantInputs } from './resolveEmptyVariant';
+
+/** Page mode, lakes read fine, one lake present, something to browse. Cases override one axis. */
+const base: EmptyVariantInputs = {
+  chatMode: false,
+  lakesError: false,
+  lakesLoading: false,
+  lakeCount: 1,
+  manageableLakeCount: 1,
+  hasSelectedLake: false,
+  isScopeEmpty: false,
+};
+
+describe('resolveEmptyVariant', () => {
+  it('only claims zero lakes when the read SUCCEEDED and the count really is zero', () => {
+    expect(resolveEmptyVariant({ ...base, lakeCount: 0, manageableLakeCount: 0 })).toBe('no-lakes');
+  });
+
+  it('still offers first-run create when the only reachable lake is one the caller cannot manage', () => {
+    // A built-in fallback lake is listed for everyone, so keying first-run on lakeCount alone would
+    // mean the prompt never appears for anyone.
+    expect(resolveEmptyVariant({ ...base, lakeCount: 1, manageableLakeCount: 0, isScopeEmpty: true })).toBe('no-lakes');
+  });
+
+  it('does not offer first-run create beside a populated tree, even with no lakes of your own', () => {
+    expect(resolveEmptyVariant({ ...base, lakeCount: 1, manageableLakeCount: 0, isScopeEmpty: false })).toBe(
+      'no-selection'
+    );
+  });
+
+  it('does not claim zero lakes just because the current scope is empty (#1645)', () => {
+    // The regression itself: lakes exist, this view has no files. Before the fix an empty scope
+    // rendered the first-run "create your first data lake" prompt.
+    expect(resolveEmptyVariant({ ...base, lakeCount: 3, isScopeEmpty: true })).not.toBe('no-lakes');
+  });
+
+  it('reports a failed lake-list read as an error, never as zero lakes', () => {
+    // The dangerous collapse: a transient error must not read as "you have none", even when the
+    // count is 0 (which it always is on a failed read) and the scope is empty.
+    expect(
+      resolveEmptyVariant({ ...base, lakesError: true, lakeCount: 0, manageableLakeCount: 0, isScopeEmpty: true })
+    ).toBe('lakes-error');
+  });
+
+  it('keeps the error state even with a lake selected and an empty scope', () => {
+    expect(
+      resolveEmptyVariant({
+        ...base,
+        lakesError: true,
+        lakeCount: 0,
+        manageableLakeCount: 0,
+        hasSelectedLake: true,
+        isScopeEmpty: true,
+      })
+    ).toBe('lakes-error');
+  });
+
+  it('never flashes the first-run prompt while the lake list is still loading', () => {
+    // In flight, so the count is 0 but unknown - the neutral state asserts nothing.
+    expect(
+      resolveEmptyVariant({ ...base, lakesLoading: true, lakeCount: 0, manageableLakeCount: 0, isScopeEmpty: true })
+    ).toBe('no-selection');
+  });
+
+  it('prefers the error over the loading state when both are somehow set', () => {
+    expect(
+      resolveEmptyVariant({ ...base, lakesError: true, lakesLoading: true, lakeCount: 0, manageableLakeCount: 0 })
+    ).toBe('lakes-error');
+  });
+
+  it('reports an empty SELECTED lake as lake-empty, so the offer is add-files not create-lake', () => {
+    expect(resolveEmptyVariant({ ...base, lakeCount: 2, hasSelectedLake: true, isScopeEmpty: true })).toBe(
+      'lake-empty'
+    );
+  });
+
+  it('stays neutral for a selected lake that does have content', () => {
+    expect(resolveEmptyVariant({ ...base, hasSelectedLake: true, isScopeEmpty: false })).toBe('no-selection');
+  });
+
+  it('says the lakes are empty rather than pointing at a tree branch that does not exist', () => {
+    // no-selection reads "pick a branch from the tree", so it may only be used when the tree HAS
+    // branches. With lakes present but no files anywhere, there is nothing to point at.
+    expect(resolveEmptyVariant({ ...base, lakeCount: 2, hasSelectedLake: false, isScopeEmpty: true })).toBe(
+      'all-lakes-empty'
+    );
+  });
+
+  it('never consults the lake list in chat mode, whatever it says', () => {
+    // Chat mode has no rail and no create-first affordance, so every lake signal is irrelevant.
+    for (const override of [
+      { lakesError: true },
+      { lakesLoading: true },
+      { lakeCount: 0, manageableLakeCount: 0 },
+      { hasSelectedLake: true, isScopeEmpty: true },
+    ]) {
+      expect(resolveEmptyVariant({ ...base, chatMode: true, ...override })).toBe('no-selection');
+    }
+  });
+});

--- a/apps/client/app/components/datalake/resolveEmptyVariant.ts
+++ b/apps/client/app/components/datalake/resolveEmptyVariant.ts
@@ -1,0 +1,68 @@
+import type { DataLakeEmptyVariant } from './DataLakeArticle';
+
+export interface EmptyVariantInputs {
+  /** Chat mode keeps its historical pick-a-branch state and never consults the lake list. */
+  chatMode: boolean;
+  /** The lake-list read failed. Takes precedence over every other signal. */
+  lakesError: boolean;
+  /** The lake-list read is still in flight, so the lake count is not yet known. */
+  lakesLoading: boolean;
+  /** Number of lakes the caller can reach. Only meaningful once the read succeeded. */
+  lakeCount: number;
+  /**
+   * Of those, how many the caller can actually MANAGE. Load-bearing for the first-run prompt: the
+   * list includes built-in fallback lakes (and strangers' public ones), which every user can reach
+   * and nobody owns, so `lakeCount` alone is effectively never 0 and keying the prompt on it would
+   * retire first-run guidance entirely. "No lakes of your own" is the question being asked.
+   */
+  manageableLakeCount: number;
+  /** Whether a specific lake is currently scoped. */
+  hasSelectedLake: boolean;
+  /** Nothing to browse in the CURRENT scope - says nothing about how many lakes exist. */
+  isScopeEmpty: boolean;
+}
+
+/**
+ * Picks the article pane's "nothing to read" state.
+ *
+ * The precedence is the correctness of this function, not a detail of it. The bug it replaces
+ * (#1645) inferred a ZERO-LAKE state from an EMPTY-SCOPE test, so a user who already had lakes was
+ * shown "Create your first data lake" whenever the current view happened to hold no files.
+ *
+ * Two orderings are load-bearing:
+ *  - `lakesError` outranks everything. A failed read must never degrade into `no-lakes`: that would
+ *    borrow the zero-state's meaning from an unknown, and invite a user with lakes to create a
+ *    duplicate. "Could not read" and "there are none" are different facts.
+ *  - `lakesLoading` outranks `no-lakes` for the same reason - an in-flight read has no count yet, so
+ *    a confident zero would flash the first-run prompt on every page load.
+ *
+ * Both therefore fall back to `no-selection`, the neutral state that asserts nothing about how many
+ * lakes exist.
+ *
+ * The empty-scope split is the same principle one level down: `no-selection` tells the user to pick
+ * a branch, so it may only be used when there ARE branches. With lakes present but no files
+ * anywhere, the all-lakes view has an empty tree, and pointing at it would be the same kind of lie.
+ */
+export function resolveEmptyVariant({
+  chatMode,
+  lakesError,
+  lakesLoading,
+  lakeCount,
+  manageableLakeCount,
+  hasSelectedLake,
+  isScopeEmpty,
+}: EmptyVariantInputs): DataLakeEmptyVariant {
+  if (chatMode) return 'no-selection';
+  if (lakesError) return 'lakes-error';
+  if (lakesLoading) return 'no-selection';
+  if (lakeCount === 0) return 'no-lakes';
+  if (isScopeEmpty) {
+    if (hasSelectedLake) return 'lake-empty';
+    // Nothing to browse AND nothing of the caller's own: a genuine first run, even though a
+    // read-only built-in lake is listed. Gated on isScopeEmpty so this can never appear beside a
+    // populated tree - "create your first lake" over someone else's browsable content is its own lie.
+    if (manageableLakeCount === 0) return 'no-lakes';
+    return 'all-lakes-empty';
+  }
+  return 'no-selection';
+}

--- a/apps/client/app/components/datalake/scopeTagCountsToLake.test.ts
+++ b/apps/client/app/components/datalake/scopeTagCountsToLake.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { scopeTagCountsToLake, type TagCount } from './scopeTagCountsToLake';
+
+const counts: TagCount[] = [
+  { tag: 'research:reports:market', count: 3 },
+  { tag: 'research:interviews:ops', count: 2 },
+  { tag: 'legal:contracts', count: 5 },
+  { tag: 'opti:solvers', count: 1 },
+];
+
+describe('scopeTagCountsToLake', () => {
+  it('keeps only the selected lake tags, so the tree shows that lake alone', () => {
+    expect(scopeTagCountsToLake(counts, { fileTagPrefix: 'research:' }).map(c => c.tag)).toEqual([
+      'research:reports:market',
+      'research:interviews:ops',
+    ]);
+  });
+
+  it('returns every tag untouched in the all-lakes scope', () => {
+    // Identity, not merely equal-length: the unscoped page must behave exactly as before.
+    expect(scopeTagCountsToLake(counts, null)).toBe(counts);
+  });
+
+  it('preserves counts, not just tag names', () => {
+    expect(scopeTagCountsToLake(counts, { fileTagPrefix: 'legal:' })).toEqual([{ tag: 'legal:contracts', count: 5 }]);
+  });
+
+  it('yields nothing for a lake with no tagged content, rather than falling back to everything', () => {
+    // The empty-vs-unscoped distinction is load-bearing: returning all tags here would make an
+    // empty lake look like it contained every other lake's content.
+    expect(scopeTagCountsToLake(counts, { fileTagPrefix: 'empty-lake:' })).toEqual([]);
+  });
+
+  it('does not match a prefix that merely shares a leading substring', () => {
+    // 'research' without the colon must not match 'researchers:'; the trailing colon is what makes
+    // the prefix a namespace boundary rather than a text match.
+    const withNeighbour: TagCount[] = [...counts, { tag: 'researchers:notes', count: 9 }];
+    expect(scopeTagCountsToLake(withNeighbour, { fileTagPrefix: 'research:' }).map(c => c.tag)).not.toContain(
+      'researchers:notes'
+    );
+  });
+
+  it('documents the overlapping-prefix case: a parent prefix absorbs a child lake tags', () => {
+    // Not desired behaviour - it is the consequence of prefix containment, and the reason
+    // overlapping prefixes are refused at create time (tagPrefixIssue). Pinned so that if the
+    // create-time guard is ever relaxed, this shows up as a decision rather than a surprise.
+    const nested: TagCount[] = [
+      { tag: 'research:reports:market', count: 3 },
+      { tag: 'research:deep:genomics', count: 7 },
+    ];
+    expect(scopeTagCountsToLake(nested, { fileTagPrefix: 'research:' })).toHaveLength(2);
+    expect(scopeTagCountsToLake(nested, { fileTagPrefix: 'research:deep:' }).map(c => c.tag)).toEqual([
+      'research:deep:genomics',
+    ]);
+  });
+
+  it('handles an empty payload without throwing', () => {
+    expect(scopeTagCountsToLake([], { fileTagPrefix: 'research:' })).toEqual([]);
+  });
+});

--- a/apps/client/app/components/datalake/scopeTagCountsToLake.ts
+++ b/apps/client/app/components/datalake/scopeTagCountsToLake.ts
@@ -1,0 +1,27 @@
+/** A lake, reduced to what scoping needs. */
+export interface TagScopeLake {
+  fileTagPrefix: string;
+}
+
+export type TagCount = { tag: string; count: number };
+
+/**
+ * Narrows the browse surface's tag counts to a single lake, which is what makes the page's lake
+ * selection scope the taxonomy tree (#1645).
+ *
+ * This is a client-side filter on the SAME `/api/data-lakes/tag-counts` payload the unscoped tree
+ * already reads - every taxonomy tag in a lake is namespaced under that lake's `fileTagPrefix` - so
+ * switching lakes costs no request. `null` means the all-lakes scope and returns the list untouched.
+ *
+ * KNOWN ASSUMPTION: prefix containment is the membership test, so a lake whose prefix is a prefix OF
+ * ANOTHER lake's (`research:` vs `research:deep:`) would absorb that lake's tags into its scope.
+ * Overlapping prefixes are refused at create time for exactly this reason (see `tagPrefixIssue` in
+ * `@bike4mind/common`, which blocks an overlapping prefix with "They would share files"), so this
+ * cannot arise for a lake created through the wizard. A legacy lake predating that rule could still
+ * overlap; the scope would over-include rather than leak across a tenant boundary, because the
+ * counts payload is already access-filtered server-side before it reaches here.
+ */
+export function scopeTagCountsToLake(tagCounts: TagCount[], lake: TagScopeLake | null): TagCount[] {
+  if (!lake) return tagCounts;
+  return tagCounts.filter(tc => tc.tag.startsWith(lake.fileTagPrefix));
+}

--- a/apps/client/app/components/datalake/surfaceTokens.tsx
+++ b/apps/client/app/components/datalake/surfaceTokens.tsx
@@ -45,10 +45,39 @@ export interface DataLakeSurfaceCopy {
   dropAcceptedHint: string;
   emptyTitle: string;
   emptyHint: string;
-  /** Zero-state variants, shown instead of `empty*` when the create-first CTA is offered. */
+  /**
+   * TRUE zero-lake state only: the caller has no accessible lakes at all. Never shown merely
+   * because the current browse scope holds no files - that conflated "you have no lakes" with
+   * "there is nothing here", telling a user with lakes to create their first one (#1645).
+   */
   zeroTitle: string;
   zeroHint: string;
+  /**
+   * Lake selected, but it holds no files yet. The hint must stay source-agnostic: connecting a
+   * Drive folder is an ORG-lake, owner/manager capability, and this copy is chosen surface-wide
+   * with no knowledge of the selected lake's scope - so naming it here would promise a control a
+   * personal lake never shows. The lake header advertises Drive where it genuinely applies.
+   */
+  lakeEmptyTitle: string;
+  lakeEmptyHint: string;
+  /**
+   * Lakes exist but NONE of them hold a file, so the all-lakes view has no tree at all. Distinct
+   * from `empty*`, which tells the user to pick a branch - there is no branch to pick here.
+   */
+  allLakesEmptyTitle: string;
+  allLakesEmptyHint: string;
+  /**
+   * The lake list could not be READ. Distinct from `zero*` on purpose: a failed read must never
+   * borrow the zero-state's meaning, or a transient error invites a user who already has lakes to
+   * create a duplicate.
+   */
+  lakesErrorTitle: string;
+  lakesErrorHint: string;
   createLabel: string;
+  /** Rail heading over the lake list. */
+  railTitle: string;
+  /** Rail row that clears the lake scope and browses every reachable lake at once. */
+  allLakesLabel: string;
   /** Label for the shared manage-knowledge affordance (`ManageKnowledgeButton`). */
   manageLabel: string;
   askAboutLabel: string;
@@ -114,7 +143,15 @@ export const DEFAULT_DATA_LAKE_SURFACE_TOKENS: DataLakeSurfaceTokens = {
     emptyHint: 'Pick a branch from the tree, or jump into one of the largest categories below.',
     zeroTitle: 'Nothing here yet',
     zeroHint: `Create your first ${DATA_LAKE.toLowerCase()} to turn your files into searchable knowledge.`,
+    lakeEmptyTitle: 'This lake has no files yet',
+    lakeEmptyHint: 'Add files to make them searchable in chat.',
+    allLakesEmptyTitle: 'No files yet',
+    allLakesEmptyHint: `Pick a ${DATA_LAKE.toLowerCase()} on the left and add files to make them searchable.`,
+    lakesErrorTitle: `Couldn't load your ${DATA_LAKES.toLowerCase()}`,
+    lakesErrorHint: 'Something went wrong reading the list. Retry - nothing has been lost.',
     createLabel: `Create ${DATA_LAKE.toLowerCase()}`,
+    railTitle: `My ${DATA_LAKES.toLowerCase()}`,
+    allLakesLabel: `All ${DATA_LAKES.toLowerCase()}`,
     manageLabel: 'Manage lakes',
     askAboutLabel: 'Ask about this document',
     askAboutPrompt: title => `Tell me about this document: ${title}`,

--- a/apps/client/app/components/datalake/surfaceTokens.tsx
+++ b/apps/client/app/components/datalake/surfaceTokens.tsx
@@ -53,10 +53,11 @@ export interface DataLakeSurfaceCopy {
   zeroTitle: string;
   zeroHint: string;
   /**
-   * Lake selected, but it holds no files yet. The hint must stay source-agnostic: connecting a
-   * Drive folder is an ORG-lake, owner/manager capability, and this copy is chosen surface-wide
-   * with no knowledge of the selected lake's scope - so naming it here would promise a control a
-   * personal lake never shows. The lake header advertises Drive where it genuinely applies.
+   * Lake selected, but it holds no files yet. The hint must promise NO action: this copy is chosen
+   * surface-wide with no knowledge of the selected lake, and the lake may be one the viewer cannot
+   * write to at all (a built-in/registry lake, or someone else's public lake), where neither
+   * "add files" nor "connect a folder" is offered. The Add-files button beside it appears only when
+   * the viewer can manage the lake, and that button - not this sentence - is the call to action.
    */
   lakeEmptyTitle: string;
   lakeEmptyHint: string;
@@ -144,7 +145,7 @@ export const DEFAULT_DATA_LAKE_SURFACE_TOKENS: DataLakeSurfaceTokens = {
     zeroTitle: 'Nothing here yet',
     zeroHint: `Create your first ${DATA_LAKE.toLowerCase()} to turn your files into searchable knowledge.`,
     lakeEmptyTitle: 'This lake has no files yet',
-    lakeEmptyHint: 'Add files to make them searchable in chat.',
+    lakeEmptyHint: 'Nothing has been added to this lake yet.',
     allLakesEmptyTitle: 'No files yet',
     allLakesEmptyHint: `Pick a ${DATA_LAKE.toLowerCase()} on the left and add files to make them searchable.`,
     lakesErrorTitle: `Couldn't load your ${DATA_LAKES.toLowerCase()}`,

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -251,6 +251,11 @@ function useLifecycleMutation(action: LifecycleAction, successMessage: string, e
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.archived });
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.deleted });
+      // A lifecycle move changes what is BROWSABLE, not just which lakes are listed: archiving
+      // stamps archivedAt on the lake's files, which both tag counters exclude. Without this the
+      // lake list and the tag tree disagree - the page's lake rail (sourced from `list`) drops the
+      // row while the tree beside it still shows that lake's branches and counts it in the totals.
+      queryClient.invalidateQueries({ queryKey: dataLakeKeys.tagCountsRoot });
       toast.success(successMessage);
     },
     onError: (error: Error) => {

--- a/apps/client/app/hooks/data/googleDrive.ts
+++ b/apps/client/app/hooks/data/googleDrive.ts
@@ -13,6 +13,20 @@ export type LakeDriveConnection = {
   connectedAt: string | null;
 };
 
+/**
+ * User-facing label + severity per connection status. Lives beside the type so every surface that
+ * renders a Drive connection (the wizard's connect action, the lake detail panel, the page header)
+ * reads the SAME wording - three hand-synced copies would drift the moment a status is added.
+ */
+export const DRIVE_STATUS_BADGE: Record<
+  LakeDriveConnection['status'],
+  { label: string; color: 'success' | 'warning' | 'danger' }
+> = {
+  connected: { label: 'Connected', color: 'success' },
+  needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
+  credential_error: { label: 'Credential error', color: 'danger' },
+};
+
 const lakeDriveConnectionKey = (dataLakeId?: string) => ['lake-drive-connection', dataLakeId];
 
 export function useConnectGoogleDrive() {
@@ -40,10 +54,13 @@ export function useDisconnectGoogleDrive() {
 }
 
 /** The current Drive connection feeding a lake (null when none). Org owner/manager only, server-side. */
-export function useLakeDriveConnection(dataLakeId?: string) {
+export function useLakeDriveConnection(dataLakeId?: string, enabled = true) {
   return useQuery({
     queryKey: lakeDriveConnectionKey(dataLakeId),
-    enabled: !!dataLakeId,
+    // `enabled` lets a caller skip a request that cannot succeed: the route resolves the lake's
+    // ORGANIZATION, so a personal lake always 404s. Passing false there keeps a guaranteed failure
+    // (and its console error) off every personal lake, instead of firing and discarding it.
+    enabled: !!dataLakeId && enabled,
     queryFn: async () => {
       const response = await api.get<{ connection: LakeDriveConnection | null }>(
         `/api/data-lakes/${dataLakeId}/drive-connection`

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -159,12 +159,18 @@ interface DataLakeWizardStore {
   isManagerOpen: boolean;
   /** Which manager tab to show on open: the caller's own lakes, or the public discover catalog. */
   managerTab: ManagerTab;
+  /**
+   * Lake to preselect when the manager opens, so a per-lake action on another surface lands on
+   * that lake instead of the manager root (landing on a list is the friction #1645 is about).
+   * Cleared on close so re-deep-linking the SAME lake still fires the panel's sync effect.
+   */
+  managerLakeId: string | null;
 
   // Navigation
   openWizard: () => void;
   openWizardForLake: (lake: WizardTargetLake) => void;
   closeWizard: () => void;
-  openManager: (tab?: ManagerTab) => void;
+  openManager: (tab?: ManagerTab, lakeId?: string | null) => void;
   closeManager: () => void;
   setStep: (step: WizardStep) => void;
 
@@ -214,6 +220,7 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   targetLake: null,
   isManagerOpen: false,
   managerTab: 'mine',
+  managerLakeId: null,
 
   // ── Navigation ──────────────────────────────────────────────────────────
 
@@ -222,8 +229,9 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   // Management panel (list lakes, add files, lifecycle). Its internal "Create"
   // button calls openWizard, which stacks the wizard on top and returns here on close.
   // An optional tab lets callers deep-link straight to the public discover catalog.
-  openManager: (tab: ManagerTab = 'mine') => set({ isManagerOpen: true, managerTab: tab }),
-  closeManager: () => set({ isManagerOpen: false }),
+  openManager: (tab: ManagerTab = 'mine', lakeId: string | null = null) =>
+    set({ isManagerOpen: true, managerTab: tab, managerLakeId: lakeId }),
+  closeManager: () => set({ isManagerOpen: false, managerLakeId: null }),
 
   // Append mode: upload into an existing lake. Preseeds config from the lake so
   // the (locked) Config step shows the right values.


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

Captured on a local self-host stack seeded with a 12-file taxonomy (images to be attached to this PR by the author - they cannot be uploaded from the CLI):

1. **All-lakes scope** - the rail on the left reads `My data lakes 2`, an `All data lakes 12` row, then one row per lake with its scope and file count. None of this was visible on the page before; you had to open a modal to learn you had lakes.
2. **Lake selected** - picking a lake adds the header (`Research Corpus` / `Private` / `research:` / `12 files` / **Add files** / **Configure**) and scopes the tree beside it.
3. **Drilled in with a file open** - rail (which lake) -> tree (`Reports` -> three documents) -> reader, with the ticker showing `DEPTH 3 Research : Reports : Market`.

## Description

`/data-lakes` opened on a cross-lake **file** browser, so a **lake** was never an object on the page: the lake list lived one modal deep behind **Manage lakes**, and lake-level actions were three navigations away (`Manage lakes` -> pick a lake -> `Add files`). On top of that the page's empty state was computed from an **empty-scope** test (no files under the current tag path) but rendered **zero-lake** copy, so a user who already had lakes was told to "Create your first data lake".

This is the information-architecture inversion described in #1645, plus the safety half of the teardown complaint in its comments: nothing on the surface where you inspect or delete a lake showed that a Google Drive folder was attached to it.

> [!IMPORTANT]
> **This is a prototype for design review, not a settled layout.** #1645 explicitly leaves the final design to the design owner. It is built to be refined - or replaced - rather than merged as-is on visual grounds. The two things I'd most want pushed back on are called out under *Design questions* below.

Scoped to **page mode only**. Chat and the premium `/opti` surface are untouched, gated on the existing `chatMode` discriminator.

## Changes

**The lake becomes the primary object (page mode)**

- New `DataLakeRail` - a persistent lake list on `/data-lakes`. Selecting a lake scopes the taxonomy tree by filtering the **same** `tag-counts` payload on that lake's `fileTagPrefix`, so there is no extra request and no new endpoint. An explicit "All data lakes" row keeps the previous cross-lake browse as a *choice* rather than an unlabelled default.
- New `SelectedLakeHeader` - a home for lake-level actions, including the whole Drive connect / re-sync / disconnect control for an org lake. That makes "attach a Drive folder" one step from the page instead of three.
- Lifecycle (settings / archive / delete / purge) is deliberately **not** duplicated on the new header. **Configure** deep-links into the manager with the lake preselected, via a new `managerLakeId` on the wizard store.

**Honest empty / scope states**

A single `isEmpty` boolean is replaced by `resolveEmptyVariant`, a pure, unit-tested function whose **check order is the actual fix**:

| Situation | What the user now sees |
|---|---|
| Lake-list read **failed** | "Couldn't load your data lakes" + Retry - **never** the first-run prompt |
| Lake-list read **in flight** | Neutral state; no first-run prompt flash |
| No lakes the caller can **manage** | "Create your first data lake" + CTA |
| A lake is selected but holds no files | "This lake has no files yet" + Add files |
| Lakes exist but none hold files | "No files yet - pick a data lake and add files" |
| Otherwise | The pre-existing pick-a-branch state |

Two of these are less obvious than they look:

- A **failed read** must not degrade into "you have no lakes". That borrows the zero-state's meaning from an unknown and invites the user to create a duplicate.
- The first-run prompt keys on lakes the caller can **manage**, not on reachable lakes. A read-only built-in fallback lake is listed for *everyone*, so keying it on the reachable count (which is how #1645 words it) would have retired first-run guidance entirely. This was found by running it, not by reading it.

**Drive-connection visibility (the teardown-safety half)**

- `LakeInfoPanel` now shows an attached Drive folder and its status. That panel is where a user goes to inspect or delete a lake, and it previously gave no sign a source was attached at all.
- The purge dialog names the connection and says to disconnect **first**. It deliberately does **not** claim that purging releases it, because today it does not - see #1807. When #1807 lands, that wording must change with it (noted in the code).
- The Drive read is skipped for personal lakes, which can never hold a connection and would only ever 404. The purge warning is deliberately left **ungated**: withholding a warning before an irreversible action is worse than one wasted request.

**A built-in lake is no longer labelled "Private"**

A static registry lake (`DATA_LAKES`) has no owner, no org and is not a public opt-in, so every arm of the visibility label fell through to `Private`. It is none of those: it is entitlement-gated shared content nobody owns. It now reads **`Built-in`**.

Keyed on registry membership, **not** inferred from `isOwn`/`organizationId` - those same values also describe a *stranger's private lake as seen by a global admin* (whose list is unscoped), and collapsing the two would relabel someone's genuinely private lake as built-in. Landed in the one shared helper so the rail and the manager's detail panel change together. (Note for the design owner: this alters a label on an existing surface, deliberately, as a factual correction.)

**Correctness found in self-review + a live run (later commits)**

- `PurgeDriveWarning` - a **failed** connection read no longer collapses into the silent "no connection" case. It warned only when the read SUCCEEDED, so a transient error before an irreversible purge hid the very hazard the warning exists for. A 404 still resolves to `null` and stays quiet, so ordinary purges are not nagged.
- `useLifecycleMutation` now invalidates `tagCountsRoot`. Archive/delete/restore changes what is **browsable**, not just which lakes are listed, so the rail (from `list`) dropped a row while the tree beside it still showed that lake's branches and counted them in the totals. Pre-existing, but this PR is what puts the two counts side by side.
- The empty-lake hint no longer promises an action the viewer may not have. It read "Add files to make them searchable in chat" on a **built-in** lake, where no Add-files button is offered - the same false-promise shape as the "connect a folder" clause already removed from that sentence. It now states the fact; the Add-files button (already gated on `canManage`) is the call to action.

**Consolidation**

- Three copies of the visibility-label ternary -> one `lakeVisibility` helper (long + short + `isBuiltInLake`).
- The lake-scoping filter moved out of an inline `useMemo` into `scopeTagCountsToLake` - it is the load-bearing logic of the feature and nothing could reach it to test it.
- Two copies of the Drive status-label map -> one exported `DRIVE_STATUS_BADGE`.

## Guide for Testers

Target: a **PR preview** env (`app.pr<N>.preview.bike4mind.com`) once a maintainer triggers one, or staging. Requires the `EnableDataLakes` admin setting to be **on**.

### A. The reported bug: an empty view must not claim you have no lakes

1. Sign in and confirm **Admin -> Settings -> Experimental -> Enable Data Lakes** is **on**.
2. Navigate to `/data-lakes`.
3. **Expected:** a left rail titled **"My data lakes"** with a count chip, an **"All data lakes"** row, and one row per lake showing its name, scope (`Private` / `Org` / `Public` / `Built-in`) and file count. A built-in lake (e.g. *Optimization Knowledge Base*) must read **`Built-in`**, never `Private`.
4. Click **+ Create data lake**, name it `Tester Empty Lake`, and complete the wizard with **one** small `.txt` file. (A lake cannot currently be created with no files - see *Known limitations*.)
5. Return to `/data-lakes` and click **All data lakes** in the rail.
6. **Expected:** the rail count is at least 1 and your lake is listed. The right pane must **NOT** say *"Create your first data lake"*. With no files anywhere it reads *"No files yet"*; with files present it reads *"Nothing selected yet"*.
7. **This is the regression:** before this PR, step 6 showed *"Nothing here yet / Create your first data lake"* whenever the current view had no files, even with lakes present.

### B. Lake scoping and the new header

1. On `/data-lakes`, click your lake in the rail.
2. **Expected:** a header appears above the browse panes with the lake name, its scope chip, its `prefix:` chip, an `N files` chip, and **Add files** + **Configure** buttons.
3. **Expected:** the tree to the right now shows **only** that lake's categories, and the top-right ticker's `DOCUMENTS` count matches that lake alone.
4. Click **All data lakes** in the rail.
5. **Expected:** the header disappears and the tree shows every reachable lake's categories again.
6. Click your lake, drill into a category, then click a file.
7. **Expected:** the document opens in the right pane; the breadcrumb/`DEPTH` ticker reflects the path. Switch to a different lake in the rail.
8. **Expected:** the tree resets to that lake's root - it must **not** keep the previous lake's breadcrumb or leave a stale file open.

### C. Empty-lake state

1. Create a lake, then remove its files (or select a lake with 0 files).
2. Click that lake in the rail.
3. **Expected:** *"This lake has no files yet"* with an **Add files** button (shown only if you can manage the lake). It must **not** offer "Create data lake".
4. Click **Add files**. **Expected:** the wizard opens in append mode titled `Add Files — <lake name>`.

### D. Failed-read state (the important negative case)

1. On `/data-lakes`, open DevTools -> **Network** -> enable request blocking for the URL pattern `*/api/data-lakes`.
2. Reload the page and wait ~10 seconds (React Query retries before settling).
3. **Expected:** the rail shows *"Couldn't load your data lakes"* + a **Retry** button, and the right pane shows the same message + Retry. The rail count chip is **absent**.
4. **Expected — the key assertion:** *"Create your first data lake"* must **NOT** appear. A failed read must never read as "you have zero lakes".
5. Remove the request block and click **Retry**.
6. **Expected:** the rail repopulates with your lakes; no reload needed.

### E. Drive-connection visibility (needs an **org** lake)

1. As an org owner/manager, open **Manage lakes** and select an **org** lake.
2. **Expected:** if a Drive folder is connected, a chip showing the folder name and status (`Connected` / `Needs reconnect` / `Credential error`) appears in the detail panel's chip row. If none is connected, no chip - and no error.
3. On `/data-lakes`, select that org lake in the rail. **Expected:** the header shows the Drive connect / re-sync / disconnect control directly.
4. Select a **personal** lake. **Expected:** no Drive control and no Drive chip (Drive is an org-lake capability). Confirm the console shows **no** `404 .../drive-connection` request for the personal lake.
5. Soft-delete a lake that has a Drive connection, then **Manage lakes -> Deleted -> Purge permanently**.
6. **Expected:** the confirm dialog additionally warns that the lake still syncs a named Drive folder, that purging leaves the connection behind, and to restore + disconnect first.
7. To check the failure branch: with the purge dialog open, block `*/drive-connection` in DevTools and reopen it. **Expected:** a cautious warning that the connection could **not be checked** (not silence). A lake with genuinely no connection shows neither warning.

### F. Configure deep-link

1. On `/data-lakes`, select a lake and click **Configure**.
2. **Expected:** the manager modal opens **already showing that lake's** detail panel - not the root lake list.
3. Close it, then open **Manage lakes** from the page header instead.
4. **Expected:** the manager opens at its normal root view.

### Regression Checks

1. **Chat Data Lake mode** (main app): toggle Data Lake mode on in a chat. **Expected:** unchanged - the tree rail beside the chat, row actions (attach / view / remove) all behave as before. There must be **no** lake rail and **no** lake header in chat mode.
2. **Premium `/opti`**: open the Quantum page's Data Lake mission. **Expected:** unchanged for the same reason (it renders the Explorer with a `chatSlot`, i.e. chat mode).
3. **Manage lakes modal**: create / add files / archive / restore / delete / purge, the Discover catalog tab, AI-tag review entry points, and Rebuild passages all behave as before.
4. **Rail and tree agree after a lifecycle move**: with `/data-lakes` open, archive a populated lake from the manager and close the modal **without reloading**. **Expected:** the rail count drops AND that lake's branches disappear from the tree, with the DOCUMENTS ticker falling to match. They must not disagree.
5. **Deep-link** `/data-lakes?article=<id>` still opens that document in the reader.
6. **Drag-and-drop** onto `/data-lakes` still opens the destination picker and ingests.

### What NOT to test

- No server, API, model, schema, or migration changes - all 17 files are under `apps/client/app/`. Nothing about ingestion, chunking, retrieval, grounding, or lake lifecycle *behavior* changed.
- No new admin settings; nothing to hydrate.
- Drive OAuth itself is unchanged - this PR only surfaces existing connection state and reuses the existing connect flow.
- #1807 (purge stranding a Drive connection) is **not** fixed here. This PR only warns about it. Testing that the connection is released is out of scope and will still fail.
- #1648 (org lakes invisible under the account-switcher org) is **not** fixed here either.

## Additional Information

**Verification**

- Host: full `apps/client` suite green (994 files / 10,280 tests), `tsgo` typecheck clean, `pnpm lint:check` clean, and the ASCII / control-byte guards run over every added line on the branch.
- New tests: `resolveEmptyVariant.test.ts` (the variant precedence, including the failed-read and fallback-lake cases), `DataLakeRail.test.tsx`, `lakeVisibility.test.ts` (including that a stranger's private lake is not mistaken for a built-in one), `scopeTagCountsToLake.test.ts` (namespace-boundary and overlapping-prefix behaviour), four `PurgeDriveWarning` states (connected / read failed / no connection / in flight), and `DataLakeArticle.test.tsx` extended with a regression pin that the create CTA cannot appear from `onCreate` alone.
- Verified live in a browser on a local self-host stack (each with the observed value, not just "looks right"): rail count `2` with no first-run prompt; lake scoping (a second lake's root disappears, DOCUMENTS 15 -> 12); `Built-in` vs `Private`; the empty-lake state with **no** Add-files affordance on an unmanageable lake; breadcrumb reset on lake switch (DEPTH `3 Research : Reports : Market` -> `0 top`, open file cleared); `Configure` landing on the lake's own detail panel; **no** `drive-connection` request fired for a personal lake; the failed lake-list read (fault-injected) showing the error state and recovering on **Retry**; and archive-without-reload leaving the rail and tree in agreement.
- **Not** verified live: the purge dialog's failed-read warning, which needs a real Drive connection (no Google OAuth locally). Covered by unit tests instead - stated plainly rather than implied.
- **Premium overlays tested against this branch**, since two of them consume the changed components:
  - `premium-optihashi` - typecheck clean, **95 files / 960 tests pass**.
  - `premium-libreoncology` - **57 files / 513 tests pass**. Its 2 typecheck errors (`Resource.fabFileBucket`, a `documentStore` arg type) are **pre-existing**: the identical two errors reproduce on the parent commit without this change.
  - `premium-overwatch`, `premium-pi`, `premium-tavern` reference none of the changed symbols.
  - No overlay references the surface-token types at all, so the new `DataLakeSurfaceCopy` fields break nothing (overrides are `Partial<>` per section).

**Behavior that is not purely visual** (small, but worth a reviewer's eye)

- `useGetDataLakes` is now enabled on the page, not just in chat mode - one extra `GET /api/data-lakes` per page visit. It is what lets the page answer "do I have any lakes?", which is the root of the bug. Confirmed this adds no row-delete affordances to the page: those handlers only feed `DataLakeChatTree`.
- `useLakeDriveConnection` now runs for an **org** lake opened in the manager, and when the purge dialog opens.
- `DataLakeArticle`'s `onCreate` no longer implies the zero-state. There is exactly **one** production render site, so this is contained.

**Known limitations / deliberately out of scope**

- **A Drive-only lake still cannot be created.** #1645 asks for a "Drive-first" creation path, and the create-mode **Connect Google Drive** button remains disabled. This is bigger than it appears: every wizard step gates on `allFiles.some(f => !f.excluded)`, and `useBatchUpload` opens with `if (included.length === 0) throw new Error('No files to upload')` - it creates the lake as *step 1 of an upload*. There is no fileless commit path, so this needs a parallel create-and-connect branch through the wizard. Filing separately rather than growing this PR. The rail does remove most of the pain: Drive connect is now one click for any existing org lake.
- The rail has **no per-row Drive indicator**. `ManageableDataLakeConfig` carries no connection field, so a per-row badge would cost one request per lake. Status lives on the header (one request) instead. A rail indicator wants a `driveConnected` flag on the list projection first.

## Design questions

Flagging these rather than deciding them:

1. **Three columns is dense.** Rail + tree + reader means three columns of chrome before any content, and the reader is where the value is. A collapsible rail, or folding the lake into the tree's **root tier** (keeping two panes), are both reasonable. I chose the rail because making lakes a tier of the tag hierarchy re-subordinates the lake and leaves lake-level actions with no header to live on - but that is a judgment call, not a conclusion.
2. **Narrow widths.** The rail is a fixed 248px with no collapse behaviour yet. Needs a responsive answer.

## Developer Notes (Optional)

- **`resolveEmptyVariant` (new pure module)** - the pattern here is worth reusing: when a UI state depends on distinguishing *"the answer is none"* from *"we could not get an answer"*, put the precedence in a pure function and unit-test the ordering. Inlined in a component it is untestable, and the ordering is exactly what regresses.
- **`DataLakeEmptyVariant` (new discriminated union)** - replaces inferring a state from which optional callbacks happen to be set. The old `onCreate`-presence inference is precisely what let an empty-scope test masquerade as a zero-lake state; the distinction now lives in the type where a caller cannot fudge it.
- **`useLakeDriveConnection(id, enabled)`** - gained an opt-out so a caller can skip a request that cannot succeed (a personal lake always 404s), rather than firing and discarding it.
- **`useDataLakeWizardStore.openManager(tab, lakeId)`** - the manager can now be deep-linked to a specific lake from any surface. Any future per-lake action elsewhere can land on that lake instead of the manager root.
- **`lakeVisibility` / `DRIVE_STATUS_BADGE`** - two shared derivations for values that several surfaces render side by side, where independent copies would eventually disagree about the same document.

Closes #1645

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) — with the caveats under *Design questions*: narrow-width behaviour is explicitly unresolved and wants the designer
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) — n/a, no user guide exists for this surface
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc — n/a, no telemetry changes
