### PR TITLE
fix(feedback): deliver reports and surface delivery failures

### DIFF
--- a/apps/client/pages/api/feedback/index.ts
+++ b/apps/client/pages/api/feedback/index.ts
@@ -12,7 +12,9 @@ import { adminSettingsRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
 import { NotFoundError } from '@server/utils/errors';
 import { EmailEvents } from '@server/utils/eventBus';
-import { postFeedbackToSlack } from '@server/integrations/slack/slack';
+import { postFeedbackToSlack, type FeedbackDeliveryOutcome } from '@server/integrations/slack/slack';
+import { emitFeedbackDeliveryMetric, FeedbackDeliveryMetrics } from '@server/utils/cloudwatch';
+import { Logger } from '@bike4mind/observability';
 import { toRedactedFeedback } from '@server/utils/redactedFeedback';
 import sanitizeHtml from 'sanitize-html';
 import { z } from 'zod';
@@ -90,9 +92,17 @@ const handler = baseApi()
       );
 
     // Send feedback to Slack if enabled
+    // Delivery outcomes are collected rather than ignored. The record above is already saved, so
+    // the submitter is correctly told it succeeded; the failure this tracks is ours - nobody on our
+    // side hearing about the feedback at all.
+    const delivery: { slack: FeedbackDeliveryOutcome; email: FeedbackDeliveryOutcome } = {
+      slack: { status: 'skipped', reason: 'disabled' },
+      email: { status: 'skipped', reason: 'disabled' },
+    };
+
     if (getSettingsValue('EnableFeedBackToSlack', settings)) {
       console.log('Sending feedback to Slack is enabled');
-      await postFeedbackToSlack(
+      delivery.slack = await postFeedbackToSlack(
         type || 'CS',
         organization,
         username,
@@ -109,6 +119,10 @@ const handler = baseApi()
     console.log(`Sending feedback to all of these folks: ${feedbackEmails}`);
 
     // Send Feedback to Email
+    if (getSettingsValue('EnableFeedBackToEmail', settings) && feedbackEmails.length === 0) {
+      delivery.email = { status: 'skipped', reason: 'no_recipients' };
+    }
+
     if (getSettingsValue('EnableFeedBackToEmail', settings) && feedbackEmails.length > 0) {
       console.log('Sending feedback to email is enabled');
       const sanitizedContent = sanitizeHtml(content);
@@ -120,12 +134,13 @@ const handler = baseApi()
         ? sanitizeHtml(JSON.stringify(promptMetaForExternalEgress, null, 2))
         : '';
 
-      await Promise.all(
-        feedbackEmails.map((email: string) =>
-          EmailEvents.Send.publish({
-            to: email,
-            subject: 'New Feedback Received',
-            body: `
+      try {
+        await Promise.all(
+          feedbackEmails.map((email: string) =>
+            EmailEvents.Send.publish({
+              to: email,
+              subject: 'New Feedback Received',
+              body: `
               <!DOCTYPE html>
               <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
               <head>
@@ -248,12 +263,32 @@ const handler = baseApi()
               </body>
               </html>
               `,
-          })
-        )
-      );
+            })
+          )
+        );
+        delivery.email = { status: 'delivered' };
+      } catch (error) {
+        // Never rethrow: the feedback is stored, and failing the request would tell the submitter
+        // their report was lost when it was not.
+        Logger.error('Error sending feedback to email:', error);
+        delivery.email = { status: 'failed', reason: error instanceof Error ? error.message : String(error) };
+      }
     }
 
-    return res.status(201).send(newFeedback);
+    const failedChannels = (Object.keys(delivery) as Array<keyof typeof delivery>).filter(
+      channel => delivery[channel].status === 'failed'
+    );
+
+    if (failedChannels.length > 0) {
+      Logger.error('Feedback delivery failed', { feedbackId: newFeedback.id, delivery });
+      // Fire-and-forget, and deliberately not awaited into the response path: a metric write must
+      // not delay or fail a submission whose record is already committed.
+      void emitFeedbackDeliveryMetric(FeedbackDeliveryMetrics.FAILED, failedChannels.length, {
+        channels: failedChannels.join(','),
+      });
+    }
+
+    return res.status(201).send({ ...newFeedback.toObject(), delivery });
   });
 
 export const config = {

--- a/apps/client/server/integrations/slack/postFeedbackToSlack.test.ts
+++ b/apps/client/server/integrations/slack/postFeedbackToSlack.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockPost = vi.fn();
+const mockGetSettingsMap = vi.fn();
+const mockGetSettingsValue = vi.fn();
+
+vi.mock('axios', () => ({
+  default: { post: (...args: unknown[]) => mockPost(...args) },
+}));
+
+vi.mock('@bike4mind/utils', () => ({
+  getSettingsMap: (...args: unknown[]) => mockGetSettingsMap(...args),
+  getSettingsValue: (...args: unknown[]) => mockGetSettingsValue(...args),
+}));
+
+vi.mock('@bike4mind/database', () => ({ adminSettingsRepository: {} }));
+
+vi.mock('@bike4mind/observability', () => ({
+  Logger: { error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@bike4mind/common', () => ({ isPlaceholderValue: () => false }));
+
+vi.mock('@server/utils/config', () => ({ Config: {} }));
+
+vi.mock('./emailMirror', () => ({ buildEmailMirrorMessage: vi.fn() }));
+
+import { postFeedbackToSlack } from './slack';
+
+const WEBHOOK = 'https://hooks.slack.example/T000/B000/xxx';
+
+const callWithFeedback = () =>
+  postFeedbackToSlack('BUG', 'Acme', 'someone', 'someone@example.com', 'user-1', 'the answer was wrong', '{}');
+
+describe('postFeedbackToSlack', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSettingsMap.mockResolvedValue({});
+    mockGetSettingsValue.mockReturnValue(WEBHOOK);
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('reports delivered when the webhook accepts the post', async () => {
+    mockPost.mockResolvedValue({ status: 200 });
+
+    await expect(callWithFeedback()).resolves.toEqual({ status: 'delivered' });
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports skipped, not delivered, when no webhook is configured', async () => {
+    mockGetSettingsValue.mockReturnValue(undefined);
+
+    await expect(callWithFeedback()).resolves.toEqual({
+      status: 'skipped',
+      reason: 'no_webhook_configured',
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('reports failed instead of swallowing a transport error', async () => {
+    mockPost.mockRejectedValue(new Error('channel_not_found'));
+
+    await expect(callWithFeedback()).resolves.toEqual({
+      status: 'failed',
+      reason: 'channel_not_found',
+    });
+  });
+
+  // Regression guard. This function used to return early unless NODE_ENV === 'production', which
+  // made delivery unverifiable anywhere except production while doing nothing to keep stages apart
+  // (deployed stages run a production build regardless). Stage separation comes from admin settings
+  // being per-stage, so re-adding an environment gate here would silently break non-prod delivery.
+  it.each(['development', 'test', undefined])('posts when NODE_ENV is %s', async nodeEnv => {
+    if (nodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = nodeEnv;
+    mockPost.mockResolvedValue({ status: 200 });
+
+    await expect(callWithFeedback()).resolves.toEqual({ status: 'delivered' });
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/server/integrations/slack/slack.ts
+++ b/apps/client/server/integrations/slack/slack.ts
@@ -57,6 +57,16 @@ export async function postMessageToSlack(message: string): Promise<void> {
   }
 }
 
+/**
+ * Outcome of one delivery attempt. Returned rather than swallowed because the feedback record is
+ * already saved by the time this runs - the submitter is correctly told it succeeded, and the only
+ * thing that can go wrong from here is that nobody on our side ever hears about it.
+ */
+export type FeedbackDeliveryOutcome =
+  | { status: 'delivered' }
+  | { status: 'skipped'; reason: 'disabled' | 'no_webhook_configured' | 'no_recipients' }
+  | { status: 'failed'; reason: string };
+
 export async function postFeedbackToSlack(
   type: string,
   organization: string,
@@ -65,12 +75,13 @@ export async function postFeedbackToSlack(
   userId: string,
   content: string,
   promptMeta: string
-): Promise<void> {
+): Promise<FeedbackDeliveryOutcome> {
   try {
-    // only production feedbacks is sent to Slack
-    if (process.env.NODE_ENV !== 'production') return;
-
-    // Feedback routes to the feedback channel.
+    // No NODE_ENV gate. Admin settings are per-stage (each stage has its own database, see the
+    // %STAGE% placeholder in the MONGODB_URI template), so SlackFeedbackWebhookUrl already routes
+    // each stage to its own channel. Gating on NODE_ENV instead made non-production stages
+    // unverifiable while doing nothing to separate them, since deployed stages run a production
+    // build regardless.
     const settings = await getSettingsMap({ adminSettings: adminSettingsRepository });
     const slackWebhookUrl = resolveSlackWebhookUrl('SlackFeedbackWebhookUrl', settings);
 
@@ -78,7 +89,7 @@ export async function postFeedbackToSlack(
       Logger.error(
         'Error posting feedback to Slack: no SlackFeedbackWebhookUrl / SlackDefaultWebhookUrl set in admin settings or config'
       );
-      return;
+      return { status: 'skipped', reason: 'no_webhook_configured' };
     }
 
     const message = `*Type:* ${type}\n*User Details:* ${organization} - ${username} (ID: ${userId})\n*User Email:* ${userEmail}\n*Feedback:* ${content}
@@ -91,8 +102,11 @@ export async function postFeedbackToSlack(
         headers: { 'Content-Type': 'application/json' },
       }
     );
+
+    return { status: 'delivered' };
   } catch (error) {
     Logger.error('Error posting feedback to Slack:', error);
+    return { status: 'failed', reason: error instanceof Error ? error.message : String(error) };
   }
 }
 

--- a/apps/client/server/utils/cloudwatch.ts
+++ b/apps/client/server/utils/cloudwatch.ts
@@ -502,3 +502,36 @@ export async function recordReconcileRun(): Promise<void> {
 export async function recordTaxonomyTagsApplySkipped(count: number): Promise<void> {
   return emitDataLakeBatchMetric(DataLakeBatchMetrics.TAXONOMY_TAGS_APPLY_SKIPPED, count, {}, StandardUnit.Count);
 }
+
+// --- Feedback delivery ---------------------------------------------------------------------
+
+const FEEDBACK_DELIVERY_NAMESPACE = 'Lumina5/FeedbackDelivery';
+
+/**
+ * Feedback delivery metric names (typed constants).
+ *
+ * Keep in sync with infra/alarms.ts (`feedbackDeliveryFailure`), which alarms on FAILED.
+ *
+ * SKIPPED and FAILED are deliberately separate: a skip means the route is switched off or
+ * unconfigured (an operator decision, or a gap in setup), while a failure means it was switched on
+ * and the send did not land. Collapsing them would make a disabled integration look like an outage
+ * and an outage look like a config choice.
+ */
+export const FeedbackDeliveryMetrics = {
+  DELIVERED: 'Delivered',
+  FAILED: 'Failed',
+  SKIPPED: 'Skipped',
+} as const;
+
+/**
+ * Feedback delivery metric emitter. Fire-and-forget, like every other emitter here: a metric write
+ * must never fail the feedback submission it is reporting on, since the record is already saved.
+ */
+export async function emitFeedbackDeliveryMetric(
+  metricName: string,
+  value: number,
+  dimensions: MetricDimensions = {},
+  unit: StandardUnit = StandardUnit.Count
+): Promise<void> {
+  return emitMetric(FEEDBACK_DELIVERY_NAMESPACE, metricName, value, dimensions, unit);
+}

--- a/infra/alarms.ts
+++ b/infra/alarms.ts
@@ -129,6 +129,10 @@ export const dataLakeStuckBatchesAlarm = isMonitoredStage
   ? new sst.aws.SnsTopic('DataLakeStuckBatchesAlarm')
   : undefined;
 
+export const feedbackDeliveryFailureAlarm = isMonitoredStage
+  ? new sst.aws.SnsTopic('FeedbackDeliveryFailureAlarm')
+  : undefined;
+
 // --- MetricAlarm definitions (only created for monitored stages) ---
 
 if (isMonitoredStage) {
@@ -1015,6 +1019,35 @@ if (isMonitoredStage) {
    * asked for. Alarms match one exact dimension set, so this uses the Stage-only
    * datapoint; the per-model breakdown lives on the model-sunset dashboard.
    */
+  /**
+   * Alarm: Feedback Delivery Failure
+   *
+   * A user reported a problem, the record was saved, and the notification did not reach anyone.
+   * Threshold 0 (any failure) because the whole point of the delivery path is that a human hears
+   * about it - one dropped report is already the failure this alarm exists to catch, and the volume
+   * is far too low for a rate-based threshold to fire before the signal is lost.
+   *
+   * Metric emitted by: pages/api/feedback/index.ts, via emitFeedbackDeliveryMetric
+   * Namespace: Lumina5/FeedbackDelivery / Failed
+   */
+  new aws.cloudwatch.MetricAlarm('feedbackDeliveryFailure', {
+    name: `${$app.name}-${$app.stage}-feedback-delivery-failure`,
+    alarmDescription: 'Feedback was saved but could not be delivered to Slack or email',
+    comparisonOperator: 'GreaterThanThreshold',
+    evaluationPeriods: 1,
+    metricName: 'Failed',
+    namespace: 'Lumina5/FeedbackDelivery',
+    period: 3600, // 1 hour - submissions are sporadic, so a short window would mostly be empty
+    statistic: 'Sum',
+    threshold: 0,
+    treatMissingData: 'notBreaching',
+    alarmActions: [feedbackDeliveryFailureAlarm!.arn],
+    tags: {
+      Application: 'Feedback',
+      Severity: 'High',
+    },
+  });
+
   new aws.cloudwatch.MetricAlarm('deprecatedModelRequest', {
     name: `${$app.name}-${$app.stage}-deprecated-model-request`,
     alarmDescription: 'A request arrived pinned to a deprecated model - a session or agent pin needs upgrading',


### PR DESCRIPTION
# Pull Request

## Description

Feedback delivery is gated behind four independent conditions. When any of them is unmet the handler
still saves the record and returns `201` -- which is correct as far as it goes, because the feedback
genuinely is captured -- but nothing on our side ever finds out that the notification did not land.
The failure is silent on our side, not the submitter's.

Deliberately **not** changed: the `201`. The record is committed by the time delivery runs, so
telling the submitter it failed would be false in the other direction and would discourage exactly
the submissions we want more of. The defect was never that the user is wrongly reassured; it is that
we never hear.

First item of #1878.

## Changes

- `postFeedbackToSlack` returns a `FeedbackDeliveryOutcome` instead of `void`, so a skip (route
  switched off, or no webhook configured) and a transport failure are distinguishable rather than
  collapsed into a swallowed `Logger.error`.
- **Drops the `NODE_ENV === 'production'` gate.** Admin settings are per-stage -- each stage has its
  own database (the `MONGODB_URI` template carries a `%STAGE%` placeholder) -- so
  `SlackFeedbackWebhookUrl` already routes each stage to its own channel. The env gate separated
  nothing and made delivery unverifiable anywhere except production. A regression test pins this.
- The email path no longer lets an exception escape into the request, for the same reason as the
  `201`: the record is stored, so failing the request would report a loss that did not happen.
- Emits `Lumina5/FeedbackDelivery` / `Failed` via the existing `emitMetric` helper, and alarms on it
  at threshold 0. Submission volume is far too low for a rate-based threshold to fire before the
  signal is lost.
- The `201` body carries the per-channel outcome additively, so existing consumers reading the
  feedback document (`.id`) are unaffected.

## Guide for Testers

This is backend + infra only. There is no UI change.

**What NOT to test:** the feedback modal, the help modal, or any visual surface. Submitting feedback
looks and behaves exactly as before from the user's side -- that is the intent.

1. In Admin Settings on a non-production stage, set `SlackFeedbackWebhookUrl` to a webhook pointing
   at a scratch channel, and turn `EnableFeedBackToSlack` on.
2. Submit any feedback (message overflow menu -> Bug/Feedback, or the Help modal's feedback box).
3. Expect a message in the scratch channel **within a few seconds**. Before this PR nothing arrived
   on a non-production stage at all, because of the `NODE_ENV` gate.
4. Set `SlackFeedbackWebhookUrl` to an invalid URL (e.g. `https://hooks.slack.example/nope`) and
   submit again.
5. Expect: the submission still succeeds in the UI (`201`, no error toast), **and** a
   `Feedback delivery failed` error appears in the logs with a per-channel outcome.
6. Confirm the `Lumina5/FeedbackDelivery` / `Failed` datapoint appears in CloudWatch for the stage.

**Regression check:** with `EnableFeedBackToSlack` off, submitting feedback must still return `201`
and still persist the record; the response's `delivery.slack` should read
`{ status: 'skipped', reason: 'disabled' }`.

## Additional Information

`postFeedbackToSlack` had no test coverage. Added `postFeedbackToSlack.test.ts` (6 cases). The
`NODE_ENV` case is a regression guard and was mutation-checked: re-adding the gate fails the suite.

The alarm follows the existing `deprecatedModelRequest` shape in `infra/alarms.ts` and adds no new
`process.env` read, so `infra/deploy-contract.json` is unchanged.

## Developer Notes (Optional)

- `FeedbackDeliveryOutcome` gives the delivery path a return type where it previously had none;
  the email channel reuses it, so a third channel would slot in without a new shape.
- `emitFeedbackDeliveryMetric` + `FeedbackDeliveryMetrics` follow the existing `WebhookMetrics`
  pattern in `server/utils/cloudwatch.ts`.
- `skipped` and `failed` are separate states on purpose: a disabled integration should not look like
  an outage, and an outage should not look like a config choice.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a, no new settings; this PR only stops ignoring existing ones
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) -- n/a, no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc -- n/a, the new metric is an operational counter with no user content or identity
