### PR TITLE
fix(client): stop the users WS push wiping non-projected user fields

### DIFF
--- a/apps/client/app/contexts/SessionsContext.lastNotebook.test.tsx
+++ b/apps/client/app/contexts/SessionsContext.lastNotebook.test.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ISessionDocument } from '@bike4mind/common';
 
-// changeSession reads the user through the provider's non-reactive `useUser.getState()`
-// snapshot, so the write only fires when this mock carries a lastNotebookId that differs
-// from the session being opened.
+// changeSession reads the user reactively via `useUser(s => s.currentUser?.id)` and
+// `...?.lastNotebookId`, so the write only fires when this mock carries a lastNotebookId that
+// differs from the session being opened.
 const mocks = vi.hoisted(() => ({
   currentUser: { id: 'u1', lastNotebookId: 'session-old' } as { id: string; lastNotebookId: string | null },
   updateUserToServer: vi.fn(),
@@ -14,9 +14,13 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@client/app/utils/userAPICalls', () => ({ updateUserToServer: mocks.updateUserToServer }));
 
-vi.mock('@client/app/contexts/UserContext', () => ({
-  useUser: Object.assign(vi.fn().mockReturnValue(null), { getState: () => ({ currentUser: mocks.currentUser }) }),
-}));
+vi.mock('@client/app/contexts/UserContext', () => {
+  const useUser = (selector?: (s: { currentUser: typeof mocks.currentUser }) => unknown): unknown => {
+    const state = { currentUser: mocks.currentUser };
+    return selector ? selector(state) : state;
+  };
+  return { useUser: Object.assign(useUser, { getState: () => ({ currentUser: mocks.currentUser }) }) };
+});
 
 vi.mock('@client/app/utils/sessionsAPICalls', () => ({
   pushChatMessage: vi.fn().mockResolvedValue({}),
@@ -120,15 +124,19 @@ describe('SessionsContext - lastNotebookId write on session switch', () => {
     expect(lastNotebookErrors()).toHaveLength(0);
   });
 
-  it('skips the write when the user is already on that notebook', async () => {
+  it('skips the write when the user is already on that notebook, but still refreshes the session', async () => {
     mocks.currentUser = { id: 'u1', lastNotebookId: NEW_SESSION_ID };
-    const { result } = renderSessions();
+    const { result, invalidateSpy } = renderSessions();
 
     await act(async () => {
       await result.current.changeSession(NEW_SESSION_ID);
     });
 
     expect(mocks.updateUserToServer).not.toHaveBeenCalled();
+    // #1632 finding 3: the ['sessions', id] invalidation must not be gated on the user-record
+    // comparison. If it were still inside the write guard, opening your stored last notebook
+    // would skip the refresh and serve up-to-30-min-stale data.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions', NEW_SESSION_ID] });
     expect(result.current.currentSessionId).toBe(NEW_SESSION_ID);
   });
 

--- a/apps/client/app/contexts/SessionsContext.tsx
+++ b/apps/client/app/contexts/SessionsContext.tsx
@@ -299,7 +299,12 @@ export const useSystemPromptFiles = () => {
 export const useSessionAgents = (sessionId?: string) => {};
 
 export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
-  const { currentUser } = useUser.getState();
+  // Read reactively (not useUser.getState()): a point-in-time snapshot leaves changeSession
+  // comparing against a stale lastNotebookId, and a null snapshot at mount makes it return early
+  // before opening the session or writing. Narrow primitive selectors keep re-renders to genuine
+  // id / lastNotebookId changes.
+  const currentUserId = useUser(s => s.currentUser?.id);
+  const currentUserLastNotebookId = useUser(s => s.currentUser?.lastNotebookId);
 
   // The current session ID, many components use this to determine if they should render
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
@@ -543,7 +548,7 @@ export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
     async (sessionId: string) => {
       // Early exit if already on this session
       if (sessionId === currentSessionId) return;
-      if (!currentUser?.id) return;
+      if (!currentUserId) return;
 
       // Optimistic session IDs are seeded into the cache and into context by
       // useSendMessage before navigation. The server doesn't know about them
@@ -581,19 +586,24 @@ export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
 
       // Session switch completed - files will be restored via useEffect
 
+      // Refresh the opened session's cached data on every open. Kept independent of the
+      // user-record write below: coupling it to the lastNotebookId comparison meant reopening
+      // your stored last notebook skipped the refresh, so getOrFetchSession could serve a cache
+      // entry up to 30 min stale (ensureQueryData staleTime in app/hooks/data/sessions.ts).
+      queryClient.invalidateQueries({ queryKey: ['sessions', sessionId] });
+
       // Fire-and-forget on purpose: lastNotebookId feeds API chat routing (getSessionId in
       // pages/api/chat.ts), session resumption, and Slack notebook resolution (notebook-manager
       // in b4m-core/slack, which only ever reads it - a lost write is repaired by the next
       // web-app message, never by a Slack one). Awaiting would hold up the switch, and a toast
       // would interrupt a path the user is actively navigating.
-      if (sessionId && currentUser.lastNotebookId !== sessionId) {
-        updateUserToServer(currentUser.id, { lastNotebookId: sessionId }).catch(error => {
+      if (currentUserLastNotebookId !== sessionId) {
+        updateUserToServer(currentUserId, { lastNotebookId: sessionId }).catch(error => {
           console.error('[SessionsContext] Failed to persist lastNotebookId to server', error);
         });
-        queryClient.invalidateQueries({ queryKey: ['sessions', sessionId] });
       }
     },
-    [currentSessionId, currentUser?.id, queryClient, currentUser?.lastNotebookId, setWorkBenchFiles, initializeSession]
+    [currentSessionId, currentUserId, queryClient, currentUserLastNotebookId, setWorkBenchFiles, initializeSession]
   );
 
   // Whether the context's session copy can be BELIEVED about having no knowledge files: every

--- a/apps/client/app/contexts/UserContext.test.tsx
+++ b/apps/client/app/contexts/UserContext.test.tsx
@@ -8,6 +8,7 @@ import {
   resolveIdentifyEffect,
   shouldAdoptIdentifyToken,
   shouldRevokeForTokenVersion,
+  applyUserPush,
 } from './UserContext';
 
 // Builds a JWT-shaped string (unsigned - decodeTokenVersion never verifies the
@@ -183,6 +184,58 @@ describe('shouldRevokeForTokenVersion — JWT kill switch (legacy-token gap fix)
   it('does not revoke a legacy token while the DB version is still 0/unset', () => {
     const legacyToken = fakeToken({ id: 'u1' });
     expect(shouldRevokeForTokenVersion({ accessToken: legacyToken, userTokenVersion: 0 })).toBe(false);
+  });
+});
+
+describe('applyUserPush - merge a users WS push onto the store user (#1632)', () => {
+  it('preserves fields absent from the push (the projection-wipe bug)', () => {
+    // A full document from /api/identify, then a push carrying only the projected subset.
+    const existing = fakeUser({
+      lastNotebookId: 'nb-1',
+      blogIntegration: { enabled: true },
+      isBanned: true,
+    } as Partial<IUserDocument>);
+    const pushed = { id: 'u1', currentCredits: 42 } as unknown as IUserDocument;
+
+    const merged = applyUserPush(existing, pushed) as unknown as Record<string, unknown>;
+
+    // Projected field updates...
+    expect(merged.currentCredits).toBe(42);
+    // ...while every non-projected field survives instead of being wiped to undefined.
+    expect(merged.lastNotebookId).toBe('nb-1');
+    expect(merged.blogIntegration).toEqual({ enabled: true });
+    expect(merged.isBanned).toBe(true);
+  });
+
+  it('lets a field present in the push win, so server-side clears still propagate', () => {
+    const existing = fakeUser({ lastNotebookId: 'nb-1' } as Partial<IUserDocument>);
+    // The field is in the projection and was cleared server-side: present-as-null overwrites.
+    const pushed = { id: 'u1', lastNotebookId: null } as unknown as IUserDocument;
+
+    const merged = applyUserPush(existing, pushed) as unknown as Record<string, unknown>;
+
+    expect(merged.lastNotebookId).toBeNull();
+  });
+
+  it('adopts the pushed subset as-is when there is no existing user', () => {
+    const pushed = { id: 'u1', currentCredits: 7 } as unknown as IUserDocument;
+
+    const merged = applyUserPush(null, pushed) as unknown as Record<string, unknown>;
+
+    expect(merged).toEqual({ id: 'u1', currentCredits: 7 });
+  });
+
+  it('keeps store-derived flags (isBanned/isModerated) intact when the push omits them', () => {
+    // The blast-radius trap: these flags are not in the projection, so a replace reset them to
+    // false. Fed through setCurrentUser, the merged object must keep the real values.
+    useUser.setState({ currentUser: null, isHydrated: false });
+    const existing = fakeUser({ isBanned: true, isModerated: true } as Partial<IUserDocument>);
+    const pushed = { id: 'u1', currentCredits: 1 } as unknown as IUserDocument;
+
+    useUser.getState().setCurrentUser(applyUserPush(existing, pushed));
+
+    expect(useUser.getState().isBanned).toBe(true);
+    expect(useUser.getState().isModerated).toBe(true);
   });
 });
 

--- a/apps/client/app/contexts/UserContext.tsx
+++ b/apps/client/app/contexts/UserContext.tsx
@@ -378,6 +378,16 @@ export function resolveIdentifyEffect(params: {
  */
 export const shouldAdoptIdentifyToken = (heldToken: string | null | undefined): boolean => !heldToken;
 
+/**
+ * Merge a `users` WebSocket push onto the existing store user. The push carries only the
+ * subscription's projected fields, so replacing would wipe every non-projected field (integration
+ * settings, lastNotebookId, isBanned/isModerated, ...); merging updates the projected fields and
+ * preserves the rest. `existing` may be null (no user yet), in which case the pushed subset is
+ * adopted as-is. Exported for unit testing.
+ */
+export const applyUserPush = (existing: IUserDocument | null, pushed: IUserDocument): IUserDocument =>
+  ({ ...(existing ?? {}), ...pushed }) as IUserDocument;
+
 /** Provides user data and operations to children via the zustand store. */
 export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
   const [userId, setCurrentUser] = useUser(useShallow(s => [s.currentUser?.id, s.setCurrentUser, s.refreshUser]));
@@ -397,7 +407,13 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       (_type: string, data: IUserDocument) => {
         if (data && data.id === userId) {
           try {
-            setCurrentUser({ ...data });
+            // The 'users' push carries only the projected `fields` (see the options below), so
+            // replacing the store user would wipe every field outside that projection (integration
+            // settings, lastNotebookId, isBanned/isModerated, ...). Merge onto the existing user so
+            // a push updates the projected fields and leaves the rest intact. Tradeoff: a field
+            // cleared server-side but absent from the projection keeps its stale value until the
+            // next refreshUser()/identify.
+            setCurrentUser(applyUserPush(useUser.getState().currentUser, data));
             // Real-time kill switch: if the user's tokenVersion has advanced
             // past the version embedded in this tab's access token, the session
             // was revoked server-side (password reset / MFA change / unlink) -
@@ -461,8 +477,9 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         // Security and permissions
         mfa: 1,
         groups: 1,
-        // Integration settings (subscription replaces currentUser entirely,
-        // so slackSettings must be included or it gets wiped on every update)
+        // Integration settings: projected so a real-time slackSettings change reaches this tab.
+        // The handler now merges rather than replaces, so a field absent here is no longer wiped -
+        // it just doesn't update in real time and refreshes on the next refreshUser()/identify.
         slackSettings: 1,
       },
     }


### PR DESCRIPTION
## Description

Closes #1632.

The `users` WebSocket subscription in `UserContext` replaced the whole store user with the narrow projected payload (`setCurrentUser({ ...data })`), so any field outside the subscription's `fields` projection - integration settings (`blogIntegration`, `platformEmailAddress`, ...), `lastNotebookId`, `isBanned`/`isModerated`, and every field added later - was dropped from the store on every push. With `fetchInitialData: true` the subscription fetches on mount, so this could happen seconds after login with no user action. The projection was silently load-bearing for correctness (the old `slackSettings` comment is the tell), and every new field was opt-in to surviving.

This addresses all three coupled findings the issue tracked, all client-side.

## Changes

**Finding 1 - merge instead of replace (`UserContext.tsx`)**
- New exported pure helper `applyUserPush(existing, pushed)` = `{ ...existing, ...pushed }`, following the file's existing exported-helper-plus-unit-test pattern (`resolveIdentifyEffect`, `shouldAdoptIdentifyToken`, `shouldRevokeForTokenVersion`).
- The subscription handler now merges the push onto the current store user instead of replacing it, so a push updates the projected fields and leaves the rest intact. This also closes the latent `isBanned`/`isModerated` reset-to-false noted in the issue's blast radius (neither is projected).
- Rewrote the now-obsolete `slackSettings` projection comment to describe why the field is projected (real-time propagation) rather than the wipe it no longer prevents.
- Tradeoff (chosen direction): a field cleared server-side but absent from the projection keeps its stale value until the next `refreshUser()`/`identify`. This is strictly better than the prior wipe-to-undefined, and it reduces the number of hand-maintained field lists rather than growing them.

**Finding 2 - reactive read (`SessionsContext.tsx`)**
- `SessionsProvider` took the user via `useUser.getState()`, a point-in-time snapshot: the `lastNotebookId` guard compared a stale value, and a null snapshot at mount made `changeSession` return early before opening the session or writing. Switched to narrow reactive selectors (`s => s.currentUser?.id`, `s => s.currentUser?.lastNotebookId`) so re-renders track only genuine id/lastNotebookId changes.

**Finding 3 - decoupled invalidation (`SessionsContext.tsx`)**
- The `['sessions', id]` invalidation sat inside the user-record guard, so reopening your stored last notebook skipped the refresh and `getOrFetchSession` could serve a cache entry up to 30 min stale (`ensureQueryData` staleTime). Hoisted it to run on every session open, independent of the `lastNotebookId` comparison.

## Guide for Testers

Client-only. Two independent behaviours to confirm; no reload between the trigger and the check.

**A - a configured integration must survive a push:**
1. Sign in with an account that has Profile -> Settings -> email or blog integration configured.
2. Send one message in any notebook. This changes `currentCredits` (which is projected), so the `users` subscription pushes and the handler updates the store user.
3. Reopen Profile -> Settings **without reloading**. Expected: the integration still shows its saved values. (On `main` it reads as unconfigured until a reload.)

**B - no redundant lastNotebookId write, and the session still refreshes:**
1. Sign in, open DevTools -> Network, filter on `update`.
2. Note your current notebook (the stored `lastNotebookId`). Open a *different* notebook -> exactly one `PUT /api/users/<id>/update`.
3. Reopen the notebook already recorded as `lastNotebookId` -> **no** `PUT`. (On `main`, after a push has landed, essentially every switch writes because the store's `lastNotebookId` was `undefined`.)
4. Reopening that stored notebook still refreshes its session data (the `['sessions', id]` invalidation runs regardless of the user-record comparison).

## Additional Information

**Design decision.** The issue left the finding-1 approach open (merge vs extend the projection) and said a reviewer should not treat either as pre-agreed. This PR takes **merge**: it fixes the whole class in one place, covers fields added later, and shrinks rather than grows the hand-maintained field lists the issue flagged. The documented downside (a server-side clear of a non-projected field lingers until the next identify) is accepted as strictly better than the current wipe.

**Verification (author self-verification).** The exact WS-push code path is not naturally drivable from a preview by hand, so it is unit- and mutation-covered rather than driven live:
- `applyUserPush` - preserves non-projected fields, lets a present field win (server clears still propagate), adopts the pushed subset when there is no existing user, and (through `setCurrentUser`) keeps the derived `isBanned`/`isModerated` flags. Mutation: reverting to a replace (`{ ...pushed }`) fails the preserve + derived-flag tests.
- The decoupled invalidation - a dedicated test asserts the `['sessions', id]` invalidation fires even when the write is skipped. Mutation: moving the invalidation back inside the write guard fails it.
- Both changed suites plus the two sibling `SessionsContext` suites: 40/40 green.
- Local `tsc` here only surfaces the known stale-`@bike4mind/common`-dist errors in unrelated files; none touch these files, and the diff adds no new `@bike4mind/common` type surface. CI's fresh build is the typecheck arbiter.

I checked every other `setCurrentUser({...})` call site (Agent views, TagSidebar, mcpServers, UserSettings): all already merge onto `currentUser` (`{ ...currentUser, field }`), so the subscription handler was the only replace-with-projection site - no sibling of the bug left behind.

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (n/a - no settings)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) (n/a - no UI change)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings