### PR TITLE
fix(marketing): populate required feedback fields and handle submit errors

### DIFF
--- a/apps/client/app/components/BugReportModal.tsx
+++ b/apps/client/app/components/BugReportModal.tsx
@@ -61,20 +61,24 @@ const BugReportModal: React.FC<BugReportModalProps> = ({ open, onClose, promptMe
     },
   });
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     console.log('Submitting bug report:', bugReport);
-    createFeedbackOnServer({
-      userId: userContext?.currentUser?.id ?? 'Unknown',
-      username: userContext?.currentUser?.username ?? 'Unknown',
-      userEmail: userContext?.currentUser?.email ?? 'Unknown',
-      tags: ['bug', 'feedback', 'bugReport'],
-      type: feedbackType,
-      content: bugReport || 'No feedback details provided',
-      promptMeta: promptMeta ?? {},
-    });
-    onClose();
-    toast.success(`${feedbackType} report submitted successfully`);
-    setBugReport('');
+    try {
+      await createFeedbackOnServer({
+        userId: userContext?.currentUser?.id ?? 'Unknown',
+        username: userContext?.currentUser?.username ?? 'Unknown',
+        userEmail: userContext?.currentUser?.email ?? 'Unknown',
+        tags: ['bug', 'feedback', 'bugReport'],
+        type: feedbackType,
+        content: bugReport || 'No feedback details provided',
+        promptMeta: promptMeta ?? {},
+      });
+      onClose();
+      toast.success(`${feedbackType} report submitted successfully`);
+      setBugReport('');
+    } catch {
+      toast.error('Something went wrong. Please try again.');
+    }
   };
 
   return (

--- a/apps/client/app/components/BugReportModal.tsx
+++ b/apps/client/app/components/BugReportModal.tsx
@@ -23,6 +23,7 @@ interface BugReportModalProps {
 const BugReportModal: React.FC<BugReportModalProps> = ({ open, onClose, promptMeta }) => {
   const [bugReport, setBugReport] = useState('');
   const [feedbackType, setFeedbackType] = useState<FeedbackType>(FeedbackType.BUG);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const userContext = useUser();
   const theme = useTheme();
   const handleFeedbackTypeChange = (type: FeedbackType) => {
@@ -62,7 +63,9 @@ const BugReportModal: React.FC<BugReportModalProps> = ({ open, onClose, promptMe
   });
 
   const handleSubmit = async () => {
+    if (isSubmitting) return;
     console.log('Submitting bug report:', bugReport);
+    setIsSubmitting(true);
     try {
       await createFeedbackOnServer({
         userId: userContext?.currentUser?.id ?? 'Unknown',
@@ -76,8 +79,11 @@ const BugReportModal: React.FC<BugReportModalProps> = ({ open, onClose, promptMe
       onClose();
       toast.success(`${feedbackType} report submitted successfully`);
       setBugReport('');
-    } catch {
+    } catch (error) {
+      console.error('Failed to submit bug report:', error);
       toast.error('Something went wrong. Please try again.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -136,7 +142,7 @@ const BugReportModal: React.FC<BugReportModalProps> = ({ open, onClose, promptMe
           <Button onClick={onClose} variant="outlined">
             Cancel
           </Button>
-          <Button onClick={handleSubmit} variant="solid">
+          <Button onClick={handleSubmit} variant="solid" disabled={isSubmitting}>
             Submit
           </Button>
         </Box>

--- a/apps/client/app/components/HelpModal.tsx
+++ b/apps/client/app/components/HelpModal.tsx
@@ -80,10 +80,7 @@ export const HelpModal: React.FC = () => {
         console.error('Feedback content is empty');
         return;
       }
-      toast.success('Thank you! Your feedback has been submitted.');
       console.log('Submitting feedback:', currentUser?.email);
-
-      toggleShowHelp();
 
       const feedbackCreated = await createFeedbackOnServer({
         userId: userId,
@@ -99,9 +96,12 @@ export const HelpModal: React.FC = () => {
         metadata: { id: feedbackCreated.id, content: feedbackCreated.content },
       });
 
+      toast.success('Thank you! Your feedback has been submitted.');
+      toggleShowHelp();
       setFeedbackContent('');
     } catch (error) {
       console.error('Failed to submit feedback:', error);
+      toast.error('Something went wrong. Please try again.');
     }
   };
   if (!settings.showHelp) return null;

--- a/apps/client/app/components/HelpModal.tsx
+++ b/apps/client/app/components/HelpModal.tsx
@@ -39,6 +39,7 @@ export const HelpModal: React.FC = () => {
   const logEvent = useLogEvent();
   const { settings, updatePreferences } = useUserSettings();
   const [feedbackContent, setFeedbackContent] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const theme = useTheme();
   const [productType] = useState<ProductType>(ProductType.Bike4Mind);
   const [productTitle] = useState<string>(APP_NAME);
@@ -75,12 +76,14 @@ export const HelpModal: React.FC = () => {
   };
 
   const handleSubmitFeedback = async () => {
+    if (isSubmitting) return;
     try {
       if (!feedbackContent.trim()) {
         console.error('Feedback content is empty');
         return;
       }
       console.log('Submitting feedback:', currentUser?.email);
+      setIsSubmitting(true);
 
       const feedbackCreated = await createFeedbackOnServer({
         userId: userId,
@@ -102,6 +105,8 @@ export const HelpModal: React.FC = () => {
     } catch (error) {
       console.error('Failed to submit feedback:', error);
       toast.error('Something went wrong. Please try again.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
   if (!settings.showHelp) return null;
@@ -222,6 +227,7 @@ export const HelpModal: React.FC = () => {
               },
             }}
             onClick={handleSubmitFeedback}
+            disabled={isSubmitting}
           >
             Send Feedback
           </Button>

--- a/apps/client/app/components/b4m/ComingSoon.test.tsx
+++ b/apps/client/app/components/b4m/ComingSoon.test.tsx
@@ -40,10 +40,8 @@ describe('ComingSoon', () => {
 
     await waitFor(() => expect(createFeedbackOnServer).toHaveBeenCalledTimes(1));
     const payload = createFeedbackOnServer.mock.calls[0][0];
-    expect(payload.content).toEqual(expect.any(String));
-    expect(payload.content.length).toBeGreaterThan(0);
-    expect(payload.username).toEqual(expect.any(String));
-    expect(payload.username.length).toBeGreaterThan(0);
+    expect(payload.content).toBe('Coming soon signup');
+    expect(payload.username).toBe('signup@example.com');
     expect(payload.userEmail).toBe('signup@example.com');
 
     expect(toast.success).toHaveBeenCalled();
@@ -61,5 +59,27 @@ describe('ComingSoon', () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('disables the submit button while the request is in flight, so a second click cannot double-submit', async () => {
+    let resolveSubmit: () => void = () => {};
+    createFeedbackOnServer.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveSubmit = resolve;
+        })
+    );
+    const user = userEvent.setup();
+
+    render(<ComingSoon />, { wrapper: TestWrapper });
+    await user.type(screen.getByTestId('coming-soon-email-input'), 'signup@example.com');
+    const submitBtn = screen.getByTestId('coming-soon-submit-btn');
+    await user.click(submitBtn);
+
+    await waitFor(() => expect(submitBtn).toBeDisabled());
+    expect(createFeedbackOnServer).toHaveBeenCalledTimes(1);
+
+    resolveSubmit();
+    await waitFor(() => expect(submitBtn).not.toBeDisabled());
   });
 });

--- a/apps/client/app/components/b4m/ComingSoon.test.tsx
+++ b/apps/client/app/components/b4m/ComingSoon.test.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import ComingSoon from './ComingSoon';
+
+const createFeedbackOnServer = vi.fn();
+
+vi.mock('@client/app/utils/feedbackAPICalls', () => ({
+  createFeedbackOnServer: (...args: unknown[]) => createFeedbackOnServer(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+describe('ComingSoon', () => {
+  beforeEach(async () => {
+    createFeedbackOnServer.mockReset();
+    const { toast } = await import('sonner');
+    (toast.success as ReturnType<typeof vi.fn>).mockReset();
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('sends a schema-satisfying payload and shows success on a resolved submit', async () => {
+    createFeedbackOnServer.mockResolvedValue({});
+    const { toast } = await import('sonner');
+    const user = userEvent.setup();
+
+    render(<ComingSoon />, { wrapper: TestWrapper });
+    await user.type(screen.getByTestId('coming-soon-email-input'), 'signup@example.com');
+    await user.click(screen.getByTestId('coming-soon-submit-btn'));
+
+    await waitFor(() => expect(createFeedbackOnServer).toHaveBeenCalledTimes(1));
+    const payload = createFeedbackOnServer.mock.calls[0][0];
+    expect(payload.content).toEqual(expect.any(String));
+    expect(payload.content.length).toBeGreaterThan(0);
+    expect(payload.username).toEqual(expect.any(String));
+    expect(payload.username.length).toBeGreaterThan(0);
+    expect(payload.userEmail).toBe('signup@example.com');
+
+    expect(toast.success).toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast, not a success toast, when the submit rejects', async () => {
+    createFeedbackOnServer.mockRejectedValue(new Error('422'));
+    const { toast } = await import('sonner');
+    const user = userEvent.setup();
+
+    render(<ComingSoon />, { wrapper: TestWrapper });
+    await user.type(screen.getByTestId('coming-soon-email-input'), 'signup@example.com');
+    await user.click(screen.getByTestId('coming-soon-submit-btn'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/b4m/ComingSoon.tsx
+++ b/apps/client/app/components/b4m/ComingSoon.tsx
@@ -60,6 +60,7 @@ const ComingSoon = () => {
         }}
       >
         <Input
+          data-testid="coming-soon-email-input"
           placeholder="Your Email Address"
           type="email"
           value={email}
@@ -67,6 +68,7 @@ const ComingSoon = () => {
           sx={{ width: '100%', maxWidth: '400px' }}
         />
         <Button
+          data-testid="coming-soon-submit-btn"
           type="submit"
           sx={{ mt: 2, backgroundColor: 'primary', '&:hover': { backgroundColor: 'primary.dark' } }}
         >

--- a/apps/client/app/components/b4m/ComingSoon.tsx
+++ b/apps/client/app/components/b4m/ComingSoon.tsx
@@ -18,14 +18,20 @@ const ComingSoon = () => {
       return;
     }
 
-    await createFeedbackOnServer({
-      userId: 'Unknown',
-      userEmail: email,
-      tags: ['comingSoon', 'marketing'],
-      status: FeedbackStatus.New,
-    });
+    try {
+      await createFeedbackOnServer({
+        userId: 'Unknown',
+        content: 'Coming soon signup',
+        username: email,
+        userEmail: email,
+        tags: ['comingSoon', 'marketing'],
+        status: FeedbackStatus.New,
+      });
 
-    toast.success('Thank you! You will be notified when we launch.');
+      toast.success('Thank you! You will be notified when we launch.');
+    } catch {
+      toast.error('Something went wrong. Please try again.');
+    }
   };
 
   return (

--- a/apps/client/app/components/b4m/ComingSoon.tsx
+++ b/apps/client/app/components/b4m/ComingSoon.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 
 const ComingSoon = () => {
   const [email, setEmail] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);
@@ -17,7 +18,9 @@ const ComingSoon = () => {
       toast.error('Please fill out all fields.');
       return;
     }
+    if (isSubmitting) return;
 
+    setIsSubmitting(true);
     try {
       await createFeedbackOnServer({
         userId: 'Unknown',
@@ -29,8 +32,11 @@ const ComingSoon = () => {
       });
 
       toast.success('Thank you! You will be notified when we launch.');
-    } catch {
+    } catch (error) {
+      console.error('Failed to submit signup:', error);
       toast.error('Something went wrong. Please try again.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -70,6 +76,7 @@ const ComingSoon = () => {
         <Button
           data-testid="coming-soon-submit-btn"
           type="submit"
+          disabled={isSubmitting}
           sx={{ mt: 2, backgroundColor: 'primary', '&:hover': { backgroundColor: 'primary.dark' } }}
         >
           Notify Me

--- a/apps/client/pages/api/feedback/__tests__/logEvent.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/logEvent.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: unknown, res: unknown) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    get: () => chain,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const savedFeedback = { id: 'fb1' };
+const mockSave = vi.fn().mockResolvedValue(undefined);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function FeedbackModelMock(this: any, data: unknown) {
+  Object.assign(this, data, { id: savedFeedback.id, save: mockSave });
+}
+
+vi.mock('@bike4mind/database', () => ({
+  FeedbackModel: FeedbackModelMock,
+  User: { findOne: vi.fn().mockReturnValue({ populate: vi.fn().mockResolvedValue(null) }) },
+  adminSettingsRepository: {},
+}));
+
+const mockLogEvent = vi.fn().mockResolvedValue(undefined);
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: (...args: unknown[]) => mockLogEvent(...args) }));
+
+vi.mock('@server/integrations/slack/slack', () => ({ postFeedbackToSlack: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@server/utils/eventBus', () => ({ EmailEvents: { Send: { publish: vi.fn().mockResolvedValue(undefined) } } }));
+vi.mock('@bike4mind/utils', () => ({
+  getSettingsMap: vi.fn().mockResolvedValue({}),
+  getSettingsValue: vi.fn(() => false),
+}));
+
+import '../index';
+
+describe('POST /api/feedback - logs the authenticated caller, not the request body', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs req.user.id even when the body carries a non-ObjectId placeholder userId', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        userId: 'Unknown',
+        content: 'Coming soon signup',
+        tags: ['comingSoon', 'marketing'],
+        username: 'tester@example.com',
+        userEmail: 'tester@example.com',
+      },
+    });
+    (req as unknown as { isAuthenticated: () => boolean }).isAuthenticated = () => true;
+    (req as unknown as { user: { id: string; username: string; email: string } }).user = {
+      id: 'real-user-id',
+      username: 'real-user',
+      email: 'real-user@example.com',
+    };
+
+    await mockRefs.postHandler!(req, res);
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1);
+    const [event] = mockLogEvent.mock.calls[0];
+    expect(event.userId).toBe('real-user-id');
+    expect(event.userId).not.toBe('Unknown');
+  });
+});

--- a/apps/client/pages/api/feedback/index.ts
+++ b/apps/client/pages/api/feedback/index.ts
@@ -85,7 +85,7 @@ const handler = baseApi()
 
     if (authenticated)
       await logEvent(
-        { userId, type: FeedbackEvents.CREATE_FEEDBACK, metadata: { id: newFeedback.id, content } },
+        { userId: req.user.id, type: FeedbackEvents.CREATE_FEEDBACK, metadata: { id: newFeedback.id, content } },
         { ability: req.ability }
       );
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="722" height="110" alt="bug-report-modal-success-toast" src="https://github.com/user-attachments/assets/624c3184-bf15-4652-b6a5-28b3d0ef8d26" />

*Figure: a real Report submission, live in the app - the success toast only appears once the request actually resolves.*
<img width="722" height="122" alt="help-modal-success-toast" src="https://github.com/user-attachments/assets/eee76d1d-0d72-4c67-a42d-aa1d72f11ffb" />

*Figure: the Help modal's feedback submission, showing the same fixed success-gating live.*

## Description
The marketing "Coming Soon" signup form submits `{ userId, userEmail, tags, status }` to `/api/feedback`, but that endpoint's schema requires `content` and `username` too, so every submission returns a 422. The submit call isn't caught, and the success toast fires unconditionally, so users see "Thank you!" while their signup is silently dropped.

Fixed by adding the missing fields and gating the success toast on the request actually resolving. A repo-wide sweep for the same shape found two more feedback submit handlers with the identical "toast fires regardless of outcome" defect (one didn't even await the call), so those are fixed here too. Verifying the fix live also surfaced a second, previously-masked bug on the same route: with the schema fix in place, an authenticated submission of the placeholder `userId` used to 404 (a logging call was keyed off the raw request body instead of the actual signed-in user), which is fixed alongside it.

Closes #1897

## Changes
- `ComingSoon.tsx`: populate `content`/`username`, wrap the submit in try/catch, show an error toast on failure
- `BugReportModal.tsx`: await the submit, gate success on resolution, add an error toast
- `HelpModal.tsx`: move the success toast/modal-close to after the request resolves instead of before it starts; add an error toast on catch
- `apps/client/pages/api/feedback/index.ts`: log the authenticated user's own id instead of the request body's, fixing the newly-surfaced 404
- `ComingSoon.test.tsx`: new coverage for the success and failure submit paths
- `pages/api/feedback/__tests__/logEvent.test.ts`: pins that the logged id is the authenticated caller's, not the request body's

## Guide for Testers

1. Verify the server-side fix directly against a self-hosted local instance: create a session with `POST /api/test/create-user` (`{"username":"t","email":"t-e2e@test.com","name":"T","password":"TestPassword123!"}`, header `x-e2e-cleanup-secret: <your local E2E_CLEANUP_SECRET>`), take the returned `accessToken`, then `curl -X POST http://localhost:3000/api/feedback -H "Content-Type: application/json" -H "Authorization: Bearer <accessToken>" -d '{"userId":"Unknown","content":"Coming soon signup","username":"tester@example.com","userEmail":"tester@example.com","tags":["comingSoon","marketing"],"status":"New"}'` -> expect HTTP 201, not 422 or 404.
2. In the app, open a chat session, hover an assistant message, open its options menu, click "Report". Fill in the text box and click "Submit". Expected: the modal only closes and shows the "report submitted successfully" toast after the request completes; it no longer closes/toasts immediately regardless of the network result.
3. Open Profile -> General Settings, click "Help". In "Bug Reports, Questions and Feedback", type a message and click "Send Feedback". Expected: the success toast now appears only once the submission actually completes, not before the request is even sent.

What NOT to test: the marketing `ComingSoon` page itself has no live-reachable path in the current app (confirmed by toggling server status to both `maintenance` and `offline` against a real non-admin session: `maintenance` renders a separate gamified loading page, and nothing else ever renders `ComingSoon`). Step 1 above verifies its server-side fix directly; the client-side toast gating is covered by `ComingSoon.test.tsx` (see Additional Information).

## Additional Information
`ComingSoon.test.tsx` unit-tests the success/error toast gating (`pnpm --filter @bike4mind/client test ComingSoon.test.tsx`); BugReportModal/HelpModal share the identical logic shape but have no pre-existing test file, matching their prior untested convention.

## Developer Notes (Optional)
`/api/feedback` defaults to `baseApi()`'s `auth: true`, so even once `ComingSoon` is reachable again, an anonymous marketing visitor would 401 before reaching this fix's validation logic. Fixing reachability and/or anonymous access is a separate, deliberate change; flagging so a future PR re-enabling this surface accounts for both gaps.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
