### PR TITLE
fix(client): webhook delivery alarm now receives DeliveryFailed data

### DIFF
--- a/apps/client/server/queueHandlers/githubWebhook.test.ts
+++ b/apps/client/server/queueHandlers/githubWebhook.test.ts
@@ -352,5 +352,23 @@ describe('processOrgWebhook — delivery-status priority chain', () => {
       const failedCalls = mockEmitWebhookDeliveryMetric.mock.calls.filter(c => c[0] === 'DeliveryFailed');
       expect(failedCalls).toHaveLength(0);
     });
+
+    it('also emits a dimensionless DeliveryFailed total, so the alarm (which has no dimension filter) receives data', async () => {
+      mockFindByOrgAndRepo.mockResolvedValue([makeSubscriber('user-a'), makeSubscriber('user-b')]);
+      mockHandle.mockResolvedValue({
+        notifiedUserIds: [],
+        failedNotifications: [
+          { userId: 'user-a', error: 'channel_not_found' },
+          { userId: 'user-b', error: 'account_inactive' },
+        ],
+      });
+
+      await dispatch(makeSqsEvent(makeOrgMessage()), mockContext, mockLogger);
+
+      const calls = mockEmitWebhookDeliveryMetric.mock.calls;
+      const dimensionless = calls.find(c => c[0] === 'DeliveryFailed' && Object.keys(c[2] as object).length === 0);
+      expect(dimensionless).toBeDefined();
+      expect(dimensionless![1]).toBe(2);
+    });
   });
 });

--- a/apps/client/server/queueHandlers/githubWebhook.ts
+++ b/apps/client/server/queueHandlers/githubWebhook.ts
@@ -451,6 +451,17 @@ async function emitDeliveryFailureMetrics(
     );
   }
 
+  // Dimensionless copy of the total: webhookDeliveryHighFailures (infra/alarms.ts) alarms on
+  // this metric with no dimension filter, so it needs its own dimensionless data point to
+  // receive any data - see apps/client/server/utils/cloudwatch.ts:recordWebhookDeliveryFailure
+  // for the same pattern on the per-user MCP delivery path.
+  const totalFailureCount = counts.handlerErrorCount + counts.perUserFailureCount + counts.dispatchErrorCount;
+  if (totalFailureCount > 0) {
+    emissions.push(
+      emitWebhookDeliveryMetric(WebhookMetrics.DELIVERY_FAILED, totalFailureCount, {}, StandardUnit.Count)
+    );
+  }
+
   await Promise.all(emissions);
 }
 

--- a/apps/client/server/queueHandlers/githubWebhook.ts
+++ b/apps/client/server/queueHandlers/githubWebhook.ts
@@ -409,8 +409,9 @@ async function processOrgWebhook(message: z.infer<typeof OrgWebhookPayloadSchema
 }
 
 /**
- * Emit DeliveryFailed metrics in batched calls, one per error category, so
- * the alarm sees realistic totals without exploding metric cardinality.
+ * Emit DeliveryFailed metrics in batched calls, one per error category plus a
+ * dimensionless total, so the alarm sees realistic totals without exploding
+ * metric cardinality.
  */
 async function emitDeliveryFailureMetrics(
   orgId: string,

--- a/apps/client/server/utils/cloudwatch.test.ts
+++ b/apps/client/server/utils/cloudwatch.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const send = vi.fn();
+
+vi.mock('@aws-sdk/client-cloudwatch', () => ({
+  CloudWatchClient: vi.fn(function (this: any) {
+    this.send = send;
+  }),
+  PutMetricDataCommand: vi.fn(function (this: any, input: unknown) {
+    this.input = input;
+  }),
+  StandardUnit: { Count: 'Count', Milliseconds: 'Milliseconds', None: 'None', Percent: 'Percent' },
+}));
+
+import { recordWebhookDeliveryFailure } from './cloudwatch';
+
+describe('recordWebhookDeliveryFailure', () => {
+  beforeEach(() => {
+    send.mockReset().mockResolvedValue(undefined);
+  });
+
+  // webhookDeliveryHighFailures (infra/alarms.ts) alarms on DeliveryFailed with no
+  // dimension filter, so it only receives data from a dimensionless datapoint - the
+  // dimensioned one is a separate CloudWatch metric stream the alarm never sees.
+  it('emits a dimensionless DeliveryFailed datapoint alongside the dimensioned one', async () => {
+    await recordWebhookDeliveryFailure('org-1', 'event.type', 100, 500, 'timeout');
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const { MetricData } = send.mock.calls[0][0].input;
+    const failedData = MetricData.filter((d: { MetricName: string }) => d.MetricName === 'DeliveryFailed');
+
+    expect(failedData).toHaveLength(2);
+    expect(failedData).toContainEqual(
+      expect.objectContaining({
+        MetricName: 'DeliveryFailed',
+        Value: 1,
+        Dimensions: [
+          { Name: 'orgId', Value: 'org-1' },
+          { Name: 'eventType', Value: 'event.type' },
+          { Name: 'errorType', Value: 'timeout' },
+        ],
+      })
+    );
+    expect(failedData).toContainEqual(
+      expect.objectContaining({ MetricName: 'DeliveryFailed', Value: 1, Dimensions: [] })
+    );
+  });
+
+  it('still emits the dimensionless DeliveryFailed datapoint when httpStatusCode is absent', async () => {
+    await recordWebhookDeliveryFailure('org-1', 'event.type', 100, 0, 'timeout');
+
+    const { MetricData } = send.mock.calls[0][0].input;
+    const dimensionless = MetricData.filter(
+      (d: { MetricName: string; Dimensions: unknown[] }) =>
+        d.MetricName === 'DeliveryFailed' && d.Dimensions.length === 0
+    );
+    expect(dimensionless).toHaveLength(1);
+  });
+
+  it('leaves the other emitted metrics unchanged', async () => {
+    await recordWebhookDeliveryFailure('org-1', 'event.type', 100, 500, 'timeout');
+
+    const { MetricData } = send.mock.calls[0][0].input;
+    const names = MetricData.map((d: { MetricName: string }) => d.MetricName);
+    expect(names).toEqual([
+      'DeliveryAttempted',
+      'DeliveryFailed',
+      'DeliveryFailed',
+      'DeliveryLatency',
+      'HttpResponseCode',
+    ]);
+  });
+});

--- a/apps/client/server/utils/cloudwatch.ts
+++ b/apps/client/server/utils/cloudwatch.ts
@@ -228,6 +228,9 @@ export async function recordWebhookDeliveryFailure(
       dimensions: { ...baseDimensions, errorType },
       unit: StandardUnit.Count,
     },
+    // Dimensionless copy: webhookDeliveryHighFailures (infra/alarms.ts) alarms on this metric
+    // with no dimension filter, so it needs its own dimensionless data point to receive any data.
+    { name: WebhookMetrics.DELIVERY_FAILED, value: 1, dimensions: {}, unit: StandardUnit.Count },
     { name: WebhookMetrics.DELIVERY_LATENCY, value: latencyMs, dimensions: { orgId }, unit: StandardUnit.Milliseconds },
     ...(httpStatusCode > 0
       ? [


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="699" height="429" alt="live-cloudwatch-roundtrip" src="https://github.com/user-attachments/assets/a6caab47-1d48-4f5f-bedd-9d52961b525c" />

A real round trip against the dev AWS account: the patched code sent one synthetic test event, then `list-metrics` shows the new dimensionless `DeliveryFailed` stream, and `get-metric-statistics` (using the alarm's own query shape) returns a real datapoint instead of the empty result it returned before this fix.

## Description

The `webhookDeliveryHighFailures` alarm (`infra/alarms.ts`) watches `DeliveryFailed` in the `Lumina5/WebhookDelivery` namespace with no dimension filter, so it only matches a dimensionless data point. Both producers of that metric only ever emitted a dimensioned one (scoped to `orgId`/`eventType`/`errorType`), and CloudWatch treats that as a separate metric stream. The alarm sat permanently in `INSUFFICIENT_DATA`, regardless of real failures.

Fixes both producers: `recordWebhookDeliveryFailure` (per-user MCP delivery path) and `emitDeliveryFailureMetrics` (org webhook fan-out path, found while auditing for other unfixed copies of the same gap), each now also emits an unconditional dimensionless `DeliveryFailed` point alongside its existing dimensioned one.

Closes #1896

## Changes

- `apps/client/server/utils/cloudwatch.ts`: `recordWebhookDeliveryFailure` emits a dimensionless `DeliveryFailed` datapoint alongside the dimensioned one.
- `apps/client/server/queueHandlers/githubWebhook.ts`: `emitDeliveryFailureMetrics` emits a dimensionless total (sum of the three error-category counts) alongside its per-category emissions; docstring updated to match.
- Unit tests for both producers asserting the dimensionless datapoint is present.

## Guide for Testers

This is a backend metrics-emission fix with no UI or API route surface. The CloudWatch alarm itself can't be shown transitioning out of `INSUFFICIENT_DATA` from a PR preview alone: that state is set by a live evaluation window against real CloudWatch data. The steps below reproduce the live check behind the attached screenshot, against the dev AWS account.

1. Authenticate: `aws sso login --profile <your dev profile>`.
2. From this branch, invoke the patched function directly against real AWS (no mocking) with a test payload, e.g. `recordWebhookDeliveryFailure('test-org', 'test-event', 100, 500, 'test-error')`. Use a clearly-synthetic org id so the datapoint is easy to identify.
3. Run `aws cloudwatch list-metrics --namespace Lumina5/WebhookDelivery --metric-name DeliveryFailed`. Expected: two `DeliveryFailed` entries, one with `"Dimensions": []` (new) and one with the usual `orgId`/`eventType`/`errorType` dimensions (existing).
4. Run `aws cloudwatch get-metric-statistics --namespace Lumina5/WebhookDelivery --metric-name DeliveryFailed --statistics Sum --period 300 --start-time <15 minutes ago> --end-time <now>` (no `--dimensions` flag: this is the exact query `webhookDeliveryHighFailures` runs). Expected: a real `Datapoints` entry with a nonzero `Sum`. Before this fix, this exact call returned an empty `Datapoints` array.
5. Code-level check (no AWS access needed): open `infra/alarms.ts` and confirm the `webhookDeliveryHighFailures` alarm has no `dimensions` key, then open `apps/client/server/utils/cloudwatch.ts` and `apps/client/server/queueHandlers/githubWebhook.ts` and confirm both `recordWebhookDeliveryFailure` and `emitDeliveryFailureMetrics` now emit a `DeliveryFailed` entry with empty dimensions alongside their existing dimensioned one(s).

**What NOT to test:** there is no UI or API route change here. Steps 1-4 write one harmless synthetic datapoint to the dev account; nowhere near the alarm's real threshold (10 failures/5min), so it will not page anyone.

## Additional Information

N/A

## Developer Notes (Optional)

N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

