### PR TITLE
chore(client): consolidate chunk-size clamp comments and fix duplicate testid

### DIFF
--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -21,8 +21,8 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
   // stored value loads the fallback applies, and the two answers now differ by ~4x (512 vs a stored
   // 2100) where they used to differ by 5% - so a cold mount would silently chunk at a different
   // granularity than a warm one. The effect below resyncs if the setting arrives after mount.
-  // clamped - see clampChunkSize (chunkSize.ts)
   const configuredChunkSize = useGetSettingsValue('DefaultChunkSize');
+  // clamped in the initializer below - see clampChunkSize (chunkSize.ts)
   const [chunkSize, setChunkSize] = useState<number>(
     clampChunkSize(Number(configuredChunkSize) || DEFAULT_PASSAGE_TOKEN_TARGET)
   );

--- a/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeChunkControls.tsx
@@ -21,10 +21,7 @@ export const KnowledgeChunkControls: React.FC<IKnowledgeChunkControlsProps> = ({
   // stored value loads the fallback applies, and the two answers now differ by ~4x (512 vs a stored
   // 2100) where they used to differ by 5% - so a cold mount would silently chunk at a different
   // granularity than a warm one. The effect below resyncs if the setting arrives after mount.
-  // `clampChunkSize` matters here too: a legacy stored value above the ceiling reaches this raw
-  // (the settings-fetch route has no clamp of its own), and submitting it unclamped would resolve
-  // as a silent false "success" here (chunkFileUtility swallows the route's rejection) rather than
-  // a visible error.
+  // clamped - see clampChunkSize (chunkSize.ts)
   const configuredChunkSize = useGetSettingsValue('DefaultChunkSize');
   const [chunkSize, setChunkSize] = useState<number>(
     clampChunkSize(Number(configuredChunkSize) || DEFAULT_PASSAGE_TOKEN_TARGET)

--- a/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
@@ -12,6 +12,7 @@ const mockChunkMutate = vi.fn();
 
 let messageFiles: IFabFileDocument[] = [];
 let workBenchFiles: IFabFileDocument[] = [];
+let systemFiles: IFabFileDocument[] = [];
 let currentUserId = 'me';
 let sessionUserId = 'me';
 // Keyed so a test can set only the setting it cares about; other keys stay undefined,
@@ -28,7 +29,7 @@ vi.mock('@client/app/hooks/useNotebookContextFiles', () => ({
 
 vi.mock('@client/app/contexts/SessionsContext', () => ({
   useSessions: () => ({ currentSessionId: 's1', currentSession: { id: 's1', userId: sessionUserId } }),
-  useSystemPromptFiles: () => ({ systemFiles: [], globalSystemFileIds: [], userSystemFileIds: [] }),
+  useSystemPromptFiles: () => ({ systemFiles, globalSystemFileIds: [], userSystemFileIds: [] }),
   useWorkBenchActions: () => ({ setWorkBenchFiles: vi.fn() }),
   useWorkBenchFiles: () => workBenchFiles,
 }));
@@ -67,6 +68,7 @@ describe('FilesSection message-scoped files', () => {
     mockIsPending.mockReturnValue(false);
     messageFiles = [];
     workBenchFiles = [];
+    systemFiles = [];
     currentUserId = 'me';
     sessionUserId = 'me';
     settingsValues = {};
@@ -154,9 +156,23 @@ describe('FilesSection message-scoped files', () => {
     workBenchFiles = [{ ...fab('w1', 'roster.pdf'), embeddingModel: 'model-a' } as IFabFileDocument];
 
     renderPanel();
-    fireEvent.click(screen.getByTestId('files-section-reprocess-btn-w1-workbench'));
+    fireEvent.click(screen.getByTestId('files-section-reprocess-btn-workbench-w1'));
 
     expect(mockChunkMutate).toHaveBeenCalledOnce();
     expect(mockChunkMutate.mock.calls[0][0]).toMatchObject({ fabFileId: 'w1', chunkSize: 1500 });
+  });
+
+  it('renders distinct reprocess testids when the same file id appears in both lists', () => {
+    // Locks the fix: handleReprocessFile treats a file as possibly present in both the
+    // system and workbench lists, so an unsuffixed testid would collide and getByTestId
+    // would throw on more than one match.
+    settingsValues.defaultEmbeddingModel = 'model-b';
+    systemFiles = [{ ...fab('dup1', 'shared.pdf'), embeddingModel: 'model-a' } as IFabFileDocument];
+    workBenchFiles = [{ ...fab('dup1', 'shared.pdf'), embeddingModel: 'model-a' } as IFabFileDocument];
+
+    renderPanel();
+
+    expect(screen.getByTestId('files-section-reprocess-btn-system-dup1')).toBeTruthy();
+    expect(screen.getByTestId('files-section-reprocess-btn-workbench-dup1')).toBeTruthy();
   });
 });

--- a/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
@@ -154,7 +154,7 @@ describe('FilesSection message-scoped files', () => {
     workBenchFiles = [{ ...fab('w1', 'roster.pdf'), embeddingModel: 'model-a' } as IFabFileDocument];
 
     renderPanel();
-    fireEvent.click(screen.getByTestId('files-section-reprocess-btn-w1'));
+    fireEvent.click(screen.getByTestId('files-section-reprocess-btn-w1-workbench'));
 
     expect(mockChunkMutate).toHaveBeenCalledOnce();
     expect(mockChunkMutate.mock.calls[0][0]).toMatchObject({ fabFileId: 'w1', chunkSize: 1500 });

--- a/apps/client/app/components/Session/AISettings/FilesSection.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.tsx
@@ -459,7 +459,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
                       arrow
                     >
                       <IconButton
-                        data-testid={`files-section-reprocess-btn-${file.id}-system`}
+                        data-testid={`files-section-reprocess-btn-system-${file.id}`}
                         size="sm"
                         variant="plain"
                         color="danger"
@@ -563,7 +563,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
                       arrow
                     >
                       <IconButton
-                        data-testid={`files-section-reprocess-btn-${file.id}-workbench`}
+                        data-testid={`files-section-reprocess-btn-workbench-${file.id}`}
                         size="sm"
                         variant="plain"
                         color="danger"

--- a/apps/client/app/components/Session/AISettings/FilesSection.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.tsx
@@ -162,10 +162,8 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
   const { currentUser } = useUser();
   const modelInfo = useModelInfo()?.data?.find(m => m.id === model);
   const currentEmbeddingModel = useGetSettingsValue('defaultEmbeddingModel');
-  // Fall back to the canonical chunker default, not a third hand-copied number. Clamped: a legacy
-  // stored value above the ceiling reaches this raw (the settings-fetch route applies no clamp of
-  // its own), and submitting it unclamped would resolve as a silent false "success" here
-  // (chunkFileUtility swallows the route's rejection) rather than a visible error.
+  // Fall back to the canonical chunker default, not a third hand-copied number.
+  // clamped - see clampChunkSize (chunkSize.ts)
   const defaultChunkSize = clampChunkSize(
     Number(useGetSettingsValue('DefaultChunkSize')) || DEFAULT_PASSAGE_TOKEN_TARGET
   );
@@ -207,7 +205,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
       const isSystemFile = systemFiles.some(sysFile => sysFile.id === file.id);
 
       chunkFile.mutate(
-        { fabFileId: file.id, chunkSize: Number(defaultChunkSize) }, // Use default chunk size from settings
+        { fabFileId: file.id, chunkSize: defaultChunkSize }, // Use default chunk size from settings
         {
           onSuccess: () => {
             toast.success(`Successfully reprocessed "${file.fileName}" with the current embedding model`);
@@ -461,7 +459,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
                       arrow
                     >
                       <IconButton
-                        data-testid={`files-section-reprocess-btn-${file.id}`}
+                        data-testid={`files-section-reprocess-btn-${file.id}-system`}
                         size="sm"
                         variant="plain"
                         color="danger"
@@ -565,7 +563,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
                       arrow
                     >
                       <IconButton
-                        data-testid={`files-section-reprocess-btn-${file.id}`}
+                        data-testid={`files-section-reprocess-btn-${file.id}-workbench`}
                         size="sm"
                         variant="plain"
                         color="danger"

--- a/apps/client/app/utils/chunkSize.ts
+++ b/apps/client/app/utils/chunkSize.ts
@@ -10,5 +10,7 @@ import { settingsMap } from '@bike4mind/common';
  * value here would resolve as a silent false "success" with nothing queued, not a visible error.
  */
 export function clampChunkSize(value: number): number {
+  // {} is safe only because this setting's clamp ignores its scope arg (settings.ts); a future
+  // scope-aware clamp on DefaultChunkSize would need this call to pass a real scope instead.
   return settingsMap.DefaultChunkSize.scope?.clamp?.(value, {}) ?? value;
 }

--- a/apps/client/app/utils/chunkSize.ts
+++ b/apps/client/app/utils/chunkSize.ts
@@ -5,9 +5,11 @@ import { settingsMap } from '@bike4mind/common';
  * Use this at every client-side read/prefill/submit site for a chunk size, so a legacy stored value
  * above the ceiling (settings.ts documents this as a real, reachable state) or a hand-typed number
  * can never bypass the same bound the resolver enforces server-side
- * (`settingsMap.DefaultChunkSize.scope.clamp`) - only POST /api/files/chunk's own check catches it
- * otherwise, and chunkFileUtility swallows a rejected request (filesAPICalls.ts), so an unclamped
- * value here would resolve as a silent false "success" with nothing queued, not a visible error.
+ * (`settingsMap.DefaultChunkSize.scope.clamp`). The settings-fetch route applies no clamp of its
+ * own, so an above-ceiling stored value reaches every read site here raw; only POST
+ * /api/files/chunk's own check catches it otherwise, and chunkFileUtility swallows a rejected
+ * request (filesAPICalls.ts), so an unclamped value here would resolve as a silent false "success"
+ * with nothing queued, not a visible error.
  */
 export function clampChunkSize(value: number): number {
   // {} is safe only because this setting's clamp ignores its scope arg (settings.ts); a future


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
No screenshot or video applies here. Every change in this PR is invisible to a user: two comments, a redundant type cast, and a `data-testid` attribute (a test hook, not a rendered element). See the Guide for Testers below for the test-based proof instead.

## Description
Four non-blocking nits deferred from review of #1826 (comment/test-only, kept separate to avoid dismissing an existing approval). The chunk-size clamp rationale had drifted into a near-verbatim copy at both call sites; this collapses them into one-line pointers back to `clampChunkSize`'s JSDoc (the source of truth since #1826), which now also carries back a clause the consolidation had dropped. Also drops a redundant `Number()` cast on an already-numeric value, pins the "clamp ignores its scope arg" assumption with a comment so a future scope-aware clamp doesn't get silently skipped, and suffixes the reprocess-button `data-testid` so the system-file and workbench-file buttons no longer collide when the same file appears in both lists.

Closes #1904

## Changes
- Reduced the two duplicated call-site comments to one-line pointers back to `clampChunkSize`'s JSDoc, and folded a dropped clause (the settings-fetch route applies no clamp of its own) back into that JSDoc
- Removed the redundant `Number(defaultChunkSize)` cast in `FilesSection.tsx` (`clampChunkSize` already returns a `number`)
- Added a comment in `chunkSize.ts` pinning the "clamp ignores its scope arg" assumption behind the `{}` scope argument
- Suffixed the reprocess-button `data-testid` (`-system-`/`-workbench-`, prefix kept contiguous) so the two lists' buttons are unambiguous
- Added a test asserting both suffixed testids resolve distinctly when the same file id appears in both lists, and updated the existing workbench assertion to match

## Guide for Testers
No live QA steps apply. Every change in this PR is invisible to a user or a running app: a consolidated comment, a redundant cast on an already-numeric value, and a `data-testid` attribute (a test hook, never rendered or clicked). There is no reachable UI path, API response, or log line that differs before and after this diff.

What NOT to test: the chunk-size clamp math, the reprocess flow, and the file lists behave identically to before this PR. Review this as a diff-read, not a live walkthrough.

## Additional Information
Proof this is behavior-neutral: `pnpm --filter @bike4mind/client test -- FilesSection.test.tsx` (10 passed, including the new same-id-in-both-lists testid-collision test), `pnpm --filter @bike4mind/client test -- KnowledgeChunkControls.test.tsx` (7 passed), and `pnpm turbo:typecheck` (clean).

## Developer Notes (Optional)
N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc


