### PR TITLE
fix(files): mark an uploaded FabFile complete before post-processing

### DIFF
--- a/apps/client/server/s3/objectCreated.test.ts
+++ b/apps/client/server/s3/objectCreated.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const h = vi.hoisted(() => ({
   findOne: vi.fn(),
+  updateOne: vi.fn(),
   findOneAndUpdate: vi.fn(),
+  findById: vi.fn(),
   userFindById: vi.fn(),
   getSettingsValue: vi.fn(),
   claimFileStatus: vi.fn(),
@@ -25,7 +27,12 @@ vi.mock('@bike4mind/database', () => ({
   adminSettingsRepository: { getSettingsValue: h.getSettingsValue },
   changeStorageSize: vi.fn(),
   dataLakeBatchRepository: { claimFileStatus: h.claimFileStatus, incrementCounter: h.incrementCounter },
-  FabFile: { findOne: h.findOne, findOneAndUpdate: h.findOneAndUpdate, findById: vi.fn() },
+  FabFile: {
+    findOne: h.findOne,
+    updateOne: h.updateOne,
+    findOneAndUpdate: h.findOneAndUpdate,
+    findById: h.findById,
+  },
   imageModerationIncidentRepository: {},
   User: { findById: h.userFindById },
   withTransaction: (fn: (session: unknown) => Promise<unknown>) => fn(undefined),
@@ -67,6 +74,7 @@ const metadata = (over: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  h.updateOne.mockResolvedValue({ modifiedCount: 1 });
   h.findOneAndUpdate.mockResolvedValue({ id: 'ff1' });
   h.moderateUploadedFile.mockResolvedValue({ moderationStatus: 'clean' });
   h.userFindById.mockReturnValue({ session: () => ({ id: 'u1', currentStorageSize: 1, save: vi.fn() }) });
@@ -136,5 +144,48 @@ describe('objectCreated - data lake stats (#1342)', () => {
     await run();
 
     expect(h.recomputeUploaded).not.toHaveBeenCalled();
+  });
+});
+
+describe('objectCreated - upload status is recorded independently of post-processing', () => {
+  let file: ReturnType<typeof metadata> & { status?: string; moderationStatus?: string };
+
+  beforeEach(() => {
+    file = metadata({ status: 'pending', moderationStatus: 'pending' });
+    h.findOne.mockResolvedValue(file);
+    h.findOneAndUpdate.mockResolvedValue({ ...file, moderationStatus: 'scanning' });
+  });
+
+  it("marks the file 'complete' even when the owner lookup fails", async () => {
+    h.userFindById.mockReturnValue({ session: () => null });
+
+    await run();
+
+    expect(h.updateOne).toHaveBeenCalledWith({ _id: 'ff1' }, { $set: { status: 'complete' } });
+  });
+
+  it("marks the file 'complete' before a moderation scan that throws", async () => {
+    h.moderateUploadedFile.mockRejectedValue(new Error('Rekognition unavailable'));
+
+    await expect(run()).rejects.toThrow('Rekognition unavailable');
+
+    expect(h.updateOne).toHaveBeenCalledWith({ _id: 'ff1' }, { $set: { status: 'complete' } });
+  });
+
+  it('marks the file complete on the happy path and leaves the moderation verdict on the record', async () => {
+    await run();
+
+    expect(h.updateOne).toHaveBeenCalledWith({ _id: 'ff1' }, { $set: { status: 'complete' } });
+    expect(file.status).toBe('complete');
+    expect(file.moderationStatus).toBe('clean');
+    expect(file.save).toHaveBeenCalled();
+  });
+
+  it('skips the write when a redelivered event finds the file already complete', async () => {
+    file.status = 'complete';
+
+    await run();
+
+    expect(h.updateOne).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/server/s3/objectCreated.test.ts
+++ b/apps/client/server/s3/objectCreated.test.ts
@@ -161,7 +161,18 @@ describe('objectCreated - upload status is recorded independently of post-proces
 
     await run();
 
-    expect(h.updateOne).toHaveBeenCalledWith({ _id: 'ff1' }, { $set: { status: 'complete' } });
+    expect(h.updateOne).toHaveBeenCalledWith(
+      { _id: 'ff1', status: { $ne: 'complete' } },
+      { $set: { status: 'complete' } }
+    );
+  });
+
+  it('recomputes the lakes the file joined even when the owner lookup fails', async () => {
+    h.userFindById.mockReturnValue({ session: () => null });
+
+    await run();
+
+    expect(h.recomputeUploaded).toHaveBeenCalledWith(file, { logger });
   });
 
   it("marks the file 'complete' before a moderation scan that throws", async () => {
@@ -169,13 +180,19 @@ describe('objectCreated - upload status is recorded independently of post-proces
 
     await expect(run()).rejects.toThrow('Rekognition unavailable');
 
-    expect(h.updateOne).toHaveBeenCalledWith({ _id: 'ff1' }, { $set: { status: 'complete' } });
+    expect(h.updateOne).toHaveBeenCalledWith(
+      { _id: 'ff1', status: { $ne: 'complete' } },
+      { $set: { status: 'complete' } }
+    );
   });
 
   it('marks the file complete on the happy path and leaves the moderation verdict on the record', async () => {
     await run();
 
-    expect(h.updateOne).toHaveBeenCalledWith({ _id: 'ff1' }, { $set: { status: 'complete' } });
+    expect(h.updateOne).toHaveBeenCalledWith(
+      { _id: 'ff1', status: { $ne: 'complete' } },
+      { $set: { status: 'complete' } }
+    );
     expect(file.status).toBe('complete');
     expect(file.moderationStatus).toBe('clean');
     expect(file.save).toHaveBeenCalled();

--- a/apps/client/server/s3/objectCreated.ts
+++ b/apps/client/server/s3/objectCreated.ts
@@ -59,12 +59,13 @@ export const func = withContext(async (event, context, logger) => {
 
     // `status` tracks the UPLOAD, and the bytes are in S3 by the time this event fires, so
     // record it here rather than at the end of the transaction below. Everything after this
-    // point can bail out (missing owner) or throw (a scan that keeps failing), and either
-    // would otherwise strand the record on 'pending' - permanently invisible to content-hash
-    // dedup, which excludes 'pending' as a never-landed upload (FabFileModel.findByContentHashes).
+    // point can bail out (a missing owner returns null out of the transaction) or throw with
+    // every Lambda attempt exhausted, and either would otherwise strand the record on
+    // 'pending' - permanently invisible to content-hash dedup, which excludes 'pending' as a
+    // never-landed upload (FabFileModel.findByContentHashes).
     // Serving stays gated by moderationStatus, which this does not touch.
     if (metadata.status !== 'complete') {
-      await FabFile.updateOne({ _id: metadata._id }, { $set: { status: 'complete' } });
+      await FabFile.updateOne({ _id: metadata._id, status: { $ne: 'complete' } }, { $set: { status: 'complete' } });
       metadata.status = 'complete';
     }
 
@@ -165,6 +166,11 @@ export const func = withContext(async (event, context, logger) => {
       return user;
     });
 
+    // The lakes this file's meta-tags name can count it as soon as the bytes are known to have
+    // landed - same reason the status write moved up, and every site that marks a FabFile
+    // 'complete' owes this call. Does not depend on the owner resolving.
+    await recomputeStatsForUploadedFile(metadata, { logger });
+
     if (!user) continue;
 
     // sendToClient must be outside the transaction to avoid
@@ -205,9 +211,6 @@ export const func = withContext(async (event, context, logger) => {
         logger.error(`Error updating batch progress for batchId ${metadata.batchId}: ${error}`);
       }
     }
-
-    // Now that the bytes are in storage, the lakes this file's meta-tags name can count it.
-    await recomputeStatsForUploadedFile(metadata, { logger });
 
     const enableKnowledgeAutoChunk = await adminSettingsRepository.getSettingsValue('enableAutoChunk');
 

--- a/apps/client/server/s3/objectCreated.ts
+++ b/apps/client/server/s3/objectCreated.ts
@@ -57,6 +57,17 @@ export const func = withContext(async (event, context, logger) => {
 
     logger.updateMetadata({ fabFileId: metadata.id, ownerId: metadata.userId });
 
+    // `status` tracks the UPLOAD, and the bytes are in S3 by the time this event fires, so
+    // record it here rather than at the end of the transaction below. Everything after this
+    // point can bail out (missing owner) or throw (a scan that keeps failing), and either
+    // would otherwise strand the record on 'pending' - permanently invisible to content-hash
+    // dedup, which excludes 'pending' as a never-landed upload (FabFileModel.findByContentHashes).
+    // Serving stays gated by moderationStatus, which this does not touch.
+    if (metadata.status !== 'complete') {
+      await FabFile.updateOne({ _id: metadata._id }, { $set: { status: 'complete' } });
+      metadata.status = 'complete';
+    }
+
     // Atomically claim the right to scan this file BEFORE the transaction
     // below touches it. `metadata` above was read outside a transaction with retry/backoff
     // - two concurrent invocations (a slow in-flight scan racing an S3 at-least-once
@@ -148,7 +159,6 @@ export const func = withContext(async (event, context, logger) => {
         }
       }
 
-      metadata.status = 'complete';
       changeStorageSize(user, object.size);
       await Promise.all([metadata.save({ session }), user.save({ session })]);
 


### PR DESCRIPTION
## Description

Closes #1000.

`objectCreated.ts` set `metadata.status = 'complete'` at the very end of the `withTransaction`
callback. Two paths return before reaching it with the S3 object already written:

1. **Owner lookup fails.** `User.findById(metadata.userId)` returns null, the callback returns
   `null`, and the outer loop hits `if (!user) continue;`. The bytes are in S3; the FabFile stays
   `pending` forever.
2. **Moderation throws with every Lambda attempt exhausted.** `moderateUploadedFile` raising
   propagates out of the transaction and `withContext` rethrows. This is a narrower window than
   #1000 describes: the `pending -> scanning` scan claim is a `findOneAndUpdate` with no session,
   so it is already committed when the scan throws. The retry's CAS then matches nothing, the
   handler takes the claim-lost branch, skips the scan, and the old end-of-callback assignment
   ran fine -- so a throwing scan self-healed on the *first* retry. Only a failure that spans
   every async attempt (e.g. a Mongo outage) stranded the record. Path 1 is the real strand;
   this is the residual window.

Since #928, `findByContentHashes` and `findByContentHashesInDataLake` both filter
`status: { $ne: 'pending' }`, so a record stranded this way is permanently invisible to
content-hash dedup: re-uploading the same content silently creates a second copy, with no signal
to the user and no self-healing path.

Of the three directions the issue lists, this takes the first (smallest fix, covers both paths, no
schema change and no reconciliation sweep): `status` describes the *upload*, and the S3 event
itself proves the bytes landed, so it is recorded at that point rather than after post-processing
that can bail out or throw.

## Changes

- `apps/client/server/s3/objectCreated.ts`: set `status: 'complete'` right after the FabFile
  metadata lookup succeeds, via a single `FabFile.updateOne` whose filter carries the
  `status: { $ne: 'complete' }` guard, so a redelivered S3 event is a no-op even when two
  redeliveries read the same stale snapshot. The in-memory doc is updated too; the old assignment
  at the end of the transaction callback is removed.
- `recomputeStatsForUploadedFile` is hoisted above the `if (!user) continue` bail-out. Its own
  contract is "call from every site that marks a FabFile 'complete'", and the marking site moved
  up -- otherwise the exact record this PR rescues becomes a countable lake member that the lake's
  persisted stats never see. The helper only reads `batchId`/`tags`, so it does not need the owner.
- Storage accounting (`changeStorageSize` / `user.save`) still only runs when the owner resolves --
  that part genuinely depends on the user record.
- `moderationStatus` is untouched, so the fail-closed serving gate is unchanged. A file can now be
  `status: 'complete'` while `moderationStatus` is still `pending`/`scanning`; dedup keys off
  `status` only, which matches the field's meaning and mirrors what the self-host handler
  `pages/api/internal/s3/object-created.ts` already does.
- `apps/client/server/s3/objectCreated.test.ts`: 5 new cases covering both strand paths, the lake
  recompute on the missing-owner path, the happy path, and redelivery idempotency (the three cases
  that write assert the guard in the `updateOne` filter).

## Guide for Testers

This is a backend Lambda change with no UI surface. Behaviour is covered by unit tests; the
observable effect is a database field.

### What NOT to test

No UI to click through. Do not look for a visual change -- nothing in the app renders `status`
directly.

### Regression check (optional, requires DB access)

1. Upload any file through the normal upload flow (Sidebar -> Files -> upload).
2. Wait for the upload to finish and the file to appear in the list.
3. In the database, find the `fabfiles` document whose `filePath` matches the uploaded key.
4. Expected: `status` is `complete`. Previously it was also `complete` on this happy path, so this
   step is a regression check, not the fix.
5. Upload the exact same file a second time.
6. Expected: it is deduped against the first copy as before -- no second stored object.

## Additional Information

Neither strand path was reproduced against a live Lambda; both were read from source and are
covered by unit tests with the handler's dependencies mocked. Path 1 in particular requires an
orphaned `userId`, which is awkward to construct against a real environment.

Known gap left standing, not addressed here: a file whose scan throws keeps `moderationStatus`
pinned at `'scanning'` with nothing that re-scans it, which makes it permanently unviewable. This
PR makes such a record *visible* to dedup and lake stats instead of invisible -- still better than
silently duplicating forever, but the moderation half of #1000's acceptance criteria wants its own
issue.

Deliberately not done, since the issue lists them as alternatives rather than additions: no
terminal `failed` state added to the enum, and no reconciliation sweep for aged-out `pending`
records.

Verified: `apps/client/server/s3` suite (49 tests) passes, `pnpm --filter @bike4mind/client
typecheck` and `pnpm lint:check` are clean.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
