### PR TITLE
test(client): give real-Mongo suites a 60s budget instead of the shard's unit-test default

### DIFF
--- a/apps/client/__tests__/mongoTestTimeoutBudget.test.ts
+++ b/apps/client/__tests__/mongoTestTimeoutBudget.test.ts
@@ -6,11 +6,11 @@ import * as ts from 'typescript';
 /**
  * Structural guard for the client shard's real-Mongo suites.
  *
- * A suite that boots a real mongod pays a 16-22s cold start (see MONGO_TEST_TIMEOUT_MS in
+ * A suite that boots a real mongod pays a cold start whose cost scales with runner contention -
+ * 3-12s per file on a healthy CI run, past 35s on a busy machine (see MONGO_TEST_TIMEOUT_MS in
  * packages/database/src/__test__/createMongoServer.ts). This shard sets a 30s test budget and
- * inherits a 30s hook budget, both sized for unit tests, so such a suite has under 14s of real
- * headroom and reddens CI at random on a runner sharing cores - a timeout with no failed
- * assertion, green on re-run of the same commit.
+ * inherits a 30s hook budget, both sized for unit tests, so they sit inside that spread and get
+ * crossed at random - a timeout with no failed assertion, green on re-run of the same commit.
  *
  * Auditing that by hand only holds until the next suite is added, so the audit lives here: every
  * real-Mongo suite in this shard must declare the shared budget for its tests AND its hooks, and

--- a/apps/client/__tests__/mongoTestTimeoutBudget.test.ts
+++ b/apps/client/__tests__/mongoTestTimeoutBudget.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+/**
+ * Structural guard for the client shard's real-Mongo suites.
+ *
+ * A suite that boots a real mongod pays a 16-22s cold start (see MONGO_TEST_TIMEOUT_MS in
+ * packages/database/src/__test__/createMongoServer.ts). This shard sets a 30s test budget and
+ * inherits a 30s hook budget, both sized for unit tests, so such a suite has under 14s of real
+ * headroom and reddens CI at random on a runner sharing cores - a timeout with no failed
+ * assertion, green on re-run of the same commit.
+ *
+ * Auditing that by hand only holds until the next suite is added, so the audit lives here: every
+ * real-Mongo suite in this shard must declare the shared budget for its tests AND its hooks, and
+ * none may pin itself back with a literal.
+ *
+ * The checks parse the TypeScript AST rather than matching source text. Regex was tried first and
+ * could not carry the invariant: it missed `30_000`, single-line `it(..., 30000)` and Prettier's
+ * wrapped `},\n  30000\n)`, while false-positiving on the last line of any multi-line call such as
+ * `expect(spy).toHaveBeenCalledWith({\n ... \n}, 2)`. Each `it` reports ALL offenders at once so
+ * one run tells you everything to fix.
+ */
+
+const CLIENT_ROOT = path.resolve(__dirname, '..');
+// Anchored to top-level segments: a nested directory that happens to be called `e2e` holds real
+// unit suites and must still be audited (vitest's own `exclude` is a separate glob - keeping this
+// list narrow is what stops the two from silently disagreeing).
+const SKIP_TOP_LEVEL = new Set(['.next', '.open-next', 'e2e', 'dist', '.turbo']);
+
+// Only an actual import binding counts, so this guard - which names the factories in prose and in
+// the identifiers below - never flags itself.
+const MONGO_FACTORY_IMPORT = /import\s+\{[^}]*\b(?:createMongoServer|createMongoReplSet)\b[^}]*\}\s*from/;
+const SHARED_BUDGET_IMPORT = /import\s+\{[^}]*\bMONGO_TEST_TIMEOUT_MS\b[^}]*\}\s*from/;
+
+const BUDGET_IDENTIFIER = 'MONGO_TEST_TIMEOUT_MS';
+const HOOKS = new Set(['beforeAll', 'afterAll', 'beforeEach', 'afterEach']);
+const TESTS_AND_SUITES = new Set(['it', 'test', 'describe']);
+
+type SourceFile = { relativePath: string; source: ts.SourceFile };
+
+const walk = (dir: string, out: string[] = []): string[] => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const topLevel = path.relative(CLIENT_ROOT, full).split(path.sep)[0];
+      if (entry.name !== 'node_modules' && !SKIP_TOP_LEVEL.has(topLevel)) walk(full, out);
+    } else if (/\.test\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+// Text-matches to pick the class out of ~1000 files, then parses only the handful that matched.
+const realMongoSuites: SourceFile[] = walk(CLIENT_ROOT)
+  .reduce<SourceFile[]>((suites, absolutePath) => {
+    const content = fs.readFileSync(absolutePath, 'utf-8');
+    if (MONGO_FACTORY_IMPORT.test(content)) {
+      suites.push({
+        relativePath: path.relative(CLIENT_ROOT, absolutePath).split(path.sep).join('/'),
+        source: ts.createSourceFile(absolutePath, content, ts.ScriptTarget.Latest, true),
+      });
+    }
+    return suites;
+  }, [])
+  .sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+/** Leftmost identifier of a callee, so `it.each([...])(...)` and `describe.only(...)` both read as their base. */
+const rootCalleeName = (expression: ts.Expression): string | undefined => {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return rootCalleeName(expression.expression);
+  if (ts.isCallExpression(expression)) return rootCalleeName(expression.expression);
+  return undefined;
+};
+
+const forEachCall = (source: ts.SourceFile, visit: (call: ts.CallExpression) => void): void => {
+  const recurse = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) visit(node);
+    ts.forEachChild(node, recurse);
+  };
+  ts.forEachChild(source, recurse);
+};
+
+const lineOf = (source: ts.SourceFile, node: ts.Node): number =>
+  source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+
+const isBudgetIdentifier = (node: ts.Node): boolean => ts.isIdentifier(node) && node.text === BUDGET_IDENTIFIER;
+
+/** `{ timeout: ... }` on a test/suite/hook call, if present. */
+const timeoutProperty = (argument: ts.Expression): ts.PropertyAssignment | undefined => {
+  if (!ts.isObjectLiteralExpression(argument)) return undefined;
+  return argument.properties.find(
+    (property): property is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(property) && property.name.getText() === 'timeout'
+  );
+};
+
+/**
+ * Timeout arguments on a test/suite/hook call that are NOT the shared budget - a trailing numeric
+ * literal (`it(name, fn, 30000)`, `beforeAll(fn, 30000)`) or a `{ timeout: <literal> }` option.
+ */
+const offendingTimeouts = (file: SourceFile): string[] => {
+  const offenders: string[] = [];
+
+  forEachCall(file.source, call => {
+    const callee = rootCalleeName(call.expression);
+    if (!callee || (!HOOKS.has(callee) && !TESTS_AND_SUITES.has(callee))) return;
+
+    for (const argument of call.arguments) {
+      if (ts.isNumericLiteral(argument)) {
+        offenders.push(`${file.relativePath}:${lineOf(file.source, argument)}: ${callee}(..., ${argument.getText()})`);
+        continue;
+      }
+      const timeout = timeoutProperty(argument);
+      if (timeout && !isBudgetIdentifier(timeout.initializer)) {
+        offenders.push(`${file.relativePath}:${lineOf(file.source, timeout)}: ${callee}(..., ${timeout.getText()})`);
+      }
+    }
+  });
+
+  return offenders;
+};
+
+/**
+ * The budget the file actually runs on: the LAST `vi.setConfig` wins at runtime, so a file that
+ * declares the shared budget up top and narrows it further down is running on the narrow one.
+ */
+const effectiveSetConfig = (source: ts.SourceFile): ts.ObjectLiteralExpression | undefined => {
+  let last: ts.ObjectLiteralExpression | undefined;
+
+  forEachCall(source, call => {
+    if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== 'setConfig') return;
+    const [argument] = call.arguments;
+    if (argument && ts.isObjectLiteralExpression(argument)) last = argument;
+  });
+
+  return last;
+};
+
+const declaresSharedBudget = (source: ts.SourceFile): boolean => {
+  const config = effectiveSetConfig(source);
+  if (!config) return false;
+
+  return (['testTimeout', 'hookTimeout'] as const).every(key => {
+    const property = config.properties.find(
+      (candidate): candidate is ts.PropertyAssignment =>
+        ts.isPropertyAssignment(candidate) && candidate.name.getText() === key
+    );
+    return property !== undefined && isBudgetIdentifier(property.initializer);
+  });
+};
+
+describe('real-Mongo suites in the client shard declare the shared 60s budget', () => {
+  it('finds the real-Mongo suites to audit (guards the detector itself)', () => {
+    // A broken detector would make every assertion below vacuously pass, so pin the class as
+    // non-empty and pin the suite the budget was first raised for.
+    expect(realMongoSuites.length).toBeGreaterThan(10);
+    expect(realMongoSuites.map(file => file.relativePath)).toContain(
+      'server/services/deleteOrganizationTransaction.e2e.test.ts'
+    );
+  });
+
+  it('imports MONGO_TEST_TIMEOUT_MS rather than inventing a budget', () => {
+    const missing = realMongoSuites
+      .filter(file => !SHARED_BUDGET_IMPORT.test(file.source.getFullText()))
+      .map(file => file.relativePath);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('applies the budget to tests AND hooks via the effective vi.setConfig', () => {
+    const missing = realMongoSuites.filter(file => !declaresSharedBudget(file.source)).map(file => file.relativePath);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('never pins a test, suite or hook back with a literal timeout', () => {
+    expect(realMongoSuites.flatMap(offendingTimeouts)).toEqual([]);
+  });
+});

--- a/apps/client/pages/api/admin/__tests__/model-logs.test.ts
+++ b/apps/client/pages/api/admin/__tests__/model-logs.test.ts
@@ -4,7 +4,10 @@ import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source
 // (same convention as apps/client's other e2e/integration tests against a real Mongo).
-import { createMongoServer } from '../../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../../packages/database/src/__test__/createMongoServer';
 import { Quest } from '@bike4mind/database';
 
 // This route's fix is a MongoDB query-semantics question (does $elemMatch actually match an
@@ -36,6 +39,10 @@ vi.mock('@server/utils/errors', () => ({
 }));
 
 import handler from '../model-logs';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const run = (query: Record<string, string> = {}) => {
   const { req, res } = createMocks({ method: 'GET', query });

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.e2e.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.e2e.test.ts
@@ -3,7 +3,10 @@ import { createMocks } from 'node-mocks-http';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../../../../packages/database/src/__test__/createMongoServer';
 import { userApiKeyRepository } from '@bike4mind/database/auth';
 import { checkApiKeyRateLimit } from '@server/utils/apiKeyRateLimitCheck';
 import { ApiKeyScope } from '@bike4mind/common';
@@ -47,16 +50,20 @@ vi.mock('@bike4mind/database', async importOriginal => {
 
 import handler from '../user-api-keys';
 
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
   mockUserFind.mockReset();

--- a/apps/client/pages/api/api-keys/__tests__/create.crossType.e2e.test.ts
+++ b/apps/client/pages/api/api-keys/__tests__/create.crossType.e2e.test.ts
@@ -3,7 +3,10 @@ import { createMocks } from 'node-mocks-http';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../../packages/database/src/__test__/createMongoServer';
 import { apiKeyRepository } from '@bike4mind/database';
 import { ApiKeyType } from '@bike4mind/common';
 import { configureSecretsAtRest, generateEncryptionKey } from '@bike4mind/utils/security';
@@ -37,6 +40,10 @@ vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn(async () => undef
 
 import handler from '../create';
 
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
@@ -46,11 +53,11 @@ beforeAll(async () => {
   // seam never fires. Register a key so provider-key creation (now fail-closed without one)
   // stores ciphertext; findAllByUserId decrypts it back, so the plaintext assertions hold.
   configureSecretsAtRest(generateEncryptionKey());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
 });

--- a/apps/client/pages/api/feedback/__tests__/create.userId-mismatch.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/create.userId-mismatch.test.ts
@@ -3,10 +3,17 @@ import { createMocks } from 'node-mocks-http';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../../packages/database/src/__test__/createMongoServer';
 import { FeedbackModel, User, UserActivityCounter, Organization, CounterLog } from '@bike4mind/database';
 import { FeedbackEvents } from '@bike4mind/common';
 import errorHandler from '@server/middlewares/errorHandler';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end regression test for the real chain: POST handler -> logEvent -> incrementUserCounter
@@ -70,12 +77,12 @@ let mongoServer: MongoMemoryServer;
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 
 afterEach(async () => {
   await mongoose.connection.dropDatabase();

--- a/apps/client/pages/api/users/[id]/__tests__/docx-template.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/docx-template.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest
 import { createMocks } from 'node-mocks-http';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
-import { createMongoServer } from '../../../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../../../packages/database/src/__test__/createMongoServer';
 import { User } from '@bike4mind/database';
 import { AppFile } from '@bike4mind/database/content';
 
@@ -32,17 +35,21 @@ vi.mock('@server/middlewares/baseApi', () => ({
 
 import handler from '../docx-template';
 
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 
 afterEach(async () => {
   await mongoose.connection.dropDatabase();

--- a/apps/client/pages/api/users/__tests__/counterLogs.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.test.ts
@@ -3,7 +3,10 @@ import { createMocks } from 'node-mocks-http';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../../packages/database/src/__test__/createMongoServer';
 import { CounterLog, User } from '@bike4mind/database';
 import { SAFE_USER_LOOKUP_PROJECT, USER_SECRET_FIELDS } from '@bike4mind/common';
 
@@ -47,6 +50,10 @@ import handler from '../counterLogs';
 import { buildUserActivityPipeline } from '@server/analytics/userActivityQuery';
 import { ApiKeyScope } from '@bike4mind/common';
 
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
@@ -55,12 +62,12 @@ beforeAll(async () => {
   // Ensure declared indexes exist before querying. autoIndex is fire-and-forget, so on a fresh
   // database the first query can race the index build.
   await CounterLog.init();
-}, 30000);
+});
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 
 afterEach(async () => {
   await mongoose.connection.dropDatabase();

--- a/apps/client/server/analytics/userActivityQuery.e2e.test.ts
+++ b/apps/client/server/analytics/userActivityQuery.e2e.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { buildUserActivityPipeline } from './userActivityQuery';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * Agreement test: the unit tests assert the pipeline's SHAPE, which cannot catch a stage
@@ -59,12 +63,12 @@ beforeAll(async () => {
     // Outside the requested window.
     log({ datetime: new Date('2026-06-01T10:00:00.000Z') }),
   ]);
-}, 60000);
+});
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 60000);
+});
 
 describe('user activity pipeline against MongoDB', () => {
   it('groups per day, counter and user, and counts the repeats', async () => {

--- a/apps/client/server/analytics/userActivityQuery.rowUnit.e2e.test.ts
+++ b/apps/client/server/analytics/userActivityQuery.rowUnit.e2e.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { buildUserActivityPipeline } from './userActivityQuery';
 import {
   asWindow,
@@ -12,6 +12,10 @@ import {
   windowRowsFor,
   type UserActivityWindow,
 } from './userActivityCache';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * Acceptance test for the row unit: the server's rows must match what the pre-pagination client
@@ -198,12 +202,12 @@ beforeAll(async () => {
     { _id: USER_B, email: EMAIL[USER_B.toString()] },
   ]);
   await counterLogs.insertMany(FIXTURE);
-}, 60000);
+});
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 60000);
+});
 
 beforeEach(() => {
   windowCache = new Map();

--- a/apps/client/server/chatCompletion/external/embedRoute.integration.test.ts
+++ b/apps/client/server/chatCompletion/external/embedRoute.integration.test.ts
@@ -128,10 +128,17 @@ vi.mock('@server/utils/storage', () => ({
 vi.mock('@server/utils/config', () => ({ Config: { MONGODB_URI: 'mongodb://unused/%STAGE%', STAGE: 'test' } }));
 
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../packages/database/src/__test__/createMongoServer';
 import { Organization, AdminSettings, Agent, Project, FabFile, FabFileChunk, UsageEvent } from '@bike4mind/database';
 import { User } from '../../../../../packages/database/src/models/auth/UserModel';
 import { registerEmbedRoutes } from './embedRoute';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 let mongoServer: MongoMemoryServer;
 let server: Server;
@@ -151,7 +158,7 @@ beforeAll(async () => {
       resolve();
     });
   });
-}, 60000);
+});
 
 afterAll(async () => {
   server?.close();
@@ -161,7 +168,7 @@ afterAll(async () => {
     mkdirSync(process.env.B4M_EVIDENCE_OUT, { recursive: true });
     writeFileSync(join(process.env.B4M_EVIDENCE_OUT, 'cases.json'), JSON.stringify(evidence, null, 2));
   }
-}, 30000);
+});
 
 afterEach(async () => {
   await mongooseDirect.connection.dropDatabase();
@@ -295,7 +302,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
     expect(text).toContain('42 gold pieces');
     expect(text).not.toContain('SECRET-OUT-OF-SCOPE-DELTA');
     expect(text).toContain('[DONE]');
-  }, 30000);
+  });
 
   it('rejects retrieve_knowledge_content for an out-of-scope file id owned by the SAME user', async () => {
     const { outScope } = await seed();
@@ -305,7 +312,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
 
     expect(text).toContain('No document found with ID');
     expect(text).not.toContain('SECRET-OUT-OF-SCOPE-DELTA');
-  }, 30000);
+  });
 
   it('serves a file curated into the project even when owned by another user (curation is the grant)', async () => {
     const { curatedForeign } = await seed();
@@ -314,7 +321,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
     const { text } = await post('curated not-owned file is readable');
 
     expect(text).toContain('curated by a teammate');
-  }, 30000);
+  });
 
   it('a denied KB tool never reaches the backend tool list', async () => {
     await seed({ agent: { deniedTools: ['search_knowledge_base'] } });
@@ -327,7 +334,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
     expect(names).toContain('retrieve_knowledge_content');
     expect(text).toContain('TOOL_UNAVAILABLE:search_knowledge_base');
     expect(text).not.toContain('42 gold pieces');
-  }, 30000);
+  });
 
   it('an opted-in curated tool is materialized and executable alongside the KB defaults', async () => {
     await seed({ agent: { allowedTools: ['current_datetime'] } });
@@ -341,7 +348,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
     );
     expect(text).toContain('ANSWER::');
     expect(text).not.toContain('TOOL_UNAVAILABLE');
-  }, 30000);
+  });
 
   it('an opted-in key-gated tool with no configured key never reaches the backend tool list', async () => {
     // weather_info is in the embed curated universe (embedToolResolver.ts) and the agent opts
@@ -357,7 +364,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
     expect(names).not.toContain('weather_info');
     expect(names).toContain('search_knowledge_base');
     expect(text).toContain('TOOL_UNAVAILABLE:weather_info');
-  }, 30000);
+  });
 
   it('an agent with no project gets an empty KB: search returns nothing, never the owner corpus', async () => {
     await seed({ skipProject: true });
@@ -368,7 +375,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
     expect(text).toContain('No documents found');
     expect(text).not.toContain('42 gold pieces');
     expect(text).not.toContain('SECRET-OUT-OF-SCOPE-DELTA');
-  }, 30000);
+  });
 
   it('an org-owned agent whose project belongs to an org teammate still gets its KB', async () => {
     await seed({ projectOwnedByTeammate: true });
@@ -378,7 +385,7 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
 
     expect(text).toContain('42 gold pieces');
     expect(text).not.toContain('SECRET-OUT-OF-SCOPE-DELTA');
-  }, 30000);
+  });
 
   it('meters the multi-turn tool run against the owner org', async () => {
     const { org, owner } = await seed();
@@ -396,12 +403,17 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
         expect(found).toHaveLength(1);
         return found;
       },
-      { timeout: 5000, interval: 50 }
+      // Scaled off the suite budget, not a flat 5s: this poll waits on real DB work under the same
+      // contention the budget exists to absorb, so a fixed 5s window turns a slow runner into a
+      // "expected length 1, got 0" assertion failure that does not even look like a timeout. A
+      // fraction rather than the whole budget, so this poll's own failure surfaces (with the
+      // useful message) before the test-level timeout fires.
+      { timeout: MONGO_TEST_TIMEOUT_MS / 2, interval: 50 }
     );
     expect(String(events[0].ownerId)).toBe(org.id);
     expect(events[0].ownerType).toBe('Organization');
     expect(String(events[0].userId)).toBe(owner.id);
     expect(events[0].inputTokens).toBe(120);
     expect(events[0].outputTokens).toBe(40);
-  }, 30000);
+  });
 });

--- a/apps/client/server/cron/dataLakeBatchReconcile.e2e.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.e2e.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { dataLakeBatchRepository } from '@bike4mind/database';
 import { dataLakeService } from '@bike4mind/services';
 
@@ -27,16 +27,20 @@ vi.mock('@server/utils/cloudwatch', () => ({
 
 import { runStuckBatchSweep } from './dataLakeBatchReconcile';
 
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
   vi.clearAllMocks();

--- a/apps/client/server/queueHandlers/dataLakeBatchRetryGating.e2e.test.ts
+++ b/apps/client/server/queueHandlers/dataLakeBatchRetryGating.e2e.test.ts
@@ -7,7 +7,10 @@ import { KnowledgeType } from '@bike4mind/common';
 // A REAL replica set is required here (not createMongoServer, used by the sibling e2e suites):
 // fabFileVectorize's success path writes chunk vectors via withTransaction, and a standalone
 // mongod rejects the first write inside a session with MongoServerError code 20.
-import { createMongoReplSet } from '../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoReplSet,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../packages/database/src/__test__/createMongoServer';
 import {
   User,
   FabFile,
@@ -81,16 +84,20 @@ vi.mock('sst', () => ({ Resource: new Proxy({}, { get: () => new Proxy({}, { get
 
 import { dispatch } from './fabFileVectorize';
 
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
 let replSet: MongoMemoryReplSet;
 
 beforeAll(async () => {
   replSet = await createMongoReplSet();
   await mongoose.connect(replSet.getUri());
-}, 60000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await replSet?.stop();
-}, 60000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
 });

--- a/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { FabFile, Session } from '@bike4mind/database';
 import { notebookImportService } from '@bike4mind/services';
 import { createChatHistoryWrites, createSessionWrites } from './notebookImportComplete';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * Knowledge files were built with field names the schema does not have (`name`/`size`/`path` rather
@@ -26,11 +30,11 @@ const USER = 'knowledge-import-owner';
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 60000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 60000);
+});
 afterEach(async () => {
   await Promise.all([FabFile.deleteMany({}, { hardDelete: true }), Session.deleteMany({}, { hardDelete: true })]);
 });
@@ -118,19 +122,19 @@ describe('notebook import writes knowledge files', () => {
     // The bytes were uploaded to this path, so the record has to point at the same one.
     expect(file?.filePath).toBe(uploaded[0]);
     expect(result.importedAttachments).toBe(1);
-  }, 60000);
+  });
 
   it('carries the original knowledge type through the export', async () => {
     await makeService().importNotebooks(USER, payload([knowledgeFile({ type: 'URL' })]) as never, OPTIONS as never);
 
     expect((await FabFile.findOne({ userId: USER }))?.type).toBe('URL');
-  }, 60000);
+  });
 
   it('falls back to FILE for exports written before type was carried', async () => {
     await makeService().importNotebooks(USER, payload([knowledgeFile({ type: undefined })]) as never, OPTIONS as never);
 
     expect((await FabFile.findOne({ userId: USER }))?.type).toBe('FILE');
-  }, 60000);
+  });
 
   it('records an id on the notebook that resolves to the file it wrote', async () => {
     await makeService().importNotebooks(USER, payload([knowledgeFile()]) as never, OPTIONS as never);
@@ -140,7 +144,7 @@ describe('notebook import writes knowledge files', () => {
 
     expect(notebook?.knowledgeIds).toHaveLength(1);
     expect(notebook?.knowledgeIds?.[0]).toBe(String(file?.id));
-  }, 60000);
+  });
 
   it('keeps the notebook and the files that worked when one file fails', async () => {
     const broken = knowledgeFile({ id: 'kf-2', name: 'broken.txt', content: undefined });
@@ -162,7 +166,7 @@ describe('notebook import writes knowledge files', () => {
     const file = await FabFile.findOne({ userId: USER });
     expect(notebook?.knowledgeIds).toEqual([String(file?.id)]);
     expect(result.warnings?.[0]).toContain('broken.txt');
-  }, 60000);
+  });
 
   it('degrades an unrecognised type rather than losing the file', async () => {
     await makeService().importNotebooks(
@@ -172,7 +176,7 @@ describe('notebook import writes knowledge files', () => {
     );
 
     expect((await FabFile.findOne({ userId: USER }))?.type).toBe('FILE');
-  }, 60000);
+  });
 
   it('warns once, not twice, when a file has an unknown type and also fails to write', async () => {
     // Content resolves, so the upload succeeds and the loop reaches the write - which then fails
@@ -188,7 +192,7 @@ describe('notebook import writes knowledge files', () => {
     expect(await FabFile.countDocuments({})).toBe(0);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings?.[0]).toContain('Failed to import knowledge file');
-  }, 60000);
+  });
 
   it('marks the file servable rather than leaving it for a scan that cannot see it', async () => {
     await makeService().importNotebooks(USER, payload([knowledgeFile()]) as never, OPTIONS as never);
@@ -196,7 +200,7 @@ describe('notebook import writes knowledge files', () => {
     // The row is written inside the import's transaction, and the S3 scan that would flip this
     // gives up ~7.5s later - long before a real import commits. A 'pending' file never recovers.
     expect((await FabFile.findOne({ userId: USER }))?.moderationStatus).toBe('clean');
-  }, 60000);
+  });
 
   it('reports a degraded type as an import, not as a failure', async () => {
     const result = await makeService().importNotebooks(
@@ -209,7 +213,7 @@ describe('notebook import writes knowledge files', () => {
     expect(result.importedAttachments).toBe(1);
     expect(result.warnings?.[0]).toContain('Imported');
     expect(result.warnings?.[0]).not.toContain('Failed to import');
-  }, 60000);
+  });
 
   it('refuses a file that would only reference the exporter storage', async () => {
     const remote = knowledgeFile({ content: undefined, contentUrl: 'https://other-env.test/knowledge/kf-1' });
@@ -221,7 +225,7 @@ describe('notebook import writes knowledge files', () => {
     expect(await FabFile.countDocuments({})).toBe(0);
     expect(result.importedAttachments).toBe(0);
     expect(result.warnings?.[0]).toContain('not implemented');
-  }, 60000);
+  });
 
   it('reports a store that returns no id rather than recording a dangling reference', async () => {
     const service = makeService({ knowledgeRepository: { create: async () => ({}) } });
@@ -230,7 +234,7 @@ describe('notebook import writes knowledge files', () => {
 
     expect(result.importedAttachments).toBe(0);
     expect(result.warnings?.[0]).toContain('no id');
-  }, 60000);
+  });
 
   it('reports a failed attachment instead of claiming success', async () => {
     // No content and no contentUrl: the service cannot resolve a path, so this one must fail.
@@ -245,5 +249,5 @@ describe('notebook import writes knowledge files', () => {
     expect(result.warnings?.[0]).toContain('notes.txt');
     // The count must reflect what landed, not what the file claimed.
     expect(result.importedAttachments).toBe(0);
-  }, 60000);
+  });
 });

--- a/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { Quest, Session, sessionRepository } from '@bike4mind/database';
 import { notebookImportService } from '@bike4mind/services';
 import { createChatHistoryWrites, createSessionWrites } from './notebookImportComplete';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * Guards the invariant this handler exists for: importing an export NEVER rewrites messages that
@@ -31,11 +35,11 @@ const USER = 'import-owner';
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 60000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 60000);
+});
 afterEach(async () => {
   await Promise.all([Quest.deleteMany({}, { hardDelete: true }), Session.deleteMany({}, { hardDelete: true })]);
 });
@@ -143,7 +147,7 @@ describe('notebook import does not overwrite existing messages', () => {
     // Nothing partial lands: bulkWrite is ordered and every id collides on the first op.
     expect(await Quest.countDocuments({ sessionId })).toBe(5);
     expect(await Quest.countDocuments({})).toBe(5);
-  }, 60000);
+  });
 
   it('copies messages into a new notebook rather than moving them', async () => {
     const { sessionId, ids } = await seedNotebook('Shared Name', 5);
@@ -162,7 +166,7 @@ describe('notebook import does not overwrite existing messages', () => {
     expect(await Quest.countDocuments({ sessionId })).toBe(5);
     // 5 originals + 5 copies; a move would leave the total at 5.
     expect(await Quest.countDocuments({})).toBe(10);
-  }, 60000);
+  });
 
   it('replaces rather than collides when overwriting an existing notebook', async () => {
     const { sessionId, ids } = await seedNotebook('Shared Name', 5);
@@ -182,7 +186,7 @@ describe('notebook import does not overwrite existing messages', () => {
     expect(result.errors).toEqual([]);
     expect(await Quest.countDocuments({ sessionId })).toBe(5);
     expect(await Quest.countDocuments({})).toBe(5);
-  }, 60000);
+  });
 
   it('updates the existing notebook metadata when overwriting', async () => {
     const { sessionId, ids } = await seedNotebook('Same Name', 2);
@@ -204,7 +208,7 @@ describe('notebook import does not overwrite existing messages', () => {
     expect(result.errors).toEqual([]);
     const after = await Session.findById(sessionId);
     expect(after?.lastUpdated?.toISOString()).toBe('2027-03-04T05:06:07.000Z');
-  }, 60000);
+  });
 
   it('imports a message whose prompt is empty, as the exporter emits', async () => {
     const { ids } = await seedNotebook('Shared Name', 2);
@@ -223,5 +227,5 @@ describe('notebook import does not overwrite existing messages', () => {
 
     expect(result.errors).toEqual([]);
     expect(await Quest.countDocuments({ prompt: '' })).toBe(1);
-  }, 60000);
+  });
 });

--- a/apps/client/server/services/acceptGroupInvite.e2e.test.ts
+++ b/apps/client/server/services/acceptGroupInvite.e2e.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { InviteType } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import {
   Group,
   Organization,
@@ -17,6 +17,10 @@ import {
   projectRepository,
 } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard for #1224: driving the REAL sharingService.acceptInvite through the REAL
@@ -40,11 +44,11 @@ const db = {
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
 });

--- a/apps/client/server/services/dataLakePurgeIndexScope.e2e.test.ts
+++ b/apps/client/server/services/dataLakePurgeIndexScope.e2e.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { KnowledgeType } from '@bike4mind/common';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import {
   FabFile,
   DataLakeModel,
@@ -15,6 +15,10 @@ import {
 } from '@bike4mind/database';
 import { dataLakeService } from '@bike4mind/services';
 import type { RetrievalIndexPort, RetrievalIndexRemoval } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard for the data lake purge index-removal contract, driving the REAL
@@ -35,11 +39,11 @@ let mongoServer: MongoMemoryServer;
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
 });

--- a/apps/client/server/services/dataLakeStaticRegistryPrefixGate.e2e.test.ts
+++ b/apps/client/server/services/dataLakeStaticRegistryPrefixGate.e2e.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { KnowledgeType } from '@bike4mind/common';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import {
   FabFile,
   User,
@@ -13,6 +13,10 @@ import {
   userRepository,
 } from '@bike4mind/database';
 import { fabFilesService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard, against REAL Mongo rather than a mock, for the static-registry namespace gate
@@ -37,11 +41,11 @@ beforeAll(async () => {
   const admin = await User.create({ username: 'platform-admin', name: 'Admin', isAdmin: true });
   ownerId = owner.id as string;
   adminId = admin.id as string;
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await FabFile.deleteMany({});
 });
@@ -86,7 +90,7 @@ describe('data-lake static-registry prefix gate (real Mongo, both single-file do
 
       const persisted = await FabFile.findById(file.id);
       expect(persisted?.tags ?? []).toEqual([]);
-    }, 30000);
+    });
 
     it('allows an admin to apply a static-registry-prefixed tag', async () => {
       const file = await makeFile([], adminId);
@@ -95,7 +99,7 @@ describe('data-lake static-registry prefix gate (real Mongo, both single-file do
 
       const persisted = await FabFile.findById(file.id);
       expect((persisted?.tags ?? []).map(t => t.name)).toEqual(['opti:report']);
-    }, 30000);
+    });
 
     it('allows a non-admin to remove a legacy static-registry-prefixed tag already on their file', async () => {
       const file = await makeFile([{ name: 'opti:legacy' }]);
@@ -104,7 +108,7 @@ describe('data-lake static-registry prefix gate (real Mongo, both single-file do
 
       const persisted = await FabFile.findById(file.id);
       expect(persisted?.tags ?? []).toEqual([]);
-    }, 30000);
+    });
   });
 
   describe('updateFabFile (whole-array PUT /api/files/[id] path)', () => {
@@ -122,7 +126,7 @@ describe('data-lake static-registry prefix gate (real Mongo, both single-file do
 
       const persisted = await FabFile.findById(file.id);
       expect(persisted?.tags ?? []).toEqual([]);
-    }, 30000);
+    });
 
     it('does not block an unrelated edit to a file that already carries a legacy static-registry-prefixed tag', async () => {
       const file = await makeFile([{ name: 'opti:legacy' }]);
@@ -142,7 +146,7 @@ describe('data-lake static-registry prefix gate (real Mongo, both single-file do
 
       const persisted = await FabFile.findById(file.id);
       expect((persisted?.tags ?? []).map(t => t.name).sort()).toEqual(['opti:legacy', 'unrelated']);
-    }, 30000);
+    });
 
     it('allows an admin whole-array write that newly adds a static-registry-prefixed tag', async () => {
       const file = await makeFile([], adminId);
@@ -156,6 +160,6 @@ describe('data-lake static-registry prefix gate (real Mongo, both single-file do
 
       const persisted = await FabFile.findById(file.id);
       expect((persisted?.tags ?? []).map(t => t.name)).toEqual(['opti:report']);
-    }, 30000);
+    });
   });
 });

--- a/apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts
+++ b/apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryReplSet } from 'mongodb-memory-server';
 // createMongoReplSet is not exported from the package barrel / dist; deep-import the source.
-import { createMongoReplSet } from '../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoReplSet,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../packages/database/src/__test__/createMongoServer';
 import {
   Group,
   Organization,
@@ -13,6 +16,10 @@ import {
   withTransaction,
 } from '@bike4mind/database';
 import { organizationService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * Transactional guard for #1219: proves the org soft-delete participates in the caller's
@@ -42,11 +49,11 @@ const adapters = {
 beforeAll(async () => {
   replSet = await createMongoReplSet();
   await mongoose.connect(replSet.getUri());
-}, 60000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await replSet?.stop();
-}, 60000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
 });

--- a/apps/client/server/services/embedSpendCap.e2e.test.ts
+++ b/apps/client/server/services/embedSpendCap.e2e.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { ApiKeyScope, CreditHolderType } from '@bike4mind/common';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { userApiKeyRepository, UserApiKey } from '@bike4mind/database';
 import { userApiKeyService, assertKeySpendWithinCap } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard for the embed spend-cap chain, driving the REAL service
@@ -24,11 +28,11 @@ const adapters = { db: { userApiKeys: userApiKeyRepository } };
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
 });

--- a/apps/client/server/services/groupInviteAuth.e2e.test.ts
+++ b/apps/client/server/services/groupInviteAuth.e2e.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { InviteType, Permission } from '@bike4mind/common';
 import { BadRequestError, ForbiddenError, UnauthorizedError } from '@bike4mind/utils';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import {
   Group,
   Organization,
@@ -17,6 +17,10 @@ import {
   userRepository,
 } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard for the group-scoped invite auth path, driving the REAL
@@ -50,11 +54,11 @@ const platformAdminUser = { id: 'platform-1', username: 'padmin', groups: [], is
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 // Targeted deletes, not dropDatabase(): dropping the database discards the indexes too, so every
 // subsequent test pays to rebuild them on first write, which is a real cost across 8 cases on a
 // contended CI shard. Group.deleteMany also clears the raw `groups` insert the legacy-group case

--- a/apps/client/server/services/prefixArmLakeMembership.e2e.test.ts
+++ b/apps/client/server/services/prefixArmLakeMembership.e2e.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { KnowledgeType, Permission } from '@bike4mind/common';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import {
   DataLakeModel,
   FabFile,
@@ -14,6 +14,10 @@ import {
   userRepository,
 } from '@bike4mind/database';
 import { fabFilesService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard, against REAL Mongo rather than a mock, for a file whose ONLY lake membership
@@ -39,11 +43,11 @@ beforeAll(async () => {
   const editor = await User.create({ username: 'shared-editor', name: 'Editor' });
   ownerId = owner.id as string;
   editorId = editor.id as string;
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await FabFile.deleteMany({});
   await DataLakeModel.deleteMany({});
@@ -100,7 +104,7 @@ describe('reconcileLakeTags (via updateFabFile) against real Mongo', () => {
     expect((persistedFile?.tags ?? []).map(t => t.name)).toEqual(['lk:invoices']);
     const persistedLake = await DataLakeModel.findById(lake.id);
     expect(persistedLake?.fileCount).toBe(1);
-  }, 30000);
+  });
 
   it('preserves membership on a whole-array drop regardless of manage rights', async () => {
     await makeLake();
@@ -115,7 +119,7 @@ describe('reconcileLakeTags (via updateFabFile) against real Mongo', () => {
 
     const persistedFile = await FabFile.findById(file.id);
     expect((persistedFile?.tags ?? []).map(t => t.name)).toEqual(['lk:invoices']);
-  }, 30000);
+  });
 
   // A prefix-arm JOIN needs no manage-rights gate on the membership itself (the read-side
   // predicate grants it purely on the tag), but recomputeLakeStats's activation side effect
@@ -137,7 +141,7 @@ describe('reconcileLakeTags (via updateFabFile) against real Mongo', () => {
     const persistedLake = await DataLakeModel.findById(lake.id);
     expect(persistedLake?.status).toBe('draft');
     expect(persistedLake?.fileCount).toBe(1);
-  }, 30000);
+  });
 
   it('publishes a draft lake when the OWNER triggers the same join', async () => {
     const lake = await makeLake({ status: 'draft', fileCount: 0, totalSizeBytes: 0 });
@@ -153,7 +157,7 @@ describe('reconcileLakeTags (via updateFabFile) against real Mongo', () => {
     const persistedLake = await DataLakeModel.findById(lake.id);
     expect(persistedLake?.status).toBe('active');
     expect(persistedLake?.fileCount).toBe(1);
-  }, 30000);
+  });
 });
 
 describe('toggleTags against real Mongo', () => {
@@ -178,7 +182,7 @@ describe('toggleTags against real Mongo', () => {
     expect(persistedFile?.tags ?? []).toEqual([]);
     const persistedLake = await DataLakeModel.findById(lake.id);
     expect(persistedLake?.fileCount).toBe(0);
-  }, 30000);
+  });
 
   it('refuses a shared editor who is not the lake creator, persisting nothing in the batch', async () => {
     await makeLake();
@@ -201,7 +205,7 @@ describe('toggleTags against real Mongo', () => {
 
     const persistedFile = await FabFile.findById(file.id);
     expect((persistedFile?.tags ?? []).map(t => t.name)).toEqual(['lk:invoices']);
-  }, 30000);
+  });
 
   it('corrects a draft lake stats without publishing it when a shared editor triggers the join', async () => {
     const lake = await makeLake({ status: 'draft', fileCount: 0, totalSizeBytes: 0 });
@@ -223,5 +227,5 @@ describe('toggleTags against real Mongo', () => {
     const persistedLake = await DataLakeModel.findById(lake.id);
     expect(persistedLake?.status).toBe('draft');
     expect(persistedLake?.fileCount).toBe(1);
-  }, 30000);
+  });
 });

--- a/apps/client/server/services/projectInviteAuth.e2e.test.ts
+++ b/apps/client/server/services/projectInviteAuth.e2e.test.ts
@@ -1,12 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { InviteType, Permission } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { Invite, Project, inviteRepository, projectRepository, userRepository } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard for the project-scoped invite auth path, driving the REAL
@@ -38,11 +42,11 @@ const PROJECT_NAME = 'Confidential Project';
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 // Targeted deletes, not dropDatabase(): dropping the database discards the indexes too, so every
 // subsequent test pays to rebuild them on first write. Under a sharded CI run that was enough to
 // push the first test past the 15s testTimeout in vitest.shared.ts. Same approach as

--- a/apps/client/server/services/tagDelete.e2e.test.ts
+++ b/apps/client/server/services/tagDelete.e2e.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { KnowledgeType } from '@bike4mind/common';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { DataLakeModel, dataLakeRepository, FabFile, fabFileRepository, fileTagRepository } from '@bike4mind/database';
 import { tagService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard that deleting a tag leaves the three surfaces AGREEING: the tag documents, the
@@ -34,11 +38,11 @@ const TagModel = () => mongoose.model('Tag');
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await Promise.all([FabFile.deleteMany({}), TagModel().deleteMany({}), DataLakeModel.deleteMany({})]);
 });
@@ -128,7 +132,7 @@ describe('tagService.remove keeps tag documents, file tags and the count aggrega
     );
     expect(await countOf('invoices')).toBe(0);
     expect(await countOf('receipts')).toBe(2);
-  }, 30000);
+  });
 });
 
 // Against REAL Mongo, not a mock: proves the recompute reads the aggregate AFTER the bulk strip
@@ -151,5 +155,5 @@ describe('tagService.remove recomputes a lake whose prefix-arm signal it just st
 
     const persisted = await DataLakeModel.findById(lake.id);
     expect(persisted?.fileCount).toBe(0);
-  }, 30000);
+  });
 });

--- a/apps/client/server/services/tagRename.e2e.test.ts
+++ b/apps/client/server/services/tagRename.e2e.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { KnowledgeType } from '@bike4mind/common';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { DataLakeModel, dataLakeRepository, FabFile, fabFileRepository, fileTagRepository } from '@bike4mind/database';
 import { tagService } from '@bike4mind/services';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * End-to-end guard that renaming a tag - INTO a name the user already has, with duplicates, a
@@ -35,11 +39,11 @@ const TagModel = () => mongoose.model('Tag');
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await Promise.all([FabFile.deleteMany({}), TagModel().deleteMany({}), DataLakeModel.deleteMany({})]);
 });
@@ -137,7 +141,7 @@ describe('tagService.update keeps tag documents, file tags and the count aggrega
     expect(await rawTagsOf(duplicated)).toEqual(['Receipts']);
     expect(await rawTagsOf(alreadyHasTarget)).toEqual(['Receipts']);
     expect(await countOf('Receipts')).toBe(4);
-  }, 30000);
+  });
 });
 
 // Against REAL Mongo, not a mock: proves the recompute reads the aggregate AFTER the rename has
@@ -160,7 +164,7 @@ describe('tagService.update recomputes a lake whose prefix-arm signal the rename
 
     const persisted = await DataLakeModel.findById(lake.id);
     expect(persisted?.fileCount).toBe(1);
-  }, 30000);
+  });
 
   it('drops fileCount when the rename moves the file to no longer carry a prefix tag', async () => {
     const lake = await DataLakeModel.create({
@@ -179,5 +183,5 @@ describe('tagService.update recomputes a lake whose prefix-arm signal the rename
 
     const persisted = await DataLakeModel.findById(lake.id);
     expect(persisted?.fileCount).toBe(0);
-  }, 30000);
+  });
 });

--- a/apps/client/server/utils/__tests__/dataLakeSpendGateIntegration.test.ts
+++ b/apps/client/server/utils/__tests__/dataLakeSpendGateIntegration.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
-import { createMongoServer } from '../../../../../packages/database/src/__test__/createMongoServer';
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../packages/database/src/__test__/createMongoServer';
 import {
   DataLakeModel,
   dataLakeRepository,
@@ -17,6 +20,10 @@ import {
 } from '@bike4mind/database';
 import { dataLakeService, recordOperationalUsage } from '@bike4mind/services';
 import { getSettingsByNames } from '@bike4mind/utils';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 // Only the admin-settings SOURCE is stubbed (an external config leaf, not the seam under
 // test) - resolveSpendLevers' own parsing/clamping still runs for real against these values.

--- a/apps/client/server/utils/apiKeyRateLimitReset.e2e.test.ts
+++ b/apps/client/server/utils/apiKeyRateLimitReset.e2e.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
-import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
 import { cacheRepository } from '@bike4mind/database';
 import { buildRateLimitKeys, checkApiKeyRateLimit, resetApiKeyRateLimit } from './apiKeyRateLimitCheck';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 /**
  * Agreement test for the rate-limit reset, driving the REAL enforcer and the
@@ -23,11 +27,11 @@ const rateLimit = { requestsPerMinute: 2, requestsPerDay: 1000 };
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-}, 30000);
+});
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
-}, 30000);
+});
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
 });

--- a/packages/database/src/__test__/createMongoServer.ts
+++ b/packages/database/src/__test__/createMongoServer.ts
@@ -49,6 +49,31 @@ const withPortRetry = async <T>(start: () => Promise<T>): Promise<T> => {
   throw lastError;
 };
 
+/**
+ * Time budget for every test and hook in a suite that boots a real mongod through the factories
+ * below. Declare it once per file, right after the imports:
+ *
+ *   vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+ *
+ * Both keys matter - mongod boots in a hook, and a `describe` option covers only tests. Prefer
+ * this over per-test/per-hook third arguments: one lever per file, and no literal left behind to
+ * silently pin a suite back to the old budget.
+ *
+ * The unit-test defaults these suites otherwise inherit are too tight for them. Booting mongod
+ * costs an unavoidable cold start on the first write: Mongoose builds every model's index set on
+ * connect (autoIndex CANNOT be disabled - index-dependent suites need it) plus first-collection
+ * creation, measured at 16-22s under the client shard's file parallelism. Against that shard's
+ * 30s test budget and the shared 30s hook budget, a suite has under 14s of real headroom, so on a
+ * CI runner sharing cores it times out at random rather than on anything it asserts.
+ *
+ * This is not a hang mask - it is the correct budget for work that starts a database. A genuinely
+ * hung test still fails, just later. Keep it the single lever for the whole class: raising the
+ * shard default instead would hand the same slack to ~1000 unit tests that must stay tight.
+ * `apps/client/__tests__/mongoTestTimeoutBudget.test.ts` fails the build if a real-Mongo suite in
+ * that shard declares anything else.
+ */
+export const MONGO_TEST_TIMEOUT_MS = 60_000;
+
 export const createMongoServer = async (): Promise<MongoMemoryServer> =>
   withPortRetry(() => MongoMemoryServer.create());
 

--- a/packages/database/src/__test__/createMongoServer.ts
+++ b/packages/database/src/__test__/createMongoServer.ts
@@ -62,9 +62,12 @@ const withPortRetry = async <T>(start: () => Promise<T>): Promise<T> => {
  * The unit-test defaults these suites otherwise inherit are too tight for them. Booting mongod
  * costs an unavoidable cold start on the first write: Mongoose builds every model's index set on
  * connect (autoIndex CANNOT be disabled - index-dependent suites need it) plus first-collection
- * creation, measured at 16-22s under the client shard's file parallelism. Against that shard's
- * 30s test budget and the shared 30s hook budget, a suite has under 14s of real headroom, so on a
- * CI runner sharing cores it times out at random rather than on anything it asserts.
+ * creation. What matters is that the cost SCALES with how contended the runner is, which is what
+ * makes the resulting failure intermittent rather than reproducible. Measured spread for a whole
+ * file: 3-12s on a healthy CI run, 16-22s under this shard's file parallelism (see the note in
+ * apps/client/vitest.config.mts), and past 35s on a busy dev machine. A 30s test budget and the
+ * shared 30s hook budget sit inside that spread, so the suites cross it at random - which is why
+ * one fails on a timeout, asserts nothing, and goes green on re-run of the same commit.
  *
  * This is not a hang mask - it is the correct budget for work that starts a database. A genuinely
  * hung test still fails, just later. Keep it the single lever for the whole class: raising the


### PR DESCRIPTION
# Pull Request

## Description

`Run Tests (client)` fails intermittently on the real-Mongo suites, always by timeout rather than assertion, and goes green on re-run of the same commit. The cause is a budget mismatch, not a regression.

The client shard sets `testTimeout: 30000` (`apps/client/vitest.config.mts`) and inherits the shared `hookTimeout: 30000` (`vitest.shared.ts`) - both sized for unit tests. A suite that boots a real mongod pays a cold start on its first write: Mongoose builds every model's index set on connect (autoIndex cannot be disabled - index-dependent suites need it) plus first-collection creation.

The key point is that this cost **scales with how contended the runner is**, which is why the failure is intermittent rather than reproducible. Measured spread for a whole file: **3-12s on a healthy CI run** (see the numbers from this branch's own CI run below), **16-22s under this shard's file parallelism** (the existing measurement in `vitest.config.mts`), and **past 35s on a busy dev machine**. The 30s budgets sit inside that spread, so the suites cross them at random.

Auditing the class turned up **24** such suites in this shard, not just the two named in the issue. Every one already deep-imports the same helper module, which makes that module the natural place for a single shared budget.

### Why `vi.setConfig` rather than a per-test argument or a `describe` option

The issue suggested either a per-test third argument or a suite-level `{ timeout }`. Neither is sufficient: **mongod boots in a hook**, and a `describe` option governs tests only. I verified this with a probe - a `describe(..., { timeout: 3000 })` wrapping a `beforeAll` that sleeps past a lowered hook budget still fails with `Hook timed out`. Both suggested fixes would have left the 30s hook budget in place.

`vi.setConfig({ testTimeout, hookTimeout })` covers both in one file-scoped declaration, and leaves no literal behind to silently pin a suite back to the old budget.

It also avoided real collateral damage. I implemented the `describe`-option route first: Prettier reflowed the long describe headers into multi-line calls and reindented their entire bodies, producing **~1000 lines of churn** across the shard. The `vi.setConfig` diff is +462/-127, and no assertion or test body is touched.

## Changes

- **`packages/database/src/__test__/createMongoServer.ts`** - export `MONGO_TEST_TIMEOUT_MS = 60_000` beside the `createMongoServer` / `createMongoReplSet` factories, documenting the cold-start measurement and why raising the shard default instead is wrong (it would hand the same slack to ~1000 unit tests that must stay tight).
- **All 24 real-Mongo suites in the client shard** - declare the budget once per file via `vi.setConfig` for both `testTimeout` and `hookTimeout`; remove all **88** hard-coded `}, 30000)` / `}, 60000)` literals so the file-scoped budget is the only lever.
- **`apps/client/server/chatCompletion/external/embedRoute.integration.test.ts`** - scale the inner `vi.waitFor` off the same constant instead of a flat 5s. It polls a fire-and-forget `UsageEvent` write, so under the exact contention this PR absorbs it fails as `expected length 1, got 0` - a flake that does not even look like a timeout, and one the outer budget cannot fix.
- **`apps/client/__tests__/mongoTestTimeoutBudget.test.ts`** (new) - structural guard so the audit does not decay. Parses the TypeScript AST of every real-Mongo suite in the shard and fails the build if one omits the shared budget or pins itself back with a literal.

The guard parses the AST rather than matching source text. A regex version was tried first and could not carry the invariant: it missed `30_000`, single-line `it(..., 30000)` and Prettier's wrapped `},\n  30000\n)`, while false-positiving on the last line of any multi-line call such as `expect(spy).toHaveBeenCalledWith({\n ... \n}, 2)`.

## Guide for Testers

This is a test-infrastructure-only PR. There is nothing to click - all verification is CI and command-line.

### Primary check: CI

1. Open this PR on GitHub and wait for the checks to finish.
2. Confirm **`Run Tests (client)`** is green. That is the shard this PR targets.
3. Confirm **`Run Tests (data)`**, **Core Build**, **Typecheck** and **Lint** are green.
4. Expected result: all required checks pass with no timeout failures.

### Confirm the fix is load-bearing (local, optional)

1. Check out this branch and run `pnpm install && pnpm turbo:core:build`.
2. Run the two suites named in the issue with per-test timings:
   ```
   cd apps/client
   npx vitest run server/services/deleteOrganizationTransaction.e2e.test.ts \
     server/chatCompletion/external/embedRoute.integration.test.ts --reporter=verbose
   ```
3. Expected result: `Test Files 2 passed`, `Tests 11 passed`.
4. Look at the duration printed for the **first** test in each file. Expected result: it is well above 10s (measured at 20.6-37.7s depending on machine load) - that is the mongod cold start, and any value over 30s is a run that would have failed before this PR.

### Confirm the guard actually guards

1. Run the guard alone and confirm it is green:
   ```
   cd apps/client && npx vitest run __tests__/mongoTestTimeoutBudget.test.ts
   ```
   Expected result: `Tests 4 passed`.
2. Break it deliberately - in `apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts`, delete the `vi.setConfig({ ... })` line.
3. Re-run the guard. Expected result: it fails on `applies the budget to tests AND hooks via the effective vi.setConfig`, naming that file.
4. Restore the line, then instead append `, 30000` as a third argument to either `it(...)` block (i.e. `}, 30000);`).
5. Re-run the guard. Expected result: it fails on `never pins a test, suite or hook back with a literal timeout`, naming the file and line.
6. Restore the file. Expected result: guard green again, `git status` clean.

### Regression Checks

1. Confirm no assertion or test body changed anywhere in this PR:
   ```
   git diff origin/main..HEAD -- apps/client/pages apps/client/server \
     | grep -E "^[+-].*(expect\(|await |it\(|test\(|describe\()" | wc -l
   ```
   Expected result: `0`. Every changed line in the 24 suites is an import, the `vi.setConfig` declaration plus its comment, or a closing brace.
2. Confirm no timeout was *lowered*: every removed literal was `30000` or `60000`, and the shared constant is `60000`.
3. Confirm the suites that previously had a genuine 60s per-test budget (`notebookImportKnowledge`, `notebookImportOverwrite`) still get 60s - now from the file-scoped declaration.
4. Confirm `deleteOrganizationTransaction.e2e.test.ts` still runs against a **replica set** (`createMongoReplSet`), not a standalone mongod. It cannot run on a standalone - the first write in a session fails with `MongoServerError` code 20 - so the transaction-participation guard this suite exists for stays intact.

### What NOT to test

- No UI, no API, no runtime behaviour changes. Nothing ships to a preview environment worth clicking.
- No product surface to exercise: `MONGO_TEST_TIMEOUT_MS` lives in a `__test__` directory that is not exported from the package barrel or `dist`, so it is not part of the published `@bike4mind/database` API.
- No AdminSettings, telemetry fields, or migrations involved.

## Additional Information

**Full-shard verification was not possible locally, and this is worth knowing when reading the CI result.** While verifying, four other worktrees on the same machine were running their own test suites concurrently (load average peaked at 48 on 15 cores, with 54 stray `mongod` processes). Under that, files that take 0.5-21s in isolation took 70-335s, and suites failed on both the clean tree and this branch. So my local full-shard runs are stress tests rather than verification - CI is the real check.

That said, the clean-tree baseline run is itself informative: **without** this change, 18 of these 24 suites failed under load, including both `deleteOrganizationTransaction` tests - the issue's flake reproducing locally. With the change, the same suites passed that run.

What is solidly verified:

- The mechanism reaches tests **and** hooks - both `Test timed out in 60000ms` and `Hook timed out in 60000ms` were observed firing, confirming `vi.setConfig` applies where a `describe` option would not.
- The named suites pass, with the first test measured at 21.5s idle and 37.7s under moderate load. The 37.7s run is a direct demonstration: it would have failed on the old 30s budget and passes now, same commit.
- `typecheck:fast` (the stricter tsgo gate) clean for `apps/client` and `packages/database`; `pnpm lint:check` clean; both ASCII guards clean.
- 7 mutation tests prove each guard rule is load-bearing rather than vacuously green, including that a multi-line `toHaveBeenCalledWith({...}, 2)` stays green.

**Follow-up, deliberately not in this PR:** `packages/database` has the identical asymmetry - `hookTimeout: 60000, testTimeout: 30000` in its own `vitest.config.ts`, across ~60 real-Mongo suites. Same root cause, but the right fix there is one config line rather than 60 file edits, and it would also relax the budget for that package's pure unit tests. That is a scope decision worth making explicitly rather than folding in here.

## Measured headroom on the CI runner

This branch's `Run Tests (client)` run went green - **1009 passed | 10 skipped (1019)**, zero failures, 1075s wall clock (job cap is 20 min). Per-file totals for the 24 suites in this PR, pulled from that run's log:

| suite | file total |
|---|---|
| `model-logs.test.ts` | 12,172ms |
| `embedRoute.integration.test.ts` | 5,848ms |
| `embedSpendCap.e2e.test.ts` | 5,834ms |
| `dataLakeBatchRetryGating.e2e.test.ts` | 5,040ms |
| `counterLogs.test.ts` | 4,996ms |
| `deleteOrganizationTransaction.e2e.test.ts` | 4,563ms |
| ... remaining 18 suites | 342ms - 4,827ms |

So on a healthy runner the whole class finishes well inside the old 30s budget - which is exactly why this reproduces only intermittently. The flake needs roughly a 6.5x slowdown to breach 30s; against 60s it needs about 13x. The change therefore roughly doubles the margin against the degradation that caused the original red, rather than papering over a suite that is habitually slow.

Worth noting for reviewers: this means you should NOT expect to see these suites taking tens of seconds in a normal CI log. If one ever does, that is the signal to look at runner health, not to raise the constant again.

## Developer Notes (Optional)

- **New extension point:** `MONGO_TEST_TIMEOUT_MS` is the single lever for the whole real-Mongo class. If CI ever needs more headroom, change one number rather than 88 literals.
- **Reusable pattern:** file-scoped `vi.setConfig({ testTimeout, hookTimeout })` is the right way to rebudget an integration suite in this repo - it covers hooks (where mongod boots) and cannot be silently overridden by a stale per-test literal. This is the first use of `vi.setConfig` in the codebase.
- **Reusable pattern:** the guard shows how to write an AST-based convention check with no new dependency (`typescript` is already a direct dependency of `apps/client`). Worth copying for other "every file in class X must declare Y" invariants, where regex-based checks tend to both over- and under-match.
- **Architecture decision:** the budget lives next to the factories that cause the cost rather than in the shard config, so the slack is scoped to the suites that need it and ~1000 unit tests keep a tight budget that still catches genuine hangs.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a

Closes #1925
