### PR TITLE
fix(api-keys): require ADMIN scope on remaining admin financial endpoints

### DIFF
--- a/apps/client/pages/api/admin/__tests__/credit-adjustments.test.ts
+++ b/apps/client/pages/api/admin/__tests__/credit-adjustments.test.ts
@@ -1,19 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
+import { ApiKeyScope } from '@bike4mind/common';
 
 const { mockQueryPage, mockUserFind } = vi.hoisted(() => ({
   mockQueryPage: vi.fn(),
   mockUserFind: vi.fn(),
 }));
 
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  baseApi: (config?: unknown) => {
     const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
     const chain = Object.assign(
       (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
       {
         use: () => chain,
         get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
+        _config: config,
       }
     );
     return chain;
@@ -47,6 +52,11 @@ beforeEach(() => {
 });
 
 describe('GET /api/admin/credit-adjustments', () => {
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
   it('rejects non-admin callers', async () => {
     const { promise } = run({}, { id: 'u2', isAdmin: false });
     await expect(promise).rejects.toThrow(/Admin access required/);

--- a/apps/client/pages/api/admin/__tests__/platform-usage.test.ts
+++ b/apps/client/pages/api/admin/__tests__/platform-usage.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ApiKeyScope } from '@bike4mind/common';
+
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: (config?: unknown) => {
+    const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
+    const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
+    chain.use = () => chain;
+    chain.get = (fn: (typeof handlers)[string]) => {
+      handlers.GET = fn;
+      return chain;
+    };
+    chain._config = config;
+    return chain;
+  },
+}));
+
+const mockPlatformUsageSummary = vi.fn();
+const mockPlatformEndpointUsage = vi.fn();
+const mockUserApiKeyFind = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  usageEventRepository: { platformUsageSummary: (...a: unknown[]) => mockPlatformUsageSummary(...a) },
+  apiKeyUsageLogRepository: { platformEndpointUsage: (...a: unknown[]) => mockPlatformEndpointUsage(...a) },
+  userApiKeyRepository: { find: (...a: unknown[]) => mockUserApiKeyFind(...a) },
+}));
+
+const mockOrgFind = vi.fn();
+vi.mock('@bike4mind/database/infra', () => ({
+  organizationRepository: { find: (...a: unknown[]) => mockOrgFind(...a) },
+}));
+
+const mockResolveUserNames = vi.fn();
+vi.mock('@server/utils/resolveUserNames', () => ({
+  resolveUserNames: (...a: unknown[]) => mockResolveUserNames(...a),
+}));
+
+import handler from '../platform-usage';
+
+function call(options: { isAdmin?: boolean; hasUser?: boolean; query?: object }) {
+  const { req, res } = createMocks({ method: 'GET', query: options.query ?? {} });
+  if (options.hasUser !== false) {
+    (req as unknown as { user: { isAdmin: boolean; id: string } }).user = {
+      isAdmin: options.isAdmin ?? true,
+      id: 'admin-1',
+    };
+  }
+  return { req, res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+describe('GET /api/admin/platform-usage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPlatformUsageSummary.mockResolvedValue({
+      overTime: [],
+      byFeature: [],
+      byConsumer: [],
+      byModel: [],
+      totals: { requests: 0, cogsUsd: 0, creditsCharged: 0 },
+    });
+    mockPlatformEndpointUsage.mockResolvedValue(null);
+    mockUserApiKeyFind.mockResolvedValue([]);
+    mockOrgFind.mockResolvedValue([]);
+    mockResolveUserNames.mockResolvedValue(new Map());
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    // Guards platform usage against a narrowly-scoped key inheriting its owner's
+    // isAdmin: apiKeyAuth rejects the key before req.user is set. JWT/browser
+    // admins skip that check and are unaffected.
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    const { run } = call({ hasUser: false });
+    await expect(run()).rejects.toThrow();
+    expect(mockPlatformUsageSummary).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-admin', async () => {
+    const { run } = call({ isAdmin: false });
+    await expect(run()).rejects.toThrow(/[Aa]dmin/);
+    expect(mockPlatformUsageSummary).not.toHaveBeenCalled();
+  });
+
+  it('returns the platform usage summary for an admin', async () => {
+    const { res, run } = call({ query: { days: '7' } });
+    await run();
+    expect(mockPlatformUsageSummary).toHaveBeenCalledWith({ days: 7, source: undefined, ownerType: undefined });
+    expect(res._getJSONData().days).toBe(7);
+  });
+});

--- a/apps/client/pages/api/admin/__tests__/provider-invoices.test.ts
+++ b/apps/client/pages/api/admin/__tests__/provider-invoices.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
+import { ApiKeyScope } from '@bike4mind/common';
 
 // Middleware stripped so the handler body runs directly (same pattern as
 // __tests__/model-prices.test.ts). The chain object doubles as the exported
-// handler and dispatches on req.method.
+// handler and dispatches on req.method. Captures the config so a test can assert
+// requiredScopes: the scope gate lives in apiKeyAuth (real middleware, not
+// exercised here), so asserting the handler is registered with it is the only
+// guard available at this level.
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  baseApi: (config?: unknown) => {
     const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
     const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
     chain.use = () => chain;
@@ -17,6 +21,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
       handlers.POST = fn;
       return chain;
     };
+    chain._config = config;
     return chain;
   },
 }));
@@ -45,6 +50,11 @@ function call(options: { method: 'GET' | 'POST'; isAdmin?: boolean; body?: objec
 
 describe('GET /api/admin/provider-invoices', () => {
   beforeEach(() => vi.clearAllMocks());
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
 
   it('rejects non-admin users', async () => {
     const { run } = call({ method: 'GET', isAdmin: false });

--- a/apps/client/pages/api/admin/__tests__/session-usage.test.ts
+++ b/apps/client/pages/api/admin/__tests__/session-usage.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 import { NotFoundError } from '@bike4mind/utils';
+import { ApiKeyScope } from '@bike4mind/common';
 
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  baseApi: (config?: unknown) => {
     const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
     const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
     chain.use = () => chain;
@@ -11,6 +15,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
       handlers.GET = fn;
       return chain;
     };
+    chain._config = config;
     return chain;
   },
 }));
@@ -60,6 +65,11 @@ describe('GET /api/admin/session-usage — access', () => {
     mockSessionBelongsToOwner.mockResolvedValue(true);
     mockSessionUsageSummary.mockResolvedValue(emptyUsage);
     mockFindBillingBySessionId.mockResolvedValue([]);
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
   });
 
   it('lets an admin read the whole session cross-org (unscoped queries, no ownership probe)', async () => {

--- a/apps/client/pages/api/admin/__tests__/transactions.test.ts
+++ b/apps/client/pages/api/admin/__tests__/transactions.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 import { NotFoundError } from '@bike4mind/utils';
+import { ApiKeyScope } from '@bike4mind/common';
 
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  baseApi: (config?: unknown) => {
     const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
     const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
     chain.use = () => chain;
@@ -11,6 +15,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
       handlers.GET = fn;
       return chain;
     };
+    chain._config = config;
     return chain;
   },
 }));
@@ -49,6 +54,11 @@ describe('GET /api/admin/transactions — access', () => {
     vi.clearAllMocks();
     mockVerifyOrgAccess.mockResolvedValue({ id: ORG });
     mockQueryLedgerPage.mockResolvedValue({ data: [], total: 0 });
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
   });
 
   it('rejects an unauthenticated request', async () => {

--- a/apps/client/pages/api/admin/__tests__/usage-margin.test.ts
+++ b/apps/client/pages/api/admin/__tests__/usage-margin.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ApiKeyScope } from '@bike4mind/common';
+
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: (config?: unknown) => {
+    const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
+    const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
+    chain.use = () => chain;
+    chain.get = (fn: (typeof handlers)[string]) => {
+      handlers.GET = fn;
+      return chain;
+    };
+    chain._config = config;
+    return chain;
+  },
+}));
+
+const mockMarginByModelDay = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  usageEventRepository: { marginByModelDay: (...a: unknown[]) => mockMarginByModelDay(...a) },
+  userRepository: { findByIds: vi.fn().mockResolvedValue([]) },
+}));
+
+import handler from '../usage-margin';
+
+function call(options: { isAdmin?: boolean; hasUser?: boolean; query?: object }) {
+  const { req, res } = createMocks({ method: 'GET', query: options.query ?? { view: 'model-day' } });
+  if (options.hasUser !== false) {
+    (req as unknown as { user: { isAdmin: boolean; id: string } }).user = {
+      isAdmin: options.isAdmin ?? true,
+      id: 'admin-1',
+    };
+  }
+  return { req, res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+describe('GET /api/admin/usage-margin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMarginByModelDay.mockResolvedValue([]);
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    // Guards margin data against a narrowly-scoped key inheriting its owner's
+    // isAdmin: apiKeyAuth rejects the key before req.user is set. JWT/browser
+    // admins skip that check and are unaffected.
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
+  it('rejects a non-admin', async () => {
+    const { run } = call({ isAdmin: false });
+    await expect(run()).rejects.toThrow(/[Aa]dmin/);
+    expect(mockMarginByModelDay).not.toHaveBeenCalled();
+  });
+
+  it('returns model-day margin rows for an admin', async () => {
+    mockMarginByModelDay.mockResolvedValue([{ model: 'opus', day: '2026-08-01', cogsUsd: 5, creditsCharged: 500 }]);
+    const { res, run } = call({ query: { view: 'model-day', days: '14' } });
+    await run();
+    expect(res._getJSONData().rows).toHaveLength(1);
+  });
+});

--- a/apps/client/pages/api/admin/credit-adjustments.ts
+++ b/apps/client/pages/api/admin/credit-adjustments.ts
@@ -1,6 +1,7 @@
 import { creditTransactionRepository, userRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { ApiKeyScope } from '@bike4mind/common';
 import { ForbiddenError } from '@server/utils/errors';
 import { z } from 'zod';
 
@@ -33,7 +34,11 @@ export interface IAdminAdjustmentsResponse {
   totalPages: number;
 }
 
-const handler = baseApi().get(
+// requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+// before req.user is set, so a key issued for a narrow integration can't read
+// admin credit adjustments just because its owner is an admin. JWT/browser admins
+// skip that check and still pass the isAdmin gate below.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
   asyncHandler<{}, unknown, unknown, { page?: string; limit?: string; days?: string }>(async (req, res) => {
     if (!req.user?.isAdmin) {
       throw new ForbiddenError('Unauthorized. Admin access required.');

--- a/apps/client/pages/api/admin/platform-usage.ts
+++ b/apps/client/pages/api/admin/platform-usage.ts
@@ -2,6 +2,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { usageEventRepository, apiKeyUsageLogRepository, userApiKeyRepository } from '@bike4mind/database';
 import { organizationRepository } from '@bike4mind/database/infra';
 import {
+  ApiKeyScope,
   COMPLETION_SOURCES,
   CreditHolderType,
   type IPlatformEndpointUsage,
@@ -35,8 +36,13 @@ const QuerySchema = z.object({
  *    ownerType-filterable, with API-key consumers resolved to key/owner labels.
  *  - ApiKeyUsageLog-derived endpoint/latency (request counts only, no credits).
  * Admin-only.
+ *
+ * requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+ * before req.user is set, so a key issued for a narrow integration can't read
+ * platform usage just because its owner is an admin. JWT/browser admins skip that
+ * check and still pass the isAdmin gate below.
  */
-const handler = baseApi().get(async (req, res) => {
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(async (req, res) => {
   if (!req.user) {
     throw new ForbiddenError('Authentication required');
   }

--- a/apps/client/pages/api/admin/provider-invoices.ts
+++ b/apps/client/pages/api/admin/provider-invoices.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { baseApi } from '@server/middlewares/baseApi';
 import { providerInvoiceRepository } from '@bike4mind/database';
+import { ApiKeyScope } from '@bike4mind/common';
 import { ForbiddenError, BadRequestError } from '@server/utils/errors';
 
 /**
@@ -18,7 +19,11 @@ const InvoiceBody = z.object({
   note: z.string(),
 });
 
-const handler = baseApi()
+// requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+// before req.user is set, so a key issued for a narrow integration can't read or
+// enter provider invoices just because its owner is an admin. JWT/browser admins
+// skip that check and still pass the isAdmin gates below.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] })
   .get(async (req, res) => {
     if (!req.user?.isAdmin) throw new ForbiddenError('Admin access required');
     return res.json({ invoices: await providerInvoiceRepository.newestPerMonthProvider() });

--- a/apps/client/pages/api/admin/session-usage.ts
+++ b/apps/client/pages/api/admin/session-usage.ts
@@ -1,6 +1,7 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { usageEventRepository, agentExecutionRepository } from '@bike4mind/database';
 import {
+  ApiKeyScope,
   CreditHolderType,
   type ISessionAgentExecution,
   type ISessionAgentModelUsage,
@@ -35,8 +36,16 @@ const QuerySchema = z.object({
  * that starts personal and later runs under an org). So a non-admin's view is
  * scoped to their org: they see only their org's slice, never another owner's.
  * Admins keep the full cross-org rollup.
+ *
+ * requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+ * before req.user is set, so a key issued for a narrow integration can't read
+ * session spend just because its owner is an admin. JWT/browser callers (admin or
+ * org owner/manager) skip that check and still go through the access logic above.
+ * A non-admin org owner/manager calling via API key now also needs the ADMIN
+ * scope - there's no narrower "org-scoped" key scope to grant self-service access
+ * without it.
  */
-const handler = baseApi().get(async (req, res) => {
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(async (req, res) => {
   if (!req.user) {
     throw new ForbiddenError('Authentication required');
   }

--- a/apps/client/pages/api/admin/session-usage.ts
+++ b/apps/client/pages/api/admin/session-usage.ts
@@ -41,9 +41,9 @@ const QuerySchema = z.object({
  * before req.user is set, so a key issued for a narrow integration can't read
  * session spend just because its owner is an admin. JWT/browser callers (admin or
  * org owner/manager) skip that check and still go through the access logic above.
- * A non-admin org owner/manager calling via API key now also needs the ADMIN
- * scope - there's no narrower "org-scoped" key scope to grant self-service access
- * without it.
+ * ApiKeyScope.ADMIN has no mint path (excluded from every key-creation UI and
+ * rejected server-side), so this closes the API-key path entirely for a
+ * non-admin org owner/manager - only a JWT/browser session still works for them.
  */
 const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(async (req, res) => {
   if (!req.user) {

--- a/apps/client/pages/api/admin/transactions.ts
+++ b/apps/client/pages/api/admin/transactions.ts
@@ -58,9 +58,9 @@ const QuerySchema = z.object({
  * before req.user is set, so a key issued for a narrow integration can't read an
  * org's ledger just because its owner is an admin. JWT/browser callers (admin or
  * org owner/manager) skip that check and still go through verifyOrgAccess below.
- * A non-admin org owner/manager calling via API key now also needs the ADMIN
- * scope - there's no narrower "org-scoped" key scope to grant self-service access
- * without it.
+ * ApiKeyScope.ADMIN has no mint path (excluded from every key-creation UI and
+ * rejected server-side), so this closes the API-key path entirely for a
+ * non-admin org owner/manager - only a JWT/browser session still works for them.
  */
 const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(async (req, res) => {
   if (!req.user) {

--- a/apps/client/pages/api/admin/transactions.ts
+++ b/apps/client/pages/api/admin/transactions.ts
@@ -1,6 +1,7 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { creditTransactionRepository } from '@bike4mind/database';
 import {
+  ApiKeyScope,
   CreditHolderType,
   COMPLETION_SOURCES,
   CREDIT_ADD_TRANSACTION_TYPES,
@@ -52,8 +53,16 @@ const QuerySchema = z.object({
  *
  * Access: platform admins (cross-org) plus the org's own owner/manager, via
  * verifyOrgAccess - which pins non-admins to their org and 404s the rest.
+ *
+ * requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+ * before req.user is set, so a key issued for a narrow integration can't read an
+ * org's ledger just because its owner is an admin. JWT/browser callers (admin or
+ * org owner/manager) skip that check and still go through verifyOrgAccess below.
+ * A non-admin org owner/manager calling via API key now also needs the ADMIN
+ * scope - there's no narrower "org-scoped" key scope to grant self-service access
+ * without it.
  */
-const handler = baseApi().get(async (req, res) => {
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(async (req, res) => {
   if (!req.user) {
     throw new ForbiddenError('Authentication required');
   }

--- a/apps/client/pages/api/admin/usage-margin.ts
+++ b/apps/client/pages/api/admin/usage-margin.ts
@@ -1,6 +1,7 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { usageEventRepository, userRepository } from '@bike4mind/database';
 import { usdToCredits } from '@bike4mind/utils';
+import { ApiKeyScope } from '@bike4mind/common';
 import { ForbiddenError, BadRequestError } from '@server/utils/errors';
 
 const VIEWS = ['model-day', 'user', 'provider-month', 'settlement'] as const;
@@ -13,8 +14,13 @@ type MarginView = (typeof VIEWS)[number];
  * Responses include targetCreditsPerUsd = usdToCredits(1): what current pricing
  * charges per $1 of COGS. Rows below it were charged under older pricing or
  * indicate a leak.
+ *
+ * requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+ * before req.user is set, so a key issued for a narrow integration can't read
+ * margin data just because its owner is an admin. JWT/browser admins skip that
+ * check and still pass the isAdmin gate below.
  */
-const handler = baseApi().get(async (req, res) => {
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(async (req, res) => {
   if (!req.user?.isAdmin) {
     throw new ForbiddenError('Admin access required');
   }


### PR DESCRIPTION
## Description

Closes #1628. The admin financial endpoints authenticated with a bare `baseApi()` and gated only on `req.user?.isAdmin`. Because `apiKeyAuth` assigns `req.user` wholesale, an API key issued to an admin for a narrow integration inherited that admin's privileges and passed the gate - the scopes the key was actually minted with never entered the decision. A leaked or over-broad narrow-scope key could therefore read organization-wide financial data (spend, revenue, per-model cost, margins, transactions, credit adjustments, provider invoices).

This is the same fix already applied to `/api/admin/spend` (#1556) and `/api/users/counterLogs` (#1558): adopt the `requiredScopes: [ApiKeyScope.ADMIN]` gate, which `apiKeyAuth` enforces before `req.user` is ever set. The check runs only for API-key callers - JWT/browser admins are unaffected.

Two of the six endpoints (`transactions.ts`, `session-usage.ts`) also let a non-admin org owner/manager through via `verifyOrgAccess`, not just platform admins. There's no narrower "org-scoped" `ApiKeyScope` to preserve that self-service path, so the blanket fix means a non-admin org owner's API key can no longer call these two endpoints for their own org - only an ADMIN-scoped key or a browser/JWT session can, going forward. Accepted as the simpler, consistent fix over building a more surgical per-branch scope check.

A broader repo-wide audit (~28 more `admin/*.ts` routes with the identical `req.user?.isAdmin`-only gap, two of which - `create-user.ts`, `bulk-create-users.ts` - allow privilege escalation to a brand-new admin account, not just a data read) is filed separately as #1937 and intentionally out of scope here.

## Changes

- `platform-usage.ts`, `usage-margin.ts`, `credit-adjustments.ts`, `provider-invoices.ts`: added `requiredScopes: [ApiKeyScope.ADMIN]` to `baseApi()`. Straightforward - these gate purely on `isAdmin` with no other access path. `provider-invoices.ts` has both GET and POST handlers on the same `baseApi()` chain, so one gate covers both.
- `session-usage.ts`, `transactions.ts`: same `requiredScopes: [ApiKeyScope.ADMIN]` addition. See the tradeoff noted above re: non-admin org owner API-key access.
- Test coverage: added a `requiredScopes` config-assertion test (mirrors the existing pattern in `spend.test.ts`) to all four endpoints that already had test files, and wrote new test files for `platform-usage.ts` and `usage-margin.ts`, which had no coverage before this PR.

## Guide for Testers

This is an API-only change with no UI surface - test via curl against this PR's preview env (`pr<N>.preview.bike4mind.com`, posted by a maintainer once triggered).

1. As an existing admin user on `pr<N>.preview.bike4mind.com`, create a user API key scoped only to `notebooks:read` (Settings -> API Keys -> New Key -> select only the Notebooks Read scope).
2. Run `curl -H "Authorization: Bearer <key>" https://pr<N>.preview.bike4mind.com/api/admin/platform-usage`.
   Expected: HTTP 403 with an "Insufficient API key permissions" error body.

   <img width="756" height="225" alt="image" src="https://github.com/user-attachments/assets/26dc88b5-ef28-443c-959f-a2b074d76584" />

3. Repeat step 2 against `/api/admin/usage-margin?view=model-day`, `/api/admin/session-usage?sessionId=<any>`, `/api/admin/transactions?organizationId=<any>`, `/api/admin/credit-adjustments`, and `/api/admin/provider-invoices`.
   Expected: HTTP 403 on all six.
4. Log into the admin UI as a browser session (JWT auth, no API key) and open `/admin` -> **Credit Analytics** tab, then check each sub-tab: **Margins** (`usage-margin` + `provider-invoices`), **Ledger** (`transactions`; click into a session link on a ledger row to open the Session Usage detail modal, which hits `session-usage`), and **Adjustments** (`credit-adjustments`).
   Expected: no change in behavior - all four sub-tabs and the modal load normally, since JWT/browser auth never goes through the scope check.

`platform-usage` has no UI consumer (no client hook or component calls it - backend-only), so it can't be exercised through a page; step 3's curl covers its only reachable surface.

There is no step where a tester mints an ADMIN-scoped key to confirm the positive (matching-scope-succeeds) case: `ApiKeyScope.ADMIN` has no self-service or admin-console mint path by design (`apps/client/app/constants/apiKeyScopes.ts` excludes it from every UI scope picker, and #1906 closed the API-level bypass on both key-creation endpoints). The matching-scope branch is generic `apiKeyAuth` logic, not per-route - it's the same code path already serving `/api/admin/spend` (#1556) and `/api/users/counterLogs` (#1558) in production today, so correctness there is inherited rather than re-verified per endpoint here.

### What NOT to test

No UI changes - this PR only adds a server-side auth gate. The response shape, pagination, and data returned by all six endpoints is unchanged for any caller that already passes.

## Additional Information

Verified: `pnpm --filter client typecheck` clean, `pnpm lint:check` clean on all touched files, ASCII/smart-punctuation checks clean. `apps/client/pages/api/admin/__tests__` full directory green (154 passed, including the 6 new/updated scope-assertion tests).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
