### PR TITLE
feat(datalake): create a data lake from a Google Drive folder alone

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
@@ -13,9 +13,10 @@ import DataLakeWizardModal from './DataLakeWizardModal';
  * check vs. a retry that calls mutate() directly) stay in sync.
  */
 
-const { toastMock, batchUploadMutate } = vi.hoisted(() => ({
+const { toastMock, batchUploadMutate, driveCommitMutate } = vi.hoisted(() => ({
   toastMock: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
   batchUploadMutate: vi.fn(),
+  driveCommitMutate: vi.fn(),
 }));
 
 vi.mock('sonner', () => ({ toast: toastMock }));
@@ -23,6 +24,7 @@ vi.mock('sonner', () => ({ toast: toastMock }));
 // module so the config gate is checked against the real validation logic.
 vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
   useBatchUpload: () => ({ mutate: batchUploadMutate, isPending: false }),
+  useCreateLakeFromDrive: () => ({ mutate: driveCommitMutate, isPending: false }),
   useComputeHashes: () => ({ mutate: vi.fn(), isPending: false }),
   useCheckDuplicates: () => ({ mutate: vi.fn(), isPending: false }),
   OFFLINE_MESSAGE: 'No internet connection. Check your network and try again.',
@@ -38,6 +40,9 @@ vi.mock('@client/app/hooks/data/dataLakes', () => ({
 // SourceSelectionStep now renders DriveConnectAction, which pulls in React Query (useConfig /
 // lake-connection hooks); stub it so this wizard test needs no QueryClientProvider.
 vi.mock('@client/app/components/DataLakeWizard/steps/DriveConnectAction', () => ({
+  default: () => null,
+}));
+vi.mock('@client/app/components/DataLakeWizard/steps/DrivePendingConnectAction', () => ({
   default: () => null,
 }));
 // ConfigStep's embedding-cost estimate reads admin settings via react-query; stub it so this
@@ -57,11 +62,14 @@ describe('DataLakeWizardModal — handleStartUpload offline pre-check', () => {
     prefixClash.current = undefined;
     toastMock.error.mockClear();
     batchUploadMutate.mockClear();
+    driveCommitMutate.mockClear();
     useDataLakeWizardStore.setState({
       isOpen: true,
       step: 'config',
       targetLake: null,
-      allFiles: [],
+      // Configure is only reachable with a source in hand, and the button gates on that too - so
+      // seed one file, or every prefix assertion below would be measuring the missing-source gate.
+      allFiles: [{ relativePath: 'a.txt', size: 1, excluded: false }] as never,
       config: {
         name: 'Test Lake',
         description: '',
@@ -384,5 +392,112 @@ describe('DataLakeWizardModal - streamlined step order', () => {
     const state = useDataLakeWizardStore.getState();
     expect(state.step).toBe('config');
     expect(state.config.tagPrefix).toBe('legal-contracts:');
+  });
+});
+
+/**
+ * A lake whose only source is a Google Drive folder (#1916). Every step used to gate on local
+ * files, so this path was unreachable: with zero files the source step's Next never enabled, and
+ * the commit threw before it created anything.
+ */
+describe('DataLakeWizardModal - Drive-only create', () => {
+  const driveFolder = { driveFolderId: 'FOLDER1', folderName: 'Contracts' };
+
+  const seedDriveOnly = (over: { step?: 'source' | 'config'; name?: string } = {}) =>
+    useDataLakeWizardStore.setState(state => ({
+      isOpen: true,
+      step: over.step ?? 'source',
+      targetLake: null,
+      allFiles: [],
+      pendingDriveFolder: driveFolder,
+      config: { ...state.config, name: over.name ?? 'Drive Only Lake', tagPrefix: 'drive:' },
+    }));
+
+  const renderModal = () =>
+    render(
+      <TestWrapper>
+        <DataLakeWizardModal />
+      </TestWrapper>
+    );
+
+  beforeEach(() => {
+    prefixClash.current = undefined;
+    batchUploadMutate.mockClear();
+    driveCommitMutate.mockClear();
+    toastMock.error.mockClear();
+  });
+
+  afterEach(() => {
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('advances past the source step on a Drive folder alone, with no files', () => {
+    seedDriveOnly();
+
+    renderModal();
+
+    expect(screen.getByTestId('wizard-next-btn')).not.toBeDisabled();
+  });
+
+  it('still requires a usable name, which the lake is created with either way', () => {
+    seedDriveOnly({ name: 'x' }); // slugifies below the server's 2-character minimum
+
+    renderModal();
+
+    expect(screen.getByTestId('wizard-next-btn')).toBeDisabled();
+  });
+
+  it('offers a create action rather than an upload, and runs the fileless commit', () => {
+    seedDriveOnly({ step: 'config' });
+
+    renderModal();
+    const commitBtn = screen.getByTestId('wizard-start-upload-btn');
+
+    expect(commitBtn).toHaveTextContent('Create and sync');
+    commitBtn.click();
+    expect(driveCommitMutate).toHaveBeenCalledTimes(1);
+    expect(batchUploadMutate).not.toHaveBeenCalled();
+  });
+
+  it('runs the upload commit when files are present too, Drive folder or not', () => {
+    seedDriveOnly({ step: 'config' });
+    useDataLakeWizardStore.setState({
+      allFiles: [{ relativePath: 'a.txt', size: 1, excluded: false }] as never,
+    });
+
+    renderModal();
+    const commitBtn = screen.getByTestId('wizard-start-upload-btn');
+
+    expect(commitBtn).toHaveTextContent('Start Upload');
+    commitBtn.click();
+    expect(batchUploadMutate).toHaveBeenCalledTimes(1);
+    expect(driveCommitMutate).not.toHaveBeenCalled();
+  });
+
+  it('treats a picked folder as unsaved progress and discards it on close, creating nothing', () => {
+    // The whole point of deferring the connect: abandoning the wizard must leave no lake and no
+    // connection row, because neither was ever created.
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    seedDriveOnly();
+
+    renderModal();
+    screen.getByText('Cancel').click();
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(useDataLakeWizardStore.getState().pendingDriveFolder).toBeNull();
+    expect(driveCommitMutate).not.toHaveBeenCalled();
+    expect(batchUploadMutate).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('keeps the picked folder when the discard is declined', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    seedDriveOnly();
+
+    renderModal();
+    screen.getByText('Cancel').click();
+
+    expect(useDataLakeWizardStore.getState().pendingDriveFolder).toEqual(driveFolder);
+    confirmSpy.mockRestore();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '@mui/joy/styles';
 import { toast } from 'sonner';
 import { useDataLakeWizardStore, type OptionalSteps } from '@client/app/stores/useDataLakeWizardStore';
 import type { WizardStep } from '@client/app/stores/useDataLakeWizardStore';
-import { useBatchUpload, OFFLINE_MESSAGE } from '@client/app/hooks/data/dataLakeWizard';
+import { useBatchUpload, useCreateLakeFromDrive, OFFLINE_MESSAGE } from '@client/app/hooks/data/dataLakeWizard';
 import { isValidDataLakeSlug } from '@client/app/hooks/data/dataLakeSlug';
 import {
   hasBlankTagPrefixSegment,
@@ -46,8 +46,18 @@ export default function DataLakeWizardModal() {
   const config = useDataLakeWizardStore(s => s.config);
   const deriveTagPrefixFromName = useDataLakeWizardStore(s => s.deriveTagPrefixFromName);
   const targetLake = useDataLakeWizardStore(s => s.targetLake);
+  const pendingDriveFolder = useDataLakeWizardStore(s => s.pendingDriveFolder);
 
   const batchUpload = useBatchUpload();
+  const createLakeFromDrive = useCreateLakeFromDrive();
+
+  // A Drive folder picked during create is a source in its own right, so it satisfies every gate
+  // that used to demand local files - that gate is what made a Drive-only lake impossible (#1916).
+  const hasIncludedFiles = allFiles.some(f => !f.excluded);
+  const hasSource = hasIncludedFiles || !!pendingDriveFolder;
+  // Nothing to upload, so the commit is the create + Drive connect, not the upload pipeline.
+  const isDriveOnlyCommit = !hasIncludedFiles && !!pendingDriveFolder;
+  const commit = isDriveOnlyCommit ? createLakeFromDrive : batchUpload;
 
   const STEP_ORDER = stepOrderFor({ optionalSteps });
   // What the create request will carry, which is what every rule below judges - see
@@ -65,12 +75,16 @@ export default function DataLakeWizardModal() {
         // Counts INCLUDED files, not raw ones: auto-exclusion can empty a selection on its own
         // (e.g. only junk files picked), and Preview - which used to be the mandatory home of
         // this check - is now skippable, so nothing else would stop the user reaching Start
-        // Upload with zero files to send. Identity is gated here too, by the same slug.min(2)
-        // rule the server enforces; append mode reuses the lake's own slug.
-        return allFiles.some(f => !f.excluded) && (!!targetLake || isValidDataLakeSlug(config.name));
+        // Upload with zero files to send. A pending Drive folder is the other way to satisfy it.
+        // Identity is gated here too, by the same slug.min(2) rule the server enforces; append
+        // mode reuses the lake's own slug.
+        return hasSource && (!!targetLake || isValidDataLakeSlug(config.name));
       case 'preview':
-        return allFiles.some(f => !f.excluded);
+        return hasSource;
       case 'config':
+        // Source is re-checked, not assumed from having got here: the commit throws without one,
+        // and the button must never be the thing that discovers that.
+        //
         // Every rule the create endpoint enforces on identity is mirrored here, so a value it
         // will refuse cannot reach Start Upload and fail the whole upload at the last step:
         // slug.min(2), the prefix bounds, the reserved namespace, a blank ":" segment, and an
@@ -84,6 +98,7 @@ export default function DataLakeWizardModal() {
         // ":" before POSTing, so 30 colon-less characters are 31 on arrival (refused) and a
         // bare "a" is the legal "a:" (accepted). Sizing the field got both of those wrong.
         return (
+          hasSource &&
           (!!targetLake || isValidDataLakeSlug(config.name)) &&
           effectivePrefix.length >= MIN_TAG_PREFIX_LENGTH &&
           !isReservedTagPrefix(effectivePrefix) &&
@@ -117,9 +132,10 @@ export default function DataLakeWizardModal() {
   };
 
   const handleClose = () => {
-    // Files can now be gathered without leaving the source step, so having files - not being
-    // past source - is what marks unsaved progress worth confirming away.
-    if (allFiles.length > 0) {
+    // Files can now be gathered without leaving the source step, so having a source - not being
+    // past source - is what marks unsaved progress worth confirming away. A picked Drive folder
+    // counts: nothing has been created yet, so closing really does discard it (#1916).
+    if (allFiles.length > 0 || pendingDriveFolder) {
       if (!window.confirm('You have unsaved progress. Are you sure you want to close the wizard?')) {
         return;
       }
@@ -127,14 +143,14 @@ export default function DataLakeWizardModal() {
     resetWizard();
   };
 
-  const handleStartUpload = () => {
-    // Belt-and-suspenders with the same check inside useBatchUpload's mutationFn:
+  const handleCommit = () => {
+    // Belt-and-suspenders with the same check inside each commit mutation's mutationFn:
     // checking here means the button never even flips into its loading state for
     // the common "already offline" case, instead of depending on the mutation
     // lifecycle to notice and unwind.
     if (typeof navigator !== 'undefined' && !navigator.onLine) {
       const message = OFFLINE_MESSAGE;
-      // Mirror useBatchUpload's onError so uploadProgress reflects this failure
+      // Mirror the mutation's onError so uploadProgress reflects this failure
       // the same way regardless of which of the two entry points caught it, and
       // reuse its toast id so a repeated offline click/retry replaces the same
       // toast instead of stacking a new one.
@@ -142,11 +158,11 @@ export default function DataLakeWizardModal() {
       toast.error(message, {
         id: 'data-lake-batch-upload-error',
         duration: 8000,
-        action: { label: 'Retry', onClick: handleStartUpload },
+        action: { label: 'Retry', onClick: handleCommit },
       });
       return;
     }
-    batchUpload.mutate();
+    commit.mutate();
   };
 
   const renderStep = () => {
@@ -215,14 +231,17 @@ export default function DataLakeWizardModal() {
             )}
             {step === 'config' ? (
               <Button
+                // One commit button, two labels: the testid is deliberately unchanged so every
+                // existing selector still finds the wizard's primary action.
                 data-testid="wizard-start-upload-btn"
                 variant="solid"
                 color="success"
-                disabled={!canGoNext || batchUpload.isPending}
-                loading={batchUpload.isPending}
-                onClick={handleStartUpload}
+                disabled={!canGoNext || commit.isPending}
+                loading={commit.isPending}
+                onClick={handleCommit}
               >
-                Start Upload
+                {/* Nothing is uploaded on the Drive-only path, so don't call it an upload. */}
+                {isDriveOnlyCommit ? 'Create and sync' : 'Start Upload'}
               </Button>
             ) : step !== 'upload' ? (
               <Button

--- a/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.test.tsx
@@ -53,11 +53,6 @@ beforeEach(() => {
 });
 
 describe('DriveConnectAction', () => {
-  it('disables the action in create mode, before the lake exists', () => {
-    wrap(<DriveConnectAction lake={null} />);
-    expect(screen.getByTestId('drive-connect-disabled-btn')).toBeDisabled();
-  });
-
   it('offers an enabled Connect button when the lake has no connection yet', () => {
     wrap(<DriveConnectAction lake={{ id: 'lake1' }} />);
     expect(screen.getByTestId('drive-connect-btn')).not.toBeDisabled();

--- a/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.tsx
@@ -4,131 +4,47 @@ import SyncIcon from '@mui/icons-material/Sync';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import { useState } from 'react';
 import { toast } from 'sonner';
-import useDrivePicker from 'react-google-drive-picker';
-import { api } from '@client/app/contexts/ApiContext';
-import { useConfig } from '@client/app/hooks/data/settings';
-import { ensureGoogleDrivePickerStyles } from '@client/app/utils/googleDrivePickerStyles';
 import {
   useLakeDriveConnection,
   useConnectDriveFolderToLake,
   useDisconnectLakeDrive,
   DRIVE_STATUS_BADGE,
 } from '@client/app/hooks/data/googleDrive';
+import { useDriveFolderPicker } from '@client/app/hooks/data/useDriveFolderPicker';
 
 /** The specific server `error` message off an axios failure, if the response carried one. */
 function serverError(e: unknown): string | undefined {
   return (e as { response?: { data?: { error?: string } } })?.response?.data?.error;
 }
-function httpStatus(e: unknown): number | undefined {
-  return (e as { response?: { status?: number } })?.response?.status;
-}
 
 /**
- * Connect a Google Drive FOLDER to an existing data lake. Reuses the same OAuth-token flow the chat
- * attach button uses (redirect to consent when not yet connected, else open the Google Picker), but
- * with folder-select enabled so the picked item is a folder id. Only meaningful against an existing
- * lake - in create mode the lake has no id yet, so the action is disabled with guidance.
+ * Connect a Google Drive FOLDER to an EXISTING data lake: pick a folder and the connection is
+ * created straight away, since the lake already has an id to bind to. Create mode has no id yet
+ * and so uses DrivePendingConnectAction, which parks the selection until commit (#1916).
  */
-export default function DriveConnectAction({ lake }: { lake: { id: string } | null | undefined }) {
-  const { data: config } = useConfig();
-  const googleClientId = config?.googleClientId;
-  const [openPicker] = useDrivePicker();
-  const [isPicking, setIsPicking] = useState(false);
+export default function DriveConnectAction({ lake }: { lake: { id: string } }) {
   const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
 
-  const { data: connection, isLoading, isError } = useLakeDriveConnection(lake?.id);
+  const { data: connection, isLoading, isError } = useLakeDriveConnection(lake.id);
   const connect = useConnectDriveFolderToLake();
   const disconnect = useDisconnectLakeDrive();
 
-  if (!lake) {
-    return (
-      <Tooltip title="Save the data lake first, then connect a Google Drive folder to it.">
-        <span>
-          <Button
-            data-testid="drive-connect-disabled-btn"
-            variant="outlined"
-            color="neutral"
-            startDecorator={<CloudIcon />}
-            disabled
-          >
-            Connect Google Drive
-          </Button>
-        </span>
-      </Tooltip>
-    );
-  }
-
   const lakeId = lake.id;
 
-  const openFolderPicker = async () => {
-    if (isPicking || connect.isPending) return; // re-entrancy guard: never open a second picker
-    setIsPicking(true);
-    try {
-      let token: { accessToken?: string; authUrl?: string };
-      try {
-        const { data } = await api.get<{ accessToken?: string; authUrl?: string }>('/api/google-drive/token');
-        token = data;
-      } catch (e) {
-        // First-time user: /token 400s ("Google Drive not connected") when Drive was never linked.
-        // Send them to Google's consent screen (the same POST /connect the profile flow uses); they
-        // come back and can then pick a folder. Any other error falls through to the outer catch.
-        if (httpStatus(e) === 400) {
-          const { data } = await api.post<{ authUrl: string }>('/api/google-drive/connect');
-          window.location.href = data.authUrl;
-          return;
+  const { openFolderPicker, isPicking } = useDriveFolderPicker({
+    busy: connect.isPending,
+    onPicked: folder =>
+      connect.mutate(
+        { dataLakeId: lakeId, ...folder },
+        {
+          onSuccess: () =>
+            toast.success(`Syncing "${folder.folderName || folder.driveFolderId}" into this data lake...`),
+          // Surface the server's specific message (folder claimed elsewhere, lake already bound to a
+          // different folder, "connect Drive first", ...) rather than one generic string for every 409.
+          onError: (e: unknown) => toast.error(serverError(e) || 'Could not connect that folder. Please try again.'),
         }
-        throw e;
-      }
-
-      // Not connected / refresh failed: /token hands back an authUrl instead of a token.
-      if (token.authUrl) {
-        window.location.href = token.authUrl;
-        return;
-      }
-      if (!token.accessToken || !googleClientId) {
-        toast.error('Google Drive is unavailable right now. Please try again.');
-        setIsPicking(false);
-        return;
-      }
-
-      ensureGoogleDrivePickerStyles(); // keep the picker above the wizard modal (z-index 1400)
-      openPicker({
-        clientId: googleClientId,
-        developerKey: '',
-        viewId: 'FOLDERS', // folder-first browse; the user selects a folder to ingest
-        viewMimeTypes: '',
-        token: token.accessToken,
-        showUploadFolders: false,
-        supportDrives: true,
-        multiselect: false,
-        setIncludeFolders: true,
-        setSelectFolderEnabled: true, // pick a FOLDER, not a file - its id feeds the ingest
-        disableDefaultView: false,
-        callbackFunction: pick => {
-          // Clear the button's loading state as the picker closes. openPicker() is synchronous, so
-          // this must happen in the callback, not right after the call - otherwise the button drops
-          // its loading state while the picker is still open and a second click opens a second picker.
-          if (pick.action === 'picked' || pick.action === 'cancel') setIsPicking(false);
-          if (pick.action !== 'picked') return;
-          const folder = pick.docs?.[0];
-          if (!folder?.id) return;
-          connect.mutate(
-            { dataLakeId: lakeId, driveFolderId: folder.id, folderName: folder.name },
-            {
-              onSuccess: () => toast.success(`Syncing "${folder.name}" into this data lake...`),
-              // Surface the server's specific message (folder claimed elsewhere, lake already bound to a
-              // different folder, "connect Drive first", ...) rather than one generic string for every 409.
-              onError: (e: unknown) =>
-                toast.error(serverError(e) || 'Could not connect that folder. Please try again.'),
-            }
-          );
-        },
-      });
-    } catch {
-      toast.error('Could not open Google Drive. Please try again.');
-      setIsPicking(false);
-    }
-  };
+      ),
+  });
 
   if (isLoading) {
     return <CircularProgress size="sm" data-testid="drive-connection-loading" />;

--- a/apps/client/app/components/DataLakeWizard/steps/DrivePendingConnectAction.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DrivePendingConnectAction.test.tsx
@@ -1,0 +1,104 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+
+/**
+ * Create-mode Drive selection (#1916): the wizard has no lake id yet, so picking a folder must park
+ * it in wizard state rather than connect anything - that deferral is what keeps an abandoned wizard
+ * from leaving a lake or a connection row behind.
+ */
+
+const h = vi.hoisted(() => ({
+  selectedAccount: { current: null as { id: string; name: string; personal: boolean } | null },
+  openFolderPicker: vi.fn(),
+}));
+
+vi.mock('@client/app/components/Credits/AccountSelector', () => ({
+  useSelectedAccount: (selector: (s: { selectedAccount: unknown }) => unknown) =>
+    selector({ selectedAccount: h.selectedAccount.current }),
+}));
+// The picker itself (OAuth prelude + Google Picker) is not the subject here; capture the callback
+// so a test can simulate a pick without a browser.
+vi.mock('@client/app/hooks/data/useDriveFolderPicker', () => ({
+  useDriveFolderPicker: (args: { onPicked: (f: { driveFolderId: string; folderName?: string }) => void }) => {
+    h.openFolderPicker.mockImplementation(() => args.onPicked({ driveFolderId: 'FOLDER1', folderName: 'Contracts' }));
+    return { openFolderPicker: h.openFolderPicker, isPicking: false };
+  },
+}));
+
+import DrivePendingConnectAction from './DrivePendingConnectAction';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const wrap = (ui: ReactNode) => render(<CssVarsProvider theme={appTheme}>{ui}</CssVarsProvider>);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.selectedAccount.current = { id: 'org1', name: 'Acme', personal: false };
+  useDataLakeWizardStore.getState().resetWizard();
+});
+
+describe('DrivePendingConnectAction', () => {
+  it('offers an enabled Connect button in an organization scope', () => {
+    wrap(<DrivePendingConnectAction />);
+    expect(screen.getByTestId('drive-connect-btn')).not.toBeDisabled();
+  });
+
+  it('parks the picked folder in wizard state instead of connecting it', () => {
+    wrap(<DrivePendingConnectAction />);
+
+    fireEvent.click(screen.getByTestId('drive-connect-btn'));
+
+    expect(useDataLakeWizardStore.getState().pendingDriveFolder).toEqual({
+      driveFolderId: 'FOLDER1',
+      folderName: 'Contracts',
+    });
+  });
+
+  it('shows the pending selection and what will happen to it', () => {
+    useDataLakeWizardStore.setState({ pendingDriveFolder: { driveFolderId: 'FOLDER1', folderName: 'Contracts' } });
+
+    wrap(<DrivePendingConnectAction />);
+
+    expect(screen.getByTestId('drive-pending-selection')).toHaveTextContent('Contracts');
+    expect(screen.getByTestId('drive-pending-selection')).toHaveTextContent('Connects when you create');
+  });
+
+  it('falls back to the folder id when Drive gave no name', () => {
+    useDataLakeWizardStore.setState({ pendingDriveFolder: { driveFolderId: 'FOLDER1' } });
+
+    wrap(<DrivePendingConnectAction />);
+
+    expect(screen.getByTestId('drive-pending-selection')).toHaveTextContent('FOLDER1');
+  });
+
+  it('clears the selection, so a mistaken pick is not baked into the commit', () => {
+    useDataLakeWizardStore.setState({ pendingDriveFolder: { driveFolderId: 'FOLDER1', folderName: 'Contracts' } });
+
+    wrap(<DrivePendingConnectAction />);
+    fireEvent.click(screen.getByTestId('drive-pending-clear-btn'));
+
+    expect(useDataLakeWizardStore.getState().pendingDriveFolder).toBeNull();
+  });
+
+  it('disables the action in a personal scope, which drive-sync refuses', () => {
+    // POST /api/data-lakes/drive-sync 400s on a lake with no organizationId, so offering this in
+    // Personal scope could only ever create a lake and then fail to connect it.
+    h.selectedAccount.current = { id: 'me', name: 'Me', personal: true };
+
+    wrap(<DrivePendingConnectAction />);
+
+    expect(screen.getByTestId('drive-connect-personal-scope-btn')).toBeDisabled();
+    expect(screen.queryByTestId('drive-connect-btn')).toBeNull();
+  });
+
+  it('disables the action before any account is selected, rather than assuming an org', () => {
+    h.selectedAccount.current = null;
+
+    wrap(<DrivePendingConnectAction />);
+
+    expect(screen.getByTestId('drive-connect-personal-scope-btn')).toBeDisabled();
+  });
+});

--- a/apps/client/app/components/DataLakeWizard/steps/DrivePendingConnectAction.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DrivePendingConnectAction.tsx
@@ -1,0 +1,104 @@
+import { Button, Chip, Stack, Tooltip, Typography } from '@mui/joy';
+import CloudIcon from '@mui/icons-material/Cloud';
+import CloseIcon from '@mui/icons-material/Close';
+import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
+import { useDriveFolderPicker } from '@client/app/hooks/data/useDriveFolderPicker';
+import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
+
+/**
+ * Pick a Google Drive folder while CREATING a data lake. There is no lake id to bind to yet, so the
+ * selection is parked in wizard state and connected on commit - which is what lets a lake be created
+ * from a Drive folder alone, with no local files, and lets abandoning the wizard leave nothing behind
+ * (#1916). The existing-lake surface is DriveConnectAction, which connects immediately.
+ */
+export default function DrivePendingConnectAction() {
+  const pendingDriveFolder = useDataLakeWizardStore(s => s.pendingDriveFolder);
+  const setPendingDriveFolder = useDataLakeWizardStore(s => s.setPendingDriveFolder);
+
+  // POST /api/data-lakes/drive-sync refuses a lake with no organizationId, and the wizard creates
+  // the lake in whatever scope the account switcher is on - so in Personal scope this action could
+  // only ever create a lake and then fail to connect it. Same condition as SelectedLakeHeader's
+  // canConnectDrive, minus the role half: create mode has no lake to read canManage off, so org
+  // owner/manager stays the server's call and a refusal rolls the new lake back (see
+  // useCreateLakeFromDrive).
+  const selectedAccount = useSelectedAccount(s => s.selectedAccount);
+  const isOrgScope = !!selectedAccount && !selectedAccount.personal;
+
+  const { openFolderPicker, isPicking } = useDriveFolderPicker({
+    onPicked: folder => setPendingDriveFolder(folder),
+  });
+
+  if (!isOrgScope) {
+    return (
+      <Tooltip
+        title={`Google Drive folders can only feed an organization ${DATA_LAKE}. Switch to your organization in the account selector, then connect a folder.`}
+      >
+        <span>
+          <Button
+            data-testid="drive-connect-personal-scope-btn"
+            variant="outlined"
+            color="neutral"
+            startDecorator={<CloudIcon />}
+            disabled
+          >
+            Connect Google Drive
+          </Button>
+        </span>
+      </Tooltip>
+    );
+  }
+
+  if (pendingDriveFolder) {
+    return (
+      <Stack direction="row" gap={1} alignItems="center" flexWrap="wrap" data-testid="drive-pending-selection">
+        <Chip
+          variant="soft"
+          color="primary"
+          startDecorator={<CloudIcon sx={{ fontSize: 16 }} />}
+          endDecorator={
+            <Button
+              data-testid="drive-pending-clear-btn"
+              size="sm"
+              variant="plain"
+              color="neutral"
+              aria-label="Remove the selected Google Drive folder"
+              onClick={() => setPendingDriveFolder(null)}
+              sx={{ minHeight: 0, minWidth: 0, p: 0.25 }}
+            >
+              <CloseIcon sx={{ fontSize: 14 }} />
+            </Button>
+          }
+        >
+          {pendingDriveFolder.folderName || pendingDriveFolder.driveFolderId}
+        </Chip>
+        <Typography level="body-xs" color="neutral">
+          Connects when you create the {DATA_LAKE}
+        </Typography>
+        <Button
+          data-testid="drive-pending-change-btn"
+          size="sm"
+          variant="plain"
+          color="neutral"
+          loading={isPicking}
+          onClick={openFolderPicker}
+        >
+          Change folder
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Button
+      data-testid="drive-connect-btn"
+      variant="outlined"
+      color="neutral"
+      startDecorator={<CloudIcon />}
+      loading={isPicking}
+      onClick={openFolderPicker}
+    >
+      Connect Google Drive
+    </Button>
+  );
+}

--- a/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.test.tsx
@@ -20,10 +20,13 @@ vi.mock('@client/app/components/Credits/AccountSelector', () => ({
     selector({ selectedAccount: selectedAccount.current }),
 }));
 vi.mock('sonner', () => ({ toast: { info: toastInfo } }));
-// DriveConnectAction pulls in React Query (useConfig / lake-connection hooks); stub it so these
-// step-order/name-validation tests need no QueryClientProvider. Its own behavior is covered by
-// DriveConnectAction.test.tsx.
+// Both Drive actions pull in React Query (useConfig / lake-connection hooks); stub them so these
+// step-order/name-validation tests need no QueryClientProvider. Their own behavior is covered by
+// DriveConnectAction.test.tsx and DrivePendingConnectAction.test.tsx.
 vi.mock('@client/app/components/DataLakeWizard/steps/DriveConnectAction', () => ({
+  default: () => null,
+}));
+vi.mock('@client/app/components/DataLakeWizard/steps/DrivePendingConnectAction', () => ({
   default: () => null,
 }));
 

--- a/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
@@ -30,6 +30,7 @@ import { useGetDataLakes } from '@client/app/hooks/data/dataLakes';
 import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
 import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
 import DriveConnectAction from './DriveConnectAction';
+import DrivePendingConnectAction from './DrivePendingConnectAction';
 
 const supportsWebkitDirectory =
   typeof HTMLInputElement !== 'undefined' && 'webkitdirectory' in HTMLInputElement.prototype;
@@ -304,7 +305,9 @@ export default function SourceSelectionStep() {
           </Dropdown>
         </Box>
 
-        <DriveConnectAction lake={targetLake} />
+        {/* Append mode has a lake to bind to, so the folder connects on the spot. Create mode
+            does not, so the selection is parked and connected on commit (#1916). */}
+        {targetLake ? <DriveConnectAction lake={targetLake} /> : <DrivePendingConnectAction />}
       </Stack>
 
       {/* Once files are in hand: what was picked up, plus the two opt-in steps. Both default

--- a/apps/client/app/components/DataLakeWizard/steps/UploadStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/UploadStep.test.tsx
@@ -192,3 +192,69 @@ describe('UploadStep - in-progress failure alert (#1412)', () => {
     expect(screen.queryByText(/failed/)).not.toBeInTheDocument();
   });
 });
+
+/**
+ * The fileless Drive commit (#1916) shares uploadProgress with the upload path, so this step has to
+ * tell them apart: with zero files every counter is 0, and the file-count screens above would read
+ * that as "nothing uploaded" - a failure - for what is a successful hand-off to Drive ingest.
+ */
+describe('UploadStep - Drive-only commit (#1916)', () => {
+  afterEach(() => {
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  function renderDriveCommit(status: UploadProgress['status'], overrides: Partial<UploadProgress> = {}) {
+    useDataLakeWizardStore.setState(state => ({
+      targetLake: null,
+      allFiles: [],
+      pendingDriveFolder: { driveFolderId: 'FOLDER1', folderName: 'Contracts' },
+      uploadProgress: { ...state.uploadProgress, totalFiles: 0, status, ...overrides },
+    }));
+    return render(
+      <TestWrapper>
+        <UploadStep />
+      </TestWrapper>
+    );
+  }
+
+  it('reports the folder it is about to sync while idle', () => {
+    renderDriveCommit('idle');
+    expect(screen.getByTestId('drive-only-commit-idle')).toHaveTextContent('Contracts');
+  });
+
+  it('reports the create + connect in progress, not an upload', () => {
+    renderDriveCommit('uploading');
+    expect(screen.getByTestId('drive-only-commit-pending')).toBeInTheDocument();
+    expect(screen.queryByText(/Uploading files/)).toBeNull();
+  });
+
+  it('reads success as a created lake with ingest running, not zero files uploaded', () => {
+    renderDriveCommit('complete');
+    const complete = screen.getByTestId('drive-only-commit-complete');
+    expect(complete).toHaveTextContent('Contracts');
+    expect(complete).toHaveTextContent('background');
+    expect(screen.queryByText('Upload Complete!')).toBeNull();
+  });
+
+  it('surfaces the refusal and states that no lake survived it', () => {
+    // Matches useCreateLakeFromDrive's rollback: a failed connect deletes the lake it created, so
+    // the user has nothing to clean up before retrying.
+    renderDriveCommit('error', { errorMessage: 'This Drive folder is already connected to another data lake' });
+    const failed = screen.getByTestId('drive-only-commit-error');
+    expect(failed).toHaveTextContent('This Drive folder is already connected to another data lake');
+    expect(failed).toHaveTextContent('No Data Lake was created.');
+  });
+
+  it('sends a failed commit back to Configure, where the name and prefix can be fixed', () => {
+    renderDriveCommit('error', { errorMessage: 'nope' });
+    screen.getByText('Back to Configuration').click();
+    expect(useDataLakeWizardStore.getState().step).toBe('config');
+  });
+
+  it('keeps the file-count screens when files were uploaded alongside a Drive folder', () => {
+    // The mixed path is a real upload, so it must keep the upload UI even though a folder is pending.
+    renderDriveCommit('complete', { totalFiles: 2, uploadedFiles: 2, chunkedFiles: 2, vectorizedFiles: 2 });
+    expect(screen.getByText('Upload Complete!')).toBeInTheDocument();
+    expect(screen.queryByTestId('drive-only-commit-complete')).toBeNull();
+  });
+});

--- a/apps/client/app/components/DataLakeWizard/steps/UploadStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/UploadStep.test.tsx
@@ -236,13 +236,25 @@ describe('UploadStep - Drive-only commit (#1916)', () => {
     expect(screen.queryByText('Upload Complete!')).toBeNull();
   });
 
-  it('surfaces the refusal and states that no lake survived it', () => {
-    // Matches useCreateLakeFromDrive's rollback: a failed connect deletes the lake it created, so
-    // the user has nothing to clean up before retrying.
+  // Pins the word spacing, not just the words. Built from JSX text interleaved with {DATA_LAKE}
+  // expressions, this sentence rendered live as "Data Lakeslist" - JSX drops the space between an
+  // expression and the text after it, and toHaveTextContent's substring match never saw it.
+  it('keeps the spaces around the branded nouns in the syncing sentence', () => {
+    renderDriveCommit('complete');
+    const text = screen.getByTestId('drive-only-commit-complete').textContent ?? '';
+    expect(text).toContain('Files appear in this Data Lake as they are pulled in');
+    expect(text).toContain('the Data Lakes list shows');
+    expect(text).not.toMatch(/Data Lakes\S/);
+  });
+
+  it('surfaces the refusal and says the new lake was rolled back', () => {
+    // Matches useCreateLakeFromDrive's rollback: a failed connect archives the lake it created, so
+    // the user has nothing to clean up before retrying. Archive, not erase - the copy must not
+    // promise a hard delete (verified live: the row survives with status 'archived').
     renderDriveCommit('error', { errorMessage: 'This Drive folder is already connected to another data lake' });
     const failed = screen.getByTestId('drive-only-commit-error');
     expect(failed).toHaveTextContent('This Drive folder is already connected to another data lake');
-    expect(failed).toHaveTextContent('No Data Lake was created.');
+    expect(failed).toHaveTextContent('The new Data Lake was rolled back');
   });
 
   it('sends a failed commit back to Configure, where the name and prefix can be fixed', () => {

--- a/apps/client/app/components/DataLakeWizard/steps/UploadStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/UploadStep.test.tsx
@@ -251,10 +251,32 @@ describe('UploadStep - Drive-only commit (#1916)', () => {
     // Matches useCreateLakeFromDrive's rollback: a failed connect archives the lake it created, so
     // the user has nothing to clean up before retrying. Archive, not erase - the copy must not
     // promise a hard delete (verified live: the row survives with status 'archived').
-    renderDriveCommit('error', { errorMessage: 'This Drive folder is already connected to another data lake' });
+    renderDriveCommit('error', {
+      errorMessage: 'This Drive folder is already connected to another data lake',
+      driveRollback: 'archived',
+    });
     const failed = screen.getByTestId('drive-only-commit-error');
     expect(failed).toHaveTextContent('This Drive folder is already connected to another data lake');
     expect(failed).toHaveTextContent('The new Data Lake was rolled back');
+  });
+
+  // The compound failure: connect refused AND the rollback archive itself failed. The lake is still
+  // live in the user's list, so claiming it was rolled back would send them off looking for nothing.
+  it('does not claim a rollback when the rollback itself failed', () => {
+    renderDriveCommit('error', { errorMessage: 'nope', driveRollback: 'failed' });
+    const failed = screen.getByTestId('drive-only-commit-error');
+    expect(failed).not.toHaveTextContent('The new Data Lake was rolled back');
+    expect(failed).toHaveTextContent('may still be in your Data Lakes list');
+    expect(failed.textContent ?? '').not.toMatch(/Data Lakes\S/);
+  });
+
+  it('claims nothing about a rollback that was never attempted', () => {
+    // No driveRollback means no delete ran (e.g. the create itself was refused), so the screen
+    // states only the refusal.
+    renderDriveCommit('error', { errorMessage: 'nope' });
+    const failed = screen.getByTestId('drive-only-commit-error');
+    expect(failed).not.toHaveTextContent('rolled back');
+    expect(failed).not.toHaveTextContent('may still be in your');
   });
 
   it('sends a failed commit back to Configure, where the name and prefix can be fixed', () => {

--- a/apps/client/app/components/DataLakeWizard/steps/UploadStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/UploadStep.tsx
@@ -2,8 +2,8 @@ import { Alert, Box, Button, Chip, CircularProgress, LinearProgress, Stack, Typo
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
-import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
-import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
+import { useDataLakeWizardStore, type UploadProgress } from '@client/app/stores/useDataLakeWizardStore';
+import { DATA_LAKE, DATA_LAKES } from '@client/app/components/datalake/dataLakeBranding';
 import { useBatchProgressListener } from '@client/app/hooks/data/dataLakeWizard';
 
 /**
@@ -65,6 +65,89 @@ function describeFailures(failedFiles: number, processingFailedFiles: number): s
   return parts.join('; ');
 }
 
+/**
+ * The fileless Drive commit's own status screen (#1916): create the lake, bind the folder, hand off
+ * to background ingest. No per-file counters exist on this path - the files arrive later, from
+ * Drive - so it reports the connection instead of a progress bar it could only ever draw at 0%.
+ */
+function DriveOnlyCommitStatus({
+  status,
+  errorMessage,
+  folderLabel,
+  onDone,
+  onBack,
+}: {
+  status: UploadProgress['status'];
+  errorMessage: string | undefined;
+  folderLabel: string;
+  onDone: () => void;
+  onBack: () => void;
+}) {
+  const centered = {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 2,
+  } as const;
+
+  if (status === 'complete') {
+    return (
+      <Box sx={centered} data-testid="drive-only-commit-complete">
+        <CheckCircleIcon sx={{ fontSize: 64, color: 'success.500' }} />
+        <Typography level="title-lg">{DATA_LAKE} Created</Typography>
+        <Typography level="body-sm" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
+          Google Drive ingest is running in the background for &ldquo;{folderLabel}&rdquo;. Files appear in this{' '}
+          {DATA_LAKE} as they are pulled in - the {DATA_LAKES} list shows the connection&apos;s status.
+        </Typography>
+        <Button variant="solid" color="primary" onClick={onDone}>
+          Done
+        </Button>
+      </Box>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Box sx={centered} data-testid="drive-only-commit-error">
+        <ErrorOutlineIcon sx={{ fontSize: 64, color: 'danger.500' }} />
+        <Typography level="title-lg" color="danger">
+          Could not connect Google Drive
+        </Typography>
+        <Typography level="body-sm" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
+          {errorMessage || 'The Google Drive folder could not be connected. Please try again.'}
+        </Typography>
+        {/* The rollback is the reason this can be retried from Configure with no cleanup: a failed
+            connect deletes the lake it just created (see useCreateLakeFromDrive). */}
+        <Typography level="body-xs" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
+          No {DATA_LAKE} was created.
+        </Typography>
+        <Button variant="outlined" color="neutral" onClick={onBack}>
+          Back to Configuration
+        </Button>
+      </Box>
+    );
+  }
+
+  if (status === 'uploading') {
+    return (
+      <Box sx={centered} data-testid="drive-only-commit-pending">
+        <CircularProgress size="lg" />
+        <Typography level="title-md">Creating the {DATA_LAKE} and connecting Google Drive&hellip;</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={centered} data-testid="drive-only-commit-idle">
+      <Typography level="title-md" color="neutral">
+        Ready to create this {DATA_LAKE} and sync &ldquo;{folderLabel}&rdquo;.
+      </Typography>
+    </Box>
+  );
+}
+
 function ProgressRow({ label, current, total }: { label: string; current: number; total: number }) {
   const pct = total > 0 ? Math.round((current / total) * 100) : 0;
   return (
@@ -84,9 +167,17 @@ export default function UploadStep() {
   const progress = useDataLakeWizardStore(s => s.uploadProgress);
   const closeWizard = useDataLakeWizardStore(s => s.closeWizard);
   const resetWizard = useDataLakeWizardStore(s => s.resetWizard);
+  const setStep = useDataLakeWizardStore(s => s.setStep);
   // Append mode locks the Config fields to the existing lake, so a "fix your Name /
   // Tag Prefix" hint would point at inputs the user can't edit.
   const isAppendMode = useDataLakeWizardStore(s => s.targetLake !== null);
+  const pendingDriveFolder = useDataLakeWizardStore(s => s.pendingDriveFolder);
+  // The fileless Drive commit (#1916) shares uploadProgress with the upload path, so it is told
+  // apart by having a Drive folder and no files at all - the one shape the upload path can't
+  // produce (it refuses an empty batch). Everything below then reads in Drive terms instead of
+  // file counts, which would all be zero and read as a failure.
+  const isDriveOnlyCommit = !!pendingDriveFolder && progress.totalFiles === 0;
+  const driveFolderLabel = pendingDriveFolder?.folderName || 'your Drive folder';
   // AI tagging is never offered in append mode (the source step hides the toggle there too).
   const wantsTaxonomy = useDataLakeWizardStore(s => s.optionalSteps.taxonomy) && !isAppendMode;
 
@@ -97,6 +188,20 @@ export default function UploadStep() {
   const isError = progress.status === 'error';
   const isUploading = progress.status === 'uploading';
   const isIdle = progress.status === 'idle';
+
+  if (isDriveOnlyCommit) {
+    return (
+      <Box data-testid="wizard-upload-step" sx={{ flex: 1, display: 'flex', flexDirection: 'column', p: 3 }}>
+        <DriveOnlyCommitStatus
+          status={progress.status}
+          errorMessage={progress.errorMessage}
+          folderLabel={driveFolderLabel}
+          onDone={resetWizard}
+          onBack={() => setStep('config')}
+        />
+      </Box>
+    );
+  }
 
   // Uploads finish before chunk/vectorize (async, and skipped entirely in
   // self-host without the worker - see #822/#828). Drive the completion copy
@@ -222,14 +327,7 @@ export default function UploadStep() {
               </Typography>
             </Alert>
           )}
-          <Button
-            variant="outlined"
-            color="neutral"
-            onClick={() => {
-              const setStep = useDataLakeWizardStore.getState().setStep;
-              setStep('config');
-            }}
-          >
+          <Button variant="outlined" color="neutral" onClick={() => setStep('config')}>
             Back to Configuration
           </Button>
         </Box>

--- a/apps/client/app/components/DataLakeWizard/steps/UploadStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/UploadStep.tsx
@@ -73,12 +73,14 @@ function describeFailures(failedFiles: number, processingFailedFiles: number): s
 function DriveOnlyCommitStatus({
   status,
   errorMessage,
+  driveRollback,
   folderLabel,
   onDone,
   onBack,
 }: {
   status: UploadProgress['status'];
   errorMessage: string | undefined;
+  driveRollback: UploadProgress['driveRollback'];
   folderLabel: string;
   onDone: () => void;
   onBack: () => void;
@@ -100,6 +102,9 @@ function DriveOnlyCommitStatus({
     `Google Drive ingest is running in the background for ${quoted}. ` +
     `Files appear in this ${DATA_LAKE} as they are pulled in - the ${DATA_LAKES} list shows the connection's status.`;
   const idleSentence = `Ready to create this ${DATA_LAKE} and sync ${quoted}.`;
+  const rollbackFailedSentence =
+    `The empty ${DATA_LAKE} could not be cleaned up, so it may still be in your ${DATA_LAKES} list. ` +
+    `Check the list and delete it before trying again, or contact support if it will not go away.`;
 
   if (status === 'complete') {
     return (
@@ -126,12 +131,20 @@ function DriveOnlyCommitStatus({
         <Typography level="body-sm" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
           {errorMessage || 'The Google Drive folder could not be connected. Please try again.'}
         </Typography>
-        {/* The rollback is the reason this can be retried from Configure with no cleanup: a failed
-            connect archives the lake it just created (see useCreateLakeFromDrive). Archived, not
-            erased - so this says what the user can observe, and does not promise a hard delete. */}
-        <Typography level="body-xs" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
-          The new {DATA_LAKE} was rolled back - nothing was added to your list.
-        </Typography>
+        {/* Say only what the rollback actually did. 'archived' is the reason this can be retried
+            from Configure with no cleanup; 'failed' means the archive call itself failed, so the
+            empty lake is still live and a blind retry would add a second one next to it. Anything
+            else (no rollback attempted, e.g. the create never succeeded) claims nothing. */}
+        {driveRollback === 'archived' && (
+          <Typography level="body-xs" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
+            The new {DATA_LAKE} was rolled back - nothing was added to your list.
+          </Typography>
+        )}
+        {driveRollback === 'failed' && (
+          <Typography level="body-xs" color="warning" textAlign="center" sx={{ maxWidth: 420 }}>
+            {rollbackFailedSentence}
+          </Typography>
+        )}
         <Button variant="outlined" color="neutral" onClick={onBack}>
           Back to Configuration
         </Button>
@@ -204,6 +217,7 @@ export default function UploadStep() {
         <DriveOnlyCommitStatus
           status={progress.status}
           errorMessage={progress.errorMessage}
+          driveRollback={progress.driveRollback}
           folderLabel={driveFolderLabel}
           onDone={resetWizard}
           onBack={() => setStep('config')}

--- a/apps/client/app/components/DataLakeWizard/steps/UploadStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/UploadStep.tsx
@@ -92,14 +92,22 @@ function DriveOnlyCommitStatus({
     gap: 2,
   } as const;
 
+  // Whole sentences, not JSX text interleaved with {DATA_LAKE} expressions: JSX drops the space
+  // between an expression and the text that follows it, which shipped a live "Data Lakeslist".
+  // One string per sentence also keeps the copy greppable. Curly quotes as escapes per CLAUDE.md.
+  const quoted = `\u201c${folderLabel}\u201d`;
+  const syncingSentence =
+    `Google Drive ingest is running in the background for ${quoted}. ` +
+    `Files appear in this ${DATA_LAKE} as they are pulled in - the ${DATA_LAKES} list shows the connection's status.`;
+  const idleSentence = `Ready to create this ${DATA_LAKE} and sync ${quoted}.`;
+
   if (status === 'complete') {
     return (
       <Box sx={centered} data-testid="drive-only-commit-complete">
         <CheckCircleIcon sx={{ fontSize: 64, color: 'success.500' }} />
         <Typography level="title-lg">{DATA_LAKE} Created</Typography>
         <Typography level="body-sm" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
-          Google Drive ingest is running in the background for &ldquo;{folderLabel}&rdquo;. Files appear in this{' '}
-          {DATA_LAKE} as they are pulled in - the {DATA_LAKES} list shows the connection&apos;s status.
+          {syncingSentence}
         </Typography>
         <Button variant="solid" color="primary" onClick={onDone}>
           Done
@@ -119,9 +127,10 @@ function DriveOnlyCommitStatus({
           {errorMessage || 'The Google Drive folder could not be connected. Please try again.'}
         </Typography>
         {/* The rollback is the reason this can be retried from Configure with no cleanup: a failed
-            connect deletes the lake it just created (see useCreateLakeFromDrive). */}
+            connect archives the lake it just created (see useCreateLakeFromDrive). Archived, not
+            erased - so this says what the user can observe, and does not promise a hard delete. */}
         <Typography level="body-xs" color="neutral" textAlign="center" sx={{ maxWidth: 420 }}>
-          No {DATA_LAKE} was created.
+          The new {DATA_LAKE} was rolled back - nothing was added to your list.
         </Typography>
         <Button variant="outlined" color="neutral" onClick={onBack}>
           Back to Configuration
@@ -142,7 +151,7 @@ function DriveOnlyCommitStatus({
   return (
     <Box sx={centered} data-testid="drive-only-commit-idle">
       <Typography level="title-md" color="neutral">
-        Ready to create this {DATA_LAKE} and sync &ldquo;{folderLabel}&rdquo;.
+        {idleSentence}
       </Typography>
     </Box>
   );

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -732,9 +732,10 @@ describe('useCreateLakeFromDrive (#1916)', () => {
     expect(uploadProgress.totalFiles).toBe(0);
   });
 
-  it('deletes the lake it just created when the connect is refused, leaving no orphan', async () => {
+  it('rolls the lake it just created back when the connect is refused, leaving no visible orphan', async () => {
     // The acceptance criterion the whole deferral exists for: an attempt that cannot finish must
-    // leave neither a lake nor a connection row.
+    // leave the user with neither a lake nor a connection row. The route archives rather than hard
+    // deletes, which is what keeps it out of every list (verified live on local self-host).
     apiPost.mockImplementation((url: string) => {
       if (url === '/api/data-lakes') return Promise.resolve({ data: { id: 'lake1' } });
       if (url === '/api/data-lakes/drive-sync') {
@@ -761,7 +762,7 @@ describe('useCreateLakeFromDrive (#1916)', () => {
     );
   });
 
-  it('still reports the refusal when the rollback delete also fails', async () => {
+  it('still reports the refusal when the rollback archive also fails', async () => {
     // Cleanup is best-effort; it must never mask the error the user needs to read.
     apiPost.mockImplementation((url: string) => {
       if (url === '/api/data-lakes') return Promise.resolve({ data: { id: 'lake1' } });

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -33,7 +33,7 @@ vi.mock('@client/app/contexts/WebsocketContext', () => ({
 vi.mock('@client/app/hooks/data/dataLakes', () => ({ activeOrgId: () => undefined }));
 vi.mock('@client/app/hooks/useGearsStatus', () => ({ invalidateGearsStatusWhileLocked: () => {} }));
 
-import { useBatchUpload, useBatchProgressListener } from './dataLakeWizard';
+import { useBatchUpload, useBatchProgressListener, useCreateLakeFromDrive } from './dataLakeWizard';
 import { slugifyDataLakeName } from './dataLakeSlug';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 
@@ -663,6 +663,266 @@ describe('useBatchUpload rollback (#816)', () => {
     expect(deleteCalledWith('/api/data-lakes/lake1')).toBe(true);
     expect(putCall('/api/data-lakes/batches/batch1')?.[1]).toMatchObject({ status: 'failed' });
     expect(toastMock.success).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The fileless commit (#1916): a lake whose only source is a Google Drive folder. Before this the
+ * wizard could not produce one at all - the commit path was an upload pipeline that threw on an
+ * empty file set - so these cover the create + connect ordering and, above all, that a commit which
+ * cannot be completed leaves nothing behind.
+ */
+describe('useCreateLakeFromDrive (#1916)', () => {
+  const seedDriveOnly = (folder: { driveFolderId: string; folderName?: string } = { driveFolderId: 'FOLDER1' }) =>
+    useDataLakeWizardStore.setState({
+      targetLake: null,
+      allFiles: [],
+      pendingDriveFolder: folder,
+      config: {
+        name: 'Drive Only Lake',
+        description: '',
+        tagPrefix: 'drive:',
+        requiredUserTag: '',
+        requiredEntitlement: '',
+        conflictResolution: 'skip',
+      },
+    });
+
+  const mountDriveCommit = () => mountHook(useCreateLakeFromDrive);
+
+  beforeEach(() => {
+    apiPost.mockReset();
+    apiPut.mockReset().mockResolvedValue({ data: { success: true } });
+    apiDelete.mockReset().mockResolvedValue({ data: { success: true } });
+    toastMock.error.mockClear();
+    toastMock.success.mockClear();
+    installApiPostRouter();
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('creates the lake and binds the folder, with no batch or upload in between', async () => {
+    seedDriveOnly({ driveFolderId: 'FOLDER1', folderName: 'Contracts' });
+
+    const { result } = mountDriveCommit();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postCall('/api/data-lakes')?.[1]).toMatchObject({ name: 'Drive Only Lake', fileTagPrefix: 'drive:' });
+    expect(postCall('/api/data-lakes/drive-sync')?.[1]).toEqual({
+      dataLakeId: 'lake1',
+      driveFolderId: 'FOLDER1',
+      folderName: 'Contracts',
+    });
+    // No files, so nothing that belongs to the upload pipeline should have run.
+    expect(postCall('/api/data-lakes/batches')).toBeUndefined();
+    expect(uploadFileToUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('lands the wizard on the upload step with a fileless progress record', async () => {
+    seedDriveOnly();
+
+    const { result } = mountDriveCommit();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const { step, uploadProgress } = useDataLakeWizardStore.getState();
+    expect(step).toBe('upload');
+    expect(uploadProgress.status).toBe('complete');
+    // UploadStep tells the Drive commit apart by this zero, so it must stay zero.
+    expect(uploadProgress.totalFiles).toBe(0);
+  });
+
+  it('deletes the lake it just created when the connect is refused, leaving no orphan', async () => {
+    // The acceptance criterion the whole deferral exists for: an attempt that cannot finish must
+    // leave neither a lake nor a connection row.
+    apiPost.mockImplementation((url: string) => {
+      if (url === '/api/data-lakes') return Promise.resolve({ data: { id: 'lake1' } });
+      if (url === '/api/data-lakes/drive-sync') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed'), {
+            isAxiosError: true,
+            response: { status: 403, data: { error: 'You do not have permission to read that Google Drive folder.' } },
+          })
+        );
+      }
+      return Promise.resolve({ data: { success: true } });
+    });
+    seedDriveOnly();
+
+    const { result } = mountDriveCommit();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(deleteCalledWith('/api/data-lakes/lake1')).toBe(true);
+    expect(toastMock.success).not.toHaveBeenCalled();
+    // The server's specific refusal reaches the user, not a generic string.
+    expect(useDataLakeWizardStore.getState().uploadProgress.errorMessage).toBe(
+      'You do not have permission to read that Google Drive folder.'
+    );
+  });
+
+  it('still reports the refusal when the rollback delete also fails', async () => {
+    // Cleanup is best-effort; it must never mask the error the user needs to read.
+    apiPost.mockImplementation((url: string) => {
+      if (url === '/api/data-lakes') return Promise.resolve({ data: { id: 'lake1' } });
+      if (url === '/api/data-lakes/drive-sync') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed'), {
+            isAxiosError: true,
+            response: { status: 409, data: { error: 'This Drive folder is already connected to another data lake' } },
+          })
+        );
+      }
+      return Promise.resolve({ data: { success: true } });
+    });
+    apiDelete.mockRejectedValue(new Error('delete failed'));
+    seedDriveOnly();
+
+    const { result } = mountDriveCommit();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(useDataLakeWizardStore.getState().uploadProgress.errorMessage).toBe(
+      'This Drive folder is already connected to another data lake'
+    );
+  });
+
+  it('creates nothing at all when the lake create itself is refused', async () => {
+    apiPost.mockImplementation((url: string) => {
+      if (url === '/api/data-lakes') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed'), { isAxiosError: true, response: { status: 422, data: {} } })
+        );
+      }
+      return Promise.resolve({ data: { success: true } });
+    });
+    seedDriveOnly();
+
+    const { result } = mountDriveCommit();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(postCall('/api/data-lakes/drive-sync')).toBeUndefined();
+    expect(apiDelete).not.toHaveBeenCalled();
+  });
+
+  it('fails fast without ever calling the API when offline', async () => {
+    const onLineSpy = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+    seedDriveOnly();
+
+    const { result } = mountDriveCommit();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(apiPost).not.toHaveBeenCalled();
+    expect(useDataLakeWizardStore.getState().uploadProgress.errorKind).toBe('network');
+    onLineSpy.mockRestore();
+  });
+
+  it('refuses to run with no folder picked, before creating a lake it could not connect', async () => {
+    useDataLakeWizardStore.setState({ targetLake: null, allFiles: [], pendingDriveFolder: null });
+
+    const { result } = mountDriveCommit();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(apiPost).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Files AND a Drive folder picked in the same create: the batch owns the lake's creation, and the
+ * Drive folder is bound afterwards - late enough that the total-failure rollback can't strand it.
+ */
+describe('useBatchUpload with a pending Drive folder (#1916)', () => {
+  beforeEach(() => {
+    apiPost.mockReset();
+    apiPut.mockReset().mockResolvedValue({ data: { success: true } });
+    apiDelete.mockReset().mockResolvedValue({ data: { success: true } });
+    uploadFileToUrlMock.mockReset().mockResolvedValue(undefined);
+    toastMock.error.mockClear();
+    toastMock.success.mockClear();
+    installApiPostRouter();
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('connects the folder to the lake the batch created', async () => {
+    seedWizard({ names: ['a.txt'] });
+    useDataLakeWizardStore.setState({ pendingDriveFolder: { driveFolderId: 'FOLDER1', folderName: 'Contracts' } });
+
+    const { result } = mountBatchUpload();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postCall('/api/data-lakes/drive-sync')?.[1]).toMatchObject({ dataLakeId: 'lake1' });
+  });
+
+  it('does not connect when every upload failed, since that rolls the lake back', async () => {
+    // Connecting before the outcome was known would leave a connection row pointing at a deleted
+    // lake - the stranding #1807 describes.
+    uploadFileToUrlMock.mockRejectedValue(new Error('PUT failed'));
+    seedWizard({ names: ['a.txt'] });
+    useDataLakeWizardStore.setState({ pendingDriveFolder: { driveFolderId: 'FOLDER1' } });
+
+    const { result } = mountBatchUpload();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(postCall('/api/data-lakes/drive-sync')).toBeUndefined();
+    expect(deleteCalledWith('/api/data-lakes/lake1')).toBe(true);
+  });
+
+  it('keeps the batch a success when only the Drive connect fails, and says which half failed', async () => {
+    apiPost.mockImplementation((url: string, body?: { files?: { fileName: string }[] }) => {
+      if (url === '/api/data-lakes/drive-sync') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed'), {
+            isAxiosError: true,
+            response: { status: 403, data: { error: 'You do not have permission to read that Google Drive folder.' } },
+          })
+        );
+      }
+      if (url === '/api/data-lakes') return Promise.resolve({ data: { id: 'lake1' } });
+      if (url === '/api/data-lakes/batches') return Promise.resolve({ data: { id: 'batch1' } });
+      if (url === '/api/files/generate-presigned-urls-batch') {
+        const files = (body?.files ?? []).map(f => ({
+          fileId: `id-${f.fileName}`,
+          fileKey: `key-${f.fileName}`,
+          url: `https://s3.example.com/${f.fileName}`,
+          fileName: f.fileName,
+        }));
+        return Promise.resolve({ data: { files } });
+      }
+      return Promise.resolve({ data: { success: true } });
+    });
+    seedWizard({ names: ['a.txt'] });
+    useDataLakeWizardStore.setState({ pendingDriveFolder: { driveFolderId: 'FOLDER1' } });
+
+    const { result } = mountBatchUpload();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The files landed, so the lake stays and the batch is a success...
+    expect(deleteCalledWith('/api/data-lakes/lake1')).toBe(false);
+    expect(useDataLakeWizardStore.getState().uploadProgress.status).toBe('complete');
+    // ...but the user is told the Drive half did not, why, and where to retry - this mutation
+    // offers no retry of its own once the files have landed.
+    expect(toastMock.error).toHaveBeenCalledWith(
+      expect.stringContaining('You do not have permission to read that Google Drive folder.'),
+      expect.anything()
+    );
+    expect(toastMock.error.mock.calls[0]?.[0]).toContain("connect it from the data lake's header");
+  });
+
+  it('never connects in append mode, where the lake already has its own Drive control', async () => {
+    seedWizard({ names: ['a.txt'], targetLake: { id: 'existing', slug: 'existing-slug' } });
+    useDataLakeWizardStore.setState({ pendingDriveFolder: { driveFolderId: 'FOLDER1' } });
+
+    const { result } = mountBatchUpload();
+    act(() => result.current.mutate());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postCall('/api/data-lakes/drive-sync')).toBeUndefined();
   });
 });
 

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -760,6 +760,8 @@ describe('useCreateLakeFromDrive (#1916)', () => {
     expect(useDataLakeWizardStore.getState().uploadProgress.errorMessage).toBe(
       'You do not have permission to read that Google Drive folder.'
     );
+    // Archive succeeded, so the Failed screen is cleared to say the lake is gone.
+    expect(useDataLakeWizardStore.getState().uploadProgress.driveRollback).toBe('archived');
   });
 
   it('still reports the refusal when the rollback archive also fails', async () => {
@@ -786,6 +788,8 @@ describe('useCreateLakeFromDrive (#1916)', () => {
     expect(useDataLakeWizardStore.getState().uploadProgress.errorMessage).toBe(
       'This Drive folder is already connected to another data lake'
     );
+    // ...and the screen must not claim a rollback that did not happen: the lake is still live.
+    expect(useDataLakeWizardStore.getState().uploadProgress.driveRollback).toBe('failed');
   });
 
   it('creates nothing at all when the lake create itself is refused', async () => {
@@ -805,6 +809,8 @@ describe('useCreateLakeFromDrive (#1916)', () => {
 
     expect(postCall('/api/data-lakes/drive-sync')).toBeUndefined();
     expect(apiDelete).not.toHaveBeenCalled();
+    // No rollback was attempted because no lake exists - the screen claims nothing either way.
+    expect(useDataLakeWizardStore.getState().uploadProgress.driveRollback).toBeUndefined();
   });
 
   it('fails fast without ever calling the API when offline', async () => {

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -746,6 +746,7 @@ export function useCreateLakeFromDrive() {
         // Clear any error from a prior attempt so a retry starts clean.
         errorMessage: undefined,
         errorKind: undefined,
+        driveRollback: undefined,
       });
 
       try {
@@ -753,8 +754,15 @@ export function useCreateLakeFromDrive() {
       } catch (err) {
         // Archives the lake (the route is a reversible archive, not a hard delete), which is enough
         // to keep it out of every list the user sees. Best-effort: a cleanup failure must not mask
-        // the refusal the user needs to read.
-        await api.delete(`/api/data-lakes/${dataLakeId}`).catch(() => {});
+        // the refusal the user needs to read - but its outcome has to reach the Failed screen,
+        // which otherwise tells the user the lake is gone while it is still live in their list.
+        // Set before rethrowing: updateUploadProgress merges, so onError's status/error fields
+        // land on top of this rather than replacing it.
+        const driveRollback = await api
+          .delete(`/api/data-lakes/${dataLakeId}`)
+          .then(() => 'archived' as const)
+          .catch(() => 'failed' as const);
+        updateUploadProgress({ driveRollback });
         throw err;
       }
 

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -15,6 +15,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   useDataLakeWizardStore,
+  type DataLakeFormValues,
+  type PendingDriveFolder,
   type UploadProgress,
   type UploadErrorKind,
 } from '@client/app/stores/useDataLakeWizardStore';
@@ -273,6 +275,53 @@ function classifyUploadError(error: unknown): { kind: UploadErrorKind; message: 
 }
 
 /**
+ * Zeroed progress counters for a fresh commit attempt. `totalFiles` is left at 0 for the caller
+ * that knows the real count to override - the fileless Drive commit genuinely has none.
+ */
+function zeroProgressCounts(): Partial<UploadProgress> {
+  return {
+    totalFiles: 0,
+    uploadedFiles: 0,
+    chunkedFiles: 0,
+    vectorizedFiles: 0,
+    failedFiles: 0,
+    failedFileNames: [],
+    processingFailedFiles: 0,
+  };
+}
+
+/**
+ * Create the lake the wizard is configuring (create mode only). Shared by both commit paths - the
+ * batch upload and the fileless Drive-only create - so a lake is born from exactly the same fields
+ * either way.
+ *
+ * `tagPrefix` is passed in rather than derived here: it is the value every client-side gate already
+ * judged (see submittedTagPrefix), and re-deriving it would let the two drift.
+ */
+async function createWizardLake(config: DataLakeFormValues, tagPrefix: string): Promise<string> {
+  // Scope to the active account-switcher org (Personal -> undefined). activeOrgId reads the store
+  // at call time, like the wizard config itself, so it can't go stale.
+  const organizationId = activeOrgId();
+  const res = await api.post<{ id: string }>('/api/data-lakes', {
+    name: config.name,
+    // The slug we ask for. The server disambiguates it against lakes in scope, so the created
+    // lake's real slug can differ - everything downstream keys off the id.
+    slug: slugifyDataLakeName(config.name),
+    description: config.description || undefined,
+    fileTagPrefix: tagPrefix,
+    requiredUserTag: config.requiredUserTag || undefined,
+    requiredEntitlement: config.requiredEntitlement || undefined,
+    ...(organizationId ? { organizationId } : {}),
+  } satisfies CreateDataLakeRequestInputType);
+  return res.data.id;
+}
+
+/** Bind a Drive folder picked during create to the lake that now exists (POST drive-sync). */
+async function connectPendingDriveFolder(dataLakeId: string, folder: PendingDriveFolder): Promise<void> {
+  await api.post('/api/data-lakes/drive-sync', { dataLakeId, ...folder });
+}
+
+/**
  * Upload one file to the URL the server returned - a same-origin proxy (self-host) or an
  * S3 presigned URL (hosted). The auth routing (authenticated api client vs raw axios) lives
  * in uploadFileToUrl so this and the single-file path stay in sync.
@@ -309,7 +358,7 @@ export function useBatchUpload() {
 
       // Read from store at mutation time to avoid stale closure
       // (same pattern as useComputeHashes)
-      const { config, allFiles, targetLake, optionalSteps } = useDataLakeWizardStore.getState();
+      const { config, allFiles, targetLake, optionalSteps, pendingDriveFolder } = useDataLakeWizardStore.getState();
       let included = allFiles.filter(f => !f.excluded);
       if (included.length === 0) throw new Error('No files to upload');
 
@@ -352,26 +401,7 @@ export function useBatchUpload() {
       const tagPrefix = submittedTagPrefix(config.tagPrefix);
 
       // Step 1: Create the data lake; skipped in append mode (upload into the existing lake).
-      let dataLakeId: string;
-      if (targetLake) {
-        dataLakeId = targetLake.id;
-      } else {
-        // Scope to the active account-switcher org (Personal -> undefined). activeOrgId reads
-        // the store at mutation time, like the wizard config above, so it can't go stale.
-        const organizationId = activeOrgId();
-        const dataLakeRes = await api.post<{ id: string }>('/api/data-lakes', {
-          name: config.name,
-          // The slug we ask for. The server disambiguates it against lakes in scope, so the
-          // created lake's real slug can differ - everything downstream keys off the id.
-          slug: slugifyDataLakeName(config.name),
-          description: config.description || undefined,
-          fileTagPrefix: tagPrefix,
-          requiredUserTag: config.requiredUserTag || undefined,
-          requiredEntitlement: config.requiredEntitlement || undefined,
-          ...(organizationId ? { organizationId } : {}),
-        } satisfies CreateDataLakeRequestInputType);
-        dataLakeId = dataLakeRes.data.id;
-      }
+      const dataLakeId = targetLake ? targetLake.id : await createWizardLake(config, tagPrefix);
       let uploadedCount = 0;
       // Hoisted above the try so the outcome branch + the catch can reconcile the batch
       // and clean up the records setup created. `failedFileIds` are the FabFiles presign
@@ -414,13 +444,8 @@ export function useBatchUpload() {
         // Switch to upload step and set initial progress
         setStep('upload');
         updateUploadProgress({
+          ...zeroProgressCounts(),
           totalFiles: included.length,
-          uploadedFiles: 0,
-          chunkedFiles: 0,
-          vectorizedFiles: 0,
-          failedFiles: 0,
-          failedFileNames: [],
-          processingFailedFiles: 0,
           status: 'uploading',
           currentBatchId: batchId,
           // Clear any error from a prior attempt so a retry starts clean.
@@ -593,6 +618,28 @@ export function useBatchUpload() {
           })
           .catch(() => {});
 
+        // A Drive folder picked during create (#1916) is connected only HERE - after the lake
+        // exists and its files have landed. Connecting any earlier would strand a connection row
+        // behind the rollback the total-failure branch above performs on the new lake (#1807).
+        // Never in append mode: there DriveConnectAction already connected on the spot.
+        if (!targetLake && pendingDriveFolder) {
+          try {
+            await connectPendingDriveFolder(dataLakeId, pendingDriveFolder);
+          } catch (e) {
+            // The files are in, so the batch is a success - don't fail it over the Drive half.
+            // Name the actual refusal (not an org manager, folder claimed elsewhere, Drive not
+            // linked) AND where to retry, since this mutation offers no retry of its own.
+            // Reason last: it is a server sentence of its own, with no punctuation we can rely on
+            // to splice mid-message.
+            toast.error(
+              `Files uploaded, but the Google Drive folder was not connected - connect it from the data lake's header to retry. ${
+                classifyUploadError(e).message
+              }`,
+              { duration: 10000 }
+            );
+          }
+        }
+
         updateUploadProgress({ status: 'complete' });
 
         queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
@@ -639,6 +686,90 @@ export function useBatchUpload() {
       // toast instead of stacking a new one on top of it - same id as the
       // pre-flight check in DataLakeWizardModal's handleStartUpload, since both
       // represent the one current upload attempt's error state.
+      toast.error(message, {
+        id: 'data-lake-batch-upload-error',
+        duration: 8000,
+        action: { label: 'Retry', onClick: () => retryRef.current() },
+      });
+    },
+  });
+
+  useEffect(() => {
+    retryRef.current = () => mutation.mutate();
+  });
+  return mutation;
+}
+
+/**
+ * Hook: the wizard's FILELESS commit - create the lake, then bind the Drive folder picked during
+ * create so ingest runs from Drive alone, with no local upload (#1916).
+ *
+ * The upload pipeline (useBatchUpload) cannot serve this: it creates the lake as a side effect of a
+ * batch and refuses an empty file set. This is the same create call, followed by the connect, with
+ * one rule the upload path shares - a commit that cannot be completed leaves NOTHING behind, so a
+ * refused connect (Personal-scope lake, non-manager, folder already claimed) deletes the lake it
+ * just made rather than stranding an empty one.
+ *
+ * Reuses uploadProgress for its status/error state so the Complete and Failed screens, the error
+ * classification, and the retry toast are the same ones the upload path uses; UploadStep tells the
+ * two apart by `totalFiles === 0` and swaps in Drive wording.
+ */
+export function useCreateLakeFromDrive() {
+  const updateUploadProgress = useDataLakeWizardStore(s => s.updateUploadProgress);
+  const setStep = useDataLakeWizardStore(s => s.setStep);
+  const queryClient = useQueryClient();
+  // Same indirection as useBatchUpload: lets onError's retry action call the mutation it belongs to.
+  const retryRef = useRef<() => void>(() => {});
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      // Matches useBatchUpload's guard: fail before the request rather than letting it reject.
+      if (typeof navigator !== 'undefined' && !navigator.onLine) {
+        throw new Error(OFFLINE_MESSAGE);
+      }
+
+      // Read at mutation time to avoid a stale closure, as everywhere else in this module.
+      const { config, pendingDriveFolder, targetLake } = useDataLakeWizardStore.getState();
+      if (!pendingDriveFolder) throw new Error('No Google Drive folder selected');
+      // Append mode never reaches here - it has a lake, so DriveConnectAction connects directly.
+      if (targetLake) throw new Error('This data lake already exists - connect Drive from its header instead');
+
+      const tagPrefix = submittedTagPrefix(config.tagPrefix);
+      const dataLakeId = await createWizardLake(config, tagPrefix);
+
+      setStep('upload');
+      updateUploadProgress({
+        ...zeroProgressCounts(),
+        status: 'uploading',
+        // Clear any error from a prior attempt so a retry starts clean.
+        errorMessage: undefined,
+        errorKind: undefined,
+      });
+
+      try {
+        await connectPendingDriveFolder(dataLakeId, pendingDriveFolder);
+      } catch (err) {
+        // Best-effort, and deliberately not awaited into the error: a cleanup failure must not mask
+        // the refusal the user needs to read.
+        await api.delete(`/api/data-lakes/${dataLakeId}`).catch(() => {});
+        throw err;
+      }
+
+      updateUploadProgress({ status: 'complete' });
+      queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
+      // First lake unlocks the 'datalakes' nav slot; no files yet, so 'files' stays locked (#833).
+      invalidateGearsStatusWhileLocked(queryClient, ['datalakes']);
+
+      return { dataLakeId };
+    },
+    onSuccess: () => {
+      const { pendingDriveFolder } = useDataLakeWizardStore.getState();
+      toast.success(`Syncing "${pendingDriveFolder?.folderName || 'your Drive folder'}" into the new data lake...`);
+    },
+    onError: (error: unknown) => {
+      const { kind, message } = classifyUploadError(error);
+      updateUploadProgress({ status: 'error', errorKind: kind, errorMessage: message });
+      // Same toast id as the upload path: both represent the one current commit attempt's error.
       toast.error(message, {
         id: 'data-lake-batch-upload-error',
         duration: 8000,

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -706,9 +706,11 @@ export function useBatchUpload() {
  *
  * The upload pipeline (useBatchUpload) cannot serve this: it creates the lake as a side effect of a
  * batch and refuses an empty file set. This is the same create call, followed by the connect, with
- * one rule the upload path shares - a commit that cannot be completed leaves NOTHING behind, so a
- * refused connect (Personal-scope lake, non-manager, folder already claimed) deletes the lake it
- * just made rather than stranding an empty one.
+ * one rule the upload path shares - a commit that cannot be completed leaves nothing the user can
+ * see, so a refused connect (Personal-scope lake, non-manager, folder already claimed) rolls the
+ * lake it just made back rather than stranding a visible empty one. DELETE /api/data-lakes/:id is
+ * a reversible ARCHIVE, so the row survives out of the user's lists - same as the upload path's
+ * total-failure rollback, which archives too.
  *
  * Reuses uploadProgress for its status/error state so the Complete and Failed screens, the error
  * classification, and the retry toast are the same ones the upload path uses; UploadStep tells the
@@ -749,7 +751,8 @@ export function useCreateLakeFromDrive() {
       try {
         await connectPendingDriveFolder(dataLakeId, pendingDriveFolder);
       } catch (err) {
-        // Best-effort, and deliberately not awaited into the error: a cleanup failure must not mask
+        // Archives the lake (the route is a reversible archive, not a hard delete), which is enough
+        // to keep it out of every list the user sees. Best-effort: a cleanup failure must not mask
         // the refusal the user needs to read.
         await api.delete(`/api/data-lakes/${dataLakeId}`).catch(() => {});
         throw err;

--- a/apps/client/app/hooks/data/useDriveFolderPicker.ts
+++ b/apps/client/app/hooks/data/useDriveFolderPicker.ts
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import useDrivePicker from 'react-google-drive-picker';
+import { api } from '@client/app/contexts/ApiContext';
+import { useConfig } from '@client/app/hooks/data/settings';
+import { ensureGoogleDrivePickerStyles } from '@client/app/utils/googleDrivePickerStyles';
+
+export type PickedDriveFolder = { driveFolderId: string; folderName?: string };
+
+function httpStatus(e: unknown): number | undefined {
+  return (e as { response?: { status?: number } })?.response?.status;
+}
+
+/**
+ * Open the Google Picker in folder-select mode, handling the OAuth prelude: redirect to Google's
+ * consent screen when Drive was never linked (or the refresh failed), else fetch a token and open
+ * the picker. `onPicked` receives the chosen folder; cancel and every failure path clear `isPicking`.
+ *
+ * Shared by both Drive-connect surfaces - the existing-lake action, which connects immediately, and
+ * the create-mode action, which parks the selection in wizard state until the lake exists (#1916).
+ * One implementation because the OAuth branches and the picker's z-index workaround are the awkward
+ * part, and two copies of them would drift.
+ *
+ * `busy` folds the caller's own in-flight work (e.g. a connect mutation) into the re-entrancy guard,
+ * so a second picker can never open on top of the first.
+ */
+export function useDriveFolderPicker({
+  onPicked,
+  busy = false,
+}: {
+  onPicked: (folder: PickedDriveFolder) => void;
+  busy?: boolean;
+}): { openFolderPicker: () => Promise<void>; isPicking: boolean } {
+  const { data: config } = useConfig();
+  const googleClientId = config?.googleClientId;
+  const [openPicker] = useDrivePicker();
+  const [isPicking, setIsPicking] = useState(false);
+
+  const openFolderPicker = async () => {
+    if (isPicking || busy) return; // re-entrancy guard: never open a second picker
+    setIsPicking(true);
+    try {
+      let token: { accessToken?: string; authUrl?: string };
+      try {
+        const { data } = await api.get<{ accessToken?: string; authUrl?: string }>('/api/google-drive/token');
+        token = data;
+      } catch (e) {
+        // First-time user: /token 400s ("Google Drive not connected") when Drive was never linked.
+        // Send them to Google's consent screen (the same POST /connect the profile flow uses); they
+        // come back and can then pick a folder. Any other error falls through to the outer catch.
+        if (httpStatus(e) === 400) {
+          const { data } = await api.post<{ authUrl: string }>('/api/google-drive/connect');
+          window.location.href = data.authUrl;
+          return;
+        }
+        throw e;
+      }
+
+      // Not connected / refresh failed: /token hands back an authUrl instead of a token.
+      if (token.authUrl) {
+        window.location.href = token.authUrl;
+        return;
+      }
+      if (!token.accessToken || !googleClientId) {
+        toast.error('Google Drive is unavailable right now. Please try again.');
+        setIsPicking(false);
+        return;
+      }
+
+      ensureGoogleDrivePickerStyles(); // keep the picker above the wizard modal (z-index 1400)
+      openPicker({
+        clientId: googleClientId,
+        developerKey: '',
+        viewId: 'FOLDERS', // folder-first browse; the user selects a folder to ingest
+        viewMimeTypes: '',
+        token: token.accessToken,
+        showUploadFolders: false,
+        supportDrives: true,
+        multiselect: false,
+        setIncludeFolders: true,
+        setSelectFolderEnabled: true, // pick a FOLDER, not a file - its id feeds the ingest
+        disableDefaultView: false,
+        callbackFunction: pick => {
+          // Clear the loading state as the picker closes. openPicker() is synchronous, so this must
+          // happen in the callback, not right after the call - otherwise the button drops its
+          // loading state while the picker is still open and a second click opens a second picker.
+          if (pick.action === 'picked' || pick.action === 'cancel') setIsPicking(false);
+          if (pick.action !== 'picked') return;
+          const folder = pick.docs?.[0];
+          if (!folder?.id) return;
+          onPicked({ driveFolderId: folder.id, folderName: folder.name });
+        },
+      });
+    } catch {
+      toast.error('Could not open Google Drive. Please try again.');
+      setIsPicking(false);
+    }
+  };
+
+  return { openFolderPicker, isPicking };
+}

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -30,6 +30,20 @@ export interface OptionalSteps {
   taxonomy: boolean;
 }
 
+/**
+ * A Google Drive folder picked during CREATE, held until the lake it will feed exists.
+ *
+ * The wizard has no lake id to connect to while it is still collecting, so the selection is
+ * carried here and the connect fires on commit (see useCreateLakeFromDrive for the fileless
+ * case, useBatchUpload for files + Drive). Keeping it in wizard state is what makes abandoning
+ * the wizard leave nothing behind - nothing has been created yet. Never set in append mode:
+ * there the lake already exists, so DriveConnectAction connects immediately.
+ */
+export interface PendingDriveFolder {
+  driveFolderId: string;
+  folderName?: string;
+}
+
 export interface DataLakeFormValues {
   name: string;
   description: string;
@@ -116,6 +130,7 @@ const freshSession = () => ({
   uploadProgress: { ...DEFAULT_UPLOAD_PROGRESS },
   hashingProgress: { total: 0, completed: 0, status: 'idle' as const },
   targetLake: null as WizardTargetLake | null,
+  pendingDriveFolder: null as PendingDriveFolder | null,
 });
 
 // ── Store ───────────────────────────────────────────────────────────────────
@@ -155,6 +170,8 @@ interface DataLakeWizardStore {
   hashingProgress: { total: number; completed: number; status: 'idle' | 'hashing' | 'done' };
   /** Non-null when appending to an existing lake (vs creating a new one). */
   targetLake: WizardTargetLake | null;
+  /** Drive folder chosen during create, connected on commit once the lake has an id. */
+  pendingDriveFolder: PendingDriveFolder | null;
   /** Drives the Data Lakes management panel (list + lifecycle), distinct from the wizard. */
   isManagerOpen: boolean;
   /** Which manager tab to show on open: the caller's own lakes, or the public discover catalog. */
@@ -177,6 +194,7 @@ interface DataLakeWizardStore {
   // Source step
   setFiles: (files: File[]) => void;
   setOptionalStep: (key: keyof OptionalSteps, enabled: boolean) => void;
+  setPendingDriveFolder: (folder: PendingDriveFolder | null) => void;
 
   // Preview step
   toggleFolderExclusion: (path: string) => void;
@@ -218,6 +236,7 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   uploadProgress: { ...DEFAULT_UPLOAD_PROGRESS },
   hashingProgress: { total: 0, completed: 0, status: 'idle' as const },
   targetLake: null,
+  pendingDriveFolder: null,
   isManagerOpen: false,
   managerTab: 'mine',
   managerLakeId: null,
@@ -263,6 +282,8 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   },
 
   setOptionalStep: (key, enabled) => set(state => ({ optionalSteps: { ...state.optionalSteps, [key]: enabled } })),
+
+  setPendingDriveFolder: folder => set({ pendingDriveFolder: folder }),
 
   // ── Preview Step ────────────────────────────────────────────────────────
 

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -75,6 +75,13 @@ export interface UploadProgress {
   /** Always a human-friendly, translated message - never raw zod/validator text. */
   errorMessage?: string;
   errorKind?: UploadErrorKind;
+  /**
+   * Outcome of the Drive-only commit's own rollback (useCreateLakeFromDrive archives the lake it
+   * just created when the Drive connect is refused). 'failed' means the archive call itself failed,
+   * so the lake is still live in the user's list - the Failed screen must not claim otherwise.
+   * Undefined when no rollback was attempted (the upload path, or a create that never succeeded).
+   */
+  driveRollback?: 'archived' | 'failed';
   currentBatchId?: string;
   /**
    * Background AI-tag suggestion phase, pushed over the same batch-progress


### PR DESCRIPTION
# Pull Request

## Description

A data lake could not be created from a Google Drive folder alone. The create wizard **showed** a `Connect Google Drive` button next to `Upload`, but it was permanently disabled, and the only route to a Drive-backed lake was: create the lake by uploading some throwaway local file, then reopen it via `Manage lakes` -> select the lake -> `Add files` -> `Connect Google Drive`.

The disabled button was the symptom, not the cause. **Every step of the wizard gated on having local files, and the commit path was an upload pipeline that created the lake as a side effect and threw on an empty file set.** Enabling the button alone would have changed nothing: with zero files the source step's `Next` never enabled, and even past it the commit refused before creating anything.

This adds the fileless commit path the wizard never had, using **deferred connect** (option A in #1916):

- Picking a folder during create parks the selection in wizard state (`pendingDriveFolder`).
- Step gates treat a pending folder as a source in its own right.
- On commit, the lake is created and *then* the folder is connected.
- Abandoning the wizard therefore creates nothing at all - no lake, no connection row - because nothing has been created yet.

Ordering matters for the mixed case (files **and** a folder in one create): the folder binds **after** the upload lands. Connecting any earlier would strand a connection row behind the rollback that a total upload failure performs on the new lake - the stranding described in #1807.

Closes #1916

## Changes

- **`useDataLakeWizardStore`** - `pendingDriveFolder` + setter, cleared by `freshSession()`/`resetWizard` so a new session can never inherit a stale pick.
- **`useDriveFolderPicker`** (new) - the OAuth prelude + Google Picker folder-select flow, extracted from `DriveConnectAction` so both Drive surfaces share one implementation instead of two copies of the awkward part.
- **`DrivePendingConnectAction`** (new) - the create-mode control: picks into the store, shows the pending selection with Change/Remove, and is disabled with an accurate tooltip in Personal scope (which `POST /api/data-lakes/drive-sync` refuses).
- **`DriveConnectAction`** - now existing-lake only; its dead `!lake` branch and non-null prop removed. Behaviour for an existing lake is unchanged.
- **`useCreateLakeFromDrive`** (new) - the fileless commit: create lake -> `drive-sync`, and **roll the lake back if the connect is refused** (Personal-scope lake, non-manager, folder already claimed elsewhere, Drive not linked). `DELETE /api/data-lakes/:id` is a reversible archive, so the row survives out of every list the user sees - same semantics as the upload path's existing total-failure rollback. The archive is best-effort so a cleanup failure never masks the refusal, but **its outcome is recorded** on `uploadProgress.driveRollback` (`'archived' | 'failed'`) so the Failed screen can only claim a rollback that actually happened.
- **`useBatchUpload`** - shares the extracted `createWizardLake` helper, and connects a pending folder after a successful upload. A Drive failure never fails the batch; it toasts the specific reason and names where to retry.
- **`DataLakeWizardModal`** - `hasSource` gates (source/preview/config), commit routing, and a `Create and sync` label when there are no files. The close confirmation now also treats a picked folder as unsaved progress.
- **`UploadStep`** - a Drive-only status screen that reports the connection instead of a 0-of-0 progress bar (every file counter is zero on this path, which the file-count screens would read as a failure).

## Guide for Testers

Requires an **organization** data lake context: `drive-sync` refuses a lake with no `organizationId`, so the control is deliberately disabled in Personal scope. You also need Google Drive available in the environment (a configured `GOOGLE_CLIENT_ID`) to open the picker.

### A. The headline case - create a lake from a Drive folder alone

1. Go to `app.pr<N>.preview.bike4mind.com` and log in as a user who is an **owner or manager of an organization**.
2. Open the account selector and switch to your **organization (Team)** scope, not Personal.
3. Navigate to `/data-lakes`.
4. Click `Create data lake`. Expected: the wizard opens on `Select Source`, and the `Connect Google Drive` button is **enabled** (on `main` it is greyed out with the tooltip "Save the data lake first...").
5. Type `Drive Only Lake` in the `Data Lake Name` field. Expected: the helper text shows `Slug: drive-only-lake`, and `Next` is **still disabled** - a name alone is not a source.
6. Click `Connect Google Drive`, then pick any Drive folder you own in the Google Picker.
7. Expected: the button is replaced by a chip showing the folder name, the text `Connects when you create the Data Lake`, and a `Change folder` action. **`Next` is now enabled even though you have added zero local files.** This is the behaviour the PR adds.
8. Click `Next`. Expected: the `Configure` step, with `Tag Prefix` pre-filled as `drive-only-lake:`.
9. Expected: the primary footer button reads **`Create and sync`**, not `Start Upload`.
10. Click `Create and sync`. Expected: a brief `Creating the Data Lake and connecting Google Drive...` screen, then `Data Lake Created` naming your folder and saying ingest is running in the background, plus a toast `Syncing "<your folder>" into the new data lake...`.
11. Click `Done`, then look at the lake list. Expected: `Drive Only Lake` is listed.
12. Select `Drive Only Lake` in the list. Expected: the lake header shows the Drive connection with your folder name and a `Connected` badge (this surface already existed as of #1915).
13. Wait a few minutes and re-check the lake's file count. Expected: files from the Drive folder appear as ingest pulls them in.

### B. Abandoning must create nothing

14. Click `Create data lake` again, type `Abandoned Lake`, and connect a Drive folder as in steps 6-7.
15. Click `Cancel`. Expected: a browser confirm appears - `You have unsaved progress. Are you sure you want to close the wizard?`
16. Click OK, then check the lake list. Expected: **no** `Abandoned Lake` exists, and the lake count is unchanged. Nothing was created, so there is nothing to clean up.
17. Repeat steps 14-15 but click **Cancel** on the confirm instead. Expected: the wizard stays open with your folder still selected.

### C. Files and a Drive folder in the same create

18. Click `Create data lake`, type `Mixed Source Lake`, click `Upload` and pick 2-3 small `.txt` or `.pdf` files.
19. Also click `Connect Google Drive` and pick a **different** Drive folder from the one used in section A (a folder may only be claimed by one lake).
20. Click `Next`. Expected: the primary button reads `Start Upload` (not `Create and sync`) - files present means this is a real upload.
21. Click `Start Upload`. Expected: the normal per-file progress screen (Uploaded / Chunked / Vectorized), then `Upload Complete!`.
22. Select `Mixed Source Lake` in the list. Expected: your uploaded files are there **and** the header shows the Drive connection. The folder is connected after the upload finishes, so this may take a moment longer than the files.

### D. Personal scope is honestly refused

23. Switch the account selector back to **Personal**.
24. Click `Create data lake`. Expected: `Connect Google Drive` is **disabled**, and hovering it shows `Google Drive folders can only feed an organization Data Lake. Switch to your organization in the account selector, then connect a folder.` The tooltip names an action that actually exists - the old one pointed at a "Save the data lake first" step the wizard never offered.

### E. Refusal is recoverable and leaves nothing visible

25. In org scope, start a create, name it `Claimed Folder Lake`, and connect **the same Drive folder you already used in section A**.
26. Click `Create and sync`. Expected: a `Could not connect Google Drive` screen with the server's specific reason (`This Drive folder is already connected to another data lake`), plus `The new Data Lake was rolled back - nothing was added to your list.`
27. Check the lake list. Expected: **no** `Claimed Folder Lake`. The lake created a moment earlier was rolled back when the connect failed.

The rollback sentence in step 26 is **conditional on the archive itself succeeding**. If the `DELETE` fails too, the lake is still live, so the screen instead warns `The empty Data Lake could not be cleaned up, so it may still be in your Data Lakes list.` That branch is not reachable through the UI (it needs the delete call to fail), so it is covered by unit tests rather than a manual step - see the compound-failure note below.

### Regression Checks

28. **Existing-lake Drive connect is unchanged.** Select an existing **org** lake, click `Connect Google Drive` in its header, pick a fresh folder. Expected: it connects immediately, showing the folder name, a status badge, and `Re-sync` / `Disconnect`. `Disconnect` still requires a confirm click.
29. **Ordinary file-only create still works.** Create a lake with files and no Drive folder at all. Expected: `Start Upload` label, normal progress screen, files land - identical to before.
30. **Append mode (`Add files` on an existing lake) is unchanged.** Expected: no name field, Config fields locked to the lake's values, and the header/step shows the *immediate* Drive connect control, not a "connects when you create" chip.
31. **Optional steps still work.** In a file-based create, tick `Review and exclude files` on the source step. Expected: a `Preview` step is spliced into the indicator, and excluding every file disables `Next`.
32. **Offline pre-check.** With the wizard on `Configure`, go offline in DevTools and click the primary button. Expected: an offline toast with a `Retry` action, and no spinner stuck on the button. This applies to both `Start Upload` and `Create and sync`.

### What NOT to test

- **Drive ingest correctness** (which files are pulled, chunking, vectorizing, re-sync dedup) - unchanged by this PR; it is the existing `driveLakeIngestQueue` pipeline from #1589.
- **Personal-lake Drive support** - still deliberately unsupported server-side; this PR only makes the client stop offering it in a way that could only fail.
- **The org owner/manager check** - enforced server-side as before. In create mode there is no lake to read `canManage` from, so a non-manager in org scope will see the lake created and then rolled back, with the server's reason surfaced. That is expected, not a bug.

## Additional Information

**Verified live on local self-host** (app from source against Docker infra), driving the real UI with Playwright. Confirmed end to end: the create-mode button is enabled in org scope and disabled with the new tooltip in Personal; a valid name with zero files still gates `Next`; picking a folder opens the gate; the `Create and sync` label; the refusal screen with the server's message; and **the rollback - the created lake left every list the user sees and the lake count returned to its prior value**.

Two limitations of that run, both environmental:

- The local env has no `GOOGLE_CLIENT_ID`, so the real picker cannot open. Clicking the button did drive the whole OAuth prelude and reach Google's consent screen, proving the control is genuinely wired; to exercise everything downstream of a pick, the picker call was temporarily stubbed locally (reverted - no stub exists in this diff).
- `drive-sync` needs a real Drive credential *and* a real folder-access check, so a successful 202 is unreachable locally. Only that response was faked client-side to verify the wizard's own success handling. **The actual Drive ingest is unverified and wants a preview with Drive configured** - section A step 13 is the check that matters.

Two defects came out of that live pass that the unit tests could not see, and both are fixed here:

1. The rollback **archives** rather than hard-deletes, so the original copy "No Data Lake was created." overstated it. It now states what the user can observe.
2. The syncing sentence rendered as `Data Lakeslist` - JSX drops the space between an expression and the text following it, and `toHaveTextContent`'s substring matching never noticed. Both Drive-only sentences are now built as whole strings, with a test pinning the *spacing*, not just the words.

A third defect came out of code review and is also fixed here:

3. **The Failed screen claimed a rollback it never checked.** The archive is deliberately best-effort (`.catch(() => {})`) so a cleanup failure cannot mask the refusal the user needs to read - but that swallowed its outcome too, and the screen stated the rollback as fact regardless. On a transient `DELETE` failure the empty lake stayed live in the user's list while the screen said the opposite, and a retry from `Back to Configuration` would then add a second lake beside the orphan. The outcome is now tracked as `uploadProgress.driveRollback` and the copy branches on it: the rollback sentence only when the archive succeeded, a check-your-list warning when it failed, and **no claim at all** when no rollback was attempted (the create itself was refused, so there is nothing to roll back). Tests pin all three states.

## Developer Notes (Optional)

- **`useDriveFolderPicker`** is a reusable seam for "let the user pick a Drive folder" - it owns the OAuth branches (first-time consent redirect, expired-refresh `authUrl`, missing client id) and the picker's z-index workaround. Any future surface that needs a folder id should call it rather than re-deriving that flow. Its `busy` input folds the caller's own in-flight work into the re-entrancy guard.
- **Deferred-commit pattern for wizard state.** `pendingDriveFolder` shows how to let a wizard collect a *side effect that needs a server id* without inverting its collect-then-commit contract: park the selection, fire it on commit, and get "abandoning creates nothing" for free. The same shape would fit any other post-create binding the wizard grows.
- **`createWizardLake` / `zeroProgressCounts`** are now the single source of truth shared by both commit paths, so the two cannot drift on what fields a new lake carries or how a fresh attempt resets progress.
- **Rollback semantics are archive, not erase.** Worth knowing before writing user-facing copy about either commit path: `DELETE /api/data-lakes/:id` is reversible, so "nothing was created" is never literally true - phrase it in terms of what the user can see.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a, no user guide covers Drive lakes yet
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry changes

