### PR TITLE
fix(ci): run the test files that live outside every pnpm workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,36 @@ jobs:
           CI: true
           VITEST_MAX_WORKERS: ${{ matrix.shard.workers }}
 
+      # Tests that live outside every pnpm workspace, which the sharded run above cannot reach:
+      # infra/ has no package.json, and scripts/codemods is not in pnpm-workspace.yaml, so
+      # `pnpm --recursive ... test` has no project to run in either. They passed locally and
+      # nowhere else, which is worse than having no tests - infra/__tests__ holds the guard that
+      # is meant to fail the build when a WAF shadow rule flips from Count to Block, and it could
+      # not have.
+      #
+      # Pinned to the misc shard, the negative-filter catch-all, so this runs exactly once rather
+      # than once per matrix leg.
+      #
+      # `--dir` rather than a path argument: a bare `vitest run infra/` is a SUBSTRING filter, so
+      # it also collects packages/database/src/models/infra/**, whose model tests need that
+      # package's own vitest setup and fail under the root config (30 files, 16 failures). The
+      # preview gate's path glob is anchored against the same trap.
+      #
+      # `pnpm exec`, not `pnpm vitest`: the latter resolves as a recursive script and errors with
+      # "Command vitest not found" even though vitest is a root devDependency.
+      #
+      # A directory with no test files exits non-zero, so moving or renaming these files reddens
+      # CI instead of quietly reporting success - which is the failure mode this step exists to
+      # end.
+      - name: Run root-level tests (outside pnpm workspaces)
+        if: matrix.shard.name == 'misc'
+        run: |
+          pnpm exec vitest run --dir infra
+          pnpm exec vitest run --dir scripts/codemods
+        env:
+          CI: true
+          VITEST_MAX_WORKERS: ${{ matrix.shard.workers }}
+
   # Aggregate gate for the sharded test matrix. Branch protection requires a
   # status check literally named "Run Tests"; the matrix above reports per-shard
   # names ("Run Tests (client)", …), so this job re-exposes the exact required


### PR DESCRIPTION
Found while acting on a P1 in review on Bike4Mind/bike4mind#1893: the test file that PR adds is never executed by CI, so the PR's entire contribution would have been inert. That turned out not to be specific to one file.

## The gap

CI's only test invocation is `pnpm --recursive --workspace-concurrency=4 <filter> test`. pnpm's workspace globs are `apps/*`, `packages/*`, `packages/premium/*` and `b4m-core/*`. Root `infra/` has no `package.json` and `scripts/codemods` is not a workspace, so pnpm has no project to run in either directory and their tests have never executed in CI.

Four suites, 63 tests, passing locally and nowhere else:

| location | suites | tests |
| --- | --- | --- |
| `infra/__tests__` | 1 | 23 |
| `scripts/codemods/__tests__` | 3 | 40 |

Worth being precise about the count, because a naive filename match overstates it badly: `scripts/codemods` contains about 44 more files matching `*.test.ts` that are codemod **fixtures**, test data rather than suites. Vitest collects 3 files there, not 47.

This is worse than having no tests. `infra/__tests__/wafPolicy.test.ts` holds the guard that is supposed to fail the build if a WAF shadow rule flips from `Count` to `Block`, described in review on Bike4Mind/bike4mind#1851 as making that flip "fail the build instead of quietly enforcing an unvalidated limit". It could not have failed anything.

## The change

One step on the `misc` shard, the negative-filter catch-all, so it runs once rather than once per matrix leg.

## Two invocation details that both fail quietly if guessed wrong

Recording these because each looks right and is not, and I only found them by running the commands rather than reasoning about them.

**`--dir` rather than a path argument.** `vitest run infra/` looks like a directory but is a substring filter, so it also collects `packages/database/src/models/infra/**` - Mongo model tests that need the database package's own vitest setup and fail under the root config. Measured: 30 files collected, 16 failed. That would have reddened CI on merge. It is the same trap the preview gate's path glob is explicitly anchored against, per its own comment about not matching data-model dirs.

**`pnpm exec vitest` rather than `pnpm vitest`.** The latter resolves as a recursive script and dies with `Command "vitest" not found`, even though vitest is a root devDependency. Verified `pnpm exec` resolves it in a checkout with a real install.

Third property, deliberate: a directory containing no test files exits non-zero. Renaming or moving these files reddens CI instead of silently reporting success, which is exactly the failure this step exists to end.

## Verification

`.github/workflows/**` is not in the changes-filter's non-deployable exclude list, so the shards run on this PR and this step executes here rather than first proving itself after merge. The check to apply on this run: the step should report **23 tests** for `infra` and **40** for `scripts/codemods`. "No test files found" means the scoping is wrong and nothing has been fixed.

Locally, `--dir infra` reports 1 file and 23 tests, and `--dir scripts/codemods` reports 3 files and 40 tests. I also confirmed `--dir` is future-proof rather than tied to the `__tests__` layout: a temporary `infra/probe.test.ts` outside that directory was collected, where an `infra/__tests__` path filter missed it. The probe was removed.

The infra count becomes 24 once Bike4Mind/bike4mind#1893 merges, which adds one test to that file.

## Scope note

Two directories are fixed together because it is one defect with one mechanism, and both were verified passing. Happy to split `scripts/codemods` out if you would rather keep this to the directory that is blocking - it is not blocking anything itself, it is just the other half of the same hole.
