### PR TITLE
fix(waf): scope the production rate limit to /api/ before the WAF is enabled

### DIFF
--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -266,6 +266,54 @@ describe('wafPolicy', () => {
     });
   });
 
+  // A rate limit that matches the raw path is evadable. Verified against staging with
+  // curl --path-as-is: /./api/otc/send and //api/otc/send both reach the API and answer with
+  // application/json, while neither literally starts with "/api/", so a rule matching the
+  // untransformed path never counts them. NORMALIZE_PATH closes that; URL_DECODE does not,
+  // because the percent-encoded form (/%61pi/...) is routed to the SPA shell and never reaches
+  // an endpoint. Limits only - for an Allow or an exemption, an unrecognised path failing to
+  // match is the safe direction.
+  describe('rate limit path matching', () => {
+    for (const stage of ['dev', 'production']) {
+      it(`normalizes the path before matching in every ${stage} rate limit`, () => {
+        const rules: WafRule[] = JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
+
+        // any: RateBasedStatement scope-down shape is deeply nested and varies by statement type
+        const limits = rules.filter(r => (r.Statement as any).RateBasedStatement?.ScopeDownStatement);
+        expect(limits.length).toBeGreaterThan(0);
+
+        for (const rule of limits) {
+          const byteMatch = (rule.Statement as any).RateBasedStatement.ScopeDownStatement.ByteMatchStatement;
+          const types = (byteMatch.TextTransformations ?? []).map((t: { Type: string }) => t.Type);
+
+          expect(types, `${rule.Name} must normalize the path`).toContain('NORMALIZE_PATH');
+          // NONE alongside real transformations is dead weight that reads as intent.
+          expect(types, `${rule.Name} should not carry a NONE transformation`).not.toContain('NONE');
+        }
+      });
+    }
+
+    // /_next/image is a live server-side fetch and resize, not a static file: it answers with
+    // application/json from a function. The blanket rule used to cover it and the scoped rule
+    // does not, so without this it is the one expensive path with no ceiling at all.
+    it('bounds the production image optimizer, below the static-asset ceiling', () => {
+      const rules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      const image = rules.find(r => r.Name === 'image-rate-limit');
+      expect(image).toBeDefined();
+
+      // any: see above
+      const rateBased = (image!.Statement as any).RateBasedStatement;
+      const staticRule = rules.find(r => r.Name === 'static-asset-rate-limit');
+      const staticLimit = (staticRule!.Statement as any).RateBasedStatement.Limit;
+
+      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/image');
+      expect(rateBased.Limit).toBeLessThan(staticLimit);
+    });
+  });
+
   describe('buildDevWafRuleJson — production stage', () => {
     it('pins Allow-LLM-API at Priority 0 so completions endpoint is not counted by ai-route-rate-limit', () => {
       const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' });

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -285,6 +285,38 @@ describe('wafPolicy', () => {
       expect(rateLimitRule.Statement.RateBasedStatement.Limit).toBe(2000);
     });
 
+    // 2000 per IP per 5 min is a sane ceiling for API calls and a wrong one for a page load:
+    // roughly 56% of comparable traffic is /_next/static/ assets, and measured on staging the
+    // unscoped form would have counted 331,374 of 517,542 requests in a day, with single IPs
+    // reaching 18k in a 5-minute window. The limit was never the defect; applying it to every
+    // request was. Assert the scope-down so the blanket form cannot come back unnoticed.
+    it('scopes the production rate limit to /api/ so static assets do not consume the budget', () => {
+      const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' });
+      const parsed = JSON.parse(ruleJson);
+
+      const rateLimitRule = parsed.find((rule: WafRule) => rule.Name === 'api-rate-limit');
+      const rateBased = (rateLimitRule.Statement as any).RateBasedStatement;
+
+      expect(rateBased.ScopeDownStatement).toBeDefined();
+      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/api/');
+      expect(rateBased.ScopeDownStatement.ByteMatchStatement.PositionalConstraint).toBe('STARTS_WITH');
+      expect(rateBased.ScopeDownStatement.ByteMatchStatement.FieldToMatch.UriPath).toBeDefined();
+    });
+
+    // The asset backstop that makes the scope-down above safe: assets stop counting against the
+    // API budget, but are still bounded so they cannot become a free amplification target.
+    it('keeps a separate, higher ceiling for static assets', () => {
+      const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' });
+      const parsed = JSON.parse(ruleJson);
+
+      const assetRule = parsed.find((rule: WafRule) => rule.Name === 'static-asset-rate-limit');
+      expect(assetRule).toBeDefined();
+
+      const rateBased = (assetRule.Statement as any).RateBasedStatement;
+      expect(rateBased.Limit).toBe(50000);
+      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/static/');
+    });
+
     it('includes the ai-route-rate-limit rule at Priority 4', () => {
       const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' });
       const parsed = JSON.parse(ruleJson);

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -357,9 +357,15 @@ describe('wafPolicy', () => {
       const rateBased = (fallback!.Statement as any).RateBasedStatement;
       const apiLimit = (rules.find(r => r.Name === 'api-rate-limit')!.Statement as any).RateBasedStatement.Limit;
 
-      // Negated: it applies to everything EXCEPT assets, which carry their own ceilings.
-      expect(rateBased.ScopeDownStatement.NotStatement.Statement.ByteMatchStatement.SearchString).toBe('/_next/');
-      // Above the API limit, so the specific rule is what bites on API traffic.
+      // Excludes only real assets. /_next/static/ is the sole prefix CloudFront routes to the
+      // bucket, so /_next/data, /_next/image and any case variant stay function-backed and must
+      // fall through to this ceiling rather than into the 50000 asset bucket.
+      expect(rateBased.ScopeDownStatement.NotStatement.Statement.ByteMatchStatement.SearchString).toBe(
+        '/_next/static/'
+      );
+      // Pinned, not bounded: this number is about to be retuned off a shadow reading, and a
+      // greater-than assertion would pass a 10x loosening while failing a tightening.
+      expect(rateBased.Limit).toBe(5000);
       expect(rateBased.Limit).toBeGreaterThan(apiLimit);
     });
 
@@ -430,10 +436,10 @@ describe('wafPolicy', () => {
 
       const rateBased = (assetRule.Statement as any).RateBasedStatement;
       expect(rateBased.Limit).toBe(50000);
-      // CloudFront routes the whole /_next/ prefix to the assets bucket, not just /_next/static/,
-      // so the carve-out covers the prefix. image-rate-limit sits behind this at a higher priority
-      // and is still reached while this rule is under its limit.
-      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/');
+      // Only /_next/static/ is routed to the assets bucket: probed staging, /_next/static/x answers
+      // from AmazonS3 while /_next/x and /_NEXT/static/x both come from the default origin. So the
+      // carve-out stops here and everything else under /_next/ stays function-backed.
+      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/static/');
     });
 
     it('includes the ai-route-rate-limit rule at Priority 4', () => {

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -266,29 +266,57 @@ describe('wafPolicy', () => {
     });
   });
 
-  // A rate limit that matches the raw path is evadable. Verified against staging with
-  // curl --path-as-is: /./api/otc/send and //api/otc/send both reach the API and answer with
-  // application/json, while neither literally starts with "/api/", so a rule matching the
-  // untransformed path never counts them. NORMALIZE_PATH closes that; URL_DECODE does not,
-  // because the percent-encoded form (/%61pi/...) is routed to the SPA shell and never reaches
-  // an endpoint. Limits only - for an Allow or an exemption, an unrecognised path failing to
-  // match is the safe direction.
+  // The scope-down of a rate limit, whether asserted directly or negated with NotStatement.
+  // any: WAF statements nest differently per type; this reaches the ByteMatch in either shape.
+  function rateLimitByteMatch(rule: WafRule): any {
+    const scopeDown = (rule.Statement as any).RateBasedStatement?.ScopeDownStatement;
+    return scopeDown?.ByteMatchStatement ?? scopeDown?.NotStatement?.Statement?.ByteMatchStatement;
+  }
+
+  /** Every rate-based rule in a stage that narrows itself with a scope-down. */
+  function scopedRateLimits(stage: string): WafRule[] {
+    const rules: WafRule[] = JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
+    // any: see above
+    return rules.filter(r => (r.Statement as any).RateBasedStatement?.ScopeDownStatement);
+  }
+
+  // A rate limit that matches the raw path is evadable, and the ORDER of the transformations is
+  // the whole fix rather than their presence. They chain, each applied to the previous result, so
+  // NORMALIZE_PATH before URL_DECODE leaves nothing to normalize the decoded form: verified
+  // against staging with curl --path-as-is, /%2e/api/otc/send reaches the API with a 404
+  // application/json yet reduces to /./api/otc/send, which starts with neither /api/ nor
+  // /api/otc/send and is therefore counted by nothing. Decode, then normalize, then lowercase.
+  // Double encoding (/%252e/...) is served the SPA shell and never reaches an endpoint, so it is
+  // out of reach either way. Limits only: for an Allow or an exemption, a path that fails to
+  // match is the safe direction, which is why the exemptions keep NONE.
   describe('rate limit path matching', () => {
     for (const stage of ['dev', 'production']) {
-      it(`normalizes the path before matching in every ${stage} rate limit`, () => {
-        const rules: WafRule[] = JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
-
-        // any: RateBasedStatement scope-down shape is deeply nested and varies by statement type
-        const limits = rules.filter(r => (r.Statement as any).RateBasedStatement?.ScopeDownStatement);
+      it(`decodes before normalizing in every ${stage} rate limit`, () => {
+        const limits = scopedRateLimits(stage);
         expect(limits.length).toBeGreaterThan(0);
 
         for (const rule of limits) {
-          const byteMatch = (rule.Statement as any).RateBasedStatement.ScopeDownStatement.ByteMatchStatement;
-          const types = (byteMatch.TextTransformations ?? []).map((t: { Type: string }) => t.Type);
+          const byteMatch = rateLimitByteMatch(rule);
+          expect(byteMatch, `${rule.Name} scope-down must match on a path`).toBeDefined();
 
-          expect(types, `${rule.Name} must normalize the path`).toContain('NORMALIZE_PATH');
-          // NONE alongside real transformations is dead weight that reads as intent.
-          expect(types, `${rule.Name} should not carry a NONE transformation`).not.toContain('NONE');
+          const ordered = [...(byteMatch.TextTransformations ?? [])]
+            .sort((a: { Priority: number }, b: { Priority: number }) => a.Priority - b.Priority)
+            .map((t: { Type: string }) => t.Type);
+
+          expect(ordered, `${rule.Name} must decode, then normalize, then lowercase`).toEqual([
+            'URL_DECODE',
+            'NORMALIZE_PATH',
+            'LOWERCASE',
+          ]);
+        }
+      });
+
+      it(`anchors every ${stage} rate limit to a URI path prefix`, () => {
+        for (const rule of scopedRateLimits(stage)) {
+          const byteMatch = rateLimitByteMatch(rule);
+
+          expect(byteMatch.FieldToMatch.UriPath, `${rule.Name} must match on UriPath`).toBeDefined();
+          expect(byteMatch.PositionalConstraint, `${rule.Name} must be prefix-anchored`).toBe('STARTS_WITH');
         }
       });
     }
@@ -311,6 +339,46 @@ describe('wafPolicy', () => {
 
       expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/image');
       expect(rateBased.Limit).toBeLessThan(staticLimit);
+    });
+
+    // Scoping api-rate-limit to /api/ left everything that is neither /api/ nor an asset with no
+    // ceiling, where the blanket rule had covered it. Next's rewrites run inside the server, so
+    // the WAF only sees the pre-rewrite URI: /p/* and /uc/* are unauthenticated Lambda
+    // invocations with an S3 fetch and no app-level limiter of their own.
+    it('keeps a default ceiling on everything that is not an asset', () => {
+      const rules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      const fallback = rules.find(r => r.Name === 'default-rate-limit');
+      expect(fallback, 'production needs a catch-all rate limit').toBeDefined();
+
+      // any: see above
+      const rateBased = (fallback!.Statement as any).RateBasedStatement;
+      const apiLimit = (rules.find(r => r.Name === 'api-rate-limit')!.Statement as any).RateBasedStatement.Limit;
+
+      // Negated: it applies to everything EXCEPT assets, which carry their own ceilings.
+      expect(rateBased.ScopeDownStatement.NotStatement.Statement.ByteMatchStatement.SearchString).toBe('/_next/');
+      // Above the API limit, so the specific rule is what bites on API traffic.
+      expect(rateBased.Limit).toBeGreaterThan(apiLimit);
+    });
+
+    // Nothing else pins this. #1893's parity guard deep-equals Statement only, so flipping a
+    // production limit to Count is invisible to every other test in this file. When these do go
+    // to Count for a first week of measurement, this assertion is what makes coming back to
+    // Block something the build demands rather than something someone remembers.
+    it('enforces, rather than counts, every production rate limit', () => {
+      const rules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      // any: see above
+      const limits = rules.filter(r => (r.Statement as any).RateBasedStatement);
+      expect(limits.length).toBeGreaterThan(0);
+
+      for (const rule of limits) {
+        expect(rule.Action, `${rule.Name} must Block, not Count`).toEqual({ Block: {} });
+      }
     });
   });
 
@@ -362,7 +430,10 @@ describe('wafPolicy', () => {
 
       const rateBased = (assetRule.Statement as any).RateBasedStatement;
       expect(rateBased.Limit).toBe(50000);
-      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/static/');
+      // CloudFront routes the whole /_next/ prefix to the assets bucket, not just /_next/static/,
+      // so the carve-out covers the prefix. image-rate-limit sits behind this at a higher priority
+      // and is still reached while this rule is under its limit.
+      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/');
     });
 
     it('includes the ai-route-rate-limit rule at Priority 4', () => {

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -517,7 +517,22 @@
         "RateBasedStatement": {
           "Limit": 2000,
           "EvaluationWindowSec": 300,
-          "AggregateKeyType": "IP"
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/api/",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NONE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
         }
       },
       "Action": {

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -145,7 +145,15 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NONE"
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
                 }
               ],
               "PositionalConstraint": "STARTS_WITH"
@@ -455,7 +463,15 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NONE"
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
                 }
               ],
               "PositionalConstraint": "STARTS_WITH"
@@ -489,10 +505,14 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
                   "Type": "LOWERCASE"
                 }
               ],
@@ -527,7 +547,15 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NONE"
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
                 }
               ],
               "PositionalConstraint": "STARTS_WITH"
@@ -561,11 +589,15 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "LOWERCASE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 1,
                   "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
                 }
               ],
               "PositionalConstraint": "STARTS_WITH"
@@ -599,10 +631,14 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
                   "Type": "LOWERCASE"
                 }
               ],
@@ -618,6 +654,48 @@
         "SampledRequestsEnabled": true,
         "CloudWatchMetricsEnabled": true,
         "MetricName": "register-rate-limit-prod-shadow"
+      }
+    },
+    {
+      "Name": "image-rate-limit-prod-shadow",
+      "Priority": 15,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 1000,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/_next/image",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
+        }
+      },
+      "Action": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "image-rate-limit-prod-shadow"
       }
     }
   ],

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -145,11 +145,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -456,18 +456,18 @@
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
             "ByteMatchStatement": {
-              "SearchString": "/_next/static/",
+              "SearchString": "/_next/",
               "FieldToMatch": {
                 "UriPath": {}
               },
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -505,11 +505,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -547,11 +547,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -589,11 +589,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -631,11 +631,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -673,11 +673,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -696,6 +696,94 @@
         "SampledRequestsEnabled": true,
         "CloudWatchMetricsEnabled": true,
         "MetricName": "image-rate-limit-prod-shadow"
+      }
+    },
+    {
+      "Name": "default-rate-limit-prod-shadow",
+      "Priority": 16,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 5000,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "NotStatement": {
+              "Statement": {
+                "ByteMatchStatement": {
+                  "SearchString": "/_next/",
+                  "FieldToMatch": {
+                    "UriPath": {}
+                  },
+                  "TextTransformations": [
+                    {
+                      "Priority": 0,
+                      "Type": "URL_DECODE"
+                    },
+                    {
+                      "Priority": 1,
+                      "Type": "NORMALIZE_PATH"
+                    },
+                    {
+                      "Priority": 2,
+                      "Type": "LOWERCASE"
+                    }
+                  ],
+                  "PositionalConstraint": "STARTS_WITH"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Action": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "default-rate-limit-prod-shadow"
+      }
+    },
+    {
+      "Name": "static-asset-rate-limit-prod-shadow",
+      "Priority": 17,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 50000,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/_next/",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
+        }
+      },
+      "Action": {
+        "Count": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "static-asset-rate-limit-prod-shadow"
       }
     }
   ],

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -456,7 +456,7 @@
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
             "ByteMatchStatement": {
-              "SearchString": "/_next/",
+              "SearchString": "/_next/static/",
               "FieldToMatch": {
                 "UriPath": {}
               },
@@ -710,7 +710,7 @@
             "NotStatement": {
               "Statement": {
                 "ByteMatchStatement": {
-                  "SearchString": "/_next/",
+                  "SearchString": "/_next/static/",
                   "FieldToMatch": {
                     "UriPath": {}
                   },
@@ -754,7 +754,7 @@
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
             "ByteMatchStatement": {
-              "SearchString": "/_next/",
+              "SearchString": "/_next/static/",
               "FieldToMatch": {
                 "UriPath": {}
               },

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -171,7 +171,22 @@
         "RateBasedStatement": {
           "Limit": 2000,
           "EvaluationWindowSec": 300,
-          "AggregateKeyType": "IP"
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/api/",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NONE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
         }
       },
       "Action": {
@@ -405,6 +420,40 @@
         "SampledRequestsEnabled": true,
         "CloudWatchMetricsEnabled": true,
         "MetricName": "register-rate-limit"
+      }
+    },
+    {
+      "Name": "static-asset-rate-limit",
+      "Priority": 12,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 50000,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/_next/static/",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NONE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
+        }
+      },
+      "Action": {
+        "Block": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "static-asset-rate-limit"
       }
     }
   ],

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -143,11 +143,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -185,11 +185,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -413,11 +413,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -448,18 +448,18 @@
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
             "ByteMatchStatement": {
-              "SearchString": "/_next/static/",
+              "SearchString": "/_next/",
               "FieldToMatch": {
                 "UriPath": {}
               },
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -497,11 +497,11 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NORMALIZE_PATH"
+                  "Type": "URL_DECODE"
                 },
                 {
                   "Priority": 1,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 2,
@@ -520,6 +520,52 @@
         "SampledRequestsEnabled": true,
         "CloudWatchMetricsEnabled": true,
         "MetricName": "image-rate-limit"
+      }
+    },
+    {
+      "Name": "default-rate-limit",
+      "Priority": 14,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 5000,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "NotStatement": {
+              "Statement": {
+                "ByteMatchStatement": {
+                  "SearchString": "/_next/",
+                  "FieldToMatch": {
+                    "UriPath": {}
+                  },
+                  "TextTransformations": [
+                    {
+                      "Priority": 0,
+                      "Type": "URL_DECODE"
+                    },
+                    {
+                      "Priority": 1,
+                      "Type": "NORMALIZE_PATH"
+                    },
+                    {
+                      "Priority": 2,
+                      "Type": "LOWERCASE"
+                    }
+                  ],
+                  "PositionalConstraint": "STARTS_WITH"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Action": {
+        "Block": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "default-rate-limit"
       }
     }
   ],

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -448,7 +448,7 @@
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
             "ByteMatchStatement": {
-              "SearchString": "/_next/",
+              "SearchString": "/_next/static/",
               "FieldToMatch": {
                 "UriPath": {}
               },
@@ -534,7 +534,7 @@
             "NotStatement": {
               "Statement": {
                 "ByteMatchStatement": {
-                  "SearchString": "/_next/",
+                  "SearchString": "/_next/static/",
                   "FieldToMatch": {
                     "UriPath": {}
                   },

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -143,11 +143,15 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "LOWERCASE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 1,
                   "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
                 }
               ],
               "PositionalConstraint": "STARTS_WITH"
@@ -181,7 +185,15 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NONE"
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
                 }
               ],
               "PositionalConstraint": "STARTS_WITH"
@@ -401,10 +413,14 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "URL_DECODE"
+                  "Type": "NORMALIZE_PATH"
                 },
                 {
                   "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
                   "Type": "LOWERCASE"
                 }
               ],
@@ -439,7 +455,15 @@
               "TextTransformations": [
                 {
                   "Priority": 0,
-                  "Type": "NONE"
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
                 }
               ],
               "PositionalConstraint": "STARTS_WITH"
@@ -454,6 +478,48 @@
         "SampledRequestsEnabled": true,
         "CloudWatchMetricsEnabled": true,
         "MetricName": "static-asset-rate-limit"
+      }
+    },
+    {
+      "Name": "image-rate-limit",
+      "Priority": 13,
+      "Statement": {
+        "RateBasedStatement": {
+          "Limit": 1000,
+          "EvaluationWindowSec": 300,
+          "AggregateKeyType": "IP",
+          "ScopeDownStatement": {
+            "ByteMatchStatement": {
+              "SearchString": "/_next/image",
+              "FieldToMatch": {
+                "UriPath": {}
+              },
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NORMALIZE_PATH"
+                },
+                {
+                  "Priority": 1,
+                  "Type": "URL_DECODE"
+                },
+                {
+                  "Priority": 2,
+                  "Type": "LOWERCASE"
+                }
+              ],
+              "PositionalConstraint": "STARTS_WITH"
+            }
+          }
+        }
+      },
+      "Action": {
+        "Block": {}
+      },
+      "VisibilityConfig": {
+        "SampledRequestsEnabled": true,
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "image-rate-limit"
       }
     }
   ],


### PR DESCRIPTION
This is the first finding out of the staging shadow measurement, and it lands before the WAF is enabled rather than after. **It needs a threshold decision from a human, not just a code review** - see the last section.

## What staging measured

The shadow rules from Bike4Mind/bike4mind#1851 went live on staging on 18 Aug. One day of `api-rate-limit-prod-shadow`, which is production's rule exactly:

| | |
| --- | --- |
| counted (would have crossed the limit) | **331,374** |
| allowed that day | 517,542 |
| share | **64%** |
| worst single IP in one 5-minute window | **18,335** against a 2,000 budget |
| share of traffic that is `/_next/static/` | **56%** |
| staging's own rule (10000, scoped to `/api/`) blocked | **nothing** |

## The diagnosis

The limit is not the defect. 2000 API calls per IP per 5 minutes is a reasonable ceiling. Applying it to a page load is not: a cold load pulls hundreds of assets through the same per-IP bucket, so the budget is consumed by exactly the traffic nobody wanted to rate-limit. Staging never sees this because its rule is scoped to `/api/` and assets have their own 50000 ceiling. Production has neither.

## What this changes

Scope production's `api-rate-limit` to `/api/`, reusing staging's scope-down verbatim, and give production the `/_next/static/` backstop at 50000 that staging already runs. Assets stop competing with API calls but stay bounded, so the carve-out is not a free amplification target.

Also re-points `api-rate-limit-prod-shadow` at the new statement. That keeps the dev/production parity guard in Bike4Mind/bike4mind#1893 satisfied, and it means staging now measures the rule we intend to enable rather than the one we already have an answer about.

**No live effect.** Production still deploys with `ENABLE_WAF` unset, so this changes the policy the next enablement builds from, not anything serving traffic today.

## Being straight about the evidence

Staging traffic is CI-heavy, so 64% is not a prediction for production. When this same rule was last live on production, in January, it blocked **2,021 of 279,554** requests - about 0.7%. Real users rarely approach 2000 in five minutes; CI and large shared NATs do.

So this is a latent design fault rather than a certain outage, and I would rather say that than oversell it. What makes it worth fixing before enablement instead of after: those 2,021 January blocks were never explained, the production WAF log group has since aged to zero stored bytes so they cannot be examined, and the failure mode is now demonstrated rather than hypothetical.

## Coverage, stated explicitly

The blanket rule counted every request. After this change production limits these and nothing else:

| priority | rule | scope | ceiling |
| --- | --- | --- | --- |
| 4 | `ai-route-rate-limit` | `/api/ai/` | 300 |
| 5 | `api-rate-limit` | `/api/` | 2000 |
| 11 | `register-rate-limit` | `/api/otc/send` | 100 |
| 12 | `static-asset-rate-limit` | `/_next/` | 50000 |
| 13 | `image-rate-limit` | `/_next/image` | 1000 |
| 14 | `default-rate-limit` | **NOT** `/_next/` | 5000 |

The catch-all at 14 is what keeps the post-change coverage from being narrower than the blanket rule it replaces. Raised in review and it was a real gap: Next's rewrites run inside the server, so the WAF only ever sees the pre-rewrite URI, and `/p/:path*` rewriting to `/api/publish/serve/:path*` never matches `/api/`. Probed against staging, `/p/`, `/uc/` and `/a/` all answer `404 application/json`, so they are Lambda invocations, unauthenticated, and the publish shim's own limiter is gated on `isShare`, covering `/a/` only.

## Verification

- AWS accepts both policies: **prod 1306 WCU, dev 1330**. The number that matters is **1500**, where the ACL leaves the basic price tier, not the 5000 hard cap - so real headroom is about 194 prod and 170 dev, roughly five or six more scoped rate limits rather than the hundred that citing 5000 implies.
- **33 tests** pass in `infra/__tests__`, and they gate the build now that Bike4Mind/bike4mind#1958 has landed.
- All **six** shadow pairs byte-match their production originals, including the two added here, so Bike4Mind/bike4mind#1893's parity guard is satisfied.
- Every new guard fails on its own mutation and only its own: restoring the old transformation order, deleting the catch-all, flipping a production limit to `Count`, and unanchoring a rule to `CONTAINS`.
- Worth noting the mutation coverage is now overlapping rather than isolated, because Bike4Mind/bike4mind#1893 is merged: breaking a production statement also fails the parity guard, since the shadow no longer matches. That is the guard working, but it means a single mutation reports two failures.

**Path normalization, verified rather than argued.** Transformations chain, each applied to the previous result, so `NORMALIZE_PATH` before `URL_DECODE` leaves nothing to normalize the decoded form. With `curl --path-as-is` against staging:

| path | result | matched as | counted |
| --- | --- | --- | --- |
| `/api/otc/send` | 404 `application/json` | `/api/otc/send` | yes |
| `/./api/otc/send` | 404 `application/json` | `/api/otc/send` | yes, once normalized |
| `/%2e/api/otc/send` | 404 `application/json` | `/./api/otc/send` under the old order | **no** |
| `/%252e/api/otc/send` | SPA shell, `text/html` | n/a | never reaches an endpoint |

So the old order was a live bypass of both the 2000 and the 100 bucket, not a stylistic preference. Now `URL_DECODE`, `NORMALIZE_PATH`, `LOWERCASE` on all fourteen scope-downs.

One thing this cannot prove yet: that the WAF itself counts `/%2e/...` under the new order. The production firewall is off and staging runs the merged policy rather than this branch, so the check is to send that path at staging once this lands and confirm `api-rate-limit-prod-shadow` moves.

## Two constraints worth knowing before the follow-ups

**Rate-based statements are capped at 10 per web ACL** (`wafv2` quota, CloudFront scope, confirmed against the account). Production is at 6; **dev is at 9**, because every production limit needs a shadow to be measured. One slot left, and each new production limit costs one in each file. The `static-asset-rate-limit-prod-shadow` added this round is the ninth - it exists so the parity guard can see that rule, since the guard only walks dev's shadows looking for production originals and never the reverse. If the next production limit matters more than that coverage, that shadow is the one to drop.

**Only `/_next/static/` is bucket-served.** Probed staging: `/_next/static/x` answers with `server: AmazonS3`, while `/_next/x` and `/_NEXT/static/x` both come from the default origin as `text/html`, because CloudFront path patterns are case-sensitive. Everything else under `/_next/` reaches a function, which is why the carve-out and the catch-all exclusion both stop at `/_next/static/` rather than the wider prefix.

## Thresholds, answered in review

Recording these so the numbers are not re-litigated later. Reviewer's answers, which I agree with:

1. **Keep 2000 for `/api/`.** Scoped, that is 6.7 requests per second per IP of pure API traffic, above any interactive session and above a cold-load burst now that assets are out of the bucket. Changing shape and threshold in one commit would destroy attribution on the next measurement.
2. **50000 for assets is fine** and is not the number worth attention: immutable versioned filenames from the assets bucket, so it is a DoS backstop rather than a tuned limit.
3. **Count for the first week** on every rate limit, leaving `emergency-ip-block` and the managed groups alone. Two conditions attached, both of which shape the next PR rather than this one: the `Action` guard added here must be flipped in the same change as the Count flip, and `image-rate-limit-prod-shadow` needs a reading before that rule ever goes to Block, since 1000 is the one ceiling with no measurement under it.

Still open and mine to flag rather than settle: **5000 for the catch-all** is new in this change and has no measurement behind it either. Its dev shadow will produce one.
## The decision I should not make alone

The numbers are a judgement call on a production security control, so they want your sign-off rather than mine:

1. **Keep 2000 for `/api/`, or raise it?** Scoped, 2000 is far more headroom than it sounds, since it now only counts API calls. I kept it because the scoping is the fix and changing both at once would confound the next measurement.
2. **Is 50000 right for assets?** Cloned from staging rather than derived from production traffic. It is a DoS backstop, not a tuned limit.
3. **Enable in Count or Block?** My recommendation stands: Count for the first week on production, then Block once real production counts are in.

Happy to split the asset rule out if you would rather land the scope-down alone.


