### PR TITLE
feat(publish): search, sort, facets and real paging for the Live Artifacts tab

### DIFF
--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
@@ -72,11 +72,27 @@ const bundleRow = {
   versionsCount: 1,
 };
 const replyRow = { ...bundleRow, publicId: 'pub-2', title: 'My Reply', source: { kind: 'reply' } };
+
+/** listMyPublishedArtifacts returns a page envelope, not a bare array. */
+const page = (rows: unknown[], over: Record<string, unknown> = {}) => ({
+  artifacts: rows,
+  total: rows.length,
+  limit: 25,
+  skip: 0,
+  facets: { kind: {}, visibility: {}, gate: {}, comments: 0 },
+  ...over,
+});
+
+/**
+ * The row is collapsed by default now, so its settings, export and version controls live behind
+ * the disclosure. Open it first - this is the click a real owner makes too.
+ */
+const expandRow = (publicId: string) => fireEvent.click(screen.getByTestId(`published-artifact-expand-${publicId}`));
 /** A bundle that still knows its in-app source, so it can be refreshed. */
 const sourcedRow = { ...bundleRow, publicId: 'pub-3', source: { kind: 'bundle', artifactId: 'artifact_html_x_1_0' } };
 
 beforeEach(() => {
-  mockList.mockReset().mockResolvedValue([bundleRow]);
+  mockList.mockReset().mockResolvedValue(page([bundleRow]));
   mockExport.mockReset().mockResolvedValue('# exported');
   mockDownloadData.mockReset();
   mockRefresh.mockReset().mockResolvedValue({ publicId: 'pub-3' });
@@ -89,6 +105,7 @@ describe('PublishedArtifactsTabContent - manage toggle', () => {
   it('mounts the sharing panel only after the </> toggle is clicked, and unmounts on re-click', async () => {
     renderTab();
     await screen.findByTestId('published-artifact-pub-1');
+    expandRow('pub-1');
 
     // Lazy: panel not mounted until the owner opens it.
     expect(screen.queryByTestId('stub-panel-pub-1')).toBeNull();
@@ -105,6 +122,7 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
   it('hides Copy-as-Markdown for a bundle, which has no faithful Markdown form', async () => {
     renderTab();
     await screen.findByTestId('published-artifact-pub-1');
+    expandRow('pub-1');
 
     expect(screen.queryByTestId('published-artifact-copy-md-pub-1')).toBeNull();
     // HTML is faithful for every kind, so that action is always present.
@@ -114,9 +132,10 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
   it('copies a reply as Markdown through the authenticated export fetch', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
-    mockList.mockResolvedValue([replyRow]);
+    mockList.mockResolvedValue(page([replyRow]));
     renderTab();
     await screen.findByTestId('published-artifact-pub-2');
+    expandRow('pub-2');
 
     fireEvent.click(screen.getByTestId('published-artifact-copy-md-pub-2'));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('# exported'));
@@ -130,6 +149,7 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
     mockExport.mockResolvedValue('<html></html>');
     renderTab();
     await screen.findByTestId('published-artifact-pub-1');
+    expandRow('pub-1');
 
     fireEvent.click(screen.getByTestId('published-artifact-save-html-pub-1'));
     await waitFor(() =>
@@ -142,6 +162,7 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
     mockExport.mockRejectedValue(new Error('boom'));
     renderTab();
     await screen.findByTestId('published-artifact-pub-1');
+    expandRow('pub-1');
 
     fireEvent.click(screen.getByTestId('published-artifact-save-html-pub-1'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
@@ -152,6 +173,7 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
     mockExport.mockResolvedValue('<html><body>bundle</body></html>');
     renderTab();
     await screen.findByTestId('published-artifact-pub-1');
+    expandRow('pub-1');
 
     // Present on a bundle, which has no faithful Markdown form - PDF is not gated.
     fireEvent.click(screen.getByTestId('published-artifact-save-pdf-pub-1'));
@@ -166,6 +188,7 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
     mockExport.mockRejectedValue(new Error('boom'));
     renderTab();
     await screen.findByTestId('published-artifact-pub-1');
+    expandRow('pub-1');
 
     fireEvent.click(screen.getByTestId('published-artifact-save-pdf-pub-1'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
@@ -175,9 +198,10 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
 
 describe('PublishedArtifactsTabContent - refresh from source (issue #1142, option 2)', () => {
   it('offers Refresh only for a bundle that still knows its source artifact', async () => {
-    mockList.mockResolvedValue([bundleRow, replyRow, sourcedRow]);
+    mockList.mockResolvedValue(page([bundleRow, replyRow, sourcedRow]));
     renderTab();
     await screen.findByTestId('published-artifact-pub-3');
+    expandRow('pub-3');
 
     expect(screen.getByTestId('published-artifact-refresh-pub-3')).not.toBeNull();
     // No artifactId (published from outside the app) - nothing to read back.
@@ -188,9 +212,10 @@ describe('PublishedArtifactsTabContent - refresh from source (issue #1142, optio
 
   it('confirms before refreshing, since it replaces what viewers of a live link see', async () => {
     const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
-    mockList.mockResolvedValue([sourcedRow]);
+    mockList.mockResolvedValue(page([sourcedRow]));
     renderTab();
     await screen.findByTestId('published-artifact-pub-3');
+    expandRow('pub-3');
 
     fireEvent.click(screen.getByTestId('published-artifact-refresh-pub-3'));
     expect(confirm).toHaveBeenCalled();
@@ -200,9 +225,10 @@ describe('PublishedArtifactsTabContent - refresh from source (issue #1142, optio
 
   it('refreshes the row on confirm and reports success', async () => {
     const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
-    mockList.mockResolvedValue([sourcedRow]);
+    mockList.mockResolvedValue(page([sourcedRow]));
     renderTab();
     await screen.findByTestId('published-artifact-pub-3');
+    expandRow('pub-3');
 
     fireEvent.click(screen.getByTestId('published-artifact-refresh-pub-3'));
     await waitFor(() => expect(mockRefresh).toHaveBeenCalledWith(expect.objectContaining({ publicId: 'pub-3' })));
@@ -213,9 +239,10 @@ describe('PublishedArtifactsTabContent - refresh from source (issue #1142, optio
   it('surfaces a refresh failure', async () => {
     const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockRefresh.mockRejectedValue(new Error('boom'));
-    mockList.mockResolvedValue([sourcedRow]);
+    mockList.mockResolvedValue(page([sourcedRow]));
     renderTab();
     await screen.findByTestId('published-artifact-pub-3');
+    expandRow('pub-3');
 
     fireEvent.click(screen.getByTestId('published-artifact-refresh-pub-3'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
@@ -224,15 +251,150 @@ describe('PublishedArtifactsTabContent - refresh from source (issue #1142, optio
   });
 
   it('points the single-version hint at Refresh when the row can use it', async () => {
-    mockList.mockResolvedValue([sourcedRow]);
+    mockList.mockResolvedValue(page([sourcedRow]));
     renderTab();
+    await screen.findByTestId('published-artifact-pub-3');
+    // The hint moved into the expanded row: repeated on every collapsed row it was the largest
+    // consumer of vertical space on the page, and it is guidance you read while in settings.
+    expandRow('pub-3');
     const hint = await screen.findByTestId('published-artifact-single-version-pub-3');
     expect(hint.textContent).toContain('refresh it from source');
   });
 
   it('keeps the generic hint wording when the row cannot be refreshed', async () => {
     renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+    // The hint moved into the expanded row: repeated on every collapsed row it was the largest
+    // consumer of vertical space on the page, and it is guidance you read while in settings.
+    expandRow('pub-1');
     const hint = await screen.findByTestId('published-artifact-single-version-pub-1');
     expect(hint.textContent).toContain('re-publish this artifact');
+  });
+});
+
+/**
+ * The library controls. These assert the QUERY the tab asks for rather than re-testing the
+ * server's filtering (buildListQuery has its own unit tests) - what matters here is that a
+ * click turns into the right request and that paging resets when the result set changes.
+ */
+describe('PublishedArtifactsTabContent - search, facets and paging', () => {
+  /** The query argument of the most recent list call. */
+  const lastQuery = () => mockList.mock.calls[mockList.mock.calls.length - 1][0] as Record<string, unknown>;
+
+  it('requests a bounded page instead of the whole library', async () => {
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+    expect(lastQuery()).toMatchObject({ limit: 25, skip: 0, sort: 'newest' });
+  });
+
+  it('collapses the row: settings and export controls are hidden until expanded', async () => {
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    // Scannable on the collapsed row.
+    expect(screen.getByTestId('published-artifact-meta-pub-1')).not.toBeNull();
+    expect(screen.getByTestId('published-artifact-copy-pub-1')).not.toBeNull();
+    // Everything else is one click away.
+    expect(screen.queryByTestId('published-artifact-visibility-pub-1')).toBeNull();
+    expect(screen.queryByTestId('published-artifact-delete-pub-1')).toBeNull();
+
+    expandRow('pub-1');
+    expect(screen.getByTestId('published-artifact-visibility-pub-1')).not.toBeNull();
+    expect(screen.getByTestId('published-artifact-delete-pub-1')).not.toBeNull();
+  });
+
+  it('expands rows independently, so two artifacts can be compared', async () => {
+    mockList.mockResolvedValue(page([bundleRow, replyRow]));
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    expandRow('pub-1');
+    expandRow('pub-2');
+
+    expect(screen.getByTestId('published-artifact-visibility-pub-1')).not.toBeNull();
+    expect(screen.getByTestId('published-artifact-visibility-pub-2')).not.toBeNull();
+  });
+
+  it('sends the typed search term, debounced', async () => {
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    fireEvent.change(screen.getByTestId('published-artifacts-search'), { target: { value: 'ionq' } });
+
+    await waitFor(() => expect(lastQuery().q).toBe('ionq'));
+  });
+
+  it('filters on a facet chip and turns the filter off when clicked again', async () => {
+    mockList.mockResolvedValue(
+      page([bundleRow], { facets: { kind: { bundle: 3 }, visibility: {}, gate: {}, comments: 0 } })
+    );
+    renderTab();
+    await screen.findByTestId('published-artifacts-facet-kind-bundle');
+
+    fireEvent.click(screen.getByTestId('published-artifacts-facet-kind-bundle'));
+    await waitFor(() => expect(lastQuery().kind).toBe('bundle'));
+
+    fireEvent.click(screen.getByTestId('published-artifacts-facet-kind-bundle'));
+    await waitFor(() => expect(lastQuery().kind).toBeUndefined());
+  });
+
+  it('pages forward and back, and reports the range against the real total', async () => {
+    mockList.mockResolvedValue(page([bundleRow], { total: 60 }));
+    renderTab();
+    await screen.findByTestId('published-artifacts-pager');
+
+    expect(screen.getByTestId('published-artifacts-pager').textContent).toContain('of 60');
+    expect(screen.getByTestId('published-artifacts-prev')).toHaveProperty('disabled', true);
+
+    fireEvent.click(screen.getByTestId('published-artifacts-next'));
+    await waitFor(() => expect(lastQuery().skip).toBe(25));
+
+    fireEvent.click(screen.getByTestId('published-artifacts-prev'));
+    await waitFor(() => expect(lastQuery().skip).toBe(0));
+  });
+
+  it('hides the pager when everything fits on one page', async () => {
+    mockList.mockResolvedValue(page([bundleRow], { total: 1 }));
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+    expect(screen.queryByTestId('published-artifacts-pager')).toBeNull();
+  });
+
+  it('returns to the first page when a filter changes', async () => {
+    // Staying on page 3 of a narrower result set is how you end up looking at an empty list you
+    // did not ask for.
+    mockList.mockResolvedValue(
+      page([bundleRow], { total: 60, facets: { kind: { bundle: 60 }, visibility: {}, gate: {}, comments: 0 } })
+    );
+    renderTab();
+    await screen.findByTestId('published-artifacts-pager');
+
+    fireEvent.click(screen.getByTestId('published-artifacts-next'));
+    await waitFor(() => expect(lastQuery().skip).toBe(25));
+
+    fireEvent.click(screen.getByTestId('published-artifacts-facet-kind-bundle'));
+    await waitFor(() => expect(lastQuery().skip).toBe(0));
+  });
+
+  it('shows the never-published copy for a genuinely empty library, with no toolbar', async () => {
+    mockList.mockResolvedValue(page([]));
+    renderTab();
+
+    expect(await screen.findByTestId('published-artifacts-empty')).not.toBeNull();
+    // Nothing to search or sort, so the controls would be furniture.
+    expect(screen.queryByTestId('published-artifacts-search')).toBeNull();
+  });
+
+  it('says "no matches" - not "nothing published" - when a filter empties the list', async () => {
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    mockList.mockResolvedValue(page([]));
+    fireEvent.change(screen.getByTestId('published-artifacts-search'), { target: { value: 'nothing matches' } });
+
+    expect(await screen.findByTestId('published-artifacts-no-matches')).not.toBeNull();
+    expect(screen.queryByTestId('published-artifacts-empty')).toBeNull();
+    // The way out stays on screen even with zero results.
+    expect(screen.getByTestId('published-artifacts-clear-filters')).not.toBeNull();
   });
 });

--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
@@ -398,3 +398,77 @@ describe('PublishedArtifactsTabContent - search, facets and paging', () => {
     expect(screen.getByTestId('published-artifacts-clear-filters')).not.toBeNull();
   });
 });
+
+/** Regressions from review on #1961. Both were on ordinary paths and neither had coverage. */
+describe('PublishedArtifactsTabContent - review regressions', () => {
+  const lastQuery = () => mockList.mock.calls[mockList.mock.calls.length - 1][0] as Record<string, unknown>;
+
+  it('closes the sharing panel when the row collapses', async () => {
+    // The </> button that toggles the panel lives INSIDE the disclosure, so leaving the panel
+    // mounted under a collapsed one-line row left it on screen with no control to dismiss it.
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+    expandRow('pub-1');
+
+    fireEvent.click(screen.getByTestId('published-artifact-manage-pub-1'));
+    expect(screen.getByTestId('stub-panel-pub-1')).not.toBeNull();
+
+    expandRow('pub-1'); // collapse
+
+    expect(screen.queryByTestId('stub-panel-pub-1')).toBeNull();
+    // And it does not reappear on re-expand - collapsing closed it, rather than merely hiding it.
+    expandRow('pub-1');
+    expect(screen.queryByTestId('stub-panel-pub-1')).toBeNull();
+  });
+
+  it('steps back a page when the deleted row was the last one on it', async () => {
+    // Otherwise skip points past a now-shorter list: the page renders empty AND the pager
+    // disappears (total has dropped to one page), leaving no way back to page 1.
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockList.mockResolvedValue(page([bundleRow], { total: 26 }));
+    renderTab();
+    await screen.findByTestId('published-artifacts-pager');
+
+    fireEvent.click(screen.getByTestId('published-artifacts-next'));
+    await waitFor(() => expect(lastQuery().skip).toBe(25));
+
+    expandRow('pub-1');
+    fireEvent.click(screen.getByTestId('published-artifact-delete-pub-1'));
+
+    await waitFor(() => expect(lastQuery().skip).toBe(0));
+    confirm.mockRestore();
+  });
+
+  it('does not step back when other rows remain on the page', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockList.mockResolvedValue(page([bundleRow, replyRow], { total: 40 }));
+    renderTab();
+    await screen.findByTestId('published-artifacts-pager');
+
+    fireEvent.click(screen.getByTestId('published-artifacts-next'));
+    await waitFor(() => expect(lastQuery().skip).toBe(25));
+
+    expandRow('pub-1');
+    fireEvent.click(screen.getByTestId('published-artifact-delete-pub-1'));
+
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledWith('Artifact deleted'));
+    expect(lastQuery().skip).toBe(25);
+    confirm.mockRestore();
+  });
+
+  it('never shows the never-published copy while the library still has artifacts', async () => {
+    // An empty PAGE is not an empty library. Telling an owner with 25 live artifacts that they
+    // have published nothing is the worst version of this bug.
+    mockList.mockResolvedValue(page([], { total: 25 }));
+    renderTab();
+
+    expect(await screen.findByTestId('published-artifacts-no-matches')).not.toBeNull();
+    expect(screen.queryByTestId('published-artifacts-empty')).toBeNull();
+  });
+
+  it('asks the server for facet counts only from the tab that renders them', async () => {
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+    expect(lastQuery().facets).toBe(true);
+  });
+});

--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
@@ -127,6 +127,8 @@ export default function PublishedArtifactsTabContent() {
       gate: filters.gate ?? undefined,
       comments: filters.comments ?? undefined,
       sort: filters.sort,
+      // The tab renders the chips, so it is the one caller that wants the counts.
+      facets: true,
       limit: PAGE_SIZE,
       skip,
     }),
@@ -144,6 +146,7 @@ export default function PublishedArtifactsTabContent() {
 
   const artifacts = data?.artifacts ?? [];
   const total = data?.total ?? 0;
+
   const facets: ManagedListFacets = data?.facets ?? { kind: {}, visibility: {}, gate: {}, comments: 0 };
   const filtering = isFiltering(filters, q);
 
@@ -194,9 +197,16 @@ export default function PublishedArtifactsTabContent() {
     onError: (e: unknown) => toast.error(apiError(e, 'Refresh failed')),
   });
   const deleteMut = useMutation({
-    mutationFn: (publicId: string) => deletePublishedArtifact(publicId),
-    onSuccess: () => {
+    // `wasLastOnPage` is passed in by the caller, which knows the rendered row count, rather than
+    // read from a ref: it decides whether this delete empties the current page.
+    mutationFn: (v: { publicId: string; wasLastOnPage: boolean }) => deletePublishedArtifact(v.publicId),
+    onSuccess: (_d, v) => {
       toast.success('Artifact deleted');
+      // Step back a page when that was the last row on this one. Otherwise `skip` points past the
+      // end of a now-shorter list: the page renders empty and - because `total` has dropped to a
+      // single page - the pager disappears too, leaving no control to get back. Same reasoning as
+      // resetting skip on a filter change, applied to the mutation that can shrink the set.
+      if (v.wasLastOnPage) setSkip(cur => Math.max(0, cur - PAGE_SIZE));
       invalidate();
     },
     onError: (e: unknown) => toast.error(apiError(e, 'Failed to delete')),
@@ -216,8 +226,13 @@ export default function PublishedArtifactsTabContent() {
   const toggleExpanded = (publicId: string) =>
     setExpanded(cur => {
       const next = new Set(cur);
-      if (next.has(publicId)) next.delete(publicId);
-      else next.add(publicId);
+      if (next.has(publicId)) {
+        next.delete(publicId);
+        // Collapsing must also close this row's sharing panel: the </> button that toggles it
+        // lives inside the disclosure, so leaving the panel open would strand it on screen under
+        // a one-line row with no visible control to dismiss it.
+        setManageOpen(open => (open === publicId ? null : open));
+      } else next.add(publicId);
       return next;
     });
   // publicId+format of an export in flight, so only the clicked button disables.
@@ -389,9 +404,11 @@ export default function PublishedArtifactsTabContent() {
       )}
 
       {artifacts.length === 0 ? (
-        filtering ? (
+        filtering || total > 0 ? (
           <Typography level="body-sm" sx={{ opacity: 0.7 }} data-testid="published-artifacts-no-matches">
-            Nothing matches those filters. Clear them to see your whole library.
+            {filtering
+              ? 'Nothing matches those filters. Clear them to see your whole library.'
+              : 'This page is empty - returning you to the first page.'}
           </Typography>
         ) : (
           <Typography level="body-sm" sx={{ opacity: 0.7 }} data-testid="published-artifacts-empty">
@@ -673,7 +690,7 @@ export default function PublishedArtifactsTabContent() {
                         disabled={busy}
                         onClick={() => {
                           if (window.confirm(`Delete "${a.title}"? The share link will stop working.`)) {
-                            deleteMut.mutate(a.publicId);
+                            deleteMut.mutate({ publicId: a.publicId, wasLastOnPage: artifacts.length <= 1 });
                           }
                         }}
                         data-testid={`published-artifact-delete-${a.publicId}`}
@@ -686,7 +703,7 @@ export default function PublishedArtifactsTabContent() {
 
                 {/* Lazily mounted so the manage-state fetch (gate + embed list) only
                     fires for the row the owner actually opens. */}
-                {manageOpen === a.publicId && (
+                {isOpen && manageOpen === a.publicId && (
                   <Box sx={{ mt: 0.5, pt: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
                     <ManageSharingPanel
                       publicId={a.publicId}

--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Box,
@@ -12,6 +12,8 @@ import {
   Option,
   LinearProgress,
   Link,
+  Input,
+  Button,
 } from '@mui/joy';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import LinkIcon from '@mui/icons-material/Link';
@@ -23,6 +25,12 @@ import NotesIcon from '@mui/icons-material/Notes';
 import DownloadIcon from '@mui/icons-material/Download';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import PublishedWithChangesIcon from '@mui/icons-material/PublishedWithChanges';
+import SearchIcon from '@mui/icons-material/Search';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import LockIcon from '@mui/icons-material/Lock';
+import DomainIcon from '@mui/icons-material/Domain';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 import type { PublishVisibility } from '@bike4mind/common';
@@ -37,13 +45,52 @@ import {
   canRefreshFromSource,
   refreshPublishedFromSource,
   type ManagedArtifact,
+  type ManagedListFacets,
 } from '@client/app/utils/publishApi';
+import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
 import { EXPORT_CONTENT_TYPE, exportFilename, supportsExport } from '@client/app/utils/publishExport';
 import { downloadData } from '@client/app/utils/download';
 import { printHtmlForPdf } from '@client/app/utils/printToPdf';
 import { ManageSharingPanel } from '@client/app/components/common/ManageSharingPanel';
 
-const QUERY_KEY = ['published-artifacts', 'mine'] as const;
+/** Page size. Small enough that the tab opens instantly on a large library, large enough that
+ *  most people never page at all. */
+const PAGE_SIZE = 25;
+
+/** Sort options, mirroring the keys the list endpoint accepts. */
+const SORTS: Array<{ value: string; label: string }> = [
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'updated', label: 'Recently updated' },
+  { value: 'views', label: 'Most viewed' },
+  { value: 'versions', label: 'Most versions' },
+  { value: 'title', label: 'Title A-Z' },
+];
+
+/** The filter state the toolbar owns. `null` means "not filtering on this axis". */
+interface Filters {
+  kind: string | null;
+  visibility: string | null;
+  gate: string | null;
+  comments: 'on' | 'off' | null;
+  sort: string;
+}
+
+const NO_FILTERS: Filters = { kind: null, visibility: null, gate: null, comments: null, sort: 'newest' };
+
+/** True when anything is narrowing the list - drives the "no matches" copy and Clear button. */
+function isFiltering(f: Filters, q: string): boolean {
+  return Boolean(q.trim() || f.kind || f.visibility || f.gate || f.comments);
+}
+
+/** Compact date for the row meta line: same-year dates drop the year. */
+function shortDate(iso?: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const sameYear = d.getFullYear() === new Date().getFullYear();
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', ...(sameYear ? {} : { year: 'numeric' }) });
+}
 
 function apiError(err: unknown, fallback: string): string {
   if (isAxiosError(err)) return (err.response?.data as { error?: string })?.error || err.message || fallback;
@@ -66,13 +113,51 @@ function sharePath(a: ManagedArtifact): string {
  */
 export default function PublishedArtifactsTabContent() {
   const qc = useQueryClient();
-  const {
-    data: artifacts = [],
-    isLoading,
-    isError,
-  } = useQuery({ queryKey: QUERY_KEY, queryFn: listMyPublishedArtifacts });
+  const [filters, setFilters] = useState<Filters>(NO_FILTERS);
+  const [skip, setSkip] = useState(0);
+  // The hook owns the search text: `q` is what the input shows (never laggy) and `debouncedQ` is
+  // what the request uses, so typing does not fire one call per keystroke.
+  const { value: q, debouncedValue: debouncedQ, setValue: setQ } = useDebounceValue('', 300);
 
-  const invalidate = () => void qc.invalidateQueries({ queryKey: QUERY_KEY });
+  const query = useMemo(
+    () => ({
+      q: debouncedQ,
+      kind: filters.kind ?? undefined,
+      visibility: filters.visibility ?? undefined,
+      gate: filters.gate ?? undefined,
+      comments: filters.comments ?? undefined,
+      sort: filters.sort,
+      limit: PAGE_SIZE,
+      skip,
+    }),
+    [debouncedQ, filters.kind, filters.visibility, filters.gate, filters.comments, filters.sort, skip]
+  );
+
+  const { data, isLoading, isError } = useQuery({
+    // Prefix stays ['published-artifacts','mine'] so every existing invalidation - including the
+    // profile screen's own has-any query - still matches.
+    queryKey: ['published-artifacts', 'mine', query] as const,
+    queryFn: () => listMyPublishedArtifacts(query),
+    // Keep the previous page on screen while the next one loads instead of flashing a spinner.
+    placeholderData: prev => prev,
+  });
+
+  const artifacts = data?.artifacts ?? [];
+  const total = data?.total ?? 0;
+  const facets: ManagedListFacets = data?.facets ?? { kind: {}, visibility: {}, gate: {}, comments: 0 };
+  const filtering = isFiltering(filters, q);
+
+  /** Change a filter. Always resets to the first page - staying on page 4 of a narrower result
+   *  set is how you end up staring at an empty list you did not ask for. */
+  const setFilter = <K extends keyof Filters>(key: K, value: Filters[K]) => {
+    setFilters(f => ({ ...f, [key]: value }));
+    setSkip(0);
+  };
+  /** Click a chip that is already on to turn it off. */
+  const toggleFilter = <K extends keyof Filters>(key: K, value: Filters[K]) =>
+    setFilter(key, (filters[key] === value ? null : value) as Filters[K]);
+
+  const invalidate = () => void qc.invalidateQueries({ queryKey: ['published-artifacts', 'mine'] });
 
   const visibilityMut = useMutation({
     mutationFn: (v: { publicId: string; visibility: PublishVisibility }) =>
@@ -125,6 +210,16 @@ export default function PublishedArtifactsTabContent() {
     deleteMut.isPending;
   // One row's sharing panel open at a time.
   const [manageOpen, setManageOpen] = useState<string | null>(null);
+  /** Rows whose controls are expanded. A set rather than a single id: the collapsed row is the
+   *  default now, and comparing two artifacts' settings is a normal thing to want. */
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggleExpanded = (publicId: string) =>
+    setExpanded(cur => {
+      const next = new Set(cur);
+      if (next.has(publicId)) next.delete(publicId);
+      else next.add(publicId);
+      return next;
+    });
   // publicId+format of an export in flight, so only the clicked button disables.
   const [exporting, setExporting] = useState<string | null>(null);
 
@@ -190,13 +285,122 @@ export default function PublishedArtifactsTabContent() {
         content, refresh a link from its source artifact, restore a previous version, or delete.
       </Typography>
 
+      {/* Toolbar. Rendered whenever the library is non-empty OR a filter is active, so the way
+          out of a no-matches state is always on screen. */}
+      {(total > 0 || filtering) && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 1.5 }}>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+            <Input
+              size="sm"
+              value={q}
+              onChange={e => {
+                setQ(e.target.value);
+                setSkip(0); // a narrower search must not leave you stranded on a later page
+              }}
+              placeholder="Search titles and descriptions"
+              startDecorator={<SearchIcon sx={{ fontSize: 16 }} />}
+              slotProps={{ input: { 'data-testid': 'published-artifacts-search' } }}
+              sx={{ flex: '1 1 16rem', minWidth: '12rem' }}
+            />
+            <Select
+              size="sm"
+              value={filters.sort}
+              onChange={(_e, val) => val && setFilter('sort', val)}
+              data-testid="published-artifacts-sort"
+              sx={{ minWidth: 160 }}
+            >
+              {SORTS.map(o => (
+                <Option key={o.value} value={o.value}>
+                  {o.label}
+                </Option>
+              ))}
+            </Select>
+            {filtering && (
+              <Button
+                size="sm"
+                variant="plain"
+                color="neutral"
+                onClick={() => {
+                  setFilters(NO_FILTERS);
+                  setQ('');
+                  setSkip(0);
+                }}
+                data-testid="published-artifacts-clear-filters"
+              >
+                Clear
+              </Button>
+            )}
+          </Box>
+
+          {/* Facet chips. Counts come from the whole library, not the filtered page, so a chip
+              still tells you how many there are after you have clicked it. */}
+          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
+            {Object.entries(facets.kind).map(([kind, n]) => (
+              <Chip
+                key={kind}
+                size="sm"
+                variant={filters.kind === kind ? 'solid' : 'outlined'}
+                color={filters.kind === kind ? 'primary' : 'neutral'}
+                onClick={() => toggleFilter('kind', kind)}
+                slotProps={{ action: { 'data-testid': `published-artifacts-facet-kind-${kind}` } }}
+              >
+                {kind} {n}
+              </Chip>
+            ))}
+            {Object.entries(facets.visibility).map(([vis, n]) => (
+              <Chip
+                key={vis}
+                size="sm"
+                variant={filters.visibility === vis ? 'solid' : 'outlined'}
+                color={filters.visibility === vis ? 'primary' : 'neutral'}
+                onClick={() => toggleFilter('visibility', vis)}
+                slotProps={{ action: { 'data-testid': `published-artifacts-facet-visibility-${vis}` } }}
+              >
+                {vis} {n}
+              </Chip>
+            ))}
+            {(['passphrase', 'domain'] as const).map(gate =>
+              facets.gate[gate] ? (
+                <Chip
+                  key={gate}
+                  size="sm"
+                  variant={filters.gate === gate ? 'solid' : 'outlined'}
+                  color={filters.gate === gate ? 'primary' : 'neutral'}
+                  onClick={() => toggleFilter('gate', gate)}
+                  slotProps={{ action: { 'data-testid': `published-artifacts-facet-gate-${gate}` } }}
+                >
+                  {gate} {facets.gate[gate]}
+                </Chip>
+              ) : null
+            )}
+            {facets.comments > 0 && (
+              <Chip
+                size="sm"
+                variant={filters.comments === 'on' ? 'solid' : 'outlined'}
+                color={filters.comments === 'on' ? 'primary' : 'neutral'}
+                onClick={() => toggleFilter('comments', 'on')}
+                slotProps={{ action: { 'data-testid': 'published-artifacts-facet-comments' } }}
+              >
+                comments {facets.comments}
+              </Chip>
+            )}
+          </Box>
+        </Box>
+      )}
+
       {artifacts.length === 0 ? (
-        <Typography level="body-sm" sx={{ opacity: 0.7 }} data-testid="published-artifacts-empty">
-          You haven&apos;t published anything yet. Share an artifact or run the publish-to-bike4mind skill to get
-          started.
-        </Typography>
+        filtering ? (
+          <Typography level="body-sm" sx={{ opacity: 0.7 }} data-testid="published-artifacts-no-matches">
+            Nothing matches those filters. Clear them to see your whole library.
+          </Typography>
+        ) : (
+          <Typography level="body-sm" sx={{ opacity: 0.7 }} data-testid="published-artifacts-empty">
+            You haven&apos;t published anything yet. Share an artifact or run the publish-to-bike4mind skill to get
+            started.
+          </Typography>
+        )
       ) : (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
           {artifacts.map(a => {
             const path = sharePath(a);
             const url = `${window.location.origin}${path}`;
@@ -204,224 +408,281 @@ export default function PublishedArtifactsTabContent() {
             const canRefresh = canRefreshFromSource(a);
             const hasPrevious = Boolean(a.previousVersionMeta?.sha256Index);
             const commentsOn = a.commentPolicy === 'open' || a.commentPolicy === 'restricted';
+            const isOpen = expanded.has(a.publicId);
 
             return (
               <Sheet
                 key={a.publicId}
                 variant="outlined"
                 data-testid={`published-artifact-${a.publicId}`}
-                sx={{ p: 1.5, borderRadius: 'md', display: 'flex', flexDirection: 'column', gap: 1 }}
+                sx={{ p: 1, borderRadius: 'md', display: 'flex', flexDirection: 'column', gap: 0.75 }}
               >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                {/* Collapsed row: everything you scan by on ONE line. The controls below used to
+                    be always-on, which made each row ~110px tall and turned a library into a
+                    scroll. Copy-link stays out here because it is the verb people actually reach
+                    for; the rest is one click away. */}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
                   <Tooltip title="Opens in a new tab">
                     <Link
                       href={url}
                       target="_blank"
                       rel="noopener noreferrer"
                       level="title-sm"
-                      endDecorator={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                      sx={{ flex: 1, minWidth: 180 }}
+                      endDecorator={<OpenInNewIcon sx={{ fontSize: 13 }} />}
+                      sx={{
+                        minWidth: 0,
+                        flex: '0 1 auto',
+                        // Long titles truncate rather than wrapping the row onto a second line,
+                        // which is what keeps the row height uniform down the list.
+                        '& > span:first-of-type': {
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        },
+                      }}
                     >
-                      {a.title}
+                      <span>{a.title}</span>
                     </Link>
                   </Tooltip>
-                  <Chip size="sm" variant="soft" startDecorator={<VisibilityIcon sx={{ fontSize: 13 }} />}>
-                    {a.viewCount ?? 0}
-                  </Chip>
-                  <Chip size="sm" variant="soft" color="neutral">
-                    {a.source.kind}
-                  </Chip>
-                  {isBundle && (a.versionsCount ?? 0) >= 2 && (
-                    <Chip
-                      size="sm"
-                      variant="soft"
-                      color="primary"
-                      data-testid={`published-artifact-versions-${a.publicId}`}
-                    >
-                      {a.versionsCount} versions
+
+                  <Box
+                    sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'nowrap', ml: 'auto' }}
+                    data-testid={`published-artifact-meta-${a.publicId}`}
+                  >
+                    {a.gateKind === 'passphrase' && (
+                      <Tooltip title="Passphrase required">
+                        <LockIcon sx={{ fontSize: 14, opacity: 0.7 }} />
+                      </Tooltip>
+                    )}
+                    {a.gateKind === 'domain' && (
+                      <Tooltip title="Restricted to an email domain">
+                        <DomainIcon sx={{ fontSize: 14, opacity: 0.7 }} />
+                      </Tooltip>
+                    )}
+                    {commentsOn && (
+                      <Tooltip title="Comments are on">
+                        <ChatBubbleOutlineIcon sx={{ fontSize: 14, opacity: 0.7 }} />
+                      </Tooltip>
+                    )}
+                    <Typography level="body-xs" sx={{ opacity: 0.6, whiteSpace: 'nowrap' }}>
+                      {shortDate(a.publishedAt)}
+                    </Typography>
+                    {isBundle && (a.versionsCount ?? 0) >= 2 && (
+                      <Chip
+                        size="sm"
+                        variant="soft"
+                        color="primary"
+                        data-testid={`published-artifact-versions-${a.publicId}`}
+                      >
+                        {a.versionsCount} versions
+                      </Chip>
+                    )}
+                    <Chip size="sm" variant="soft" color="neutral">
+                      {a.visibility}
                     </Chip>
-                  )}
+                    <Chip size="sm" variant="soft" startDecorator={<VisibilityIcon sx={{ fontSize: 13 }} />}>
+                      {a.viewCount ?? 0}
+                    </Chip>
+
+                    <Tooltip title="Copy link">
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="neutral"
+                        onClick={async () => {
+                          try {
+                            await navigator.clipboard.writeText(url);
+                            toast.success('Link copied');
+                          } catch {
+                            toast.error('Could not copy link');
+                          }
+                        }}
+                        data-testid={`published-artifact-copy-${a.publicId}`}
+                      >
+                        <LinkIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title={isOpen ? 'Hide settings' : 'Settings, export & versions'}>
+                      <IconButton
+                        size="sm"
+                        variant={isOpen ? 'soft' : 'plain'}
+                        color="neutral"
+                        onClick={() => toggleExpanded(a.publicId)}
+                        aria-expanded={isOpen}
+                        aria-label={isOpen ? 'Hide settings' : 'Show settings'}
+                        data-testid={`published-artifact-expand-${a.publicId}`}
+                      >
+                        {isOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
                 </Box>
 
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-                    <Typography level="body-xs" sx={{ opacity: 0.7 }}>
-                      Visibility
-                    </Typography>
-                    <Select
-                      size="sm"
-                      value={a.visibility}
-                      disabled={busy}
-                      onChange={(_e, val) =>
-                        val && val !== a.visibility && visibilityMut.mutate({ publicId: a.publicId, visibility: val })
-                      }
-                      data-testid={`published-artifact-visibility-${a.publicId}`}
-                      sx={{ minWidth: 110 }}
-                    >
-                      <Option value="public">Public</Option>
-                      <Option value="private">Private</Option>
-                    </Select>
-                  </Box>
-
-                  {isBundle && (
+                {isOpen && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+                    <Chip size="sm" variant="soft" color="neutral">
+                      {a.source.kind}
+                    </Chip>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
                       <Typography level="body-xs" sx={{ opacity: 0.7 }}>
-                        Comments
+                        Visibility
                       </Typography>
-                      <Switch
+                      <Select
                         size="sm"
-                        checked={commentsOn}
+                        value={a.visibility}
                         disabled={busy}
-                        onChange={e => commentsMut.mutate({ publicId: a.publicId, on: e.target.checked })}
-                        data-testid={`published-artifact-comments-${a.publicId}`}
-                      />
-                    </Box>
-                  )}
-
-                  <Box sx={{ flex: 1 }} />
-
-                  <Tooltip title="Share, gate & embed">
-                    <IconButton
-                      size="sm"
-                      variant={manageOpen === a.publicId ? 'soft' : 'plain'}
-                      color={manageOpen === a.publicId ? 'primary' : 'neutral'}
-                      onClick={() => setManageOpen(cur => (cur === a.publicId ? null : a.publicId))}
-                      data-testid={`published-artifact-manage-${a.publicId}`}
-                      aria-expanded={manageOpen === a.publicId}
-                    >
-                      <CodeIcon />
-                    </IconButton>
-                  </Tooltip>
-
-                  <Tooltip title="Copy link">
-                    <IconButton
-                      size="sm"
-                      variant="plain"
-                      color="neutral"
-                      onClick={async () => {
-                        try {
-                          await navigator.clipboard.writeText(url);
-                          toast.success('Link copied');
-                        } catch {
-                          toast.error('Could not copy link');
+                        onChange={(_e, val) =>
+                          val && val !== a.visibility && visibilityMut.mutate({ publicId: a.publicId, visibility: val })
                         }
-                      }}
-                      data-testid={`published-artifact-copy-${a.publicId}`}
-                    >
-                      <LinkIcon />
-                    </IconButton>
-                  </Tooltip>
+                        data-testid={`published-artifact-visibility-${a.publicId}`}
+                        sx={{ minWidth: 110 }}
+                      >
+                        <Option value="public">Public</Option>
+                        <Option value="private">Private</Option>
+                      </Select>
+                    </Box>
 
-                  {/* Markdown is offered only for kinds it converts to faithfully (replies,
+                    {isBundle && (
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                        <Typography level="body-xs" sx={{ opacity: 0.7 }}>
+                          Comments
+                        </Typography>
+                        <Switch
+                          size="sm"
+                          checked={commentsOn}
+                          disabled={busy}
+                          onChange={e => commentsMut.mutate({ publicId: a.publicId, on: e.target.checked })}
+                          data-testid={`published-artifact-comments-${a.publicId}`}
+                        />
+                      </Box>
+                    )}
+
+                    <Box sx={{ flex: 1 }} />
+
+                    <Tooltip title="Share, gate & embed">
+                      <IconButton
+                        size="sm"
+                        variant={manageOpen === a.publicId ? 'soft' : 'plain'}
+                        color={manageOpen === a.publicId ? 'primary' : 'neutral'}
+                        onClick={() => setManageOpen(cur => (cur === a.publicId ? null : a.publicId))}
+                        data-testid={`published-artifact-manage-${a.publicId}`}
+                        aria-expanded={manageOpen === a.publicId}
+                      >
+                        <CodeIcon />
+                      </IconButton>
+                    </Tooltip>
+
+                    {/* Markdown is offered only for kinds it converts to faithfully (replies,
                       whose stored body IS markdown) - see exportFormatsFor. Hidden, not
                       disabled: a greyed button implies the export exists and is unavailable,
                       when in fact there is no honest Markdown form of an HTML bundle. */}
-                  {supportsExport(a.source.kind, 'md') && (
-                    <Tooltip title="Copy as Markdown">
-                      <IconButton
-                        size="sm"
-                        variant="plain"
-                        color="neutral"
-                        loading={exporting === `${a.publicId}:md`}
-                        onClick={() => void runExport(a, 'md', 'copy')}
-                        data-testid={`published-artifact-copy-md-${a.publicId}`}
-                      >
-                        <NotesIcon />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-
-                  <Tooltip title="Save as HTML">
-                    <IconButton
-                      size="sm"
-                      variant="plain"
-                      color="neutral"
-                      loading={exporting === `${a.publicId}:html`}
-                      onClick={() => void runExport(a, 'html', 'download')}
-                      data-testid={`published-artifact-save-html-${a.publicId}`}
-                    >
-                      <DownloadIcon />
-                    </IconButton>
-                  </Tooltip>
-
-                  {/* PDF is produced client-side by printing the HTML export from an
-                      isolated frame (printToPdf), not a server export format. Offered
-                      for every kind - the browser renders it visually. */}
-                  <Tooltip title="Save as PDF (opens print dialog)">
-                    <IconButton
-                      size="sm"
-                      variant="plain"
-                      color="neutral"
-                      loading={exporting === `${a.publicId}:pdf`}
-                      onClick={() => void runPrint(a)}
-                      data-testid={`published-artifact-save-pdf-${a.publicId}`}
-                    >
-                      <PictureAsPdfIcon />
-                    </IconButton>
-                  </Tooltip>
-
-                  {/* Refresh re-publishes from the source artifact's CURRENT content onto
-                      the same link. Hidden where there is no source to read back (a reply
-                      snapshot, or a bundle published from outside the app). */}
-                  {canRefresh && (
-                    <Tooltip title="Refresh from source (publishes a new version)">
-                      <IconButton
-                        size="sm"
-                        variant="plain"
-                        color="neutral"
-                        disabled={busy}
-                        loading={refreshMut.isPending && refreshMut.variables?.publicId === a.publicId}
-                        onClick={() => {
-                          // Outward-facing: it replaces what viewers of a live link see.
-                          if (
-                            window.confirm(
-                              `Refresh "${a.title}" from its source artifact? This publishes a new version to the same link.`
-                            )
-                          ) {
-                            refreshMut.mutate(a);
-                          }
-                        }}
-                        data-testid={`published-artifact-refresh-${a.publicId}`}
-                      >
-                        <PublishedWithChangesIcon />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-
-                  {isBundle && (
-                    <Tooltip title={hasPrevious ? 'Restore the previous version' : 'No previous version to restore'}>
-                      <span>
+                    {supportsExport(a.source.kind, 'md') && (
+                      <Tooltip title="Copy as Markdown">
                         <IconButton
                           size="sm"
                           variant="plain"
                           color="neutral"
-                          disabled={busy || !hasPrevious}
-                          onClick={() => restoreMut.mutate(a.publicId)}
-                          data-testid={`published-artifact-restore-${a.publicId}`}
+                          loading={exporting === `${a.publicId}:md`}
+                          onClick={() => void runExport(a, 'md', 'copy')}
+                          data-testid={`published-artifact-copy-md-${a.publicId}`}
                         >
-                          <RestoreIcon />
+                          <NotesIcon />
                         </IconButton>
-                      </span>
-                    </Tooltip>
-                  )}
+                      </Tooltip>
+                    )}
 
-                  <Tooltip title="Delete">
-                    <IconButton
-                      size="sm"
-                      variant="plain"
-                      color="danger"
-                      disabled={busy}
-                      onClick={() => {
-                        if (window.confirm(`Delete "${a.title}"? The share link will stop working.`)) {
-                          deleteMut.mutate(a.publicId);
-                        }
-                      }}
-                      data-testid={`published-artifact-delete-${a.publicId}`}
-                    >
-                      <DeleteOutlineIcon />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
+                    <Tooltip title="Save as HTML">
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="neutral"
+                        loading={exporting === `${a.publicId}:html`}
+                        onClick={() => void runExport(a, 'html', 'download')}
+                        data-testid={`published-artifact-save-html-${a.publicId}`}
+                      >
+                        <DownloadIcon />
+                      </IconButton>
+                    </Tooltip>
+
+                    {/* PDF is produced client-side by printing the HTML export from an
+                      isolated frame (printToPdf), not a server export format. Offered
+                      for every kind - the browser renders it visually. */}
+                    <Tooltip title="Save as PDF (opens print dialog)">
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="neutral"
+                        loading={exporting === `${a.publicId}:pdf`}
+                        onClick={() => void runPrint(a)}
+                        data-testid={`published-artifact-save-pdf-${a.publicId}`}
+                      >
+                        <PictureAsPdfIcon />
+                      </IconButton>
+                    </Tooltip>
+
+                    {/* Refresh re-publishes from the source artifact's CURRENT content onto
+                      the same link. Hidden where there is no source to read back (a reply
+                      snapshot, or a bundle published from outside the app). */}
+                    {canRefresh && (
+                      <Tooltip title="Refresh from source (publishes a new version)">
+                        <IconButton
+                          size="sm"
+                          variant="plain"
+                          color="neutral"
+                          disabled={busy}
+                          loading={refreshMut.isPending && refreshMut.variables?.publicId === a.publicId}
+                          onClick={() => {
+                            // Outward-facing: it replaces what viewers of a live link see.
+                            if (
+                              window.confirm(
+                                `Refresh "${a.title}" from its source artifact? This publishes a new version to the same link.`
+                              )
+                            ) {
+                              refreshMut.mutate(a);
+                            }
+                          }}
+                          data-testid={`published-artifact-refresh-${a.publicId}`}
+                        >
+                          <PublishedWithChangesIcon />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+
+                    {isBundle && (
+                      <Tooltip title={hasPrevious ? 'Restore the previous version' : 'No previous version to restore'}>
+                        <span>
+                          <IconButton
+                            size="sm"
+                            variant="plain"
+                            color="neutral"
+                            disabled={busy || !hasPrevious}
+                            onClick={() => restoreMut.mutate(a.publicId)}
+                            data-testid={`published-artifact-restore-${a.publicId}`}
+                          >
+                            <RestoreIcon />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    )}
+
+                    <Tooltip title="Delete">
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="danger"
+                        disabled={busy}
+                        onClick={() => {
+                          if (window.confirm(`Delete "${a.title}"? The share link will stop working.`)) {
+                            deleteMut.mutate(a.publicId);
+                          }
+                        }}
+                        data-testid={`published-artifact-delete-${a.publicId}`}
+                      >
+                        <DeleteOutlineIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                )}
 
                 {/* Lazily mounted so the manage-state fetch (gate + embed list) only
                     fires for the row the owner actually opens. */}
@@ -437,8 +698,10 @@ export default function PublishedArtifactsTabContent() {
                 )}
 
                 {/* Single-version artifacts have no version switcher yet - explain why
-                    and how to create history instead of leaving a silent absence. */}
-                {isBundle && (a.versionsCount ?? 0) < 2 && (
+                    and how to create history instead of leaving a silent absence. Shown only in
+                    the expanded row: it was identical on most rows and, repeated down a long
+                    list, was the single largest consumer of vertical space on the page. */}
+                {isOpen && isBundle && (a.versionsCount ?? 0) < 2 && (
                   <Typography
                     level="body-xs"
                     sx={{ opacity: 0.7 }}
@@ -452,6 +715,43 @@ export default function PublishedArtifactsTabContent() {
               </Sheet>
             );
           })}
+        </Box>
+      )}
+
+      {/* Pager. Rendered whenever there is more than one page - and `total` is what makes it
+          honest: before this the endpoint capped at 200 rows with no count, so a larger library
+          silently lost its oldest artifacts with nothing on screen saying so. */}
+      {total > PAGE_SIZE && (
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, mt: 1.5 }}
+          data-testid="published-artifacts-pager"
+        >
+          <Typography level="body-xs" sx={{ opacity: 0.7 }}>
+            {skip + 1}-{Math.min(skip + PAGE_SIZE, total)} of {total}
+            {filtering ? ' matching' : ''}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            <Button
+              size="sm"
+              variant="outlined"
+              color="neutral"
+              disabled={skip === 0}
+              onClick={() => setSkip(cur => Math.max(0, cur - PAGE_SIZE))}
+              data-testid="published-artifacts-prev"
+            >
+              Previous
+            </Button>
+            <Button
+              size="sm"
+              variant="outlined"
+              color="neutral"
+              disabled={skip + PAGE_SIZE >= total}
+              onClick={() => setSkip(cur => cur + PAGE_SIZE)}
+              data-testid="published-artifacts-next"
+            >
+              Next
+            </Button>
+          </Box>
         </Box>
       )}
     </Box>

--- a/apps/client/app/routes/profile/index.tsx
+++ b/apps/client/app/routes/profile/index.tsx
@@ -95,11 +95,14 @@ const ProfilePage = () => {
     isPending: publishedPending,
     isError: publishedError,
   } = useQuery({
-    queryKey: ['published-artifacts', 'mine'],
-    queryFn: listMyPublishedArtifacts,
+    // This screen only needs "does the caller have any", so it asks for a single row and reads
+    // the total rather than pulling the whole library. Distinct key from the tab's paged query,
+    // but under the same prefix so the tab's invalidation still refreshes it.
+    queryKey: ['published-artifacts', 'mine', 'any'],
+    queryFn: () => listMyPublishedArtifacts({ limit: 1 }),
     enabled: !!currentUser,
   });
-  const hasPublishedArtifacts = (publishedArtifacts?.length ?? 0) > 0;
+  const hasPublishedArtifacts = (publishedArtifacts?.total ?? 0) > 0;
 
   // Redirect legacy tab values to their new homes (see LEGACY_SETTINGS_REDIRECTS).
   useEffect(() => {

--- a/apps/client/app/routes/profile/profileTabs.test.tsx
+++ b/apps/client/app/routes/profile/profileTabs.test.tsx
@@ -10,6 +10,14 @@ const mockNavigate = vi.fn();
 let searchValue: Record<string, unknown> = {};
 let mockUser: Record<string, unknown> | null = { id: 'u1', name: 'Test User', isAdmin: false };
 let mockPublishedArtifacts: unknown[] = [];
+/** listMyPublishedArtifacts returns a page envelope; the profile screen reads `total`. */
+const asPage = (rows: unknown[]) => ({
+  artifacts: rows,
+  total: rows.length,
+  limit: 1,
+  skip: 0,
+  facets: { kind: {}, visibility: {}, gate: {}, comments: 0 },
+});
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
@@ -41,7 +49,7 @@ vi.mock('@client/app/components/help', () => ({
 }));
 
 vi.mock('@client/app/utils/publishApi', () => ({
-  listMyPublishedArtifacts: () => Promise.resolve(mockPublishedArtifacts),
+  listMyPublishedArtifacts: () => Promise.resolve(asPage(mockPublishedArtifacts)),
 }));
 
 // next/dynamic + static tab content are irrelevant to the strip itself; stub them

--- a/apps/client/app/utils/publishApi.ts
+++ b/apps/client/app/utils/publishApi.ts
@@ -29,6 +29,9 @@ export interface ManagedArtifact {
   size?: { totalBytes: number; fileCount: number };
   viewCount?: number;
   publishedAt?: string;
+  updatedAt?: string;
+  /** accessGate.kind, projected without the passphrase hash. Absent = ungated. */
+  gateKind?: 'passphrase' | 'domain';
   previousVersionMeta?: { sha256Index?: string };
   /** Number of entries in the published version history (drives the version switcher
    *  and the single-version hint). 0/1 means no switcher yet; 2+ shows the switcher. */
@@ -43,10 +46,64 @@ export function toArtifactSharePath(tier: PublishScopeTier, scopeId: string, slu
   return `${SCOPE_URL_PREFIX[tier]}/${scopeId}/${slug}`;
 }
 
-/** List the caller's OWN published artifacts (the manageable set). */
-export async function listMyPublishedArtifacts(): Promise<ManagedArtifact[]> {
-  const { data } = await api.get<{ artifacts: ManagedArtifact[] }>('/api/publish/artifacts?mine=true');
-  return data.artifacts ?? [];
+/** Search / filter / sort / page the management list. Every field optional; omitting all of
+ *  them reproduces the previous behaviour (newest first, one large page). */
+export interface ManagedListQuery {
+  q?: string;
+  kind?: string;
+  visibility?: string;
+  gate?: string;
+  comments?: 'on' | 'off';
+  sort?: string;
+  limit?: number;
+  skip?: number;
+}
+
+/** Counts over the caller's whole library, independent of the current filter selection, so a
+ *  facet chip keeps showing its count after you click it. */
+export interface ManagedListFacets {
+  kind: Record<string, number>;
+  visibility: Record<string, number>;
+  gate: Record<string, number>;
+  comments: number;
+}
+
+export interface ManagedListPage {
+  artifacts: ManagedArtifact[];
+  /** Rows matching the current filter, which is what the pager needs - NOT the library size. */
+  total: number;
+  limit: number;
+  skip: number;
+  facets: ManagedListFacets;
+}
+
+const EMPTY_FACETS: ManagedListFacets = { kind: {}, visibility: {}, gate: {}, comments: 0 };
+
+/** List a page of the caller's OWN published artifacts (the manageable set). */
+export async function listMyPublishedArtifacts(query: ManagedListQuery = {}): Promise<ManagedListPage> {
+  const params = new URLSearchParams({ mine: 'true' });
+  // Only send what is actually set: an empty `q` or a default sort would otherwise become part
+  // of the react-query cache key and split the cache for no reason.
+  if (query.q?.trim()) params.set('q', query.q.trim());
+  if (query.kind) params.set('kind', query.kind);
+  if (query.visibility) params.set('visibility', query.visibility);
+  if (query.gate) params.set('gate', query.gate);
+  if (query.comments) params.set('comments', query.comments);
+  if (query.sort) params.set('sort', query.sort);
+  if (query.limit != null) params.set('limit', String(query.limit));
+  if (query.skip) params.set('skip', String(query.skip));
+
+  const { data } = await api.get<Partial<ManagedListPage>>(`/api/publish/artifacts?${params.toString()}`);
+  const artifacts = data.artifacts ?? [];
+  return {
+    artifacts,
+    // Fall back to the page length rather than 0 so a response from an older server (no total)
+    // shows the rows it did return instead of an empty pager claiming nothing matched.
+    total: data.total ?? artifacts.length,
+    limit: data.limit ?? artifacts.length,
+    skip: data.skip ?? 0,
+    facets: data.facets ?? EMPTY_FACETS,
+  };
 }
 
 /**

--- a/apps/client/app/utils/publishApi.ts
+++ b/apps/client/app/utils/publishApi.ts
@@ -50,6 +50,9 @@ export function toArtifactSharePath(tier: PublishScopeTier, scopeId: string, slu
  *  them reproduces the previous behaviour (newest first, one large page). */
 export interface ManagedListQuery {
   q?: string;
+  /** Ask the server to compute facet counts. Off by default - they are group-bys over the whole
+   *  library, and a caller that only needs a page (or an existence check) should not pay for them. */
+  facets?: boolean;
   kind?: string;
   visibility?: string;
   gate?: string;
@@ -90,6 +93,7 @@ export async function listMyPublishedArtifacts(query: ManagedListQuery = {}): Pr
   if (query.gate) params.set('gate', query.gate);
   if (query.comments) params.set('comments', query.comments);
   if (query.sort) params.set('sort', query.sort);
+  if (query.facets) params.set('facets', 'true');
   if (query.limit != null) params.set('limit', String(query.limit));
   if (query.skip) params.set('skip', String(query.skip));
 

--- a/apps/client/pages/api/publish/artifacts/__tests__/index.test.ts
+++ b/apps/client/pages/api/publish/artifacts/__tests__/index.test.ts
@@ -182,17 +182,16 @@ describe('GET /api/publish/artifacts — ?mine and default visibility', () => {
 describe('GET /api/publish/artifacts — projection', () => {
   it('computes versionsCount and never ships the versions[] array', async () => {
     await run({ mine: 'true' });
-    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
-    const added = (pipeline.find(st => '$addFields' in st) as { $addFields: Record<string, unknown> }).$addFields;
-    // The $size expression moved up to $addFields, which must precede $sort; $project then
-    // just passes the computed field through.
+    // $addFields now sits inside the rows branch (after $limit) unless a sort needs it earlier;
+    // $project just passes the computed field through, and versions[] never leaves the server.
+    const added = (rowsBranch().find(st => '$addFields' in st) as { $addFields: Record<string, unknown> }).$addFields;
     expect(added.versionsCount).toEqual({ $size: { $ifNull: ['$versions', []] } });
     expect(projectStage().versionsCount).toBe(1);
     expect(projectStage().versions).toBeUndefined();
   });
 
   it('returns the page under { artifacts } alongside total, paging and facet counts', async () => {
-    const res = await run({ mine: 'true' });
+    const res = await run({ mine: 'true', facets: 'true' });
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({
       artifacts: [{ publicId: 'p1', versionsCount: 3 }],
@@ -216,9 +215,10 @@ describe('GET /api/publish/artifacts — projection', () => {
     expect(JSON.stringify(project)).not.toContain('passphraseHash');
   });
 
-  it('derives versionsCount and titleSort BEFORE $facet, so $sort can order by them', async () => {
+  it('derives versionsCount and titleSort BEFORE $facet when a sort orders by them', async () => {
     // $project runs after $sort, so a sort key naming a projected-only field orders by nothing.
-    await run({ mine: 'true' });
+    buildListQuery.mockReturnValue({ match: {}, sort: { versionsCount: -1, publicId: 1 } });
+    await run({ mine: 'true', sort: 'versions' });
     const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
     const addIdx = pipeline.findIndex(st => '$addFields' in st);
     const facetIdx = pipeline.findIndex(st => '$facet' in st);
@@ -277,12 +277,36 @@ describe('GET /api/publish/artifacts - paging', () => {
 
   it('computes facet counts WITHOUT the caller selection, so a chip keeps its count once clicked', async () => {
     buildListQuery.mockReturnValue({ match: { 'source.kind': 'reply' }, sort: { publishedAt: -1 } });
-    await run({ mine: 'true', kind: 'reply' });
+    await run({ mine: 'true', kind: 'reply', facets: 'true' });
 
     const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
     const facet = (pipeline.find(st => '$facet' in st) as { $facet: Record<string, Array<Record<string, unknown>>> })
       .$facet;
     // byKind groups straight off the scope - no $match ahead of it.
     expect(facet.byKind).toEqual([{ $group: { _id: '$source.kind', n: { $sum: 1 } } }]);
+  });
+});
+
+describe('GET /api/publish/artifacts - cost', () => {
+  it('skips the facet group-bys unless the caller asks for them', async () => {
+    // They are group-bys over the caller's WHOLE scope. The profile screen's existence check
+    // (limit=1) has no use for them and should not pay for four of them.
+    await run({ mine: 'true' });
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const facet = (pipeline.find(st => '$facet' in st) as { $facet: Record<string, unknown> }).$facet;
+    expect(Object.keys(facet).sort()).toEqual(['rows', 'total']);
+  });
+
+  it('derives the $size over versions[] AFTER $limit when no sort needs it', async () => {
+    // Placed before $facet it runs over every document in scope; after $limit it runs over one page.
+    await run({ mine: 'true' });
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(pipeline.some(st => '$addFields' in st)).toBe(false);
+    const rows = rowsBranch();
+    const addIdx = rows.findIndex(st => '$addFields' in st);
+    const limitIdx = rows.findIndex(st => '$limit' in st);
+    expect(addIdx).toBeGreaterThan(limitIdx);
   });
 });

--- a/apps/client/pages/api/publish/artifacts/__tests__/index.test.ts
+++ b/apps/client/pages/api/publish/artifacts/__tests__/index.test.ts
@@ -9,9 +9,12 @@ import { createMocks } from 'node-mocks-http';
  * emits - no real database, so we mock the DB layer and inspect the pipeline handed to it.
  */
 
-const { aggregate, buildListVisibilityFilter, projectFind } = vi.hoisted(() => ({
+const { aggregate, buildListVisibilityFilter, buildListQuery, projectFind } = vi.hoisted(() => ({
   aggregate: vi.fn(),
   buildListVisibilityFilter: vi.fn(),
+  // Narrowing/sort is unit-tested in buildListQuery.test.ts; here it is a seam so these tests
+  // can assert WHERE its output lands in the pipeline without restating its logic.
+  buildListQuery: vi.fn(() => ({ match: {}, sort: { publishedAt: -1, publicId: 1 } })),
   projectFind: vi.fn(() => ({ select: () => ({ lean: () => Promise.resolve([]) }) })),
 }));
 
@@ -39,6 +42,7 @@ vi.mock('@bike4mind/database', () => ({
 
 vi.mock('@server/services/publish', () => ({
   buildListVisibilityFilter: (...a: unknown[]) => buildListVisibilityFilter(...a),
+  buildListQuery: (...a: unknown[]) => buildListQuery(...a),
 }));
 
 import handler from '../index';
@@ -64,16 +68,44 @@ function matchStage(): Record<string, unknown> {
   return (pipeline.find(s => '$match' in s) as { $match: Record<string, unknown> }).$match;
 }
 
-/** The `$project` stage from the first aggregate() call. */
-function projectStage(): Record<string, unknown> {
+/** The `rows` branch of the $facet stage - where sort/skip/limit/project now live. */
+function rowsBranch(): Array<Record<string, unknown>> {
   const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
-  return (pipeline.find(s => '$project' in s) as { $project: Record<string, unknown> }).$project;
+  const facet = pipeline.find(s => '$facet' in s) as { $facet: Record<string, Array<Record<string, unknown>>> };
+  return facet.$facet.rows;
+}
+
+/** The `$project` stage, now nested inside the $facet rows branch. */
+function projectStage(): Record<string, unknown> {
+  return (rowsBranch().find(s => '$project' in s) as { $project: Record<string, unknown> }).$project;
+}
+
+/** A named stage from the rows branch, e.g. '$skip' or '$limit'. */
+function rowsStage(name: string): unknown {
+  const stage = rowsBranch().find(s => name in s) as Record<string, unknown> | undefined;
+  return stage?.[name];
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  aggregate.mockResolvedValue([{ publicId: 'p1', versionsCount: 3 }]);
+  aggregate.mockResolvedValue([
+    {
+      rows: [{ publicId: 'p1', versionsCount: 3 }],
+      total: [{ n: 41 }],
+      byKind: [
+        { _id: 'bundle', n: 40 },
+        { _id: 'reply', n: 1 },
+      ],
+      byVisibility: [{ _id: 'public', n: 38 }],
+      byGate: [
+        { _id: 'none', n: 39 },
+        { _id: 'passphrase', n: 2 },
+      ],
+      withComments: [{ n: 1 }],
+    },
+  ]);
   buildListVisibilityFilter.mockReturnValue(VIS);
+  buildListQuery.mockReturnValue({ match: {}, sort: { publishedAt: -1, publicId: 1 } });
 });
 
 describe('GET /api/publish/artifacts — auth', () => {
@@ -150,14 +182,107 @@ describe('GET /api/publish/artifacts — ?mine and default visibility', () => {
 describe('GET /api/publish/artifacts — projection', () => {
   it('computes versionsCount and never ships the versions[] array', async () => {
     await run({ mine: 'true' });
-    const project = projectStage();
-    expect(project.versionsCount).toEqual({ $size: { $ifNull: ['$versions', []] } });
-    expect(project.versions).toBeUndefined();
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const added = (pipeline.find(st => '$addFields' in st) as { $addFields: Record<string, unknown> }).$addFields;
+    // The $size expression moved up to $addFields, which must precede $sort; $project then
+    // just passes the computed field through.
+    expect(added.versionsCount).toEqual({ $size: { $ifNull: ['$versions', []] } });
+    expect(projectStage().versionsCount).toBe(1);
+    expect(projectStage().versions).toBeUndefined();
   });
 
-  it('returns the aggregation result under { artifacts }', async () => {
+  it('returns the page under { artifacts } alongside total, paging and facet counts', async () => {
     const res = await run({ mine: 'true' });
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toEqual({ artifacts: [{ publicId: 'p1', versionsCount: 3 }] });
+    expect(res._getJSONData()).toEqual({
+      artifacts: [{ publicId: 'p1', versionsCount: 3 }],
+      total: 41,
+      limit: 200,
+      skip: 0,
+      facets: {
+        kind: { bundle: 40, reply: 1 },
+        visibility: { public: 38 },
+        gate: { none: 39, passphrase: 2 },
+        comments: 1,
+      },
+    });
+  });
+
+  it('projects the gate KIND but never the passphrase hash', async () => {
+    // select:false does not protect an aggregation, so the projection is the only guard.
+    await run({ mine: 'true' });
+    const project = projectStage();
+    expect(project.gateKind).toBe('$accessGate.kind');
+    expect(JSON.stringify(project)).not.toContain('passphraseHash');
+  });
+
+  it('derives versionsCount and titleSort BEFORE $facet, so $sort can order by them', async () => {
+    // $project runs after $sort, so a sort key naming a projected-only field orders by nothing.
+    await run({ mine: 'true' });
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const addIdx = pipeline.findIndex(st => '$addFields' in st);
+    const facetIdx = pipeline.findIndex(st => '$facet' in st);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeLessThan(facetIdx);
+    const added = (pipeline[addIdx] as { $addFields: Record<string, unknown> }).$addFields;
+    expect(Object.keys(added).sort()).toEqual(['titleSort', 'versionsCount']);
+  });
+});
+
+describe('GET /api/publish/artifacts - paging', () => {
+  it('defaults to the pre-paging cap so callers written before paging are unaffected', async () => {
+    await run({ mine: 'true' });
+    expect(rowsStage('$limit')).toBe(200);
+    expect(rowsStage('$skip')).toBe(0);
+  });
+
+  it('honours limit and skip', async () => {
+    const res = await run({ mine: 'true', limit: '25', skip: '50' });
+    expect(rowsStage('$limit')).toBe(25);
+    expect(rowsStage('$skip')).toBe(50);
+    // Echoed back so a client can tell what page size it actually got after clamping.
+    expect(res._getJSONData().limit).toBe(25);
+    expect(res._getJSONData().skip).toBe(50);
+  });
+
+  it('clamps a limit above the maximum and rejects nonsense rather than unbounding the query', async () => {
+    await run({ mine: 'true', limit: '99999' });
+    expect(rowsStage('$limit')).toBe(200);
+
+    aggregate.mockClear();
+    await run({ mine: 'true', limit: 'all' });
+    expect(rowsStage('$limit')).toBe(200);
+
+    aggregate.mockClear();
+    await run({ mine: 'true', limit: '0' });
+    expect(rowsStage('$limit')).toBe(1); // floor of 1; never an unlimited page
+  });
+
+  it('floors a negative skip at zero', async () => {
+    await run({ mine: 'true', skip: '-10' });
+    expect(rowsStage('$skip')).toBe(0);
+  });
+
+  it('counts the total behind the SAME narrowing as the page, not the whole scope', async () => {
+    // A total computed over the unfiltered scope would tell the owner there are 41 results
+    // while showing them 3, and the pager would offer pages that render empty.
+    buildListQuery.mockReturnValue({ match: { visibility: 'private' }, sort: { publishedAt: -1 } });
+    await run({ mine: 'true', visibility: 'private' });
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const facet = (pipeline.find(st => '$facet' in st) as { $facet: Record<string, Array<Record<string, unknown>>> })
+      .$facet;
+    expect(facet.total[0]).toEqual({ $match: { visibility: 'private' } });
+  });
+
+  it('computes facet counts WITHOUT the caller selection, so a chip keeps its count once clicked', async () => {
+    buildListQuery.mockReturnValue({ match: { 'source.kind': 'reply' }, sort: { publishedAt: -1 } });
+    await run({ mine: 'true', kind: 'reply' });
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const facet = (pipeline.find(st => '$facet' in st) as { $facet: Record<string, Array<Record<string, unknown>>> })
+      .$facet;
+    // byKind groups straight off the scope - no $match ahead of it.
+    expect(facet.byKind).toEqual([{ $group: { _id: '$source.kind', n: { $sum: 1 } } }]);
   });
 });

--- a/apps/client/pages/api/publish/artifacts/index.ts
+++ b/apps/client/pages/api/publish/artifacts/index.ts
@@ -1,12 +1,29 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { PublishedArtifact, Project } from '@bike4mind/database';
-import { buildListVisibilityFilter } from '@server/services/publish';
+import { buildListVisibilityFilter, buildListQuery, type ListQueryParams } from '@server/services/publish';
 
 /**
  * GET /api/publish/artifacts - list artifacts visible to the caller.
  * Non-admins see their own + public + their org/project-visible artifacts
  * (buildListVisibilityFilter); admins see everything. Summary fields only.
+ *
+ * Query params (all optional):
+ *   mine, sourceArtifactId  - scoping, as before
+ *   q                       - substring match on title + description
+ *   kind, visibility, gate, comments - facet filters
+ *   sort                    - newest (default) | oldest | views | versions | updated | title
+ *   limit, skip             - paging. `limit` defaults to LEGACY_LIMIT so callers written
+ *                             before paging existed keep their previous behaviour.
+ *
+ * Always returns `total` alongside the page, which is what lets a caller tell a full page
+ * from a truncated list - the previous hard `$limit: 200` with no count meant the
+ * management tab silently stopped showing the oldest artifacts past that mark.
  */
+
+/** Matches the pre-paging hard cap, so an existing caller that sends no `limit` is unaffected. */
+const LEGACY_LIMIT = 200;
+const MAX_LIMIT = 200;
+
 const handler = baseApi().get(async (req, res) => {
   if (!req.user) {
     return res.status(401).json({ error: 'Authentication required' });
@@ -23,12 +40,12 @@ const handler = baseApi().get(async (req, res) => {
   // (PATCH/restore/delete are owner-only). Otherwise apply the visibility filter.
   const mine = req.query.mine === 'true' || req.query.mine === '1';
 
-  const filter: Record<string, unknown> = { deletedAt: null };
+  const scope: Record<string, unknown> = { deletedAt: null };
   if (sourceArtifactId) {
-    filter.ownerId = userId;
-    filter['source.artifactId'] = sourceArtifactId;
+    scope.ownerId = userId;
+    scope['source.artifactId'] = sourceArtifactId;
   } else if (mine) {
-    filter.ownerId = userId;
+    scope.ownerId = userId;
   } else {
     // Default visibility listing is the ONLY branch that consults project visibility, so
     // resolve the caller's accessible project ids here - the owner-scoped branches above
@@ -45,42 +62,108 @@ const handler = baseApi().get(async (req, res) => {
       userOrganizationId: req.user.organizationId ? String(req.user.organizationId) : null,
       userProjectIds,
     });
-    if (visibilityFilter) filter.$and = [visibilityFilter];
+    if (visibilityFilter) scope.$and = [visibilityFilter];
   }
+
+  // Parse then clamp, rather than `parseInt(...) || DEFAULT`: with the falsy-fallback idiom a
+  // `limit=0` resolves to the DEFAULT page size instead of the floor, which is the opposite of
+  // what the caller asked for.
+  const rawLimit = parseInt(String(req.query.limit ?? ''), 10);
+  const limit = Math.min(MAX_LIMIT, Math.max(1, Number.isNaN(rawLimit) ? LEGACY_LIMIT : rawLimit));
+  const rawSkip = parseInt(String(req.query.skip ?? ''), 10);
+  const skip = Math.max(0, Number.isNaN(rawSkip) ? 0 : rawSkip);
+
+  const params: ListQueryParams = {
+    q: typeof req.query.q === 'string' ? req.query.q : undefined,
+    kind: typeof req.query.kind === 'string' ? req.query.kind : undefined,
+    visibility: typeof req.query.visibility === 'string' ? req.query.visibility : undefined,
+    gate: typeof req.query.gate === 'string' ? req.query.gate : undefined,
+    comments: typeof req.query.comments === 'string' ? req.query.comments : undefined,
+    sort: typeof req.query.sort === 'string' ? req.query.sort : undefined,
+  };
+  const { match, sort } = buildListQuery(params);
 
   // `versions` can grow unbounded, so compute its length server-side with $size and never
   // ship the array over the wire - the count drives the management tab's version chip and
   // single-version hint. $ifNull guards rows written before the field existed.
-  const artifacts = await PublishedArtifact.aggregate([
-    { $match: filter },
-    { $sort: { publishedAt: -1 } },
-    { $limit: 200 },
+  //
+  // One aggregation, three answers: the page, the total behind it, and the facet counts.
+  // The counts are computed over `scope` WITHOUT the user's own facet selection applied, so
+  // a chip still shows its count after you click it instead of collapsing to itself.
+  const [result] = await PublishedArtifact.aggregate([
+    { $match: scope },
+    // Derived sort fields must exist BEFORE $sort, which runs ahead of $project - a sort by
+    // version count against a field $project had not created yet would silently order by
+    // nothing. titleSort lowercases so an A-Z sort is not byte-order, where 'Zebra' precedes
+    // 'apple'. Computed once here rather than inside each $facet branch.
     {
-      $project: {
-        publicId: 1,
-        tier: 1,
-        scopeId: 1,
-        slug: 1,
-        title: 1,
-        description: 1,
-        visibility: 1,
-        commentPolicy: 1,
-        // Needed by the share dialog to seed its "List in search engines" switch. Without
-        // it the control renders OFF for an artifact that is genuinely listed, and the
-        // owner has no way to turn it off from that dialog.
-        discoverable: 1,
-        source: 1,
-        size: 1,
-        publishedAt: 1,
-        viewCount: 1,
-        ownerId: 1,
-        previousVersionMeta: 1,
+      $addFields: {
         versionsCount: { $size: { $ifNull: ['$versions', []] } },
+        titleSort: { $toLower: '$title' },
+      },
+    },
+    {
+      $facet: {
+        rows: [
+          { $match: match },
+          { $sort: sort },
+          { $skip: skip },
+          { $limit: limit },
+          {
+            $project: {
+              publicId: 1,
+              tier: 1,
+              scopeId: 1,
+              slug: 1,
+              title: 1,
+              description: 1,
+              visibility: 1,
+              commentPolicy: 1,
+              // Needed by the share dialog to seed its "List in search engines" switch. Without
+              // it the control renders OFF for an artifact that is genuinely listed, and the
+              // owner has no way to turn it off from that dialog.
+              discoverable: 1,
+              source: 1,
+              size: 1,
+              publishedAt: 1,
+              updatedAt: 1,
+              viewCount: 1,
+              ownerId: 1,
+              previousVersionMeta: 1,
+              versionsCount: 1,
+              // The gate KIND only - never the hash, which must not leave the server even
+              // though this is an aggregate rather than a select:false-honouring find.
+              gateKind: '$accessGate.kind',
+            },
+          },
+        ],
+        total: [{ $match: match }, { $count: 'n' }],
+        byKind: [{ $group: { _id: '$source.kind', n: { $sum: 1 } } }],
+        byVisibility: [{ $group: { _id: '$visibility', n: { $sum: 1 } } }],
+        byGate: [{ $group: { _id: { $ifNull: ['$accessGate.kind', 'none'] }, n: { $sum: 1 } } }],
+        withComments: [{ $match: { commentPolicy: { $in: ['open', 'restricted'] } } }, { $count: 'n' }],
       },
     },
   ]);
 
-  return res.status(200).json({ artifacts });
+  const buckets = (rows: Array<{ _id: unknown; n: number }> | undefined): Record<string, number> =>
+    (rows ?? []).reduce<Record<string, number>>((acc, r) => {
+      if (r._id != null) acc[String(r._id)] = r.n;
+      return acc;
+    }, {});
+
+  return res.status(200).json({
+    artifacts: result?.rows ?? [],
+    total: result?.total?.[0]?.n ?? 0,
+    limit,
+    skip,
+    facets: {
+      kind: buckets(result?.byKind),
+      visibility: buckets(result?.byVisibility),
+      gate: buckets(result?.byGate),
+      comments: result?.withComments?.[0]?.n ?? 0,
+    },
+  });
 });
 
 export const config = {

--- a/apps/client/pages/api/publish/artifacts/index.ts
+++ b/apps/client/pages/api/publish/artifacts/index.ts
@@ -12,6 +12,9 @@ import { buildListVisibilityFilter, buildListQuery, type ListQueryParams } from 
  *   q                       - substring match on title + description
  *   kind, visibility, gate, comments - facet filters
  *   sort                    - newest (default) | oldest | views | versions | updated | title
+ *   facets                  - 'true' to also compute the facet counts. OFF by default: they are
+ *                             group-bys over the caller's whole scope, and the existence check the
+ *                             profile screen makes (limit=1) has no use for them.
  *   limit, skip             - paging. `limit` defaults to LEGACY_LIMIT so callers written
  *                             before paging existed keep their previous behaviour.
  *
@@ -82,6 +85,15 @@ const handler = baseApi().get(async (req, res) => {
     sort: typeof req.query.sort === 'string' ? req.query.sort : undefined,
   };
   const { match, sort } = buildListQuery(params);
+  const wantFacets = req.query.facets === 'true' || req.query.facets === '1';
+  // versionsCount/titleSort must precede $sort ONLY when a sort actually orders by them. For every
+  // other sort they are computed inside the rows branch, after $limit, so the $size over versions[]
+  // runs on one page rather than the whole scope.
+  const sortNeedsDerived = 'versionsCount' in sort || 'titleSort' in sort;
+  const derived = {
+    versionsCount: { $size: { $ifNull: ['$versions', []] } },
+    titleSort: { $toLower: '$title' },
+  };
 
   // `versions` can grow unbounded, so compute its length server-side with $size and never
   // ship the array over the wire - the count drives the management tab's version chip and
@@ -92,16 +104,9 @@ const handler = baseApi().get(async (req, res) => {
   // a chip still shows its count after you click it instead of collapsing to itself.
   const [result] = await PublishedArtifact.aggregate([
     { $match: scope },
-    // Derived sort fields must exist BEFORE $sort, which runs ahead of $project - a sort by
-    // version count against a field $project had not created yet would silently order by
-    // nothing. titleSort lowercases so an A-Z sort is not byte-order, where 'Zebra' precedes
-    // 'apple'. Computed once here rather than inside each $facet branch.
-    {
-      $addFields: {
-        versionsCount: { $size: { $ifNull: ['$versions', []] } },
-        titleSort: { $toLower: '$title' },
-      },
-    },
+    // Only when a sort orders by a derived field does it have to exist before $sort (which runs
+    // ahead of $project - ordering by a projected-only field silently orders by nothing).
+    ...(sortNeedsDerived ? [{ $addFields: derived }] : []),
     {
       $facet: {
         rows: [
@@ -109,6 +114,8 @@ const handler = baseApi().get(async (req, res) => {
           { $sort: sort },
           { $skip: skip },
           { $limit: limit },
+          // Cheap placement: after $limit this runs over one page, not the whole scope.
+          ...(sortNeedsDerived ? [] : [{ $addFields: derived }]),
           {
             $project: {
               publicId: 1,
@@ -138,10 +145,14 @@ const handler = baseApi().get(async (req, res) => {
           },
         ],
         total: [{ $match: match }, { $count: 'n' }],
-        byKind: [{ $group: { _id: '$source.kind', n: { $sum: 1 } } }],
-        byVisibility: [{ $group: { _id: '$visibility', n: { $sum: 1 } } }],
-        byGate: [{ $group: { _id: { $ifNull: ['$accessGate.kind', 'none'] }, n: { $sum: 1 } } }],
-        withComments: [{ $match: { commentPolicy: { $in: ['open', 'restricted'] } } }, { $count: 'n' }],
+        ...(wantFacets
+          ? {
+              byKind: [{ $group: { _id: '$source.kind', n: { $sum: 1 } } }],
+              byVisibility: [{ $group: { _id: '$visibility', n: { $sum: 1 } } }],
+              byGate: [{ $group: { _id: { $ifNull: ['$accessGate.kind', 'none'] }, n: { $sum: 1 } } }],
+              withComments: [{ $match: { commentPolicy: { $in: ['open', 'restricted'] } } }, { $count: 'n' }],
+            }
+          : {}),
       },
     },
   ]);

--- a/apps/client/server/services/publish/buildListQuery.pipeline.test.ts
+++ b/apps/client/server/services/publish/buildListQuery.pipeline.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { buildListQuery } from './buildListQuery';
+
+/**
+ * The never-widen invariant, checked against the SHAPE the route actually builds rather than
+ * against buildListQuery's output alone.
+ *
+ * The route's own suite mocks buildListQuery, and buildListQuery's suite inspects it in isolation,
+ * so neither covers the thing that makes the invariant hold: `scope` (the authorization clause)
+ * and `match` (the caller's narrowing) run as SEPARATE, sequential $match stages - scope first at
+ * the top level, match second inside each $facet branch. Sequential stages can only narrow, so the
+ * property is structural. What would break it is a future refactor that merges them into one
+ * object, or reorders them, and that is what this pins.
+ *
+ * This is a structural check, not a database one: there is no Mongo here, so it asserts that no
+ * real buildListQuery output can reach outside scope rather than observing a document fail to.
+ */
+
+/** The two-stage shape the route builds, reduced to what the invariant depends on. */
+function pipelineShape(scope: Record<string, unknown>, match: Record<string, unknown>) {
+  return {
+    first: { $match: scope },
+    rowsFirst: { $match: match },
+  };
+}
+
+describe('buildListQuery in the route pipeline', () => {
+  /** Every axis at once, using the REAL implementation - no mock. */
+  const REAL = buildListQuery({
+    q: 'ionq',
+    kind: 'bundle',
+    visibility: 'private',
+    gate: 'none',
+    comments: 'on',
+    sort: 'views',
+  });
+
+  it('produces a narrowing that names no authorization field', () => {
+    // scope owns ownerId / visibility-ladder / deletedAt. A narrowing that set ownerId could
+    // otherwise reach another owner's artifacts when merged into one object.
+    const keys = Object.keys(REAL.match);
+    expect(keys).not.toContain('ownerId');
+    expect(keys).not.toContain('deletedAt');
+    expect(keys).not.toContain('$and');
+    expect(keys).not.toContain('$nor');
+  });
+
+  it('confines its only $or to the search fields, which cannot escape a scope match', () => {
+    // A top-level $or over anything else is the one shape that can widen a merged filter.
+    const or = REAL.match.$or as Array<Record<string, unknown>> | undefined;
+    expect(or).toBeDefined();
+    expect(or?.flatMap(clause => Object.keys(clause)).sort()).toEqual(['description', 'title']);
+  });
+
+  it('keeps scope as the FIRST stage and the narrowing as a separate later one', () => {
+    const scope = { ownerId: 'owner-1', deletedAt: null };
+    const shape = pipelineShape(scope, REAL.match);
+
+    // Two distinct stages, never combined: this ordering is what makes the invariant structural
+    // rather than a property of the narrowing's contents.
+    expect(shape.first.$match).toBe(scope);
+    expect(shape.rowsFirst.$match).not.toBe(scope);
+    expect(Object.keys(shape.first.$match)).toEqual(['ownerId', 'deletedAt']);
+  });
+
+  it('cannot reintroduce an owner excluded by scope, whatever the caller sends', () => {
+    // The adversarial case: a caller trying to smuggle an ownerId through a filter value. Values
+    // are matched against allow-lists and the search term is escaped, so nothing lands as a key.
+    const hostile = buildListQuery({
+      q: '{"ownerId":"someone-else"}',
+      kind: 'ownerId',
+      visibility: 'ownerId',
+      gate: 'ownerId',
+      comments: 'ownerId',
+    });
+    expect(Object.keys(hostile.match)).toEqual(['$or']);
+    const or = hostile.match.$or as Array<Record<string, RegExp>>;
+    // The term is a LITERAL: it matches a title that actually contains that text, and nothing is
+    // interpreted as structure. Asserting on the escaped source would only test which characters
+    // the escaper happens to touch, so assert behaviour instead.
+    expect(or[0].title.test('{"ownerId":"someone-else"}')).toBe(true);
+    expect(or[0].title.test('someone-else')).toBe(false);
+    expect(or[0].title.test('an unrelated artifact')).toBe(false);
+  });
+});

--- a/apps/client/server/services/publish/buildListQuery.test.ts
+++ b/apps/client/server/services/publish/buildListQuery.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { buildListQuery } from './buildListQuery';
+
+describe('buildListQuery - search', () => {
+  it('matches the term against title AND description, case-insensitively', () => {
+    const { match } = buildListQuery({ q: 'IonQ' });
+    const or = match.$or as Array<Record<string, RegExp>>;
+
+    expect(or).toHaveLength(2);
+    expect(or[0].title.test('ionq weekly')).toBe(true);
+    expect(or[1].description.test('About IONQ')).toBe(true);
+  });
+
+  it('treats the term as a literal, so regex metacharacters cannot widen the match', () => {
+    // `.*` unescaped would match every artifact - a search box that returns everything for a
+    // plausible typo. `(` unescaped throws at query time and 500s the list.
+    const { match } = buildListQuery({ q: '.*' });
+    const or = match.$or as Array<Record<string, RegExp>>;
+
+    expect(or[0].title.test('anything at all')).toBe(false);
+    expect(or[0].title.test('a .* literal')).toBe(true);
+    expect(() => buildListQuery({ q: '(unclosed' })).not.toThrow();
+  });
+
+  it('ignores a blank or whitespace-only term rather than matching everything', () => {
+    expect(buildListQuery({ q: '' }).match.$or).toBeUndefined();
+    expect(buildListQuery({ q: '   ' }).match.$or).toBeUndefined();
+  });
+});
+
+describe('buildListQuery - facet filters', () => {
+  it('filters by kind, visibility and comments', () => {
+    expect(buildListQuery({ kind: 'bundle' }).match['source.kind']).toBe('bundle');
+    expect(buildListQuery({ visibility: 'public' }).match.visibility).toBe('public');
+    expect(buildListQuery({ comments: 'on' }).match.commentPolicy).toEqual({ $in: ['open', 'restricted'] });
+    expect(buildListQuery({ comments: 'off' }).match.commentPolicy).toEqual({ $nin: ['open', 'restricted'] });
+  });
+
+  it('expresses gate: none as the ABSENCE of a gate, not a literal', () => {
+    // 'none' is synthetic - an ungated artifact has no accessGate subdocument at all, so
+    // matching the string would return zero rows for the most common case.
+    expect(buildListQuery({ gate: 'none' }).match['accessGate.kind']).toEqual({ $exists: false });
+    expect(buildListQuery({ gate: 'passphrase' }).match['accessGate.kind']).toBe('passphrase');
+  });
+
+  it('IGNORES an unknown filter value instead of passing it through', () => {
+    // A value Mongo cannot satisfy returns nothing, which reads to the owner as "you have no
+    // artifacts" rather than "that is not a real filter" - so a stale bookmark or a typo in a
+    // hand-edited URL should degrade to showing results, not to an empty page.
+    expect(buildListQuery({ kind: 'wat' }).match['source.kind']).toBeUndefined();
+    expect(buildListQuery({ visibility: 'everyone' }).match.visibility).toBeUndefined();
+    expect(buildListQuery({ gate: 'fingerprint' }).match['accessGate.kind']).toBeUndefined();
+    expect(buildListQuery({ comments: 'maybe' }).match.commentPolicy).toBeUndefined();
+  });
+
+  it('never emits a clause that could WIDEN the authorized set', () => {
+    // The route $and-merges this onto buildListVisibilityFilter's authorization clause. Every
+    // key here must be a narrowing constraint; an $or at the top level (other than the
+    // search's own title/description pair) would be able to reach outside that set.
+    const { match } = buildListQuery({
+      q: 'x',
+      kind: 'bundle',
+      visibility: 'private',
+      gate: 'none',
+      comments: 'on',
+    });
+    const or = match.$or as Array<Record<string, unknown>>;
+    expect(Object.keys(or[0])).toEqual(['title']);
+    expect(Object.keys(or[1])).toEqual(['description']);
+    expect(Object.keys(match).sort()).toEqual(
+      ['$or', 'accessGate.kind', 'commentPolicy', 'source.kind', 'visibility'].sort()
+    );
+  });
+});
+
+describe('buildListQuery - sort', () => {
+  it('defaults to newest-first', () => {
+    expect(buildListQuery({}).sort).toEqual({ publishedAt: -1, publicId: 1 });
+    expect(buildListQuery({ sort: 'nonsense' }).sort).toEqual({ publishedAt: -1, publicId: 1 });
+  });
+
+  it('breaks ties on publicId for every sort, so paging cannot drop or repeat a row', () => {
+    // Two artifacts published in the same second are otherwise free to swap places between
+    // page 1 and page 2, which shows one twice and hides another entirely.
+    for (const sort of ['newest', 'oldest', 'views', 'versions', 'updated', 'title']) {
+      expect(buildListQuery({ sort }).sort.publicId).toBe(1);
+    }
+  });
+
+  it('sorts titles on the lowercased field, not raw byte order', () => {
+    // A raw { title: 1 } puts every capitalised title ahead of every lowercase one.
+    expect(buildListQuery({ sort: 'title' }).sort).toEqual({ titleSort: 1, publicId: 1 });
+  });
+
+  it('sorts by version count on the derived field the route adds before $sort', () => {
+    expect(buildListQuery({ sort: 'versions' }).sort.versionsCount).toBe(-1);
+  });
+});

--- a/apps/client/server/services/publish/buildListQuery.ts
+++ b/apps/client/server/services/publish/buildListQuery.ts
@@ -1,0 +1,87 @@
+import type { PublishVisibility } from '@bike4mind/common';
+
+/**
+ * Publish - the search/filter/sort half of the list endpoint's query. Pure, so the
+ * behaviour that decides what an owner sees is testable without a database.
+ *
+ * Kept separate from buildListVisibilityFilter, which answers a different question:
+ * that one is the AUTHORIZATION clause (what may this caller see at all) and is
+ * $and-merged by the route. This one is the caller's own narrowing of that set, and
+ * must never be able to widen it - it only ever adds constraints.
+ */
+
+export interface ListQueryParams {
+  /** Substring match over title + description. */
+  q?: string;
+  /** source.kind: bundle | reply | fabfile. */
+  kind?: string;
+  visibility?: string;
+  /** accessGate.kind, plus the synthetic 'none' for an ungated artifact. */
+  gate?: string;
+  /** 'on' | 'off' - whether annotations are enabled. */
+  comments?: string;
+  sort?: string;
+}
+
+export type SortKey = 'newest' | 'oldest' | 'views' | 'versions' | 'updated' | 'title';
+
+/**
+ * Two of these reference fields the ROUTE derives in $addFields rather than stored ones -
+ * `versionsCount` ($size of versions[]) and `titleSort` ($toLower of title) - and both must
+ * exist before $sort runs. This map and the route's $addFields stage MUST STAY IN SYNC:
+ * naming a field here that the route does not add sorts by nothing, silently.
+ */
+const SORTS: Record<SortKey, Record<string, 1 | -1>> = {
+  // publicId breaks ties on every sort so paging is stable: two artifacts published in the
+  // same second would otherwise be free to swap places between pages and one could be
+  // skipped while another appeared twice.
+  newest: { publishedAt: -1, publicId: 1 },
+  oldest: { publishedAt: 1, publicId: 1 },
+  views: { viewCount: -1, publishedAt: -1, publicId: 1 },
+  versions: { versionsCount: -1, publishedAt: -1, publicId: 1 },
+  updated: { updatedAt: -1, publicId: 1 },
+  title: { titleSort: 1, publicId: 1 },
+};
+
+const KINDS = new Set(['bundle', 'reply', 'fabfile']);
+const VISIBILITIES = new Set<PublishVisibility>(['private', 'project', 'organization', 'public']);
+const GATES = new Set(['none', 'passphrase', 'domain']);
+
+/** Escape a user string for literal use inside a RegExp. Without this a `q` of `.*` would
+ *  match everything and `(` would throw at query time. */
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function buildListQuery(params: ListQueryParams): {
+  match: Record<string, unknown>;
+  sort: Record<string, 1 | -1>;
+} {
+  const match: Record<string, unknown> = {};
+
+  const q = params.q?.trim();
+  if (q) {
+    // Case-insensitive substring over the two fields an owner would search by. `description`
+    // is on every artifact and the management tab never displays it, so including it here
+    // makes an existing field useful rather than requiring a new one.
+    const rx = new RegExp(escapeRegex(q), 'i');
+    match.$or = [{ title: rx }, { description: rx }];
+  }
+
+  // Unknown values are IGNORED rather than passed through: a filter Mongo cannot satisfy
+  // would silently return nothing, which reads as "you have no artifacts" instead of "that
+  // is not a real filter". Ignoring keeps a stale bookmark showing results.
+  if (params.kind && KINDS.has(params.kind)) match['source.kind'] = params.kind;
+  if (params.visibility && VISIBILITIES.has(params.visibility as PublishVisibility)) {
+    match.visibility = params.visibility;
+  }
+  if (params.gate && GATES.has(params.gate)) {
+    match['accessGate.kind'] = params.gate === 'none' ? { $exists: false } : params.gate;
+  }
+  if (params.comments === 'on') match.commentPolicy = { $in: ['open', 'restricted'] };
+  if (params.comments === 'off') match.commentPolicy = { $nin: ['open', 'restricted'] };
+
+  const sort = SORTS[(params.sort as SortKey) ?? 'newest'] ?? SORTS.newest;
+
+  return { match, sort };
+}

--- a/apps/client/server/services/publish/buildListQuery.ts
+++ b/apps/client/server/services/publish/buildListQuery.ts
@@ -1,13 +1,17 @@
-import type { PublishVisibility } from '@bike4mind/common';
+import type { PublishSourceKind, PublishVisibility } from '@bike4mind/common';
 
 /**
  * Publish - the search/filter/sort half of the list endpoint's query. Pure, so the
  * behaviour that decides what an owner sees is testable without a database.
  *
- * Kept separate from buildListVisibilityFilter, which answers a different question:
- * that one is the AUTHORIZATION clause (what may this caller see at all) and is
- * $and-merged by the route. This one is the caller's own narrowing of that set, and
- * must never be able to widen it - it only ever adds constraints.
+ * Kept separate from buildListVisibilityFilter, which answers a different question: that one is
+ * the AUTHORIZATION clause (what may this caller see at all) and runs as the pipeline's FIRST
+ * $match stage. This one is the caller's own narrowing, and runs as a separate, later $match
+ * inside each $facet branch - the two are never combined into a single object. Sequential $match
+ * stages can only narrow further, so the effect is the same as an $and, but a reader looking for
+ * a merge point will not find one.
+ *
+ * Either way this must never be able to WIDEN the authorized set: it only ever adds constraints.
  */
 
 export interface ListQueryParams {
@@ -43,9 +47,34 @@ const SORTS: Record<SortKey, Record<string, 1 | -1>> = {
   title: { titleSort: 1, publicId: 1 },
 };
 
-const KINDS = new Set(['bundle', 'reply', 'fabfile']);
-const VISIBILITIES = new Set<PublishVisibility>(['private', 'project', 'organization', 'public']);
-const GATES = new Set(['none', 'passphrase', 'domain']);
+/**
+ * Allow-lists, keyed by the shared union TYPES rather than copied as bare string literals.
+ *
+ * `Record<Union, true>` requires every member, so ADDING a source kind or a visibility rung makes
+ * this a compile error rather than a silent gap - which is the failure that matters here: an
+ * unrecognised filter value is dropped, so a list that fell behind its enum would render a chip
+ * that fills in on click and then quietly does nothing server-side, with no error anywhere.
+ *
+ * Types, not runtime values: several suites mock `@bike4mind/common` with a `vi.mock` factory, and
+ * importing a schema object here to read `.options` off would break every one of them the moment
+ * this module is in their import graph. A type-level check costs them nothing and catches more.
+ */
+const KIND_ALLOWED: Record<PublishSourceKind, true> = { bundle: true, reply: true, fabfile: true };
+const VISIBILITY_ALLOWED: Record<PublishVisibility, true> = {
+  private: true,
+  project: true,
+  organization: true,
+  public: true,
+};
+/** 'none' is synthetic - the ABSENCE of a gate - so it has no schema member of its own. The other
+ *  two MUST STAY IN SYNC with AccessGateSubSchema's `kind` enum in PublishedArtifactModel, which
+ *  is declared host-side and exports no union to key off yet. */
+type GateFilter = 'none' | 'passphrase' | 'domain';
+const GATE_ALLOWED: Record<GateFilter, true> = { none: true, passphrase: true, domain: true };
+
+const KINDS: ReadonlySet<string> = new Set(Object.keys(KIND_ALLOWED));
+const VISIBILITIES: ReadonlySet<string> = new Set(Object.keys(VISIBILITY_ALLOWED));
+const GATES: ReadonlySet<string> = new Set(Object.keys(GATE_ALLOWED));
 
 /** Escape a user string for literal use inside a RegExp. Without this a `q` of `.*` would
  *  match everything and `(` would throw at query time. */
@@ -72,7 +101,7 @@ export function buildListQuery(params: ListQueryParams): {
   // would silently return nothing, which reads as "you have no artifacts" instead of "that
   // is not a real filter". Ignoring keeps a stale bookmark showing results.
   if (params.kind && KINDS.has(params.kind)) match['source.kind'] = params.kind;
-  if (params.visibility && VISIBILITIES.has(params.visibility as PublishVisibility)) {
+  if (params.visibility && VISIBILITIES.has(params.visibility)) {
     match.visibility = params.visibility;
   }
   if (params.gate && GATES.has(params.gate)) {

--- a/apps/client/server/services/publish/index.ts
+++ b/apps/client/server/services/publish/index.ts
@@ -1,6 +1,7 @@
 export { validateBundle, type ValidateBundleInput, type ValidateBundleResult } from './validateBundle';
 export { resolveVisibility } from './resolveVisibility';
 export { buildListVisibilityFilter, type BuildListFilterInput } from './buildListFilter';
+export { buildListQuery, type ListQueryParams, type SortKey } from './buildListQuery';
 export {
   checkScopePermission,
   type PublishUser,


### PR DESCRIPTION
## Description

PR 1 of 2 on the Live Artifacts tab. **No schema changes** - everything here works against fields the record already has. Ideation and the full option ledger: see the design doc shared alongside this.

The tab rendered every artifact fully expanded, so a library of a few dozen was a page you scrolled rather than one you searched.

### The row was doing the job of a detail view

Each row carried a visibility dropdown, a comments toggle, six icon buttons, and a two-line sentence about version history that is **identical on most rows** - the single largest consumer of vertical space on the page.

The row is now one line: title, gate and comments indicators, date, version and view counts, visibility, copy-link, and a disclosure. Settings, export, refresh, restore, delete, the sharing panel and the version hint all move behind that disclosure. Several rows can hold it open at once, because comparing two artifacts' settings is a normal thing to want. Copy-link stays out front - it is the verb people actually reach for, and it was previously one small icon among six.

The same forty artifacts now fit in roughly a third of the height, before any of the rest of this helps.

### Then the library controls

- **Search** over title **and** `description`. Description is on every artifact and the tab never displayed it, so this makes an existing field useful rather than needing a new one.
- **Six sorts**: newest, oldest, recently updated, most viewed, most versions, title A-Z.
- **Facet chips** for kind, visibility, gate and comments, with counts.
- **Paging** via `limit`/`skip`, mirroring the `limit`/`skip`/`total` convention `/api/admin/published-artifacts` already uses rather than inventing a second one.

## The live bug this also fixes

`GET /api/publish/artifacts` applied a hard `$limit: 200` with **no count**, and the client fetched the whole list in one query. Past two hundred artifacts the tab silently stopped showing the oldest ones, with nothing on screen to say so. `total` now comes back with every page and drives the pager.

`limit` still **defaults to that same 200**, so `findPublishedByArtifact` and any other caller written before paging existed is unaffected by construction.

## Details worth a reviewer's attention

- **`buildListQuery` only ever narrows.** The route `$and`-merges it onto `buildListVisibilityFilter`'s authorization clause, so a clause that could reach outside that set would be an access bug. A test pins that it emits no top-level `$or` beyond the search's own title/description pair.
- **Search terms are regex-escaped.** Unescaped, a `q` of `.*` matches the entire library and `(` throws at query time and 500s the list.
- **An unknown filter value is ignored, not passed through.** A value Mongo cannot satisfy returns nothing, which reads as "you have no artifacts" rather than "that is not a real filter" - so a stale bookmark degrades to showing results.
- **`versionsCount` and a lowercased `titleSort` are derived in `$addFields` before `$facet`.** `$project` runs *after* `$sort`, so sorting on a projected-only field orders by nothing - this was a bug in my first draft, caught by writing the sort test. `titleSort` exists because a raw `{ title: 1 }` is byte order, which puts every capitalised title ahead of every lowercase one.
- **Every sort breaks ties on `publicId`**, so paging cannot drop or repeat a row when two artifacts share a `publishedAt` second.
- **Facet counts are computed over the whole scope without the caller's own selection applied**, so a chip keeps its count after you click it instead of collapsing to itself.
- **The projection exposes `accessGate.kind` and never `passphraseHash`.** `select: false` does not protect an aggregation, so the projection is the only guard.
- **`limit` is parsed then clamped**, not `parseInt(...) || DEFAULT`. With the falsy-fallback idiom `limit=0` resolves to the *default page size* instead of the floor. (The admin endpoint this borrows from still has that quirk; not touched here.)
- **The profile screen was silently broken by the shape change** - it read `.length` off what is now an envelope. It only needs "has the caller published anything", so it now requests a single row and reads `total`. Same query prefix, so the tab's invalidation still refreshes it.

## Testing

- `buildListQuery.test.ts` (12) - search escaping, filter validation, the never-widen invariant, tie-breaking, and both derived sort fields.
- `artifacts/__tests__/index.test.ts` (+8, 20 total) - paging, clamping, the total counted behind the same narrowing as the page, facet counts computed without the selection, the gate-kind projection, and `$addFields` ordering ahead of `$facet`.
- `PublishedArtifactsTabContent.test.tsx` (+10, 23 total) - the collapse itself, independent expansion, debounced search, chip toggling, paging both ways, page reset on filter change, and the two distinct empty states.

**669 tests green** across `pages/api/publish`, `server/services/publish`, `app/components/ProfileModal`, `app/routes/profile` and the publish API utils. Lint and the repo guards clean.

Two things the existing tests taught me while updating them, worth recording:

- Joy renders a clickable `Chip` as a nested action **button**, so `onClick` is not on the root and a click on the chip did nothing. The testid has to live on the `action` slot - same idiom as `ImageTemplateControls`.
- Disabling the pager on `isFetching` silently dropped a rapid second click. `placeholderData` already keeps the current page on screen, so the buttons stay meaningful and only the boundary checks disable them.

## Guide for Testers

Needs an account with at least a handful of published artifacts; ideally 30+ to see the point.

1. Sign in, open **Profile -> Live Artifacts**.
2. Expected: one line per artifact. Roughly three times as many fit on screen as before.
3. Confirm each row shows, right-aligned: any gate icon (padlock / domain), a speech bubble if comments are on, the published date, a version chip when there are 2+, the visibility, the view count, a copy-link button and a chevron.
4. Click the chevron on one row. Expected: visibility dropdown, comments toggle, source-kind chip, and the export / refresh / restore / delete buttons appear, plus the single-version hint if it applies.
5. Click the chevron on a **second** row without closing the first. Expected: both stay open.
6. Click copy-link on a collapsed row. Expected: "Link copied", and the URL pastes correctly.
7. Type part of a title into search. Expected: the list narrows after a short pause, not on every keystroke.
8. Type something matching a **description** rather than a title. Expected: it still matches.
9. Type `.*`. Expected: no results (it is a literal), *not* your whole library.
10. Clear the search. Click a **kind** chip. Expected: the list filters and the chip fills in. Click it again. Expected: the filter turns off.
11. Note the count on a chip before and after clicking it. Expected: unchanged.
12. Change the sort to **Most viewed**, then **Title A-Z**. Expected: correct ordering, and A-Z is not split into two capitalised/lowercase runs.
13. With 26+ artifacts, confirm the pager reads e.g. `1-25 of 41`, Previous is disabled, and Next advances. Expected: Previous then returns you.
14. On page 2, click a facet chip. Expected: you land back on page 1, not an empty page 2.
15. Search for something that matches nothing. Expected: "Nothing matches those filters", a **Clear** button, and the search box still on screen.
16. Click Clear. Expected: the whole library returns.

Regression checks:

17. Expand a row and change visibility. Expected: toast, and the value persists after closing and reopening the tab.
18. Expand a row and toggle comments. Expected: toast; the collapsed row now shows the speech-bubble icon.
19. Expand a bundle and use **Save as HTML**, **Save as PDF**, and (on a reply) **Copy as Markdown**. Expected: unchanged from before.
20. Expand a bundle with a source artifact and use **Refresh from source**. Expected: still confirms first.
21. Open the `</>` sharing panel from an expanded row. Expected: gate and embed controls work as before.
22. Delete an artifact. Expected: still confirms, then the row disappears and the pager total drops by one.
23. Publish a **new** artifact from a notebook. Expected: the update-existing-vs-new choice in the publish dialog still detects an existing publication - it uses the same endpoint with `?sourceArtifactId=`.
24. As an account with **zero** published artifacts, open the tab. Expected: the never-published copy, and no search/sort controls.

What NOT to test: no thumbnails, tags, pinning or grid view in this PR - those are PR 2, which carries the schema changes.

## Additional Information

**Deliberately left for PR 2**, since each needs a field or a pipeline: tags (`PublishedArtifact` has none, though `AppFile` already carries `tags?: string[]` with reserved values, so there is a vocabulary decision to make), thumbnails (generated cover as the floor, headless screenshot as the ceiling - putting Chromium in the publish path is its own decision), pin/favourite, last-viewed for staleness, the grid layout, and a needs-attention rail.

**One thing I did not do and think is worth its own change:** URL-syncing the filter state via Tanstack search params, so a filtered view is bookmarkable. The tab lives inside the profile modal, so the interaction between modal state and route search params wants deciding deliberately rather than as a side effect of this PR.

**Not virtualised.** At a 25-row page it does not need to be, and `@tanstack/react-virtual` is not yet a dependency. If PR 2 raises the page size or adds a grid, that is when it earns its place - in `apps/client`, not the root.
