### PR TITLE
fix(feedback): make the Slack payload readable

### DIFF
--- a/apps/client/pages/api/feedback/__tests__/redaction.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/redaction.test.ts
@@ -131,9 +131,9 @@ describe('POST /api/feedback - redacts tool output before third-party egress', (
     await mockRefs.postHandler!(req, res);
 
     expect(mockPostFeedbackToSlack).toHaveBeenCalled();
-    const slackPromptMetaArg = mockPostFeedbackToSlack.mock.calls[0][6] as string;
-    expect(slackPromptMetaArg).not.toContain('PRIVATE TOOL OUTPUT');
-    expect(slackPromptMetaArg).toContain('web_search');
+    const slackPromptMetaArg = mockPostFeedbackToSlack.mock.calls[0][6];
+    expect(JSON.stringify(slackPromptMetaArg)).not.toContain('PRIVATE TOOL OUTPUT');
+    expect(JSON.stringify(slackPromptMetaArg)).toContain('web_search');
   });
 
   it('does not send returnValue to email', async () => {

--- a/apps/client/pages/api/feedback/index.ts
+++ b/apps/client/pages/api/feedback/index.ts
@@ -132,7 +132,7 @@ const handler = baseApi()
         newFeedback.userEmail ?? '',
         newFeedback.userId,
         content,
-        promptMetaForExternalEgress ? JSON.stringify(promptMetaForExternalEgress) : 'No prompt meta'
+        promptMetaForExternalEgress
       );
     } else {
       slack = { outcome: 'skipped', reason: 'disabled' };

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -120,10 +120,16 @@ describe('buildPromptMetaSummary', () => {
 
   it('never surfaces owner-only function-call fields even if a caller failed to redact them', () => {
     const summary = buildPromptMetaSummary({
-      functionCalls: [{ name: 'web_search' } as { name?: string; returnValue?: string }],
+      functionCalls: [
+        {
+          name: 'web_search',
+          returnValue: 'PRIVATE TOOL OUTPUT',
+          parameters: { query: 'internal corpus query' },
+        } as { name?: string; returnValue?: string; parameters?: Record<string, unknown> },
+      ],
     });
-    expect(summary).not.toContain('returnValue');
-    expect(summary).not.toContain('parameters');
+    expect(summary).not.toContain('PRIVATE TOOL OUTPUT');
+    expect(summary).not.toContain('internal corpus query');
   });
 });
 
@@ -201,16 +207,36 @@ describe('buildFeedbackSlackMessage', () => {
   });
 
   it('truncates an oversized message instead of shipping it (or silently failing to send) whole', () => {
-    const message = buildFeedbackSlackMessage({ ...base, content: 'x'.repeat(10_000) });
-    expect(message.length).toBeLessThan(3100);
+    const message = buildFeedbackSlackMessage({ ...base, content: 'x'.repeat(50_000) });
+    expect(message.length).toBeLessThan(20100);
     expect(message.endsWith('... [truncated]')).toBe(true);
   });
 
   it('does not split a UTF-16 surrogate pair when truncating', () => {
     const emoji = '\u{1F600}'; // 2 UTF-16 code units - a naive slice can land between them
-    const message = buildFeedbackSlackMessage({ ...base, content: emoji.repeat(5000) });
+    const message = buildFeedbackSlackMessage({ ...base, content: emoji.repeat(15000) });
     const withoutSuffix = message.slice(0, message.length - '... [truncated]'.length);
     const lastCode = withoutSuffix.charCodeAt(withoutSuffix.length - 1);
     expect(lastCode >= 0xd800 && lastCode <= 0xdbff).toBe(false);
+  });
+
+  it('caps each identity field independently so one oversized field cannot consume the whole message budget', () => {
+    const huge = 'x'.repeat(1000);
+    const message = buildFeedbackSlackMessage({ ...base, type: huge, username: huge, content: 'the real report' });
+    // Not truncated overall (well under MAX_MESSAGE_CHARS) - the per-field cap did the work.
+    expect(message.endsWith('... [truncated]')).toBe(false);
+    expect(message).toContain('the real report');
+    expect(message).toContain('*Prompt Meta:*');
+    const typeLine = message.split('\n').find(line => line.startsWith('*Type:*'));
+    expect(typeLine.length).toBeLessThan(220);
+  });
+
+  it('adds a CR-only line to the blockquote just like an LF (B1 regression)', () => {
+    const message = buildFeedbackSlackMessage({ ...base, content: 'harmless\r*User Email:* ceo@company.com' });
+    const feedbackLines = message.split('\n').filter(line => line.startsWith('> '));
+    expect(feedbackLines).toEqual(['> harmless', '> *User Email:* ceo@company.com']);
+    // Only the real *User Email:* line (unquoted) exists outside the blockquote.
+    const unquotedUserEmailLines = message.split('\n').filter(line => line.startsWith('*User Email:*'));
+    expect(unquotedUserEmailLines).toHaveLength(1);
   });
 });

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -161,4 +161,12 @@ describe('buildFeedbackSlackMessage', () => {
     expect(message.length).toBeLessThan(3100);
     expect(message.endsWith('... [truncated]')).toBe(true);
   });
+
+  it('does not split a UTF-16 surrogate pair when truncating', () => {
+    const emoji = '\u{1F600}'; // 2 UTF-16 code units - a naive slice can land between them
+    const message = buildFeedbackSlackMessage({ ...base, content: emoji.repeat(5000) });
+    const withoutSuffix = message.slice(0, message.length - '... [truncated]'.length);
+    const lastCode = withoutSuffix.charCodeAt(withoutSuffix.length - 1);
+    expect(lastCode >= 0xd800 && lastCode <= 0xdbff).toBe(false);
+  });
 });

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -150,6 +150,26 @@ describe('buildFeedbackSlackMessage', () => {
     expect(message.match(/&lt;@here&gt;/g)).toHaveLength(6);
   });
 
+  it('collapses newlines in the identity fields so they cannot forge a fake extra field', () => {
+    const forged = 'bug\n*User Email:* ceo@company.com\n*Feedback:*\n> fake wire instructions';
+    const message = buildFeedbackSlackMessage({ ...base, type: forged });
+    const typeLine = message.split('\n').find(line => line.startsWith('*Type:*'));
+    expect(typeLine).toBe('*Type:* bug *User Email:* ceo@company.com *Feedback:* &gt; fake wire instructions');
+    // The forged text is inline on the *Type:* line, not a fabricated standalone field line -
+    // only the ONE real line (from base.userEmail) actually starts with the *User Email:* label.
+    const userEmailLines = message.split('\n').filter(line => line.startsWith('*User Email:*'));
+    expect(userEmailLines).toHaveLength(1);
+  });
+
+  it('collapses newlines in username, userEmail, and userId the same way as type', () => {
+    const forged = 'jdoe\n*Feedback:* forged line';
+    for (const field of ['username', 'userEmail', 'userId'] as const) {
+      const message = buildFeedbackSlackMessage({ ...base, [field]: forged });
+      expect(message).not.toContain('jdoe\n*Feedback:* forged line');
+      expect(message).toContain('jdoe *Feedback:* forged line');
+    }
+  });
+
   it('includes the stage prefix ahead of the type line, unaffected by the promptMeta summary', () => {
     const message = buildFeedbackSlackMessage({ ...base, stagePrefix: '*[pr-1234]*\n', promptMeta: undefined });
     expect(message.startsWith('*[pr-1234]*\n*Type:*')).toBe(true);

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -14,7 +14,8 @@ describe('buildPromptMetaSummary', () => {
     expect(summary).toContain('Model: claude-sonnet-5');
     expect(summary).toContain('Tokens: 1234, est. cost $0.05');
     expect(summary).toContain('Finish reason: end_turn');
-    expect(summary).toContain('Tool calls: 2 (web_search, search_knowledge_base), 2 citable(s)');
+    expect(summary).toContain('Tool calls: 2 (web_search, search_knowledge_base)');
+    expect(summary).toContain('Citables: 2');
     expect(summary).toContain('Lake beliefs: 3 (support-docs)');
   });
 
@@ -31,6 +32,11 @@ describe('buildPromptMetaSummary', () => {
     expect(buildPromptMetaSummary({})).toBe('none');
   });
 
+  it('renders citables even with no functionCalls (a citation-only turn)', () => {
+    const summary = buildPromptMetaSummary({ citables: [{}, {}, {}] });
+    expect(summary).toBe('Citables: 3');
+  });
+
   it('renders a zero token count and a zero belief count (not swallowed by a truthy check)', () => {
     const summary = buildPromptMetaSummary({
       tokenUsage: { totalTokens: 0 },
@@ -43,6 +49,37 @@ describe('buildPromptMetaSummary', () => {
   it('falls back to actualTotalTokens when totalTokens is absent', () => {
     const summary = buildPromptMetaSummary({ tokenUsage: { actualTotalTokens: 42 } });
     expect(summary).toContain('Tokens: 42');
+  });
+
+  it('falls back to actualInputTokens + actualOutputTokens when neither totalTokens nor actualTotalTokens is set', () => {
+    const summary = buildPromptMetaSummary({ tokenUsage: { actualInputTokens: 100, actualOutputTokens: 23 } });
+    expect(summary).toContain('Tokens: 123');
+  });
+
+  it('renders an estimated cost even with no token total, formatted without scientific notation or long tails', () => {
+    const summary = buildPromptMetaSummary({ tokenUsage: { estimatedCost: 0.300000000000004 } });
+    expect(summary).toContain('Tokens: unknown, est. cost $0.3');
+  });
+
+  it('handles functionCalls: null and functionCalls: [] without throwing', () => {
+    expect(buildPromptMetaSummary({ functionCalls: null })).toBe('none');
+    expect(buildPromptMetaSummary({ functionCalls: [] })).toBe('Tool calls: 0');
+  });
+
+  it('caps function-call names and marks the overflow instead of truncating silently', () => {
+    const summary = buildPromptMetaSummary({
+      functionCalls: Array.from({ length: 7 }, (_, i) => ({ name: `tool_${i}` })),
+    });
+    expect(summary).toContain('Tool calls: 7 (tool_0, tool_1, tool_2, tool_3, tool_4, +2 more)');
+  });
+
+  it('caps data lake tags and marks the overflow instead of truncating silently', () => {
+    const summary = buildPromptMetaSummary({
+      context: {
+        lakeMemory: { beliefCount: 9, dataLakeTags: ['a', 'b', 'c', 'd', 'e', 'f', 'g'] },
+      },
+    });
+    expect(summary).toContain('Lake beliefs: 9 (a, b, c, d, e, +2 more)');
   });
 
   it('escapes Slack mrkdwn special characters inside the summary itself (model name, tool names, lake tags)', () => {
@@ -77,15 +114,25 @@ describe('buildFeedbackSlackMessage', () => {
     content: 'it broke',
   };
 
-  it('renders the label with an empty body for empty content', () => {
+  it('renders the label with a blockquoted body', () => {
+    const message = buildFeedbackSlackMessage(base);
+    expect(message).toContain('*Feedback:*\n> it broke\n');
+  });
+
+  it('renders the label with an empty quoted body for empty content', () => {
     const message = buildFeedbackSlackMessage({ ...base, content: '' });
-    expect(message).toContain('*Feedback:* \n');
+    expect(message).toContain('*Feedback:*\n> \n');
   });
 
   it('escapes an injection-shaped content value instead of letting it render as a live link', () => {
     const message = buildFeedbackSlackMessage({ ...base, content: '<https://evil.example/|Open record>' });
     expect(message).not.toContain('<https://evil.example/|Open record>');
     expect(message).toContain('&lt;https://evil.example/|Open record&gt;');
+  });
+
+  it('blockquotes every line of multi-line content so it cannot forge fake top-level fields', () => {
+    const message = buildFeedbackSlackMessage({ ...base, content: 'line one\n*User Email:* fake@evil.example' });
+    expect(message).toContain('> line one\n> *User Email:* fake@evil.example');
   });
 
   it('escapes username, userEmail, type, organization, and userId the same way as content', () => {
@@ -107,5 +154,11 @@ describe('buildFeedbackSlackMessage', () => {
     const message = buildFeedbackSlackMessage({ ...base, stagePrefix: '*[pr-1234]*\n', promptMeta: undefined });
     expect(message.startsWith('*[pr-1234]*\n*Type:*')).toBe(true);
     expect(message.split('*Prompt Meta:*')[1]).not.toContain('[pr-1234]');
+  });
+
+  it('truncates an oversized message instead of shipping it (or silently failing to send) whole', () => {
+    const message = buildFeedbackSlackMessage({ ...base, content: 'x'.repeat(10_000) });
+    expect(message.length).toBeLessThan(3100);
+    expect(message.endsWith('... [truncated]')).toBe(true);
   });
 });

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -94,6 +94,13 @@ describe('buildPromptMetaSummary', () => {
     expect(summary.match(/&lt;@here&gt;/g)).toHaveLength(4);
   });
 
+  it('collapses newlines in model.name so it cannot forge a fake extra field below the identity block', () => {
+    const forged = 'claude\n*User Email:* ceo@company.com';
+    const summary = buildPromptMetaSummary({ model: { name: forged } });
+    expect(summary).toBe('Model: claude *User Email:* ceo@company.com');
+    expect(summary.split('\n')).toHaveLength(1);
+  });
+
   it('never surfaces owner-only function-call fields even if a caller failed to redact them', () => {
     const summary = buildPromptMetaSummary({
       functionCalls: [{ name: 'web_search' } as { name?: string; returnValue?: string }],

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { buildFeedbackSlackMessage, buildPromptMetaSummary } from './feedbackMessage';
+
+describe('buildPromptMetaSummary', () => {
+  it('summarizes a full promptMeta into a short, readable set of signals', () => {
+    const summary = buildPromptMetaSummary({
+      model: { name: 'claude-sonnet-5' },
+      tokenUsage: { totalTokens: 1234, estimatedCost: 0.05 },
+      finishReason: 'end_turn',
+      functionCalls: [{ name: 'web_search' }, { name: 'search_knowledge_base' }],
+      citables: [{}, {}],
+      context: { lakeMemory: { beliefCount: 3, dataLakeTags: ['support-docs'] } },
+    });
+    expect(summary).toContain('Model: claude-sonnet-5');
+    expect(summary).toContain('Tokens: 1234, est. cost $0.05');
+    expect(summary).toContain('Finish reason: end_turn');
+    expect(summary).toContain('Tool calls: 2 (web_search, search_knowledge_base), 2 citable(s)');
+    expect(summary).toContain('Lake beliefs: 3 (support-docs)');
+  });
+
+  it('renders only the signals actually present', () => {
+    const summary = buildPromptMetaSummary({ model: { name: 'claude-sonnet-5' } });
+    expect(summary).toBe('Model: claude-sonnet-5');
+  });
+
+  it('returns "none" for an undefined promptMeta', () => {
+    expect(buildPromptMetaSummary(undefined)).toBe('none');
+  });
+
+  it('returns "none" for an empty promptMeta object', () => {
+    expect(buildPromptMetaSummary({})).toBe('none');
+  });
+
+  it('renders a zero token count and a zero belief count (not swallowed by a truthy check)', () => {
+    const summary = buildPromptMetaSummary({
+      tokenUsage: { totalTokens: 0 },
+      context: { lakeMemory: { beliefCount: 0 } },
+    });
+    expect(summary).toContain('Tokens: 0');
+    expect(summary).toContain('Lake beliefs: 0');
+  });
+
+  it('falls back to actualTotalTokens when totalTokens is absent', () => {
+    const summary = buildPromptMetaSummary({ tokenUsage: { actualTotalTokens: 42 } });
+    expect(summary).toContain('Tokens: 42');
+  });
+
+  it('escapes Slack mrkdwn special characters inside the summary itself (model name, tool names, lake tags)', () => {
+    const injected = '<@here>';
+    const summary = buildPromptMetaSummary({
+      model: { name: injected },
+      finishReason: injected,
+      functionCalls: [{ name: injected }],
+      context: { lakeMemory: { beliefCount: 1, dataLakeTags: [injected] } },
+    });
+    expect(summary).not.toContain('<@here>');
+    expect(summary.match(/&lt;@here&gt;/g)).toHaveLength(4);
+  });
+
+  it('never surfaces owner-only function-call fields even if a caller failed to redact them', () => {
+    const summary = buildPromptMetaSummary({
+      functionCalls: [{ name: 'web_search' } as { name?: string; returnValue?: string }],
+    });
+    expect(summary).not.toContain('returnValue');
+    expect(summary).not.toContain('parameters');
+  });
+});
+
+describe('buildFeedbackSlackMessage', () => {
+  const base = {
+    stagePrefix: '',
+    type: 'Bug',
+    organization: 'Acme',
+    username: 'jdoe',
+    userEmail: 'jdoe@example.com',
+    userId: 'user-1',
+    content: 'it broke',
+  };
+
+  it('renders the label with an empty body for empty content', () => {
+    const message = buildFeedbackSlackMessage({ ...base, content: '' });
+    expect(message).toContain('*Feedback:* \n');
+  });
+
+  it('escapes an injection-shaped content value instead of letting it render as a live link', () => {
+    const message = buildFeedbackSlackMessage({ ...base, content: '<https://evil.example/|Open record>' });
+    expect(message).not.toContain('<https://evil.example/|Open record>');
+    expect(message).toContain('&lt;https://evil.example/|Open record&gt;');
+  });
+
+  it('escapes username, userEmail, type, organization, and userId the same way as content', () => {
+    const injected = '<@here>';
+    const message = buildFeedbackSlackMessage({
+      stagePrefix: '',
+      type: injected,
+      organization: injected,
+      username: injected,
+      userEmail: injected,
+      userId: injected,
+      content: injected,
+    });
+    expect(message).not.toContain('<@here>');
+    expect(message.match(/&lt;@here&gt;/g)).toHaveLength(6);
+  });
+
+  it('includes the stage prefix ahead of the type line, unaffected by the promptMeta summary', () => {
+    const message = buildFeedbackSlackMessage({ ...base, stagePrefix: '*[pr-1234]*\n', promptMeta: undefined });
+    expect(message.startsWith('*[pr-1234]*\n*Type:*')).toBe(true);
+    expect(message.split('*Prompt Meta:*')[1]).not.toContain('[pr-1234]');
+  });
+});

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -101,6 +101,23 @@ describe('buildPromptMetaSummary', () => {
     expect(summary.split('\n')).toHaveLength(1);
   });
 
+  it.each([
+    ['finishReason', { finishReason: 'end\n*User Email:* fake' }, 'Finish reason: end *User Email:* fake'],
+    [
+      'functionCalls[].name',
+      { functionCalls: [{ name: 'web_search\n*User Email:* fake' }] },
+      'Tool calls: 1 (web_search *User Email:* fake)',
+    ],
+    [
+      'dataLakeTags[]',
+      { context: { lakeMemory: { beliefCount: 1, dataLakeTags: ['docs\n*User Email:* fake'] } } },
+      'Lake beliefs: 1 (docs *User Email:* fake)',
+    ],
+  ] as const)('collapses newlines in %s the same way as model.name', (_field, promptMeta, expectedLine) => {
+    const summary = buildPromptMetaSummary(promptMeta);
+    expect(summary.split('\n')).toContain(expectedLine);
+  });
+
   it('never surfaces owner-only function-call fields even if a caller failed to redact them', () => {
     const summary = buildPromptMetaSummary({
       functionCalls: [{ name: 'web_search' } as { name?: string; returnValue?: string }],

--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -228,7 +228,8 @@ describe('buildFeedbackSlackMessage', () => {
     expect(message).toContain('the real report');
     expect(message).toContain('*Prompt Meta:*');
     const typeLine = message.split('\n').find(line => line.startsWith('*Type:*'));
-    expect(typeLine.length).toBeLessThan(220);
+    expect(typeLine).toBeDefined();
+    expect(typeLine!.length).toBeLessThan(220);
   });
 
   it('adds a CR-only line to the blockquote just like an LF (B1 regression)', () => {
@@ -236,6 +237,23 @@ describe('buildFeedbackSlackMessage', () => {
     const feedbackLines = message.split('\n').filter(line => line.startsWith('> '));
     expect(feedbackLines).toEqual(['> harmless', '> *User Email:* ceo@company.com']);
     // Only the real *User Email:* line (unquoted) exists outside the blockquote.
+    const unquotedUserEmailLines = message.split('\n').filter(line => line.startsWith('*User Email:*'));
+    expect(unquotedUserEmailLines).toHaveLength(1);
+  });
+
+  it('blockquotes a U+2028 LINE SEPARATOR in content the same way as CR/LF (B2 regression)', () => {
+    const message = buildFeedbackSlackMessage({ ...base, content: 'harmless\u2028*User Email:* ceo@company.com' });
+    const feedbackLines = message.split('\n').filter(line => line.startsWith('> '));
+    expect(feedbackLines).toEqual(['> harmless', '> *User Email:* ceo@company.com']);
+    const unquotedUserEmailLines = message.split('\n').filter(line => line.startsWith('*User Email:*'));
+    expect(unquotedUserEmailLines).toHaveLength(1);
+  });
+
+  it('collapses a U+2028 LINE SEPARATOR in an identity field the same way as CR/LF (B2 regression)', () => {
+    const forged = 'bug\u2028*User Email:* ceo@company.com';
+    const message = buildFeedbackSlackMessage({ ...base, type: forged });
+    const typeLine = message.split('\n').find(line => line.startsWith('*Type:*'));
+    expect(typeLine).toBe('*Type:* bug *User Email:* ceo@company.com');
     const unquotedUserEmailLines = message.split('\n').filter(line => line.startsWith('*User Email:*'));
     expect(unquotedUserEmailLines).toHaveLength(1);
   });

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -1,0 +1,100 @@
+import { escapeSlackText } from '@bike4mind/services';
+
+/**
+ * Fields this module reads out of a feedback submission's (already-redacted)
+ * promptMeta. Deliberately NOT typed as PromptMeta: this is an explicit read
+ * allowlist for what a Slack summary is allowed to show, so a future field
+ * added to PromptMeta doesn't silently start flowing into a third-party
+ * workspace just because the type happens to be structurally compatible.
+ */
+export interface FeedbackPromptMetaInput {
+  model?: { name?: string };
+  tokenUsage?: { totalTokens?: number; actualTotalTokens?: number; estimatedCost?: number };
+  finishReason?: string;
+  functionCalls?: Array<{ name?: string }> | null;
+  citables?: unknown[];
+  context?: { lakeMemory?: { beliefCount?: number; dataLakeTags?: string[] } };
+}
+
+const MAX_FUNCTION_CALL_NAMES = 5;
+
+/**
+ * A short, readable summary of the diagnostic signals that matter for triaging a bug
+ * report - not a dump of the full object (unreadable, and Slack truncates long messages
+ * anyway). Uses `!== undefined` throughout: a zero token count or a zero belief count
+ * (the epic's own zero-retrieval signal, at context.lakeMemory.beliefCount) is meaningful
+ * and must not be swallowed by a truthy check.
+ */
+export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | null | undefined): string {
+  if (!promptMeta) return 'none';
+
+  const lines: string[] = [];
+
+  if (promptMeta.model?.name !== undefined) {
+    lines.push(`Model: ${escapeSlackText(promptMeta.model.name)}`);
+  }
+
+  const tokenUsage = promptMeta.tokenUsage;
+  const totalTokens = tokenUsage?.totalTokens ?? tokenUsage?.actualTotalTokens;
+  if (totalTokens !== undefined) {
+    const cost = tokenUsage?.estimatedCost !== undefined ? `, est. cost $${tokenUsage.estimatedCost}` : '';
+    lines.push(`Tokens: ${totalTokens}${cost}`);
+  }
+
+  if (promptMeta.finishReason !== undefined) {
+    lines.push(`Finish reason: ${escapeSlackText(promptMeta.finishReason)}`);
+  }
+
+  const functionCalls = promptMeta.functionCalls;
+  if (functionCalls != null) {
+    const names = functionCalls
+      .map(fc => fc.name)
+      .filter((name): name is string => name !== undefined)
+      .slice(0, MAX_FUNCTION_CALL_NAMES)
+      .map(escapeSlackText);
+    const citableCount = promptMeta.citables?.length;
+    const citablePart = citableCount !== undefined ? `, ${citableCount} citable(s)` : '';
+    lines.push(`Tool calls: ${functionCalls.length}${names.length ? ` (${names.join(', ')})` : ''}${citablePart}`);
+  }
+
+  const lakeMemory = promptMeta.context?.lakeMemory;
+  if (lakeMemory?.beliefCount !== undefined) {
+    const tags = lakeMemory.dataLakeTags?.map(escapeSlackText).join(', ');
+    lines.push(`Lake beliefs: ${lakeMemory.beliefCount}${tags ? ` (${tags})` : ''}`);
+  }
+
+  return lines.length ? lines.join('\n') : 'none';
+}
+
+export interface FeedbackSlackMessageInput {
+  /** Non-prod stage marker, e.g. `*[pr-1234]*\n`; empty string on production. */
+  stagePrefix: string;
+  type: string;
+  organization: string;
+  username: string;
+  userEmail: string;
+  userId: string;
+  /** User-supplied report text - escaped here, never interpolated raw. */
+  content: string;
+  /** Already redacted (functionCalls[].returnValue/.error stripped) by the caller. */
+  promptMeta?: FeedbackPromptMetaInput | null;
+}
+
+/**
+ * Builds the Slack mrkdwn message for a feedback report. Every user-influenced string
+ * (content, username, userEmail, type, organization, userId) is escaped via
+ * escapeSlackText before interpolation - unescaped, a value like
+ * `<https://example/|Open record>` renders as a live Slack link indistinguishable
+ * from a real one, and on the unauthenticated submission path username/userEmail/type
+ * are raw request-body values, the same exposure class as content.
+ */
+export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): string {
+  const { stagePrefix, type, organization, username, userEmail, userId, content, promptMeta } = input;
+  return (
+    `${stagePrefix}*Type:* ${escapeSlackText(type)}\n` +
+    `*User Details:* ${escapeSlackText(organization)} - ${escapeSlackText(username)} (ID: ${escapeSlackText(userId)})\n` +
+    `*User Email:* ${escapeSlackText(userEmail)}\n` +
+    `*Feedback:* ${escapeSlackText(content)}\n` +
+    `\n*Prompt Meta:* ${buildPromptMetaSummary(promptMeta)}`
+  );
+}

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -42,6 +42,14 @@ function joinWithOverflow(items: string[], max: number): string {
   return overflow > 0 ? `${shown.join(', ')}, +${overflow} more` : shown.join(', ');
 }
 
+/** `text.slice(0, max)`, but drops a trailing lone UTF-16 high surrogate rather than
+ * splitting a surrogate pair (which would render as a replacement character). */
+function truncateSafely(text: string, max: number): string {
+  const sliced = text.slice(0, max);
+  const lastCode = sliced.charCodeAt(sliced.length - 1);
+  return lastCode >= 0xd800 && lastCode <= 0xdbff ? sliced.slice(0, -1) : sliced;
+}
+
 /**
  * A short, readable summary of the diagnostic signals that matter for triaging a bug
  * report - not a dump of the full object (unreadable, and Slack truncates long messages
@@ -62,6 +70,8 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
   // actualTotalTokens is a field the completion pipeline has never actually populated (it
   // writes actualInputTokens/actualOutputTokens instead) - sum those as a further fallback so
   // a real completion's usage isn't silently dropped just because the summed field is absent.
+  // Only sums when BOTH halves are present - a lone actualInputTokens or actualOutputTokens
+  // isn't a total, and rendering it as one would misrepresent a partial number as the whole.
   const actualSum =
     tokenUsage?.actualInputTokens !== undefined && tokenUsage?.actualOutputTokens !== undefined
       ? tokenUsage.actualInputTokens + tokenUsage.actualOutputTokens
@@ -141,7 +151,9 @@ function toBlockquote(text: string): string {
  * from a real one, and on the unauthenticated submission path username/userEmail/type
  * are raw request-body values, the same exposure class as content. The result is capped
  * to MAX_MESSAGE_CHARS so an oversized field (a huge `content`, an unbounded `model.name`)
- * truncates the delivered message rather than failing to send at all.
+ * truncates the delivered message rather than failing to send at all. Prompt Meta sits last,
+ * so an oversized submission loses the diagnostic summary before it loses the identity
+ * fields or the feedback text itself - the more actionable half of the message for triage.
  */
 export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): string {
   const { stagePrefix, type, organization, username, userEmail, userId, content, promptMeta } = input;
@@ -151,5 +163,5 @@ export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): str
     `*User Email:* ${escapeSlackText(userEmail)}\n` +
     `*Feedback:*\n${toBlockquote(escapeSlackText(content))}\n` +
     `\n*Prompt Meta:* ${buildPromptMetaSummary(promptMeta)}`;
-  return message.length > MAX_MESSAGE_CHARS ? `${message.slice(0, MAX_MESSAGE_CHARS)}... [truncated]` : message;
+  return message.length > MAX_MESSAGE_CHARS ? `${truncateSafely(message, MAX_MESSAGE_CHARS)}... [truncated]` : message;
 }

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -56,16 +56,23 @@ function truncateSafely(text: string, max: number): string {
   return lastCode >= 0xd800 && lastCode <= 0xdbff ? sliced.slice(0, -1) : sliced;
 }
 
+// The full Unicode line-terminator set (CR, LF, TAB, VT, FF, NEL, LINE/PARAGRAPH SEPARATOR),
+// matching the collapse-to-single-line convention already established elsewhere in this repo
+// for the identical threat (see agentExecutor.firstIterationQuery.ts's escapePreambleFilename
+// and getFirstIterationMementosPreamble.ts's sanitizeSummary) - CR/LF alone misses TAB/VT/FF/
+// U+0085/U+2028/U+2029, which Slack's white-space: pre-wrap rendering also treats as breaks.
+const LINE_TERMINATORS = /\r\n|[\r\n\t\v\f\u0085\u2028\u2029]/g;
+
 /**
  * Every field this module interpolates onto a single labeled line (`*Label:* <value>`) goes
- * through this, never bare `escapeSlackText`. Slack mrkdwn has no escape for newlines, so an
- * unescaped one lets a value forge what reads as an extra top-level `*Label:*` line elsewhere
- * in the message - collapsing is lossless here since every caller of this helper is a
- * single-line value by nature. `content` is the one exception: it's blockquoted instead
- * (see `toBlockquote`) so its own real line breaks survive.
+ * through this, never bare `escapeSlackText`. Slack mrkdwn has no escape for line-terminator
+ * characters, so an unescaped one lets a value forge what reads as an extra top-level
+ * `*Label:*` line elsewhere in the message - collapsing is lossless here since every caller of
+ * this helper is a single-line value by nature. `content` is the one exception: it's
+ * blockquoted instead (see `toBlockquote`) so its own real line breaks survive.
  */
 function escapeLine(text: string): string {
-  return escapeSlackText(text).replace(/[\r\n]+/g, ' ');
+  return escapeSlackText(text).replace(LINE_TERMINATORS, ' ');
 }
 
 /**
@@ -80,9 +87,11 @@ function escapeIdentityField(text: string): string {
 /**
  * A short, readable summary of the diagnostic signals that matter for triaging a bug
  * report - not a dump of the full object (unreadable, and Slack truncates long messages
- * anyway). Uses `!== undefined` throughout: a zero token count or a zero belief count
- * (the epic's own zero-retrieval signal, at context.lakeMemory.beliefCount) is meaningful
- * and must not be swallowed by a truthy check.
+ * anyway). Checks `!== undefined` (or `!= null`) rather than truthiness for every numeric
+ * field: a zero token count or a zero belief count (the epic's own zero-retrieval signal,
+ * at context.lakeMemory.beliefCount) is meaningful and must not be swallowed. `citables` is
+ * the one array-presence check (`if (promptMeta.citables)`), which reads clearer and behaves
+ * the same, since an empty array is still truthy and still renders `Citables: 0`.
  */
 export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | null | undefined): string {
   if (!promptMeta) return 'none';
@@ -158,44 +167,35 @@ export interface FeedbackSlackMessageInput {
 }
 
 /**
- * Slack mrkdwn has no escape for `*`/`_`/newlines, so a multi-line `content` value could
- * otherwise inject what reads as extra top-level `*Label:*` lines into the message.
+ * Slack mrkdwn has no escape for line-terminator characters, so a multi-line `content` value
+ * could otherwise inject what reads as extra top-level `*Label:*` lines into the message.
  * Blockquoting every line (each prefixed with `> `) keeps injected lines visually nested
  * under "Feedback:" instead of sitting as siblings of the real fields above them. Splits on
- * any line-break variant (`\r\n`, bare `\r`, or `\n`) - a JSON string body can carry a bare
- * CR, and `escapeLine` already treats CR the same as LF, so this must too or a CR-only value
- * slips through unquoted.
+ * the same LINE_TERMINATORS class as `escapeLine` (CRLF kept as one break, not two).
  */
 function toBlockquote(text: string): string {
   return text
-    .split(/\r\n|\r|\n/)
+    .split(LINE_TERMINATORS)
     .map(line => `> ${line}`)
     .join('\n');
 }
 
 /**
- * Builds the Slack mrkdwn message for a feedback report. Every user-influenced string is
- * escaped before interpolation - unescaped, a value like `<https://example/|Open record>`
- * renders as a live Slack link indistinguishable from a real one. `/api/feedback` requires
- * auth, and a session-authenticated caller's `username`/`userEmail`/`userId` correctly come
- * from their own record - but an API-key-authenticated caller falls through to the raw
- * request body for those three instead (`req.isAuthenticated()` is false for API-key auth,
- * since `apiKeyAuth` sets `req.user` without a Passport login, so index.ts's `authenticated`
- * ternaries take their body-value branch), letting them put arbitrary text, including a
- * forged identity, in those fields. `type` is always the raw body value regardless of auth
- * path. The identity fields and the
- * promptMeta summary's string fields all go through escapeLine, which also collapses
- * newlines - each shares a line with its own `*Label:*`, so an unescaped newline could
- * otherwise forge a fake extra field. `content` is blockquoted instead so its own real line
- * breaks survive. Escaping leaves `*`/`_` alone (Slack has no backslash escape for them,
- * per `slackMarkup.ts`), so a crafted field can still emit inline bold/italic text - a known,
- * accepted residual, since the newline collapse and the blockquote are what keep it off its
- * own line, which is the part that actually matters. Each identity field is separately capped
- * (escapeIdentityField) and the whole result capped to MAX_MESSAGE_CHARS so an oversized field
- * (a huge `content`, an unbounded `model.name`) truncates the delivered message rather than
- * failing to send at all. Prompt Meta sits last, so an oversized submission loses the
- * diagnostic summary before it loses the identity fields or the feedback text itself - the
- * more actionable half of the message for triage.
+ * Builds the Slack mrkdwn message for a feedback report. `type` and `content` are raw request
+ * body values (`index.ts:29-36,129`); the identity fields (`username`/`userEmail`/`userId`)
+ * are resolved server-side from the caller's own record either way (JWT or API-key auth -
+ * `index.ts:76-81`) and escaped here for defense in depth, not because a specific forgery path
+ * exists. Every field is escaped before interpolation - unescaped, a value like
+ * `<https://example/|Open record>` renders as a live Slack link indistinguishable from a real
+ * one. The identity fields and the promptMeta summary's string fields all go through
+ * `escapeLine`, which also collapses line-terminator characters, since each shares a line with
+ * its own `*Label:*` and an unescaped one could otherwise forge a fake extra field; `content`
+ * is blockquoted instead so its own real line breaks survive. `*`/`_` are left unescaped (Slack
+ * has no backslash escape for them) as an accepted residual - the line-terminator collapse and
+ * the blockquote are what keep a crafted field off its own line, which is what actually
+ * matters. Each identity field is capped (`escapeIdentityField`) and the whole result capped to
+ * `MAX_MESSAGE_CHARS`, so an oversized field truncates the delivered message rather than
+ * failing to send, with Prompt Meta (least actionable for triage) truncated away first.
  */
 export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): string {
   const { stagePrefix, type, organization, username, userEmail, userId, content, promptMeta } = input;

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -9,7 +9,13 @@ import { escapeSlackText } from '@bike4mind/services';
  */
 export interface FeedbackPromptMetaInput {
   model?: { name?: string };
-  tokenUsage?: { totalTokens?: number; actualTotalTokens?: number; estimatedCost?: number };
+  tokenUsage?: {
+    totalTokens?: number;
+    actualTotalTokens?: number;
+    actualInputTokens?: number;
+    actualOutputTokens?: number;
+    estimatedCost?: number;
+  };
   finishReason?: string;
   functionCalls?: Array<{ name?: string }> | null;
   citables?: unknown[];
@@ -17,6 +23,24 @@ export interface FeedbackPromptMetaInput {
 }
 
 const MAX_FUNCTION_CALL_NAMES = 5;
+const MAX_DATA_LAKE_TAGS = 5;
+// Slack's incoming-webhook `text` has a documented ~40k character ceiling, but a crafted
+// submission pushing anywhere near that turns into a delivery failure (and the alarm noise
+// that follows) rather than just an unreadable message - cap well under it so an oversized
+// field truncates the message instead of losing it.
+const MAX_MESSAGE_CHARS = 3000;
+
+/** `$1.23e-7` / `$0.30000000000000004` -> a plain, short decimal string. */
+function formatCost(cost: number): string {
+  return String(parseFloat(cost.toFixed(4)));
+}
+
+/** Joins the first `max` items, appending a "+N more" marker for anything past that. */
+function joinWithOverflow(items: string[], max: number): string {
+  const shown = items.slice(0, max);
+  const overflow = items.length - shown.length;
+  return overflow > 0 ? `${shown.join(', ')}, +${overflow} more` : shown.join(', ');
+}
 
 /**
  * A short, readable summary of the diagnostic signals that matter for triaging a bug
@@ -35,10 +59,21 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
   }
 
   const tokenUsage = promptMeta.tokenUsage;
-  const totalTokens = tokenUsage?.totalTokens ?? tokenUsage?.actualTotalTokens;
-  if (totalTokens !== undefined) {
-    const cost = tokenUsage?.estimatedCost !== undefined ? `, est. cost $${tokenUsage.estimatedCost}` : '';
-    lines.push(`Tokens: ${totalTokens}${cost}`);
+  // actualTotalTokens is a field the completion pipeline has never actually populated (it
+  // writes actualInputTokens/actualOutputTokens instead) - sum those as a further fallback so
+  // a real completion's usage isn't silently dropped just because the summed field is absent.
+  const actualSum =
+    tokenUsage?.actualInputTokens !== undefined && tokenUsage?.actualOutputTokens !== undefined
+      ? tokenUsage.actualInputTokens + tokenUsage.actualOutputTokens
+      : undefined;
+  const totalTokens = tokenUsage?.totalTokens ?? tokenUsage?.actualTotalTokens ?? actualSum;
+  const cost = tokenUsage?.estimatedCost;
+  // Rendered whenever EITHER is present, not gated on totalTokens alone - a cost recorded
+  // without a token total (or vice versa) would otherwise silently vanish from the summary.
+  if (totalTokens !== undefined || cost !== undefined) {
+    const tokensPart = totalTokens !== undefined ? `${totalTokens}` : 'unknown';
+    const costPart = cost !== undefined ? `, est. cost $${formatCost(cost)}` : '';
+    lines.push(`Tokens: ${tokensPart}${costPart}`);
   }
 
   if (promptMeta.finishReason !== undefined) {
@@ -50,17 +85,22 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
     const names = functionCalls
       .map(fc => fc.name)
       .filter((name): name is string => name !== undefined)
-      .slice(0, MAX_FUNCTION_CALL_NAMES)
       .map(escapeSlackText);
-    const citableCount = promptMeta.citables?.length;
-    const citablePart = citableCount !== undefined ? `, ${citableCount} citable(s)` : '';
-    lines.push(`Tool calls: ${functionCalls.length}${names.length ? ` (${names.join(', ')})` : ''}${citablePart}`);
+    const namesPart = names.length ? ` (${joinWithOverflow(names, MAX_FUNCTION_CALL_NAMES)})` : '';
+    lines.push(`Tool calls: ${functionCalls.length}${namesPart}`);
+  }
+
+  // Independent of the functionCalls branch above - a citation-only turn (citables present,
+  // no functionCalls) must not silently lose this diagnostic.
+  if (promptMeta.citables?.length !== undefined) {
+    lines.push(`Citables: ${promptMeta.citables.length}`);
   }
 
   const lakeMemory = promptMeta.context?.lakeMemory;
   if (lakeMemory?.beliefCount !== undefined) {
-    const tags = lakeMemory.dataLakeTags?.map(escapeSlackText).join(', ');
-    lines.push(`Lake beliefs: ${lakeMemory.beliefCount}${tags ? ` (${tags})` : ''}`);
+    const tags = lakeMemory.dataLakeTags?.map(escapeSlackText) ?? [];
+    const tagsPart = tags.length ? ` (${joinWithOverflow(tags, MAX_DATA_LAKE_TAGS)})` : '';
+    lines.push(`Lake beliefs: ${lakeMemory.beliefCount}${tagsPart}`);
   }
 
   return lines.length ? lines.join('\n') : 'none';
@@ -74,10 +114,23 @@ export interface FeedbackSlackMessageInput {
   username: string;
   userEmail: string;
   userId: string;
-  /** User-supplied report text - escaped here, never interpolated raw. */
+  /** User-supplied report text - escaped and blockquoted here, never interpolated raw. */
   content: string;
   /** Already redacted (functionCalls[].returnValue/.error stripped) by the caller. */
   promptMeta?: FeedbackPromptMetaInput | null;
+}
+
+/**
+ * Slack mrkdwn has no escape for `*`/`_`/newlines, so a multi-line `content` value could
+ * otherwise inject what reads as extra top-level `*Label:*` lines into the message.
+ * Blockquoting every line (each prefixed with `> `) keeps injected lines visually nested
+ * under "Feedback:" instead of sitting as siblings of the real fields above them.
+ */
+function toBlockquote(text: string): string {
+  return text
+    .split('\n')
+    .map(line => `> ${line}`)
+    .join('\n');
 }
 
 /**
@@ -86,15 +139,17 @@ export interface FeedbackSlackMessageInput {
  * escapeSlackText before interpolation - unescaped, a value like
  * `<https://example/|Open record>` renders as a live Slack link indistinguishable
  * from a real one, and on the unauthenticated submission path username/userEmail/type
- * are raw request-body values, the same exposure class as content.
+ * are raw request-body values, the same exposure class as content. The result is capped
+ * to MAX_MESSAGE_CHARS so an oversized field (a huge `content`, an unbounded `model.name`)
+ * truncates the delivered message rather than failing to send at all.
  */
 export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): string {
   const { stagePrefix, type, organization, username, userEmail, userId, content, promptMeta } = input;
-  return (
+  const message =
     `${stagePrefix}*Type:* ${escapeSlackText(type)}\n` +
     `*User Details:* ${escapeSlackText(organization)} - ${escapeSlackText(username)} (ID: ${escapeSlackText(userId)})\n` +
     `*User Email:* ${escapeSlackText(userEmail)}\n` +
-    `*Feedback:* ${escapeSlackText(content)}\n` +
-    `\n*Prompt Meta:* ${buildPromptMetaSummary(promptMeta)}`
-  );
+    `*Feedback:*\n${toBlockquote(escapeSlackText(content))}\n` +
+    `\n*Prompt Meta:* ${buildPromptMetaSummary(promptMeta)}`;
+  return message.length > MAX_MESSAGE_CHARS ? `${message.slice(0, MAX_MESSAGE_CHARS)}... [truncated]` : message;
 }

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -24,11 +24,17 @@ export interface FeedbackPromptMetaInput {
 
 const MAX_FUNCTION_CALL_NAMES = 5;
 const MAX_DATA_LAKE_TAGS = 5;
-// Slack's incoming-webhook `text` has a documented ~40k character ceiling, but a crafted
-// submission pushing anywhere near that turns into a delivery failure (and the alarm noise
-// that follows) rather than just an unreadable message - cap well under it so an oversized
-// field truncates the message instead of losing it.
-const MAX_MESSAGE_CHARS = 3000;
+// This posts via a legacy incoming-webhook { text: message } payload (see postFeedbackToSlack),
+// whose ceiling is ~40k characters - not Block Kit's much lower per-text-object limit, which
+// doesn't apply here. Cap well under 40k so a crafted submission pushing toward it turns into a
+// truncated-but-delivered message (and no alarm noise) rather than a delivery failure, while
+// staying generous enough that an ordinary long bug report (pasted logs, repro steps) isn't cut.
+const MAX_MESSAGE_CHARS = 20000;
+// Each identity field is capped far below MAX_MESSAGE_CHARS so the five of them together can
+// never consume the budget content/Prompt Meta need - without this, a single oversized `type`
+// or `username` (raw body values with no length constraint of their own) could truncate away
+// the feedback text or the diagnostic summary despite being the least useful thing to keep.
+const MAX_IDENTITY_FIELD_CHARS = 200;
 
 /** `$1.23e-7` / `$0.30000000000000004` -> a plain, short decimal string. */
 function formatCost(cost: number): string {
@@ -60,6 +66,15 @@ function truncateSafely(text: string, max: number): string {
  */
 function escapeLine(text: string): string {
   return escapeSlackText(text).replace(/[\r\n]+/g, ' ');
+}
+
+/**
+ * Escapes and collapses like `escapeLine`, then caps to MAX_IDENTITY_FIELD_CHARS - for the
+ * five identity fields specifically, none of which have a length constraint at the request
+ * schema, so a single oversized one shouldn't be able to truncate content/Prompt Meta away.
+ */
+function escapeIdentityField(text: string): string {
+  return truncateSafely(escapeLine(text), MAX_IDENTITY_FIELD_CHARS);
 }
 
 /**
@@ -114,7 +129,7 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
 
   // Independent of the functionCalls branch above - a citation-only turn (citables present,
   // no functionCalls) must not silently lose this diagnostic.
-  if (promptMeta.citables?.length !== undefined) {
+  if (promptMeta.citables) {
     lines.push(`Citables: ${promptMeta.citables.length}`);
   }
 
@@ -146,11 +161,14 @@ export interface FeedbackSlackMessageInput {
  * Slack mrkdwn has no escape for `*`/`_`/newlines, so a multi-line `content` value could
  * otherwise inject what reads as extra top-level `*Label:*` lines into the message.
  * Blockquoting every line (each prefixed with `> `) keeps injected lines visually nested
- * under "Feedback:" instead of sitting as siblings of the real fields above them.
+ * under "Feedback:" instead of sitting as siblings of the real fields above them. Splits on
+ * any line-break variant (`\r\n`, bare `\r`, or `\n`) - a JSON string body can carry a bare
+ * CR, and `escapeLine` already treats CR the same as LF, so this must too or a CR-only value
+ * slips through unquoted.
  */
 function toBlockquote(text: string): string {
   return text
-    .split('\n')
+    .split(/\r\n|\r|\n/)
     .map(line => `> ${line}`)
     .join('\n');
 }
@@ -158,23 +176,33 @@ function toBlockquote(text: string): string {
 /**
  * Builds the Slack mrkdwn message for a feedback report. Every user-influenced string is
  * escaped before interpolation - unescaped, a value like `<https://example/|Open record>`
- * renders as a live Slack link indistinguishable from a real one, and on the unauthenticated
- * submission path type/username/userEmail/userId are raw request-body values, the same
- * exposure class as content. The identity fields and the promptMeta summary's string fields
- * all go through escapeLine, which also collapses newlines - each shares a line with its own
- * `*Label:*`, so an unescaped newline could otherwise forge a fake extra field. `content` is
- * blockquoted instead so its own real line breaks survive. The result is capped to
- * MAX_MESSAGE_CHARS so an oversized field (a huge `content`, an unbounded `model.name`)
- * truncates the delivered message rather than failing to send at all. Prompt Meta sits last,
- * so an oversized submission loses the diagnostic summary before it loses the identity
- * fields or the feedback text itself - the more actionable half of the message for triage.
+ * renders as a live Slack link indistinguishable from a real one. `/api/feedback` requires
+ * auth, and a session-authenticated caller's `username`/`userEmail`/`userId` correctly come
+ * from their own record - but an API-key-authenticated caller falls through to the raw
+ * request body for those three instead (`req.isAuthenticated()` is false for API-key auth,
+ * since `apiKeyAuth` sets `req.user` without a Passport login, so index.ts's `authenticated`
+ * ternaries take their body-value branch), letting them put arbitrary text, including a
+ * forged identity, in those fields. `type` is always the raw body value regardless of auth
+ * path. The identity fields and the
+ * promptMeta summary's string fields all go through escapeLine, which also collapses
+ * newlines - each shares a line with its own `*Label:*`, so an unescaped newline could
+ * otherwise forge a fake extra field. `content` is blockquoted instead so its own real line
+ * breaks survive. Escaping leaves `*`/`_` alone (Slack has no backslash escape for them,
+ * per `slackMarkup.ts`), so a crafted field can still emit inline bold/italic text - a known,
+ * accepted residual, since the newline collapse and the blockquote are what keep it off its
+ * own line, which is the part that actually matters. Each identity field is separately capped
+ * (escapeIdentityField) and the whole result capped to MAX_MESSAGE_CHARS so an oversized field
+ * (a huge `content`, an unbounded `model.name`) truncates the delivered message rather than
+ * failing to send at all. Prompt Meta sits last, so an oversized submission loses the
+ * diagnostic summary before it loses the identity fields or the feedback text itself - the
+ * more actionable half of the message for triage.
  */
 export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): string {
   const { stagePrefix, type, organization, username, userEmail, userId, content, promptMeta } = input;
   const message =
-    `${stagePrefix}*Type:* ${escapeLine(type)}\n` +
-    `*User Details:* ${escapeLine(organization)} - ${escapeLine(username)} (ID: ${escapeLine(userId)})\n` +
-    `*User Email:* ${escapeLine(userEmail)}\n` +
+    `${stagePrefix}*Type:* ${escapeIdentityField(type)}\n` +
+    `*User Details:* ${escapeIdentityField(organization)} - ${escapeIdentityField(username)} (ID: ${escapeIdentityField(userId)})\n` +
+    `*User Email:* ${escapeIdentityField(userEmail)}\n` +
     `*Feedback:*\n${toBlockquote(escapeSlackText(content))}\n` +
     `\n*Prompt Meta:* ${buildPromptMetaSummary(promptMeta)}`;
   return message.length > MAX_MESSAGE_CHARS ? `${truncateSafely(message, MAX_MESSAGE_CHARS)}... [truncated]` : message;

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -144,12 +144,30 @@ function toBlockquote(text: string): string {
 }
 
 /**
+ * type/organization/username/userEmail/userId each share a line with their own `*Label:*` -
+ * a newline in any of them would read as a fabricated extra top-level field (e.g. a fake
+ * `*User Email:*` line), the same forging risk `toBlockquote` closes for `content`. These are
+ * single-line values by nature, so collapsing rather than blockquoting is lossless.
+ */
+function toSingleLine(text: string): string {
+  return text.replace(/[\r\n]+/g, ' ');
+}
+
+/** Escapes Slack mrkdwn special characters, then collapses newlines - for the single-line
+ * identity fields, not `content` (which is blockquoted instead so its own line breaks survive). */
+function escapeIdentityField(text: string): string {
+  return toSingleLine(escapeSlackText(text));
+}
+
+/**
  * Builds the Slack mrkdwn message for a feedback report. Every user-influenced string
- * (content, username, userEmail, type, organization, userId) is escaped via
- * escapeSlackText before interpolation - unescaped, a value like
- * `<https://example/|Open record>` renders as a live Slack link indistinguishable
- * from a real one, and on the unauthenticated submission path username/userEmail/type
- * are raw request-body values, the same exposure class as content. The result is capped
+ * (content, username, userEmail, type, organization, userId) is escaped before interpolation -
+ * unescaped, a value like `<https://example/|Open record>` renders as a live Slack link
+ * indistinguishable from a real one, and on the unauthenticated submission path
+ * type/username/userEmail/userId are raw request-body values, the same exposure class as
+ * content. The five identity fields also get newlines collapsed (escapeIdentityField), since
+ * each shares a line with its own `*Label:*` and a newline could otherwise forge a fake extra
+ * field; `content` is blockquoted instead so its real line breaks survive. The result is capped
  * to MAX_MESSAGE_CHARS so an oversized field (a huge `content`, an unbounded `model.name`)
  * truncates the delivered message rather than failing to send at all. Prompt Meta sits last,
  * so an oversized submission loses the diagnostic summary before it loses the identity
@@ -158,9 +176,9 @@ function toBlockquote(text: string): string {
 export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): string {
   const { stagePrefix, type, organization, username, userEmail, userId, content, promptMeta } = input;
   const message =
-    `${stagePrefix}*Type:* ${escapeSlackText(type)}\n` +
-    `*User Details:* ${escapeSlackText(organization)} - ${escapeSlackText(username)} (ID: ${escapeSlackText(userId)})\n` +
-    `*User Email:* ${escapeSlackText(userEmail)}\n` +
+    `${stagePrefix}*Type:* ${escapeIdentityField(type)}\n` +
+    `*User Details:* ${escapeIdentityField(organization)} - ${escapeIdentityField(username)} (ID: ${escapeIdentityField(userId)})\n` +
+    `*User Email:* ${escapeIdentityField(userEmail)}\n` +
     `*Feedback:*\n${toBlockquote(escapeSlackText(content))}\n` +
     `\n*Prompt Meta:* ${buildPromptMetaSummary(promptMeta)}`;
   return message.length > MAX_MESSAGE_CHARS ? `${truncateSafely(message, MAX_MESSAGE_CHARS)}... [truncated]` : message;

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -51,6 +51,18 @@ function truncateSafely(text: string, max: number): string {
 }
 
 /**
+ * Every field this module interpolates onto a single labeled line (`*Label:* <value>`) goes
+ * through this, never bare `escapeSlackText`. Slack mrkdwn has no escape for newlines, so an
+ * unescaped one lets a value forge what reads as an extra top-level `*Label:*` line elsewhere
+ * in the message - collapsing is lossless here since every caller of this helper is a
+ * single-line value by nature. `content` is the one exception: it's blockquoted instead
+ * (see `toBlockquote`) so its own real line breaks survive.
+ */
+function escapeLine(text: string): string {
+  return escapeSlackText(text).replace(/[\r\n]+/g, ' ');
+}
+
+/**
  * A short, readable summary of the diagnostic signals that matter for triaging a bug
  * report - not a dump of the full object (unreadable, and Slack truncates long messages
  * anyway). Uses `!== undefined` throughout: a zero token count or a zero belief count
@@ -63,7 +75,7 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
   const lines: string[] = [];
 
   if (promptMeta.model?.name !== undefined) {
-    lines.push(`Model: ${escapeSlackText(promptMeta.model.name)}`);
+    lines.push(`Model: ${escapeLine(promptMeta.model.name)}`);
   }
 
   const tokenUsage = promptMeta.tokenUsage;
@@ -87,7 +99,7 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
   }
 
   if (promptMeta.finishReason !== undefined) {
-    lines.push(`Finish reason: ${escapeSlackText(promptMeta.finishReason)}`);
+    lines.push(`Finish reason: ${escapeLine(promptMeta.finishReason)}`);
   }
 
   const functionCalls = promptMeta.functionCalls;
@@ -95,7 +107,7 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
     const names = functionCalls
       .map(fc => fc.name)
       .filter((name): name is string => name !== undefined)
-      .map(escapeSlackText);
+      .map(escapeLine);
     const namesPart = names.length ? ` (${joinWithOverflow(names, MAX_FUNCTION_CALL_NAMES)})` : '';
     lines.push(`Tool calls: ${functionCalls.length}${namesPart}`);
   }
@@ -108,7 +120,7 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
 
   const lakeMemory = promptMeta.context?.lakeMemory;
   if (lakeMemory?.beliefCount !== undefined) {
-    const tags = lakeMemory.dataLakeTags?.map(escapeSlackText) ?? [];
+    const tags = lakeMemory.dataLakeTags?.map(escapeLine) ?? [];
     const tagsPart = tags.length ? ` (${joinWithOverflow(tags, MAX_DATA_LAKE_TAGS)})` : '';
     lines.push(`Lake beliefs: ${lakeMemory.beliefCount}${tagsPart}`);
   }
@@ -144,31 +156,15 @@ function toBlockquote(text: string): string {
 }
 
 /**
- * type/organization/username/userEmail/userId each share a line with their own `*Label:*` -
- * a newline in any of them would read as a fabricated extra top-level field (e.g. a fake
- * `*User Email:*` line), the same forging risk `toBlockquote` closes for `content`. These are
- * single-line values by nature, so collapsing rather than blockquoting is lossless.
- */
-function toSingleLine(text: string): string {
-  return text.replace(/[\r\n]+/g, ' ');
-}
-
-/** Escapes Slack mrkdwn special characters, then collapses newlines - for the single-line
- * identity fields, not `content` (which is blockquoted instead so its own line breaks survive). */
-function escapeIdentityField(text: string): string {
-  return toSingleLine(escapeSlackText(text));
-}
-
-/**
- * Builds the Slack mrkdwn message for a feedback report. Every user-influenced string
- * (content, username, userEmail, type, organization, userId) is escaped before interpolation -
- * unescaped, a value like `<https://example/|Open record>` renders as a live Slack link
- * indistinguishable from a real one, and on the unauthenticated submission path
- * type/username/userEmail/userId are raw request-body values, the same exposure class as
- * content. The five identity fields also get newlines collapsed (escapeIdentityField), since
- * each shares a line with its own `*Label:*` and a newline could otherwise forge a fake extra
- * field; `content` is blockquoted instead so its real line breaks survive. The result is capped
- * to MAX_MESSAGE_CHARS so an oversized field (a huge `content`, an unbounded `model.name`)
+ * Builds the Slack mrkdwn message for a feedback report. Every user-influenced string is
+ * escaped before interpolation - unescaped, a value like `<https://example/|Open record>`
+ * renders as a live Slack link indistinguishable from a real one, and on the unauthenticated
+ * submission path type/username/userEmail/userId are raw request-body values, the same
+ * exposure class as content. The identity fields and the promptMeta summary's string fields
+ * all go through escapeLine, which also collapses newlines - each shares a line with its own
+ * `*Label:*`, so an unescaped newline could otherwise forge a fake extra field. `content` is
+ * blockquoted instead so its own real line breaks survive. The result is capped to
+ * MAX_MESSAGE_CHARS so an oversized field (a huge `content`, an unbounded `model.name`)
  * truncates the delivered message rather than failing to send at all. Prompt Meta sits last,
  * so an oversized submission loses the diagnostic summary before it loses the identity
  * fields or the feedback text itself - the more actionable half of the message for triage.
@@ -176,9 +172,9 @@ function escapeIdentityField(text: string): string {
 export function buildFeedbackSlackMessage(input: FeedbackSlackMessageInput): string {
   const { stagePrefix, type, organization, username, userEmail, userId, content, promptMeta } = input;
   const message =
-    `${stagePrefix}*Type:* ${escapeIdentityField(type)}\n` +
-    `*User Details:* ${escapeIdentityField(organization)} - ${escapeIdentityField(username)} (ID: ${escapeIdentityField(userId)})\n` +
-    `*User Email:* ${escapeIdentityField(userEmail)}\n` +
+    `${stagePrefix}*Type:* ${escapeLine(type)}\n` +
+    `*User Details:* ${escapeLine(organization)} - ${escapeLine(username)} (ID: ${escapeLine(userId)})\n` +
+    `*User Email:* ${escapeLine(userEmail)}\n` +
     `*Feedback:*\n${toBlockquote(escapeSlackText(content))}\n` +
     `\n*Prompt Meta:* ${buildPromptMetaSummary(promptMeta)}`;
   return message.length > MAX_MESSAGE_CHARS ? `${truncateSafely(message, MAX_MESSAGE_CHARS)}... [truncated]` : message;

--- a/apps/client/server/integrations/slack/slack.test.ts
+++ b/apps/client/server/integrations/slack/slack.test.ts
@@ -47,6 +47,14 @@ vi.mock('@bike4mind/observability', () => ({
   Logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
 
+// feedbackMessage.ts pulls escapeSlackText from the real @bike4mind/services barrel, which
+// transitively imports @bike4mind/common (creditService etc.) - loading that against the partial
+// @bike4mind/common mock above breaks on missing exports it never needed otherwise. Stub with the
+// same escaping behavior instead; the real implementation is covered directly in feedbackMessage.test.ts.
+vi.mock('@bike4mind/services', () => ({
+  escapeSlackText: (value: string) => value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+}));
+
 vi.mock('@server/utils/cloudwatch', () => ({
   recordFeedbackDeliverySuccess: vi.fn(),
   recordFeedbackDeliveryFailure: vi.fn(),
@@ -176,7 +184,7 @@ describe('resolveFeedbackSlackRoute', () => {
 });
 
 describe('postFeedbackToSlack', () => {
-  const args = ['Bug', 'Acme', 'jdoe', 'jdoe@example.com', 'user-1', 'it broke', 'No prompt meta'] as const;
+  const args = ['Bug', 'Acme', 'jdoe', 'jdoe@example.com', 'user-1', 'it broke', undefined] as const;
 
   beforeEach(() => {
     mocks.config.STAGE = 'production';
@@ -282,15 +290,30 @@ describe('postFeedbackToSlack', () => {
     expect(result).toEqual({ outcome: 'failed', reason: 'error' });
   });
 
-  it('the non-prod stage marker never touches the redacted Prompt Meta section', async () => {
+  it('the non-prod stage marker never touches the Prompt Meta summary, and no owner-only field leaks through', async () => {
     mocks.config.STAGE = 'pr-1234';
     mocks.getSettingsMap.mockResolvedValue({
       SlackNonProdFeedbackWebhookUrl: 'https://hooks.slack.com/services/nonprod',
     });
-    await postFeedbackToSlack('Bug', 'Acme', 'jdoe', 'jdoe@example.com', 'user-1', 'it broke', 'REDACTED_BLOB');
+    // Shape mirrors what index.ts's redaction produces: functionCalls survive with `name`,
+    // but never returnValue/error (redactFunctionCallsForViewer already stripped those
+    // upstream - this asserts the summary doesn't reintroduce them another way).
+    await postFeedbackToSlack('Bug', 'Acme', 'jdoe', 'jdoe@example.com', 'user-1', 'it broke', {
+      functionCalls: [{ name: 'web_search' }],
+    });
     const [, body] = mocks.post.mock.calls[0];
     const promptMetaSection = body.text.split('*Prompt Meta:*')[1];
-    expect(promptMetaSection).toContain('REDACTED_BLOB');
+    expect(promptMetaSection).toContain('web_search');
+    expect(promptMetaSection).not.toContain('returnValue');
     expect(promptMetaSection).not.toContain('[pr-1234]');
+  });
+
+  it('escapes Slack mrkdwn special characters in every user-influenced field, not just content', async () => {
+    mocks.getSettingsMap.mockResolvedValue({ SlackFeedbackWebhookUrl: 'https://hooks.slack.com/services/feedback' });
+    const injected = '<https://evil.example/|Open record>';
+    await postFeedbackToSlack(injected, injected, injected, injected, injected, injected, undefined);
+    const [, body] = mocks.post.mock.calls[0];
+    expect(body.text).not.toContain(injected);
+    expect(body.text).toContain('&lt;https://evil.example/|Open record&gt;');
   });
 });

--- a/apps/client/server/integrations/slack/slack.test.ts
+++ b/apps/client/server/integrations/slack/slack.test.ts
@@ -295,16 +295,15 @@ describe('postFeedbackToSlack', () => {
     mocks.getSettingsMap.mockResolvedValue({
       SlackNonProdFeedbackWebhookUrl: 'https://hooks.slack.com/services/nonprod',
     });
-    // Shape mirrors what index.ts's redaction produces: functionCalls survive with `name`,
-    // but never returnValue/error (redactFunctionCallsForViewer already stripped those
-    // upstream - this asserts the summary doesn't reintroduce them another way).
+    // A caller that failed to redact still can't leak returnValue through the summary -
+    // buildPromptMetaSummary's read allowlist doesn't read that field at all.
     await postFeedbackToSlack('Bug', 'Acme', 'jdoe', 'jdoe@example.com', 'user-1', 'it broke', {
-      functionCalls: [{ name: 'web_search' }],
+      functionCalls: [{ name: 'web_search', returnValue: 'PRIVATE TOOL OUTPUT' } as { name?: string }],
     });
     const [, body] = mocks.post.mock.calls[0];
     const promptMetaSection = body.text.split('*Prompt Meta:*')[1];
     expect(promptMetaSection).toContain('web_search');
-    expect(promptMetaSection).not.toContain('returnValue');
+    expect(promptMetaSection).not.toContain('PRIVATE TOOL OUTPUT');
     expect(promptMetaSection).not.toContain('[pr-1234]');
   });
 

--- a/apps/client/server/integrations/slack/slack.ts
+++ b/apps/client/server/integrations/slack/slack.ts
@@ -10,6 +10,7 @@ import type {
 import { getSettingsMap, getSettingsValue } from '@bike4mind/utils';
 import { adminSettingsRepository } from '@bike4mind/database';
 import { buildEmailMirrorMessage, type EmailMirrorPayload } from './emailMirror';
+import { buildFeedbackSlackMessage, type FeedbackPromptMetaInput } from './feedbackMessage';
 import {
   recordFeedbackDeliverySuccess,
   recordFeedbackDeliveryFailure,
@@ -113,7 +114,7 @@ export async function postFeedbackToSlack(
   userEmail: string,
   userId: string,
   content: string,
-  promptMeta: string
+  promptMeta?: FeedbackPromptMetaInput | null
 ): Promise<FeedbackChannelDelivery> {
   try {
     const settings = await getSettingsMap({ adminSettings: adminSettingsRepository });
@@ -137,8 +138,16 @@ export async function postFeedbackToSlack(
     // Prefix non-prod posts with the stage name so a mis-pointed non-prod webhook is self-evident
     // in the receiving channel.
     const stagePrefix = route.stageClass === 'nonprod' ? `*[${Config.STAGE}]*\n` : '';
-    const message = `${stagePrefix}*Type:* ${type}\n*User Details:* ${organization} - ${username} (ID: ${userId})\n*User Email:* ${userEmail}\n*Feedback:* ${content}
-    \n*Prompt Meta:* ${promptMeta}`;
+    const message = buildFeedbackSlackMessage({
+      stagePrefix,
+      type,
+      organization,
+      username,
+      userEmail,
+      userId,
+      content,
+      promptMeta,
+    });
 
     try {
       await axios.post(


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1496" height="817" alt="Bug report modal with an injection-shaped comment and the message's real promptMeta preview" src="https://github.com/user-attachments/assets/74466ae6-9e1b-44c5-ae5e-cb7180fe018c" />
*Figure: the real "Report" modal, showing an injection-shaped comment typed into the content field alongside the message's actual promptMeta - see Additional Information for the resulting (escaped, summarized) Slack payload.*

## Description
The feedback-to-Slack notification `JSON.stringify`'d the entire `promptMeta` object (model config, token usage, performance maps, citables) into the message text, which is unreadable and likely truncated by Slack. It also interpolated `content`, `username`, `userEmail`, `type`, and `organization` unescaped, so a value like `<https://example/|Open record>` would render as a live Slack link indistinguishable from a real one. `type` and `content` are raw request body values; the identity fields are resolved server-side from the caller's own record and escaped here for defense in depth.

This replaces the raw dump with a short, readable summary (model, token usage, finish reason, tool-call/citable counts, lake-memory belief count) and escapes every user-influenced field via the existing `escapeSlackText` helper. The existing `functionCalls[].returnValue`/`.error` redaction is untouched.

Closes #1862

## Changes
- Add `feedbackMessage.ts`: a pure module building the Slack message and the `promptMeta` summary from an explicit read-allowlist type, mirroring the existing `emailMirror.ts` pattern
- `postFeedbackToSlack` now takes the redacted `promptMeta` object directly instead of a pre-stringified blob
- Escape `content`, `username`, `userEmail`, `type`, `organization`, and `userId` via `escapeSlackText` before they reach the Slack message
- Update `slack.test.ts` and `redaction.test.ts` for the new payload shape; add `feedbackMessage.test.ts` covering the summary format, escaping, and the redaction allowlist
- Collapse the full line-terminator class (matching this repo's existing convention for the same defense) on every single-line field so a crafted value can't forge a fake extra field; cap each identity field and the assembled message so one oversized field can't crowd out the rest

## Guide for Testers
The real UI surface for this fix is the "Report" option on any chat message's "More options" menu, which opens the bug/feedback modal shown in the attached screenshot - use it to submit a report and confirm it saves normally. The modal itself has no way to show what actually reaches Slack, though, so verifying the fix (the summary format and the escaping) needs a substitute webhook target:

1. In one terminal, start a tiny local listener that prints whatever it receives: `nc -l 8099` (or any tool that dumps an incoming HTTP POST body).
2. Start the app locally per the repo's normal local-dev setup, and set the `SlackNonProdFeedbackWebhookUrl` admin setting to `http://localhost:8099` (Admin Settings -> Feedback).
3. Set the `EnableFeedBackToSlack` admin setting to enabled.
4. `/api/feedback` requires an authenticated session. On a local/preview stage, get a token: `curl -X POST http://localhost:3000/api/test/create-user -H "x-e2e-cleanup-secret: <your local E2E_CLEANUP_SECRET>" -H "Content-Type: application/json" -d '{"username":"t","email":"t-e2e@test.com","name":"T","password":"TestPassword123!"}'` and copy the returned `accessToken`.
5. POST feedback with an injection-shaped `content`, using that token: `curl -X POST http://localhost:3000/api/feedback -H "Content-Type: application/json" -H "Authorization: Bearer <accessToken>" -d '{"userId":"test","content":"<https://evil.example/|Open record>","tags":[],"username":"tester","userEmail":"tester@example.com","type":"Bug","promptMeta":{"model":{"name":"claude-sonnet-5"},"tokenUsage":{"totalTokens":123},"finishReason":"end_turn"}}'`.
6. In the listener terminal, expected result: the captured request body's `text` field shows a short `*Prompt Meta:*` summary (`Model: claude-sonnet-5`, `Tokens: 123`, `Finish reason: end_turn`) instead of a raw JSON blob, and the injected `content` appears as `&lt;https://evil.example/|Open record&gt;` (escaped), never as `<https://evil.example/|Open record>` (which Slack would otherwise render as a clickable link).

What NOT to test: the email delivery channel and its HTML templating are untouched by this PR.

## Additional Information
[slack-webhook-capture.txt](https://github.com/user-attachments/files/31230526/slack-webhook-capture.txt) - the raw text a local stand-in webhook received when submitting the report shown above, confirming the escaped content and the summarized `*Prompt Meta:*` section.

## Developer Notes (Optional)
`feedbackMessage.ts`'s `FeedbackPromptMetaInput` is a hand-written read-allowlist, not `PromptMeta` itself - a future field added to `PromptMeta` won't silently start reaching Slack just because the type happens to be structurally compatible. Any future outbound Slack summary of user-influenced data can follow the same allowlist-plus-escape pattern.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc



