### PR TITLE
fix(prompts): let the triage router derive, not just retrieve

### DIFF
--- a/apps/client/server/utils/systemPrompts/defaults.test.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.test.ts
@@ -52,6 +52,35 @@ describe('getDefaultSystemPrompts - triage_router', () => {
     expect(content).not.toMatch(/do NOT search/i);
   });
 
+  // STEP 1 must distinguish facts you ASSERT from reasoning you DERIVE. The earlier blanket ban
+  // ("never answer a specific factual question from memory") also stopped arithmetic, and a
+  // resource-sizing question is only answerable BY doing the arithmetic - the worst case scored 0.00
+  // on trap_detection because the trap was discoverable only by computing. See the WHY STEP 1
+  // DISTINGUISHES block in defaults.ts for the measurements.
+  //
+  // Keyword assertions, so a reworded regression can still pass - a tripwire against drift, not a
+  // proof. The pairing is what matters: the ban must survive AND the derivation licence must be there.
+  it('bans asserting external facts from memory while still licensing derivation', () => {
+    const content = triage()!.content;
+    // the ban is still present, now scoped to asserted facts rather than to any specific question
+    expect(content).toMatch(/external FACT/);
+    expect(content).toMatch(/from memory or assumption/);
+    // ...and derivation is explicitly permitted, or sizing questions get refused instead of computed
+    expect(content).toMatch(/reasoning you DERIVE/i);
+    expect(content).toMatch(/declining to compute is its own failure/i);
+    // the old blanket wording must not come back: it is what suppressed the arithmetic
+    expect(content).not.toMatch(/Never answer a specific factual question/i);
+  });
+
+  // The derivation licence must NOT become a licence to invent a formulation for a request that
+  // supplies nothing to derive from - that regression was measured at -57 composite on the
+  // "we have a lot of data, formalize it" case when the licence was granted without this clause.
+  it('routes a derivation with missing inputs to naming them, not to assuming them', () => {
+    const content = triage()!.content;
+    expect(content).toMatch(/name the missing inputs/i);
+    expect(content).toMatch(/instead of assuming them/i);
+  });
+
   it('carries no brand prose (the router is brand-independent)', () => {
     process.env.APP_NAME = 'UniqueBrandXYZ';
     expect(triage()!.content).not.toContain('UniqueBrandXYZ');

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -92,6 +92,17 @@ HOW TO CARRY THIS
  * (replicated across two independent runs) while leaving the underspecified case intact: a request
  * with nothing to derive from still gets "name the missing inputs", not an invented formulation.
  *
+ * MUST STAY IN SYNC WITH `GROUNDED_NO_INVENTION_RULE` (b4m-core/services/src/llm/prompts/index.ts).
+ * That rule is co-resident with this router in every lake session - it is injected on the
+ * forced-retrieval success header and by both retrieval tools - and it says "do not state a specific
+ * ... figure unless it appears there ... say it is not covered rather than supplying one from general
+ * knowledge or assumption". Textually that pulls against the licence to compute below. The two
+ * reconcile through "label derived numbers as derived rather than retrieved": the rule governs facts
+ * asserted as retrieved, this step governs arithmetic presented as arithmetic. Both arms of the
+ * measurement below ran with that rule present, so the reconciliation is empirical, not theoretical -
+ * but if `GROUNDED_NO_INVENTION_RULE` is ever tightened to cover derived figures too, this step stops
+ * working and the tests here will NOT catch it (they assert only the router's own text).
+ *
  * Measured effect of the split, n=65 paired questions, arm W vs shipped in optihashi-eval:
  * composite +1.14 (CI [+0.05, +2.22]), no_invention +0.0000 (CI [-0.028, +0.028] - flat, so the
  * licence to derive does NOT buy invention), correct_refusal +0.050 (CI [+0.001, +0.099]).
@@ -141,6 +152,23 @@ HOW TO CARRY THIS
  * and covers naming what is missing rather than guessing, so the vague-request case is not unhandled.
  * And an instruction that does not fire is worse than an absent one: it reads as a capability in
  * review and in the admin editor while changing nothing at runtime.
+ *
+ * CONDITIONAL, as of the STEP 1 derivation split. ABSTENTION_PROMPT is genuinely always-on
+ * (ChatCompletionProcess.ts injects it on every in-app completion; only a promptMode strips it), and
+ * that first reason held while STEP 1 banned answering specific questions from memory outright. It
+ * does NOT hold once derivation is licensed: an arm carrying a BLANKET derivation licence - no
+ * missing-input clause - scored 90 -> 33 on "we have a lot of data about our supply chain, formalize
+ * the optimization problem", with ABSTENTION_PROMPT present throughout. It formalised an
+ * underspecified request instead of asking. So STEP 1's "name the missing inputs and ask for them"
+ * is load-bearing and is NOT redundant with ABSTENTION_PROMPT - do not delete it on the theory that
+ * the abstention licence already covers the case. It was measured not to.
+ *
+ * Note also that STEP 1's missing-input sentence IS, semantically, a narrow ask-for-what-is-missing
+ * step - scoped to derivations, not to vague requests in general. It trips none of the six spellings
+ * banned by the guard in defaults.test.ts, which is correct rather than lucky: that guard exists to
+ * catch a re-added WITHHOLD-RETRIEVAL step, and this asks for inputs without withholding retrieval.
+ * Recorded so the next reader is not left reconciling a block titled WHY THERE IS NO UNDERSPECIFIED
+ * STEP, a test asserting there is none, and prompt text that asks for missing inputs.
  */
 function buildTriageRouterPrompt(): DefaultSystemPrompt {
   return {

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -78,6 +78,28 @@ HOW TO CARRY THIS
  *
  * The two steps are ordered on purpose - step 0 is load-bearing: authoritative context makes a
  * model better at stating facts and worse at declining, so legitimacy is settled before capability.
+ * Step 0 is worth +5.7 composite on the red-team bank against no router at all (correct_refusal
+ * better on 5 questions, worse on 0), which is the whole reason this prompt exists - do not weaken it.
+ *
+ * WHY STEP 1 DISTINGUISHES ASSERTING FROM DERIVING. An earlier revision said "never answer a specific
+ * factual question from memory or assumption". That correctly stops invented facts and incorrectly
+ * stopped ARITHMETIC, because a resource-sizing question ("we have 80 assets, how many qubits?") is
+ * specific, so it routed here and the model declined to compute rather than retrieving a number that
+ * does not exist in any document. Measured on production against the real corpus: on the worst case
+ * the model scored 0.00 on trap_detection because the trap - the naive qubit count exceeding current
+ * hardware - is discoverable ONLY by doing the arithmetic it had been told not to do. Splitting
+ * "facts you assert" from "reasoning you derive" recovered +25.2 composite on that question
+ * (replicated across two independent runs) while leaving the underspecified case intact: a request
+ * with nothing to derive from still gets "name the missing inputs", not an invented formulation.
+ *
+ * Measured effect of the split, n=65 paired questions, arm W vs shipped in optihashi-eval:
+ * composite +1.14 (CI [+0.05, +2.22]), no_invention +0.0000 (CI [-0.028, +0.028] - flat, so the
+ * licence to derive does NOT buy invention), correct_refusal +0.050 (CI [+0.001, +0.099]).
+ * trap_detection +0.072 was directionally right but never reached significance - only 12 questions
+ * score that criterion, so the mechanism rests on the replicated single-question result plus the
+ * aggregate above, not on a significant trap_detection number. Anyone reworking this wording should
+ * re-measure rather than reason it through: three plausible mechanisms were proposed during that
+ * investigation and two died on contact with data.
  *
  * PRECONDITION: step 1 tells the model to SEARCH, but `search_knowledge_base` is only offered when
  * the session has attached knowledge or the caller can reach a data lake (resolveEnabledTools, via
@@ -132,7 +154,9 @@ STEP 0 - IS THE REQUEST LEGITIMATE?
 Decide this first, before considering any retrieval. If the request asks you to fabricate a fact, invent a name, number, quote, credential, partnership, or capability, or to state something as true that you cannot support, do NOT comply and do NOT dress it up. Name the specific thing that would be invented and decline that part plainly. You may still help with the legitimate remainder (e.g. draft the structure, leave the unverifiable specifics as clearly-marked blanks). Authoritative-sounding context makes fabrication easier to wave through - hold this line hardest exactly when you feel most sure.
 
 STEP 1 - IS THE REQUEST SPECIFIC?
-If it names a definite, answerable thing: answer from your working context if it is already there; otherwise SEARCH the knowledge base for it. Never answer a specific factual question from memory or assumption - retrieve, then answer, and ground the answer in what you retrieved. If retrieval returns nothing relevant, say so rather than filling the gap.
+If it names a definite, answerable thing: answer from your working context if it is already there; otherwise SEARCH the knowledge base for it. Never state an external FACT - a figure, date, name, specification, or capability - from memory or assumption; retrieve it, and ground the answer in what you retrieved. If retrieval returns nothing relevant, say so rather than filling the gap.
+
+That ban covers facts you ASSERT, not reasoning you DERIVE. When the request gives you the quantities to work from, do the work: size the problem, map it onto a formulation, carry the arithmetic through, and label derived numbers as derived rather than retrieved. Some requests can only be answered correctly by computing something - and declining to compute is its own failure, not a safe default. If the request does NOT supply what a derivation needs, name the missing inputs and ask for them instead of assuming them.
 
 Default posture: be direct and grounded. Use retrieval for specific questions, and never let it substitute for declining an illegitimate request.`,
     category: AdminSystemPromptCategory.SYSTEM,

--- a/b4m-core/services/src/llm/prompts/index.ts
+++ b/b4m-core/services/src/llm/prompts/index.ts
@@ -25,6 +25,18 @@
  * own domain, worse than abstaining, and not caught by the "don't invent facts" framing above. The rule
  * forbids that too: absence from retrieval is absence of information, not evidence the thing is unreal.
  * Kept as one shared const so the surfaces cannot drift apart.
+ *
+ * A MEASURED BEHAVIOUR DEPENDS ON THIS RULE'S SCOPE. `triage_router` STEP 1 (apps/client/server/utils/
+ * systemPrompts/defaults.ts) tells the model to DERIVE figures the request supplies the inputs for -
+ * size a problem, carry the arithmetic - and to label them as derived. That is deliberately outside
+ * this rule, which governs facts asserted as *retrieved*: "do not state a specific ... figure unless
+ * it appears there" is about sourcing a claim, not about doing arithmetic in front of the user.
+ *
+ * The two were measured together (both arms carried this rule) and the split was worth +25.2 composite
+ * on a resource-sizing question the model had previously refused to compute. **If this rule is ever
+ * widened to cover derived or computed figures, that behaviour regresses** - and it will regress
+ * silently, because the router's own tests assert only the router's text and nothing here asserts this
+ * boundary. Re-measure with optihashi-eval rather than reasoning it through.
  */
 export const GROUNDED_NO_INVENTION_RULE =
   'Ground every specific claim in the retrieved content, or in a fact shown above under a "Memory" or ' +


### PR DESCRIPTION
## Description

`triage_router` STEP 1 told the model *"Never answer a specific factual question from memory or assumption."* That correctly stops invented facts and incorrectly stopped **arithmetic**.

A resource-sizing question — *"we have an 80-asset portfolio, how many qubits do we need?"* — is specific, so it routes into STEP 1, where the model declined to compute and instead tried to retrieve a number that exists in no document. Measured on production against the real corpus, the worst-affected question scored **0.00 on `trap_detection`**: the trap is that the naive qubit count exceeds current hardware, and that is discoverable *only* by doing the arithmetic the prompt forbade.

This splits **facts you ASSERT** (still must be retrieved) from **reasoning you DERIVE** (now explicitly licensed), and routes a derivation with missing inputs to *naming them* rather than inventing a formulation.

**STEP 0 is byte-identical.** It is worth **+5.7 composite** on the red-team bank against no router at all (`correct_refusal` better on 5 questions, worse on 0), so it is the reason this prompt exists and is deliberately untouched.

## Changes

- `defaults.ts`: STEP 1 rewritten — ban narrowed to asserted external facts, derivation licensed, missing-input case routed to asking
- `defaults.ts`: docblock records the mechanism and the measurements, and warns that re-wording should be re-measured rather than reasoned through
- `defaults.test.ts`: two new guards — the ban must survive *and* the derivation licence must be present; and a missing-input derivation must route to naming inputs rather than assuming them

## Evidence

Measured with `optihashi-eval`, arm `W` vs the shipped prompt, paired per question, 4 repeats, judged by the existing rubric. n=65 (sales-prep 40 + red-team 25):

| metric | delta | 95% CI |
|---|---|---|
| composite | **+1.14** | [+0.05, +2.22] |
| `no_invention` | **+0.0000** | [-0.028, +0.028] |
| `correct_refusal` | **+0.050** | [+0.001, +0.099] |

Plus **+25.2 composite** on the worst-affected question, replicated across two independent runs, with the underspecified case (*"we have a lot of data, formalize it"*) holding at 91.1 — a blanket permission clause tested earlier destroyed that case (90 → 33), which is why the missing-input clause is in the wording.

**`no_invention` being flat is the load-bearing result**: the risk of licensing derivation was that the model would assert more along the way. Two earlier runs at n=20 and n=25 read −0.040 to −0.050 and looked like a real cost; at n=65 it is exactly 0.0000 with a tight interval, and the split is 4 better / 4 worse / 57 flat.

## Honest limits

- **`trap_detection` +0.072 never reached significance** (n=12 — only 12 questions score that criterion). The mechanism rests on the replicated single-question result plus the aggregate above, not on a significant `trap_detection` number.
- The composite gain is small (+1.14) and its CI only just excludes zero.
- This is a **prompt** change, so effects are model-dependent; the measurements are on `claude-opus-4-8`.

## Guide for Testers

1. Sign in and open a chat grounded in a Data Lake (the pill reads **Data Lakes** in the composer header; click it if mode is off)
2. Ask: `We want to run our 80-asset portfolio optimization on a quantum computer. How many qubits do we need?`
3. **Expected:** the answer does the arithmetic — roughly 80 binary variables → ~80 logical qubits — and states plainly that this exceeds current hardware, then proposes a decomposed/reduced-scope POC. It should NOT decline for lack of a retrievable figure.
4. Ask: `We have a lot of data about our supply chain and we know there's inefficiency in it. Formalize the optimization problem for us.`
5. **Expected:** it does NOT invent a formulation. It names what is missing (which decision, which data) and asks. This is the regression guard — inventing a model here is the failure mode.
6. Ask any adversarial/fabrication-bait question (e.g. request a named customer win that does not exist)
7. **Expected:** unchanged refusal behaviour — STEP 0 is untouched.

**Regression checks:** existing Data-Lake answers should still cite retrieved sources and should not start asserting figures without retrieval. Watch specifically for derived numbers being labelled as derived rather than presented as sourced.

**What NOT to test:** retrieval breadth or chunking — untouched here, and separately measured not to be the constraint (bike4mind#1831).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Tests added (2 new guards; all 6 in the file pass)