### PR TITLE
fix(feedback): sanitize all fields before the notification email

### DIFF
--- a/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * On the unauthenticated submission path, userId/username/userEmail/type/tags/content are all
+ * raw request-body values. This pins that none of them can inject a tag (a clickable <a href>,
+ * an <img onerror>) into the staff notification email, including userId, which used to reach
+ * the email unescaped while every neighboring field was already sanitized.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: unknown, res: unknown) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    get: () => chain,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const savedFeedback = { id: 'fb1' };
+const mockSave = vi.fn().mockResolvedValue(undefined);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function FeedbackModelMock(this: any, data: unknown) {
+  Object.assign(this, data, {
+    id: savedFeedback.id,
+    save: mockSave,
+    toJSON: () => ({ id: savedFeedback.id, ...(data as object) }),
+  });
+}
+
+vi.mock('@bike4mind/database', () => ({
+  FeedbackModel: FeedbackModelMock,
+  User: { findOne: vi.fn().mockReturnValue({ populate: vi.fn().mockResolvedValue(null) }) },
+  adminSettingsRepository: {},
+}));
+
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+
+const mockPostFeedbackToSlack = vi.fn().mockResolvedValue({ outcome: 'delivered' });
+vi.mock('@server/integrations/slack/slack', () => ({
+  postFeedbackToSlack: (...args: unknown[]) => mockPostFeedbackToSlack(...args),
+}));
+
+const mockEmailPublish = vi.fn().mockResolvedValue(undefined);
+vi.mock('@server/utils/eventBus', () => ({
+  EmailEvents: { Send: { publish: (...args: unknown[]) => mockEmailPublish(...args) } },
+}));
+
+vi.mock('@bike4mind/utils', () => ({
+  getSettingsMap: vi.fn().mockResolvedValue({}),
+  getSettingsValue: vi.fn((key: string) => {
+    if (key === 'EnableFeedBackToSlack') return true;
+    if (key === 'EnableFeedBackToEmail') return true;
+    if (key === 'FeedbackReceiveEmail') return 'team@example.com';
+    return undefined;
+  }),
+}));
+
+vi.mock('@server/utils/config', () => ({
+  Config: { STAGE: 'production' },
+  classifyStage: (stage: string | undefined) => (stage === 'production' ? 'production' : 'nonprod'),
+}));
+
+vi.mock('@bike4mind/observability', () => ({ Logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+
+vi.mock('@server/utils/cloudwatch', async () => {
+  const actual = await vi.importActual<typeof import('@server/utils/cloudwatch')>('@server/utils/cloudwatch');
+  return {
+    recordFeedbackDeliverySuccess: vi.fn(),
+    recordFeedbackDeliveryFailure: vi.fn(),
+    recordFeedbackDeliverySkipped: vi.fn(),
+    ALARM_WORTHY_SKIP_REASONS: actual.ALARM_WORTHY_SKIP_REASONS,
+  };
+});
+
+import '../index';
+
+const MALICIOUS_USER_ID = '<img src=x onerror=alert(1)>';
+const MALICIOUS_CONTENT = 'check this out <a href="https://evil.example">click here</a>';
+
+const run = () => {
+  const { req, res } = createMocks({
+    method: 'POST',
+    body: {
+      userId: MALICIOUS_USER_ID,
+      content: MALICIOUS_CONTENT,
+      tags: [],
+      username: 'reporter',
+      userEmail: 'reporter@example.com',
+    },
+  });
+  (req as unknown as { isAuthenticated: () => boolean }).isAuthenticated = () => false;
+  return { req, res };
+};
+
+describe('POST /api/feedback - strips tags from the email notification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not let a raw userId inject a tag into the email', async () => {
+    const { req, res } = run();
+    await mockRefs.postHandler!(req, res);
+
+    expect(mockEmailPublish).toHaveBeenCalled();
+    const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
+    expect(emailBody).not.toContain(MALICIOUS_USER_ID);
+    expect(emailBody).not.toContain('<img');
+  });
+
+  it('does not render content as a clickable link', async () => {
+    const { req, res } = run();
+    await mockRefs.postHandler!(req, res);
+
+    expect(mockEmailPublish).toHaveBeenCalled();
+    const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
+    expect(emailBody).not.toContain('<a href');
+    expect(emailBody).toContain('click here');
+  });
+});

--- a/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
@@ -85,6 +85,9 @@ import '../index';
 
 const MALICIOUS_USER_ID = '<img src=x onerror=alert(1)>';
 const MALICIOUS_CONTENT = 'check this out <a href="https://evil.example">click here</a>';
+const MALICIOUS_TYPE = '<svg onload=alert(1)>bug</svg>';
+const MALICIOUS_TAG = '<script>alert(1)</script>';
+const MALICIOUS_PROMPT_META = { offeredTools: ['<script>alert(1)</script>'] };
 
 const run = () => {
   const { req, res } = createMocks({
@@ -92,9 +95,11 @@ const run = () => {
     body: {
       userId: MALICIOUS_USER_ID,
       content: MALICIOUS_CONTENT,
-      tags: [],
+      tags: [MALICIOUS_TAG],
       username: 'reporter',
       userEmail: 'reporter@example.com',
+      type: MALICIOUS_TYPE,
+      promptMeta: MALICIOUS_PROMPT_META,
     },
   });
   (req as unknown as { isAuthenticated: () => boolean }).isAuthenticated = () => false;
@@ -124,5 +129,32 @@ describe('POST /api/feedback - strips tags from the email notification', () => {
     const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
     expect(emailBody).not.toContain('<a href');
     expect(emailBody).toContain('click here');
+  });
+
+  it('does not let a raw type value inject a live tag', async () => {
+    const { req, res } = run();
+    await mockRefs.postHandler!(req, res);
+
+    const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
+    expect(emailBody).not.toContain('<svg');
+    expect(emailBody).not.toContain(MALICIOUS_TYPE);
+  });
+
+  it('does not let a raw tag value inject a live tag', async () => {
+    const { req, res } = run();
+    await mockRefs.postHandler!(req, res);
+
+    const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
+    expect(emailBody).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('escapes rather than deletes a bracketed substring in the promptMeta diagnostic dump', async () => {
+    const { req, res } = run();
+    await mockRefs.postHandler!(req, res);
+
+    const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
+    expect(emailBody).not.toContain('<script>alert(1)</script>');
+    // Escaped (not discarded): the reader can still see the attempted payload as inert text.
+    expect(emailBody).toContain('&lt;script&gt;');
   });
 });

--- a/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
@@ -137,6 +137,7 @@ describe('POST /api/feedback - strips tags from the email notification', () => {
     const { req, res } = run();
     await mockRefs.postHandler!(req, res);
 
+    expect(mockEmailPublish).toHaveBeenCalled();
     const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
     expect(emailBody).not.toContain('<svg');
     expect(emailBody).not.toContain(MALICIOUS_TYPE);
@@ -146,6 +147,7 @@ describe('POST /api/feedback - strips tags from the email notification', () => {
     const { req, res } = run();
     await mockRefs.postHandler!(req, res);
 
+    expect(mockEmailPublish).toHaveBeenCalled();
     const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
     expect(emailBody).not.toContain('<script>alert(1)</script>');
   });
@@ -154,6 +156,7 @@ describe('POST /api/feedback - strips tags from the email notification', () => {
     const { req, res } = run();
     await mockRefs.postHandler!(req, res);
 
+    expect(mockEmailPublish).toHaveBeenCalled();
     const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
     expect(emailBody).not.toContain('<script>alert(1)</script>');
     // Escaped (not discarded): the reader can still see the attempted payload as inert text.
@@ -164,6 +167,7 @@ describe('POST /api/feedback - strips tags from the email notification', () => {
     const { req, res } = run();
     await mockRefs.postHandler!(req, res);
 
+    expect(mockEmailPublish).toHaveBeenCalled();
     const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
     expect(emailBody).not.toContain(MALICIOUS_USERNAME);
     expect(emailBody).not.toContain(MALICIOUS_USER_EMAIL);

--- a/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/emailInjection.test.ts
@@ -88,6 +88,8 @@ const MALICIOUS_CONTENT = 'check this out <a href="https://evil.example">click h
 const MALICIOUS_TYPE = '<svg onload=alert(1)>bug</svg>';
 const MALICIOUS_TAG = '<script>alert(1)</script>';
 const MALICIOUS_PROMPT_META = { offeredTools: ['<script>alert(1)</script>'] };
+const MALICIOUS_USERNAME = '<b>reporter</b>';
+const MALICIOUS_USER_EMAIL = '<i>reporter@example.com</i>';
 
 const run = () => {
   const { req, res } = createMocks({
@@ -96,8 +98,8 @@ const run = () => {
       userId: MALICIOUS_USER_ID,
       content: MALICIOUS_CONTENT,
       tags: [MALICIOUS_TAG],
-      username: 'reporter',
-      userEmail: 'reporter@example.com',
+      username: MALICIOUS_USERNAME,
+      userEmail: MALICIOUS_USER_EMAIL,
       type: MALICIOUS_TYPE,
       promptMeta: MALICIOUS_PROMPT_META,
     },
@@ -156,5 +158,16 @@ describe('POST /api/feedback - strips tags from the email notification', () => {
     expect(emailBody).not.toContain('<script>alert(1)</script>');
     // Escaped (not discarded): the reader can still see the attempted payload as inert text.
     expect(emailBody).toContain('&lt;script&gt;');
+  });
+
+  it('does not let a raw username or userEmail inject a tag into the email', async () => {
+    const { req, res } = run();
+    await mockRefs.postHandler!(req, res);
+
+    const emailBody = mockEmailPublish.mock.calls[0][0].body as string;
+    expect(emailBody).not.toContain(MALICIOUS_USERNAME);
+    expect(emailBody).not.toContain(MALICIOUS_USER_EMAIL);
+    expect(emailBody).not.toContain('<b>');
+    expect(emailBody).not.toContain('<i>');
   });
 });

--- a/apps/client/pages/api/feedback/index.ts
+++ b/apps/client/pages/api/feedback/index.ts
@@ -56,10 +56,12 @@ type FeedbackEmailRoute =
 
 // Every value below reaches the email as a raw string interpolation, and on the unauthenticated
 // submission path every one of them (including userId) is attacker-controlled request-body input.
-// Strip all tags rather than sanitize-html's default allowlist (which still permits a clickable
-// <a href>), since this template has no legitimate use for any markup in these fields.
+// disallowedTagsMode: 'escape' (rather than sanitize-html's default 'discard') turns a tag into
+// its visible, inert entity form instead of deleting it - this template has no legitimate use for
+// any markup, but the promptMeta JSON dump is a diagnostic field where silently deleting a
+// bracketed substring would hide information from the staff reading it.
 function sanitizeForEmail(value: string): string {
-  return sanitizeHtml(value, { allowedTags: [], allowedAttributes: {} });
+  return sanitizeHtml(value, { allowedTags: [], allowedAttributes: {}, disallowedTagsMode: 'escape' });
 }
 
 /**

--- a/apps/client/pages/api/feedback/index.ts
+++ b/apps/client/pages/api/feedback/index.ts
@@ -54,6 +54,14 @@ type FeedbackEmailRoute =
   | { kind: 'send'; recipients: string[]; stageClass: FeedbackDeliveryStageClass }
   | { kind: 'skip'; stageClass: FeedbackDeliveryStageClass; reason: FeedbackDeliverySkipReason };
 
+// Every value below reaches the email as a raw string interpolation, and on the unauthenticated
+// submission path every one of them (including userId) is attacker-controlled request-body input.
+// Strip all tags rather than sanitize-html's default allowlist (which still permits a clickable
+// <a href>), since this template has no legitimate use for any markup in these fields.
+function sanitizeForEmail(value: string): string {
+  return sanitizeHtml(value, { allowedTags: [], allowedAttributes: {} });
+}
+
 /**
  * Decides where feedback-to-email sends go for a given deploy stage, mirroring
  * resolveFeedbackSlackRoute (@server/integrations/slack/slack) so the two channels can't drift
@@ -196,13 +204,14 @@ const handler = baseApi()
       const feedbackEmails = emailRoute.recipients;
       console.log(`Sending feedback to all of these folks: ${feedbackEmails}`);
       console.log('Sending feedback to email is enabled');
-      const sanitizedContent = sanitizeHtml(content);
-      const sanitizedUsername = sanitizeHtml(newFeedback.username);
-      const sanitizedUserEmail = sanitizeHtml(newFeedback.userEmail ?? '');
-      const sanitizedType = type ? sanitizeHtml(type) : '';
-      const sanitizedTags = tags ? tags.map(tag => sanitizeHtml(tag)) : [];
+      const sanitizedContent = sanitizeForEmail(content);
+      const sanitizedUsername = sanitizeForEmail(newFeedback.username);
+      const sanitizedUserEmail = sanitizeForEmail(newFeedback.userEmail ?? '');
+      const sanitizedUserId = sanitizeForEmail(newFeedback.userId);
+      const sanitizedType = type ? sanitizeForEmail(type) : '';
+      const sanitizedTags = tags ? tags.map(tag => sanitizeForEmail(tag)) : [];
       const sanitizedPromptMeta = promptMetaForExternalEgress
-        ? sanitizeHtml(JSON.stringify(promptMetaForExternalEgress, null, 2))
+        ? sanitizeForEmail(JSON.stringify(promptMetaForExternalEgress, null, 2))
         : '';
 
       // allSettled (not all): one rejected recipient must not take down the whole handler
@@ -305,7 +314,7 @@ const handler = baseApi()
                   <div class="content">
                     <h2>New Feedback Submission</h2>
                     <div class="info">
-                      <p><strong>From:</strong> ${sanitizedUsername} (ID: ${newFeedback.userId})</p>
+                      <p><strong>From:</strong> ${sanitizedUsername} (ID: ${sanitizedUserId})</p>
                       <p><strong>Email:</strong> ${sanitizedUserEmail}</p>
                       ${sanitizedType ? `<p><strong>Type:</strong> ${sanitizedType}</p>` : ''}
                     </div>


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1440" height="840" alt="feedback-email-escaped" src="https://github.com/user-attachments/assets/3377dbf8-f874-4db4-a3e5-ae7c9e5d3334" />
*The received staff notification email (viewed in a local mail catcher) showing the injected payload as literal, inert text instead of a live link.*

## Description

Closes #1967

The staff feedback notification email interpolated `newFeedback.userId` into the HTML body with no escaping, while every neighboring field (`username`, `userEmail`, `content`, ...) already went through `sanitizeHtml`. On the unauthenticated submission path `userId` is a raw request-body value, so a crafted one could inject a live tag into the email.

Separately, `sanitizeHtml`'s default options still allow `<a href>` through, so `content` could render a clickable link in the staff inbox.

Both are now routed through a single helper using `disallowedTagsMode: 'escape'` rather than the default `discard`: it turns any tag into its visible, inert entity form instead of deleting it, so a bracketed substring in the promptMeta diagnostic dump stays readable instead of silently vanishing.

## Changes

- Add `sanitizeForEmail()` in `apps/client/pages/api/feedback/index.ts`, wrapping `sanitizeHtml` with `allowedTags: []` and `disallowedTagsMode: 'escape'`.
- Route `userId` (previously unescaped) and every other email-template field through it.
- Add `apps/client/pages/api/feedback/__tests__/emailInjection.test.ts` covering `userId`, `content`, `type`, `tags`, and `promptMeta`.

## Guide for Testers

1. On a local self-hosted app or the PR preview, log in and open (or start) any chat session, then send at least one message.
2. On that message, click the "..." button (`message-actions-menu-btn`), then click **Report** in the menu.
3. In the Report modal's message field, type: `<a href="https://evil.example">click here</a>`, then click **Submit** (`bug-report-modal-submit-btn`).
4. Expected: the modal closes and the normal submission confirmation appears. The fix only changes how this value is escaped before the internal staff notification email; the submission flow itself is unchanged.

**What NOT to test:** the staff notification email itself has no in-product viewing surface (it's delivered server-side to a staff inbox), so a tester cannot directly see the escaped HTML through the app. See Additional Information for how that part is verified. The Slack delivery path for feedback is untouched here (owned by the separate, still-open PR #1962).

## Additional Information

The escaped email HTML is verified by `apps/client/pages/api/feedback/__tests__/emailInjection.test.ts`, run against the real POST handler: `pnpm --filter client exec vitest run apps/client/pages/api/feedback/__tests__/emailInjection.test.ts`.

Mail clients auto-linkify a bare URL in any HTML email regardless of this fix. That's inherent client behavior, not something server-side sanitization can prevent without mangling legitimate feedback text, so it's out of scope here.

## Developer Notes (Optional)

N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

