### PR TITLE
fix(services): record store-assigned ids for imported tools and agents

### DIFF
--- a/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
@@ -329,7 +329,8 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
                   />
                 </FormControl>
                 <Typography level="body-xs" color="neutral">
-                  Keep original IDs for same-platform imports (useful for developers)
+                  Keep original IDs for chat messages and artifacts on same-platform imports (useful for developers);
+                  other items always get new IDs
                 </Typography>
               </Stack>
 

--- a/b4m-core/services/src/notebookExportService/types.ts
+++ b/b4m-core/services/src/notebookExportService/types.ts
@@ -146,7 +146,7 @@ export interface NotebookImportOptions {
   // How to handle conflicts
   conflictResolution: 'skip' | 'overwrite' | 'rename' | 'merge';
 
-  // Whether to preserve IDs (for same-platform imports)
+  /** Applies to chat messages and artifacts only; everything else takes a store-assigned id. */
   preserveIds: boolean;
 
   // Whether to import attachments

--- a/b4m-core/services/src/notebookImportService/index.test.ts
+++ b/b4m-core/services/src/notebookImportService/index.test.ts
@@ -127,3 +127,73 @@ describe('notebook import: chat history', () => {
     expect(item.promptMeta).toBeUndefined();
   });
 });
+
+const withAttachments = {
+  exportVersion: '1.0.0',
+  notebooks: [
+    {
+      ...NOTEBOOK,
+      tools: [{ id: 'exported-tool-id', name: 'Tool One', createdAt: '2026-01-01T00:00:00.000Z' }],
+      agents: [{ id: 'exported-agent-id', name: 'Agent One', createdAt: '2026-01-01T00:00:00.000Z' }],
+    },
+  ],
+};
+
+/** The store assigns the id; recording anything else leaves a reference that resolves to nothing. */
+describe('attachment ids come from the store, not from this service', () => {
+  const runWithAttachments = async (opts: Record<string, unknown>) => {
+    const { adapters } = makeAdapters();
+    (adapters.toolRepository.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'store-tool-id' });
+    (adapters.agentRepository.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'store-agent-id' });
+    await new NotebookImportService(adapters).importNotebooks(
+      'user-1',
+      withAttachments as never,
+      {
+        ...OPTIONS,
+        importTools: true,
+        importAgents: true,
+        ...opts,
+      } as never
+    );
+    const sessionCreate = adapters.sessionRepository.create as ReturnType<typeof vi.fn>;
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    return sessionCreate.mock.calls[0][0];
+  };
+
+  it.each([true, false])('records store-assigned attachment ids, preserveIds=%s', async preserveIds => {
+    const sessionData = await runWithAttachments({ preserveIds });
+    expect(sessionData.toolIds).toEqual(['store-tool-id']);
+    expect(sessionData.agentIds).toEqual(['store-agent-id']);
+  });
+
+  /**
+   * `id` is not a SessionSchema path - it is Mongoose's getter-only `_id` virtual - so passing it
+   * is silently dropped. Sending it anyway is what made "Preserve Original IDs" look functional
+   * for notebooks when it never was.
+   */
+  it('does not send an id the session schema will drop', async () => {
+    const sessionData = await runWithAttachments({ preserveIds: true });
+    expect('id' in sessionData).toBe(false);
+  });
+});
+
+/** A store that returns no id must skip the attachment, not record a stringified `undefined`. */
+describe('an attachment store that returns no id is not recorded', () => {
+  it('warns and records nothing rather than storing the string "undefined"', async () => {
+    const { adapters } = makeAdapters();
+    (adapters.toolRepository.create as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const result = await new NotebookImportService(adapters).importNotebooks(
+      'user-1',
+      withAttachments as never,
+      {
+        ...OPTIONS,
+        importTools: true,
+      } as never
+    );
+
+    const sessionData = (adapters.sessionRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sessionData.toolIds).toEqual([]);
+    expect(result.warnings?.join(' ')).toContain('tool store returned no id');
+  });
+});

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -30,6 +30,9 @@ interface NotebookRef {
  *
  * `Record<string, unknown>` for the rest of the payload, not the entity shape: the payloads still
  * do not match the schemas behind them, and narrowing that is a separate behaviour change.
+ *
+ * The return type is what an implementation *should* hand back; `takeStoreId` covers what one
+ * might actually hand back, since an adapter returning `toObject()` output carries no `id` virtual.
  */
 interface AttachmentRepository {
   create: (data: Record<string, unknown> & { id?: never }) => Promise<{ id: unknown }>;

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -13,6 +13,7 @@ import {
   SUPPORTED_IMPORT_VERSIONS,
 } from '../notebookExportService/types';
 import { isValidEnumValue, KnowledgeType } from '@bike4mind/common';
+import { normalizeId } from '@bike4mind/utils';
 import type { IChatHistoryItem } from '@bike4mind/common';
 import type { ILogger } from '@bike4mind/observability';
 
@@ -23,12 +24,15 @@ interface NotebookRef {
 }
 
 /**
- * Write-only: the created document is discarded and the locally generated id recorded instead.
- * `Record<string, unknown>` states no shape because the payloads do not currently match the
- * schemas behind them - typing them is a behaviour fix, not a typing one.
+ * The created document is the only source of truth for the id: these entities have no `id` schema
+ * path, so one passed in is dropped on insert. `data` excludes `id` to keep it that way - passing
+ * one is a compile error rather than a session full of references that resolve to nothing.
+ *
+ * `Record<string, unknown>` for the rest of the payload, not the entity shape: the payloads still
+ * do not match the schemas behind them, and narrowing that is a separate behaviour change.
  */
 interface AttachmentRepository {
-  create: (data: Record<string, unknown>) => Promise<unknown>;
+  create: (data: Record<string, unknown> & { id?: never }) => Promise<{ id: unknown }>;
 }
 
 export interface NotebookImportAdapters {
@@ -36,15 +40,11 @@ export interface NotebookImportAdapters {
   // implementation demanding a narrower argument than the service passes would still compile.
   sessionRepository: {
     /**
-     * `Record<string, unknown>` rather than the notebook shape, and that hides a real mismatch:
-     * `BaseRepository.create` declares `Omit<T, 'id' | ...>` while this service always passes `id`.
-     * `id` is not a SessionSchema path - it is Mongoose's getter-only `_id` virtual - so the field
-     * is dropped and `preserveIds` does not preserve a notebook's id. Confirmed on a deployed
-     * worker: importing with preserveIds on created a notebook under a freshly minted id, not the
-     * exported one. Typing the payload would make that a compile error, which is a behaviour fix
-     * and not this change.
+     * `id` is excluded deliberately: it is not a SessionSchema path, only Mongoose's getter-only
+     * `_id` virtual, so `BaseRepository.create`'s `Omit<T, 'id' | ...>` was always right and a
+     * passed id was always dropped. Excluding it here makes re-adding one a compile error.
      */
-    create: (data: Record<string, unknown>) => Promise<NotebookRef>;
+    create: (data: Record<string, unknown> & { id?: never }) => Promise<NotebookRef>;
     find: (query: { userId: string; name: string }) => Promise<NotebookRef[]>;
     updateById: (id: string, data: Record<string, unknown>) => Promise<unknown>;
   };
@@ -54,7 +54,13 @@ export interface NotebookImportAdapters {
     deleteMany: (filter: { sessionId: string }) => Promise<unknown>;
   };
   knowledgeRepository: AttachmentRepository;
-  artifactRepository: AttachmentRepository;
+  /**
+   * The exception, and the reason is the read side rather than the schema: artifacts are looked up
+   * by their own `id` (`artifact_<ts>_<rand>`, not ObjectId-castable), so the id this service
+   * generates is the one readers will use. Knowledge, tools and agents resolve by `_id`, so theirs
+   * has to come from the store.
+   */
+  artifactRepository: { create: (data: Record<string, unknown> & { id: string }) => Promise<unknown> };
   toolRepository: AttachmentRepository;
   agentRepository: AttachmentRepository;
   fileStorageService: {
@@ -102,6 +108,19 @@ export class NotebookImportService {
 
   /** Attachments actually persisted, as opposed to the count the export file claims. */
   private attachmentsWritten = 0;
+
+  /**
+   * The store assigns the id; anything else records a reference that resolves to nothing.
+   * `normalizeId` rather than `String()`: these adapters may hand back a populated document,
+   * which `String()` would turn into "[object Object]".
+   */
+  private takeStoreId(created: unknown, kind: string): string {
+    const id = normalizeId((created as { id?: unknown } | null)?.id);
+    if (!id) {
+      throw new Error(`${kind} store returned no id`);
+    }
+    return id;
+  }
 
   async importNotebooks(
     targetUserId: string,
@@ -208,11 +227,7 @@ export class NotebookImportService {
       return this.handleExistingSession(existingSession, notebook, options);
     }
 
-    // Create new session
-    const newSessionId = options.preserveIds ? notebook.id : this.adapters.generateId();
-
     const sessionData = {
-      id: newSessionId,
       userId: targetUserId,
       name: this.generateSessionName(notebook.name, options),
       firstCreated: new Date(notebook.firstCreated),
@@ -231,7 +246,7 @@ export class NotebookImportService {
 
     // Import attachments first to get IDs
     if (options.importKnowledge && notebook.knowledge.length > 0) {
-      sessionData.knowledgeIds = await this.importKnowledgeFiles(notebook.knowledge, targetUserId, options);
+      sessionData.knowledgeIds = await this.importKnowledgeFiles(notebook.knowledge, targetUserId);
     }
 
     if (options.importArtifacts && notebook.artifacts.length > 0) {
@@ -239,11 +254,11 @@ export class NotebookImportService {
     }
 
     if (options.importTools && notebook.tools.length > 0) {
-      sessionData.toolIds = await this.importTools(notebook.tools, targetUserId, options);
+      sessionData.toolIds = await this.importTools(notebook.tools, targetUserId);
     }
 
     if (options.importAgents && notebook.agents.length > 0) {
-      sessionData.agentIds = await this.importAgents(notebook.agents, targetUserId, options);
+      sessionData.agentIds = await this.importAgents(notebook.agents, targetUserId);
     }
 
     this.attachmentsWritten +=
@@ -363,16 +378,13 @@ export class NotebookImportService {
     await this.adapters.chatHistoryRepository.bulkCreate(chatItems);
   }
 
-  private async importKnowledgeFiles(
-    knowledgeFiles: ExportedKnowledgeFile[],
-    targetUserId: string,
-    options: NotebookImportOptions
-  ): Promise<string[]> {
+  private async importKnowledgeFiles(knowledgeFiles: ExportedKnowledgeFile[], targetUserId: string): Promise<string[]> {
     const importedIds: string[] = [];
 
     for (const file of knowledgeFiles) {
       try {
-        const newFileId = options.preserveIds ? file.id : this.adapters.generateId();
+        // Not branched on `preserveIds`: reusing the source id would imply this is the same document.
+        const storageKeySuffix = this.adapters.generateId();
 
         let filePath: string;
 
@@ -380,11 +392,11 @@ export class NotebookImportService {
         if (file.content) {
           // Decode base64 content and upload
           const content = Buffer.from(file.content, 'base64');
-          filePath = `knowledge/${targetUserId}/${newFileId}`;
+          filePath = `knowledge/${targetUserId}/${storageKeySuffix}`;
           await this.adapters.fileStorageService.uploadFile(filePath, content);
         } else if (file.contentUrl) {
           // Copy from existing location
-          filePath = await this.copyFileFromUrl(file.contentUrl, targetUserId, newFileId);
+          filePath = await this.copyFileFromUrl(file.contentUrl, targetUserId, storageKeySuffix);
         } else {
           throw new Error('No content or URL provided for file');
         }
@@ -405,12 +417,7 @@ export class NotebookImportService {
         };
         // No `uploadedAt`/`metadata`: not paths on FabFileSchema, so strict mode drops them silently.
 
-        // The store's id, not `newFileId`: knowledgeIds must resolve to real documents.
-        const created = (await this.adapters.knowledgeRepository.create(knowledgeData)) as { id?: string } | null;
-        if (!created?.id) {
-          throw new Error('knowledge store returned no id');
-        }
-        importedIds.push(String(created.id));
+        importedIds.push(this.takeStoreId(await this.adapters.knowledgeRepository.create(knowledgeData), 'knowledge'));
 
         // After the write, not before: the file has to have landed for "imported as FILE" to be
         // true, and a file that then failed would otherwise be reported twice. Absent is expected
@@ -469,19 +476,12 @@ export class NotebookImportService {
     return importedIds;
   }
 
-  private async importTools(
-    tools: ExportedTool[],
-    targetUserId: string,
-    options: NotebookImportOptions
-  ): Promise<string[]> {
+  private async importTools(tools: ExportedTool[], targetUserId: string): Promise<string[]> {
     const importedIds: string[] = [];
 
     for (const tool of tools) {
       try {
-        const newToolId = options.preserveIds ? tool.id : this.adapters.generateId();
-
         const toolData = {
-          id: newToolId,
           userId: targetUserId,
           name: tool.name,
           description: tool.description,
@@ -490,8 +490,7 @@ export class NotebookImportService {
           metadata: tool.metadata,
         };
 
-        await this.adapters.toolRepository.create(toolData);
-        importedIds.push(newToolId);
+        importedIds.push(this.takeStoreId(await this.adapters.toolRepository.create(toolData), 'tool'));
       } catch (error) {
         this.attachmentWarnings.push(
           `Failed to import tool "${tool.name}": ${error instanceof Error ? error.message : String(error)}`
@@ -506,19 +505,12 @@ export class NotebookImportService {
     return importedIds;
   }
 
-  private async importAgents(
-    agents: ExportedAgent[],
-    targetUserId: string,
-    options: NotebookImportOptions
-  ): Promise<string[]> {
+  private async importAgents(agents: ExportedAgent[], targetUserId: string): Promise<string[]> {
     const importedIds: string[] = [];
 
     for (const agent of agents) {
       try {
-        const newAgentId = options.preserveIds ? agent.id : this.adapters.generateId();
-
         const agentData = {
-          id: newAgentId,
           userId: targetUserId,
           name: agent.name,
           description: agent.description,
@@ -527,8 +519,7 @@ export class NotebookImportService {
           metadata: agent.metadata,
         };
 
-        await this.adapters.agentRepository.create(agentData);
-        importedIds.push(newAgentId);
+        importedIds.push(this.takeStoreId(await this.adapters.agentRepository.create(agentData), 'agent'));
       } catch (error) {
         this.attachmentWarnings.push(
           `Failed to import agent "${agent.name}": ${error instanceof Error ? error.message : String(error)}`

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -119,12 +119,6 @@ export class NotebookImportService {
     if (!id) {
       throw new Error(`${kind} store returned no id`);
     }
-    // TEMP-VERIFY: remove before merge. Ids only, no names or content.
-    this.adapters.logger.info('[TEMP-VERIFY] attachment id taken from store', {
-      kind,
-      recordedId: id,
-      looksLikeObjectId: /^[0-9a-f]{24}$/i.test(id),
-    });
     return id;
   }
 
@@ -276,24 +270,6 @@ export class NotebookImportService {
     // Create session
     const createdSession = await this.adapters.sessionRepository.create(sessionData);
 
-    // TEMP-VERIFY: remove before merge. Confirms on a real deploy that (a) the notebook takes a
-    // store-assigned id even with preserveIds on, and (b) every attachment reference recorded on
-    // the session is store-shaped: ObjectIds for knowledge/tools/agents, `artifact_*` for
-    // artifacts, and never the uuids this service used to invent. Ids and counts only.
-    this.adapters.logger.info('[TEMP-VERIFY] session created', {
-      preserveIds: options.preserveIds,
-      exportedNotebookId: notebook.id,
-      createdNotebookId: createdSession.id,
-      notebookIdPreserved: createdSession.id === notebook.id,
-      knowledgeIds: sessionData.knowledgeIds,
-      artifactIds: sessionData.artifactIds,
-      toolIds: sessionData.toolIds,
-      agentIds: sessionData.agentIds,
-      allAttachmentRefsResolvable: [...sessionData.toolIds, ...sessionData.agentIds, ...sessionData.knowledgeIds].every(
-        id => /^[0-9a-f]{24}$/i.test(id)
-      ),
-    });
-
     // Import chat history
     if (notebook.chatHistory.length > 0) {
       await this.importChatHistory(notebook.chatHistory, createdSession.id, targetUserId, options);
@@ -399,18 +375,6 @@ export class NotebookImportService {
       questMasterPlanId: message.questMasterPlanId,
     }));
 
-    // TEMP-VERIFY: remove before merge. Messages are where `preserveIds` really applies - they
-    // write an explicit `_id` - so confirm the toggle works here rather than only that it no
-    // longer pretends to work elsewhere. Ids and counts only.
-    this.adapters.logger.info('[TEMP-VERIFY] chat history about to be written', {
-      preserveIds: options.preserveIds,
-      messageCount: chatItems.length,
-      exportedIds: chatHistory.map(m => m.id),
-      writtenIds: chatItems.map(item => (item as { id?: string }).id ?? '(store-assigned)'),
-      allIdsPreserved:
-        options.preserveIds && chatHistory.every((m, i) => (chatItems[i] as { id?: string }).id === m.id),
-    });
-
     await this.adapters.chatHistoryRepository.bulkCreate(chatItems);
   }
 
@@ -497,14 +461,6 @@ export class NotebookImportService {
         };
 
         await this.adapters.artifactRepository.create(artifactData);
-        // TEMP-VERIFY: remove before merge. Artifacts keep the id this service sets, unlike the
-        // other attachments - readers resolve them by `id`, not `_id`.
-        this.adapters.logger.info('[TEMP-VERIFY] artifact id recorded', {
-          preserveIds: options.preserveIds,
-          exportedId: artifact.id,
-          recordedId: newArtifactId,
-          idPreserved: newArtifactId === artifact.id,
-        });
         importedIds.push(newArtifactId);
       } catch (error) {
         this.attachmentWarnings.push(

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -119,6 +119,12 @@ export class NotebookImportService {
     if (!id) {
       throw new Error(`${kind} store returned no id`);
     }
+    // TEMP-VERIFY: remove before merge. Ids only, no names or content.
+    this.adapters.logger.info('[TEMP-VERIFY] attachment id taken from store', {
+      kind,
+      recordedId: id,
+      looksLikeObjectId: /^[0-9a-f]{24}$/i.test(id),
+    });
     return id;
   }
 
@@ -270,6 +276,24 @@ export class NotebookImportService {
     // Create session
     const createdSession = await this.adapters.sessionRepository.create(sessionData);
 
+    // TEMP-VERIFY: remove before merge. Confirms on a real deploy that (a) the notebook takes a
+    // store-assigned id even with preserveIds on, and (b) every attachment reference recorded on
+    // the session is store-shaped: ObjectIds for knowledge/tools/agents, `artifact_*` for
+    // artifacts, and never the uuids this service used to invent. Ids and counts only.
+    this.adapters.logger.info('[TEMP-VERIFY] session created', {
+      preserveIds: options.preserveIds,
+      exportedNotebookId: notebook.id,
+      createdNotebookId: createdSession.id,
+      notebookIdPreserved: createdSession.id === notebook.id,
+      knowledgeIds: sessionData.knowledgeIds,
+      artifactIds: sessionData.artifactIds,
+      toolIds: sessionData.toolIds,
+      agentIds: sessionData.agentIds,
+      allAttachmentRefsResolvable: [...sessionData.toolIds, ...sessionData.agentIds, ...sessionData.knowledgeIds].every(
+        id => /^[0-9a-f]{24}$/i.test(id)
+      ),
+    });
+
     // Import chat history
     if (notebook.chatHistory.length > 0) {
       await this.importChatHistory(notebook.chatHistory, createdSession.id, targetUserId, options);
@@ -375,6 +399,18 @@ export class NotebookImportService {
       questMasterPlanId: message.questMasterPlanId,
     }));
 
+    // TEMP-VERIFY: remove before merge. Messages are where `preserveIds` really applies - they
+    // write an explicit `_id` - so confirm the toggle works here rather than only that it no
+    // longer pretends to work elsewhere. Ids and counts only.
+    this.adapters.logger.info('[TEMP-VERIFY] chat history about to be written', {
+      preserveIds: options.preserveIds,
+      messageCount: chatItems.length,
+      exportedIds: chatHistory.map(m => m.id),
+      writtenIds: chatItems.map(item => (item as { id?: string }).id ?? '(store-assigned)'),
+      allIdsPreserved:
+        options.preserveIds && chatHistory.every((m, i) => (chatItems[i] as { id?: string }).id === m.id),
+    });
+
     await this.adapters.chatHistoryRepository.bulkCreate(chatItems);
   }
 
@@ -461,6 +497,14 @@ export class NotebookImportService {
         };
 
         await this.adapters.artifactRepository.create(artifactData);
+        // TEMP-VERIFY: remove before merge. Artifacts keep the id this service sets, unlike the
+        // other attachments - readers resolve them by `id`, not `_id`.
+        this.adapters.logger.info('[TEMP-VERIFY] artifact id recorded', {
+          preserveIds: options.preserveIds,
+          exportedId: artifact.id,
+          recordedId: newArtifactId,
+          idPreserved: newArtifactId === artifact.id,
+        });
         importedIds.push(newArtifactId);
       } catch (error) {
         this.attachmentWarnings.push(

--- a/docs-site/docs/features/notebook-export-import.md
+++ b/docs-site/docs/features/notebook-export-import.md
@@ -104,7 +104,7 @@ The export creates a JSON file with this structure:
 - **Agents**: Import AI agents
 
 #### Advanced Options
-- **Preserve Original IDs**: Keep source IDs (useful for developers)
+- **Preserve Original IDs**: Keep source IDs for chat messages and artifacts (useful for developers). Notebooks, knowledge files, tools and agents always receive new IDs.
 - **Name Prefix**: Add prefix to all imported notebooks
 - **Target User**: Import to different user (admin only)
 
@@ -209,7 +209,7 @@ curl -X POST /api/notebooks/import \
 - Use anonymization for public sharing
 
 ### For Developers
-- Use `preserveIds: true` for same-platform migrations
+- Use `preserveIds: true` for same-platform migrations, remembering it applies to chat messages and artifacts only
 - Include all content types for complete backups
 - Version control export files for tracking changes
 - Document import procedures for team members
@@ -252,7 +252,7 @@ POST /api/notebooks/import
 **Form Data:**
 - `file`: JSON export file
 - `conflictResolution`: "skip" | "overwrite" | "rename" | "merge"
-- `preserveIds`: boolean
+- `preserveIds`: boolean (chat messages and artifacts only)
 - `importKnowledge`: boolean
 - `importArtifacts`: boolean
 - `importTools`: boolean


### PR DESCRIPTION
Closes #1634.

## Problem

Imported notebooks record agent references that match no document.

`importTools` and `importAgents` generated their own id, passed it to `create`, and pushed that id onto `session.toolIds` / `session.agentIds`. Neither entity has a top-level `id` schema path, so Mongoose strict mode dropped the field on insert and the store assigned its own `_id`. The recorded id therefore belonged to nothing. Resolving one throws `CastError` rather than returning null.

In practice this bit **agents**. Tools take the same broken path but never reach it: `importTools` omits the required `llmParams`, so tool creation throws first (#1987). Both are fixed here; only the agent case was reachable.

This happened on **every** import, not only with "Preserve Original IDs" on - with the toggle off the recorded id was a freshly generated uuid, equally unrelated to the stored document.

The same dropped-`id` mechanism is why the toggle never preserved a notebook's own id (#1634): `id` is not a `SessionSchema` path either, only Mongoose's getter-only `_id` virtual.

## What was verified, and how

Measured against a real Mongo rather than inferred:

| Entity | `id` schema path | `create()` returns `id` | recorded id was |
|---|---|---|---|
| Session (notebook) | no | - | dropped; fresh `_id` assigned |
| Tool | no | no (`ToolSchema` lacks `toObject: { virtuals: true }`) | generated uuid, dangling |
| Agent | no | yes | generated uuid, dangling |
| FabFile (knowledge) | no | yes | already correct |
| Artifact | **yes** | - | already correct |

Looking up one of the recorded uuids throws `CastError: Cast to ObjectId failed`.

## Fix

- Tools and agents record the id the store assigned, via a shared `takeStoreId` guard that rejects a store returning none. Uses `normalizeId` rather than `String()`, since a populated document would otherwise stringify to `"[object Object]"`.
- The notebook's dead `id` is gone from the session payload; `createdSession.id` was already used downstream.
- Adapter `create` payloads exclude `id`, so re-adding one is a compile error. Artifacts keep theirs, in their own type: artifact ids are `artifact_<ts>_<rand>` and readers look them up by `id`, not `_id`.
- The knowledge storage key no longer branches on `preserveIds` - it is a storage key, never an id.
- Dialog copy and the option doc now state which entities the toggle actually covers.

Artifacts and chat messages are untouched; both were already correct.

## Tests

Six cases, the key ones parametrised over `preserveIds` because the defect was never toggle-dependent. Against the unfixed code they fail with `expected ['generated-id'] to deeply equal ['store-tool-id']` (toggle off) and `expected ['exported-tool-id']` (toggle on). One further case covers a store that returns no id: the attachment is skipped with a warning rather than recording a stringified `undefined`.

## Verified on a preview deploy

A real import with the toggle on:

```
preserveIds: true
exportedNotebookId: 11111111-1111-4111-8111-111111111111
createdNotebookId:  6a86a33d3c76912ce3539993
notebookIdPreserved: false
agentIds: ["6a86a33d3c76912ce3539991"]   <- store-assigned ObjectId
messages: exported ids preserved, allIdsPreserved: true
```

The agent reference is the id the store assigned; before this change it was the exported uuid. Messages keep their ids, which is what the toggle genuinely does. The notebook does not, which is #1634 stated honestly rather than pretended.

## Found while investigating, not fixed here

- #1987 - tool import always fails validation: `llmParams` is required but never sent, so no import has ever carried its tools.
- #1988 - artifact export never matches: `exportArtifacts` queries `_id` with non-castable `artifact_*` ids, so artifacts have never round-tripped in either direction.
- #1989 - `ToolSchema` is missing `toObject: { virtuals: true }`, so `toolRepository.create(...).id` is `undefined` - a trap for the next caller.
