### PR TITLE
fix(api-keys): require ADMIN scope on four admin credit endpoints

### DIFF
--- a/apps/client/pages/api/admin/organizations/[id]/__tests__/top-up.test.ts
+++ b/apps/client/pages/api/admin/organizations/[id]/__tests__/top-up.test.ts
@@ -73,8 +73,11 @@ describe('POST /api/admin/organizations/[id]/top-up', () => {
   });
 
   it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
-    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
-    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+    // Pins the whole config object, not just requiredScopes - a sibling `auth: false`
+    // would skip baseApi's entire api-key chain (baseApi.ts's `if (resolvedOptions.auth)`)
+    // and disable this gate while leaving requiredScopes untouched.
+    const config = (handler as unknown as { _config?: unknown })._config;
+    expect(config).toEqual({ requiredScopes: [ApiKeyScope.ADMIN] });
   });
 
   it('rejects a non-admin', async () => {

--- a/apps/client/pages/api/admin/organizations/[id]/__tests__/top-up.test.ts
+++ b/apps/client/pages/api/admin/organizations/[id]/__tests__/top-up.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ApiKeyScope } from '@bike4mind/common';
+
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: (config?: unknown) => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'POST']?.(req, res),
+      {
+        use: () => chain,
+        post: (fn: (req: unknown, res: unknown) => unknown) => ((h.POST = fn), chain),
+        _config: config,
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+}));
+
+const mockAddCredits = vi.fn();
+vi.mock('@bike4mind/services', () => ({
+  creditService: { addCredits: (...a: unknown[]) => mockAddCredits(...a) },
+}));
+
+const mockOrgFindById = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  creditLotRepository: {},
+  creditTransactionRepository: {},
+  organizationRepository: { findById: (...a: unknown[]) => mockOrgFindById(...a) },
+  withTransaction: (fn: (session: unknown) => Promise<unknown>) => fn(undefined),
+}));
+
+vi.mock('@server/websocket/utils', () => ({ sendToClient: vi.fn() }));
+vi.mock('@server/utils/auditLog', () => ({
+  AdminOrgAuditEvents: { ORG_TOPPED_UP: 'org_topped_up' },
+  logAuditEvent: vi.fn(),
+}));
+vi.mock('sst', () => ({ Resource: { websocket: { managementEndpoint: 'ws-endpoint' } } }));
+
+import handler from '../top-up';
+
+function call(options: { isAdmin?: boolean; body?: object; id?: string }) {
+  const { req, res } = createMocks({
+    method: 'POST',
+    query: { id: options.id ?? 'org-1' },
+    body: options.body ?? { credits: 100, idempotencyKey: 'idem-key-12345' },
+  });
+  (req as unknown as { user: { isAdmin: boolean; id: string; username: string } }).user = {
+    isAdmin: options.isAdmin ?? true,
+    id: 'admin-1',
+    username: 'admin',
+  };
+  (req as unknown as { logger: unknown }).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+describe('POST /api/admin/organizations/[id]/top-up', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrgFindById.mockResolvedValue({ id: 'org-1', userId: 'owner-1' });
+    mockAddCredits.mockResolvedValue(undefined);
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
+  it('rejects a non-admin', async () => {
+    const { run } = call({ isAdmin: false });
+    await expect(run()).rejects.toThrow(/[Aa]dmin/);
+    expect(mockAddCredits).not.toHaveBeenCalled();
+  });
+
+  it('grants credits to the organization for an admin', async () => {
+    const { res, run } = call({});
+    await run();
+    expect(mockAddCredits).toHaveBeenCalled();
+    expect(res._getJSONData()).toMatchObject({ organizationId: 'org-1', creditsAdded: 100 });
+  });
+});

--- a/apps/client/pages/api/admin/organizations/[id]/top-up.ts
+++ b/apps/client/pages/api/admin/organizations/[id]/top-up.ts
@@ -7,7 +7,7 @@ import {
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 import { ForbiddenError } from '@server/utils/errors';
 import { creditService } from '@bike4mind/services';
-import { CreditHolderType } from '@bike4mind/common';
+import { ApiKeyScope, CreditHolderType } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { sendToClient } from '@server/websocket/utils';
@@ -33,7 +33,11 @@ interface RequestQuery {
   id: string;
 }
 
-const handler = baseApi().post(
+// requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+// before req.user is set, so a key issued for a narrow integration can't grant
+// org credits just because its owner is an admin. JWT/browser admins skip that
+// check and still pass the isAdmin gate below.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).post(
   asyncHandler(async (req, res) => {
     if (!req.user?.isAdmin) {
       throw new ForbiddenError('Unauthorized. Admin access required.');

--- a/apps/client/pages/api/admin/organizations/__tests__/grant.test.ts
+++ b/apps/client/pages/api/admin/organizations/__tests__/grant.test.ts
@@ -79,8 +79,11 @@ describe('POST /api/admin/organizations/grant', () => {
   });
 
   it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
-    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
-    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+    // Pins the whole config object, not just requiredScopes - a sibling `auth: false`
+    // would skip baseApi's entire api-key chain (baseApi.ts's `if (resolvedOptions.auth)`)
+    // and disable this gate while leaving requiredScopes untouched.
+    const config = (handler as unknown as { _config?: unknown })._config;
+    expect(config).toEqual({ requiredScopes: [ApiKeyScope.ADMIN] });
   });
 
   it('rejects a non-admin', async () => {

--- a/apps/client/pages/api/admin/organizations/__tests__/grant.test.ts
+++ b/apps/client/pages/api/admin/organizations/__tests__/grant.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import dayjs from 'dayjs';
+import { ApiKeyScope } from '@bike4mind/common';
+
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: (config?: unknown) => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'POST']?.(req, res),
+      {
+        use: () => chain,
+        post: (fn: (req: unknown, res: unknown) => unknown) => ((h.POST = fn), chain),
+        _config: config,
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+}));
+
+vi.mock('@bike4mind/common', async () => {
+  const actual = await vi.importActual<typeof import('@bike4mind/common')>('@bike4mind/common');
+  return { ...actual, dayjs };
+});
+
+const mockOrgCreate = vi.fn();
+vi.mock('@bike4mind/services', () => ({
+  organizationService: { create: (...a: unknown[]) => mockOrgCreate(...a) },
+  creditService: { addCredits: vi.fn() },
+}));
+
+const mockUserFindByEmail = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  creditLotRepository: {},
+  creditTransactionRepository: {},
+  organizationRepository: {},
+  userRepository: { findByEmail: (...a: unknown[]) => mockUserFindByEmail(...a) },
+  withTransaction: (fn: (session: unknown) => Promise<unknown>) => fn(undefined),
+}));
+
+const mockSubCreate = vi.fn();
+vi.mock('@server/models/Subscription', () => ({
+  subscriptionRepository: { create: (...a: unknown[]) => mockSubCreate(...a) },
+}));
+
+vi.mock('@server/websocket/utils', () => ({ sendToClient: vi.fn() }));
+vi.mock('@server/utils/auditLog', () => ({
+  AdminOrgAuditEvents: { ORG_GRANTED: 'org_granted' },
+  logAuditEvent: vi.fn(),
+}));
+vi.mock('sst', () => ({ Resource: { websocket: { managementEndpoint: 'ws-endpoint' } } }));
+
+import handler from '../grant';
+
+const BODY = { name: 'Acme Corp', ownerEmail: 'owner@example.com', seats: 5, initialCredits: 1000, reason: 'sales' };
+
+function call(options: { isAdmin?: boolean; body?: object }) {
+  const { req, res } = createMocks({ method: 'POST', body: options.body ?? BODY });
+  (req as unknown as { user: { isAdmin: boolean; id: string; username: string } }).user = {
+    isAdmin: options.isAdmin ?? true,
+    id: 'admin-1',
+    username: 'admin',
+  };
+  (req as unknown as { logger: unknown }).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+describe('POST /api/admin/organizations/grant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindByEmail.mockResolvedValue({ id: 'owner-1', email: 'owner@example.com' });
+    mockOrgCreate.mockResolvedValue({ id: 'org-1', name: 'Acme Corp' });
+    mockSubCreate.mockResolvedValue({ id: 'sub-1' });
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
+  it('rejects a non-admin', async () => {
+    const { run } = call({ isAdmin: false });
+    await expect(run()).rejects.toThrow(/[Aa]dmin/);
+    expect(mockOrgCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates the organization with a subscription for an admin', async () => {
+    const { res, run } = call({});
+    await run();
+    expect(mockOrgCreate).toHaveBeenCalled();
+    expect(mockSubCreate).toHaveBeenCalled();
+    expect(res._getJSONData()).toMatchObject({ organizationId: 'org-1', name: 'Acme Corp' });
+  });
+});

--- a/apps/client/pages/api/admin/organizations/__tests__/grant.test.ts
+++ b/apps/client/pages/api/admin/organizations/__tests__/grant.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
-import dayjs from 'dayjs';
 import { ApiKeyScope } from '@bike4mind/common';
 
 // Captures the config so a test can assert requiredScopes: the scope gate lives in
@@ -28,11 +27,6 @@ vi.mock('@server/middlewares/asyncHandler', () => ({
 vi.mock('@server/utils/errors', () => ({
   ForbiddenError: class ForbiddenError extends Error {},
 }));
-
-vi.mock('@bike4mind/common', async () => {
-  const actual = await vi.importActual<typeof import('@bike4mind/common')>('@bike4mind/common');
-  return { ...actual, dayjs };
-});
 
 const mockOrgCreate = vi.fn();
 vi.mock('@bike4mind/services', () => ({

--- a/apps/client/pages/api/admin/organizations/grant.ts
+++ b/apps/client/pages/api/admin/organizations/grant.ts
@@ -8,7 +8,7 @@ import {
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 import { ForbiddenError } from '@server/utils/errors';
 import { organizationService, creditService } from '@bike4mind/services';
-import { CreditHolderType, dayjs } from '@bike4mind/common';
+import { ApiKeyScope, CreditHolderType, dayjs } from '@bike4mind/common';
 import {
   ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
   ORGANIZATION_SUBSCRIPTION_PRICE_ID,
@@ -40,7 +40,11 @@ const GrantOrgSchema = z.object({
   reason: z.string().min(1).max(500),
 });
 
-const handler = baseApi().post(
+// requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+// before req.user is set, so a key issued for a narrow integration can't create
+// an org with an initial credit grant just because its owner is an admin.
+// JWT/browser admins skip that check and still pass the isAdmin gate below.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).post(
   asyncHandler(async (req, res) => {
     if (!req.user?.isAdmin) {
       throw new ForbiddenError('Unauthorized. Admin access required.');

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/credit-transactions.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/credit-transactions.test.ts
@@ -63,8 +63,11 @@ beforeEach(() => {
 
 describe('GET /api/admin/users/[userId]/credit-transactions', () => {
   it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
-    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
-    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+    // Pins the whole config object, not just requiredScopes - a sibling `auth: false`
+    // would skip baseApi's entire api-key chain (baseApi.ts's `if (resolvedOptions.auth)`)
+    // and disable this gate while leaving requiredScopes untouched.
+    const config = (handler as unknown as { _config?: unknown })._config;
+    expect(config).toEqual({ requiredScopes: [ApiKeyScope.ADMIN] });
   });
 
   it('rejects non-admin callers', async () => {

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/credit-transactions.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/credit-transactions.test.ts
@@ -1,19 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
+import { ApiKeyScope } from '@bike4mind/common';
 
 const { mockFindByOwner, mockUserFind } = vi.hoisted(() => ({
   mockFindByOwner: vi.fn(),
   mockUserFind: vi.fn(),
 }));
 
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  baseApi: (config?: unknown) => {
     const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
     const chain = Object.assign(
       (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
       {
         use: () => chain,
         get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
+        _config: config,
       }
     );
     return chain;
@@ -57,6 +62,11 @@ beforeEach(() => {
 });
 
 describe('GET /api/admin/users/[userId]/credit-transactions', () => {
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
   it('rejects non-admin callers', async () => {
     const { promise } = run({ user: { id: 'u2', isAdmin: false } });
     await expect(promise).rejects.toThrow(/Admin access required/);

--- a/apps/client/pages/api/admin/users/[userId]/credit-transactions.ts
+++ b/apps/client/pages/api/admin/users/[userId]/credit-transactions.ts
@@ -1,5 +1,5 @@
 import { creditTransactionRepository, userRepository } from '@bike4mind/database';
-import { CreditHolderType, type CreditTransactionType } from '@bike4mind/common';
+import { ApiKeyScope, CreditHolderType, type CreditTransactionType } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { ForbiddenError } from '@server/utils/errors';
@@ -52,7 +52,12 @@ export interface IUserCreditAdjustment {
   amount?: number;
 }
 
-const handler = baseApi().get(
+// requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+// before req.user is set, so a key issued for a narrow integration can't read a
+// user's credit ledger (including Stripe payment intent ids) just because its
+// owner is an admin. JWT/browser admins skip that check and still pass the
+// isAdmin gate below.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
   // `userId` is always present - it is the `[userId]` route segment.
   asyncHandler<{}, unknown, unknown, { userId: string; days?: string; types?: string }>(async (req, res) => {
     if (!req.user?.isAdmin) {

--- a/apps/client/pages/api/admin/users/[userId]/subscriptions/[subscriptionId]/__tests__/credits.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/subscriptions/[subscriptionId]/__tests__/credits.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ApiKeyScope } from '@bike4mind/common';
+
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: (config?: unknown) => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'PUT']?.(req, res),
+      {
+        use: () => chain,
+        put: (fn: (req: unknown, res: unknown) => unknown) => ((h.PUT = fn), chain),
+        _config: config,
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+}));
+
+const mockUserFindById = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  organizationRepository: {},
+  userRepository: { findById: (...a: unknown[]) => mockUserFindById(...a) },
+  withTransaction: (fn: (session: unknown) => Promise<unknown>) => fn(undefined),
+}));
+
+const mockFindByStripeSubId = vi.fn();
+const mockUpdateByStripeSubId = vi.fn();
+vi.mock('@server/models/Subscription', () => ({
+  subscriptionRepository: {
+    findByStripeSubscriptionId: (...a: unknown[]) => mockFindByStripeSubId(...a),
+    updateByStripeSubscriptionId: (...a: unknown[]) => mockUpdateByStripeSubId(...a),
+  },
+}));
+
+vi.mock('@server/websocket/utils', () => ({ sendToClient: vi.fn() }));
+vi.mock('sst', () => ({ Resource: { websocket: { managementEndpoint: 'ws-endpoint' } } }));
+
+import handler from '../credits';
+
+function call(options: { isAdmin?: boolean; body?: object; userId?: string; subscriptionId?: string }) {
+  const { req, res } = createMocks({
+    method: 'PUT',
+    query: { userId: options.userId ?? 'u1', subscriptionId: options.subscriptionId ?? 'sub_123' },
+    body: options.body ?? { creditsPerCycle: 5000 },
+  });
+  (req as unknown as { user: { isAdmin: boolean; id: string } }).user = {
+    isAdmin: options.isAdmin ?? true,
+    id: 'admin-1',
+  };
+  (req as unknown as { logger: unknown }).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+describe('PUT /api/admin/users/[userId]/subscriptions/[subscriptionId]/credits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindById.mockResolvedValue({ id: 'u1' });
+    mockFindByStripeSubId.mockResolvedValue({ id: 'sub-1', ownerType: 'User', ownerId: 'u1' });
+    mockUpdateByStripeSubId.mockResolvedValue(undefined);
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
+  it('rejects a non-admin', async () => {
+    const { run } = call({ isAdmin: false });
+    await expect(run()).rejects.toThrow(/[Aa]dmin/);
+    expect(mockUpdateByStripeSubId).not.toHaveBeenCalled();
+  });
+
+  it('updates the credit rate for an individual subscription for an admin', async () => {
+    const { res, run } = call({});
+    await run();
+    expect(mockUpdateByStripeSubId).toHaveBeenCalledWith('sub_123', { customCreditsPerCycle: 5000 });
+    expect(res._getJSONData()).toMatchObject({ success: true, creditsPerCycle: 5000 });
+  });
+});

--- a/apps/client/pages/api/admin/users/[userId]/subscriptions/[subscriptionId]/__tests__/credits.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/subscriptions/[subscriptionId]/__tests__/credits.test.ts
@@ -72,8 +72,11 @@ describe('PUT /api/admin/users/[userId]/subscriptions/[subscriptionId]/credits',
   });
 
   it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
-    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
-    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+    // Pins the whole config object, not just requiredScopes - a sibling `auth: false`
+    // would skip baseApi's entire api-key chain (baseApi.ts's `if (resolvedOptions.auth)`)
+    // and disable this gate while leaving requiredScopes untouched.
+    const config = (handler as unknown as { _config?: unknown })._config;
+    expect(config).toEqual({ requiredScopes: [ApiKeyScope.ADMIN] });
   });
 
   it('rejects a non-admin', async () => {

--- a/apps/client/pages/api/admin/users/[userId]/subscriptions/[subscriptionId]/credits.ts
+++ b/apps/client/pages/api/admin/users/[userId]/subscriptions/[subscriptionId]/credits.ts
@@ -1,5 +1,6 @@
 import { organizationRepository, userRepository, withTransaction } from '@bike4mind/database';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { ApiKeyScope } from '@bike4mind/common';
 import { ForbiddenError } from '@server/utils/errors';
 import { SubscriptionOwnerType } from '@client/lib/subscriptions/types';
 import { subscriptionRepository } from '@server/models/Subscription';
@@ -18,7 +19,11 @@ interface RequestQuery {
   subscriptionId: string;
 }
 
-const handler = baseApi().put(
+// requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+// before req.user is set, so a key issued for a narrow integration can't modify
+// a subscription's credit rate just because its owner is an admin. JWT/browser
+// admins skip that check and still pass the isAdmin gate below.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).put(
   asyncHandler(async (req, res) => {
     // Check admin authorization
     if (!req.user?.isAdmin) {


### PR DESCRIPTION
## Description

Follow-up from #1937. The prior pass (#1940, closing #1628) fixed the six admin financial *read* endpoints; this PR closes the same gap on four *write* endpoints that a review on #1940 flagged as missed by #1937's own tracking - three of them mint or grant real financial value, which is worse than any read the prior PR closed:

- `organizations/[id]/top-up.ts` - grants credits to an organization.
- `organizations/grant.ts` - creates a new organization with an initial credit grant and subscription.
- `users/[userId]/subscriptions/[subscriptionId]/credits.ts` - modifies a subscription's credit rate.
- `users/[userId]/credit-transactions.ts` - exposes a user's full credit ledger, including Stripe payment intent ids.

Same root cause as #1628: a bare `baseApi()` gated only on `req.user?.isAdmin`. Because `apiKeyAuth` assigns `req.user` wholesale, an API key issued to an admin for a narrow integration inherited that admin's privileges and passed the gate - the scopes the key was actually minted with never entered the decision. Fix is the same `requiredScopes: [ApiKeyScope.ADMIN]` gate, enforced by `apiKeyAuth` before `req.user` is ever set. The check runs only for API-key callers - JWT/browser admins are unaffected.

All four were individually verified as pure `req.user?.isAdmin`-only gates with no other access path (no `verifyOrgAccess`, no CASL check) - unlike `transactions.ts`/`session-usage.ts` in #1940, there's no non-admin self-service tradeoff to weigh here.

This does not close # 1937 - digging into why the review found these four also surfaced that #1937's original 28-file count only covered the flat top level of `apps/client/pages/api/admin/`, not nested route folders; a corrected recursive count (176 files) is posted as a comment on #1937, not yet fully triaged or fixed.

## Changes

- `top-up.ts`, `grant.ts`, `credits.ts`, `credit-transactions.ts`: added `requiredScopes: [ApiKeyScope.ADMIN]` to `baseApi()`.
- Test coverage: added a `requiredScopes` config-assertion test (mirrors the pattern from #1940) to `credit-transactions.test.ts`, which already existed, and wrote new test files for `top-up.ts`, `grant.ts`, and `credits.ts`, which had no coverage before this PR. New coverage is intentionally scoped to the scope-assertion, a non-admin-rejection test, and one happy-path test per endpoint - not full mocking of the transactional/audit/websocket machinery each handler also exercises, since that pre-existing business logic was untested before this PR and is out of scope for an auth-gate fix.

## Guide for Testers

This is a server-side auth gate with no new UI - exercise each endpoint through its existing admin page on this PR's preview env (`pr<N>.preview.bike4mind.com`, posted by a maintainer once triggered), then confirm a narrow-scope API key is rejected via curl.

1. As an existing admin user on `pr<N>.preview.bike4mind.com`, create a user API key scoped only to `notebooks:read` (Settings -> API Keys -> New Key -> select only the Notebooks Read scope).
2. Run `curl -X POST -H "Authorization: Bearer <key>" -H "Content-Type: application/json" -d '{"credits":100,"idempotencyKey":"test-key-1"}' https://pr<N>.preview.bike4mind.com/api/admin/organizations/<any-org-id>/top-up`.
   Expected: HTTP 403 with an "Insufficient API key permissions" error body.

   <img width="756" height="369" alt="image" src="https://github.com/user-attachments/assets/47b6aed9-1ef2-4cda-afd1-9fff49636d85" />

3. Repeat the same 403 check against `POST /api/admin/organizations/grant`, `PUT /api/admin/users/<any-user-id>/subscriptions/<any-subscription-id>/credits`, and `GET /api/admin/users/<any-user-id>/credit-transactions`.
   Expected: HTTP 403 on all four.
4. Log into the admin UI as a browser session (JWT auth, no API key) and confirm each write still works normally:
   - **Top up**: Admin -> Organizations tab -> an org's "..." menu -> "Top up credits".
   - **Grant**: Admin -> Organizations tab -> "Create Organization" -> toggle "Grant Free Org (no Stripe checkout)" -> fill owner email/seats/initial credits/reason -> "Grant Free Org".
   - **Credit rate**: Admin -> Users tab -> open a user -> Subscription Status card -> pencil icon "Edit credits per cycle" -> set a value -> "Update Credits".
   - **Ledger**: Admin -> Credit Analytics tab -> "User Credits" sub-tab -> a user row -> "Adjust Credits" / "Credits" button (ledger loads automatically on modal open).
   Expected: no change in behavior for any of the four - all still work, since JWT/browser auth never goes through the scope check.

As with #1940, there's no step where a tester mints an ADMIN-scoped key to confirm the positive (matching-scope-succeeds) case: `ApiKeyScope.ADMIN` has no self-service or admin-console mint path by design. The matching-scope branch is generic `apiKeyAuth` logic already proven in production by the six endpoints #1940 shipped.

### What NOT to test

No UI changes - this PR only adds a server-side auth gate to four existing handlers. The response shape and side effects (credit grants, subscription updates, org creation) of all four endpoints are unchanged for any caller that already passes.

## Additional Information

Verified: `pnpm --filter client typecheck` clean, `pnpm lint:check`-equivalent (targeted `eslint`) clean on all touched files, ASCII/smart-punctuation checks clean. Full `apps/client/pages/api/admin` suite green (280 passed across 34 files, including the 4 new/updated scope-assertion tests).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
