### PR TITLE
fix(subscriptions): fail closed when APP_URL is missing outside local development

### DIFF
--- a/apps/client/pages/api/admin/organizations/[id]/__tests__/convert-to-paid.test.ts
+++ b/apps/client/pages/api/admin/organizations/[id]/__tests__/convert-to-paid.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+// baseApi: unwrap the chain so handler.post(fn) just returns fn, and .use() is a no-op.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => ({
+    use: function () {
+      return this;
+    },
+    post: (fn: unknown) => fn,
+  }),
+}));
+
+// asyncHandler only awaits its argument (it is @deprecated and does not catch), so identity
+// preserves the throw this file asserts on.
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: unknown) => fn,
+}));
+
+// Deliberately NOT mocking the error classes: the real BadRequestError carries statusCode
+// 400, which lets the rejection test assert the status the client would actually receive
+// rather than only the message.
+import { BadRequestError, NotFoundError, HttpStatus } from '@bike4mind/common';
+
+const mockOrgFindById = vi.fn();
+const mockOrgFindOneAndUpdate = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  organizationRepository: { findById: (...args: unknown[]) => mockOrgFindById(...args) },
+  Organization: { findOneAndUpdate: (...args: unknown[]) => mockOrgFindOneAndUpdate(...args) },
+}));
+
+const mockFindActiveByOwner = vi.fn();
+vi.mock('@server/models/Subscription', () => ({
+  subscriptionRepository: {
+    findActiveSubscriptionsByOwner: (...args: unknown[]) => mockFindActiveByOwner(...args),
+  },
+}));
+
+// Needed only so importing the handler resolves; the guard rejects long before it is reached.
+vi.mock('@server/services/organizationService', () => ({ resolveSubscriptionSource: vi.fn() }));
+
+const mockLogAuditEvent = vi.fn();
+vi.mock('@server/utils/auditLog', () => ({
+  AdminOrgAuditEvents: { ORG_CONVERT_INITIATED: 'org_convert_initiated' },
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}));
+
+// Drive the origin verdict per test rather than hard-coding it: a stub pinned to `true` would
+// make the rejection path untestable, which is exactly the gap this file closes.
+const mockIsAllowedCallbackOrigin = vi.fn();
+vi.mock('@server/integrations/stripe/callbackUrl', async importOriginal => {
+  const actual = await importOriginal<typeof import('@server/integrations/stripe/callbackUrl')>();
+  return { ...actual, isAllowedCallbackOrigin: (...args: unknown[]) => mockIsAllowedCallbackOrigin(...args) };
+});
+vi.mock('@server/utils/config', () => ({ Config: { STAGE: 'test' } }));
+
+const mockSessionsCreate = vi.fn();
+const mockCreateCustomer = vi.fn();
+vi.mock('@server/integrations/stripe/stripe', () => ({
+  createCustomer: (...args: unknown[]) => mockCreateCustomer(...args),
+  CustomerType: { Organization: 'Organization' },
+  stripe: {
+    checkout: { sessions: { create: (...args: unknown[]) => mockSessionsCreate(...args) } },
+  },
+}));
+
+import handler from '../convert-to-paid';
+
+type HandlerFn = (req: unknown, res: unknown) => Promise<unknown>;
+
+const CALLBACK_URL = 'https://app.example.com/admin/organizations';
+
+function makeReq(callbackUrl = CALLBACK_URL) {
+  const { req, res } = createMocks({ method: 'POST', query: { id: 'org_1' } });
+  (req as Record<string, unknown>).body = { callbackUrl };
+  // The guard sits BELOW the isAdmin check and the id check, so both must be satisfied for
+  // the request to reach it at all.
+  (req as Record<string, unknown>).user = { id: 'admin_1', username: 'admin', isAdmin: true };
+  return { req, res };
+}
+
+describe('POST /api/admin/organizations/[id]/convert-to-paid - callbackUrl origin guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowedCallbackOrigin.mockReturnValue(true);
+  });
+
+  it('rejects a callbackUrl on a disallowed origin with a 400', async () => {
+    // Admin-initiated, but the callbackUrl still arrives in the request body - so an admin
+    // with a tampered client, or a CSRF-shaped request, could aim Stripe's post-checkout
+    // redirect off-origin.
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('https://attacker.example.net/phish');
+
+    // Asserted in ONE throw: message and status together, so the handler runs once. Invoking
+    // it twice would double every mock's call log for the assertions below.
+    // `constructor:` rather than `toBeInstanceOf` is deliberate - it pins the exact class,
+    // where toBeInstanceOf would also accept a SUBCLASS of BadRequestError carrying a
+    // different status. Do not "simplify" it.
+    await expect((handler as HandlerFn)(req, res)).rejects.toMatchObject({
+      constructor: BadRequestError,
+      statusCode: HttpStatus.BadRequest,
+      message: 'callbackUrl must point to the deployed application origin',
+    });
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith('https://attacker.example.net/phish');
+  });
+
+  it('runs the guard before any lookup, Stripe side effect, or audit write', async () => {
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('https://attacker.example.net/phish');
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toThrow();
+
+    expect(mockOrgFindById).not.toHaveBeenCalled();
+    expect(mockFindActiveByOwner).not.toHaveBeenCalled();
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+    expect(mockLogAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('lets an allowed origin through to the organization lookup', async () => {
+    // Pins the guard as the ONLY reason the rejection tests above stop early: with the same
+    // fixtures and an allowed origin, execution reaches organizationRepository.findById.
+    // Without this, `not.toHaveBeenCalled()` above could pass for the wrong reason.
+    mockOrgFindById.mockResolvedValue(null);
+    const { req, res } = makeReq();
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toMatchObject({
+      constructor: NotFoundError,
+      message: 'Organization not found',
+    });
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(mockOrgFindById).toHaveBeenCalledWith('org_1');
+  });
+});

--- a/apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts
+++ b/apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 import {
+  ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
   ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
   ORGANIZATION_SUBSCRIPTION_PRICE_ID,
 } from '@client/lib/subscriptions/constants';
@@ -22,11 +23,11 @@ vi.mock('@server/middlewares/requireStripeWebhook', () => ({
   requireStripeWebhook: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
-// Deliberately NOT mocking @bike4mind/utils: the real BadRequestError carries
-// statusCode 400, which lets the rejection test assert the status the client would
-// actually receive rather than only the message.
-import { BadRequestError } from '@bike4mind/utils';
-import { HttpStatus } from '@bike4mind/common';
+// Deliberately NOT mocking the error classes: the real BadRequestError carries statusCode
+// 400, which lets the rejection test assert the status the client would actually receive
+// rather than only the message. Imported from @bike4mind/common, the sole declaration site -
+// @bike4mind/utils is a @deprecated re-export (same class identity, non-canonical path).
+import { BadRequestError, HttpStatus } from '@bike4mind/common';
 
 const mockOrgFindById = vi.fn();
 const mockOrgUpdate = vi.fn();
@@ -86,13 +87,17 @@ describe('POST /api/organizations/subscriptions/subscribe - callbackUrl origin g
     vi.clearAllMocks();
     mockIsAllowedCallbackOrigin.mockReturnValue(true);
     mockFindByPriceIdAndOwner.mockResolvedValue(null); // no active org subscription
+    // No stripeCustomerId: the route must therefore run createCustomer AND persist via
+    // organizationRepository.update, which is what makes the "no side effect on rejection"
+    // assertions below capable of failing. With a customer id pre-set the route skipped that
+    // whole branch, so those assertions held whether the guard ran or not.
     mockOrgFindById.mockResolvedValue({
       id: 'org_1',
       name: 'Org One',
       billingContact: 'billing@example.com',
-      stripeCustomerId: 'cus_existing',
       users: [{ userId: 'user_1' }],
     });
+    mockCreateCustomer.mockResolvedValue({ id: 'cus_new' });
     mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe/session' });
   });
 
@@ -102,14 +107,16 @@ describe('POST /api/organizations/subscriptions/subscribe - callbackUrl origin g
     mockIsAllowedCallbackOrigin.mockReturnValue(false);
     const { req, res } = makeReq('https://attacker.example.net/phish');
 
-    await expect((handler as HandlerFn)(req, res)).rejects.toThrow(
-      'callbackUrl must point to the deployed application origin'
-    );
-    // Assert the status the caller actually gets, not just the message: a regression in
-    // which error class is thrown would keep the message and silently change the response.
+    // Asserted in ONE throw: message and status together, so the handler runs once. It used
+    // to be invoked twice for these two assertions - harmless only while nothing sits above
+    // the guard, since a second run would double every mock's call log below.
+    // `constructor:` rather than `toBeInstanceOf` is deliberate - it pins the exact class,
+    // where toBeInstanceOf would also accept a SUBCLASS of BadRequestError carrying a
+    // different status. Do not "simplify" it.
     await expect((handler as HandlerFn)(req, res)).rejects.toMatchObject({
       constructor: BadRequestError,
       statusCode: HttpStatus.BadRequest,
+      message: 'callbackUrl must point to the deployed application origin',
     });
 
     expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith('https://attacker.example.net/phish');
@@ -124,6 +131,7 @@ describe('POST /api/organizations/subscriptions/subscribe - callbackUrl origin g
     expect(mockFindByPriceIdAndOwner).not.toHaveBeenCalled();
     expect(mockOrgFindById).not.toHaveBeenCalled();
     expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockOrgUpdate).not.toHaveBeenCalled(); // the DB write the guard now provably precedes
     expect(mockSessionsCreate).not.toHaveBeenCalled();
   });
 
@@ -133,6 +141,8 @@ describe('POST /api/organizations/subscriptions/subscribe - callbackUrl origin g
     await (handler as HandlerFn)(req, res);
 
     expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(mockCreateCustomer).toHaveBeenCalledTimes(1);
+    expect(mockOrgUpdate).toHaveBeenCalledTimes(1);
     expect(mockSessionsCreate).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
     expect(res._getJSONData()).toEqual({ sessionUrl: 'https://checkout.stripe/session' });
@@ -151,5 +161,65 @@ describe('POST /api/organizations/subscriptions/subscribe - callbackUrl origin g
     );
     expect(args.success_url).not.toContain('%7B');
     expect(args.cancel_url).toBe(CALLBACK_URL);
+  });
+
+  // The #1424 clamp: minSeats = min(max(MIN, members + 1), MAX). Both bounds need a fixture
+  // where they actually bite - with the default one-member org the floor coincides with MIN,
+  // so asserting `minimum: MIN` passes even if the whole expression is deleted.
+  it.each([
+    { members: 10, expected: 11, why: 'floor tracks members + 1 once it exceeds MIN' },
+    {
+      members: 150,
+      expected: ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
+      why: 'ceiling clamps at MAX so minimum can never exceed maximum (#1424 wedge)',
+    },
+  ])('clamps the adjustable-quantity floor: $why', async ({ members, expected }) => {
+    mockOrgFindById.mockResolvedValue({
+      id: 'org_1',
+      name: 'Org One',
+      billingContact: 'billing@example.com',
+      users: Array.from({ length: members }, (_, i) => ({ userId: `user_${i}` })),
+    });
+    const { req, res } = makeReq();
+
+    await (handler as HandlerFn)(req, res);
+
+    const args = mockSessionsCreate.mock.calls[0][0] as {
+      line_items: { adjustable_quantity: unknown }[];
+    };
+    expect(args.line_items[0].adjustable_quantity).toEqual({
+      enabled: true,
+      minimum: expected,
+      maximum: ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('creates a customer with no org lookup on the new-organization branch', async () => {
+    // organizationData instead of organizationId is the shape CreateTeamModal sends, and it
+    // was unexercised: no org exists yet, so createCustomer runs unconditionally and the
+    // metadata carries newOrganizationName rather than an organizationId.
+    const { req, res } = createMocks({ method: 'POST' });
+    (req as Record<string, unknown>).body = {
+      priceId: ORGANIZATION_SUBSCRIPTION_PRICE_ID,
+      quantity: ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
+      organizationData: { name: 'Brand New Org' },
+      callbackUrl: CALLBACK_URL,
+    };
+    (req as Record<string, unknown>).user = { id: 'user_1', email: 'buyer@example.com', name: 'Buyer' };
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockOrgFindById).not.toHaveBeenCalled();
+    expect(mockOrgUpdate).not.toHaveBeenCalled();
+    expect(mockCreateCustomer).toHaveBeenCalledTimes(1);
+    const args = mockSessionsCreate.mock.calls[0][0] as {
+      customer: string;
+      subscription_data: { metadata: Record<string, unknown> };
+    };
+    expect(args.customer).toBe('cus_new');
+    expect(args.subscription_data.metadata).toMatchObject({ newOrganizationName: 'Brand New Org' });
+    expect(args.subscription_data.metadata).not.toHaveProperty('organizationId');
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/apps/client/pages/api/stripe/__tests__/portal.test.ts
+++ b/apps/client/pages/api/stripe/__tests__/portal.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+// baseApi: unwrap the chain so handler.post(fn) just returns fn, and .use() is a no-op.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => ({
+    use: function () {
+      return this;
+    },
+    post: (fn: unknown) => fn,
+  }),
+}));
+
+// requireStripeWebhook is applied via .use() (dropped by the baseApi mock); stub the
+// factory so importing the handler doesn't touch real webhook config.
+vi.mock('@server/middlewares/requireStripeWebhook', () => ({
+  requireStripeWebhook: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// Deliberately NOT mocking the error classes: the real BadRequestError carries statusCode
+// 400, which lets the rejection test assert the status the client would actually receive
+// rather than only the message.
+import { BadRequestError, HttpStatus } from '@bike4mind/common';
+
+const mockOrgFindById = vi.fn();
+const mockUserFindById = vi.fn();
+const mockOrgFindOneAndUpdate = vi.fn();
+const mockUserFindOneAndUpdate = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  organizationRepository: { findById: (...args: unknown[]) => mockOrgFindById(...args) },
+  userRepository: { findById: (...args: unknown[]) => mockUserFindById(...args) },
+  Organization: { findOneAndUpdate: (...args: unknown[]) => mockOrgFindOneAndUpdate(...args) },
+  User: { findOneAndUpdate: (...args: unknown[]) => mockUserFindOneAndUpdate(...args) },
+}));
+
+const mockFindActiveByOwner = vi.fn();
+vi.mock('@server/models/Subscription', () => ({
+  subscriptionRepository: {
+    findActiveSubscriptionsByOwner: (...args: unknown[]) => mockFindActiveByOwner(...args),
+  },
+}));
+
+// Needed only so importing the handler resolves; the guard rejects long before it is reached.
+vi.mock('@server/services/organizationService', () => ({ resolveSubscriptionSource: vi.fn() }));
+
+// Drive the origin verdict per test rather than hard-coding it: a stub pinned to `true` would
+// make the rejection path untestable, which is exactly the gap this file closes.
+const mockIsAllowedCallbackOrigin = vi.fn();
+vi.mock('@server/integrations/stripe/callbackUrl', async importOriginal => {
+  const actual = await importOriginal<typeof import('@server/integrations/stripe/callbackUrl')>();
+  return { ...actual, isAllowedCallbackOrigin: (...args: unknown[]) => mockIsAllowedCallbackOrigin(...args) };
+});
+
+const mockPortalSessionsCreate = vi.fn();
+const mockCreateCustomer = vi.fn();
+vi.mock('@server/integrations/stripe/stripe', () => ({
+  createCustomer: (...args: unknown[]) => mockCreateCustomer(...args),
+  CustomerType: { User: 'User', Organization: 'Organization' },
+  stripe: {
+    billingPortal: { sessions: { create: (...args: unknown[]) => mockPortalSessionsCreate(...args) } },
+  },
+}));
+
+import handler from '../portal';
+
+type HandlerFn = (req: unknown, res: unknown) => Promise<unknown>;
+
+const CALLBACK_URL = 'https://app.example.com/settings/billing';
+
+function makeReq(callbackUrl = CALLBACK_URL) {
+  const { req, res } = createMocks({ method: 'POST' });
+  (req as Record<string, unknown>).body = { callbackUrl, ownerType: 'User', ownerId: 'user_1' };
+  (req as Record<string, unknown>).user = { id: 'user_1', email: 'buyer@example.com', name: 'Buyer' };
+  return { req, res };
+}
+
+describe('POST /api/stripe/portal - callbackUrl origin guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowedCallbackOrigin.mockReturnValue(true);
+    mockUserFindById.mockResolvedValue({ id: 'user_1', email: 'buyer@example.com', stripeCustomerId: 'cus_existing' });
+    mockFindActiveByOwner.mockResolvedValue([]);
+    mockPortalSessionsCreate.mockResolvedValue({ url: 'https://billing.stripe/session' });
+  });
+
+  it('rejects a callbackUrl on a disallowed origin with a 400', async () => {
+    // The billing portal's return_url is attacker-reachable the same way checkout's
+    // success_url is: Stripe performs the redirect, so an external origin phishes off
+    // Stripe's own hosted page.
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('https://attacker.example.net/phish');
+
+    // Asserted in ONE throw: message and status together, so the handler runs once. Invoking
+    // it twice would double every mock's call log for the assertions below.
+    // `constructor:` rather than `toBeInstanceOf` is deliberate - it pins the exact class,
+    // where toBeInstanceOf would also accept a SUBCLASS of BadRequestError carrying a
+    // different status. Do not "simplify" it.
+    await expect((handler as HandlerFn)(req, res)).rejects.toMatchObject({
+      constructor: BadRequestError,
+      statusCode: HttpStatus.BadRequest,
+      message: 'callbackUrl must point to the deployed application origin',
+    });
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith('https://attacker.example.net/phish');
+  });
+
+  it('runs the guard before any lookup or Stripe side effect', async () => {
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('https://attacker.example.net/phish');
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toThrow();
+
+    expect(mockUserFindById).not.toHaveBeenCalled();
+    expect(mockOrgFindById).not.toHaveBeenCalled();
+    expect(mockFindActiveByOwner).not.toHaveBeenCalled();
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockPortalSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('passes an allowed-origin callbackUrl through as the portal return_url', async () => {
+    const { req, res } = makeReq();
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(mockPortalSessionsCreate).toHaveBeenCalledWith({ customer: 'cus_existing', return_url: CALLBACK_URL });
+    expect(res.statusCode).toBe(200);
+    expect(res._getJSONData()).toEqual({ url: 'https://billing.stripe/session' });
+  });
+});

--- a/apps/client/pages/api/stripe/__tests__/portal.test.ts
+++ b/apps/client/pages/api/stripe/__tests__/portal.test.ts
@@ -21,7 +21,7 @@ vi.mock('@server/middlewares/requireStripeWebhook', () => ({
 // Deliberately NOT mocking the error classes: the real BadRequestError carries statusCode
 // 400, which lets the rejection test assert the status the client would actually receive
 // rather than only the message.
-import { BadRequestError, HttpStatus } from '@bike4mind/common';
+import { BadRequestError, ForbiddenError, HttpStatus } from '@bike4mind/common';
 
 const mockOrgFindById = vi.fn();
 const mockUserFindById = vi.fn();
@@ -41,8 +41,11 @@ vi.mock('@server/models/Subscription', () => ({
   },
 }));
 
-// Needed only so importing the handler resolves; the guard rejects long before it is reached.
-vi.mock('@server/services/organizationService', () => ({ resolveSubscriptionSource: vi.fn() }));
+// Drives the admin-grant branch on the Organization owner path; unreached on the guard tests.
+const mockResolveSubscriptionSource = vi.fn();
+vi.mock('@server/services/organizationService', () => ({
+  resolveSubscriptionSource: (...args: unknown[]) => mockResolveSubscriptionSource(...args),
+}));
 
 // Drive the origin verdict per test rather than hard-coding it: a stub pinned to `true` would
 // make the rejection path untestable, which is exactly the gap this file closes.
@@ -68,9 +71,9 @@ type HandlerFn = (req: unknown, res: unknown) => Promise<unknown>;
 
 const CALLBACK_URL = 'https://app.example.com/settings/billing';
 
-function makeReq(callbackUrl = CALLBACK_URL) {
+function makeReq(callbackUrl = CALLBACK_URL, ownerType = 'User', ownerId = 'user_1') {
   const { req, res } = createMocks({ method: 'POST' });
-  (req as Record<string, unknown>).body = { callbackUrl, ownerType: 'User', ownerId: 'user_1' };
+  (req as Record<string, unknown>).body = { callbackUrl, ownerType, ownerId };
   (req as Record<string, unknown>).user = { id: 'user_1', email: 'buyer@example.com', name: 'Buyer' };
   return { req, res };
 }
@@ -127,5 +130,49 @@ describe('POST /api/stripe/portal - callbackUrl origin guard', () => {
     expect(mockPortalSessionsCreate).toHaveBeenCalledWith({ customer: 'cus_existing', return_url: CALLBACK_URL });
     expect(res.statusCode).toBe(200);
     expect(res._getJSONData()).toEqual({ url: 'https://billing.stripe/session' });
+  });
+
+  it('resolves the organization customer on the Organization owner path', async () => {
+    // The owner-type branch was previously unexercised: only the User path was asserted, so a
+    // regression that resolved the wrong customer here would not have failed anything.
+    mockOrgFindById.mockResolvedValue({
+      id: 'org_1',
+      userId: 'user_1',
+      name: 'Org One',
+      billingContact: 'billing@example.com',
+      stripeCustomerId: 'cus_org',
+    });
+    const { req, res } = makeReq(CALLBACK_URL, 'Organization', 'org_1');
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockOrgFindById).toHaveBeenCalledWith('org_1');
+    // 'cus_org', not the User path's 'cus_existing' - that difference is the assertion.
+    expect(mockPortalSessionsCreate).toHaveBeenCalledWith({ customer: 'cus_org', return_url: CALLBACK_URL });
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('refuses the portal for an admin-granted organization instead of bootstrapping billing', async () => {
+    // An admin-granted org has no Stripe subscription; letting the portal auto-create a customer
+    // here would quietly start a billing relationship that only convert-to-paid should begin.
+    mockOrgFindById.mockResolvedValue({
+      id: 'org_1',
+      userId: 'user_1',
+      name: 'Org One',
+      billingContact: 'billing@example.com',
+      stripeCustomerId: null,
+    });
+    mockFindActiveByOwner.mockResolvedValue([{ id: 'sub_1' }]);
+    mockResolveSubscriptionSource.mockReturnValue('admin_grant');
+    const { req, res } = makeReq(CALLBACK_URL, 'Organization', 'org_1');
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toMatchObject({
+      constructor: ForbiddenError,
+      message: 'Contact support to enable billing for this organization.',
+    });
+
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockPortalSessionsCreate).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/subscriptions/__tests__/subscribe.test.ts
+++ b/apps/client/pages/api/subscriptions/__tests__/subscribe.test.ts
@@ -18,9 +18,11 @@ vi.mock('@server/middlewares/requireStripeWebhook', () => ({
   requireStripeWebhook: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
-vi.mock('@bike4mind/utils', () => ({
-  BadRequestError: class BadRequestError extends Error {},
-}));
+// Deliberately NOT mocking the error classes: the real BadRequestError carries statusCode
+// 400, which lets the rejection test assert the status the client would actually receive
+// rather than only the message. The previous bare `class BadRequestError extends Error` had
+// no statusCode at all, so that assertion was impossible.
+import { BadRequestError, HttpStatus } from '@bike4mind/common';
 
 const mockGetSettingsValue = vi.fn();
 const mockUserUpdate = vi.fn();
@@ -52,11 +54,13 @@ vi.mock('@client/lib/userSubscriptions/constants', () => ({
 
 // Use the REAL appendSuccessParams so the success_url this route builds is
 // actually asserted below - mocking it away is what let the individual path ship
-// with an unmarked success redirect in the first place. Only the origin check is
-// stubbed, since it reads APP_URL from the environment.
+// with an unmarked success redirect in the first place. The origin check is stubbed
+// because it reads APP_URL from the environment, but driven per-test rather than pinned
+// to `true`: a hard-coded verdict asserts nothing about the rejection path.
+const mockIsAllowedCallbackOrigin = vi.fn();
 vi.mock('@server/integrations/stripe/callbackUrl', async importOriginal => {
   const actual = await importOriginal<typeof import('@server/integrations/stripe/callbackUrl')>();
-  return { ...actual, isAllowedCallbackOrigin: () => true };
+  return { ...actual, isAllowedCallbackOrigin: (...args: unknown[]) => mockIsAllowedCallbackOrigin(...args) };
 });
 vi.mock('@server/utils/config', () => ({ Config: { STAGE: 'test' } }));
 
@@ -78,9 +82,11 @@ import handler from '../subscribe';
 
 type HandlerFn = (req: unknown, res: unknown) => Promise<unknown>;
 
-function makeReq(priceId: string) {
+const CALLBACK_URL = 'https://app.example.com/cb';
+
+function makeReq(priceId: string, callbackUrl = CALLBACK_URL) {
   const { req, res } = createMocks({ method: 'POST' });
-  (req as Record<string, unknown>).body = { priceId, callbackUrl: 'https://app.example.com/cb' };
+  (req as Record<string, unknown>).body = { priceId, callbackUrl };
   (req as Record<string, unknown>).user = {
     id: 'user_1',
     email: 'buyer@example.com',
@@ -93,6 +99,7 @@ function makeReq(priceId: string) {
 describe('POST /api/subscriptions/subscribe — launch/availability gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsAllowedCallbackOrigin.mockReturnValue(true);
     mockFindUserSubByPrice.mockResolvedValue(null); // not already subscribed
     mockCustomersRetrieve.mockResolvedValue({ id: 'cus_existing' });
     mockPricesRetrieve.mockResolvedValue({ id: 'price_gated', active: true });
@@ -155,6 +162,66 @@ describe('POST /api/subscriptions/subscribe — launch/availability gate', () =>
     await (handler as HandlerFn)(req, res);
 
     expect(mockGetSettingsValue).not.toHaveBeenCalled();
+    expect(mockSessionsCreate).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('POST /api/subscriptions/subscribe - callbackUrl origin guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowedCallbackOrigin.mockReturnValue(true);
+    mockGetSettingsValue.mockResolvedValue(true);
+    mockFindUserSubByPrice.mockResolvedValue(null);
+    mockCustomersRetrieve.mockResolvedValue({ id: 'cus_existing' });
+    mockPricesRetrieve.mockResolvedValue({ id: 'price_open', active: true });
+    mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe/session' });
+  });
+
+  it('rejects a callbackUrl on a disallowed origin with a 400', async () => {
+    // The guard is the only thing between a caller-supplied callbackUrl and an open redirect
+    // off Stripe's hosted checkout page, where the redirect wears Stripe's brand.
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('price_open', 'https://attacker.example.net/phish');
+
+    // Asserted in ONE throw: message and status together, so the handler runs once. Invoking
+    // it twice would double every mock's call log for the assertions below.
+    // `constructor:` rather than `toBeInstanceOf` is deliberate - it pins the exact class,
+    // where toBeInstanceOf would also accept a SUBCLASS of BadRequestError carrying a
+    // different status. Do not "simplify" it.
+    await expect((handler as HandlerFn)(req, res)).rejects.toMatchObject({
+      constructor: BadRequestError,
+      statusCode: HttpStatus.BadRequest,
+      message: 'callbackUrl must point to the deployed application origin',
+    });
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith('https://attacker.example.net/phish');
+  });
+
+  it('runs the guard before the availability gate, any lookup, or any Stripe side effect', async () => {
+    // Ordering matters beyond tidiness: the guard sits above an admin-settings read and a
+    // subscription lookup, so a rejected callbackUrl must cost neither.
+    mockIsAllowedCallbackOrigin.mockReturnValue(false);
+    const { req, res } = makeReq('price_gated', 'https://attacker.example.net/phish');
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toThrow();
+
+    expect(mockGetSettingsValue).not.toHaveBeenCalled();
+    expect(mockFindUserSubByPrice).not.toHaveBeenCalled();
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockPricesRetrieve).not.toHaveBeenCalled();
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('passes an allowed-origin callbackUrl through to the checkout session', async () => {
+    // Pins the guard as the ONLY reason the two tests above stop early: same fixtures, allowed
+    // origin, and execution reaches Stripe. Without this, `not.toHaveBeenCalled()` could pass
+    // for the wrong reason.
+    const { req, res } = makeReq('price_open');
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockIsAllowedCallbackOrigin).toHaveBeenCalledWith(CALLBACK_URL);
     expect(mockSessionsCreate).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
   });

--- a/apps/client/server/integrations/stripe/callbackUrl.test.ts
+++ b/apps/client/server/integrations/stripe/callbackUrl.test.ts
@@ -80,7 +80,23 @@ describe('isAllowedCallbackOrigin', () => {
     expect(isAllowedCallbackOrigin('https://attacker.example.net/phish')).toBe(false);
   });
 
-  it('passes through when APP_URL is missing outside production (documented dev convenience)', () => {
+  it('fails closed when APP_URL is missing on a stage that is neither production nor development', () => {
+    // The gap this closes: the old `=== 'production'` test waved EVERY origin through on any
+    // other NODE_ENV, so a deployed stage that lost APP_URL was an open redirect. NODE_ENV is
+    // baked in by `next build` and nothing in infra/ sets it per stage, so the only line it can
+    // draw is local dev vs everything else - and everything else must reject. 'test' is also
+    // what vitest runs under, so this pins the local-test posture too.
+    vi.stubEnv('APP_URL', '');
+
+    for (const nodeEnv of ['test', 'staging'] as const) {
+      vi.stubEnv('NODE_ENV', nodeEnv);
+      expect(isAllowedCallbackOrigin('https://attacker.example.net/phish')).toBe(false);
+      // Rejects the app's own origin too - with no APP_URL there is nothing to compare against.
+      expect(isAllowedCallbackOrigin('https://app.example.com/settings/billing')).toBe(false);
+    }
+  });
+
+  it('passes through only when APP_URL is missing in local development (documented dev convenience)', () => {
     vi.stubEnv('APP_URL', '');
     vi.stubEnv('NODE_ENV', 'development');
 

--- a/apps/client/server/integrations/stripe/callbackUrl.ts
+++ b/apps/client/server/integrations/stripe/callbackUrl.ts
@@ -4,16 +4,20 @@
  * hosted page - letting an attacker (or a confused admin) point them at an
  * external domain is an open-redirect / phishing vector through Stripe's brand.
  *
- * Fail-closed semantics: if APP_URL is not configured in a production-shaped
- * environment we reject rather than waving everything through. The dev-only
- * pass-through guards against the obvious misconfiguration (typo, secret
- * rotation gone bad, new stage missing the var) silently disabling the check.
+ * Fail-closed semantics: with APP_URL missing, anything that is not local development
+ * rejects rather than waving every origin through. Deliberately `!== 'development'` and not
+ * `=== 'production'`: `next build` bakes NODE_ENV into the server bundle and nothing in
+ * infra/ sets it per stage, so it cannot tell deployed stages apart - only a local dev
+ * process from everything else. Same NODE_ENV predicate as
+ * server/utils/telemetryHashLookup.ts:16, which warns rather than rejects. APP_URL is
+ * injected per-construct rather than globally (see infra/constants.ts), so a future
+ * construct that forgets it fails closed here instead of silently disabling the check.
  */
 export function isAllowedCallbackOrigin(url: string): boolean {
   const appUrl = process.env.APP_URL;
   if (!appUrl) {
-    if (process.env.NODE_ENV === 'production') return false;
-    return true; // dev convenience; APP_URL is set in all deployed stages
+    if (process.env.NODE_ENV !== 'development') return false;
+    return true; // local dev only; APP_URL is injected in all deployed stages
   }
   try {
     return new URL(url).origin === new URL(appUrl).origin;


### PR DESCRIPTION
# Pull Request

Closes #1892

## Optional Screenshot/Video

No UI surface - this changes one server-side predicate and adds tests. The evidence that
carries the change is textual, and it is the mutation results under **Additional
Information**: each new assertion was confirmed to fail when the guard is deliberately
broken, rather than merely to pass.

## Description

`isAllowedCallbackOrigin` is the only control confining a caller-supplied `callbackUrl` to
the deployed app's own origin. Stripe redirects the customer to that URL after checkout or a
billing-portal session, so an accepted external origin is an open redirect that arrives
carrying Stripe's branding.

Its fail-closed branch was narrower than it read. With `APP_URL` unset it rejected only when
`NODE_ENV === 'production'`, so any other `NODE_ENV` passed **every** origin through. This
inverts that to `!== 'development'`, and adds the route-level rejection coverage the three
previously untested call sites were missing.

**This is defense-in-depth, not a live hole.** The changed branch is only reached when
`APP_URL` is unset, and `APP_URL` is injected per-construct at `infra/web.ts:379`,
`infra/queues.ts:1059`, `infra/mcp.ts:48` and `infra/emailMarketing.ts:42`. All four guard
call sites are Pages API routes in the web construct, so the branch is never entered there
and behavior on every deployed stage is unchanged. What makes it worth fixing is
`infra/constants.ts:27-28`, which records that `APP_URL` is deliberately not set globally and
must be injected per-construct - a future construct that forgets, hosting a future caller of
this shared helper, is exactly the case where `!== 'development'` fails closed and
`=== 'production'` does not.

`=== 'production'` was not merely narrow, it tested the wrong variable. `next build` bakes
`NODE_ENV` into the server bundle and nothing in `infra/` sets it per stage, so `NODE_ENV`
cannot distinguish deployed stages from one another - the only line it can draw is a local dev
process versus everything else, which is what the new predicate draws. That determination and
its evidence are recorded in a comment on #1892.

## Changes

- **`apps/client/server/integrations/stripe/callbackUrl.ts:19`** - inverted the fail-closed
  branch from `NODE_ENV === 'production'` to `NODE_ENV !== 'development'`, and rewrote the
  docblock, which described the old semantics. The docblock now records why `NODE_ENV` is the
  wrong variable for stage identity and points at
  `server/utils/telemetryHashLookup.ts:16` as the same predicate (noting that it warns rather
  than rejects).

- **`apps/client/server/integrations/stripe/callbackUrl.test.ts`** - added a case asserting
  `false` when `APP_URL` is unset and `NODE_ENV` is neither `production` nor `development`
  (covers `test` and `staging`, and asserts the app's own origin is rejected too, since with no
  `APP_URL` there is nothing to compare against). Retitled the surviving pass-through case,
  whose old title said "outside production" - now the wrong boundary.

- **`apps/client/pages/api/stripe/__tests__/portal.test.ts`** (new) - rejection, guard-ordering,
  and pass-through tests for the guard at `pages/api/stripe/portal.ts:25`. The pass-through
  asserts `return_url` is the callbackUrl handed to `billingPortal.sessions.create`. Also covers
  the Organization owner path, which no test reached: one case asserting it resolves the
  organization's own Stripe customer rather than the user's, and one asserting an admin-granted
  organization is refused with `ForbiddenError` instead of silently bootstrapping a Stripe
  customer through the portal.

- **`apps/client/pages/api/admin/organizations/[id]/__tests__/convert-to-paid.test.ts`** (new) -
  the same three for `pages/api/admin/organizations/[id]/convert-to-paid.ts:39`. The request
  carries `user.isAdmin` and a query `id`, because the guard sits below both of those checks.

- **`apps/client/pages/api/subscriptions/__tests__/subscribe.test.ts`** - replaced the
  hard-coded `isAllowedCallbackOrigin: () => true` stub with a test-controlled `vi.fn()`, and
  dropped the `@bike4mind/utils` mock whose bare `class BadRequestError extends Error` had no
  `statusCode`, making a 400 assertion impossible. Added the three guard tests for
  `pages/api/subscriptions/subscribe.ts:25`, and gave `makeReq` a `callbackUrl` parameter so
  callers stop building a request body only to overwrite it.

- **`apps/client/pages/api/organizations/subscriptions/__tests__/subscribe.test.ts`** - applied
  the five review findings carried over from #1885, all in this file:
  1. Dropped `stripeCustomerId` from the shared fixture. The route therefore now runs
     `createCustomer` and persists via `organizationRepository.update`, so
     `expect(mockCreateCustomer).not.toHaveBeenCalled()` on the rejection path can actually
     fail - previously the fixture short-circuited that branch and the assertion held whether
     the guard ran or not. The success path asserts both were called once, which is what
     establishes reachability, and `mockOrgUpdate` is now asserted rather than merely wired up.
  2. Folded the message into the single `toMatchObject`, so the handler is invoked once instead
     of twice for two assertions about one throw.
  3. Documented that `constructor:` is deliberate and strictly stronger than `toBeInstanceOf`,
     which would also accept a subclass carrying a different status.
  4. Pinned the #1424 seat clamp at the route level for the first time, as an `it.each` over
     two fixtures where each bound bites: 10 members must yield `minimum: 11`, and 150 members
     must yield `minimum: ORGANIZATION_SUBSCRIPTION_MAX_SEATS` (the `minimum > maximum` wedge
     #1424 fixed).
  5. Switched `BadRequestError` to `@bike4mind/common`, matching the `HttpStatus` import beside
     it - `b4m-core/utils/src/errors.ts:1-4` is a `@deprecated` re-export.

  Also added a success-path case for the `organizationData` new-organization branch
  (`pages/api/organizations/subscriptions/subscribe.ts:82-90`), which no existing test reached
  because all of them set `organizationId`. That branch is where `createCustomer` runs
  unconditionally, and the case asserts the metadata carries `newOrganizationName` and no
  `organizationId`.

The four route files themselves are unchanged; only the guard helper and tests are touched.

## Guide for Testers

This is a backend-only change with no UI. On any environment you can sign into, behavior is
identical to before, because `APP_URL` is set there and the changed branch is unreachable. The
steps below therefore confirm a **no-op**: that nothing legitimate started being rejected.

**Environment prerequisite, discovered while capturing evidence:** three of the four call
sites carry `.use(requireStripeWebhook())`, which rejects with
`Stripe webhook secret is not configured` before the origin guard runs whenever
`STRIPE_WEBHOOK_SECRET` is absent. On a preview without that secret, steps 2-5 below cannot be
executed at all - not a guard failure, just an untestable environment. Only
`convert-to-paid.ts` has no such middleware, so step 1 is always runnable. Ask a maintainer to
set the secret on the preview if you need steps 2-5.

Sign in as a **platform admin** (step 1 requires it), on the preview origin.

1. Open devtools Console on the preview and POST to
   `/api/admin/organizations/<any-id>/convert-to-paid` with `callbackUrl` set to an external
   origin such as `https://example.com/x`. The organization id need not exist - the guard runs
   before the lookup.
   **Expected:** HTTP 400, message `callbackUrl must point to the deployed application origin`.
   Then repeat with `callbackUrl` set to the app's own origin.
   **Expected:** a different error - `Organization not found` - proving the guard passed the
   request through rather than the route rejecting everything.

Steps 2-5 require `STRIPE_WEBHOOK_SECRET` on the environment:

2. Navigate to the subscription/upgrade entry point for an individual plan and start checkout.
   **Expected:** the browser lands on Stripe's hosted checkout page, and no 400 appears in the
   network tab for `/api/subscriptions/subscribe`.
3. Open the billing portal entry point (account or settings billing).
   **Expected:** the browser lands on Stripe's hosted billing portal; `/api/stripe/portal`
   returns 200 with a `url`.
4. As an organization owner, start an organization subscription checkout.
   **Expected:** Stripe's hosted checkout page loads, and the seat selector shows a minimum of
   4 and a maximum of 100.
5. Re-issue the `/api/subscriptions/subscribe` POST with `callbackUrl` edited to an external
   origin, keeping the rest of the body identical.
   **Expected:** HTTP 400, message `callbackUrl must point to the deployed application origin`,
   and no Stripe redirect.

### Regression Checks

6. Repeat step 5 against `/api/stripe/portal` (same prerequisite).
   **Expected:** HTTP 400 with the same message.
7. As a platform admin, open the admin organizations view and begin the convert-to-paid flow
   for an organization holding an active admin grant.
   **Expected:** a Stripe checkout URL is produced and the flow proceeds as before.

### What NOT to test

- Do not try to reproduce the original weakness by unsetting `APP_URL`. It is a deploy-time
  construct variable, not a runtime toggle, and removing it would fail the guard closed for
  every caller on that stage - which is the intended behavior, not a bug to observe.
- No admin setting was added, so there is nothing to seed or hydrate.
- There is no UI, styling, or responsive behavior to review.

## Additional Information

Passing tests prove little on their own, so every new assertion was checked to **fail** when
the code it guards is deliberately broken. Each mutation below was applied, run, and reverted;
a residue grep confirmed the tree clean afterwards. Counts are transcribed from those runs
(vitest's failure marker rendered here as `FAIL`).

Baseline, the five affected test files, run from `apps/client`:

```text
Test Files  5 passed (5)
Tests  34 passed (34)
```

**The changed predicate.** Reverting `callbackUrl.ts:19` to the old `=== 'production'`:

```text
FAIL fails closed when APP_URL is missing on a stage that is neither production nor development
Tests  1 failed | 10 passed (11)
```

Exactly one test fails. The pre-existing production and development cases pass under either
spelling, which is what identifies the new case as the one actually pinning this change.

**Each call site's guard.** Replacing the guard with
`if (false && !isAllowedCallbackOrigin(callbackUrl))`, one route at a time:

```text
pages/api/subscriptions/subscribe.ts                       Tests  3 failed | 5 passed (8)
pages/api/stripe/portal.ts                                 Tests  3 failed | 2 passed (5)
pages/api/admin/organizations/[id]/convert-to-paid.ts      Tests  3 failed (3)
pages/api/organizations/subscriptions/subscribe.ts         Tests  3 failed | 4 passed (7)
```

Precisely the three guard tests fail in each file and nothing else. The pass-through tests are
among the three, because they assert `toHaveBeenCalledWith` on the guard - so they fail when
the guard is merely never consulted, not only when the happy path breaks.

**The #1424 seat clamp**, which had no route-level test anywhere. Deleting the whole
`Math.min(Math.max(MIN, users.length + 1), MAX)` expression:

```text
FAIL clamps the adjustable-quantity floor: 'floor tracks members + 1 once it exceeds MIN'
FAIL clamps the adjustable-quantity floor: 'ceiling clamps at MAX so minimum can never exceed maximum'
Tests  2 failed | 5 passed (7)
```

Removing only the `Math.min(..., MAX)` ceiling, the exact regression #1424 fixed:

```text
FAIL clamps the adjustable-quantity floor: 'ceiling clamps at MAX so minimum can never exceed maximum'
Tests  1 failed | 6 passed (7)
```

Discriminating rather than blanket - the ceiling case isolates the ceiling. Worth stating that
the assertion this replaced passed with the clamp fully deleted: the one-member fixture made
`minimum` coincide with `MIN_SEATS`, so it proved nothing.

**The two new non-guard assertions**, so the mutation coverage is complete rather than
guard-only. Making the route send `organizationId` where it should send
`newOrganizationName`, and separately dropping the `organizationRepository.update` persist:

```text
FAIL creates a customer with no org lookup on the new-organization branch
Tests  1 failed | 6 passed (7)

FAIL passes an allowed-origin callbackUrl through to the checkout session
Tests  1 failed | 6 passed (7)
```

The first pins the `organizationData` branch's metadata; the second pins the DB write that the
rejection path's `not.toHaveBeenCalled()` assertions depend on for their meaning.

**The Organization owner path**, previously unexercised. Making the route resolve the wrong
customer, and separately removing the admin-grant refusal:

```text
FAIL resolves the organization customer on the Organization owner path
Tests  1 failed | 4 passed (5)

FAIL refuses the portal for an admin-granted organization instead of bootstrapping billing
Tests  1 failed | 4 passed (5)
```

### Preview capture

Run against the preview at `cc0464c`, which matches the PR head. It reaches one of the four
call sites, for a structural reason:

```text
[BLOCKED] case 1: POST /api/subscriptions/subscribe - cross-origin callbackUrl
          actual : 400 "Stripe webhook secret is not configured"

[BLOCKED] case 2: POST /api/stripe/portal - cross-origin callbackUrl
          actual : 400 "Stripe webhook secret is not configured"

[PASS]    case 3: POST /api/admin/organizations/:id/convert-to-paid - cross-origin callbackUrl
          actual : 400 "callbackUrl must point to the deployed application origin"

[BLOCKED] case 4: control on /api/subscriptions/subscribe - same-origin callbackUrl
          actual : 500 "Stripe webhook secret is not configured"

[PASS]    case 5: control on convert-to-paid - same-origin callbackUrl
          actual : 404 "Resource not found"
```

Cases 3 and 5 are a complete pair for that call site: a cross-origin `callbackUrl` refused
with the guard's own message, and a same-origin one passed through to fail later on a
nonexistent organization id. Without case 5, case 3 could have passed merely because the route
rejects everything. No Stripe checkout or billing-portal session was created.

The BLOCKED cases are an environment gap, not a guard result. `subscriptions/subscribe.ts`,
`stripe/portal.ts` and `organizations/subscriptions/subscribe.ts` all carry
`.use(requireStripeWebhook())`, which rejects before the origin guard whenever
`STRIPE_WEBHOOK_SECRET` is unset, and it is unset on this preview. `convert-to-paid.ts` is the
only one of the four without that middleware, which is exactly why it is the reachable one.
Those three are covered by the mutation runs above.

### What no test here can show

Neither the suite nor the preview exercises the changed line **on a deployed stage**, and no
achievable test could. That branch is only reached with `APP_URL` unset, and even then old and
new behave identically on a deployed stage: `next build` bakes `NODE_ENV=production` into the
server bundle, so old (`=== 'production'`) and new (`!== 'development'`) both reject. The two
diverge only when `NODE_ENV` is neither `production` nor `development`, which no deployed stage
reaches. That is the same fact this change's "defense-in-depth, not a live hole" framing rests
on, and it is why the unit case above is the proof rather than a stand-in for one.

### Incidental pre-existing finding, not touched here

`apps/client/server/middlewares/requireStripeWebhook.ts:28-36` calls `next(err)` without
returning and then calls `next()` unconditionally, so both the error and success paths fire
when the secret is missing. Visible in the capture above: the same endpoint returned 400 in
case 1 and 500 in case 4. Out of scope for a one-line guard change, and filed separately as
#1990 with the sibling sweep that shows these two lines are the only non-terminal bare
`next(err)` calls in `apps/client/server/middlewares/`.

### Known limitations, stated rather than smoothed over

- The runtime `NODE_ENV` value inside a deployed web-construct lambda has not been read
  directly. The determination recorded on #1892 rests on three in-repo sources plus the
  `next build` mechanism. `Verify.md` carries the runtime check as a step with an explicit fail
  condition.
- `pages/api/subscriptions/__tests__/subscribe.test.ts` still contains two non-ASCII characters
  (an em dash and a right-arrow in two test titles). They are byte-identical to `origin/main`
  and the repo guard checks added lines only, so they sit outside this diff and were left alone
  rather than adding unrelated churn.
- The four route test files share 39 non-trivial byte-identical lines of mock preamble (46
  counting braces). Extracting a helper was considered and rejected on a mechanical rather than
  a volume argument: `vi.mock` is hoisted per file by vitest's transform and only for calls it
  can see syntactically in that file, so a helper cannot issue the mocks on a caller's behalf -
  each file would still need its own `vi.mock` calls. The per-route mock bodies also differ
  (different repositories, different Stripe surfaces, a different `subscriptionRepository`
  method each), so what stays shareable is the `baseApi` unwrap, the `callbackUrl` partial-mock,
  and their comments. Reasonable to revisit; noted rather than hidden.

## Developer Notes (Optional)

- The `toMatchObject({ constructor: SomeError, statusCode, message })` idiom is now used across
  four route test files and carries a comment in each explaining why it is not
  `toBeInstanceOf`: it pins the exact class, where `toBeInstanceOf` also accepts a subclass with
  a different status. Worth reusing for route error assertions, and worth not "simplifying".
- The pattern of pairing a rejection test with a pass-through test that asserts
  `toHaveBeenCalledWith` on the guard is what makes the accompanying `not.toHaveBeenCalled()`
  assertions meaningful. Without it, those can pass because the code never reached the call at
  all.
- Reusable lesson from finding 4 above: an assertion whose expected value coincides with a
  constant in the default fixture proves nothing. Vary the fixture until the expected value is
  one only the logic under test can produce.

## Security Testing

The two staging/preview reproduction steps in the template do not apply here, and are marked
so rather than left to imply pending work.

- [ ] N/A - **not reproducible on staging or any deployed stage, by construction.** The
  weakened branch is only reached when `APP_URL` is unset, and `APP_URL` is injected into every
  construct these four routes run in (`infra/web.ts:379`, `infra/queues.ts:1059`,
  `infra/mcp.ts:48`, `infra/emailMarketing.ts:42`). There is no request that reaches it, so
  there is no script or curl that can demonstrate the weakness against a deployed environment.
  The unit case added in this PR is the reproduction, and it is verified to fail against the
  old predicate.
- [ ] N/A - fix verification on a preview environment follows from the same reasoning: with
  `APP_URL` present the guard's observable behavior is unchanged, so a preview run confirms a
  no-op rather than a fix. The **Guide for Testers** steps above are the useful preview
  exercise, and step 5 confirms the origin check itself still rejects.
- [ ] Confirmed no upstream fix had already landed:
  `git log origin/main -- apps/client/server/integrations/stripe/callbackUrl.ts`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI surface
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
