### PR TITLE
test(client): await real broadcast delivery in the sibling-adoption tests

### DIFF
--- a/apps/client/app/utils/refreshCoordinator.test.ts
+++ b/apps/client/app/utils/refreshCoordinator.test.ts
@@ -138,12 +138,36 @@ describe('refreshCoordinator', () => {
   });
 
   describe('sibling-tab adoption', () => {
-    /** Post as another tab would and let the message loop deliver it. */
+    const openChannels: BroadcastChannel[] = [];
+
+    afterEach(() => {
+      openChannels.forEach(c => c.close());
+      openChannels.length = 0;
+    });
+
+    /**
+     * Post as another tab would, and return only once the coordinator has actually seen it.
+     *
+     * A fixed `setTimeout(0)` is not a delivery barrier. BroadcastChannel dispatch is a queued
+     * task, so on a loaded runner the coordinator's listener can run after that tick and the
+     * assertion then reads pre-delivery state - which is how this raced in CI. The probe channel
+     * is opened after the coordinator's (`listenForSiblingRefresh` runs first in every test
+     * here), and a post is delivered to channels in creation order, so the probe receiving the
+     * message proves the coordinator's listener has already run.
+     *
+     * That barrier matters just as much to the two "ignores ..." cases below: they assert the
+     * token is UNCHANGED, so without proof of delivery they would also pass when the message
+     * never arrived at all, and would stop pinning the guard they exist for.
+     */
     const broadcastFromSibling = async (payload: unknown) => {
       const sibling = new BroadcastChannel('b4m.auth');
+      const probe = new BroadcastChannel('b4m.auth');
+      openChannels.push(sibling, probe);
+      const delivered = new Promise<void>(resolve =>
+        probe.addEventListener('message', () => resolve(), { once: true })
+      );
       sibling.postMessage(payload);
-      await new Promise(resolve => setTimeout(resolve, 0));
-      sibling.close();
+      await delivered;
     };
 
     const fromSibling = token(SID, 'from-sibling');


### PR DESCRIPTION
## Why

`Run Tests (client)` failed on an unrelated PR of mine with a single red: `refreshCoordinator > sibling-tab adoption > takes a sibling's freshly minted token without a round trip of its own`. 1 failed, 10,482 passed. A re-run of the identical commit passed, and the diff on that PR touched nothing in this file's import graph.

The mechanism is the barrier itself:

```js
sibling.postMessage(payload);
await new Promise(resolve => setTimeout(resolve, 0));  // not a delivery guarantee
sibling.close();                                       // and this races delivery too
```

BroadcastChannel dispatch is a queued task. One macrotask tick is a bet on duration, not a wait for the event, so on a loaded runner the coordinator's listener can run after it and the assertion reads pre-delivery state. The failing shard took 18 minutes across 10,564 tests.

## What

A probe channel opened after the coordinator's receives the same post after it does, because a post is delivered to channels in creation order. The probe receiving the message is therefore proof the coordinator's listener has already run. Channels close in `afterEach` instead of mid-flight.

**This is not a timeout bump.** [#1098](https://github.com/Bike4Mind/bike4mind/issues/1098) records that raising thresholds one test at a time has already failed to converge, and it is right. This waits for the event rather than betting on a duration, so it converges by construction.

## The part that is arguably more important than the flake

The same barrier is load-bearing for the two `ignores a broadcast ...` cases, which assert the token is **unchanged**. Without proof of delivery those pass equally well when the message never arrived at all. So under exactly the conditions that make the positive test flake, the negative tests do not fail. They quietly stop pinning the guard they exist for, and a real regression in the `mfaPending || expired` path could land green.

Verified by mutation rather than by argument. Deleting `if (mfaPending || expired) return;` from `refreshCoordinator.ts`:

```
× ignores a broadcast while mid-MFA, so a shed session is never resurrected
× ignores a broadcast while already torn down, so a shed session is never resurrected
  Tests  2 failed | 7 passed (9)
```

Guard restored afterwards, so this PR is test-only.

## What I could not show

I could not reproduce the original failure locally. The pre-change file passed 30/30 under twelve competing busy-loop processes, and so does the new one. So this is not a measured before/after: the case for it is the observed CI red, plus the fact that a fixed tick is definitionally not a delivery barrier. Calling that out rather than implying I reproduced it.

## Verification

- `refreshCoordinator.test.ts` . 9 pass
- 30/30 green under deliberate CPU contention
- Mutation test above, then guard restored
- `pnpm --filter @bike4mind/client typecheck` clean, `eslint` clean on the file

Refs #1098
