### PR TITLE
fix(services): send llmParams so tool import stops failing validation

### DIFF
--- a/b4m-core/services/src/notebookImportService/index.test.ts
+++ b/b4m-core/services/src/notebookImportService/index.test.ts
@@ -161,6 +161,25 @@ describe('attachment ids come from the store, not from this service', () => {
     return sessionCreate.mock.calls[0][0];
   };
 
+  // ToolSchema requires llmParams; without it every tool write was rejected and swallowed.
+  it('sends llmParams so the tool write is not rejected', async () => {
+    const { adapters } = makeAdapters();
+    (adapters.toolRepository.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'store-tool-id' });
+
+    await new NotebookImportService(adapters).importNotebooks(
+      'user-1',
+      withAttachments as never,
+      {
+        ...OPTIONS,
+        importTools: true,
+      } as never
+    );
+
+    expect(adapters.toolRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ llmParams: DefaultLLMParams })
+    );
+  });
+
   it.each([true, false])('records store-assigned attachment ids, preserveIds=%s', async preserveIds => {
     const sessionData = await runWithAttachments({ preserveIds });
     expect(sessionData.toolIds).toEqual(['store-tool-id']);
@@ -191,11 +210,6 @@ describe('an attachment store that returns no id is not recorded', () => {
         ...OPTIONS,
         importTools: true,
       } as never
-    );
-
-    // ToolSchema requires llmParams; without it every tool write was rejected and swallowed.
-    expect(adapters.toolRepository.create).toHaveBeenCalledWith(
-      expect.objectContaining({ llmParams: DefaultLLMParams })
     );
 
     const sessionData = (adapters.sessionRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];

--- a/b4m-core/services/src/notebookImportService/index.test.ts
+++ b/b4m-core/services/src/notebookImportService/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { DefaultLLMParams } from '@bike4mind/common';
 import { NotebookImportService } from './index';
 import type { NotebookImportAdapters } from './index';
 
@@ -190,6 +191,11 @@ describe('an attachment store that returns no id is not recorded', () => {
         ...OPTIONS,
         importTools: true,
       } as never
+    );
+
+    // ToolSchema requires llmParams; without it every tool write was rejected and swallowed.
+    expect(adapters.toolRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ llmParams: DefaultLLMParams })
     );
 
     const sessionData = (adapters.sessionRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -12,7 +12,7 @@ import {
   NotebookImportError,
   SUPPORTED_IMPORT_VERSIONS,
 } from '../notebookExportService/types';
-import { isValidEnumValue, KnowledgeType } from '@bike4mind/common';
+import { DefaultLLMParams, isValidEnumValue, KnowledgeType } from '@bike4mind/common';
 import { normalizeId } from '@bike4mind/utils';
 import type { IChatHistoryItem } from '@bike4mind/common';
 import type { ILogger } from '@bike4mind/observability';
@@ -489,6 +489,9 @@ export class NotebookImportService {
 
     for (const tool of tools) {
       try {
+        // No `workBenchFiles`: it holds whole knowledge-file documents, which would need remapping
+        // onto the files this import creates under new ids. Mongoose defaults it to [].
+        // `description`/`configuration`/`metadata` are not ToolSchema paths and are dropped.
         const toolData = {
           userId: targetUserId,
           name: tool.name,
@@ -496,6 +499,10 @@ export class NotebookImportService {
           configuration: tool.configuration,
           createdAt: new Date(tool.createdAt),
           metadata: tool.metadata,
+          // ToolSchema requires llmParams and no export carries one, so an imported tool takes the
+          // app's declared defaults. Not `{}`: that would apply the schema's own defaults, which
+          // still name gpt-3.5-turbo.
+          llmParams: DefaultLLMParams,
         };
 
         importedIds.push(this.takeStoreId(await this.adapters.toolRepository.create(toolData), 'tool'));

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -502,7 +502,7 @@ export class NotebookImportService {
           // ToolSchema requires llmParams and no export carries one, so an imported tool takes the
           // app's declared defaults. Not `{}`: that would apply the schema's own defaults, which
           // still name gpt-3.5-turbo.
-          llmParams: DefaultLLMParams,
+          llmParams: { ...DefaultLLMParams },
         };
 
         importedIds.push(this.takeStoreId(await this.adapters.toolRepository.create(toolData), 'tool'));

--- a/packages/database/src/models/ai/ToolModel.integration.test.ts
+++ b/packages/database/src/models/ai/ToolModel.integration.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import mongoose from 'mongoose';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../__test__/createMongoServer';
+import { toolRepository } from './ToolModel';
+
+// Booting mongod exceeds the default unit-test budget; see createMongoServer's own guidance.
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
+let server: Awaited<ReturnType<typeof createMongoServer>>;
+
+beforeAll(async () => {
+  server = await createMongoServer();
+  await mongoose.connect(server.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server?.stop();
+});
+
+// `create` takes a full document type, so every call site needs the cast.
+const create = (data: Record<string, unknown>) => toolRepository.create(data as never);
+
+/**
+ * The contract the notebook import depends on. Mongoose applies a subdocument's defaults only when
+ * the path is set to a non-nullish value, so omitting `llmParams` fails its `required` check -
+ * which is why tool import silently produced no tools.
+ */
+describe('ToolModel create contract', () => {
+  it('rejects a payload with no llmParams', async () => {
+    await expect(create({ userId: new mongoose.Types.ObjectId(), name: 'no-params' })).rejects.toThrow(/llmParams/);
+  });
+
+  it('applies llmParams defaults and returns a usable id', async () => {
+    const created = await create({ userId: new mongoose.Types.ObjectId(), name: 'defaulted', llmParams: {} });
+
+    expect(created.llmParams.model).toBe('gpt-3.5-turbo');
+    expect(created.llmParams.temperature).toBe(0.9);
+    // `BaseRepository.create` returns `toObject()`, which omits virtuals unless the schema opts in.
+    expect(String(created.id)).toMatch(/^[0-9a-f]{24}$/i);
+  });
+});

--- a/packages/database/src/models/ai/ToolModel.integration.test.ts
+++ b/packages/database/src/models/ai/ToolModel.integration.test.ts
@@ -18,7 +18,8 @@ afterAll(async () => {
   await server?.stop();
 });
 
-// `create` takes a full document type, so every call site needs the cast.
+// The payload cannot be typed: the first case is invalid by design, omitting the required
+// `llmParams` to pin the rejection this suite exists for.
 const create = (data: Record<string, unknown>) => toolRepository.create(data as never);
 
 /**

--- a/packages/database/src/models/ai/ToolModel.ts
+++ b/packages/database/src/models/ai/ToolModel.ts
@@ -38,6 +38,10 @@ const ToolSchema: Schema = new Schema(
     toJSON: {
       virtuals: true,
     },
+    // BaseRepository.create returns toObject(), so callers need the id virtual here.
+    toObject: {
+      virtuals: true,
+    },
   }
 );
 


### PR DESCRIPTION
Closes #1987. Closes #1989.

## Problem

Tool import has never worked. `importTools` built its payload without `llmParams`, which `ToolSchema` declares required, so every tool threw a `ValidationError`. The per-attachment catch downgraded it to a warning, so the import completed and reported success with no tools attached.

```
ToolModel validation failed: llmParams: Path `llmParams` is required.
```

Observed on a preview deploy while verifying #1980: `toolIds: []` on every imported notebook.

## Fix

Send `llmParams: DefaultLLMParams` from `@bike4mind/common`.

Not `{}`: an empty object would let the schema apply its own defaults, which still name `gpt-3.5-turbo`. `DefaultLLMParams` already existed for exactly this purpose, was referenced nowhere, and carries `gpt-4o-mini`. Passing it also removes a second source of truth for tool defaults.

`workBenchFiles` is left to default. It holds whole knowledge-file documents, which would need remapping onto the files the same import creates under new ids - out of scope here.

A consequence worth naming: since `ExportedTool` carries no `llmParams`, an export-import round trip rewrites any tool to these defaults - `gpt-4o-mini`, `max_tokens: 3999` - rather than preserving what it had. Harmless today, because nothing in the repo reads `Tool.llmParams`, but it is a real semantic loss and the reason option 1 in #1987 (export the config) remains the fuller fix.

`description`, `configuration` and `metadata` are still sent and still silently stripped; none are `ToolSchema` paths and the export never emits them, so nothing is lost today. Noted in a comment rather than changed.

## ToolSchema also gains `toObject: { virtuals: true }` (#1989)

Deliberately a schema change, unlike `llmParams`, and worth stating plainly: **this is not what makes the live import resolve.** The production adapter returns the hydrated document from `Tool.create([data], { session })`, whose `id` virtual works regardless of `toObject` options. The broken path is `BaseRepository.create`, which returns `toObject()` and which nothing reaches for tools today. So this is model hygiene closing a trap for the next caller - every sibling model already sets it; `ToolSchema` was the only one missing it. Measured cost: ~0.7us per document.

The distinction: this corrects the model itself, whereas giving `llmParams` a schema default would bend a shared model to suit one caller and would turn "you forgot the config" into a silent obsolete-model default for interactive tool creation.

## Verified end to end against a real Mongo

Driven through the import dialog with the toggle on, then the real S3 worker run against the uploaded object, writing through the real service and repositories:

```
tool count        1                            (previously always 0)
session.toolIds   ["6a86b8021672310db78dc98a"]
created tool _id   6a86b8021672310db78dc98a     -> identical, the reference resolves
llmParams.model   gpt-4o-mini
```

## Tests

- unit: the payload carries `llmParams: DefaultLLMParams`; a store returning no id records nothing and warns.
- new `ToolModel.integration.test.ts` against a real Mongo: a payload without `llmParams` is rejected (pinning the bug's mechanism - Mongoose applies a subdocument's defaults only when the path is set to a non-nullish value); `{}` applies defaults; `create()` returns a usable id. The last case was confirmed red without the `toObject` fix: `String(created.id)` yields `'undefined'`, so the assertion fails as a `toMatch` mismatch against `/^[0-9a-f]{24}$/i`.

## Follow-ups, not fixed here

- #1633 - artifact import still writes nothing (`ArtifactSchema` wants `title` plus four required content fields).
- #1988 - artifact export never matches, so artifacts do not round-trip in either direction.
- An export-to-import round-trip integration test asserting every attachment kind lands. This class has now been found three times, one entity at a time; that one test would catch the next.

