### PR TITLE
ci: add secrets scan (GHAS replacement)

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,0 +1,22 @@
+name: secrets
+
+# Replaces GitHub Advanced Security Secret Protection, which bills per active
+# committer across every repository it is enabled on.
+#
+# Scans only the commits a pull request adds, so pre-existing history cannot fail
+# unrelated PRs. Full history is covered by the nightly org-wide sweep in
+# Bike4Mind/workflow-templates.
+#
+# The runner comes from the SECRETS_SCAN_RUNNER_LABEL org variable, so retargeting
+# the fleet is one variable edit rather than a commit here.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    uses: Bike4Mind/workflow-templates/.github/workflows/secrets-scan.yml@main


### PR DESCRIPTION
Adds the shared secrets scan that replaces GitHub Advanced Security Secret Protection.

GHAS bills $19 per active committer per month, currently 19 licenses across the org at roughly $361/mo. Michael confirmed no requirement for it, so it is being replaced with gitleaks plus trufflehog running on our own runners. This also widens coverage: we pay for 6 repositories today and there are 23 active ones, so most of the org has no secret scanning at all right now.

## What this adds

One job calling the shared reusable in `Bike4Mind/workflow-templates`. Nothing repository-specific, and the runner comes from the `SECRETS_SCAN_RUNNER_LABEL` org variable so retargeting the fleet never needs a commit here.

It scans only the commits a pull request adds. Scanning full history on every PR would fail every PR in any repository with a pre-existing finding anywhere in its past, including PRs touching nothing related, which teaches people to route around the check. Full history is covered by the nightly org-wide sweep instead, which already runs and has this repository clean.

If this repository has its own `.gitleaks.toml` it is used; otherwise the org default bundled with the action applies.

## Proven before this rollout

Piloted on `b4m-optihashi`, the repository carrying 18 of the 19 billable licenses. Clean branch passes in about 20 seconds, a planted generated AWS key makes it fail with the right annotation, and removing the key makes it pass again. It runs on the self-hosted `b4m-deployer-light` fleet.

The check on this PR is the proof for this repository.

## Not required yet

This is advisory. It becomes a required status check only once every repository is onboarded, because requiring it earlier would block pull requests in repositories that have not added it. GHAS stays enabled until then.
