### PR TITLE
fix(sst): make state.purge an allowlist so only pr#### previews are purgeable

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -7,11 +7,24 @@ export default $config({
     const permanent = ['production', 'shared-dev'].includes(input?.stage);
     // Purge is narrower than `permanent` on purpose. It runs SST's Purge() on a
     // successful `sst remove`, which deletes the stage's secrets AND its encryption
-    // passphrase — unrecoverable (sst/sst#6593). `dev` is the shared STAGING box
-    // (see isStagingStage / PRODUCTION_STAGES in infra/constants.ts), so it is
-    // excluded even though `sst remove` is not blocked there. Only genuinely
-    // ephemeral stages — personal stages and pr#### previews — are purgeable.
-    const purgeable = !permanent && input?.stage !== 'dev';
+    // passphrase — unrecoverable (sst/sst#6593).
+    //
+    // This is an ALLOWLIST of stages that are genuinely disposable, not a
+    // denylist of the ones we remembered to protect. Only `pr####` previews
+    // qualify: CI creates and destroys those per pull request. Written as a
+    // denylist, every stage was purgeable unless somebody thought to exclude it,
+    // so the blast radius grew silently as stages were added — a future `qa` or
+    // `demo`, a second staging box, or a typo like `--stage de` would each have
+    // destroyed secrets on `sst remove`.
+    //
+    // Deliberately NOT purgeable: the permanent stages, the shared STAGING box
+    // `dev` (see isStagingStage / PRODUCTION_STAGES in infra/constants.ts), the
+    // long-dormant `bike4mind` stage, and every personal stage. Personal stages
+    // WERE purgeable under the denylist; that is an intentional change, and it
+    // means removing one now leaves its secrets and passphrase in SSM rather
+    // than destroying them. Narrowing that back to a maintained roster of
+    // developer stage names is a separate decision.
+    const purgeable = /^pr\d+$/.test(input?.stage ?? '');
     return {
       name: process.env.SEED_APP_NAME || 'bike4mind',
       removal: permanent ? 'retain' : 'remove',

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -7,13 +7,13 @@ export default $config({
     const permanent = ['production', 'shared-dev'].includes(input?.stage);
     // Purge is narrower than `permanent` on purpose. It runs SST's Purge() on a
     // successful `sst remove`, which deletes the stage's secrets AND its encryption
-    // passphrase — unrecoverable (sst/sst#6593).
+    // passphrase - unrecoverable (sst/sst#6593).
     //
     // This is an ALLOWLIST of stages that are genuinely disposable, not a
     // denylist of the ones we remembered to protect. Only `pr####` previews
     // qualify: CI creates and destroys those per pull request. Written as a
     // denylist, every stage was purgeable unless somebody thought to exclude it,
-    // so the blast radius grew silently as stages were added — a future `qa` or
+    // so the blast radius grew silently as stages were added - a future `qa` or
     // `demo`, a second staging box, or a typo like `--stage de` would each have
     // destroyed secrets on `sst remove`.
     //


### PR DESCRIPTION
One line, but unlike the sibling polaris fix this one **does change behaviour** for personal stages. Details below.

## The problem

```ts
const purgeable = !permanent && input?.stage !== 'dev';
```

`Purge()` runs on a successful `sst remove` and deletes the stage's secrets **and** its encryption passphrase, unrecoverably (sst/sst#6593). Written as a denylist, every stage is purgeable *unless* somebody remembered to exclude it, so the blast radius grows silently as stages get added. A future `qa` or `demo` stage, a second staging box, or a typo like `--stage de` would each have destroyed secrets on `sst remove`. An `undefined` stage evaluated as purgeable too.

## The fix

```ts
const purgeable = /^pr\d+$/.test(input?.stage ?? '');
```

Only `pr####` previews, which CI creates and destroys per pull request. Anything new is safe by default rather than dangerous by default.

## What changes

| stage | before | after |
|---|---|---|
| `production` | false | false |
| `shared-dev` | false | false |
| `dev` | false | false |
| `pr9650` | **true** | **true** |
| `qa` / `demo` / `de` (typo) | true | **false** |
| `undefined` | true | **false** |
| **personal stages** (`erikbethke`, `jan`, `conard`, `allangargar`, …) | **true** | **false** |
| **`bike4mind`** (dormant, real state) | **true** | **false** |

**The personal-stage row is a real change, not a no-op.** Roughly 20 of them are live in the dev account. They were purgeable by an earlier deliberate decision; under this change `sst remove` on one leaves its secrets and passphrase in SSM instead of destroying them.

That is the intended direction. The cost is some leftover SSM parameters, weighed against unrecoverable secret loss on any stage nobody thought to list. Narrowing back to a maintained roster of developer stage names is a separate decision, deliberately not made here.

Worth flagging separately: the stage literally named **`bike4mind`** holds 7.3 MB of real state, untouched since 27 February, and was purgeable until now.

## Verify it yourself

```
gh pr checkout <this PR>
node -e 'const p=s=>/^pr\d+$/.test(s??""); [undefined,"production","shared-dev","dev","pr9650","jan","bike4mind","de"].forEach(s=>console.log(String(s).padEnd(12),p(s)))'
```

Config-only, no infra diff: `purgeable` feeds `state.purge`, which is CLI-side state handling and produces no AWS resource change. `state.retention` is untouched.

## Context

Same defect shipped to four repos from one upgrade pattern. Already fixed in MillionOnMars/vibes-trader#276 (merged, had been live in production) and MillionOnMars/vibeswire#352. The polaris equivalent is FuturumGroup/polaris#5992, which is a true no-op there because only `dev`, `production` and `pr####` exist.
