### PR TITLE
fix(client): stop the chat composer latching itself dead

### DIFF
--- a/apps/client/app/components/Session/LexicalChatInput.tsx
+++ b/apps/client/app/components/Session/LexicalChatInput.tsx
@@ -581,12 +581,16 @@ export const LexicalChatInput = forwardRef<LexicalChatInputRef, LexicalChatInput
       [agents]
     );
 
-    // The plugin's lookup effect keys on the `items` identity and answers with
-    // setResults([]) - a fresh array React cannot dedupe - so an inline object
-    // literal here schedules an un-bailable update on every render. That is what
-    // keeps React's nested-update chain alive until something trips "Maximum
-    // update depth exceeded". It also re-registers the plugin's nine lexical
-    // commands each render.
+    // Canonical note on why this identity matters (referenced from SessionBottom).
+    //
+    // lexical-beautiful-mentions' lookup effect keys on `items` and answers with
+    // setResults([]) - a fresh array, so React can never bail out on an unchanged
+    // value. An inline object literal here therefore schedules an un-bailable
+    // update on EVERY render, which keeps React's cumulative nested-update chain
+    // from ever settling until some unrelated setState trips "Maximum update depth
+    // exceeded". Unstable `items` also re-registers the plugin's ten lexical
+    // commands per render: `items` is not in that effect's dep array, but it feeds
+    // a `triggers = useMemo(..., [props.triggers, items])` that is.
     const mentionItems = useMemo(() => ({ '@': agentMentionItems }), [agentMentionItems]);
 
     // Stable identity: EditorRefPlugin keys its effect on this callback.

--- a/apps/client/app/components/Session/LexicalChatInput.tsx
+++ b/apps/client/app/components/Session/LexicalChatInput.tsx
@@ -132,6 +132,14 @@ export function $collectMentions(root: LexicalNode): LexicalMention[] {
 export const CHAT_MARKDOWN_TRANSFORMERS = [CODE, ...TEXT_FORMAT_TRANSFORMERS, UNORDERED_LIST, ORDERED_LIST];
 
 /**
+ * Transformers for the live typing shortcuts (lists are handled by our own
+ * plugin instead). Module-level so the identity is stable: MarkdownShortcutPlugin
+ * keys its registration effect on this array, so an inline literal re-registers
+ * every markdown shortcut on every render of the composer.
+ */
+const MARKDOWN_SHORTCUT_TRANSFORMERS = [CODE, INLINE_CODE];
+
+/**
  * Inline text formats that `CHAT_MARKDOWN_TRANSFORMERS` can actually serialize.
  *
  * Deliberately excludes underline / subscript / superscript: `RichTextPlugin`
@@ -573,6 +581,19 @@ export const LexicalChatInput = forwardRef<LexicalChatInputRef, LexicalChatInput
       [agents]
     );
 
+    // The plugin's lookup effect keys on the `items` identity and answers with
+    // setResults([]) - a fresh array React cannot dedupe - so an inline object
+    // literal here schedules an un-bailable update on every render. That is what
+    // keeps React's nested-update chain alive until something trips "Maximum
+    // update depth exceeded". It also re-registers the plugin's nine lexical
+    // commands each render.
+    const mentionItems = useMemo(() => ({ '@': agentMentionItems }), [agentMentionItems]);
+
+    // Stable identity: EditorRefPlugin keys its effect on this callback.
+    const handleEditorRef = useCallback((ref: LexicalChatInputRef) => {
+      editorRefStore.current = ref;
+    }, []);
+
     // Handle editor changes - export plain text for display/sync
     // Wrapped in useCallback to prevent unnecessary re-renders of OnChangePlugin
     const handleEditorChange = useCallback(
@@ -656,13 +677,11 @@ export const LexicalChatInput = forwardRef<LexicalChatInputRef, LexicalChatInput
           </PluginErrorBoundary>
 
           {/* Markdown shortcuts for inline code only (lists handled by custom plugin above) */}
-          <MarkdownShortcutPlugin transformers={[CODE, INLINE_CODE]} />
+          <MarkdownShortcutPlugin transformers={MARKDOWN_SHORTCUT_TRANSFORMERS} />
 
           {/* Beautiful Mentions Plugin for @mentions - third-party library, already stable */}
           <BeautifulMentionsPlugin
-            items={{
-              '@': agentMentionItems,
-            }}
+            items={mentionItems}
             menuAnchorClassName="mentions-menu-anchor"
             menuComponent={CustomMentionsMenu}
           />
@@ -679,7 +698,7 @@ export const LexicalChatInput = forwardRef<LexicalChatInputRef, LexicalChatInput
 
           {/* Editor ref plugin - exposes getMarkdown, insertContent, setSelection, and focus methods */}
           <PluginErrorBoundary pluginName="EditorRefPlugin">
-            <EditorRefPlugin onRef={ref => (editorRefStore.current = ref)} skipSyncRef={skipSyncRef} />
+            <EditorRefPlugin onRef={handleEditorRef} skipSyncRef={skipSyncRef} />
           </PluginErrorBoundary>
         </div>
       </LexicalComposer>

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -292,7 +292,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   }, [pendingMessageFiles]);
 
   const { data: sessionAgents = [] } = useGetSessionAgents(effectiveSessionId);
-  const { data: availableAgents = [] } = useGetAgents();
+  // Deliberately not defaulted to []: a literal default mints a fresh array on
+  // every render until the query resolves, which would defeat the memo below
+  // during exactly the window where it matters most (first typing on a cold page).
+  const { data: availableAgents } = useGetAgents();
 
   // Get chat history for the current session
   const { data: questsData } = useGetSessionQuests(effectiveSessionId);
@@ -301,12 +304,50 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   // Combine session agents and workBench agents for display
   const displayAgents = currentSessionId ? sessionAgents : workBenchAgents;
 
-  // Prepare data for LexicalChatInput
-  const lexicalAgents = availableAgents.map(agent => ({
-    id: agent.id,
-    name: agent.name,
-    triggerWords: agent.triggerWords,
-  }));
+  // Prepare data for LexicalChatInput.
+  //
+  // Memoised because the identity travels a long way: it becomes the mention
+  // plugin's `items`, and lexical-beautiful-mentions' lookup effect reacts to
+  // that identity by calling setResults([]) - a fresh array, so React can never
+  // dedupe it as an unchanged value. A new array per render therefore schedules
+  // an un-bailable update on every render, which keeps React's nested-update
+  // chain from ever settling. The chain is what eventually trips "Maximum update
+  // depth exceeded", reported from whichever setState happens to be the 51st
+  // link (in practice lexical's placeholder listener, which runs twice per
+  // editor commit). Unstable `items` also makes the plugin re-register its nine
+  // lexical commands on every render.
+  const lexicalAgents = useMemo(
+    () =>
+      (availableAgents ?? []).map(agent => ({
+        id: agent.id,
+        name: agent.name,
+        triggerWords: agent.triggerWords,
+      })),
+    [availableAgents]
+  );
+
+  // Both handlers are memoised: LexicalChatInput hands them to OnChangePlugin and
+  // SubmitOnEnterPlugin, which key their lexical registrations on the identity, so
+  // inline arrows re-register an editor listener and a command on every render.
+  const handleInputChange = useCallback(
+    (newValue: string) => {
+      setChatInputValue(newValue);
+
+      // Save draft as user types. A new notebook has no id yet, so
+      // draft under the stable new-notebook key - it survives a
+      // full-page reload and is restored by useMessageDraft.
+      setDraft(currentSessionId ?? NEW_NOTEBOOK_DRAFT_KEY, newValue);
+
+      const shouldShowSlashSuggestions =
+        typeof newValue === 'string' &&
+        newValue.startsWith('/') &&
+        !newValue.startsWith('/admin') &&
+        !newValue.includes(' '); // Hide when user has completed the command and added a space
+
+      setShowSlashSuggestions(shouldShowSlashSuggestions);
+    },
+    [setChatInputValue, setDraft, currentSessionId]
+  );
 
   const { rollRandomDice } = useRollDice();
 
@@ -318,6 +359,13 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
     setChatCompletion,
     onAgentsAttached: () => setAgentBenchCollapsed(false),
   });
+
+  const handleEditorSubmit = useCallback(async () => {
+    // Block Enter-to-send while a response is still streaming
+    // or while files are still uploading/scanning.
+    if (shouldShowStopButton || submitting || hasActiveUploads) return;
+    await handleSendClick();
+  }, [shouldShowStopButton, submitting, hasActiveUploads, handleSendClick]);
 
   // Expose handleSendClick for programmatic use (e.g., InteractiveChessBoard)
   const sendPromptCallback = useCallback(
@@ -588,28 +636,8 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                     <LexicalChatInput
                       ref={lexicalInputRef}
                       value={chatInputValue}
-                      onChange={newValue => {
-                        setChatInputValue(newValue);
-
-                        // Save draft as user types. A new notebook has no id yet, so
-                        // draft under the stable new-notebook key - it survives a
-                        // full-page reload and is restored by useMessageDraft.
-                        setDraft(currentSessionId ?? NEW_NOTEBOOK_DRAFT_KEY, newValue);
-
-                        const shouldShowSlashSuggestions =
-                          typeof newValue === 'string' &&
-                          newValue.startsWith('/') &&
-                          !newValue.startsWith('/admin') &&
-                          !newValue.includes(' '); // Hide when user has completed the command and added a space
-
-                        setShowSlashSuggestions(shouldShowSlashSuggestions);
-                      }}
-                      onSubmit={async () => {
-                        // Block Enter-to-send while a response is still streaming
-                        // or while files are still uploading/scanning.
-                        if (shouldShowStopButton || submitting || hasActiveUploads) return;
-                        await handleSendClick();
-                      }}
+                      onChange={handleInputChange}
+                      onSubmit={handleEditorSubmit}
                       onPaste={handlePaste}
                       placeholder={`${t('session.typeYourMessage')}...`}
                       agents={lexicalAgents}

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -293,8 +293,8 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
 
   const { data: sessionAgents = [] } = useGetSessionAgents(effectiveSessionId);
   // Deliberately not defaulted to []: a literal default mints a fresh array on
-  // every render until the query resolves, which would defeat the memo below
-  // during exactly the window where it matters most (first typing on a cold page).
+  // every render until the query resolves, defeating the memo below during
+  // exactly the window that matters (first typing on a cold page).
   const { data: availableAgents } = useGetAgents();
 
   // Get chat history for the current session
@@ -304,18 +304,9 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   // Combine session agents and workBench agents for display
   const displayAgents = currentSessionId ? sessionAgents : workBenchAgents;
 
-  // Prepare data for LexicalChatInput.
-  //
-  // Memoised because the identity travels a long way: it becomes the mention
-  // plugin's `items`, and lexical-beautiful-mentions' lookup effect reacts to
-  // that identity by calling setResults([]) - a fresh array, so React can never
-  // dedupe it as an unchanged value. A new array per render therefore schedules
-  // an un-bailable update on every render, which keeps React's nested-update
-  // chain from ever settling. The chain is what eventually trips "Maximum update
-  // depth exceeded", reported from whichever setState happens to be the 51st
-  // link (in practice lexical's placeholder listener, which runs twice per
-  // editor commit). Unstable `items` also makes the plugin re-register its nine
-  // lexical commands on every render.
+  // Prepare data for LexicalChatInput. Memoised because the identity becomes the
+  // mention plugin's `items`, where a new array per render drives an un-bailable
+  // update storm - see the note at `mentionItems` in LexicalChatInput.tsx.
   const lexicalAgents = useMemo(
     () =>
       (availableAgents ?? []).map(agent => ({

--- a/apps/client/app/components/Session/SessionBottom/composerStability.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/composerStability.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guards for the chat composer's update storm.
+ *
+ * lexical-beautiful-mentions' lookup effect keys on `items` and answers with
+ * setResults([]) - a fresh array React can never bail out on - so an unstable
+ * `items` schedules an un-bailable update on every render and keeps React's
+ * cumulative nested-update chain from settling until an unrelated setState trips
+ * "Maximum update depth exceeded". Re-inlining any link in the memo chain is a
+ * one-character regression that silently restores the bug, which is what these
+ * assert against.
+ *
+ * Source-level assertions are used (rather than a render) because SessionBottom
+ * needs a large web of context providers that adds little signal beyond locking
+ * these invariants, and because identity stability is precisely what a render
+ * asserts poorly. Mirrors SessionBottom.dedup.test.ts.
+ */
+describe('chat composer - prop identity stability (regression)', () => {
+  const sessionBottom = readFileSync(resolve(__dirname, 'SessionBottom.tsx'), 'utf8');
+  const lexicalChatInput = readFileSync(resolve(__dirname, '../LexicalChatInput.tsx'), 'utf8');
+  const useSendMessage = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
+
+  describe('SessionBottom', () => {
+    it('builds lexicalAgents through useMemo', () => {
+      expect(sessionBottom).toMatch(/const lexicalAgents = useMemo\(/);
+    });
+
+    it('does not default useGetAgents to a fresh array literal', () => {
+      // `= []` mints a new array every render until the query resolves, which is
+      // exactly the window (first typing on a cold page) the memo has to cover.
+      expect(sessionBottom).toContain('const { data: availableAgents } = useGetAgents();');
+      expect(sessionBottom).not.toMatch(/data: availableAgents = \[\]/);
+    });
+
+    it('passes memoized handlers to the composer rather than inline arrows', () => {
+      expect(sessionBottom).toContain('onChange={handleInputChange}');
+      expect(sessionBottom).toContain('onSubmit={handleEditorSubmit}');
+      expect(sessionBottom).toMatch(/const handleInputChange = useCallback\(/);
+      expect(sessionBottom).toMatch(/const handleEditorSubmit = useCallback\(/);
+    });
+  });
+
+  describe('LexicalChatInput', () => {
+    it('passes a memoized items object to the mentions plugin', () => {
+      expect(lexicalChatInput).toContain('items={mentionItems}');
+      expect(lexicalChatInput).toMatch(/const mentionItems = useMemo\(/);
+    });
+
+    it('passes a module-level transformers array to MarkdownShortcutPlugin', () => {
+      expect(lexicalChatInput).toContain('transformers={MARKDOWN_SHORTCUT_TRANSFORMERS}');
+      expect(lexicalChatInput).toMatch(/^const MARKDOWN_SHORTCUT_TRANSFORMERS = /m);
+    });
+
+    it('passes a stable callback to EditorRefPlugin', () => {
+      expect(lexicalChatInput).toContain('onRef={handleEditorRef}');
+      expect(lexicalChatInput).toMatch(/const handleEditorRef = useCallback\(/);
+    });
+  });
+
+  describe('useSendMessage', () => {
+    it('exports a handleSendClick that is stable across renders', () => {
+      // Consumers (SubmitOnEnterPlugin, the useChatActions registration) key
+      // lexical/zustand registrations on this identity, so a bare `async () => {}`
+      // in the hook body re-registers on every render and defeats every
+      // useCallback downstream of it.
+      const declaration = useSendMessage.match(/const handleSendClick = useCallback\([\s\S]*?\n {4}\[\]\n {2}\);/);
+      expect(declaration).not.toBeNull();
+    });
+
+    it('routes the send body through the submit mutex', () => {
+      expect(useSendMessage).toContain('withSubmitMutex(submittingRef, setSubmittingState');
+      expect(useSendMessage).toMatch(/const runSendClick = async \(/);
+    });
+  });
+
+  it('rolls back the optimistic Stop affordance before the other state writes', () => {
+    // Ordering invariant: a throw in setWorkBenchAgents/setSubmitting must not
+    // skip the rollback, or `completed: false` plus the generating sentinel keeps
+    // shouldShowStopButton true and the composer renders Stop forever - a latch
+    // that releasing the submit mutex cannot undo.
+    const catchBody = useSendMessage.match(/data = await handler\(sessionToSend\);[\s\S]*?\n {6}return;/);
+    expect(catchBody).not.toBeNull();
+    const body = catchBody?.[0] ?? '';
+
+    const rollbackIdx = body.indexOf('setChatCompletion(prev =>');
+    const submittingIdx = body.indexOf('setSubmitting(false)');
+    const workBenchIdx = body.indexOf('setWorkBenchAgents([])');
+
+    expect(rollbackIdx).toBeGreaterThan(-1);
+    expect(rollbackIdx).toBeLessThan(workBenchIdx);
+    expect(rollbackIdx).toBeLessThan(submittingIdx);
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.hostCreate.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.hostCreate.test.ts
@@ -43,7 +43,8 @@ describe('useSendMessage — host-managed first-message creation (regression)', 
   });
 
   it('resets submitting state on the host-create early-return path', () => {
-    // setSubmitting(true) is a re-entrancy lock at the top of handleSendClick.
+    // setSubmitting(true) is a re-entrancy lock at the top of runSendClick (the
+    // send body that `handleSendClick` wraps).
     // The host-create path must call setSubmitting(false) before returning so the
     // UI is not left stuck in a submitting state.
     expect(source).toMatch(/await hostCreateSession\(prompt\);[\s\S]*?setSubmitting\(false\);[\s\S]*?return;/);

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -328,7 +328,9 @@ export function useSendMessage({
     }
   };
 
-  const handleSendClick = async (
+  // Body of the send. Always call it through `handleSendClick` below, never
+  // directly: the wrapper is what releases the submit mutex if this throws.
+  const runSendClick = async (
     newPrompt?: string,
     options?: { forceEnableQuestMaster?: boolean; toolsOverride?: B4MLLMTools[] }
   ): Promise<IChatHistoryItemDocument | undefined> => {
@@ -1126,6 +1128,42 @@ export function useSendMessage({
     setTimeout(() => {
       lexicalInputRef.current?.blur();
     }, 100);
+  };
+
+  /**
+   * Send, with a guaranteed release of the submit mutex on failure.
+   *
+   * `submittingRef` is flipped synchronously at the top of the body and is only
+   * cleared on paths the body reaches, so ANY throw in between latches it true
+   * for the lifetime of the mount - and because the guard at the top is a bare
+   * `return`, every later Enter, click and programmatic send goes silently
+   * nowhere until a reload. (Observed for real: React's "Maximum update depth
+   * exceeded", raised by the `setSubmitting(true)` state write itself while the
+   * composer's editor was in an update storm.)
+   *
+   * The ref is released directly rather than via `setSubmitting`, because the
+   * state write is exactly what can throw again here; the ref is what gates
+   * sending, so it must come first and unconditionally. A successful send is
+   * untouched: no throw, no release, and `submitting` stays true for the
+   * duration of the stream so the Stop affordance keeps rendering.
+   */
+  const handleSendClick = async (
+    newPrompt?: string,
+    options?: { forceEnableQuestMaster?: boolean; toolsOverride?: B4MLLMTools[] }
+  ): Promise<IChatHistoryItemDocument | undefined> => {
+    try {
+      return await runSendClick(newPrompt, options);
+    } catch (error) {
+      submittingRef.current = false;
+      try {
+        setSubmittingState(false);
+      } catch {
+        // Swallowed on purpose: if React is the thing failing, the ref release
+        // above has already restored sending, and the original error below is
+        // the one worth surfacing.
+      }
+      throw error;
+    }
   };
 
   // Auto-submit quest goal when websocket is ready (from /quests New Quest modal)

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -6,6 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useLocation, useSearch } from '@tanstack/react-router';
 import { createOptimisticPromptBubble, createOptimisticSessionId } from '@client/app/utils/llm';
 import { useSessionRouter } from '@client/app/hooks/useSessionRouter';
+import { withSubmitMutex } from './withSubmitMutex';
 import useDataLakeMode from '@client/app/hooks/useDataLakeMode';
 import useCreateDataLakeSession from '@client/app/hooks/useCreateDataLakeSession';
 
@@ -70,7 +71,7 @@ import perfLogger from '../../../utils/performanceLogger';
 import { consumeQuestLaunchIntent } from '../../../utils/questLaunchIntent';
 import { LexicalChatInputRef } from '../LexicalChatInput';
 
-// Sentinel statusMessage written by `handleSendClick` to render the Stop
+// Sentinel statusMessage written by the send path to render the Stop
 // affordance the instant the user clicks Send, masking backend cold-start
 // latency before the WS handler has emitted a real stream event. The real
 // stream overwrites this on first event; the error path detects it via strict
@@ -267,7 +268,7 @@ export function useSendMessage({
   const [submitting, setSubmittingState] = useState<boolean>(false);
   // Ref-based mutex: React state updates are batched, so two rapid calls can
   // both read `submitting === false` from their closure. The ref flips
-  // synchronously, making the guard at the top of handleSendClick airtight.
+  // synchronously, making the guard at the top of runSendClick airtight.
   const submittingRef = useRef(false);
   const setSubmitting = useCallback((value: boolean) => {
     submittingRef.current = value;
@@ -1082,16 +1083,20 @@ export function useSendMessage({
       // rendering; `SessionMiddle` clears the `pendingFirstMessage` overlay once
       // the failed quest lands in `flattenQuests`, so the chat shows prompt +
       // error reply in context.
-      setWorkBenchAgents([]);
-      setSubmitting(false);
-      // Roll back the optimistic Stop affordance only when no real stream
+      // Roll back the optimistic Stop affordance FIRST, only when no real stream
       // event landed - `statusMessage` strict-equals the sentinel iff the WS
       // handler never overwrote it. Leaves a real in-flight stream untouched.
+      // Ordering is load-bearing: if either state write below throws, a skipped
+      // rollback leaves `completed: false` with the generating sentinel, so
+      // `shouldShowStopButton` stays true and the composer renders Stop and
+      // swallows Enter for good - dead in a way releasing the mutex cannot fix.
       setChatCompletion(prev =>
         prev.statusMessage === OPTIMISTIC_GENERATING_STATUS
           ? { ...prev, completed: true, statusMessage: undefined }
           : prev
       );
+      setWorkBenchAgents([]);
+      setSubmitting(false);
       return;
     }
 
@@ -1130,41 +1135,45 @@ export function useSendMessage({
     }, 100);
   };
 
+  // Latest-ref so the exported `handleSendClick` below can be permanently
+  // stable. The body closes over most of this hook's state, so a `useCallback`
+  // with real dependencies would change identity every render anyway (and a
+  // truncated dep array would send stale state). Same pattern as
+  // `useProgrammaticSubmit`.
+  const runSendClickRef = useRef(runSendClick);
+  // eslint-disable-next-line react-hooks/refs
+  runSendClickRef.current = runSendClick;
+
   /**
-   * Send, with a guaranteed release of the submit mutex on failure.
+   * The composer's send entry point. Stable across renders: consumers hand it to
+   * lexical plugins and zustand registrations that key on the identity, so an
+   * unstable one re-registers a command per keystroke.
    *
-   * `submittingRef` is flipped synchronously at the top of the body and is only
-   * cleared on paths the body reaches, so ANY throw in between latches it true
-   * for the lifetime of the mount - and because the guard at the top is a bare
-   * `return`, every later Enter, click and programmatic send goes silently
-   * nowhere until a reload. (Observed for real: React's "Maximum update depth
-   * exceeded", raised by the `setSubmitting(true)` state write itself while the
-   * composer's editor was in an update storm.)
-   *
-   * The ref is released directly rather than via `setSubmitting`, because the
-   * state write is exactly what can throw again here; the ref is what gates
-   * sending, so it must come first and unconditionally. A successful send is
-   * untouched: no throw, no release, and `submitting` stays true for the
-   * duration of the stream so the Stop affordance keeps rendering.
+   * `withSubmitMutex` guarantees the submit mutex is released if the body throws,
+   * which is what stops a single failure from latching the composer dead. An
+   * unexpected throw is surfaced and consumed here rather than rethrown: every
+   * caller drops the rejection, so rethrowing only bought an unhandled rejection
+   * with no error visible to the user.
    */
-  const handleSendClick = async (
-    newPrompt?: string,
-    options?: { forceEnableQuestMaster?: boolean; toolsOverride?: B4MLLMTools[] }
-  ): Promise<IChatHistoryItemDocument | undefined> => {
-    try {
-      return await runSendClick(newPrompt, options);
-    } catch (error) {
-      submittingRef.current = false;
+  const handleSendClick = useCallback(
+    async (
+      newPrompt?: string,
+      options?: { forceEnableQuestMaster?: boolean; toolsOverride?: B4MLLMTools[] }
+    ): Promise<IChatHistoryItemDocument | undefined> => {
       try {
-        setSubmittingState(false);
-      } catch {
-        // Swallowed on purpose: if React is the thing failing, the ref release
-        // above has already restored sending, and the original error below is
-        // the one worth surfacing.
+        return await withSubmitMutex(submittingRef, setSubmittingState, () =>
+          runSendClickRef.current(newPrompt, options)
+        );
+      } catch (error) {
+        // Reached only on an unexpected throw: `runSendClick` already handles
+        // send failures itself (LLMCommand toasts, optimistic rollback).
+        console.error('Unexpected error sending message:', error);
+        toast.error("Couldn't send your message - please try again.");
+        return undefined;
       }
-      throw error;
-    }
-  };
+    },
+    []
+  );
 
   // Auto-submit quest goal when websocket is ready (from /quests New Quest modal)
   useEffect(() => {

--- a/apps/client/app/components/Session/SessionBottom/withSubmitMutex.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/withSubmitMutex.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withSubmitMutex } from './withSubmitMutex';
+
+describe('withSubmitMutex', () => {
+  it('leaves the mutex held on a successful send', async () => {
+    const ref = { current: true };
+    const setSubmitting = vi.fn();
+
+    await expect(withSubmitMutex(ref, setSubmitting, async () => 'sent')).resolves.toBe('sent');
+
+    // Still true: the stream is in flight, so the Stop affordance must keep rendering.
+    expect(ref.current).toBe(true);
+    expect(setSubmitting).not.toHaveBeenCalled();
+  });
+
+  it('releases the mutex and rethrows when the send throws', async () => {
+    const ref = { current: true };
+    const setSubmitting = vi.fn();
+    const boom = new Error('Maximum update depth exceeded');
+
+    await expect(
+      withSubmitMutex(ref, setSubmitting, async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+
+    expect(ref.current).toBe(false);
+    expect(setSubmitting).toHaveBeenCalledWith(false);
+  });
+
+  it('still releases the ref when the state write itself throws', async () => {
+    const ref = { current: true };
+    const boom = new Error('original failure');
+    const setSubmitting = vi.fn(() => {
+      throw new Error('React is broken too');
+    });
+
+    // The original error propagates, not the state-write error.
+    await expect(
+      withSubmitMutex(ref, setSubmitting, async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+
+    expect(ref.current).toBe(false);
+  });
+
+  it('releases the ref before attempting the state write', async () => {
+    const ref = { current: true };
+    let refAtStateWrite: boolean | undefined;
+    const setSubmitting = vi.fn(() => {
+      refAtStateWrite = ref.current;
+    });
+
+    await expect(
+      withSubmitMutex(ref, setSubmitting, async () => {
+        throw new Error('nope');
+      })
+    ).rejects.toThrow('nope');
+
+    expect(refAtStateWrite).toBe(false);
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/withSubmitMutex.ts
+++ b/apps/client/app/components/Session/SessionBottom/withSubmitMutex.ts
@@ -1,0 +1,35 @@
+/**
+ * Runs a send with a guaranteed release of the submit mutex on failure.
+ *
+ * `submittingRef` is flipped synchronously at the top of the send body and is
+ * only cleared on paths that body reaches, so ANY throw in between latches it
+ * true for the lifetime of the mount - and because the re-entrancy guard is a
+ * bare `return`, every later Enter, click and programmatic send then goes
+ * silently nowhere until a reload. (Observed for real: React's "Maximum update
+ * depth exceeded", raised by the `setSubmitting(true)` state write itself while
+ * the composer's editor was in an update storm.)
+ *
+ * The ref is released before `setSubmitting`, because the state write is exactly
+ * what can throw again here and the ref is what gates sending. A successful send
+ * is untouched: no release, so `submitting` stays true for the duration of the
+ * stream and the Stop affordance keeps rendering.
+ */
+export async function withSubmitMutex<T>(
+  submittingRef: { current: boolean },
+  setSubmitting: (value: boolean) => void,
+  send: () => Promise<T>
+): Promise<T> {
+  try {
+    return await send();
+  } catch (error) {
+    submittingRef.current = false;
+    try {
+      setSubmitting(false);
+    } catch {
+      // Swallowed on purpose: if React is the thing failing, the ref release
+      // above has already restored sending, and the original error is the one
+      // worth propagating.
+    }
+    throw error;
+  }
+}

--- a/apps/client/app/hooks/useChatPaste.ts
+++ b/apps/client/app/hooks/useChatPaste.ts
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { IFabFileDocument, ISessionDocument, KnowledgeType, isImageAttachment } from '@bike4mind/common';
 import { QueryClient } from '@tanstack/react-query';
@@ -83,148 +83,18 @@ function addFileToWorkbench(
 }
 
 export function useChatPaste(deps: UseChatPasteDeps) {
-  const {
-    currentSession,
-    currentSessionId,
-    chatHistory,
-    chatInputValue,
-    setChatInputValue,
-    setWorkBenchFiles,
-    setCurrentSession,
-    queryClient,
-    lexicalInputRef,
-  } = deps;
+  // Latest-ref so the returned handler is permanently stable. PasteHandlerPlugin
+  // keys its PASTE_COMMAND registration on the identity, and `chatInputValue` /
+  // `chatHistory` change on every keystroke - as a dep array that re-registered
+  // the command once per character typed. Reading at fire time is also strictly
+  // more correct for a paste handler: it sees the current draft, not the draft as
+  // of the render that produced the handler.
+  const depsRef = useRef(deps);
+  // eslint-disable-next-line react-hooks/refs
+  depsRef.current = deps;
 
-  return useCallback(
-    async (e: React.ClipboardEvent<HTMLTextAreaElement> | ClipboardEvent): Promise<boolean> => {
-      const clipboardData = e.clipboardData;
-      if (!clipboardData) return false;
-      const items = clipboardData.items;
-
-      // Check for image paste
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        if (isImageAttachment(item.type)) {
-          e.preventDefault();
-          const file = item.getAsFile();
-          if (file) {
-            const loadingToast = toast.loading('Uploading image...');
-
-            const smartFileName = await generateSmartFileName('', 'image', {
-              hasSession: !!currentSession,
-              chatHistory,
-            });
-            console.log('Generated smart filename for image:', smartFileName);
-            const renamedFile = new File([file], smartFileName, { type: file.type });
-
-            try {
-              const fabFile = await createFabFileOnServerWithUpload(
-                {
-                  type: KnowledgeType.FILE,
-                  fileName: renamedFile.name,
-                  mimeType: renamedFile.type,
-                  fileSize: renamedFile.size,
-                },
-                renamedFile
-              );
-
-              addFileToWorkbench(fabFile, { currentSessionId, currentSession, setWorkBenchFiles, setCurrentSession });
-              addToFileBrowserCache(queryClient, fabFile);
-
-              toast.dismiss(loadingToast);
-              toast.success('Image uploaded successfully');
-
-              const fileTag = `[[${fabFile.fileName}]]`;
-              insertFileTag(fileTag, lexicalInputRef, chatInputValue, setChatInputValue);
-            } catch (error) {
-              queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
-              console.error('Failed to upload pasted image:', error);
-              toast.dismiss(loadingToast);
-              toast.error('Failed to upload image');
-            }
-            return true;
-          }
-        }
-      }
-
-      // Check for text paste
-      const pastedContent = clipboardData.getData('text');
-      const lines = pastedContent.split('\n');
-
-      // if already wrapped with snippet meta, skip processing
-      if (pastedContent.includes('<!--snippet-meta')) {
-        return false;
-      }
-
-      // Handle large text (more than 30 lines) as file upload
-      if (lines.length > 30) {
-        e.preventDefault();
-
-        const loadingToast = toast.loading(`Uploading ${lines.length} lines of text as file...`);
-
-        const smartFileName = await generateSmartFileName(pastedContent, 'text');
-        console.log('Generated smart filename for text:', smartFileName);
-
-        const blob = new Blob([pastedContent], { type: 'text/plain' });
-        const file = new File([blob], smartFileName, { type: 'text/plain' });
-
-        try {
-          const fabFile = await createFabFileOnServerWithUpload(
-            {
-              type: KnowledgeType.FILE,
-              fileName: file.name,
-              mimeType: 'text/plain',
-              fileSize: file.size,
-            },
-            file
-          );
-
-          addFileToWorkbench(fabFile, { currentSessionId, currentSession, setWorkBenchFiles, setCurrentSession });
-          addToFileBrowserCache(queryClient, fabFile);
-
-          toast.dismiss(loadingToast);
-          toast.success(`Large text (${lines.length} lines) uploaded as file`);
-
-          const fileTag = `[[${fabFile.fileName}]]`;
-          insertFileTag(fileTag, lexicalInputRef, chatInputValue, setChatInputValue);
-        } catch (error) {
-          queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
-          console.error('Failed to upload pasted text as file:', error);
-          toast.dismiss(loadingToast);
-          toast.error('Failed to upload text as file');
-        }
-        return true;
-      }
-
-      // Original behavior for smaller text (20-30 lines) - create code block
-      if (lines.length > 20) {
-        e.preventDefault();
-
-        const contentType = detectContentType(pastedContent);
-        const contentWithNewline = pastedContent.endsWith('\n') ? pastedContent : `${pastedContent}\n`;
-        const codeBlock = `\`\`\`${contentType}\n${contentWithNewline}\`\`\``;
-
-        if (lexicalInputRef.current) {
-          try {
-            lexicalInputRef.current.insertContent(codeBlock);
-          } catch (error) {
-            console.error('Failed to insert code block:', error);
-            toast.error('Failed to add code block to input');
-            const newValue = chatInputValue.trim() ? `${chatInputValue.trim()}\n\n${codeBlock}` : codeBlock;
-            setChatInputValue(newValue);
-          }
-        } else {
-          const newValue = chatInputValue.trim() ? `${chatInputValue.trim()}\n\n${codeBlock}` : codeBlock;
-          setChatInputValue(newValue);
-        }
-
-        return true;
-      }
-
-      // Small text - let Lexical handle it normally
-      return false;
-    },
-    [
+  return useCallback(async (e: React.ClipboardEvent<HTMLTextAreaElement> | ClipboardEvent): Promise<boolean> => {
+    const {
       currentSession,
       currentSessionId,
       chatHistory,
@@ -234,6 +104,133 @@ export function useChatPaste(deps: UseChatPasteDeps) {
       setCurrentSession,
       queryClient,
       lexicalInputRef,
-    ]
-  );
+    } = depsRef.current;
+
+    const clipboardData = e.clipboardData;
+    if (!clipboardData) return false;
+    const items = clipboardData.items;
+
+    // Check for image paste
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (isImageAttachment(item.type)) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (file) {
+          const loadingToast = toast.loading('Uploading image...');
+
+          const smartFileName = await generateSmartFileName('', 'image', {
+            hasSession: !!currentSession,
+            chatHistory,
+          });
+          console.log('Generated smart filename for image:', smartFileName);
+          const renamedFile = new File([file], smartFileName, { type: file.type });
+
+          try {
+            const fabFile = await createFabFileOnServerWithUpload(
+              {
+                type: KnowledgeType.FILE,
+                fileName: renamedFile.name,
+                mimeType: renamedFile.type,
+                fileSize: renamedFile.size,
+              },
+              renamedFile
+            );
+
+            addFileToWorkbench(fabFile, { currentSessionId, currentSession, setWorkBenchFiles, setCurrentSession });
+            addToFileBrowserCache(queryClient, fabFile);
+
+            toast.dismiss(loadingToast);
+            toast.success('Image uploaded successfully');
+
+            const fileTag = `[[${fabFile.fileName}]]`;
+            insertFileTag(fileTag, lexicalInputRef, chatInputValue, setChatInputValue);
+          } catch (error) {
+            queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
+            console.error('Failed to upload pasted image:', error);
+            toast.dismiss(loadingToast);
+            toast.error('Failed to upload image');
+          }
+          return true;
+        }
+      }
+    }
+
+    // Check for text paste
+    const pastedContent = clipboardData.getData('text');
+    const lines = pastedContent.split('\n');
+
+    // if already wrapped with snippet meta, skip processing
+    if (pastedContent.includes('<!--snippet-meta')) {
+      return false;
+    }
+
+    // Handle large text (more than 30 lines) as file upload
+    if (lines.length > 30) {
+      e.preventDefault();
+
+      const loadingToast = toast.loading(`Uploading ${lines.length} lines of text as file...`);
+
+      const smartFileName = await generateSmartFileName(pastedContent, 'text');
+      console.log('Generated smart filename for text:', smartFileName);
+
+      const blob = new Blob([pastedContent], { type: 'text/plain' });
+      const file = new File([blob], smartFileName, { type: 'text/plain' });
+
+      try {
+        const fabFile = await createFabFileOnServerWithUpload(
+          {
+            type: KnowledgeType.FILE,
+            fileName: file.name,
+            mimeType: 'text/plain',
+            fileSize: file.size,
+          },
+          file
+        );
+
+        addFileToWorkbench(fabFile, { currentSessionId, currentSession, setWorkBenchFiles, setCurrentSession });
+        addToFileBrowserCache(queryClient, fabFile);
+
+        toast.dismiss(loadingToast);
+        toast.success(`Large text (${lines.length} lines) uploaded as file`);
+
+        const fileTag = `[[${fabFile.fileName}]]`;
+        insertFileTag(fileTag, lexicalInputRef, chatInputValue, setChatInputValue);
+      } catch (error) {
+        queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
+        console.error('Failed to upload pasted text as file:', error);
+        toast.dismiss(loadingToast);
+        toast.error('Failed to upload text as file');
+      }
+      return true;
+    }
+
+    // Original behavior for smaller text (20-30 lines) - create code block
+    if (lines.length > 20) {
+      e.preventDefault();
+
+      const contentType = detectContentType(pastedContent);
+      const contentWithNewline = pastedContent.endsWith('\n') ? pastedContent : `${pastedContent}\n`;
+      const codeBlock = `\`\`\`${contentType}\n${contentWithNewline}\`\`\``;
+
+      if (lexicalInputRef.current) {
+        try {
+          lexicalInputRef.current.insertContent(codeBlock);
+        } catch (error) {
+          console.error('Failed to insert code block:', error);
+          toast.error('Failed to add code block to input');
+          const newValue = chatInputValue.trim() ? `${chatInputValue.trim()}\n\n${codeBlock}` : codeBlock;
+          setChatInputValue(newValue);
+        }
+      } else {
+        const newValue = chatInputValue.trim() ? `${chatInputValue.trim()}\n\n${codeBlock}` : codeBlock;
+        setChatInputValue(newValue);
+      }
+
+      return true;
+    }
+
+    // Small text - let Lexical handle it normally
+    return false;
+  }, []);
 }


### PR DESCRIPTION
## What

Two independent faults in the shared chat composer, both reachable by typing a long first message. They compound: the first one throws, the second one turns that throw into a permanently dead input that only a page reload clears.

## 1. Unstable props kept React's nested-update chain alive

`lexicalAgents` was rebuilt on every render of `SessionBottom` and travelled into the mention plugin's `items`. That plugin's lookup effect keys on the identity and answers with `setResults([])` - a fresh array, so React can never dedupe it as an unchanged value - scheduling an un-bailable update on every render.

React's `nestedUpdateCount` is a **cumulative chain** counter that only resets when a commit leaves the root idle, so the chain never settled and eventually threw `Maximum update depth exceeded` from whichever `setState` happened to be the 51st link. In practice that was lexical's placeholder listener, which runs **twice** per editor commit: `RichTextPlugin` mounts a `Placeholder` unconditionally (even when passed `placeholder={null}`) while `ContentEditable` mounts its own. The reported stack therefore pointed at lexical rather than at the actual driver, which is what made this hard to place.

Fixed by memoising the agent list and the mention `items` object, plus giving stable identities to the markdown shortcut transformers, the editor ref callback, and the composer's `onChange` / `onSubmit`. Those were re-registering an editor listener, a lexical command and every markdown shortcut on each render.

`useGetAgents()` is no longer defaulted to `[]` inline: a literal default mints a new array until the query resolves, which would defeat the memo during exactly the window that matters - first typing on a cold page.

Stabilising `onSubmit` needed the send handler itself to be stable. `handleSendClick` was a bare `async () => {}` in the hook body, so memoising its wrapper bought nothing. A `useCallback` with real dependencies is not available - the send body closes over most of the hook's state, so it would change identity every render anyway, and a truncated dep array would send stale state - so it now routes through a latest-ref, the pattern `useProgrammaticSubmit` already uses. `useChatPaste` got the same treatment: `chatInputValue` and `chatHistory` in its dep array re-registered `PASTE_COMMAND` once per character typed, and reading at fire time is strictly more correct for a paste handler anyway.

## 2. A throw during send latched the composer permanently

`submittingRef` is flipped synchronously at the top of the send and is only cleared on paths the body reaches, so any throw in between left it `true` for the lifetime of the mount. The re-entrancy guard is a bare `return`, so every later Enter, click and programmatic send went silently nowhere, with the draft still sitting in the editor.

The update storm above was one way to trigger it, but the ~700 unguarded lines between the flip and the first reset offer plenty of others.

Fixed by `withSubmitMutex`, which always releases the mutex on failure. The ref is released before `setSubmitting`, because the state write is exactly what can throw again. A successful send is untouched: no release, so `submitting` stays true for the duration of the stream and the Stop affordance still renders.

The mutex was not the only latch on that path. The existing send-failure catch ran `setWorkBenchAgents([])` and `setSubmitting(false)` **before** the `setChatCompletion` rollback, so a throw in either state write skipped the rollback and left `completed: false` with the generating sentinel - `shouldShowStopButton` true for good, composer rendering Stop and swallowing Enter, dead in a way releasing the mutex cannot fix. The rollback now runs first, and the ordering is recorded as load-bearing.

An unexpected throw is also surfaced rather than rethrown. Every caller drops the rejection, so rethrowing only bought an unhandled rejection with no error visible to the user; `handleSendClick` now logs and toasts once and consumes it. `runSendClick`'s own failure handling (LLMCommand toasts, optimistic rollback) is untouched.

## Testing

**Update storm** - identical 352-character message typed into the composer, counting thrown updates in the console:

| | thrown updates |
|---|---|
| before | 6 |
| after | 0 |

**Mutex** - forced a throw at the original failure point (the `setSubmitting(true)` state write). Before: the send button stayed `disabled` indefinitely and neither Enter nor click did anything until a reload. After: the button stays enabled and the next attempt sends normally.

**Regression** - typing, Enter-to-send, draft restore and the streaming Stop button all still behave; no `ReferenceError` / `TypeError` in the console.

**Automated:**

- `withSubmitMutex.test.ts` - the mutex release extracted as a pure helper, unit-tested with no providers: a throwing body releases the ref and rethrows the original error, a state write that throws too still leaves the ref released, the ref is released before the state write is attempted, and a successful send keeps the mutex held for the stream.
- `composerStability.test.ts` - source-level guards on the identity chain (`lexicalAgents` via `useMemo`, no `= []` default on `useGetAgents`, `items={mentionItems}`, module-level transformers, stable ref callback, stable `handleSendClick`) and on the rollback ordering. Re-inlining any link is a one-character regression that silently restores the bug.

`SessionBottom` suites: 13 files / 58 tests pass. `apps/client` typechecks clean; eslint on the changed files reports 0 errors (4 pre-existing `no-explicit-any` warnings on untouched lines). Remaining workspace typecheck failures are pre-existing and confined to private overlay packages that are stale in this checkout.

## Notes for review

- The `handleEditorSubmit` callback is declared *after* the `useSendMessage()` destructure on purpose: its dependency array is evaluated eagerly and reads `submitting` / `handleSendClick`, so hoisting it would be a TDZ error.
- The `useChatPaste` diff is mostly a prettier reindent - collapsing the dep array to `[]` lets prettier hug the callback, shifting the whole body two spaces. `git diff -w` is the readable view.
- This does not touch the lexical `SyncValuePlugin` feedback cycle (`editor -> onChange -> store -> value -> editor`). Its two re-entrancy guards are inert because of microtask ordering, and the only thing breaking the cycle today is a string compare. Worth a separate look, but it is not what was throwing.

## Known related issues, deliberately left out of this PR

All three are real and reproducible, and each needs a decision rather than a mechanical fix:

- A session's "still streaming" state can leak into a brand-new chat, showing a Stop button and swallowing Enter. The root is the incoming-chunk filter accepting **any** session's chunks while `sessionId` is null - a rule that exists because a new session's first chunks legitimately arrive in that window. Narrowing it safely needs a trustworthy "a session is being created right now" signal, otherwise first replies get dropped silently.
- The failure path of `handleStopMessage` leaves `completed: false` with a `Cancelling generation...` status, so the Stop button stays truthy forever. The correct behaviour depends on whether the server-side generation is still alive (a 404 on a just-created session should unblock; a transient network error should keep Stop available).
- `setChatInputValue('')` and both `clearDraft` calls run before `await handler(...)`, and nothing restores them, so an ordinary network failure loses the typed message from the editor and the persisted draft. Restoring it is a behaviour decision - the optimistic prompt bubble is already rendered by then - not a mechanical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
