### PR TITLE
feat(client): optional leading decorator on session rows, aligned chrome headers

### DIFF
--- a/apps/client/app/components/Session/DockedChatPanel.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.tsx
@@ -42,7 +42,9 @@ const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActio
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          height: '48px',
+          // Matches the sidenav header and the /opti mission-deck header so the
+          // three top bars line up across the app chrome.
+          height: '56px',
           padding: '0 16px',
           backgroundColor: theme.palette.background.level1,
           borderBottom: '1px solid',

--- a/apps/client/app/components/Session/SidenavItem.tsx
+++ b/apps/client/app/components/Session/SidenavItem.tsx
@@ -52,7 +52,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/joy';
-import { FC, memo, useRef, useState, useCallback, useMemo, useEffect } from 'react';
+import { FC, ReactNode, memo, useRef, useState, useCallback, useMemo, useEffect } from 'react';
 
 import SessionMetadataModal from '@client/app/components/common/SessionMetadataModal';
 import ShareDocumentModal from '@client/app/components/common/ShareModal';
@@ -102,6 +102,9 @@ const SessionSidenavItem: FC<{
    *  not `currentSessionId`) pass this so the highlight matches the open chat rather than a
    *  stale/foreign context value. Omit it to keep the default context-driven behavior. */
   selected?: boolean;
+  /** Optional icon/badge rendered before the session name. Surface-scoped rails use it to
+   *  mark rows that carry a surface-specific artifact; omitted rows render unchanged. */
+  leadingDecorator?: ReactNode;
 }> = ({
   session,
   onClick,
@@ -114,6 +117,7 @@ const SessionSidenavItem: FC<{
   showMessageCount = true,
   displayNameOverride,
   selected,
+  leadingDecorator,
 }): React.JSX.Element => {
   const { currentSessionId } = useSessions();
   const { currentUser, isAdmin } = useUser();
@@ -403,6 +407,7 @@ const SessionSidenavItem: FC<{
                     minWidth: 0,
                   }}
                 >
+                  {leadingDecorator}
                   <Typography
                     ref={textRef}
                     level="body-xs"
@@ -690,6 +695,7 @@ const SessionSidenavItem: FC<{
                         </Box>
                       </Tooltip>
                     )}
+                    {leadingDecorator}
                     <Typography
                       ref={textRef}
                       level="body-xs"

--- a/apps/client/app/components/layouts/Notebook/Sidenav/Header.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/Header.tsx
@@ -50,6 +50,10 @@ const SideNavHeader = () => {
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
+        // Pinned rather than derived from the logo box: the docked chat header
+        // and the mission-deck header line up against this number.
+        height: '56px',
+        boxSizing: 'border-box',
         p: '10px',
       })}
     >


### PR DESCRIPTION
## Description

Two small, generic client-chrome extensions that a premium overlay consumes; the overlay's CI typechecks against `main`, so it needs these upstream. Per the open-core policy, overlay specifics stay in the private repo.

- `SessionSidenavItem` gains an optional `leadingDecorator?: ReactNode`, rendered immediately before the session name in both row layouts. Rows that omit it render byte-for-byte as before.
- The sidenav header and the docked chat header are pinned at `56px` (`boxSizing: border-box`) so the app's top bars align instead of each deriving its own height from content.

## Changes

- `apps/client/app/components/Session/SidenavItem.tsx` - optional `leadingDecorator` prop, rendered in the compact and full row layouts.
- `apps/client/app/components/layouts/Notebook/Sidenav/Header.tsx` - explicit `height: 56px` + `boxSizing: border-box`.
- `apps/client/app/components/Session/DockedChatPanel.tsx` - header `48px` -> `56px` to match.

## Guide for Testers

1. Open app.staging.bike4mind.com and sign in.
2. Look at the sidebar's session list: rows render exactly as before (the new prop is unused by any core surface).
3. Open any chat so the docked chat panel shows: its header and the sidenav header share one 56px height - the borders line up horizontally.

### Regression Checks
- Session rows: hover, selection highlight, context menu, rename, favorite - unchanged.
- Docked chat header actions (close, expand) still centered vertically after the 8px height change.

## Additional Information

The decorator is deliberately a bare `ReactNode` with no styling contract: the caller owns the geometry, the row only reserves its flex slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
