### PR TITLE
fix(services): query artifacts by id so exporting a notebook stops failing

### DIFF
--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -139,6 +139,20 @@ describe('notebook export', () => {
     expect(find.mock.calls.map(([, opts]) => opts?.skip)).toEqual([0, 100]);
   });
 
+  it('finds artifacts by their own id, not by _id', async () => {
+    // Artifact ids are not ObjectId-castable, so the real collection throws on an `_id` query.
+    const find = vi.fn(async (query: Record<string, { $in?: string[] }>) => {
+      if (!query.id?.$in) {
+        throw new Error('CastError: Cast to ObjectId failed for value "artifact_1_probe" at path "_id"');
+      }
+      return query.id.$in.map(id => ({ id, title: 'My Chart', type: 'recharts' }));
+    });
+
+    const payload = await exportOnce({ artifactRepository: { find } });
+
+    expect(payload.notebooks[0].artifacts.map((a: { id: string }) => a.id)).toEqual(['artifact-1']);
+  });
+
   it('names an artifact from its title, which is the field the entity actually has', async () => {
     const payload = await exportOnce({
       artifactRepository: {

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -153,6 +153,34 @@ describe('notebook export', () => {
     expect(payload.notebooks[0].artifacts.map((a: { id: string }) => a.id)).toEqual(['artifact-1']);
   });
 
+  it('warns by id about an artifact reference it could not resolve, so the gap is not silent', async () => {
+    const { adapters, uploaded } = makeAdapters({
+      artifactRepository: { find: vi.fn().mockResolvedValue([]) },
+    });
+    await new NotebookExportService(adapters).exportNotebooks('user-1', OPTIONS);
+
+    expect(uploaded).toHaveLength(1);
+    expect(adapters.logger.warn).toHaveBeenCalledWith(
+      'Some artifacts could not be resolved',
+      expect.objectContaining({ unresolved: ['artifact-1'] })
+    );
+  });
+
+  it('leaves a soft-deleted artifact out of the export, like every other artifact reader', async () => {
+    const find = vi.fn(async (query: Record<string, unknown>) => {
+      // Mirrors the collection: a row whose deletedAt is set does not match `deletedAt: null`.
+      if (query.deletedAt !== null) {
+        return [{ id: 'artifact-1', title: 'Deleted Chart', type: 'recharts', deletedAt: new Date() }];
+      }
+      return [];
+    });
+
+    const payload = await exportOnce({ artifactRepository: { find } });
+
+    expect(payload.notebooks[0].artifacts).toEqual([]);
+    expect(find).toHaveBeenCalledWith(expect.objectContaining({ deletedAt: null }));
+  });
+
   it('names an artifact from its title, which is the field the entity actually has', async () => {
     const payload = await exportOnce({
       artifactRepository: {

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -153,7 +153,7 @@ describe('notebook export', () => {
     expect(payload.notebooks[0].artifacts.map((a: { id: string }) => a.id)).toEqual(['artifact-1']);
   });
 
-  it('warns by id about an artifact reference it could not resolve, so the gap is not silent', async () => {
+  it('warns by id about an artifact it could not export, so the gap is not silent', async () => {
     const { adapters, uploaded } = makeAdapters({
       artifactRepository: { find: vi.fn().mockResolvedValue([]) },
     });
@@ -161,8 +161,8 @@ describe('notebook export', () => {
 
     expect(uploaded).toHaveLength(1);
     expect(adapters.logger.warn).toHaveBeenCalledWith(
-      'Some artifacts could not be resolved',
-      expect.objectContaining({ unresolved: ['artifact-1'] })
+      'Some artifacts were not exported',
+      expect.objectContaining({ notExported: ['artifact-1'] })
     );
   });
 

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -77,6 +77,14 @@ async function exportOnce(over: AdapterOverrides = {}) {
   return JSON.parse(uploaded[0]);
 }
 
+/** Same run, but hands back the adapters so a test can assert on what was NOT logged. */
+async function exportOnceWithAdapters(over: AdapterOverrides = {}) {
+  const { adapters, uploaded } = makeAdapters(over);
+  await new NotebookExportService(adapters).exportNotebooks('user-1', OPTIONS);
+  expect(uploaded).toHaveLength(1);
+  return { payload: JSON.parse(uploaded[0]), adapters };
+}
+
 describe('notebook export', () => {
   it('emits promptMeta from the nested groups it is actually stored in', async () => {
     const payload = await exportOnce();
@@ -167,6 +175,11 @@ describe('notebook export', () => {
   });
 
   it('leaves a soft-deleted artifact out of the export, like every other artifact reader', async () => {
+    // What this pins is that the filter is SENT and that a matching row is excluded. It cannot
+    // establish MongoDB's own null-matches-missing behaviour, which is what makes the filter safe
+    // for the normal rows that have no `deletedAt` field at all - the repository here is a stub.
+    // That half rests on the schema: `deletedAt` has no default, so those rows omit the field, and
+    // an equality-to-null query matches missing-or-null.
     const find = vi.fn(async (query: Record<string, unknown>) => {
       // Mirrors the collection: a row whose deletedAt is set does not match `deletedAt: null`.
       if (query.deletedAt !== null) {
@@ -207,12 +220,15 @@ describe('notebook export', () => {
   });
 
   it('names an artifact from its title, which is the field the entity actually has', async () => {
-    const payload = await exportOnce({
+    const { payload, adapters } = await exportOnceWithAdapters({
       artifactRepository: {
         find: vi.fn().mockResolvedValue([{ id: 'artifact-1', title: 'My Chart', type: 'recharts' }]),
       },
     });
 
     expect(payload.notebooks[0].artifacts[0].name).toBe('My Chart');
+    // An export where every id resolved must say nothing. Without this a spurious warn - the kind
+    // an off-by-one in the notExported predicate produces - would ship green.
+    expect(adapters.logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -181,6 +181,31 @@ describe('notebook export', () => {
     expect(find).toHaveBeenCalledWith(expect.objectContaining({ deletedAt: null }));
   });
 
+  it('leaves out an artifact the exporter cannot read, and scopes the query to them', async () => {
+    // `session.artifactIds` is client-supplied and written through unvalidated, so an id arriving
+    // at the export is not necessarily the caller's. The normal read path denies such a row; the
+    // export must not be the way around it. The stub answers only when the query carries the
+    // access clause, so this cannot pass by resolving everything.
+    const find = vi.fn().mockImplementation((query: Record<string, unknown>) => {
+      if (!query.$or) return [{ id: 'artifact-1', title: 'Someone Elses Artifact', type: 'react' }];
+      return [];
+    });
+
+    const payload = await exportOnce({ artifactRepository: { find } });
+
+    expect(payload.notebooks[0].artifacts).toEqual([]);
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $or: [
+          { userId: 'user-1' },
+          { 'permissions.canRead': 'user-1' },
+          { visibility: 'public' },
+          { 'permissions.isPublic': true },
+        ],
+      })
+    );
+  });
+
   it('names an artifact from its title, which is the field the entity actually has', async () => {
     const payload = await exportOnce({
       artifactRepository: {

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -374,9 +374,17 @@ export class NotebookExportService {
   private async exportArtifacts(artifactIds: string[], options: NotebookExportOptions): Promise<ExportedArtifact[]> {
     if (artifactIds.length === 0) return [];
 
+    // Artifact ids are `artifact_<ts>_<rand>`, not ObjectIds, so an `_id` query throws a CastError.
     const artifacts = await this.adapters.artifactRepository.find({
-      _id: { $in: artifactIds },
+      id: { $in: artifactIds },
     });
+
+    // Sessions can still hold references to artifacts that no longer exist; without this the
+    // export is quietly incomplete. Names them, since this fires once per notebook.
+    const unresolved = artifactIds.filter(id => !artifacts.some((a: ArtifactRow) => a.id === id));
+    if (unresolved.length > 0) {
+      this.adapters.logger.warn('Some artifacts could not be resolved', { unresolved });
+    }
 
     return artifacts.map((artifact: ArtifactRow) => ({
       id: artifact.id,
@@ -392,6 +400,9 @@ export class NotebookExportService {
   private async exportTools(toolIds: string[], options: NotebookExportOptions): Promise<ExportedTool[]> {
     if (toolIds.length === 0) return [];
 
+    // `_id` is correct here, unlike artifacts: tools and agents are ObjectId-keyed. Sessions
+    // imported before the id fix can still hold uuids that cast-throw - resilience tracked
+    // separately, not a reason to change the key.
     const tools = await this.adapters.toolRepository.find({
       _id: { $in: toolIds },
     });

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -159,7 +159,7 @@ export class NotebookExportService {
 
       // Process each session
       for (const session of sessions) {
-        const exportedNotebook = await this.exportSession(session, options);
+        const exportedNotebook = await this.exportSession(session, options, userId);
         exportData.notebooks.push(exportedNotebook);
 
         totalMessages += exportedNotebook.chatHistory.length;
@@ -228,14 +228,20 @@ export class NotebookExportService {
     return await this.adapters.sessionRepository.find(query);
   }
 
-  private async exportSession(session: SessionRow, options: NotebookExportOptions): Promise<ExportedNotebook> {
+  private async exportSession(
+    session: SessionRow,
+    options: NotebookExportOptions,
+    userId: string
+  ): Promise<ExportedNotebook> {
     // Export chat history
     const chatHistory = await this.exportChatHistory(session.id, options);
 
     // Export attachments based on options
     const knowledge = options.includeKnowledge ? await this.exportKnowledge(session.knowledgeIds || [], options) : [];
 
-    const artifacts = options.includeArtifacts ? await this.exportArtifacts(session.artifactIds || [], options) : [];
+    const artifacts = options.includeArtifacts
+      ? await this.exportArtifacts(session.artifactIds || [], options, userId)
+      : [];
 
     const tools = options.includeTools ? await this.exportTools(session.toolIds || [], options) : [];
 
@@ -371,22 +377,35 @@ export class NotebookExportService {
     );
   }
 
-  private async exportArtifacts(artifactIds: string[], options: NotebookExportOptions): Promise<ExportedArtifact[]> {
+  private async exportArtifacts(
+    artifactIds: string[],
+    options: NotebookExportOptions,
+    userId: string
+  ): Promise<ExportedArtifact[]> {
     if (artifactIds.length === 0) return [];
 
     // Artifact ids are `artifact_<ts>_<rand>`, not ObjectIds, so an `_id` query throws a CastError.
     // `deletedAt: null` matches every read helper on ArtifactRepository - it only started to
     // matter once the query above began resolving rows at all.
+    //
+    // The `$or` is the same predicate `ArtifactRepository.findByUserWithAccess` expresses and
+    // `artifactService/get` enforces via `canUserAccessArtifact`. It is needed HERE because
+    // `getSessionsToExport` scopes SESSIONS by userId and the scoping stops there:
+    // `session.artifactIds` is a client-supplied `z.array(z.string())` that `updateSession` writes
+    // through unvalidated, so an id arriving here is not necessarily the caller's. Reachable only
+    // since this query started resolving rows - before that it threw and returned nothing.
     const artifacts = await this.adapters.artifactRepository.find({
       id: { $in: artifactIds },
       deletedAt: null,
+      $or: [{ userId }, { 'permissions.canRead': userId }, { visibility: 'public' }, { 'permissions.isPublic': true }],
     });
 
-    // Covers two causes, and deliberately does not distinguish them: an artifact the user has
-    // since deleted (routine - the session keeps referencing it), and a row that is genuinely
-    // gone (rare). Neither is exportable, and telling them apart would cost a second query to
-    // sharpen a log line nothing alarms on. Named because a partial export must not read as a
-    // complete one; fires once per notebook.
+    // Covers three causes, and deliberately does not distinguish them: an artifact the user has
+    // since deleted (routine - the session keeps referencing it), a row that is genuinely gone
+    // (rare), and one the exporter cannot read. None is exportable, and telling them apart would
+    // cost a second query to sharpen a log line nothing alarms on - and for the third it would
+    // also confirm the id exists to someone with no access to it. Named because a partial export
+    // must not read as a complete one; fires once per notebook.
     const notExported = artifactIds.filter(id => !artifacts.some((a: ArtifactRow) => a.id === id));
     if (notExported.length > 0) {
       this.adapters.logger.warn('Some artifacts were not exported', { notExported });

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -375,8 +375,11 @@ export class NotebookExportService {
     if (artifactIds.length === 0) return [];
 
     // Artifact ids are `artifact_<ts>_<rand>`, not ObjectIds, so an `_id` query throws a CastError.
+    // `deletedAt: null` matches every read helper on ArtifactRepository - it only started to
+    // matter once the query above began resolving rows at all.
     const artifacts = await this.adapters.artifactRepository.find({
       id: { $in: artifactIds },
+      deletedAt: null,
     });
 
     // Sessions can still hold references to artifacts that no longer exist; without this the

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -394,6 +394,13 @@ export class NotebookExportService {
     // `session.artifactIds` is a client-supplied `z.array(z.string())` that `updateSession` writes
     // through unvalidated, so an id arriving here is not necessarily the caller's. Reachable only
     // since this query started resolving rows - before that it threw and returned nothing.
+    //
+    // Two consequences that are visible rather than hidden, both deliberate: neither this clause
+    // nor `canUserAccessArtifact` honours `visibility: 'project' | 'organization'`, so an
+    // org-shared artifact drops out of an export - this makes export exactly as strict as
+    // `GET /artifacts/:id` and no stricter, which is the right default but is a change. And in a
+    // collaborative session an artifact owned by another participant now leaves the owner's
+    // export. Widen both together with the normal read path, never here alone.
     const artifacts = await this.adapters.artifactRepository.find({
       id: { $in: artifactIds },
       deletedAt: null,

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -382,11 +382,14 @@ export class NotebookExportService {
       deletedAt: null,
     });
 
-    // Sessions can still hold references to artifacts that no longer exist; without this the
-    // export is quietly incomplete. Names them, since this fires once per notebook.
-    const unresolved = artifactIds.filter(id => !artifacts.some((a: ArtifactRow) => a.id === id));
-    if (unresolved.length > 0) {
-      this.adapters.logger.warn('Some artifacts could not be resolved', { unresolved });
+    // Covers two causes, and deliberately does not distinguish them: an artifact the user has
+    // since deleted (routine - the session keeps referencing it), and a row that is genuinely
+    // gone (rare). Neither is exportable, and telling them apart would cost a second query to
+    // sharpen a log line nothing alarms on. Named because a partial export must not read as a
+    // complete one; fires once per notebook.
+    const notExported = artifactIds.filter(id => !artifacts.some((a: ArtifactRow) => a.id === id));
+    if (notExported.length > 0) {
+      this.adapters.logger.warn('Some artifacts were not exported', { notExported });
     }
 
     return artifacts.map((artifact: ArtifactRow) => ({


### PR DESCRIPTION
Closes #1988.

## Problem

`exportArtifacts` queried `_id: { $in: artifactIds }`, but artifact ids are `artifact_<ts>_<rand>` (`createArtifactId`) and are not ObjectId-castable. The query throws rather than returning nothing:

```
Artifact.find({ _id: { $in: ['artifact_1787540000000_probe01'] } })
  -> CastError: Cast to ObjectId failed for value "artifact_1787540000000_probe01" at path "_id"
```

`exportSession` has no error handling, the session loop in `exportNotebooks` has none, and the outer handler rethrows as `EXPORT_FAILED`. So one artifact on one notebook fails the user's entire export, including notebooks that have no artifacts - and Artifacts is checked by default in the export dialog.

Reproduced in the running app, attaching a single artifact to one notebook and clicking Export All:

```
[TEMP-VERIFY] exportArtifacts input
ERROR  Notebook export failed  { name: "CastError" }
ERROR  Notebook export failed  { code: "EXPORT_FAILED" }
```

## Fix

Query the `id` path. Artifact ids live on the artifacts collection's own `id` field, are held in `session.artifactIds`, and are queried as `{ id }` by every reader I could find - three call sites across `b4m-core/services` and `apps/client/server`, none using `_id`. The field is `unique: true, index: true`, so the `$in` is index-backed.

`_id` remains correct for knowledge, tools and agents, which are ObjectId-keyed. A comment at `exportTools` now says so, because this diff would otherwise teach the next reader that `_id` is the bug rather than the mismatch.

## New warning

Before, an unresolvable artifact reference threw. Now it would simply be absent from the export file, so the fix would trade a loud failure for a quiet one. Added a `logger.warn` naming the unresolved ids - named rather than counted, since it fires once per notebook and a bare count cannot be mapped back to anything.

## Test

The pre-existing artifact test passes against the broken code, because its mock answers any query. The new test's stub behaves like the real collection - it throws unless queried by `id` - so it fails on the old code with the production failure mode rather than by asserting on the query shape. Verified red before the fix, green after.

## Note on the issue text

#1988 describes this as the export never matching, which reads as "exports are missing their artifacts". The measured behaviour is a thrown `CastError` that fails the whole export. Leaving the issue as written; recording the correction here.

## Not in this PR

- #2053 - sessions imported before the store-assigned-id fix hold uuid `toolIds`/`agentIds`, which cast-throw the same way. Measured: `Tool.find({ _id: { $in: ['<uuid>'] } })` throws, the ObjectId equivalent returns the row. Those users still cannot export. That fix is about per-entity isolation and surfacing warnings through `ExportResult`, not about changing the query key.
- #1633 - artifact import still writes nothing. It needs the export to carry `content` first, since `createArtifactSchema` requires a body and derives `contentHash`/`contentSize`/`contentId` from it.
- Moving the id-field knowledge into `ArtifactRepository` as a `findByIds`. The repository already owns this fact in `update`, `softDelete`, `restore` and `findByQuestIds`, so the export fell into a gap the class had half-closed. Deferred deliberately: it widens the `ExportReads` adapter contract and reaches into `packages/database`, and the export is broken in production now.
