### PR TITLE
fix(client): scope @datalake list to lakes the caller can write and address

### DIFF
--- a/apps/client/server/slack/dataLakeIngestAuthz.test.ts
+++ b/apps/client/server/slack/dataLakeIngestAuthz.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildSlackAccessContext, type SlackIngestActor } from './dataLakeIngestAuthz';
+
+/**
+ * Covers `buildSlackAccessContext`'s entitlement-resolution rule directly. The handler tests mock
+ * this module, so they can only assert the call site passes the opt-in; the ingest tests exercise
+ * the two DEFAULT paths. Neither reaches the opt-in branch itself, which is the branch `list`
+ * depends on - an admin evaluated through the non-admin arms needs real keys or an entitlement-gated
+ * lake drops out of a reply `add` still accepts.
+ */
+describe('buildSlackAccessContext entitlement resolution', () => {
+  const actor = (isAdmin: boolean): SlackIngestActor => ({
+    id: 'u1',
+    isAdmin,
+    tags: ['beta'],
+    email: 'u1@example.com',
+    emailVerified: true,
+  });
+
+  const deps = () => ({
+    resolveEntitlementKeys: vi.fn().mockResolvedValue(['product:pro']),
+    resolveMembershipOrgIds: vi.fn().mockResolvedValue(['org-a']),
+  });
+
+  it('resolves keys for a non-admin, opt-in or not', async () => {
+    const d = deps();
+
+    const ctx = await buildSlackAccessContext(actor(false), d);
+
+    expect(d.resolveEntitlementKeys).toHaveBeenCalledWith(actor(false));
+    expect(ctx.entitlementKeys).toEqual(['product:pro']);
+    expect(ctx.organizationIds).toEqual(['org-a']);
+  });
+
+  it('skips resolution for an admin by default, since the write gates never read the keys', async () => {
+    const d = deps();
+
+    const ctx = await buildSlackAccessContext(actor(true), d);
+
+    expect(d.resolveEntitlementKeys).not.toHaveBeenCalled();
+    expect(ctx.entitlementKeys).toEqual([]);
+    expect(ctx.isAdmin).toBe(true);
+  });
+
+  it('resolves keys for an admin when the caller opts in', async () => {
+    const d = deps();
+
+    const ctx = await buildSlackAccessContext(actor(true), d, { resolveEntitlementsForAdmin: true });
+
+    expect(d.resolveEntitlementKeys).toHaveBeenCalledWith(actor(true));
+    // The keys must land in the context, not merely be fetched: the list query reads them through
+    // findAccessible's requirement constraint.
+    expect(ctx.entitlementKeys).toEqual(['product:pro']);
+    expect(ctx.isAdmin).toBe(true);
+  });
+
+  it('treats an explicit false like the default', async () => {
+    const d = deps();
+
+    const ctx = await buildSlackAccessContext(actor(true), d, { resolveEntitlementsForAdmin: false });
+
+    expect(d.resolveEntitlementKeys).not.toHaveBeenCalled();
+    expect(ctx.entitlementKeys).toEqual([]);
+  });
+});

--- a/apps/client/server/slack/dataLakeIngestAuthz.ts
+++ b/apps/client/server/slack/dataLakeIngestAuthz.ts
@@ -58,7 +58,7 @@ export interface LakeAuthzDeps {
    * the check here.
    */
   adminSettings: Pick<IAdminSettingsRepository, 'findAll' | 'findBySettingNames'>;
-  /** Entitlement keys for the actor; admins skip resolution, mirroring `toAccessContext`. */
+  /** Entitlement keys for the actor; admins skip resolution unless the caller opts in (see below). */
   resolveEntitlementKeys(actor: SlackIngestActor): Promise<string[]>;
   /** Authoritative org membership set for the actor, mirroring `toAccessContext` (#1674). */
   resolveMembershipOrgIds(userId: string): Promise<string[]>;
@@ -76,7 +76,8 @@ export interface LakeAuthzDeps {
  */
 export async function buildSlackAccessContext(
   actor: SlackIngestActor,
-  deps: Pick<LakeAuthzDeps, 'resolveEntitlementKeys' | 'resolveMembershipOrgIds'>
+  deps: Pick<LakeAuthzDeps, 'resolveEntitlementKeys' | 'resolveMembershipOrgIds'>,
+  opts?: { resolveEntitlementsForAdmin?: boolean }
 ): Promise<AccessContext> {
   const isAdmin = !!actor.isAdmin;
   return {
@@ -84,7 +85,11 @@ export async function buildSlackAccessContext(
     isAdmin,
     userTags: actor.tags ?? [],
     organizationIds: await deps.resolveMembershipOrgIds(actor.id),
-    entitlementKeys: isAdmin ? [] : await deps.resolveEntitlementKeys(actor),
+    // Skipped for an admin by default, mirroring toAccessContext: the write gates grant an admin
+    // outright and never read the keys. `resolveEntitlementsForAdmin` exists for the one caller
+    // that deliberately evaluates an admin through the NON-admin arms (the `list` reply in
+    // handleDataLakeCommand), where the keys decide whether an entitlement-gated lake is reachable.
+    entitlementKeys: isAdmin && !opts?.resolveEntitlementsForAdmin ? [] : await deps.resolveEntitlementKeys(actor),
   };
 }
 

--- a/apps/client/server/slack/handleDataLakeCommand.test.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.test.ts
@@ -199,6 +199,24 @@ describe('handleDataLakeCommand', () => {
         expect(reply).not.toContain('Org-less Notes');
       });
 
+      it('drops a slug whose WINNING lake is unwritable, even when a lower-priority one is writable', async () => {
+        // findBySlug takes the own-org lake by priority alone and never falls back when it turns
+        // out to be unwritable, so `add` would refuse this slug outright. Printing the org-less
+        // lake because it happens to be writable would name a lake the command never targets.
+        listDataLakes.mockResolvedValue([
+          { slug: 'notes', name: 'My Org-less Notes', canManage: true },
+          { slug: 'notes', name: 'Read-only Org Notes', canManage: false, organizationId: 'org-a' },
+        ]);
+
+        buildSlackAccessContext.mockResolvedValue({ ...adminCtx, isAdmin: false });
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: false } }));
+
+        expect(printedSlugs(reply)).not.toContain('notes');
+        expect(reply).not.toContain('My Org-less Notes');
+        expect(reply).toMatch(/cannot add to any data lakes/i);
+      });
+
       it('never prints a slug `add` cannot resolve (listed implies addable)', async () => {
         const catalog = [
           { slug: 'personal', name: 'Personal', canManage: true },
@@ -207,10 +225,13 @@ describe('handleDataLakeCommand', () => {
           { slug: 'open-lake', name: 'Open', canManage: true, organizationId: 'org-b', isPublic: true },
           { slug: 'notes', name: 'Org-less Notes', canManage: true },
           { slug: 'notes', name: 'Org Notes', canManage: true, organizationId: 'org-a' },
+          // Deliberately NOT uniformly writable: the winning lake for `shared` is unwritable, so
+          // `add` refuses the slug and the guard must see the reply omit it rather than print the
+          // writable org-less one. A catalog with canManage: true everywhere cannot catch that.
+          { slug: 'shared', name: 'Writable Org-less Shared', canManage: true },
+          { slug: 'shared', name: 'Read-only Org Shared', canManage: false, organizationId: 'org-a' },
         ];
         listDataLakes.mockResolvedValue(catalog);
-
-        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
 
         // Mirrors DataLakeModel.findBySlug: an own-org match first (lowest org id), then the
         // org-less fallback. If that rule changes, this guard is what catches the divergence.
@@ -221,12 +242,26 @@ describe('handleDataLakeCommand', () => {
           return own[0] ?? catalog.find(l => l.slug === slug && !l.organizationId) ?? null;
         };
 
-        const slugs = printedSlugs(reply);
-        expect(slugs.length).toBeGreaterThan(0);
-        for (const slug of slugs) {
-          const resolved = findBySlug(slug);
-          expect(resolved, `add to \`${slug}\` would be refused`).not.toBeNull();
-          expect(reply).toContain(resolved!.name);
+        // Both actors, because the write gate differs: an admin is granted outright on any
+        // non-registry lake, so an admin-only run cannot see an unwritable winner at all.
+        for (const isAdmin of [true, false]) {
+          buildSlackAccessContext.mockResolvedValue({ ...adminCtx, isAdmin });
+
+          const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin } }));
+
+          const slugs = printedSlugs(reply);
+          expect(slugs.length, `no rows printed for isAdmin=${isAdmin}`).toBeGreaterThan(0);
+          for (const slug of slugs) {
+            const resolved = findBySlug(slug);
+            expect(resolved, `add to \`${slug}\` would be refused`).not.toBeNull();
+            expect(reply).toContain(resolved!.name);
+            // `add` gates the lake findBySlug returned, with no retry against a same-slug sibling,
+            // so a printed slug whose winner fails that gate is a promise the command breaks.
+            // No registry lakes in this catalog, so the admin arm of isWritable is just isAdmin.
+            expect(resolved!.canManage || isAdmin, `add to \`${slug}\` resolves a lake this caller cannot write`).toBe(
+              true
+            );
+          }
         }
       });
     });

--- a/apps/client/server/slack/handleDataLakeCommand.test.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.test.ts
@@ -72,9 +72,9 @@ describe('handleDataLakeCommand', () => {
     });
 
     it('caps a long list with a "+N more" tail instead of overrunning Slack', async () => {
-      // For an admin, findAccessible returns every draft/active lake on the platform, all
-      // canManage. Past Slack's 40k-character text limit chat.postMessage errors and the
-      // orchestrator's catch turns the whole reply into "something went wrong".
+      // A caller in a large org can have more manageable lakes than fit Slack's 40k-character
+      // text limit; past it chat.postMessage errors and the orchestrator's catch turns the whole
+      // reply into "something went wrong".
       listDataLakes.mockResolvedValue(
         Array.from({ length: 63 }, (_, i) => ({ slug: `lake-${i}`, name: `Lake ${i}`, canManage: true }))
       );
@@ -93,6 +93,142 @@ describe('handleDataLakeCommand', () => {
       const reply = await handleDataLakeCommand(baseParams());
 
       expect(reply).toMatch(/cannot add to any data lakes/i);
+    });
+
+    describe('scoping', () => {
+      const adminCtx = { userId: 'u1', isAdmin: true, userTags: [], entitlementKeys: [], organizationIds: ['org-a'] };
+      const printedSlugs = (reply: string) => Array.from(reply.matchAll(/^- `([^`]+)`/gm), m => m[1]);
+
+      beforeEach(() => buildSlackAccessContext.mockResolvedValue(adminCtx));
+
+      it('queries the row set with the platform-admin bypass suppressed', async () => {
+        listDataLakes.mockResolvedValue([{ slug: 'mine', name: 'Mine', canManage: true }]);
+
+        await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        // The disclosure in question is findAccessible's admin short-circuit returning every lake
+        // on the platform. This surface must never take it: the reply is a channel message.
+        expect(listDataLakes).toHaveBeenCalledWith(
+          expect.objectContaining({ isAdmin: false, userId: 'u1' }),
+          expect.anything()
+        );
+      });
+
+      it('resolves entitlement keys for an admin, since the row set is built from the non-admin arms', async () => {
+        listDataLakes.mockResolvedValue([{ slug: 'mine', name: 'Mine', canManage: true }]);
+
+        await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        // Without the keys, an entitlement-gated lake in the admin's own org fails findAccessible's
+        // requirement constraint and drops off a list that `add` still accepts.
+        expect(buildSlackAccessContext).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+          resolveEntitlementsForAdmin: true,
+        });
+      });
+
+      it('omits a lake belonging to an organization the caller is not a member of', async () => {
+        listDataLakes.mockResolvedValue([
+          { slug: 'ours', name: 'Ours', canManage: true, organizationId: 'org-a' },
+          { slug: 'theirs', name: 'Theirs', canManage: true, organizationId: 'org-b' },
+        ]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toContain('ours');
+        // findBySlug is org-scoped, so this slug would refuse on `add` - and naming another org's
+        // lake in a shared channel is the disclosure itself.
+        expect(reply).not.toContain('theirs');
+      });
+
+      it('never offers a built-in registry lake, which is read-only even for an admin', async () => {
+        // listDataLakes stamps every static-registry lake canManage:false because assertLakeWritable
+        // refuses an admin too, so the admin manage label must not be restored over one.
+        listDataLakes.mockResolvedValue([
+          { id: 'opti-knowledge', slug: 'opti-knowledge', name: 'Optimization Knowledge Base', canManage: false },
+        ]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toMatch(/cannot add to any data lakes/i);
+      });
+
+      it('omits a cross-org PUBLIC lake, which findAccessible returns but findBySlug cannot resolve', async () => {
+        listDataLakes.mockResolvedValue([
+          { slug: 'open-lake', name: 'Open', canManage: true, organizationId: 'org-b', isPublic: true },
+        ]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toMatch(/cannot add to any data lakes/i);
+      });
+
+      it("keeps an org-less lake and one in the caller's own org", async () => {
+        listDataLakes.mockResolvedValue([
+          { slug: 'personal', name: 'Personal', canManage: true },
+          { slug: 'ours', name: 'Ours', canManage: true, organizationId: 'org-a' },
+        ]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(printedSlugs(reply)).toEqual(['personal', 'ours']);
+      });
+
+      it('labels a scoped row manageable for an admin even when the suppressed context did not', async () => {
+        // Suppressing isAdmin for the query also silences canManageLake's admin rung, so an org
+        // lake the admin did not create comes back canManage:false. The label is restored; the row
+        // set is not widened.
+        listDataLakes.mockResolvedValue([{ slug: 'ours', name: 'Ours', canManage: false, organizationId: 'org-a' }]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toContain('ours');
+      });
+
+      it('prints one row per slug, naming the lake `add` would resolve', async () => {
+        listDataLakes.mockResolvedValue([
+          { slug: 'notes', name: 'Org-less Notes', canManage: true },
+          { slug: 'notes', name: 'Org Notes', canManage: true, organizationId: 'org-a' },
+        ]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(printedSlugs(reply)).toEqual(['notes']);
+        // findBySlug prefers an own-org lake over the org-less fallback, so that is the lake the
+        // printed slug actually targets.
+        expect(reply).toContain('Org Notes');
+        expect(reply).not.toContain('Org-less Notes');
+      });
+
+      it('never prints a slug `add` cannot resolve (listed implies addable)', async () => {
+        const catalog = [
+          { slug: 'personal', name: 'Personal', canManage: true },
+          { slug: 'ours', name: 'Ours', canManage: true, organizationId: 'org-a' },
+          { slug: 'theirs', name: 'Theirs', canManage: true, organizationId: 'org-b' },
+          { slug: 'open-lake', name: 'Open', canManage: true, organizationId: 'org-b', isPublic: true },
+          { slug: 'notes', name: 'Org-less Notes', canManage: true },
+          { slug: 'notes', name: 'Org Notes', canManage: true, organizationId: 'org-a' },
+        ];
+        listDataLakes.mockResolvedValue(catalog);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        // Mirrors DataLakeModel.findBySlug: an own-org match first (lowest org id), then the
+        // org-less fallback. If that rule changes, this guard is what catches the divergence.
+        const findBySlug = (slug: string) => {
+          const own = catalog
+            .filter(l => l.slug === slug && l.organizationId && adminCtx.organizationIds.includes(l.organizationId))
+            .sort((a, b) => String(a.organizationId).localeCompare(String(b.organizationId)));
+          return own[0] ?? catalog.find(l => l.slug === slug && !l.organizationId) ?? null;
+        };
+
+        const slugs = printedSlugs(reply);
+        expect(slugs.length).toBeGreaterThan(0);
+        for (const slug of slugs) {
+          const resolved = findBySlug(slug);
+          expect(resolved, `add to \`${slug}\` would be refused`).not.toBeNull();
+          expect(reply).toContain(resolved!.name);
+        }
+      });
     });
   });
 

--- a/apps/client/server/slack/handleDataLakeCommand.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.ts
@@ -121,8 +121,9 @@ const preferredBySlug = (a: ListableLake, b: ListableLake): ListableLake => {
 
 /**
  * One row per slug. A slug is unique per org, so a collision means two lakes the caller can reach
- * under one name - print the one `add` would write to, or the reply names a lake the command does
- * not target.
+ * under one name - keep the one `add` would resolve, or the reply names a lake the command does not
+ * target. Runs over every ADDRESSABLE lake, before the write gate, because `findBySlug` resolves by
+ * org priority without consulting write access (see the note in `handleList`).
  */
 const dedupeBySlug = (lakes: ListableLake[]): ListableLake[] => {
   const bySlug = new Map<string, ListableLake>();
@@ -158,9 +159,13 @@ async function handleList(params: HandleDataLakeCommandParams): Promise<string> 
     { ...ctx, isAdmin: false },
     { db: { dataLakes: params.deps.dataLakes } }
   );
-  // `isWritable` restores the manage LABEL that suppressing isAdmin also silenced in canManageLake.
-  // It re-labels an already-scoped row set and can never add a row to it.
-  const writable = dedupeBySlug(lakes.filter(lake => isWritable(lake, ctx) && isSlugAddressable(lake, ctx)));
+  // Order matters, and it mirrors `add`: resolve the slug's winning lake FIRST, then apply the write
+  // gate to that winner. `findBySlug` picks by org priority alone and never falls back when the lake
+  // it picked turns out to be unwritable, so gating before the dedupe would hide a higher-priority
+  // lake and print a slug `add` resolves elsewhere and refuses. `isWritable` also restores the
+  // manage LABEL that suppressing isAdmin silenced in canManageLake; it only ever removes rows.
+  const addressable = lakes.filter(lake => isSlugAddressable(lake, ctx));
+  const writable = dedupeBySlug(addressable).filter(lake => isWritable(lake, ctx));
 
   if (writable.length === 0) {
     return 'You cannot add to any data lakes yet. You can add to lakes you created, or ask an admin.';

--- a/apps/client/server/slack/handleDataLakeCommand.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.ts
@@ -1,6 +1,7 @@
 import { parseDataLakeCommand, type ParsedDataLakeCommand, type SlackAttachment } from '@bike4mind/slack';
 import { dataLakeService } from '@bike4mind/services';
-import type { IDataLakeRepository } from '@bike4mind/common';
+import { STATIC_LAKE_IDS } from '@bike4mind/common';
+import type { AccessContext, IDataLakeRepository, ManageableDataLakeConfig } from '@bike4mind/common';
 import { buildSlackAccessContext, type SlackIngestActor } from './dataLakeIngestAuthz';
 import { ingestSlackFilesIntoLake, type SlackLakeIngestDeps, type SlackLakeIngestOutcome } from './dataLakeFileIngest';
 import { ingestSlackLinkIntoLake, type SlackLinkIngestDeps, type SlackLinkIngestOutcome } from './dataLakeLinkIngest';
@@ -76,22 +77,98 @@ export async function handleDataLakeCommand(params: HandleDataLakeCommandParams)
   }
 }
 
+/** The lake fields the `list` scoping rules and the rendered rows need. */
+type ListableLake = Pick<ManageableDataLakeConfig, 'id' | 'slug' | 'name' | 'organizationId' | 'canManage'>;
+
+/** The caller facts both scoping rules key off. */
+type ListScope = Pick<AccessContext, 'isAdmin' | 'organizationIds'>;
+
+/** An org-scoped lake's org id, with a blank string read as org-less (both forms are stored). */
+const lakeOrgId = (lake: ListableLake): string | undefined => lake.organizationId?.trim() || undefined;
+
 /**
- * The lakes the caller may ADD to - i.e. `canManage` (admin or creator), not merely readable.
- * Listing everything they can read would advertise lakes every add would then refuse.
+ * Whether the caller may WRITE to this lake. `canManage` arrives computed under the
+ * isAdmin-suppressed context (see `handleList`), so a platform admin's own manage rung is restored
+ * here - EXCEPT on a built-in registry lake, which is read-only for everyone including admins
+ * (`assertLakeWritable`; `listDataLakes` stamps every fallback `canManage: false` for that reason).
+ * Restoring it there would advertise a lake `add` always refuses.
+ */
+const isWritable = (lake: ListableLake, scope: ListScope): boolean =>
+  lake.canManage || (scope.isAdmin && !STATIC_LAKE_IDS.has(lake.id));
+
+/**
+ * Whether `@datalake add to <slug>` can RESOLVE this lake for this caller: an org-less lake, or one
+ * scoped to an org the caller belongs to. Mirrors `findBySlug`'s own-org-then-org-less lookup
+ * (packages/database/src/models/ai/DataLakeModel.ts) and must stay in sync with it - a row that
+ * fails there is a slug this reply promised and `add` then refuses as "No Data Lake found".
+ */
+const isSlugAddressable = (lake: ListableLake, scope: ListScope): boolean => {
+  const orgId = lakeOrgId(lake);
+  return !orgId || (scope.organizationIds ?? []).includes(orgId);
+};
+
+/**
+ * Of two lakes sharing a slug, the one `findBySlug` would resolve: an org-scoped lake beats an
+ * org-less one, and among org-scoped ones the lowest org id wins (the model sorts ascending).
+ */
+const preferredBySlug = (a: ListableLake, b: ListableLake): ListableLake => {
+  const aOrg = lakeOrgId(a);
+  const bOrg = lakeOrgId(b);
+  if (!aOrg) return bOrg ? b : a;
+  if (!bOrg) return a;
+  return bOrg < aOrg ? b : a;
+};
+
+/**
+ * One row per slug. A slug is unique per org, so a collision means two lakes the caller can reach
+ * under one name - print the one `add` would write to, or the reply names a lake the command does
+ * not target.
+ */
+const dedupeBySlug = (lakes: ListableLake[]): ListableLake[] => {
+  const bySlug = new Map<string, ListableLake>();
+  for (const lake of lakes) {
+    const existing = bySlug.get(lake.slug);
+    bySlug.set(lake.slug, existing ? preferredBySlug(existing, lake) : lake);
+  }
+  return Array.from(bySlug.values());
+};
+
+/**
+ * The lakes the caller may ADD to (see `isWritable`), not merely read. Listing everything they can
+ * read would advertise lakes every add would then refuse.
+ *
+ * Two scoping rules, both needed, because `list` and `add` resolve lakes differently:
+ *
+ * 1. The row set is queried with the platform-admin bypass SUPPRESSED, so an admin's reply is built
+ *    from the same org/visibility arms as everyone else's. Left on, `findAccessible` short-circuits
+ *    to every draft/active lake on the platform - and unlike the web manager list, this reply is a
+ *    channel message, so that set lands somewhere shared, searchable and permanent.
+ * 2. Every surviving row must be addressable BY SLUG for this caller, because `add` resolves through
+ *    the org-scoped `findBySlug` while `findAccessible`'s public arm ignores the org constraint.
+ *
+ * The invariant is "listed implies addable", NOT the converse: a lake an admin could write to purely
+ * by platform-admin power, holding no ownership or org claim on it, stays out of the channel.
  */
 async function handleList(params: HandleDataLakeCommandParams): Promise<string> {
-  const ctx = await buildSlackAccessContext(params.actor, params.deps);
-  const lakes = await dataLakeService.listDataLakes(ctx, { db: { dataLakes: params.deps.dataLakes } });
-  const writable = lakes.filter(lake => lake.canManage);
+  // Entitlement keys are resolved even for an admin, unlike the write path: rule 1 evaluates them
+  // through the non-admin arms, so without the keys an entitlement-gated lake in the admin's OWN
+  // org would fail findAccessible's requirement constraint and vanish from a list `add` still takes.
+  const ctx = await buildSlackAccessContext(params.actor, params.deps, { resolveEntitlementsForAdmin: true });
+  const lakes = await dataLakeService.listDataLakes(
+    { ...ctx, isAdmin: false },
+    { db: { dataLakes: params.deps.dataLakes } }
+  );
+  // `isWritable` restores the manage LABEL that suppressing isAdmin also silenced in canManageLake.
+  // It re-labels an already-scoped row set and can never add a row to it.
+  const writable = dedupeBySlug(lakes.filter(lake => isWritable(lake, ctx) && isSlugAddressable(lake, ctx)));
 
   if (writable.length === 0) {
     return 'You cannot add to any data lakes yet. You can add to lakes you created, or ask an admin.';
   }
 
-  // Capped: for an ADMIN, findAccessible short-circuits to every draft/active lake on the
-  // platform, all canManage. Past Slack's 40k-character `text` limit chat.postMessage errors, the
-  // orchestrator catches it, and the admin gets "something went wrong" instead of any list at all.
+  // Capped: a caller in a large org can still have more manageable lakes than fit Slack's
+  // 40k-character `text` limit, and past it chat.postMessage errors, the orchestrator catches it,
+  // and they get "something went wrong" instead of any list at all.
   const shown = writable.slice(0, LIST_LIMIT);
   const rows = shown.map(lake => `- \`${lake.slug}\` - ${lake.name}`).join('\n');
   const more = writable.length > shown.length ? `\n- ...and ${writable.length - shown.length} more` : '';


### PR DESCRIPTION
# Pull Request

## Description

`@datalake list` and `@datalake add` resolved lakes by different rules, so the command that exists
to say what you can feed did not agree with the command that feeds it. `list` went through
`listDataLakes` -> `findAccessible`, which applies no organization or visibility constraint for a
platform admin; `add` goes through `assertLakeWriteAccess` -> `findBySlug`, which matches inside the
caller's own organizations and then falls back to an org-less lake. The result was a reply, posted
into a shared channel, whose rows an admin often could not use and whose scope did not match what
the caller may address.

This scopes the `list` reply to the lakes the caller can actually write to AND name by slug, so the
reply is built from the same organization and visibility arms every other caller gets. The
invariant the change pins is **listed implies addable**: every slug printed resolves for the caller
who asked, among the lakes `list` can see (Additional Information records where that qualifier
matters). The reverse direction (a lake reachable by grant, or by platform-admin power alone, that
`list` does not show) is deliberately not restored here - see Additional Information.

Nothing about the `add` path, the web manager list, or `findAccessible` itself changes.

Closes #2022
Closes #2023

## Changes

- `apps/client/server/slack/handleDataLakeCommand.ts`
  - `handleList` (:153) now builds its row set with the platform-admin bypass suppressed
    (`{ ...ctx, isAdmin: false }`), so the query takes the same organization and visibility arms as
    any other caller instead of the admin short-circuit.
  - `isWritable` (:96) re-applies the admin manage label over that already-scoped row set, except on
    a static-registry lake (`STATIC_LAKE_IDS`), which is read-only for everyone including admins -
    labelling one manageable would advertise a lake `add` always refuses.
  - `isSlugAddressable` (:105) keeps only lakes whose slug resolves for this caller (org-less, or in
    one of the caller's organizations), mirroring `findBySlug` in
    `packages/database/src/models/ai/DataLakeModel.ts`.
  - `preferredBySlug` / `dedupeBySlug` (:114, :128) print one row per slug, choosing the lake
    `findBySlug` would resolve (own-org over org-less, lowest organization id first).
  - The dedupe runs BEFORE the write gate (:167-168), which is the order `add` uses. `findBySlug`
    picks a slug's lake by organization priority alone and never falls back when that lake turns out
    to be unwritable, so gating first would hide the winning lake and print a slug `add` then
    resolves elsewhere and refuses. Reachable for a non-admin whose own-org lake shares a slug with
    one they can read but not manage.
  - `lakeOrgId` (:87) reads a blank organization string as org-less, since both forms are stored.
  - The `LIST_LIMIT` comment no longer explains the cap by the admin short-circuit, which this
    surface no longer takes.
- `apps/client/server/slack/dataLakeIngestAuthz.ts`
  - `buildSlackAccessContext` takes an optional `{ resolveEntitlementsForAdmin }` (:80, :92). The
    write path is unchanged and still skips entitlement resolution for admins; only `list` opts in,
    because it evaluates an admin through the non-admin arms, where an entitlement-gated lake in the
    admin's own organization would otherwise drop out of a list that `add` still accepts.
- `apps/client/server/slack/dataLakeIngestAuthz.test.ts` (new file)
  - 4 tests covering `buildSlackAccessContext`'s entitlement rule directly: resolved for a
    non-admin, skipped for an admin by default, resolved for an admin on opt-in, and an explicit
    `false` behaving like the default. The handler tests mock this module and the ingest tests only
    reach the default paths, so without this the opt-in branch had no unit coverage.
- `apps/client/server/slack/handleDataLakeCommand.test.ts`
  - 10 tests under `list > scoping`, including a guard that replays every printed slug through a
    `findBySlug` fake built from the model's rule, so the listed-implies-addable invariant fails
    loudly if either side drifts. The guard runs for both an admin and a non-admin caller and
    requires the resolved lake to pass that caller's write gate, because the two gates differ and an
    admin-only run cannot see an unwritable winner at all.

## Tests

Automated tests in this diff: 10 new cases in the `list > scoping` block of
`handleDataLakeCommand.test.ts`, plus a new `dataLakeIngestAuthz.test.ts` with 4. Commands run, with
the output seen:

- `pnpm exec vitest run server/slack` (in `apps/client`) - 4 files, 86 tests passing.
- `pnpm --filter @bike4mind/client typecheck` - no errors. Note: run `pnpm turbo:core:build` first,
  or stale core dists produce unrelated "no exported member" errors.
- `pnpm exec eslint` on the three changed files - clean.

Every guard was checked by mutation, one revert at a time. The first five run against the 39 tests
in `handleDataLakeCommand.test.ts`, the last against the 4 in `dataLakeIngestAuthz.test.ts`:

- Passing the admin context straight through instead of suppressing the bypass: 1 failure, the case
  that asserts the row set is queried with the bypass suppressed. Nothing else can feel that revert,
  because the fake repository in those tests returns a fixed row set regardless of `isAdmin` - the
  suppression's downstream effect is carried by the preview run, not by the fixtures.
- Dropping the addressability filter: 3 failures - the lake in an organization the caller is not a
  member of, the cross-org public lake, and the listed-implies-addable guard.
- Reverting both scoping changes together: 4 failures.
- Dropping the static-registry condition in `isWritable`: exactly 1 failure, the built-in lake case,
  so that guard pins one behavior and does not overlap the others.
- Gating on writability before the dedupe rather than after: 2 failures - the unwritable-winner
  collision case and the listed-implies-addable guard.
- Ignoring the `resolveEntitlementsForAdmin` opt-in: 1 failure, the admin opt-in case.

Live QA on the PR preview at `ee82f41`: 13 checks, 0 failures, covering every assertion in the
Guide for Testers below, including the entitlement case in step 16. The two checks the linked issues
turn on both pass: with a lake scoped to an organization the acting admin is not a member of, `list`
does not print its slug and `add` to that same slug is refused as not found, so the two commands
agree about it.

Reported as counts rather than transcripts on purpose: the reply this PR changes is a chat message
whose rows are tenant data, so pasting one here would publish the kind of content the change is
about. Per-step evidence from the run is held locally and can be shared with a maintainer on
request. There is no BEFORE run - see Security Testing.

## Guide for Testers

No UI changed in this PR. Every assertion is made in Slack; the web app is used only to build
fixtures and for the regression checks.

**Preconditions**

1. `EnableDataLakes` is ON for the environment. If it is off the `@datalake` surface does not answer
   at all, and every step below would pass for the wrong reason.
2. The Slack app points at the preview link, is a member of one test channel, and answers
   `@datalake help` with help text before you start. Note the flow you used to link the account -
   step 18 needs it again.
3. Two accounts: one platform admin (ADMIN) and one ordinary account (OTHER). ADMIN must belong to
   at least one organization. The Slack account link stays on ADMIN for steps 10-17 and moves to
   OTHER only for step 18.
4. ADMIN and OTHER must NOT share an organization. If they do, the fixture in step 8 is reachable by
   ADMIN and steps 11 and 13 cannot fail, so those two prove nothing.

**Building the fixtures (web app)**

The Create Data Lake wizard has no organization field. It stamps the organization from whichever
account is selected in the bottom-left account switcher, so set that switcher before each creation
or the fixture lands in the wrong scope and the step it feeds becomes meaningless. Each creation is
`Sidebar -> Data Lakes -> Create data lake`, attaching any small `.txt`, and the wizard shows the
derived slug under the name field.

5. As ADMIN, switcher on the personal account: create `QA Admin Lake`, Access Tag and Required
   Entitlement both blank. Expected: slug `qa-admin-lake`, badged `Private`. This is the lake ADMIN
   can address, without which the reply in step 10 is empty.
6. As ADMIN, switcher on one of ADMIN's organizations: create a second lake also named
   `QA Admin Lake`. Expected: the same slug `qa-admin-lake`, badged `Org`, so one slug now names two
   lakes ADMIN can reach. If the wizard rejects the Tag Prefix, change it (the prefix is unique per
   creator; the slug is the part that must collide).
7. As OTHER, switcher on the personal account: create `QA Private Lake`, both gates blank. Expected:
   slug `qa-private-lake`, badged `Private`. Org-less and gate-less means it grants a non-owner
   nothing.
8. As OTHER, switcher on an organization ADMIN does NOT belong to: create `QA Cross Org Lake`.
   Expected: slug `qa-cross-org-lake`, badged `Org`.
9. As OTHER, switcher back on the personal account: create `QA Entitlement Lake` with Access Tag
   left BLANK and Required Entitlement set to a key ADMIN holds. To find one, sign in as ADMIN and
   open `Admin -> Users -> ADMIN's row -> Admin`, then read the Product Access column and take any
   key shown as Held. Expected: badged `Private`, and `Manage lakes -> QA Entitlement Lake ->
   Access` lists exactly one access channel, the entitlement. The blank access tag is required: with
   a tag set, the tag arm could satisfy the check instead of the entitlement arm and step 16 proves
   nothing.

**The assertions (Slack, as ADMIN, in the test channel)**

10. Post `@datalake list`. Expected: a reply headed `Data lakes you can add to`, one row per lake as
    a slug in backticks followed by the lake name. Record the row count and the exact slugs.
11. Read every row. Expected: each lake is org-less or in one of ADMIN's own organizations, and
    `qa-cross-org-lake` and `qa-private-lake` are both absent. Fail: either appears.
12. Post `@datalake add to <slug>` with a small `.txt` attached, once for EVERY slug from step 10 -
    the whole list, not a sample. Expected: each answers `Added 1 file to <lake name>`. Fail: any
    single row answers `No Data Lake <slug> found.`, which is the two commands disagreeing.
13. Post `@datalake add to qa-cross-org-lake` with a `.txt` attached. Expected:
    `No Data Lake qa-cross-org-lake found.` With step 11 this is the point of the change: both
    commands now agree about that lake instead of one offering what the other refuses. Fail: it is
    accepted, meaning `list` is under-reporting rather than `add` over-refusing.
14. Look for a built-in platform lake in the step 10 reply. Expected: absent. Then post
    `@datalake add to opti-knowledge` with a `.txt`. Expected: a refusal naming it as built into the
    platform and read-only, so list and add agree about built-ins too.
15. Count how many times `qa-admin-lake` appears in the step 10 reply. Expected: exactly once,
    despite steps 5 and 6 giving that slug two lakes. Then open `Sidebar -> Data Lakes` as ADMIN:
    expected, the file from step 12 landed in the ORG-scoped lake, not the org-less one, because
    that is the one `add` resolves. Fail: two rows for one slug, or the file in the org-less lake.
16. Confirm `qa-entitlement-lake` IS among the step 10 rows, then post
    `@datalake add to qa-entitlement-lake` with a `.txt`. Expected: listed, and the add answers
    `Added 1 file`. Fail: absent from the reply, which means an admin's entitlement keys are not
    being resolved and `add` accepts a lake `list` hides.
17. As OTHER, a member of the same channel, read ADMIN's step 10 reply. Expected: its rows are
    exactly the ones recorded in step 10, and none of them belongs to an organization OTHER is not a
    member of. Fail: OTHER can read a row from a tenant they have no claim on.
18. Move the Slack account link to OTHER using the flow from precondition 2, then post
    `@datalake list`, then `@datalake add to <slug>` for each slug it prints. Expected: OTHER's own
    lakes still list, `qa-admin-lake` is NOT among them, and each printed slug still accepts the
    file. Fail: a lake OTHER owns has disappeared, or a listed slug is refused - either would mean
    the change narrowed ordinary users.

### Regression Checks

19. As ADMIN, open the preview link and go to `Sidebar -> Data Lakes`. Expected: the manager still
    lists every lake in the database, `qa-private-lake` included, even though ADMIN's Slack `list`
    does not print it. Same actor, same data, two surfaces - this PR did not touch the web one.
20. Post `@datalake add to qa-admin-lake <any public URL>` with no attachment. Expected: the link is
    ingested and reported, unchanged by this PR.
21. Post `@datalake help`. Expected: the help text renders as before.

### What NOT to test

- There is nothing to inspect visually in the web app beyond step 19. No component, style or route
  changed.
- Do not treat a green test suite, typecheck or lint run as evidence for any step above. Those are
  reported under Tests and say nothing about the deployed surface.

## Additional Information

Known limitations, deliberate and named rather than papered over:

- The invariant is one-directional. A lake reachable only through an access grant is still not
  listed (tracked in #2034), and a lake an admin could write to purely by platform-admin power, with
  no ownership or organization claim on it, is intentionally not listed on this surface.
- The two issues' acceptance criteria conflict on one row: #2022 asks that an org-less lake still
  appear, #2023 asks that another user's private lake not appear, and an org-less gate-less lake is
  both. This PR resolves that toward #2023 - the reply omits it, and it stays addable by slug for
  anyone already entitled to it.
- The invariant holds against the lakes `list` can see, not against everything `findBySlug`
  searches. `findBySlug`'s own-org lookup applies no status or requirement filter, so it can resolve
  a same-slug lake that `findAccessible` never returned - one gated on an entitlement the caller
  lacks, or an archived one. In that case `list` prints the slug naming the lake it can see and
  `add` refuses, resolving the invisible sibling instead. Not a regression: the previous
  `canManage`-only filter printed the same slug. Not fixable from the list side without an unscoped
  query, so it is recorded here rather than worked around.
- The web app's admin listing at `apps/client/pages/api/data-lakes/index.ts` is explicitly out of
  scope per #2023, and the identifier-form divergence in #2035 is untouched.

No screenshots are attached: this PR changes no UI, and the only visual surface involved is a chat
reply whose contents are tenant data. Per-step evidence from the preview run is held locally and can
be provided to a maintainer on request.

## Developer Notes (Optional)

- **Reusable pattern**: a surface that must show only what the caller may address can query with the
  platform-admin bypass suppressed and re-apply the admin label afterwards, instead of filtering an
  admin-wide result set in the handler. It keeps the organization and visibility rules in the model,
  where they already exist, rather than duplicating them per surface.
- **Extension point**: `buildSlackAccessContext` now takes an options argument, so a Slack caller
  can opt into entitlement resolution for admins without changing the write path's context.
- **Invariant test as a pattern**: the listed-implies-addable guard reimplements the resolver's rule
  in the test and replays real output through it, which catches drift between two commands that
  resolve the same identifier differently. Worth copying wherever a list feeds another command.

## Security Testing (for security-labeled PRs only)

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment) -
      NOT POSSIBLE, and left unticked deliberately rather than skipped: the Slack app is not
      installed on staging, so this surface cannot be exercised there at all. What stands in its
      place is in Tests above - the per-guard mutation figures, and the preview run.
- [x] Fix verified on **PR preview** env with the same script (output attached as PR comment) - 13
      checks, 0 failures, reported as counts in Tests above rather than as a separate comment.
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- apps/client/server/slack/handleDataLakeCommand.ts packages/database/src/models/ai/DataLakeModel.ts`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
