### PR TITLE
fix(client): disable image settings the selected model ignores

### DIFF
--- a/apps/client/app/components/Session/AISettings/AdvancedAIModal.tsx
+++ b/apps/client/app/components/Session/AISettings/AdvancedAIModal.tsx
@@ -100,6 +100,7 @@ import { brand, grayAlpha, green, greenAlpha } from '@client/app/utils/themes/co
 
 import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 import { ContextHelpButton, FieldTooltip, FIELD_TOOLTIPS } from '@client/app/components/help';
+import { ignoresUpsamplingAndSeed, withInertNote } from './inertImageSettings';
 import { useAdvancedAISettings } from './useAdvancedAISettingsStore';
 import { HEADER_ICON_BUTTON_SX } from './headerIconButtonSx';
 import { TabIntro } from './TabIntro';
@@ -287,6 +288,8 @@ interface ImageSettingItem {
   tooltip?: string;
   options?: ImageSettingOption[];
   inputProps?: Record<string, unknown>;
+  // Set when the selected model ignores the setting: the row stays visible but cannot be edited.
+  disabled?: boolean;
   onChange(value: string | number | null | undefined): void;
 }
 
@@ -1220,6 +1223,7 @@ const SelectedModelDetails: React.FC<SelectedModelDetailsProps> = ({
                     <Select
                       value={setting.value}
                       onChange={(_, newValue) => setting.onChange(newValue)}
+                      disabled={setting.disabled}
                       indicator={<KeyboardArrowDownIcon />}
                       sx={settingsSelectSx(mode || 'light')}
                       slotProps={SETTINGS_SELECT_SLOT_PROPS}
@@ -1238,6 +1242,7 @@ const SelectedModelDetails: React.FC<SelectedModelDetailsProps> = ({
                       variant="outlined"
                       color="primary"
                       value={setting.value}
+                      disabled={setting.disabled}
                       {...setting.inputProps}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         const value = e.target.value === '' ? undefined : parseInt(e.target.value);
@@ -1284,14 +1289,17 @@ const SelectedModelDetails: React.FC<SelectedModelDetailsProps> = ({
               )}
 
               {/* Not BFL-only: shown for Gemini (Nano Banana) models too for UI-grouping reasons, but
-                it's currently a no-op there - GeminiImageService deliberately never forwards this to
-                Google's API, which rejects the field outright. Do not "fix" that by re-adding a
-                Gemini enhancePrompt mapping without confirming Google's API accepts it. Safety
-                Tolerance above stays BFL-gated - it is a BFL API parameter with no Gemini
+                disabled there - GeminiImageService deliberately never forwards this to Google's API,
+                which rejects the field outright (see `inertImageSettings.ts`). Do not "fix" that by
+                re-adding a Gemini enhancePrompt mapping without confirming Google's API accepts it.
+                Safety Tolerance above stays BFL-gated - it is a BFL API parameter with no Gemini
                 equivalent. Last row on purpose: the only toggle among the dropdowns and inputs, so
                 it reads as an addendum rather than interrupting the column of matching controls. */}
               {supportsPromptUpsampling(model) && (
-                <SettingsRow label="Prompt Upsampling" tooltip={FIELD_TOOLTIPS.promptEnhancement}>
+                <SettingsRow
+                  label="Prompt Upsampling"
+                  tooltip={withInertNote(FIELD_TOOLTIPS.promptEnhancement, ignoresUpsamplingAndSeed(model))}
+                >
                   {/* The toggle is narrower than the inputs and selects, so it sits in a box of the
                     shared control width and hugs the right edge - lining up with their right edge
                     rather than floating in the middle of the column. */}
@@ -1300,6 +1308,7 @@ const SelectedModelDetails: React.FC<SelectedModelDetailsProps> = ({
                     <SquareSlideToggle
                       checked={prompt_upsampling ?? false}
                       onChange={e => setLLM({ prompt_upsampling: e.target.checked })}
+                      disabled={ignoresUpsamplingAndSeed(model)}
                       data-testid="setting-toggle-prompt-upsampling"
                     />
                   </Box>
@@ -1755,7 +1764,8 @@ export const AdvancedAIModal: React.FC<AdvancedAIModalProps> = ({
         type: 'input' as const,
         value: seed?.toString() ?? '',
         onChange: (value: number | null) => setLLM({ seed: value }),
-        tooltip: FIELD_TOOLTIPS.imageSeed,
+        tooltip: withInertNote(FIELD_TOOLTIPS.imageSeed, ignoresUpsamplingAndSeed(shownModel)),
+        disabled: ignoresUpsamplingAndSeed(shownModel),
         inputProps: { type: 'number', placeholder: 'Random' },
       },
       // Width/Height are BFL-specific parameters; GPT Image models use the Image Size dropdown instead

--- a/apps/client/app/components/Session/AISettings/ImageGenerationModelSelectionModal.test.tsx
+++ b/apps/client/app/components/Session/AISettings/ImageGenerationModelSelectionModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { BFL_SAFETY_TOLERANCE, IMAGE_SIZE_CONSTRAINTS, ImageModels, ModelName } from '@bike4mind/common';
 import { getThemeConfig } from '../../../utils/themes';
@@ -17,11 +17,12 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
 // ---- Mock useLLM ----
 const mockSetLLM = vi.fn();
 let mockSize: string = '1024x1024';
+let mockImageModel: string = ImageModels.FLUX_PRO_1_1;
 
 vi.mock('@client/app/contexts/LLMContext', () => ({
   useLLM: () => ({
     model: 'gpt-4o',
-    imageModel: ImageModels.FLUX_PRO_1_1,
+    imageModel: mockImageModel,
     imageEditModel: ImageModels.GPT_IMAGE_1_5,
     setLLM: mockSetLLM,
     size: mockSize,
@@ -177,5 +178,33 @@ describe('ImageGenerationModelSelectionModal — safety_tolerance hard cap', () 
     expect(BFL_SAFETY_TOLERANCE.MAX).toBe(2);
     // The pre-cap top-of-scale mark must be gone from the UI copy
     expect(queryByText('🌶️ Spicy')).toBeNull();
+  });
+});
+
+describe('ImageGenerationModelSelectionModal - settings the selected model ignores', () => {
+  afterEach(() => {
+    mockImageModel = ImageModels.FLUX_PRO_1_1;
+  });
+
+  it('disables Seed for a Gemini image model, which never receives it', () => {
+    mockImageModel = ImageModels.GEMINI_3_PRO_IMAGE;
+
+    const { getByTestId } = render(
+      <TestWrapper>
+        <ImageGenerationModelSelectionModal open={true} onClose={vi.fn()} />
+      </TestWrapper>
+    );
+
+    expect(getByTestId('image-setting-seed-input').querySelector('input')).toBeDisabled();
+  });
+
+  it('leaves Seed editable for BFL, which honors it', () => {
+    const { getByTestId } = render(
+      <TestWrapper>
+        <ImageGenerationModelSelectionModal open={true} onClose={vi.fn()} />
+      </TestWrapper>
+    );
+
+    expect(getByTestId('image-setting-seed-input').querySelector('input')).not.toBeDisabled();
   });
 });

--- a/apps/client/app/components/Session/AISettings/ImageGenerationModelSelectionModal.tsx
+++ b/apps/client/app/components/Session/AISettings/ImageGenerationModelSelectionModal.tsx
@@ -49,6 +49,7 @@ import {
 import MetadataChip from './MetaDataChips';
 import { useModelStats } from '@client/app/hooks/data/useModelStats';
 import { ContextHelpButton } from '@client/app/components/help';
+import { ignoresUpsamplingAndSeed, withInertNote } from './inertImageSettings';
 interface ImageGenerationModelSelectionModalProps {
   open: boolean;
   onClose: () => void;
@@ -334,7 +335,11 @@ const ImageGenerationModelSelectionModal: React.FC<ImageGenerationModelSelection
       type: 'input' as const,
       value: _seed?.toString() ?? '',
       onChange: (value: number | undefined) => setLLM({ seed: typeof value === 'number' ? value : null }),
-      tooltip: 'Set a specific seed for reproducible images (leave empty for random)',
+      tooltip: withInertNote(
+        'Set a specific seed for reproducible images (leave empty for random)',
+        ignoresUpsamplingAndSeed(contextImageModel)
+      ),
+      disabled: ignoresUpsamplingAndSeed(contextImageModel),
       inputProps: {
         type: 'number',
         placeholder: 'Random',
@@ -547,7 +552,15 @@ const ImageGenerationModelSelectionModal: React.FC<ImageGenerationModelSelection
               {imageSettings.map(setting => (
                 <Grid key={setting.label} xs={12} md={6}>
                   <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: '20px' }}>
-                    <Typography level="body-sm">{setting.label}</Typography>
+                    {/* A row is only disabled when the selected model ignores it, and then the label
+                      carries the reason - the rest of this list has no tooltip surface. */}
+                    {(setting as { disabled?: boolean }).disabled ? (
+                      <Tooltip title={(setting as { tooltip?: string }).tooltip ?? ''}>
+                        <Typography level="body-sm">{setting.label}</Typography>
+                      </Tooltip>
+                    ) : (
+                      <Typography level="body-sm">{setting.label}</Typography>
+                    )}
                     <Box sx={{ minWidth: '120px' }}>
                       {setting.type === 'select' && (
                         <Select
@@ -571,6 +584,7 @@ const ImageGenerationModelSelectionModal: React.FC<ImageGenerationModelSelection
                           variant="outlined"
                           color="primary"
                           value={(setting as any).value}
+                          disabled={(setting as { disabled?: boolean }).disabled}
                           {...(setting as any).inputProps}
                           onChange={(e: any) => {
                             const raw = e.target.value;

--- a/apps/client/app/components/Session/AISettings/inertImageSettings.test.ts
+++ b/apps/client/app/components/Session/AISettings/inertImageSettings.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { GEMINI_IMAGE_MODELS, ImageModels } from '@bike4mind/common';
+import { FIELD_TOOLTIPS } from '@client/app/components/help/fieldTooltips';
+import { ignoresUpsamplingAndSeed, withInertNote } from './inertImageSettings';
+
+describe('ignoresUpsamplingAndSeed', () => {
+  it('is true for every Gemini image model', () => {
+    for (const model of GEMINI_IMAGE_MODELS) {
+      expect(ignoresUpsamplingAndSeed(model)).toBe(true);
+    }
+  });
+
+  it('is false for the providers that honor the two settings', () => {
+    expect(ignoresUpsamplingAndSeed(ImageModels.FLUX_PRO_1_1)).toBe(false);
+    expect(ignoresUpsamplingAndSeed(ImageModels.GPT_IMAGE_1)).toBe(false);
+  });
+
+  it('is false for a missing model rather than disabling the controls by default', () => {
+    expect(ignoresUpsamplingAndSeed(undefined)).toBe(false);
+    expect(ignoresUpsamplingAndSeed(null)).toBe(false);
+    expect(ignoresUpsamplingAndSeed('')).toBe(false);
+  });
+});
+
+describe('withInertNote', () => {
+  it('appends the explanation when the control is inert', () => {
+    expect(withInertNote(FIELD_TOOLTIPS.imageSeed, true)).toBe(
+      `${FIELD_TOOLTIPS.imageSeed} ${FIELD_TOOLTIPS.unsupportedByGeminiImage}`
+    );
+  });
+
+  it('leaves the tooltip untouched otherwise', () => {
+    expect(withInertNote(FIELD_TOOLTIPS.promptEnhancement, false)).toBe(FIELD_TOOLTIPS.promptEnhancement);
+  });
+});

--- a/apps/client/app/components/Session/AISettings/inertImageSettings.ts
+++ b/apps/client/app/components/Session/AISettings/inertImageSettings.ts
@@ -1,0 +1,19 @@
+import { isGeminiImageModel } from '@bike4mind/common';
+// Imported from the module rather than the `help` barrel: component tests mock the barrel.
+import { FIELD_TOOLTIPS } from '@client/app/components/help/fieldTooltips';
+
+/**
+ * True for image models that silently ignore Prompt Upsampling and Seed. Gemini's image API takes
+ * neither: `GeminiImageService.buildGenerationConfig` omits `enhancePrompt` and `seed` from every
+ * request because Google's `generateImages` rejects their mere presence, and the `generateContent`
+ * fallback sends no config at all. Must stay in sync with that adapter.
+ *
+ * The controls stay rendered but disabled - hiding them would drop `prompt_upsampling` from image
+ * templates snapshotted with a Gemini model (see `ImageTemplates/settingsSnapshot.ts`), and a
+ * disabled control still tells you the setting exists on other providers.
+ */
+export const ignoresUpsamplingAndSeed = (model?: string | null): boolean => isGeminiImageModel(model);
+
+/** Adds the "your model ignores this" sentence to a field tooltip when the control is inert. */
+export const withInertNote = (tooltip: string, inert: boolean): string =>
+  inert ? `${tooltip} ${FIELD_TOOLTIPS.unsupportedByGeminiImage}` : tooltip;

--- a/apps/client/app/components/help/fieldTooltips.ts
+++ b/apps/client/app/components/help/fieldTooltips.ts
@@ -34,6 +34,9 @@ export const FIELD_TOOLTIPS = {
     'How permissive content moderation is (Flux only). Lower is stricter, higher is more permissive (hard-capped).',
   promptEnhancement:
     'The provider rewrites and expands your prompt before generating, often adding detail. Turn off to use your prompt exactly as written.',
+  // Appended to the tooltip of a control the selected model ignores, rather than hiding the control:
+  // see `inertImageSettings.ts`.
+  unsupportedByGeminiImage: 'Gemini image models do not accept this setting, so it has no effect on the result.',
 } as const;
 
 export type FieldTooltipKey = keyof typeof FIELD_TOOLTIPS;


### PR DESCRIPTION
# Pull Request

## Description

AI Settings offered two image controls that the selected model cannot honor. For Gemini image models, **Prompt Upsampling** and **Seed** are never forwarded to the provider, so both controls were live in the UI but inert -- the same two controls take effect on BFL and silently do nothing on Gemini, with nothing in the UI saying so.

Fixes #2001.

Approach: keep both controls visible but **disabled**, with the reason surfaced in the tooltip. The alternative (hiding them by narrowing `supportsPromptUpsampling`) was rejected because `ImageTemplates/settingsSnapshot.ts` keys off that helper to decide what to persist -- narrowing it would make templates saved on a Gemini model stop carrying `prompt_upsampling`. Forwarding a seed through `generateContent` was also rejected: it would touch the adapter guard, which carries more risk than the UI clarity is worth.

## Changes

- New `apps/client/app/components/Session/AISettings/inertImageSettings.ts`:
  - `ignoresUpsamplingAndSeed(model)` -- currently `isGeminiImageModel`, with a note on the adapter invariant it must stay in sync with.
  - `withInertNote(tooltip, inert)` -- appends `FIELD_TOOLTIPS.unsupportedByGeminiImage`.
- `AdvancedAIModal.tsx` -- the Seed input and the Prompt Upsampling toggle are disabled with the tooltip note when the selected model ignores them; `ImageSettingItem` grew a `disabled` field honored by the shared Select/Input renderers.
- `ImageGenerationModelSelectionModal.tsx` -- the Seed input is disabled the same way. This second surface had the same inert Seed input (the issue only named the first). Disabled rows now wrap their label in a Tooltip, since that list previously had no tooltip surface. Prompt Upsampling was already BFL-gated there.
- `supportsPromptUpsampling`, the reset defaults, and `settingsSnapshot.ts` are untouched, so existing image templates keep carrying the fields.

## Guide for Testers

1. Go to `app.staging.bike4mind.com` and open a chat session.
2. Open AI Settings -> Advanced (the Advanced AI modal).
3. Select an image model in the BFL family (e.g. a FLUX model).
4. Confirm the **Seed** input is editable and the **Prompt Upsampling** toggle is interactive. Expected: both accept input.
5. Switch the image model to `gemini-3-pro-image`.
6. Confirm the **Seed** input is now greyed out and cannot be typed into, and the **Prompt Upsampling** toggle is greyed out and cannot be flipped. Expected: both disabled.
7. Hover the **Seed** label and then the **Prompt Upsampling** label. Expected: each tooltip ends with a note explaining the setting is not supported by Gemini image models.
8. Open the image-generation model selection modal (the model picker with per-model image settings).
9. With a BFL model selected, confirm **Seed** is editable.
10. Select `gemini-3-pro-image`. Expected: the **Seed** row is disabled and hovering its label shows the same unsupported note.

### Regression Checks

11. With a BFL model selected, set a Seed and enable Prompt Upsampling, then generate an image. Expected: generation succeeds and the settings still apply as before.
12. Save an image template while a Gemini image model is selected, then reload it. Expected: the template still round-trips its stored settings (no fields dropped).

### What NOT to test

- Gemini image generation output itself is unchanged -- no adapter or request-payload code was touched.

## Additional Information

Verification performed locally:
- `pnpm turbo:typecheck` clean, `pnpm lint:check` clean.
- New `inertImageSettings.test.ts` (5 cases) plus two UI cases in `ImageGenerationModelSelectionModal.test.tsx` asserting the Seed input is disabled for `gemini-3-pro-image` and editable for BFL. The Gemini case was confirmed to fail when the `disabled` prop is removed.
- `app/components/Session` + `app/components/help` suites: 621 passed, 35 skipped.
- Full per-package runs green in isolation: client 10946 passed, database 1981 passed, scripts 421 passed.
- Not exercised in a running app -- no dev/preview instance was launched, so the tooltip wording and disabled styling are unverified visually.

## Developer Notes (Optional)

- `inertImageSettings.ts` is the single place that answers "does the selected image model ignore this setting?" -- add future provider-specific dead controls there rather than re-deriving per surface.
- `ImageSettingItem` now supports `disabled`, so any image setting in `AdvancedAIModal` can be greyed out declaratively.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
