### PR TITLE
fix(files): make AI Settings reprocess actually re-embed the file

### DIFF
--- a/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
@@ -12,7 +12,10 @@ const mockChunkMutate = vi.fn();
 const mockReprocessMutate = vi.fn();
 const { mockToastSuccess } = vi.hoisted(() => ({ mockToastSuccess: vi.fn() }));
 const mockSetWorkBenchFiles = vi.fn();
-const { mockSetQueriesData } = vi.hoisted(() => ({ mockSetQueriesData: vi.fn() }));
+const { mockSetQueriesData, mockInvalidateQueries } = vi.hoisted(() => ({
+  mockSetQueriesData: vi.fn(),
+  mockInvalidateQueries: vi.fn(),
+}));
 
 let messageFiles: IFabFileDocument[] = [];
 let workBenchFiles: IFabFileDocument[] = [];
@@ -55,7 +58,7 @@ vi.mock('@client/app/hooks/useEmbeddingMismatchStatus', () => ({
 }));
 vi.mock('@client/app/components/Knowledge/KnowledgeViewer', () => ({ setKnowledgeViewer: vi.fn() }));
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn(), setQueriesData: mockSetQueriesData }),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries, setQueriesData: mockSetQueriesData }),
 }));
 vi.mock('@client/app/hooks/useSessionLayout', () => ({
   default: (sel: (s: unknown) => unknown) => sel({ pendingMessageFiles: [], recentArtifacts: [] }),
@@ -77,6 +80,7 @@ const fab = (id: string, name: string, userId = 'me', mimeType = 'application/pd
 
 describe('FilesSection message-scoped files', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     mockIsPending.mockReturnValue(false);
     messageFiles = [];
@@ -211,6 +215,7 @@ describe('FilesSection message-scoped files', () => {
       { ...fab('sys1', 'policy.pdf'), embeddingModel: 'model-a', chunked: true, vectorized: true } as IFabFileDocument,
     ];
 
+    vi.useFakeTimers();
     renderPanel();
     fireEvent.click(screen.getByTestId('files-section-reprocess-btn-system-sys1'));
     mockReprocessMutate.mock.calls[0][1].onSuccess();
@@ -218,9 +223,16 @@ describe('FilesSection message-scoped files', () => {
     // System files go through the react-query cache, not the workbench store.
     expect(mockSetWorkBenchFiles).not.toHaveBeenCalled();
     expect(mockSetQueriesData).toHaveBeenCalledOnce();
+    expect(mockSetQueriesData.mock.calls[0][0]).toMatchObject({ queryKey: ['system-prompt-files'] });
     const updated = mockSetQueriesData.mock.calls[0][1](systemFiles);
     expect(updated[0]).toMatchObject({ chunked: false, vectorized: false, isChunking: true });
     expect(updated[0].embeddingModel).toBe('model-a');
+
+    // No deferred refetch: ['system-prompt-files', ids] is active while the panel is open, so an
+    // invalidation would replace the pending row with server state (resetChunkStateByIds writes
+    // isChunking:false) and re-arm the button mid-rebuild.
+    vi.advanceTimersByTime(5000);
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
   });
 
   it('renders distinct reprocess testids when the same file id appears in both lists', () => {

--- a/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
@@ -12,6 +12,7 @@ const mockChunkMutate = vi.fn();
 const mockReprocessMutate = vi.fn();
 const { mockToastSuccess } = vi.hoisted(() => ({ mockToastSuccess: vi.fn() }));
 const mockSetWorkBenchFiles = vi.fn();
+const { mockSetQueriesData } = vi.hoisted(() => ({ mockSetQueriesData: vi.fn() }));
 
 let messageFiles: IFabFileDocument[] = [];
 let workBenchFiles: IFabFileDocument[] = [];
@@ -53,7 +54,9 @@ vi.mock('@client/app/hooks/useEmbeddingMismatchStatus', () => ({
   useEmbeddingMismatchStatus: () => ({ hasEmbeddingMismatch: () => false }),
 }));
 vi.mock('@client/app/components/Knowledge/KnowledgeViewer', () => ({ setKnowledgeViewer: vi.fn() }));
-vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn(), setQueriesData: mockSetQueriesData }),
+}));
 vi.mock('@client/app/hooks/useSessionLayout', () => ({
   default: (sel: (s: unknown) => unknown) => sel({ pendingMessageFiles: [], recentArtifacts: [] }),
   setSessionLayout: vi.fn(),
@@ -190,10 +193,33 @@ describe('FilesSection message-scoped files', () => {
     expect(mockToastSuccess.mock.calls[0][0]).toMatch(/Re-processing/);
     expect(mockToastSuccess.mock.calls[0][0]).not.toMatch(/Successfully reprocessed/);
 
-    // The optimistic write must not claim the rebuild finished under the current model.
+    // The optimistic write must not claim the rebuild finished under the current model, and must
+    // land in the current session's bucket - a wrong key would write pending state nowhere visible.
     expect(mockSetWorkBenchFiles).toHaveBeenCalledOnce();
+    expect(mockSetWorkBenchFiles.mock.calls[0][0]).toBe('s1');
     const updated = mockSetWorkBenchFiles.mock.calls[0][1](workBenchFiles);
     expect(updated[0]).toMatchObject({ chunked: false, vectorized: false });
+    expect(updated[0].embeddingModel).toBe('model-a');
+    // Feeds the row's disabled predicate, so the button cannot re-arm mid-rebuild and buy a
+    // second real reset + re-embed on a stray click.
+    expect(updated[0].isChunking).toBe(true);
+  });
+
+  it('marks a system-scoped file pending in the system-prompt-files cache', () => {
+    settingsValues.defaultEmbeddingModel = 'model-b';
+    systemFiles = [
+      { ...fab('sys1', 'policy.pdf'), embeddingModel: 'model-a', chunked: true, vectorized: true } as IFabFileDocument,
+    ];
+
+    renderPanel();
+    fireEvent.click(screen.getByTestId('files-section-reprocess-btn-system-sys1'));
+    mockReprocessMutate.mock.calls[0][1].onSuccess();
+
+    // System files go through the react-query cache, not the workbench store.
+    expect(mockSetWorkBenchFiles).not.toHaveBeenCalled();
+    expect(mockSetQueriesData).toHaveBeenCalledOnce();
+    const updated = mockSetQueriesData.mock.calls[0][1](systemFiles);
+    expect(updated[0]).toMatchObject({ chunked: false, vectorized: false, isChunking: true });
     expect(updated[0].embeddingModel).toBe('model-a');
   });
 

--- a/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
@@ -9,6 +9,9 @@ const mockAdd = vi.fn().mockResolvedValue(undefined);
 const mockRemove = vi.fn().mockResolvedValue(undefined);
 const mockIsPending = vi.fn().mockReturnValue(false);
 const mockChunkMutate = vi.fn();
+const mockReprocessMutate = vi.fn();
+const { mockToastSuccess } = vi.hoisted(() => ({ mockToastSuccess: vi.fn() }));
+const mockSetWorkBenchFiles = vi.fn();
 
 let messageFiles: IFabFileDocument[] = [];
 let workBenchFiles: IFabFileDocument[] = [];
@@ -30,15 +33,22 @@ vi.mock('@client/app/hooks/useNotebookContextFiles', () => ({
 vi.mock('@client/app/contexts/SessionsContext', () => ({
   useSessions: () => ({ currentSessionId: 's1', currentSession: { id: 's1', userId: sessionUserId } }),
   useSystemPromptFiles: () => ({ systemFiles, globalSystemFileIds: [], userSystemFileIds: [] }),
-  useWorkBenchActions: () => ({ setWorkBenchFiles: vi.fn() }),
+  useWorkBenchActions: () => ({ setWorkBenchFiles: mockSetWorkBenchFiles }),
   useWorkBenchFiles: () => workBenchFiles,
 }));
 
+vi.mock('sonner', () => ({ toast: { success: mockToastSuccess, error: vi.fn() } }));
 vi.mock('@client/app/contexts/UserContext', () => ({ useUser: () => ({ currentUser: { id: currentUserId } }) }));
 vi.mock('@client/app/hooks/useMessageFiles', () => ({ useMessageFiles: () => messageFiles }));
 vi.mock('@client/app/hooks/data/useModelInfo', () => ({ useModelInfo: () => ({ data: undefined }) }));
 vi.mock('@client/app/hooks/data/settings', () => ({ useGetSettingsValue: (key: string) => settingsValues[key] }));
-vi.mock('@client/app/hooks/data/fabFiles', () => ({ useChunkFile: () => ({ mutate: mockChunkMutate }) }));
+// useChunkFile stays mocked even though FilesSection no longer calls it, so a regression that
+// routes reprocess back through the non-resetting /api/files/chunk door fails on the assertion
+// below rather than on a missing-export error.
+vi.mock('@client/app/hooks/data/fabFiles', () => ({
+  useChunkFile: () => ({ mutate: mockChunkMutate }),
+  useReprocessFile: () => ({ mutate: mockReprocessMutate }),
+}));
 vi.mock('@client/app/hooks/useEmbeddingMismatchStatus', () => ({
   useEmbeddingMismatchStatus: () => ({ hasEmbeddingMismatch: () => false }),
 }));
@@ -148,9 +158,12 @@ describe('FilesSection message-scoped files', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('clamps a legacy above-ceiling DefaultChunkSize before reprocessing a mismatched file', () => {
-    // Reachable state settings.ts documents explicitly: a value stored before the ceiling shipped
-    // resolves at its stored size on this raw settings-fetch read, with no clamp of its own.
+  it('reprocesses a mismatched file through the state-resetting door, not the plain chunk call', () => {
+    // /api/files/chunk leaves chunked: true in place, so the queue handler's duplicate-delivery
+    // guard drops the message and the file is never re-embedded. Only /api/files/reprocess resets
+    // the flags first. No chunkSize goes with it: the rebuild inherits the owner-altitude
+    // DefaultChunkSize policy resolved server-side (this test previously asserted a clamped
+    // client-side chunkSize, which the reprocess door does not and should not accept).
     settingsValues.DefaultChunkSize = 5000;
     settingsValues.defaultEmbeddingModel = 'model-b';
     workBenchFiles = [{ ...fab('w1', 'roster.pdf'), embeddingModel: 'model-a' } as IFabFileDocument];
@@ -158,8 +171,30 @@ describe('FilesSection message-scoped files', () => {
     renderPanel();
     fireEvent.click(screen.getByTestId('files-section-reprocess-btn-workbench-w1'));
 
-    expect(mockChunkMutate).toHaveBeenCalledOnce();
-    expect(mockChunkMutate.mock.calls[0][0]).toMatchObject({ fabFileId: 'w1', chunkSize: 1500 });
+    expect(mockChunkMutate).not.toHaveBeenCalled();
+    expect(mockReprocessMutate).toHaveBeenCalledOnce();
+    expect(mockReprocessMutate.mock.calls[0][0]).toBe('w1');
+  });
+
+  it('reports the rebuild as started and does not mark the file complete off the queue ack', () => {
+    settingsValues.defaultEmbeddingModel = 'model-b';
+    workBenchFiles = [
+      { ...fab('w1', 'roster.pdf'), embeddingModel: 'model-a', chunked: true, vectorized: true } as IFabFileDocument,
+    ];
+
+    renderPanel();
+    fireEvent.click(screen.getByTestId('files-section-reprocess-btn-workbench-w1'));
+    mockReprocessMutate.mock.calls[0][1].onSuccess();
+
+    expect(mockToastSuccess).toHaveBeenCalledOnce();
+    expect(mockToastSuccess.mock.calls[0][0]).toMatch(/Re-processing/);
+    expect(mockToastSuccess.mock.calls[0][0]).not.toMatch(/Successfully reprocessed/);
+
+    // The optimistic write must not claim the rebuild finished under the current model.
+    expect(mockSetWorkBenchFiles).toHaveBeenCalledOnce();
+    const updated = mockSetWorkBenchFiles.mock.calls[0][1](workBenchFiles);
+    expect(updated[0]).toMatchObject({ chunked: false, vectorized: false });
+    expect(updated[0].embeddingModel).not.toBe('model-b');
   });
 
   it('renders distinct reprocess testids when the same file id appears in both lists', () => {

--- a/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.test.tsx
@@ -194,7 +194,7 @@ describe('FilesSection message-scoped files', () => {
     expect(mockSetWorkBenchFiles).toHaveBeenCalledOnce();
     const updated = mockSetWorkBenchFiles.mock.calls[0][1](workBenchFiles);
     expect(updated[0]).toMatchObject({ chunked: false, vectorized: false });
-    expect(updated[0].embeddingModel).not.toBe('model-b');
+    expect(updated[0].embeddingModel).toBe('model-a');
   });
 
   it('renders distinct reprocess testids when the same file id appears in both lists', () => {

--- a/apps/client/app/components/Session/AISettings/FilesSection.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.tsx
@@ -4,13 +4,7 @@ import { Badge, Box, Chip, CircularProgress, Divider, IconButton, Tooltip, Typog
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import {
-  DEFAULT_PASSAGE_TOKEN_TARGET,
-  IFabFileDocument,
-  MimeType,
-  isImageAttachment,
-  isImageServeable,
-} from '@bike4mind/common';
+import { IFabFileDocument, MimeType, isImageAttachment, isImageServeable } from '@bike4mind/common';
 import { setKnowledgeViewer } from '@client/app/components/Knowledge/KnowledgeViewer';
 import {
   useSessions,
@@ -22,11 +16,10 @@ import { useUser } from '@client/app/contexts/UserContext';
 import { useNotebookContextFiles } from '@client/app/hooks/useNotebookContextFiles';
 import { useModelInfo } from '@client/app/hooks/data/useModelInfo';
 import { useGetSettingsValue } from '@client/app/hooks/data/settings';
-import { useChunkFile } from '@client/app/hooks/data/fabFiles';
+import { useReprocessFile } from '@client/app/hooks/data/fabFiles';
 import { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 import useSessionLayout from '@client/app/hooks/useSessionLayout';
 import { useMessageFiles } from '@client/app/hooks/useMessageFiles';
-import { clampChunkSize } from '@client/app/utils/chunkSize';
 import { renameDuplicateFiles } from '@client/app/utils/fabFileUtils';
 import { buildSortedKnowledgeItems } from '@client/app/utils/knowledgeViewerSorting';
 import { useQueryClient } from '@tanstack/react-query';
@@ -162,12 +155,7 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
   const { currentUser } = useUser();
   const modelInfo = useModelInfo()?.data?.find(m => m.id === model);
   const currentEmbeddingModel = useGetSettingsValue('defaultEmbeddingModel');
-  // Fall back to the canonical chunker default, not a third hand-copied number.
-  // clamped - see clampChunkSize (chunkSize.ts)
-  const defaultChunkSize = clampChunkSize(
-    Number(useGetSettingsValue('DefaultChunkSize')) || DEFAULT_PASSAGE_TOKEN_TARGET
-  );
-  const chunkFile = useChunkFile();
+  const reprocessFile = useReprocessFile();
   const queryClient = useQueryClient();
 
   // Files attached to individual messages
@@ -204,60 +192,50 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
       // Check if this is a system file
       const isSystemFile = systemFiles.some(sysFile => sysFile.id === file.id);
 
-      chunkFile.mutate(
-        { fabFileId: file.id, chunkSize: defaultChunkSize }, // Use default chunk size from settings
-        {
-          onSuccess: () => {
-            toast.success(`Successfully reprocessed "${file.fileName}" with the current embedding model`);
-            setReprocessingFiles(prev => ({ ...prev, [file.id]: false }));
+      reprocessFile.mutate(file.id, {
+        onSuccess: () => {
+          // Only the queue ack - the rebuild runs async, so say started, not done.
+          toast.success(`Re-processing "${file.fileName}" - it will be re-embedded with the current model`);
+          setReprocessingFiles(prev => ({ ...prev, [file.id]: false }));
 
-            if (isSystemFile) {
-              // For system files, first manually update the cache data
-              queryClient.setQueriesData({ queryKey: ['system-prompt-files'], exact: false }, (oldData: any) => {
-                if (Array.isArray(oldData)) {
-                  return oldData.map((f: IFabFileDocument) =>
-                    f.id === file.id
-                      ? { ...f, embeddingModel: String(currentEmbeddingModel), vectorized: true, chunked: true }
-                      : f
-                  );
-                }
-                return oldData;
+          // /api/files/reprocess has cleared the flags server-side; mirror that rather than
+          // claiming completion. The real end state arrives over update_file_chunk_vector_status.
+          const markPending = (f: IFabFileDocument) =>
+            f.id === file.id ? { ...f, vectorized: false, chunked: false } : f;
+
+          if (isSystemFile) {
+            // For system files, first manually update the cache data
+            queryClient.setQueriesData({ queryKey: ['system-prompt-files'], exact: false }, (oldData: any) => {
+              if (Array.isArray(oldData)) {
+                return oldData.map(markPending);
+              }
+              return oldData;
+            });
+
+            // Then invalidate after a delay to allow server processing
+            setTimeout(() => {
+              queryClient.invalidateQueries({
+                queryKey: ['system-prompt-files'],
+                exact: false,
               });
 
-              // Then invalidate after a delay to allow server processing
-              setTimeout(() => {
-                queryClient.invalidateQueries({
-                  queryKey: ['system-prompt-files'],
-                  exact: false,
-                });
-
-                // Also invalidate any individual file queries
-                queryClient.invalidateQueries({
-                  queryKey: ['fab-file', file.id],
-                  exact: false,
-                });
-              }, 1500); // 1.5 second delay to allow server to process the file
-            } else {
-              // Update the file in the workbench store to reflect the new embedding model
-              if (currentSessionId) {
-                setWorkBenchFiles(currentSessionId, prevFiles =>
-                  prevFiles.map(f =>
-                    f.id === file.id
-                      ? { ...f, embeddingModel: String(currentEmbeddingModel), vectorized: true, chunked: true }
-                      : f
-                  )
-                );
-              }
-            }
-          },
-          onError: (error: any) => {
-            toast.error(`Failed to reprocess file: ${error?.message || 'Unknown error'}`);
-            setReprocessingFiles(prev => ({ ...prev, [file.id]: false }));
-          },
-        }
-      );
+              // Also invalidate any individual file queries
+              queryClient.invalidateQueries({
+                queryKey: ['fab-file', file.id],
+                exact: false,
+              });
+            }, 1500); // 1.5 second delay to allow server to process the file
+          } else if (currentSessionId) {
+            setWorkBenchFiles(currentSessionId, prevFiles => prevFiles.map(markPending));
+          }
+        },
+        onError: (error: any) => {
+          toast.error(`Failed to reprocess file: ${error?.message || 'Unknown error'}`);
+          setReprocessingFiles(prev => ({ ...prev, [file.id]: false }));
+        },
+      });
     },
-    [chunkFile, defaultChunkSize, currentSessionId, setWorkBenchFiles, currentEmbeddingModel, systemFiles, queryClient]
+    [reprocessFile, currentSessionId, setWorkBenchFiles, systemFiles, queryClient]
   );
 
   // Check if the file is supported by the model

--- a/apps/client/app/components/Session/AISettings/FilesSection.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.tsx
@@ -199,9 +199,14 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
           setReprocessingFiles(prev => ({ ...prev, [file.id]: false }));
 
           // /api/files/reprocess has cleared the flags server-side; mirror that rather than
-          // claiming completion. The real end state arrives over update_file_chunk_vector_status.
+          // claiming completion. Nothing reconciles this panel in-session: it has no
+          // update_file_chunk_vector_status subscriber, and the workbench store is zustand, so the
+          // hook's ['fabFiles'] invalidation cannot reach it either - the row stays pending until a
+          // remount or session switch rehydrates it (SessionsContext's knowledgeIds effect).
+          // isChunking is what the disabled predicates below read, so setting it keeps the button
+          // from re-arming mid-rebuild; a second click would be a second real reset + re-embed.
           const markPending = (f: IFabFileDocument) =>
-            f.id === file.id ? { ...f, vectorized: false, chunked: false } : f;
+            f.id === file.id ? { ...f, vectorized: false, chunked: false, isChunking: true } : f;
 
           if (isSystemFile) {
             // For system files, first manually update the cache data
@@ -224,7 +229,10 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
                 queryKey: ['fab-file', file.id],
                 exact: false,
               });
-            }, 1500); // 1.5 second delay to allow server to process the file
+              // Vestigial under these semantics: at t+1.5s the row can only re-confirm the reset
+              // this handler just mirrored, never observe completion. Kept because the refetch is
+              // harmless and picking up the real end state needs the deferred subscriber instead.
+            }, 1500);
           } else if (currentSessionId) {
             setWorkBenchFiles(currentSessionId, prevFiles => prevFiles.map(markPending));
           }

--- a/apps/client/app/components/Session/AISettings/FilesSection.tsx
+++ b/apps/client/app/components/Session/AISettings/FilesSection.tsx
@@ -209,30 +209,18 @@ const FilesSection: React.FC<FilesSectionProps> = ({ model, onEmbeddingMismatchC
             f.id === file.id ? { ...f, vectorized: false, chunked: false, isChunking: true } : f;
 
           if (isSystemFile) {
-            // For system files, first manually update the cache data
+            // No follow-up invalidation: ['system-prompt-files', allSystemFileIds]
+            // (SessionsContext) is active while this panel is open, so a refetch would replace this
+            // row with server state that already reads isChunking:false - resetChunkStateByIds
+            // writes it - and re-arm the button mid-rebuild, which is exactly what markPending
+            // exists to prevent. It could never observe completion anyway; that needs the deferred
+            // update_file_chunk_vector_status subscriber.
             queryClient.setQueriesData({ queryKey: ['system-prompt-files'], exact: false }, (oldData: any) => {
               if (Array.isArray(oldData)) {
                 return oldData.map(markPending);
               }
               return oldData;
             });
-
-            // Then invalidate after a delay to allow server processing
-            setTimeout(() => {
-              queryClient.invalidateQueries({
-                queryKey: ['system-prompt-files'],
-                exact: false,
-              });
-
-              // Also invalidate any individual file queries
-              queryClient.invalidateQueries({
-                queryKey: ['fab-file', file.id],
-                exact: false,
-              });
-              // Vestigial under these semantics: at t+1.5s the row can only re-confirm the reset
-              // this handler just mirrored, never observe completion. Kept because the refetch is
-              // harmless and picking up the real end state needs the deferred subscriber instead.
-            }, 1500);
           } else if (currentSessionId) {
             setWorkBenchFiles(currentSessionId, prevFiles => prevFiles.map(markPending));
           }

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -220,8 +220,10 @@ export function useChunkFile(options: { onSuccess?: () => void } = {}) {
  * (e.g. re-embedding under a new embedding model) actually happen. Chunk size is not sent - the
  * rebuild inherits the owner-altitude DefaultChunkSize policy resolved server-side.
  *
- * A 200 is only the queue ack, not a finished rebuild; the real state arrives over the
- * update_file_chunk_vector_status websocket message.
+ * A 200 is only the queue ack, not a finished rebuild. The ['fabFiles'] invalidation below picks
+ * the end state up for react-query consumers; a caller holding files somewhere else (e.g. the
+ * zustand workbench store) is not reconciled by it and needs its own update_file_chunk_vector_status
+ * subscriber, which no caller has yet.
  */
 export function useReprocessFile() {
   const queryClient = useQueryClient();

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -211,6 +211,32 @@ export function useChunkFile(options: { onSuccess?: () => void } = {}) {
   });
 }
 
+/**
+ * Hook: reset a fabFile's chunk state and re-run chunking + vectorization.
+ *
+ * Distinct from useChunkFile: POST /api/files/chunk deliberately leaves the processing flags
+ * alone, so the queue handler's duplicate-delivery guard drops the message for any file that is
+ * already chunked. /api/files/reprocess clears those flags first, which is what makes a rebuild
+ * (e.g. re-embedding under a new embedding model) actually happen. Chunk size is not sent - the
+ * rebuild inherits the owner-altitude DefaultChunkSize policy resolved server-side.
+ *
+ * A 200 is only the queue ack, not a finished rebuild; the real state arrives over the
+ * update_file_chunk_vector_status websocket message.
+ */
+export function useReprocessFile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (fabFileId: string) => {
+      const res = await api.post<{ messageId: string }>('/api/files/reprocess', { fabFileId });
+      return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
+    },
+  });
+}
+
 export function useGetFabFiles(
   search: string = '',
   filters: {

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -234,6 +234,11 @@ export function useReprocessFile() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
     },
+    // No toast here - callers own the wording. Log anyway so a caller that forgets its own
+    // onError leaves a trace instead of failing silently.
+    onError: error => {
+      console.error(error);
+    },
   });
 }
 


### PR DESCRIPTION
## Description

Fixes #2017

The "Reprocess with the current embedding model" button in Session -> AI Settings -> Files never re-embedded anything. It posted to `/api/files/chunk`, which deliberately does **not** reset a file's processing state, so `fabFileChunk`'s duplicate-delivery guard (`if (fabFile.chunked || ...) return`) dropped the message and the file stayed on its old embedding model.

This was a 100% no-op, not an occasional one: `hasEmbeddingMismatch` only shows the button when `file.embeddingModel` is set, and that field is only stamped after a successful chunk+vectorize pass - so every file the button can target is already `chunked: true`.

Worse, it was silent. The 200 the UI treated as success is only the SQS enqueue ack, and the optimistic cache write stamped `{ embeddingModel: <current>, vectorized: true, chunked: true }`, which cleared the mismatch badge too - the user got a success toast, the warning disappeared, and nothing had happened.

The queue handler's guard is correct and load-bearing (it stops a duplicate delivery from wiping chunks a prior run created, since `chunkFabfile` unconditionally deletes existing chunks first), so the caller is what's wrong, not the guard. The right door already exists: `POST /api/files/reprocess` calls `fabFileRepository.resetChunkStateByIds` before enqueuing, which clears the processing flags and health rollups, stamps `chunkRebuildRequestedAt`, and uses `isChunking: { $ne: true }` as a per-document precondition so a lost race throws instead of handing back a bogus success. The data lake panel's per-file reprocess already uses it.

## Changes

- Added `useReprocessFile` in `apps/client/app/hooks/data/fabFiles.ts` - posts to `/api/files/reprocess` and invalidates `['fabFiles']`. Toasts are left to the caller (the lake panel's `useReprocessFabFile` keeps its own).
- `FilesSection.handleReprocessFile` now calls `useReprocessFile` instead of `useChunkFile`.
- No client-side `chunkSize` is sent. The rebuild inherits the owner-altitude `DefaultChunkSize` policy resolved in `fabFileChunk.ts`, the same as the lake rebuild door - one fewer path that can bypass the policy ceiling. The clamp and its `clampChunkSize`/`DEFAULT_PASSAGE_TOKEN_TARGET` imports are gone from this component.
- The toast now reports the rebuild as **started**, not finished: `Re-processing "<name>" - it will be re-embedded with the current model`.
- The optimistic cache write now mirrors the server-side reset (`chunked: false, vectorized: false`) instead of asserting completion. `embeddingModel` is left alone, so the mismatch badge honestly stays up until the rebuild actually lands; the real end state arrives over the existing `update_file_chunk_vector_status` websocket message and the invalidation path.
- `useReprocessFile` has an `onError` that only `console.error`s - no toast, so callers keep ownership of the wording, but a caller that forgets its own `onError` leaves a trace instead of failing silently. Every other mutation in `fabFiles.ts` logs on error; this keeps that consistent.
- `useChunkFile` and `/api/files/chunk` are untouched - `ResearchTasks/File.tsx` and `KnowledgeChunkControls.tsx` still use them.

### Tests

`apps/client/app/components/Session/AISettings/FilesSection.test.tsx`:

- **Replaced** `clamps a legacy above-ceiling DefaultChunkSize before reprocessing a mismatched file`. That test asserted `mockChunkMutate` was called with `{ fabFileId: 'w1', chunkSize: 1500 }`, i.e. it locked in the broken call shape. Its replacement, `reprocesses a mismatched file through the state-resetting door, not the plain chunk call`, keeps the same setup (including the above-ceiling `DefaultChunkSize`) and asserts the chunk mutation is **not** called and the reprocess mutation is called with the file id. The clamp helper itself has no test file of its own; its coverage is `KnowledgeChunkControls.test.tsx:159` (the same legacy 5000 -> 1500 case, at the other `clampChunkSize` call site) and `settings.test.ts:458`, which tests the retroactive clamp that `chunkSize.ts` is a one-line delegate to. No coverage is lost by dropping the assertion here.
- **Added** `reports the rebuild as started and does not mark the file complete off the queue ack` - asserts the toast wording and that the optimistic workbench write sets `chunked: false, vectorized: false` and does not stamp the current embedding model.
- `useChunkFile` stays in the module mock even though the component no longer calls it, so a regression that routes reprocess back through the non-resetting door fails on the assertion rather than on a missing-export error.

Both new tests fail on `main` and pass with the fix (verified by reverting the two source files and re-running: 2 failed / 9 passed, then 11 passed).

### Review follow-ups

Folded in after review, all at `1f7b4320`+:

- The comments in `FilesSection.tsx` and `fabFiles.ts` claimed the real end state "arrives over `update_file_chunk_vector_status`". It does not arrive here: `FilesSection` has no subscriber for that action, and the workbench store is zustand, so the hook's `['fabFiles']` invalidation cannot reach it either. Both comments now say what actually happens - the row stays pending until a remount or session switch rehydrates it. A comment asserting a reconciliation that does not exist is the same class of problem as the toast this PR is fixing.
- The optimistic write now also sets `isChunking: true`, which feeds the row's existing `disabled` predicate. Without it the button re-armed seconds after the click while the rebuild was still running, so a stray second click bought either a confusing `FabFile is currently being chunked` 400 or a second real reset and re-embed of the same document. The only workbench-store consumer of `isChunking` is this panel's two `disabled` predicates, so nothing else changes behaviour.
- `FilesSection.test.tsx` mocked the query client as `{ invalidateQueries }` only, so the `isSystemFile` branch this PR rewrites would have thrown `setQueriesData is not a function` for anyone testing it. Added `setQueriesData` to the mock plus a test covering that branch.
- The optimistic-write test now also asserts the session id it writes under, matching the sibling assertion at `:113`.

Left deferred: subscribing to `update_file_chunk_vector_status` here so the badge clears on completion without a reload. That is item 2 below, and the `isChunking` change above removes the cost of not having it.

## Guide for Testers

Requires admin access to change the default embedding model.

1. Go to `app.staging.bike4mind.com` and sign in as an admin.
2. Upload a text or PDF file to a notebook's knowledge and wait for it to finish chunking and vectorizing (the file shows no processing spinner).
3. Go to Sidebar -> Admin -> Settings and change `defaultEmbeddingModel` to a different model than the one currently set. Save.
4. Return to the notebook, open AI Settings -> Files. Expected: the file from step 2 shows an orange warning badge and a reprocess button.
5. Click the reprocess button. Expected: a toast reading `Re-processing "<filename>" - it will be re-embedded with the current model`. Expected: the toast does NOT say "Successfully reprocessed".
6. Wait ~30 seconds, then reload the page and reopen AI Settings -> Files. Expected: the warning badge is gone and the file no longer offers a reprocess button, because it has been re-embedded under the new model.
7. Before this fix, step 6 would still show the warning badge (after the optimistic state was refetched away), because nothing was re-embedded.

### Regression Checks

8. In a notebook, open the Knowledge viewer for a file that has never been chunked and click its Chunk button (`ResearchTasks/File.tsx`). Expected: chunking starts and completes as before - this path still uses `/api/files/chunk` and is unchanged.
9. Open a data lake, expand a file row and click its per-file reprocess action. Expected: unchanged behaviour, toast reads `Re-processing started - chunking and vectorization will re-run.`
10. In AI Settings -> Files, verify the promote-to-notebook action on a message-scoped file still works, and that files with no embedding mismatch show no reprocess button.

### What NOT to test

- Chunk size tuning: this PR removes the client-supplied chunk size from this one control only; the admin `DefaultChunkSize` setting and its clamp are unchanged and still apply server-side.

## Additional Information

Two related items found while diagnosing, deliberately **not** included here to keep the fix minimal - both are worth their own tickets:

1. `KnowledgeChunkControls.tsx` disables its Chunk button only when `fabFile.chunked && fabFile.vectorized`. A file that is `chunked: true` but `vectorized: false` therefore passes the button's guard, hits the same queue-handler guard, and toasts `Successfully chunked and vectorized "<name>"` for a no-op. Same class of bug, different caller.
2. Reprocess is still fire-and-forget. The `update_file_chunk_vector_status` websocket channel already exists, so the UI could track the rebuild to completion and give a toast that's truthful about finishing rather than about queueing.

## Developer Notes

- `useReprocessFile` (in `fabFiles.ts`) is the generic, lake-independent counterpart to `useReprocessFabFile` (in `dataLakes.ts`). Any future UI that needs to rebuild a file's chunks should use one of these two, never `useChunkFile` - `/api/files/chunk` is only correct for files that have never been chunked.



