### PR TITLE
fix(client): recover a running agent execution when the socket comes back

### DIFF
--- a/apps/client/app/hooks/useAgentExecution.test.ts
+++ b/apps/client/app/hooks/useAgentExecution.test.ts
@@ -22,13 +22,16 @@ import React from 'react';
 // vi.mock factories are hoisted, so anything they reference must be created via
 // vi.hoisted. `subscribeToAction` is a stable identity so the subscription
 // effect (keyed on it) doesn't re-run across renders.
-const { navigateMock, toastMock, handlers, subscribeToAction, dispatchUiSideEffectsMock } = vi.hoisted(() => {
+const { navigateMock, toastMock, handlers, subscribeToAction, dispatchUiSideEffectsMock, ws } = vi.hoisted(() => {
   const handlers: Record<string, (msg: unknown) => Promise<void>> = {};
   return {
     navigateMock: vi.fn(),
     toastMock: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }),
     dispatchUiSideEffectsMock: vi.fn(),
     handlers,
+    // Mutable socket state so a test can mount with the socket already up (or
+    // still down) without re-mocking the module.
+    ws: { readyState: 3 /* CLOSED */, sendJsonMessage: vi.fn() },
     subscribeToAction: (action: string, cb: (msg: unknown) => Promise<void>) => {
       handlers[action] = cb;
       return () => {
@@ -42,7 +45,14 @@ const { navigateMock, toastMock, handlers, subscribeToAction, dispatchUiSideEffe
 vi.mock('@client/app/router', () => ({ router: { navigate: navigateMock } }));
 vi.mock('sonner', () => ({ toast: toastMock }));
 vi.mock('@client/app/contexts/WebsocketContext', () => ({
-  useWebsocket: () => ({ subscribeToAction }),
+  // ReadyState is re-exported by the real module and the hook compares against
+  // it, so the mock has to carry it too.
+  ReadyState: { UNINSTANTIATED: -1, CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 },
+  useWebsocket: () => ({
+    subscribeToAction,
+    readyState: ws.readyState,
+    sendJsonMessage: ws.sendJsonMessage,
+  }),
 }));
 vi.mock('@client/app/utils/uiSideEffectDispatcher', () => ({
   dispatchUiSideEffects: dispatchUiSideEffectsMock,
@@ -307,5 +317,69 @@ describe('useAgentExecutionSubscriptions — iteration_step UI side-effects', ()
     });
 
     expect(dispatchUiSideEffectsMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression coverage for the run that never finishes on screen.
+ *
+ * Agent progress is pushed to the connection id captured when the run started,
+ * and a failed push is only logged. So a socket that dies mid-run misses every
+ * later frame including `completed`, and the UI keeps showing "In Progress"
+ * for a run the server finished long ago (observed on production: a ~2 minute
+ * run still spinning 81 minutes later). The repair round-trip existed on both
+ * ends already - it just had no caller. These tests pin the caller.
+ */
+describe('useAgentExecutionSubscriptions -- recovering a run after the socket comes back', () => {
+  beforeEach(() => {
+    ws.sendJsonMessage.mockClear();
+    ws.readyState = 3; // CLOSED
+    Object.keys(handlers).forEach(k => delete handlers[k]);
+    useAgentExecutionStore.getState().clearAll();
+  });
+
+  const reconnectCalls = () =>
+    ws.sendJsonMessage.mock.calls.map(c => c[0] as Record<string, unknown>).filter(m => m.command === 'reconnect');
+
+  it('asks the server to re-state a still-running execution once the socket is open', () => {
+    useAgentExecutionStore.getState().startExecution('exec-1', 'sess-1');
+    ws.readyState = 1; // OPEN
+
+    mountSubscriptions();
+
+    expect(reconnectCalls()).toEqual([
+      { action: 'agent_execute', command: 'reconnect', sessionId: 'sess-1', executionId: 'exec-1' },
+    ]);
+    // The response does not echo the sessionId back, so it must be queued for
+    // `reconnect_result` to stamp on - same contract the dispatch hook honors.
+    expect(useAgentExecutionStore.getState().pendingReconnects).toContain('sess-1');
+  });
+
+  it('stays silent while the socket is down', () => {
+    useAgentExecutionStore.getState().startExecution('exec-1', 'sess-1');
+    ws.readyState = 3; // CLOSED
+
+    mountSubscriptions();
+
+    expect(reconnectCalls()).toEqual([]);
+  });
+
+  it('does not re-ask about a run that already finished', () => {
+    const store = useAgentExecutionStore.getState();
+    store.startExecution('exec-1', 'sess-1');
+    store.setStatus('exec-1', 'completed');
+    ws.readyState = 1; // OPEN
+
+    mountSubscriptions();
+
+    expect(reconnectCalls()).toEqual([]);
+  });
+
+  it('sends nothing when this tab is not watching any run', () => {
+    ws.readyState = 1; // OPEN
+
+    mountSubscriptions();
+
+    expect(reconnectCalls()).toEqual([]);
   });
 });

--- a/apps/client/app/hooks/useAgentExecution.test.ts
+++ b/apps/client/app/hooks/useAgentExecution.test.ts
@@ -351,8 +351,11 @@ describe('useAgentExecutionSubscriptions -- recovering a run after the socket co
       { action: 'agent_execute', command: 'reconnect', sessionId: 'sess-1', executionId: 'exec-1' },
     ]);
     // The response does not echo the sessionId back, so it must be queued for
-    // `reconnect_result` to stamp on - same contract the dispatch hook honors.
-    expect(useAgentExecutionStore.getState().pendingReconnects).toContain('sess-1');
+    // `reconnect_result` to stamp on - keyed by executionId so a sweep over
+    // several runs cannot be mis-paired by arrival order.
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([
+      { sessionId: 'sess-1', executionId: 'exec-1' },
+    ]);
   });
 
   it('stays silent while the socket is down', () => {
@@ -381,5 +384,99 @@ describe('useAgentExecutionSubscriptions -- recovering a run after the socket co
     mountSubscriptions();
 
     expect(reconnectCalls()).toEqual([]);
+  });
+});
+
+/**
+ * A socket-open sweep asks about several runs at once, and each request is answered by an
+ * independent server invocation whose cost scales with that run's child count - so the
+ * responses routinely come back in a different order than they were sent. Correlating them
+ * by arrival order would stamp a live run with another session's id, which is worse than the
+ * spinner this recovery exists to clear: the run vanishes from the session the user is
+ * looking at and reappears under one it does not belong to, and nothing corrects it.
+ */
+describe('useAgentExecutionSubscriptions -- reconnect responses pair with the run that asked', () => {
+  beforeEach(() => {
+    ws.sendJsonMessage.mockClear();
+    ws.readyState = 3; // CLOSED
+    Object.keys(handlers).forEach(k => delete handlers[k]);
+    useAgentExecutionStore.getState().clearAll();
+  });
+
+  const reconnectResult = (executionId: string) =>
+    handlers['reconnect_result']({
+      action: 'reconnect_result',
+      found: true,
+      executionId,
+      status: 'running',
+    });
+
+  it('keeps each session on its own run when the responses arrive out of order', async () => {
+    const store = useAgentExecutionStore.getState();
+    store.startExecution('exec-1', 'sess-A');
+    store.startExecution('exec-2', 'sess-B');
+    ws.readyState = 1; // OPEN
+
+    mountSubscriptions();
+
+    // exec-2 answers first - the case that arrival-order pairing gets wrong.
+    await reconnectResult('exec-2');
+    await reconnectResult('exec-1');
+
+    const executions = useAgentExecutionStore.getState().executions;
+    expect(executions['exec-2']?.sessionId).toBe('sess-B');
+    expect(executions['exec-1']?.sessionId).toBe('sess-A');
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([]);
+  });
+
+  it('still answers the mount-time probe, which has no execution id to key on', async () => {
+    // The probe asks "is anything running in this session?" before any id exists.
+    useAgentExecutionStore.getState().registerPendingReconnect('sess-C');
+    mountSubscriptions();
+
+    await reconnectResult('exec-9');
+
+    expect(useAgentExecutionStore.getState().executions['exec-9']?.sessionId).toBe('sess-C');
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([]);
+  });
+});
+
+/**
+ * Production never mounts into an already-open socket - it mounts once at app root and the
+ * socket goes down and comes back underneath it. The mount-time cases above cannot see a
+ * regression in that transition, so drive it directly.
+ */
+describe('useAgentExecutionSubscriptions -- the sweep runs on the transition, not just at mount', () => {
+  beforeEach(() => {
+    ws.sendJsonMessage.mockClear();
+    ws.readyState = 3; // CLOSED
+    Object.keys(handlers).forEach(k => delete handlers[k]);
+    useAgentExecutionStore.getState().clearAll();
+  });
+
+  const reconnectCalls = () =>
+    ws.sendJsonMessage.mock.calls.map(c => c[0] as Record<string, unknown>).filter(m => m.command === 'reconnect');
+
+  it('sweeps when a mounted subscriber sees the socket come back', () => {
+    useAgentExecutionStore.getState().startExecution('exec-1', 'sess-1');
+    const { rerender } = mountSubscriptions();
+    expect(reconnectCalls()).toEqual([]);
+
+    ws.readyState = 1; // OPEN
+    rerender();
+
+    expect(reconnectCalls()).toEqual([
+      { action: 'agent_execute', command: 'reconnect', sessionId: 'sess-1', executionId: 'exec-1' },
+    ]);
+  });
+
+  it('does not re-sweep while the socket stays open', () => {
+    useAgentExecutionStore.getState().startExecution('exec-1', 'sess-1');
+    ws.readyState = 1; // OPEN
+    const { rerender } = mountSubscriptions();
+    rerender();
+    rerender();
+
+    expect(reconnectCalls()).toHaveLength(1);
   });
 });

--- a/apps/client/app/hooks/useAgentExecution.ts
+++ b/apps/client/app/hooks/useAgentExecution.ts
@@ -20,7 +20,7 @@
  * first events. Subscriptions live at the WebsocketProvider scope now.
  */
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import { ReadyState, useWebsocket } from '@client/app/contexts/WebsocketContext';
@@ -174,7 +174,8 @@ function notifyBackgroundCompletion(agentName: string, finalAnswer?: string, onV
 }
 
 export function useAgentExecutionSubscriptions(): void {
-  const { subscribeToAction, readyState, sendJsonMessage } = useWebsocket();
+  const { subscribeToAction, readyState } = useWebsocket();
+  const { reconnect } = useAgentExecutionDispatch();
   const queryClient = useQueryClient();
 
   // Re-ask the server for the state of every run this tab still believes is live,
@@ -193,22 +194,29 @@ export function useAgentExecutionSubscriptions(): void {
   // `handleReconnect` -> `reconnect_result`) and simply had no caller. This is
   // that caller. Cheap by construction: it fires only on a socket transition
   // and only when the store holds an active run, so an idle tab sends nothing.
+  //
+  // Each request carries its executionId, which is what keeps a sweep over
+  // several runs from mis-pairing: the responses come from independent handler
+  // invocations whose latency scales with each run's child count, so they
+  // routinely arrive out of order (see `consumePendingReconnect`).
+  //
+  // The dispatcher is read through a ref and the effect is keyed on `readyState`
+  // alone: the dispatcher's identity is memoised over `sendJsonMessage`, which
+  // churns whenever the access token refreshes, and holding it in the deps would
+  // re-send the whole sweep each time it did. Same guard, same reason, as the
+  // mount-time caller in `ActiveAgentExecutions`.
+  const reconnectRef = useRef(reconnect);
+  useEffect(() => {
+    reconnectRef.current = reconnect;
+  }, [reconnect]);
   useEffect(() => {
     if (readyState !== ReadyState.OPEN) return;
-    const store = useAgentExecutionStore.getState();
-    for (const [executionId, execution] of Object.entries(store.executions)) {
+    const { executions } = useAgentExecutionStore.getState();
+    for (const [executionId, execution] of Object.entries(executions)) {
       if (!isActiveStatus(execution.status)) continue;
-      // Mirrors the dispatch hook: the response doesn't echo the sessionId, so
-      // it has to be queued here for `reconnect_result` to stamp back on.
-      if (execution.sessionId) store.registerPendingReconnect(execution.sessionId);
-      sendJsonMessage({
-        action: 'agent_execute',
-        command: 'reconnect',
-        sessionId: execution.sessionId,
-        executionId,
-      } as unknown as Parameters<typeof sendJsonMessage>[0]);
+      reconnectRef.current(execution.sessionId, executionId);
     }
-  }, [readyState, sendJsonMessage]);
+  }, [readyState]);
 
   // Navigate via the `router` singleton, NOT useNavigate(): this hook's host
   // (AgentExecutionSubscriber) mounts in providers.tsx, OUTSIDE the
@@ -401,7 +409,7 @@ export function useAgentExecutionSubscriptions(): void {
         // Always drain the pending sessionId, even on a `found: false` response;
         // otherwise the queue would carry a stale entry and pair it with the
         // next reconnect, mis-attributing the execution to the wrong session.
-        const sessionId = store().consumePendingReconnect();
+        const sessionId = store().consumePendingReconnect(msg.executionId);
         if (!msg.found || !msg.executionId || !msg.status) return;
         const executionId = msg.executionId;
 
@@ -716,7 +724,7 @@ export function useAgentExecutionDispatch() {
         // when sessionId is absent (callers reconnecting by executionId
         // already know their target).
         if (sessionId) {
-          useAgentExecutionStore.getState().registerPendingReconnect(sessionId);
+          useAgentExecutionStore.getState().registerPendingReconnect(sessionId, executionId);
         }
         sendJsonMessage({
           action: 'agent_execute',

--- a/apps/client/app/hooks/useAgentExecution.ts
+++ b/apps/client/app/hooks/useAgentExecution.ts
@@ -23,13 +23,14 @@
 import { useEffect, useMemo } from 'react';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
-import { useWebsocket } from '@client/app/contexts/WebsocketContext';
+import { ReadyState, useWebsocket } from '@client/app/contexts/WebsocketContext';
 import { router } from '@client/app/router';
 import { AGENT_TRACE_ROUTE, buildAgentTraceSearch } from '@client/app/utils/agentTraceLink';
 import type { IMessageDataToClient } from '@bike4mind/common';
 import {
   useAgentExecutionStore,
   findChildAnyDepth,
+  isActiveStatus,
   AGENT_EXECUTION_STATUSES,
   type AgentExecutionStatus,
   type ChildExecution,
@@ -173,8 +174,41 @@ function notifyBackgroundCompletion(agentName: string, finalAnswer?: string, onV
 }
 
 export function useAgentExecutionSubscriptions(): void {
-  const { subscribeToAction } = useWebsocket();
+  const { subscribeToAction, readyState, sendJsonMessage } = useWebsocket();
   const queryClient = useQueryClient();
+
+  // Re-ask the server for the state of every run this tab still believes is live,
+  // each time the socket comes up.
+  //
+  // Server->client progress is fire-and-forget: `createWsSender` in the agent
+  // executor posts to the connection id captured when the run started and only
+  // logs a failed post. A socket that dies mid-run - a suspended tab, a laptop
+  // lid, a network switch - therefore misses EVERY later frame, `completed`
+  // among them, and nothing corrects the UI afterwards: the run sits at "In
+  // Progress", counting up, while the server finished it minutes ago. Seen on
+  // production: a run that completed in ~2 minutes was still spinning 81
+  // minutes later, its 127 pushes all logged as failed sends.
+  //
+  // The repair path already existed on both ends (`reconnect` -> the server's
+  // `handleReconnect` -> `reconnect_result`) and simply had no caller. This is
+  // that caller. Cheap by construction: it fires only on a socket transition
+  // and only when the store holds an active run, so an idle tab sends nothing.
+  useEffect(() => {
+    if (readyState !== ReadyState.OPEN) return;
+    const store = useAgentExecutionStore.getState();
+    for (const [executionId, execution] of Object.entries(store.executions)) {
+      if (!isActiveStatus(execution.status)) continue;
+      // Mirrors the dispatch hook: the response doesn't echo the sessionId, so
+      // it has to be queued here for `reconnect_result` to stamp back on.
+      if (execution.sessionId) store.registerPendingReconnect(execution.sessionId);
+      sendJsonMessage({
+        action: 'agent_execute',
+        command: 'reconnect',
+        sessionId: execution.sessionId,
+        executionId,
+      } as unknown as Parameters<typeof sendJsonMessage>[0]);
+    }
+  }, [readyState, sendJsonMessage]);
 
   // Navigate via the `router` singleton, NOT useNavigate(): this hook's host
   // (AgentExecutionSubscriber) mounts in providers.tsx, OUTSIDE the

--- a/apps/client/app/stores/useAgentExecutionStore.test.ts
+++ b/apps/client/app/stores/useAgentExecutionStore.test.ts
@@ -87,30 +87,71 @@ describe('useAgentExecutionStore — clearForSession', () => {
   });
 });
 
-describe('useAgentExecutionStore — pending reconnect FIFO queue', () => {
+describe('useAgentExecutionStore -- pending reconnect queue', () => {
   beforeEach(resetStore);
 
   it('registerPendingReconnect enqueues in order', () => {
     const { registerPendingReconnect } = useAgentExecutionStore.getState();
     registerPendingReconnect('session-A');
     registerPendingReconnect('session-B');
-    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual(['session-A', 'session-B']);
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([
+      { sessionId: 'session-A', executionId: undefined },
+      { sessionId: 'session-B', executionId: undefined },
+    ]);
   });
 
-  it('consumePendingReconnect drains FIFO and returns the head', () => {
+  it('consumePendingReconnect drains un-keyed entries FIFO', () => {
     const { registerPendingReconnect, consumePendingReconnect } = useAgentExecutionStore.getState();
     registerPendingReconnect('session-A');
     registerPendingReconnect('session-B');
 
     expect(consumePendingReconnect()).toBe('session-A');
-    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual(['session-B']);
-
     expect(useAgentExecutionStore.getState().consumePendingReconnect()).toBe('session-B');
     expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([]);
   });
 
   it('consumePendingReconnect returns undefined when the queue is empty', () => {
     expect(useAgentExecutionStore.getState().consumePendingReconnect()).toBeUndefined();
+  });
+
+  // A socket-open sweep asks about several runs at once and their responses come back in
+  // whatever order the server finishes them, so arrival order cannot be the correlation.
+  it('answers a keyed entry by its executionId, whatever the queue order', () => {
+    const { registerPendingReconnect } = useAgentExecutionStore.getState();
+    registerPendingReconnect('session-A', 'exec-1');
+    registerPendingReconnect('session-B', 'exec-2');
+
+    expect(useAgentExecutionStore.getState().consumePendingReconnect('exec-2')).toBe('session-B');
+    expect(useAgentExecutionStore.getState().consumePendingReconnect('exec-1')).toBe('session-A');
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([]);
+  });
+
+  it('leaves keyed entries alone when an un-keyed response drains', () => {
+    const { registerPendingReconnect } = useAgentExecutionStore.getState();
+    registerPendingReconnect('session-A', 'exec-1');
+    registerPendingReconnect('session-probe');
+
+    // A `found: false` response carries no executionId; it must not steal exec-1's entry.
+    expect(useAgentExecutionStore.getState().consumePendingReconnect()).toBe('session-probe');
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([
+      { sessionId: 'session-A', executionId: 'exec-1' },
+    ]);
+  });
+
+  it('falls back to an un-keyed entry when no entry matches the response id', () => {
+    const { registerPendingReconnect } = useAgentExecutionStore.getState();
+    registerPendingReconnect('session-probe');
+
+    // The mount-time probe cannot know the id it will be answered with.
+    expect(useAgentExecutionStore.getState().consumePendingReconnect('exec-9')).toBe('session-probe');
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([]);
+  });
+
+  it('clearAll drops the correlation queues, not just the executions', () => {
+    const store = useAgentExecutionStore.getState();
+    store.registerPendingReconnect('session-A', 'exec-1');
+    store.clearAll();
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([]);
   });
 });
 

--- a/apps/client/app/stores/useAgentExecutionStore.ts
+++ b/apps/client/app/stores/useAgentExecutionStore.ts
@@ -155,6 +155,13 @@ export interface ParentExecution {
   pendingTextByIteration?: Record<number, string>;
 }
 
+/** One outstanding `reconnect` request, waiting for the response that answers it. */
+export interface PendingReconnect {
+  sessionId: string;
+  /** Absent when the caller was asking "is anything running here?" and had no id yet. */
+  executionId?: string;
+}
+
 interface AgentExecutionState {
   executions: Record<string, ParentExecution>;
   /** Sessions awaiting their first `execution_started` event. Dispatch enqueues,
@@ -163,11 +170,17 @@ interface AgentExecutionState {
    * `concurrent_limit` check. */
   pendingDispatches: string[];
   /** Sessions awaiting their `reconnect_result` response. The server's payload
-   * doesn't echo sessionId back (the response shape is kept stable), so we use
-   * the same FIFO correlation as `pendingDispatches` to stamp the sessionId
-   * onto the hydrated execution. WS event ordering is preserved per connection,
-   * and mount-time reconnect is one-shot per session, so a queue is sufficient. */
-  pendingReconnects: string[];
+   * doesn't echo sessionId back (the response shape is kept stable), so the
+   * sessionId has to be carried here to be stamped onto the hydrated execution.
+   *
+   * Correlation is by `executionId` whenever the caller knew one - a socket-open
+   * sweep asks about several runs at once, and independent handler invocations
+   * answer in whatever order their work finishes, so arrival order alone would
+   * pair a response with another run's session. Callers that cannot know the id
+   * yet (the mount-time "is anything running in this session?" probe) enqueue
+   * without one and are matched FIFO among themselves, which is safe because
+   * that probe is one-shot per session. */
+  pendingReconnects: PendingReconnect[];
 
   // Lifecycle
   startExecution: (executionId: string, sessionId?: string) => void;
@@ -282,8 +295,10 @@ interface AgentExecutionState {
   // Dispatch correlation
   registerPendingDispatch: (sessionId: string) => void;
   consumePendingDispatch: () => string | undefined;
-  registerPendingReconnect: (sessionId: string) => void;
-  consumePendingReconnect: () => string | undefined;
+  /** `executionId` when the caller already knows which run it is asking about. */
+  registerPendingReconnect: (sessionId: string, executionId?: string) => void;
+  /** Pass the id the response carries; falls back to FIFO for un-keyed entries. */
+  consumePendingReconnect: (executionId?: string) => string | undefined;
 
   // Cleanup
   clear: (executionId: string) => void;
@@ -435,12 +450,21 @@ export const useAgentExecutionStore = create<AgentExecutionState>((set, get) => 
     return head;
   },
 
-  registerPendingReconnect: sessionId => set(state => ({ pendingReconnects: [...state.pendingReconnects, sessionId] })),
+  registerPendingReconnect: (sessionId, executionId) =>
+    set(state => ({ pendingReconnects: [...state.pendingReconnects, { sessionId, executionId }] })),
 
-  consumePendingReconnect: () => {
-    const [head, ...rest] = get().pendingReconnects;
-    set({ pendingReconnects: rest });
-    return head;
+  consumePendingReconnect: executionId => {
+    const queue = get().pendingReconnects;
+    // A keyed entry answers only to its own run. Fall through to the oldest
+    // un-keyed entry otherwise, which is both the mount-time probe's own case
+    // and what a `found: false` response (no executionId on the wire) drains.
+    const at = executionId
+      ? queue.findIndex(e => e.executionId === executionId)
+      : queue.findIndex(e => e.executionId === undefined);
+    const index = at === -1 ? queue.findIndex(e => e.executionId === undefined) : at;
+    if (index === -1) return undefined;
+    set({ pendingReconnects: queue.filter((_, i) => i !== index) });
+    return queue[index].sessionId;
   },
 
   startExecution: (executionId, sessionId) =>
@@ -725,7 +749,10 @@ export const useAgentExecutionStore = create<AgentExecutionState>((set, get) => 
       return { executions: next, pendingDispatches };
     }),
 
-  clearAll: () => set({ executions: {} }),
+  // The pending queues are correlation state for requests already in flight, so a reset that
+  // dropped the executions but kept them would leave entries that can only ever mis-pair with
+  // whatever comes next.
+  clearAll: () => set({ executions: {}, pendingDispatches: [], pendingReconnects: [] }),
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

An agent run can finish on the server while the UI shows it as still running, forever.

Server -> client progress is fire-and-forget. `createWsSender` in the agent executor posts to the connection id captured when the run started, and a failed post is only logged (`[WS] Failed to send <action> to <connectionId>`). So a socket that dies mid-run - a suspended tab, a laptop lid, a network switch - misses **every** later frame, including the terminal `completed`. Nothing corrects the UI afterwards, so the run sits at "In Progress", counting up.

Observed in production: a run that finished successfully in about two minutes was still showing "In Progress - Iteration 1 - 81m 3s" more than an hour later. Its logs show the execution completing normally (`[Complete] Agent execution finished ... hasAnswer=true`) with all 127 pushes for that run - the text deltas, the iteration steps, and `completed` - logged as failed sends.

## Why nothing recovered

The repair round-trip already exists on both ends:

- the client hook exposes a `reconnect` command (`useAgentExecutionDispatch`),
- the server handles it (`handleReconnect` in `websocket/agentExecute.ts`, complete with a re-stream budget),
- and answers with `reconnect_result`, which the client already knows how to apply.

It had **no caller**. Grepping the whole client for an invocation of that command returns nothing - the recovery path was wired up end to end and never triggered.

## The fix

Add the caller. On every transition to an open socket, `useAgentExecutionSubscriptions` (which mounts once at app root) re-asks the server about each execution this tab still believes is active, and queues the sessionId the same way the dispatch hook does so `reconnect_result` can stamp it back on.

Cheap by construction: it fires only on a socket transition, and only when the store holds an active run, so an idle tab sends nothing and a healthy run is unaffected.

This is the client half. The server half - re-resolving a user's live connections instead of posting to one captured id, the way `sendToClient` already does - is worth doing too, but it cannot help the case above on its own: that tab had no live socket at all when the run finished (its HTTP polling had stopped for the whole window), so there was nothing to re-resolve to. Recovery has to be driven by the client when it comes back.

## Testing

`apps/client/app/hooks/useAgentExecution.test.ts` gains four cases: re-states an active run once the socket is open (and queues the pending reconnect), stays silent while the socket is down, ignores a run that already finished, and sends nothing when the tab is watching no run.

Verified the coverage is real by mutation: with the new effect short-circuited, exactly the first case fails and the other twelve still pass.

`Test Files 1 passed (1) / Tests 13 passed (13)`, and `tsc --noEmit` is clean for the touched files.
