### PR TITLE
fix(client): enforce delegation denials at the dependency gate, not the name list

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   applySessionToolPolicy,
+  delegationOffer,
   runHasAttachments,
   DELEGATION_TOOLS,
   type SessionToolPolicyInput,
@@ -200,5 +201,56 @@ describe('runHasAttachments', () => {
     // Session knowledge alone counts: it is how a file attached to the notebook (rather than to
     // this message) reaches the agent, and it is the case that first surfaced this bug.
     expect(runHasAttachments({}, ['f1'])).toBe(true);
+  });
+});
+
+/**
+ * The two delegation tools are injected as OBJECTS in sharedToolBuilder, keyed on
+ * `deps.agentStore` / `deps.dagDispatcher` - `enabledTools` names never see them
+ * (issue #1829). So the only enforcement a profile's or session's denial can have
+ * is deciding these two dependency gates, which is what this helper does and what
+ * agentExecutor consumes when it builds toolDeps.
+ */
+describe('delegationOffer -- profile and session denials reach the dependency gates', () => {
+  it('offers both surfaces when nothing denies them', () => {
+    expect(delegationOffer({ profileDeniedTools: [], session: {} })).toEqual({
+      offerDelegate: true,
+      offerDag: true,
+    });
+  });
+
+  it('withholds both when the profile denies both (the optimizer profile)', () => {
+    expect(
+      delegationOffer({
+        profileDeniedTools: ['image_generation', 'delegate_to_agent', 'coordinate_task'],
+        session: {},
+      })
+    ).toEqual({ offerDelegate: false, offerDag: false });
+  });
+
+  it('can withhold DAG decomposition while keeping single-agent delegation', () => {
+    expect(delegationOffer({ profileDeniedTools: ['coordinate_task'], session: {} })).toEqual({
+      offerDelegate: true,
+      offerDag: false,
+    });
+  });
+
+  it('honors the session contract: disableUserIntegrations withholds both', () => {
+    expect(delegationOffer({ profileDeniedTools: [], session: { disableUserIntegrations: true } })).toEqual({
+      offerDelegate: false,
+      offerDag: false,
+    });
+  });
+
+  it('honors a session-level disabledTools entry', () => {
+    expect(
+      delegationOffer({ profileDeniedTools: [], session: { disabledTools: ['delegate_to_agent'] } })
+    ).toEqual({ offerDelegate: false, offerDag: true });
+  });
+
+  it('a denial of unrelated tools withholds nothing', () => {
+    expect(
+      delegationOffer({ profileDeniedTools: ['image_generation'], session: { disabledTools: ['web_search'] } })
+    ).toEqual({ offerDelegate: true, offerDag: true });
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.ts
@@ -111,3 +111,31 @@ export function runHasAttachments(
     (sessionKnowledgeIds?.length ?? 0) > 0
   );
 }
+
+/**
+ * Whether the run may offer each delegation surface. Consumed at `buildSharedTools`'
+ * DEPENDENCY level, not the name level, because names cannot gate these two tools:
+ * `delegate_to_agent` and `coordinate_task` are pushed as objects, gated only on
+ * `deps.agentStore` / `deps.dagDispatcher` being present - `enabledTools` never sees
+ * them (issue #1829; the chat path enforces the same contract by resolving
+ * `agentStore: undefined`, see ChatCompletionProcess).
+ *
+ * So a profile that names either tool in `deniedTools` - or a session whose
+ * `disableUserIntegrations` promises "no agent delegation" - has exactly one
+ * enforcement point: withhold the dependency the injection keys off. `offerDag`
+ * implies nothing about `offerDelegate`; a profile may deny only `coordinate_task`
+ * and keep single-agent delegation.
+ */
+export function delegationOffer(input: {
+  profileDeniedTools?: readonly string[];
+  session: { disabledTools?: string[] | null; disableUserIntegrations?: boolean | null };
+}): { offerDelegate: boolean; offerDag: boolean } {
+  const denied = new Set([...(input.profileDeniedTools ?? []), ...(input.session.disabledTools ?? [])]);
+  if (input.session.disableUserIntegrations) {
+    for (const tool of DELEGATION_TOOLS) denied.add(tool);
+  }
+  return {
+    offerDelegate: !denied.has('delegate_to_agent'),
+    offerDag: !denied.has('coordinate_task'),
+  };
+}

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -106,7 +106,7 @@ import type { DagHandoffSignal } from '@bike4mind/services';
 // (Mongo, AWS SDK, ReActAgent, etc.). `maybeBuildFirstIterationQuery` wraps
 // it with the new-execution/iteration-0 gate so the gate is testable too.
 import { maybeBuildFirstIterationQuery } from './agentExecutor.firstIterationQuery';
-import { applySessionToolPolicy, runHasAttachments } from './agentExecutor.sessionToolPolicy';
+import { applySessionToolPolicy, delegationOffer, runHasAttachments } from './agentExecutor.sessionToolPolicy';
 import { toUserFacingFailureMessage } from './agentExecutor.failureMessage';
 import { buildReActAgentRuntimeConfig } from './agentExecutor.reActAgentConfig';
 // Per-iteration billing (delta math + #657 context-window guard + tool-internal
@@ -1286,6 +1286,20 @@ async function processExecution(
       cacheWriteTokens: 0,
     };
 
+    // Whether this run may offer each delegation surface - decided from the profile's
+    // denials and the session contract, and consumed below at the dependency level.
+    const delegation = delegationOffer({
+      profileDeniedTools: orchestrationProfile?.deniedTools,
+      session,
+    });
+    if (!delegation.offerDelegate || !delegation.offerDag) {
+      logger.info('[Orchestration] Delegation surfaces withheld for this run', {
+        offerDelegate: delegation.offerDelegate,
+        offerDag: delegation.offerDag,
+        profileId: orchestrationProfile?.id,
+      });
+    }
+
     const toolDeps: ToolBuilderDeps = {
       userId: execution.userId,
       user: user as IUserDocument,
@@ -1328,11 +1342,20 @@ async function processExecution(
         models,
       },
       apiKeyTable: apiKeyTable as ApiKeyTable,
-      agentStore,
+      // The delegation tools are injected as OBJECTS keyed on these two deps, never on
+      // `enabledTools` names (issue #1829), so a profile that denies them - the optimizer
+      // profile denies both to keep its loop single-agent - or a session whose
+      // disableUserIntegrations promises no delegation, is enforced HERE or nowhere.
+      // Observed before this gate: an optimizer run registered delegate_to_agent and
+      // coordinate_task against its own profile's deniedTools. The `agentStore` local
+      // stays intact above for exclusive-MCP resolution; only the injection key is
+      // withheld - the same shape the chat path uses (`agentStore: undefined` in
+      // ChatCompletionProcess) and `agentExecutor.latticeTools` uses for its pool.
+      agentStore: delegation.offerDelegate ? agentStore : undefined,
       getRemainingTimeMs: () => context.getRemainingTimeInMillis(),
       handoffSignal,
       dagHandoffSignal,
-      dagDispatcher,
+      dagDispatcher: delegation.offerDag ? dagDispatcher : undefined,
       getCurrentExecutionId: () => executionId,
       // In-process delegate_to_agent/coordinate_task have no pre-flight reservation of
       // their own (unlike ChatCompletionProcess), so without this a member who crosses


### PR DESCRIPTION
> Rewritten from scratch after review (`172f282f`, force-pushed). The first cut added the profile's `deniedTools` to `applySessionToolPolicy`'s final name filter - the review showed that cannot reach the delegation tools at all, and that its only real effect was stripping the DB-backed Lattice writes from agent mode. The name filter is back to exactly what `main` has.

## The bug

An orchestration profile that denies `delegate_to_agent` / `coordinate_task` - the optimizer profile denies both, precisely to keep its loop single-agent - had **no enforcement point**. Observed in production: an optimizer run registered both tools against its own profile's `deniedTools`.

Names cannot gate these two tools. They are never registered via `enabledTools`; `sharedToolBuilder` pushes them as objects, keyed only on `deps.agentStore` / `deps.dagDispatcher` being present (issue #1829). The chat path already enforces the contract at that level - `ChatCompletionProcess` resolves `agentStore: undefined` when delegation should not be offered (#1901).

## The fix

Enforce at the dependency gate, mirroring the chat path:

- `delegationOffer()` (in `sessionToolPolicy.ts`, unit-tested) decides from the profile's `deniedTools` plus the session contract (`disabledTools`, `disableUserIntegrations`) whether each delegation surface may be offered. The two gates are independent - a profile may deny only `coordinate_task` and keep single-agent delegation.
- `agentExecutor` withholds `agentStore` / `dagDispatcher` from `toolDeps` accordingly, and logs when it does. The `agentStore` local stays intact for exclusive-MCP resolution - only the injection key is withheld, the same shape `agentExecutor.latticeTools` uses for its opt-in pool.

## What this deliberately does not touch

- `applySessionToolPolicy` is unchanged from `main`. Pulling profile denials into its name filter is what broke Lattice (the four `lattice_*` writes are seeded into the default admin denylist and ride the deliberate mission/lattice appends); the reachable enforcement for the delegation pair is the dependency gate above.
- The `dagEnabled` admin kill switch keeps its existing mechanism (filtering `allowedTools`); whether it has the same object-push gap is a separate question from this PR.

## Testing

Six unit cases on `delegationOffer` (both denied, DAG-only denied, session contract, session `disabledTools`, unrelated denials, nothing denied). Mutation-checked: forcing both gates to `true` turns exactly the four denial cases red.

The executor wiring itself is verified by reading (the module has Mongo/AWS deps); the observable change on the affected surface is the `[Orchestration] Delegation surfaces withheld` log line followed by `[AgentExecutor] Registered tools` without the two names, where production previously showed `hasCoordinateTask: true`.

`Test Files 1 passed / Tests 21 passed` on the policy suite; `tsc --noEmit` clean.



## Known limits (from round-2 review, tracked as a follow-up)

- **Continuations on the persisted-agent lane:** `orchestrationProfile` resolves on new executions (and, continuation-safely, on the optimizer surface branch), so a persisted agent's `deniedTools` stops feeding this gate from the first resume; the session half is durable (re-read every invocation). Fix shape: persist the resolved denials on the execution record, the `enableLattice` pattern.
- **The dispatched-child `ToolBuilderDeps`** passes `agentStore` ungated, so a child whose own record denies `delegate_to_agent` still gets it (bounded: a parent that denied delegation cannot reach that path).

Both are follow-up material rather than blockers per review; a PR addressing them is queued behind this one.
