### PR TITLE
fix(client): let a profile declare its toolset exclusive so a payload cannot replace it

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.optiProfile.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.optiProfile.test.ts
@@ -60,10 +60,26 @@ describe('opti profile x pickEffectiveEnabledTools', () => {
     expect(pickEffectiveEnabledTools(undefined, profile)).toEqual(OPTI_AGENT_TOOLS);
   });
 
-  it('strips denied tools even when a payload override tries to re-add image generation', () => {
+  // The exclusivity is what fixes the production failure this guards: a classifier-routed
+  // send carries the chat surface's tool selection in the payload, and replacing the
+  // walk's toolset with it left the agent unable to decompose the scenario it was asked
+  // to break down. Pinned as a flag assertion too, so deleting the flag from the profile
+  // turns a test red rather than only changing behaviour.
+  it('declares its toolset exclusive, so a payload selection cannot narrow the walk', () => {
     const profile = buildOptiOrchestrationProfile();
-    const effective = pickEffectiveEnabledTools(['optihashi_formulate', 'image_generation'], profile);
-    expect(effective).toContain('optihashi_formulate');
-    expect(effective).not.toContain('image_generation');
+    expect(profile.toolsetIsExclusive).toBe(true);
+    expect(pickEffectiveEnabledTools(['optihashi_formulate'], profile)).toEqual(OPTI_AGENT_TOOLS);
+  });
+
+  // NOT a subtraction test: OPTI_AGENT_TOOLS never contained image_generation, and the
+  // exclusive toolset ignores the payload, so the denylist has nothing visible to remove
+  // here (a previous version of this case passed with OPTI_DENIED_TOOLS emptied). The
+  // denylist's real job on this profile is downstream - agentExecutor subtracts it from
+  // the run's final toolbelt after the mission/lattice appends - so what this file can
+  // honestly pin is the config itself, which the 'denies image generation and multi-agent
+  // delegation' case above already does.
+  it('yields the full optimizer toolset even when the payload names a denied tool', () => {
+    const profile = buildOptiOrchestrationProfile();
+    expect(pickEffectiveEnabledTools(['image_generation'], profile)).toEqual(OPTI_AGENT_TOOLS);
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
@@ -129,6 +129,11 @@ export function buildOptiOrchestrationProfile(
     maxIterations: { ...OPTI_MAX_ITERATIONS },
     defaultThoroughness: 'very_thorough',
     isSynthetic: true,
+    // The walk needs its whole toolbelt: decompose plans it, formulate/solve advance it, and a
+    // caller's per-run tool selection narrowing that set strands the loop midway. Observed in
+    // production - a classifier-routed send carried a payload naming a single optimizer tool, so
+    // the agent had no way to decompose the scenario it had just been asked to break down.
+    toolsetIsExclusive: true,
     systemPrompt,
     // Disable the confidence gate for the autonomous optimizer loop. The opti tools are
     // sandboxed (LLM/solver + undoable /opti side-effect, no external mutation) and the

--- a/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.test.ts
@@ -243,8 +243,29 @@ describe('pickEffectiveEnabledTools', () => {
     isSynthetic: true,
   };
 
-  it('returns the payload set when non-empty', () => {
-    expect(pickEffectiveEnabledTools(['file_read'], profile)).toEqual(['file_read']);
+  it('narrows the profile to the tools the payload names', () => {
+    expect(pickEffectiveEnabledTools(['web_search'], profile)).toEqual(['web_search']);
+  });
+
+  // Was "returns the payload set when non-empty". A payload that replaced the whitelist made the
+  // whitelist meaningless: a curated profile collapsed to whatever the caller happened to name,
+  // losing the tools its loop runs on.
+  it('does not let the payload add a tool the profile does not allow', () => {
+    expect(pickEffectiveEnabledTools(['web_search', 'file_read'], profile)).toEqual(['web_search']);
+  });
+
+  it('falls back to the profile when the payload names nothing it allows, rather than leaving the run toolless', () => {
+    expect(pickEffectiveEnabledTools(['file_read'], profile)).toEqual(['web_search', 'coordinate_task']);
+  });
+
+  it('passes the payload through when the profile declares no ceiling', () => {
+    const unrestricted: ResolvedOrchestrationProfile = { ...profile, allowedTools: [] };
+    expect(pickEffectiveEnabledTools(['file_read'], unrestricted)).toEqual(['file_read']);
+  });
+
+  it('ignores the payload entirely for a profile whose toolset is exclusive', () => {
+    const exclusive: ResolvedOrchestrationProfile = { ...profile, toolsetIsExclusive: true };
+    expect(pickEffectiveEnabledTools(['web_search'], exclusive)).toEqual(['web_search', 'coordinate_task']);
   });
 
   it('falls through to the profile when payload is undefined', () => {

--- a/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.test.ts
@@ -243,29 +243,25 @@ describe('pickEffectiveEnabledTools', () => {
     isSynthetic: true,
   };
 
-  it('narrows the profile to the tools the payload names', () => {
-    expect(pickEffectiveEnabledTools(['web_search'], profile)).toEqual(['web_search']);
-  });
-
-  // Was "returns the payload set when non-empty". A payload that replaced the whitelist made the
-  // whitelist meaningless: a curated profile collapsed to whatever the caller happened to name,
-  // losing the tools its loop runs on.
-  it('does not let the payload add a tool the profile does not allow', () => {
-    expect(pickEffectiveEnabledTools(['web_search', 'file_read'], profile)).toEqual(['web_search']);
-  });
-
-  it('falls back to the profile when the payload names nothing it allows, rather than leaving the run toolless', () => {
-    expect(pickEffectiveEnabledTools(['file_read'], profile)).toEqual(['web_search', 'coordinate_task']);
-  });
-
-  it('passes the payload through when the profile declares no ceiling', () => {
-    const unrestricted: ResolvedOrchestrationProfile = { ...profile, allowedTools: [] };
-    expect(pickEffectiveEnabledTools(['file_read'], unrestricted)).toEqual(['file_read']);
+  // The payload wins outright for a non-exclusive profile: the client's briefcase-override
+  // contract (`resolveDispatchTools`) depends on a pinned selection surviving whatever
+  // profile the run resolves, and questmaster v5 nodes ship scoped toolsets the same way.
+  it('returns the payload set when non-empty', () => {
+    expect(pickEffectiveEnabledTools(['file_read'], profile)).toEqual(['file_read']);
   });
 
   it('ignores the payload entirely for a profile whose toolset is exclusive', () => {
     const exclusive: ResolvedOrchestrationProfile = { ...profile, toolsetIsExclusive: true };
     expect(pickEffectiveEnabledTools(['web_search'], exclusive)).toEqual(['web_search', 'coordinate_task']);
+  });
+
+  it('still subtracts deniedTools from an exclusive toolset', () => {
+    const exclusive: ResolvedOrchestrationProfile = {
+      ...profile,
+      toolsetIsExclusive: true,
+      deniedTools: ['coordinate_task'],
+    };
+    expect(pickEffectiveEnabledTools(['coordinate_task'], exclusive)).toEqual(['web_search']);
   });
 
   it('falls through to the profile when payload is undefined', () => {

--- a/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.ts
@@ -42,6 +42,16 @@ export interface ResolvedOrchestrationProfile {
   /** Whether this profile was synthesized from admin defaults (vs sourced from a persisted IAgent). */
   isSynthetic: boolean;
   /**
+   * Whether `allowedTools` IS the run's toolbelt rather than a ceiling the caller may narrow.
+   *
+   * A surface that authors its own profile is picking the toolset deliberately -- the loop only
+   * works if every tool in the walk is present -- and the client already tells the user as much
+   * ("your tool selection was replaced by the agent toolset") when the router upgrades a chat
+   * send. Left false for admin-default and persisted-agent profiles, where the caller's payload
+   * is a legitimate per-run narrowing.
+   */
+  toolsetIsExclusive?: boolean;
+  /**
    * Persona system prompt for the agent (#agent-mode-persona). Sourced from a
    * persisted IAgent's `systemPrompt` / `personality` via `buildAgentPersonaPrompt`.
    * `undefined` for synthetic (agentless) profiles, which have no persona.
@@ -153,8 +163,36 @@ export function pickEffectiveEnabledTools(
   payloadEnabledTools: string[] | undefined,
   profile: ResolvedOrchestrationProfile
 ): string[] {
-  const chosen = payloadEnabledTools && payloadEnabledTools.length > 0 ? payloadEnabledTools : profile.allowedTools;
+  const chosen = pickBeforeDenials(payloadEnabledTools, profile);
   if (profile.deniedTools.length === 0) return chosen;
   const denied = new Set(profile.deniedTools);
   return chosen.filter(t => !denied.has(t));
+}
+
+/**
+ * The payload may NARROW a profile's toolbelt; it may never widen it, and it cannot touch an
+ * exclusive one.
+ *
+ * The payload used to replace `allowedTools` outright whenever it was non-empty, which made a
+ * profile's whitelist mean nothing the moment a caller shipped a list of its own: a curated
+ * surface profile got collapsed to whatever the chat composer's tool selection happened to name,
+ * silently dropping the tools its loop depends on. An empty `allowedTools` still means "no
+ * ceiling" (see `resolveTopLevelProfile`, where it is the fallback when neither the agent nor
+ * admin defaults name any), so a payload passes through untouched there.
+ */
+function pickBeforeDenials(
+  payloadEnabledTools: string[] | undefined,
+  profile: ResolvedOrchestrationProfile
+): string[] {
+  const ceiling = profile.allowedTools;
+  // The chat dispatch path ships [] when the caller has no override, so empty means "use profile".
+  if (!payloadEnabledTools || payloadEnabledTools.length === 0) return ceiling;
+  if (profile.toolsetIsExclusive) return ceiling;
+  if (ceiling.length === 0) return payloadEnabledTools;
+  const allowed = new Set(ceiling);
+  const narrowed = payloadEnabledTools.filter(t => allowed.has(t));
+  // A payload naming nothing the profile permits is not a request for a toolless agent - it is a
+  // payload that does not apply to this profile. Falling back to the ceiling keeps the run able to
+  // act at all, which an empty toolbelt never is.
+  return narrowed.length > 0 ? narrowed : ceiling;
 }

--- a/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.orchestrationProfile.ts
@@ -42,13 +42,13 @@ export interface ResolvedOrchestrationProfile {
   /** Whether this profile was synthesized from admin defaults (vs sourced from a persisted IAgent). */
   isSynthetic: boolean;
   /**
-   * Whether `allowedTools` IS the run's toolbelt rather than a ceiling the caller may narrow.
+   * Whether `allowedTools` IS the run's toolbelt rather than a default the payload may replace.
    *
    * A surface that authors its own profile is picking the toolset deliberately -- the loop only
    * works if every tool in the walk is present -- and the client already tells the user as much
    * ("your tool selection was replaced by the agent toolset") when the router upgrades a chat
    * send. Left false for admin-default and persisted-agent profiles, where the caller's payload
-   * is a legitimate per-run narrowing.
+   * (a briefcase override, a quest node's scoped toolset) legitimately takes precedence.
    */
   toolsetIsExclusive?: boolean;
   /**
@@ -151,9 +151,14 @@ export function pickEffectiveMaxIterations(
 }
 
 /**
- * Pick the effective tool whitelist - payload override beats profile default,
- * but the profile's `deniedTools` ALWAYS wins as a final subtraction so an
- * admin denylist can't be bypassed by shipping `enabledTools` in the payload.
+ * Pick the effective tool whitelist. A non-empty payload beats the profile default - the
+ * briefcase-override contract (`resolveDispatchTools` on the client) depends on a pinned
+ * selection surviving whatever profile the run resolves - EXCEPT for a profile whose
+ * `toolsetIsExclusive`: there the profile's toolset IS the toolbelt and the payload is
+ * ignored, which is the promise the client's "your tool selection was replaced by the
+ * agent toolset" banner already makes. The profile's `deniedTools` ALWAYS wins as a final
+ * subtraction so an admin denylist can't be bypassed by shipping `enabledTools` in the
+ * payload.
  *
  * An EMPTY payload array is treated as "use profile" rather than "explicitly
  * no tools" because the chat dispatch path can ship `[]` when no per-message
@@ -163,36 +168,9 @@ export function pickEffectiveEnabledTools(
   payloadEnabledTools: string[] | undefined,
   profile: ResolvedOrchestrationProfile
 ): string[] {
-  const chosen = pickBeforeDenials(payloadEnabledTools, profile);
+  const payloadApplies = payloadEnabledTools && payloadEnabledTools.length > 0 && !profile.toolsetIsExclusive;
+  const chosen = payloadApplies ? payloadEnabledTools : profile.allowedTools;
   if (profile.deniedTools.length === 0) return chosen;
   const denied = new Set(profile.deniedTools);
   return chosen.filter(t => !denied.has(t));
-}
-
-/**
- * The payload may NARROW a profile's toolbelt; it may never widen it, and it cannot touch an
- * exclusive one.
- *
- * The payload used to replace `allowedTools` outright whenever it was non-empty, which made a
- * profile's whitelist mean nothing the moment a caller shipped a list of its own: a curated
- * surface profile got collapsed to whatever the chat composer's tool selection happened to name,
- * silently dropping the tools its loop depends on. An empty `allowedTools` still means "no
- * ceiling" (see `resolveTopLevelProfile`, where it is the fallback when neither the agent nor
- * admin defaults name any), so a payload passes through untouched there.
- */
-function pickBeforeDenials(
-  payloadEnabledTools: string[] | undefined,
-  profile: ResolvedOrchestrationProfile
-): string[] {
-  const ceiling = profile.allowedTools;
-  // The chat dispatch path ships [] when the caller has no override, so empty means "use profile".
-  if (!payloadEnabledTools || payloadEnabledTools.length === 0) return ceiling;
-  if (profile.toolsetIsExclusive) return ceiling;
-  if (ceiling.length === 0) return payloadEnabledTools;
-  const allowed = new Set(ceiling);
-  const narrowed = payloadEnabledTools.filter(t => allowed.has(t));
-  // A payload naming nothing the profile permits is not a request for a toolless agent - it is a
-  // payload that does not apply to this profile. Falling back to the ceiling keeps the run able to
-  // act at all, which an empty toolbelt never is.
-  return narrowed.length > 0 ? narrowed : ceiling;
 }

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -939,9 +939,18 @@ async function processExecution(
         profileName: orchestrationProfile.name,
         isSynthetic: orchestrationProfile.isSynthetic,
         allowedToolCount: orchestrationProfile.allowedTools.length,
+        toolsetIsExclusive: orchestrationProfile.toolsetIsExclusive ?? false,
         defaultThoroughness: orchestrationProfile.defaultThoroughness,
         isContinuation: !isNewExecution,
       });
+      // An exclusive toolset voids the payload's tool selection by design - but silently
+      // voiding it is how a "why is the tool I picked missing?" report goes undiagnosable.
+      if (orchestrationProfile.toolsetIsExclusive && startPayload?.enabledTools?.length) {
+        logger.warn('[Orchestration] Payload enabledTools ignored: profile toolset is exclusive', {
+          profileId: orchestrationProfile.id,
+          ignoredToolCount: startPayload.enabledTools.length,
+        });
+      }
     }
 
     // Build tools - per-request agent store (unified agent model).


### PR DESCRIPTION
> Round-2 note: the first cut also intersected a payload with the profile's `allowedTools`; review showed that reversed the client's briefcase-override contract and questmaster v5's per-node boundary, so the intersect was deleted. What ships is exactly the flag described below - `pickEffectiveEnabledTools` is byte-identical to `main` except one clause.

## The bug

A classifier-routed send on the optimizer surface carries the chat composer's tool selection in `startPayload.enabledTools`, and the payload replaced the profile's `allowedTools` wholesale. The optimizer profile resolved correctly (8 tools) and the run still registered a single one - so the agent had no `optihashi_decompose` and could not break the scenario into steps, improvising with repeated single-instance formulations instead. Observed in production.

## The fix

`toolsetIsExclusive` on `ResolvedOrchestrationProfile`: a profile that authors its own toolset declares that `allowedTools` IS the toolbelt and the payload is ignored - the promise the client's "your tool selection was replaced by the agent toolset" banner already makes. Set on the optimizer profile, whose walk needs decompose plus formulate/solve present at once.

For every other profile the payload keeps winning outright, exactly as on `main` - the briefcase-override contract (`resolveDispatchTools`) and questmaster v5's per-node tool boundary are untouched. `deniedTools` still subtracts last, exclusive or not.

Observability: the resolved-profile log carries `toolsetIsExclusive`, and a warn fires when a payload selection is voided by an exclusive profile, so "narrowed" and "thrown away" are distinguishable in logs.

## Testing

The flag is pinned by assertion (deleting it from the optimizer profile turns tests red), exclusivity is pinned behaviourally (payload ignored, full toolset returned), and denial subtraction on an exclusive toolset is covered. Mutation-checked in both directions: dropping the exclusivity check from `pickEffectiveEnabledTools` and deleting the flag from the profile each turn exactly the right tests red.

`Test Files 3 passed / Tests 42 passed`; `tsc --noEmit` clean.
