### PR TITLE
fix(selfhost): make the LLM history import work end to end

### DIFF
--- a/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
@@ -28,6 +28,7 @@ import { CloudUpload, Upload, DataObject, History } from '@mui/icons-material';
 import { toast } from 'sonner';
 import { ContextHelpButton } from '@client/app/components/help';
 import { api } from '@client/app/contexts/ApiContext';
+import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 
 interface NotebookImportModalProps {
   open: boolean;
@@ -131,33 +132,14 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
         content = encoder.encode(jsonData).buffer;
       }
 
-      // Upload directly to S3 using XMLHttpRequest for progress tracking
-      await new Promise<void>((resolve, reject) => {
-        const xhr = new XMLHttpRequest();
-
-        xhr.upload.addEventListener('progress', event => {
-          if (event.lengthComputable) {
-            const percentComplete = Math.round((event.loaded / event.total) * 100);
-            setUploadProgress(percentComplete);
+      await uploadFileToUrl(uploadUrl, new Blob([content], { type: contentType }), contentType, {
+        onUploadProgress: event => {
+          if (event.total) {
+            setUploadProgress(Math.round((event.loaded / event.total) * 100));
           }
-        });
-
-        xhr.addEventListener('load', () => {
-          if (xhr.status >= 200 && xhr.status < 300) {
-            setUploadProgress(100);
-            resolve();
-          } else {
-            reject(new Error('Failed to upload file to storage'));
-          }
-        });
-
-        xhr.addEventListener('error', () => reject(new Error('Network error during upload')));
-        xhr.addEventListener('abort', () => reject(new Error('Upload cancelled')));
-
-        xhr.open('PUT', uploadUrl);
-        xhr.setRequestHeader('Content-Type', contentType);
-        xhr.send(content);
+        },
       });
+      setUploadProgress(100);
 
       toast.success('🚀 Import started! You will receive a notification when it is complete.', {
         description: `Import ID: ${importId}`,

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
@@ -152,9 +152,9 @@ const GeneralSettingsTab = () => {
     // proxy path on self-host, where MinIO is neither browser-reachable nor CSP-allowed.
     // uploadFileToUrl is what knows to send the app's Bearer to the latter and withhold it from
     // the former, so this must not PUT directly (see browserUploadCallSites.test.ts).
-    const uploadUrl = await api.get(`/api/import-history/upload?source=${source}`).then(res => res.data.url);
 
     try {
+      const uploadUrl = await api.get(`/api/import-history/upload?source=${source}`).then(res => res.data.url);
       // The File streams straight through; reading it into an ArrayBuffer first would hold an
       // entire history export in browser memory.
       await uploadFileToUrl(uploadUrl, file, file.type, {

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
@@ -30,6 +30,7 @@ import {
   Input,
 } from '@mui/joy';
 import axios from 'axios';
+import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 import { toast } from 'sonner';
 
 import { api } from '@client/app/contexts/ApiContext';
@@ -147,28 +148,28 @@ const GeneralSettingsTab = () => {
   const toggleHelp = () => updatePreferences({ showHelp: !settings.showHelp });
 
   const handleImportHistoryUpload = async (source: 'OpenAI' | 'Claude', file: File) => {
-    // Upload file data to S3, using the API to gather the signed URL
-    const content = await file.arrayBuffer();
+    // The server decides where the bytes go: a presigned S3 PUT when hosted, or a same-origin
+    // proxy path on self-host, where MinIO is neither browser-reachable nor CSP-allowed.
+    // uploadFileToUrl is what knows to send the app's Bearer to the latter and withhold it from
+    // the former, so this must not PUT directly (see browserUploadCallSites.test.ts).
     const uploadUrl = await api.get(`/api/import-history/upload?source=${source}`).then(res => res.data.url);
-    console.debug(`Uploading ${file.name} (${file.size} bytes) to ${uploadUrl} (content type ${file.type})`);
 
-    // Use axios instead of api here because of Authorization headers
-    const response = await axios.put(uploadUrl, content, {
-      headers: { 'Content-Type': file.type },
-      onUploadProgress: progressEvent => {
-        if (progressEvent.total) {
-          const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
-          setUploadProgress(percentCompleted);
-        }
-      },
-    });
-
-    setUploadProgress(0);
-
-    if (response.status === 200) {
+    try {
+      // The File streams straight through; reading it into an ArrayBuffer first would hold an
+      // entire history export in browser memory.
+      await uploadFileToUrl(uploadUrl, file, file.type, {
+        onUploadProgress: progressEvent => {
+          if (progressEvent.total) {
+            const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
+            setUploadProgress(percentCompleted);
+          }
+        },
+      });
       toast.success('LLM history uploaded to servers successfully');
-    } else {
-      toast.error(`Failed to upload LLM history: ${response.statusText}`);
+    } catch (err) {
+      toast.error(`Failed to upload LLM history: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setUploadProgress(0);
     }
   };
 

--- a/apps/client/app/utils/browserUploadCallSites.test.ts
+++ b/apps/client/app/utils/browserUploadCallSites.test.ts
@@ -11,9 +11,11 @@ import { join } from 'path';
  * app's Bearer to a same-origin path while withholding it from a presign.
  *
  * A raw `axios.put` / `fetch(..., {method:'PUT'})` / `xhr.open('PUT', ...)` bypasses that
- * decision, which is why the same bug has now shipped three times: fab-file uploads (#855), the
- * data-lake batch path (#1062), and the LLM history import (#1365). Each looked fine hosted and
- * failed identically on self-host.
+ * decision, which is why the same bug has now shipped four times: fab-file uploads (#855), the
+ * data-lake batch path (#1062), and the LLM history import plus the notebook import (#1365).
+ * Each looked fine hosted and failed identically on self-host. The XHR shape is in the pattern
+ * because the notebook call site used it, so an axios-only scan read as green over a live
+ * bypass.
  *
  * Exemptions are per-file and must say why. "It is not an upload" is a fine reason; "not got
  * round to it" is the bug this test exists to catch.
@@ -36,8 +38,6 @@ const ALLOWED_RAW_PUT: Record<string, string> = {
     'draft bundle upload; the server already returns a same-origin proxy URL on self-host (mintDraftUploadUrl) and that route authorizes by signed capability token, not by Bearer, so the raw PUT is correct',
   'apps/client/app/utils/blogImageUpload.ts':
     'PUTs to a third-party blog host presign, not B4M storage - no B4M proxy to route through (#1365 decision: out of scope, a CSP/blog-integration concern)',
-  'apps/client/app/components/ProfileModal/NotebookImportModal.tsx':
-    'NOT a sanctioned exemption - a known live bypass. It XHR-PUTs at the notebook-import presign, which pages/api/notebooks/import.ts does not rewrite, so the notebook data object never lands on self-host (#1365 criterion 5). Listed so the scan records the hole instead of missing it; delete this entry when the call site routes through uploadFileToUrl',
 };
 
 const rawPutCallSites = (): string[] => {

--- a/apps/client/app/utils/browserUploadCallSites.test.ts
+++ b/apps/client/app/utils/browserUploadCallSites.test.ts
@@ -10,9 +10,10 @@ import { join } from 'path';
  * server hands back a same-origin proxy path instead, and only uploadFileToUrl knows to send the
  * app's Bearer to a same-origin path while withholding it from a presign.
  *
- * A raw `axios.put` / `fetch(..., {method:'PUT'})` bypasses that decision, which is why the same
- * bug has now shipped three times: fab-file uploads (#855), the data-lake batch path (#1062), and
- * the LLM history import (#1365). Each looked fine hosted and failed identically on self-host.
+ * A raw `axios.put` / `fetch(..., {method:'PUT'})` / `xhr.open('PUT', ...)` bypasses that
+ * decision, which is why the same bug has now shipped three times: fab-file uploads (#855), the
+ * data-lake batch path (#1062), and the LLM history import (#1365). Each looked fine hosted and
+ * failed identically on self-host.
  *
  * Exemptions are per-file and must say why. "It is not an upload" is a fine reason; "not got
  * round to it" is the bug this test exists to catch.
@@ -20,6 +21,9 @@ import { join } from 'path';
 
 const REPO_ROOT = join(__dirname, '../../../..');
 const SCAN_ROOTS = ['apps/client/app'];
+
+/** Every shape a browser PUT takes here: axios, a fetch init, and XMLHttpRequest.open. */
+const RAW_PUT_PATTERN = 'axios\\.put\\(|method:\\s*[\'"`]PUT|\\.open\\(\\s*[\'"`]PUT';
 
 /**
  * Files allowed to issue a raw PUT, each with the reason it is not a bypass.
@@ -32,12 +36,14 @@ const ALLOWED_RAW_PUT: Record<string, string> = {
     'draft bundle upload; the server already returns a same-origin proxy URL on self-host (mintDraftUploadUrl) and that route authorizes by signed capability token, not by Bearer, so the raw PUT is correct',
   'apps/client/app/utils/blogImageUpload.ts':
     'PUTs to a third-party blog host presign, not B4M storage - no B4M proxy to route through (#1365 decision: out of scope, a CSP/blog-integration concern)',
+  'apps/client/app/components/ProfileModal/NotebookImportModal.tsx':
+    'NOT a sanctioned exemption - a known live bypass. It XHR-PUTs at the notebook-import presign, which pages/api/notebooks/import.ts does not rewrite, so the notebook data object never lands on self-host (#1365 criterion 5). Listed so the scan records the hole instead of missing it; delete this entry when the call site routes through uploadFileToUrl',
 };
 
 const rawPutCallSites = (): string[] => {
   let out = '';
   try {
-    out = execFileSync('grep', ['-rlE', "axios\\.put\\(|method:\\s*'PUT'", ...SCAN_ROOTS], {
+    out = execFileSync('grep', ['-rlE', RAW_PUT_PATTERN, ...SCAN_ROOTS], {
       cwd: REPO_ROOT,
       encoding: 'utf8',
     });

--- a/apps/client/app/utils/browserUploadCallSites.test.ts
+++ b/apps/client/app/utils/browserUploadCallSites.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+
+/**
+ * No browser code may PUT bytes straight at storage without going through uploadFileToUrl.
+ *
+ * On self-host the object store is not browser-reachable: a presigned URL targets the internal
+ * MinIO host, which the browser cannot resolve and the CSP connect-src allow-list blocks. So the
+ * server hands back a same-origin proxy path instead, and only uploadFileToUrl knows to send the
+ * app's Bearer to a same-origin path while withholding it from a presign.
+ *
+ * A raw `axios.put` / `fetch(..., {method:'PUT'})` bypasses that decision, which is why the same
+ * bug has now shipped three times: fab-file uploads (#855), the data-lake batch path (#1062), and
+ * the LLM history import (#1365). Each looked fine hosted and failed identically on self-host.
+ *
+ * Exemptions are per-file and must say why. "It is not an upload" is a fine reason; "not got
+ * round to it" is the bug this test exists to catch.
+ */
+
+const REPO_ROOT = join(__dirname, '../../../..');
+const SCAN_ROOTS = ['apps/client/app'];
+
+/**
+ * Files allowed to issue a raw PUT, each with the reason it is not a bypass.
+ * Keyed by repo-relative path so a moved file loses its exemption and has to re-earn it.
+ */
+const ALLOWED_RAW_PUT: Record<string, string> = {
+  'apps/client/app/utils/uploadFileToUrl.ts':
+    'the sanctioned helper itself - this IS the branch every other call site must route through',
+  'apps/client/app/utils/publishApi.ts':
+    'draft bundle upload; the server already returns a same-origin proxy URL on self-host (mintDraftUploadUrl) and that route authorizes by signed capability token, not by Bearer, so the raw PUT is correct',
+  'apps/client/app/utils/blogImageUpload.ts':
+    'PUTs to a third-party blog host presign, not B4M storage - no B4M proxy to route through (#1365 decision: out of scope, a CSP/blog-integration concern)',
+};
+
+const rawPutCallSites = (): string[] => {
+  let out = '';
+  try {
+    out = execFileSync('grep', ['-rlE', "axios\\.put\\(|method:\\s*'PUT'", ...SCAN_ROOTS], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+  } catch (e) {
+    // grep exits 1 for no matches and 2 for a real failure; only the former is tolerable here.
+    if ((e as { status?: number }).status !== 1) throw e;
+  }
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .filter(f => !/\.test\.|__tests__/.test(f));
+};
+
+describe('browser upload call sites', () => {
+  it('finds the sanctioned helper, proving the scan is not vacuous', () => {
+    // Without this, a regex that silently matched nothing would make the assertion below pass
+    // while covering no files at all.
+    expect(rawPutCallSites()).toContain('apps/client/app/utils/uploadFileToUrl.ts');
+  });
+
+  it('routes every browser upload through uploadFileToUrl, or documents why not', () => {
+    const bypasses = rawPutCallSites().filter(f => !(f in ALLOWED_RAW_PUT));
+
+    expect(
+      bypasses,
+      `raw PUT to storage outside uploadFileToUrl, with no documented exemption:\n  ${bypasses.join('\n  ')}`
+    ).toEqual([]);
+  });
+
+  it('does not carry an exemption for a file that no longer raw-PUTs', () => {
+    // A stale exemption is dead weight that would silently cover the next real bypass.
+    const found = new Set(rawPutCallSites());
+    const stale = Object.keys(ALLOWED_RAW_PUT).filter(f => !found.has(f));
+
+    expect(stale, `exempted but no longer issues a raw PUT: ${stale.join(', ')}`).toEqual([]);
+  });
+});

--- a/apps/client/pages/api/import-history/__tests__/upload.test.ts
+++ b/apps/client/pages/api/import-history/__tests__/upload.test.ts
@@ -61,8 +61,14 @@ const makeRes = () => {
   }) as unknown as Response['status'];
   res.json = vi.fn((payload: unknown) => {
     res.body = payload;
+    res.listeners.finish?.forEach(fn => fn());
     return res;
   }) as unknown as Response['json'];
+  res.listeners = {} as Record<string, Array<() => void>>;
+  res.on = vi.fn((event: string, fn: () => void) => {
+    (res.listeners[event] ??= []).push(fn);
+    return res;
+  }) as unknown as Response['on'];
   return res;
 };
 
@@ -73,6 +79,7 @@ const makeReq = (opts: { query?: Record<string, unknown>; userId?: string; chunk
     user: { id: opts.userId ?? 'user-1' },
     ability: { can: () => true },
     destroy: vi.fn(),
+    socket: { end: vi.fn() },
     async *[Symbol.asyncIterator]() {
       for (const c of chunks) yield Buffer.from(c);
     },
@@ -134,6 +141,17 @@ describe('PUT /api/import-history/upload (self-host proxy)', () => {
     expect(res.status).toHaveBeenCalledWith(413);
     expect(res.body).toEqual(expect.objectContaining({ maxBytes: MAX_HISTORY_UPLOAD_BYTES }));
     expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('tears the socket down with a FIN after the 413 flushes, never an RST', async () => {
+    // Measured against real sockets: destroying the request discards the queued response, so the
+    // client gets ECONNRESET instead of the size message. Ending after 'finish' delivers it.
+    spoolMock.mockRejectedValueOnce(new UploadTooLargeError(MAX_HISTORY_UPLOAD_BYTES));
+    const res = makeRes();
+    const req = makeReq();
+    await captured.put!(req, res);
+    expect(req.destroy).not.toHaveBeenCalled();
+    expect(req.socket.end).toHaveBeenCalledTimes(1);
   });
 
   it('uploads the spooled file by path so the bytes never sit in memory', async () => {

--- a/apps/client/pages/api/import-history/__tests__/upload.test.ts
+++ b/apps/client/pages/api/import-history/__tests__/upload.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+
+type RouteHandler = (req: Request, res: Response) => Promise<unknown>;
+
+const { uploadMock, getSignedUrlMock, captured } = vi.hoisted(() => ({
+  uploadMock: vi.fn(),
+  getSignedUrlMock: vi.fn(),
+  captured: {} as {
+    get?: (req: unknown, res: unknown) => Promise<unknown>;
+    put?: (req: unknown, res: unknown) => Promise<unknown>;
+  },
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const router = {
+      get(h: RouteHandler) {
+        captured.get = h as (req: unknown, res: unknown) => Promise<unknown>;
+        return router;
+      },
+      put(h: RouteHandler) {
+        captured.put = h as (req: unknown, res: unknown) => Promise<unknown>;
+        return router;
+      },
+    };
+    return router;
+  },
+}));
+vi.mock('@server/middlewares/asyncHandler', () => ({ asyncHandler: (h: RouteHandler) => h }));
+vi.mock('@bike4mind/common', () => ({ Permission: { create: 'create' } }));
+vi.mock('@bike4mind/database/auth', () => ({ Session: class Session {} }));
+vi.mock('@bike4mind/services', () => ({
+  importHistoryService: { ImportSource: { OPENAI: 'OpenAI', CLAUDE: 'Claude' } },
+}));
+vi.mock('@bike4mind/fab-pipeline', () => ({
+  S3Storage: class {
+    upload = uploadMock;
+    getSignedUrl = getSignedUrlMock;
+  },
+}));
+vi.mock('sst', () => ({ Resource: { historyImportBucket: { name: 'history-bucket' } } }));
+
+await import('../upload');
+
+const makeRes = () => {
+  const res = {} as Response & { statusCode: number; body: unknown };
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((payload: unknown) => {
+    res.body = payload;
+    return res;
+  }) as unknown as Response['json'];
+  return res;
+};
+
+const makeReq = (opts: { query?: Record<string, unknown>; userId?: string; chunks?: string[] } = {}) => {
+  const chunks = opts.chunks ?? ['history-zip-bytes'];
+  return {
+    query: opts.query ?? { source: 'OpenAI' },
+    user: { id: opts.userId ?? 'user-1' },
+    ability: { can: () => true },
+    destroy: vi.fn(),
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield Buffer.from(c);
+    },
+  } as unknown as Request;
+};
+
+describe('PUT /api/import-history/upload (self-host proxy)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.B4M_SELF_HOST = 'true';
+    uploadMock.mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('404s when not in self-host mode, so hosted keeps its direct-to-S3 upload', async () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const res = makeRes();
+    await captured.put!(makeReq(), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a source outside the known import sources', async () => {
+    const res = makeRes();
+    await captured.put!(makeReq({ query: { source: 'Bogus' } }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('writes under a key derived from the authenticated user, not from the client', async () => {
+    // historyUploadComplete parses userId and source back out of this key to decide whose
+    // import it is, so a client-controlled key would let a caller attribute an import to
+    // someone else. Everything the client sends about the destination is ignored.
+    const res = makeRes();
+    await captured.put!(
+      makeReq({
+        userId: 'user-1',
+        query: { source: 'OpenAI', key: 'victim/OpenAI/evil.zip', path: '../../etc/passwd' },
+      }),
+      res
+    );
+
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    const key = uploadMock.mock.calls[0][1] as string;
+    expect(key).toMatch(/^user-1\/OpenAI\/\d+\.zip$/);
+    expect(key).not.toContain('victim');
+    expect(key).not.toContain('..');
+  });
+
+  it('413s a body over the cap without uploading anything', async () => {
+    const huge = 'x'.repeat(1024 * 1024);
+    const chunks = Array.from({ length: 1100 }, () => huge); // ~1.07 GB, past the 1 GB ceiling
+    const res = makeRes();
+    await captured.put!(makeReq({ chunks }), res);
+    expect(res.status).toHaveBeenCalledWith(413);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('uploads the spooled file by path so the bytes never sit in memory', async () => {
+    const res = makeRes();
+    await captured.put!(makeReq(), res);
+    const [input] = uploadMock.mock.calls[0];
+    expect(typeof input).toBe('string');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe('GET /api/import-history/upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSignedUrlMock.mockResolvedValue('http://minio:9000/history-bucket/user-1/OpenAI/1.zip?sig=x');
+  });
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('hands back the same-origin proxy route on self-host, never the MinIO presign', async () => {
+    process.env.B4M_SELF_HOST = 'true';
+    const res = makeRes();
+    await captured.get!(makeReq(), res);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ url: '/api/import-history/upload?source=OpenAI' }));
+  });
+
+  it('hands back the presigned URL when hosted', async () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const res = makeRes();
+    await captured.get!(makeReq(), res);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'http://minio:9000/history-bucket/user-1/OpenAI/1.zip?sig=x' })
+    );
+  });
+});

--- a/apps/client/pages/api/import-history/__tests__/upload.test.ts
+++ b/apps/client/pages/api/import-history/__tests__/upload.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UploadTooLargeError } from '@server/utils/spoolRequestToFile';
 import type { Request, Response } from 'express';
 
 type RouteHandler = (req: Request, res: Response) => Promise<unknown>;
 
-const { uploadMock, getSignedUrlMock, captured } = vi.hoisted(() => ({
+const { uploadMock, getSignedUrlMock, spoolMock, captured } = vi.hoisted(() => ({
   uploadMock: vi.fn(),
   getSignedUrlMock: vi.fn(),
+  spoolMock: vi.fn(),
   captured: {} as {
     get?: (req: unknown, res: unknown) => Promise<unknown>;
     put?: (req: unknown, res: unknown) => Promise<unknown>;
@@ -40,8 +42,16 @@ vi.mock('@bike4mind/fab-pipeline', () => ({
   },
 }));
 vi.mock('sst', () => ({ Resource: { historyImportBucket: { name: 'history-bucket' } } }));
+// Real spooler by default, so the cases below still exercise the disk path. Only the 413 case
+// swaps in a rejection: crossing the 1 GB cap for real would write a gibibyte to the runner's
+// temp disk on every shard, and spoolRequestToFile.test.ts already proves the cap with 6 bytes.
+vi.mock('@server/utils/spoolRequestToFile', async importOriginal => {
+  const actual = await importOriginal<typeof import('@server/utils/spoolRequestToFile')>();
+  spoolMock.mockImplementation(actual.spoolRequestToFile);
+  return { ...actual, spoolRequestToFile: spoolMock };
+});
 
-await import('../upload');
+const { MAX_HISTORY_UPLOAD_BYTES } = await import('../upload');
 
 const makeRes = () => {
   const res = {} as Response & { statusCode: number; body: unknown };
@@ -115,11 +125,14 @@ describe('PUT /api/import-history/upload (self-host proxy)', () => {
   });
 
   it('413s a body over the cap without uploading anything', async () => {
-    const huge = 'x'.repeat(1024 * 1024);
-    const chunks = Array.from({ length: 1100 }, () => huge); // ~1.07 GB, past the 1 GB ceiling
+    spoolMock.mockRejectedValueOnce(new UploadTooLargeError(MAX_HISTORY_UPLOAD_BYTES));
     const res = makeRes();
-    await captured.put!(makeReq({ chunks }), res);
+    const req = makeReq();
+    await captured.put!(req, res);
+    // The cap the route hands the spooler is part of what breaks if this constant drifts.
+    expect(spoolMock).toHaveBeenCalledWith(req, MAX_HISTORY_UPLOAD_BYTES, { filename: 'history.zip' });
     expect(res.status).toHaveBeenCalledWith(413);
+    expect(res.body).toEqual(expect.objectContaining({ maxBytes: MAX_HISTORY_UPLOAD_BYTES }));
     expect(uploadMock).not.toHaveBeenCalled();
   });
 
@@ -146,6 +159,8 @@ describe('GET /api/import-history/upload', () => {
     const res = makeRes();
     await captured.get!(makeReq(), res);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ url: '/api/import-history/upload?source=OpenAI' }));
+    // The presign would only be discarded, so it is never minted - no MinIO round trip per import.
+    expect(getSignedUrlMock).not.toHaveBeenCalled();
   });
 
   it('hands back the presigned URL when hosted', async () => {

--- a/apps/client/pages/api/import-history/upload.ts
+++ b/apps/client/pages/api/import-history/upload.ts
@@ -87,7 +87,11 @@ const handler = baseApi({ maxBodySize: MAX_HISTORY_UPLOAD_BYTES })
         spooled = await spoolRequestToFile(req, MAX_HISTORY_UPLOAD_BYTES, { filename: 'history.zip' });
       } catch (err) {
         if (err instanceof UploadTooLargeError) {
-          req.destroy();
+          // Close only once 'finish' says the 413 body has flushed. socket.end() sends a FIN,
+          // which flushes what is already queued; req.destroy() sends an RST that discards it, so
+          // a client still mid-upload sees a network error instead of the size message. Measured:
+          // destroy loses the body every time under load, this delivers it every time.
+          res.on('finish', () => req.socket?.end());
           return res
             .status(413)
             .json({ error: 'History archive exceeds the maximum upload size', maxBytes: err.maxBytes });

--- a/apps/client/pages/api/import-history/upload.ts
+++ b/apps/client/pages/api/import-history/upload.ts
@@ -4,32 +4,109 @@ import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { importHistoryService } from '@bike4mind/services';
 import { S3Storage } from '@bike4mind/fab-pipeline';
+import { resolveBrowserHistoryImportUploadUrl } from '@server/utils/browserUploadUrl';
+import { UploadTooLargeError, spoolRequestToFile } from '@server/utils/spoolRequestToFile';
 import { Resource } from 'sst';
+import type { Request, Response } from 'express';
 
 interface IParams {
   source: string;
 }
 
-const handler = baseApi().get(
-  asyncHandler<{}, unknown, unknown, IParams>(async (req, res) => {
-    const { source } = req.query;
-    if (source !== importHistoryService.ImportSource.OPENAI && source !== importHistoryService.ImportSource.CLAUDE) {
-      throw new Error('Invalid source');
-    }
+/**
+ * Ceiling for a proxied history upload. Deliberately NOT the `MaxFileSize` admin setting the
+ * fab-file and app-file proxies use: that defaults to 20MB and describes user file uploads,
+ * while a real ChatGPT export is routinely far larger, so reusing it would silently break the
+ * feature on self-host. The hosted presigned path has no cap at all, so this is a self-host-only
+ * limit whose job is bounding disk use, not policing content.
+ */
+const MAX_HISTORY_UPLOAD_BYTES = 1024 * 1024 * 1024; // 1 GB
 
-    if (!req.ability?.can(Permission.create, Session)) throw new Error('Cannot create session');
+const isKnownSource = (source: string): boolean =>
+  source === importHistoryService.ImportSource.OPENAI || source === importHistoryService.ImportSource.CLAUDE;
 
-    const bucket = Resource.historyImportBucket.name;
-    const s3 = new S3Storage(bucket);
-    const key = `${req.user?.id}/${source}/${Date.now()}.zip`;
-    const url = await s3.getSignedUrl(key, 'put', { expiresIn: 600 });
+/**
+ * The storage key IS the identity record for this upload: server/s3/historyUploadComplete.ts
+ * splits userId and source back out of it to decide whose history is being imported. It is
+ * therefore always computed from the authenticated request and never from anything the client
+ * sends - there is no owning DB row to check a client-supplied key against.
+ */
+const historyImportKey = (userId: string, source: string): string => `${userId}/${source}/${Date.now()}.zip`;
 
-    return res.json({ success: true, url });
-  })
-);
+const handler = baseApi({ maxBodySize: MAX_HISTORY_UPLOAD_BYTES })
+  .get(
+    asyncHandler<{}, unknown, unknown, IParams>(async (req, res) => {
+      const { source } = req.query;
+      if (!isKnownSource(source)) {
+        throw new Error('Invalid source');
+      }
+
+      if (!req.ability?.can(Permission.create, Session)) throw new Error('Cannot create session');
+
+      const bucket = Resource.historyImportBucket.name;
+      const s3 = new S3Storage(bucket);
+      const key = historyImportKey(String(req.user?.id), source);
+      const url = await s3.getSignedUrl(key, 'put', { expiresIn: 600 });
+
+      // Self-host gets the same-origin proxy below; hosted keeps the presign untouched.
+      return res.json({ success: true, url: resolveBrowserHistoryImportUploadUrl(source, url) });
+    })
+  )
+  /**
+   * Self-host upload proxy (PUT). MinIO is not browser-reachable and its presign is blocked by
+   * the CSP connect-src allow-list, so the browser PUTs here instead and the bytes are written
+   * to storage server-side under the same key shape. The MinIO ObjectCreated webhook then fires
+   * and historyUploadComplete runs unchanged.
+   *
+   * Spooled to disk rather than buffered: a history export is large enough that holding it in
+   * the app pod would be a real memory problem, and S3Storage.upload takes a path.
+   *
+   * Self-host only (404 otherwise).
+   */
+  .put(
+    asyncHandler(async (req: Request, res: Response) => {
+      if (process.env.B4M_SELF_HOST !== 'true') {
+        return res.status(404).json({ error: 'Not found' });
+      }
+
+      const source = String((req.query as { source?: string }).source ?? '');
+      if (!isKnownSource(source)) {
+        return res.status(400).json({ error: 'Invalid source' });
+      }
+      // Same gate the GET applies, re-checked here: this route accepts bytes on its own, so it
+      // cannot rely on the presign step having happened.
+      if (!req.ability?.can(Permission.create, Session)) {
+        return res.status(403).json({ error: 'Cannot create session' });
+      }
+
+      let spooled;
+      try {
+        spooled = await spoolRequestToFile(req, MAX_HISTORY_UPLOAD_BYTES, { filename: 'history.zip' });
+      } catch (err) {
+        if (err instanceof UploadTooLargeError) {
+          req.destroy();
+          return res
+            .status(413)
+            .json({ error: 'History archive exceeds the maximum upload size', maxBytes: err.maxBytes });
+        }
+        throw err;
+      }
+
+      try {
+        const key = historyImportKey(String(req.user.id), source);
+        await new S3Storage(Resource.historyImportBucket.name).upload(spooled.path, key);
+        req.logger?.info(`[import-history] proxied upload user=${req.user.id} source=${source} bytes=${spooled.bytes}`);
+        return res.status(200).json({ success: true });
+      } finally {
+        await spooled.cleanup();
+      }
+    })
+  );
 
 export const config = {
   api: {
+    // The PUT streams its body; the GET has none.
+    bodyParser: false,
     externalResolver: true,
   },
 };

--- a/apps/client/pages/api/import-history/upload.ts
+++ b/apps/client/pages/api/import-history/upload.ts
@@ -20,7 +20,7 @@ interface IParams {
  * feature on self-host. The hosted presigned path has no cap at all, so this is a self-host-only
  * limit whose job is bounding disk use, not policing content.
  */
-const MAX_HISTORY_UPLOAD_BYTES = 1024 * 1024 * 1024; // 1 GB
+export const MAX_HISTORY_UPLOAD_BYTES = 1024 * 1024 * 1024; // 1 GB
 
 const isKnownSource = (source: string): boolean =>
   source === importHistoryService.ImportSource.OPENAI || source === importHistoryService.ImportSource.CLAUDE;
@@ -43,12 +43,15 @@ const handler = baseApi({ maxBodySize: MAX_HISTORY_UPLOAD_BYTES })
 
       if (!req.ability?.can(Permission.create, Session)) throw new Error('Cannot create session');
 
-      const bucket = Resource.historyImportBucket.name;
-      const s3 = new S3Storage(bucket);
-      const key = historyImportKey(String(req.user?.id), source);
-      const url = await s3.getSignedUrl(key, 'put', { expiresIn: 600 });
+      // Self-host gets the same-origin proxy below; hosted keeps the presign untouched. Minting
+      // one on self-host would be a wasted MinIO round trip: the resolver discards it, and the
+      // key it burns is not the key the PUT handler lands the bytes under.
+      let url = '';
+      if (process.env.B4M_SELF_HOST !== 'true') {
+        const s3 = new S3Storage(Resource.historyImportBucket.name);
+        url = await s3.getSignedUrl(historyImportKey(String(req.user?.id), source), 'put', { expiresIn: 600 });
+      }
 
-      // Self-host gets the same-origin proxy below; hosted keeps the presign untouched.
       return res.json({ success: true, url: resolveBrowserHistoryImportUploadUrl(source, url) });
     })
   )

--- a/apps/client/pages/api/internal/s3/__tests__/object-created.test.ts
+++ b/apps/client/pages/api/internal/s3/__tests__/object-created.test.ts
@@ -1,12 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Request, Response } from 'express';
 
-const { findOneMock, saveMock, getSettingsValueMock, sendToQueueMock, recomputeUploadedMock } = vi.hoisted(() => ({
+const {
+  findOneMock,
+  saveMock,
+  getSettingsValueMock,
+  sendToQueueMock,
+  recomputeUploadedMock,
+  historyDispatchMock,
+  notebookDispatchMock,
+} = vi.hoisted(() => ({
   findOneMock: vi.fn(),
   saveMock: vi.fn(),
   getSettingsValueMock: vi.fn(),
   sendToQueueMock: vi.fn(),
   recomputeUploadedMock: vi.fn(),
+  historyDispatchMock: vi.fn().mockResolvedValue(undefined),
+  notebookDispatchMock: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@server/middlewares/baseApi', () => ({ baseApi: () => ({ post: (h: unknown) => h }) }));
@@ -22,7 +32,15 @@ vi.mock('@server/utils/sqs', () => ({ sendToQueue: sendToQueueMock }));
 vi.mock('@server/dataLakes/recomputeStatsForUploadedFile', () => ({
   recomputeStatsForUploadedFile: recomputeUploadedMock,
 }));
-vi.mock('sst', () => ({ Resource: { fabFileChunkQueue: { url: 'http://sqs/fabFileChunkQueue' } } }));
+vi.mock('sst', () => ({
+  Resource: {
+    fabFileChunkQueue: { url: 'http://sqs/fabFileChunkQueue' },
+    fabFileBucket: { name: 'b4m-fab-file' },
+    historyImportBucket: { name: 'b4m-history-import' },
+  },
+}));
+vi.mock('@server/s3/historyUploadComplete', () => ({ dispatch: historyDispatchMock }));
+vi.mock('@server/s3/notebookImportComplete', () => ({ dispatch: notebookDispatchMock }));
 
 const handler = (await import('../object-created')).default as (req: Request, res: Response) => Promise<unknown>;
 
@@ -127,5 +145,70 @@ describe('POST /api/internal/s3/object-created', () => {
 
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(sendToQueueMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * One MinIO webhook feeds every bucket, but the body above only ever did fab-file work. Hosted
+ * wires THREE ObjectCreated notifications (app-files, history-import, and history-import again
+ * under the notebooks/ prefix); self-host wired one, so LLM history import and notebook import
+ * both uploaded successfully and were then never processed.
+ */
+describe('POST /api/internal/s3/object-created - bucket dispatch', () => {
+  const makeBucketReq = (bucket: string | undefined, key: string) =>
+    ({
+      headers: { authorization: 'secret-token' },
+      body: { Records: [{ s3: { ...(bucket ? { bucket: { name: bucket } } : {}), object: { key } } }] },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    }) as unknown as Request;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.B4M_SELF_HOST = 'true';
+    process.env.INTERNAL_S3_WEBHOOK_SECRET = 'secret-token';
+    getSettingsValueMock.mockResolvedValue(true);
+    saveMock.mockResolvedValue(undefined);
+    findOneMock.mockResolvedValue({ id: 'ff1', _id: 'ff1', userId: 'u1', status: 'pending', save: saveMock });
+  });
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+    delete process.env.INTERNAL_S3_WEBHOOK_SECRET;
+  });
+
+  it('sends a history-import object to the history handler, not the fab-file path', async () => {
+    await handler(makeBucketReq('b4m-history-import', 'user1/OpenAI/1234.zip'), makeRes());
+    expect(historyDispatchMock).toHaveBeenCalledTimes(1);
+    expect(findOneMock).not.toHaveBeenCalled();
+  });
+
+  it('sends a notebooks/ object to the notebook handler (same bucket, different prefix)', async () => {
+    await handler(makeBucketReq('b4m-history-import', 'notebooks/user1/1234.json'), makeRes());
+    expect(notebookDispatchMock).toHaveBeenCalledTimes(1);
+    expect(historyDispatchMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the record through as an S3-shaped event the hosted handler already understands', async () => {
+    await handler(makeBucketReq('b4m-history-import', 'user1/OpenAI/1234.zip'), makeRes());
+    const [event] = historyDispatchMock.mock.calls[0];
+    expect(event.Records[0].s3.bucket.name).toBe('b4m-history-import');
+    expect(event.Records[0].s3.object.key).toBe('user1/OpenAI/1234.zip');
+  });
+
+  it('still runs the fab-file path for a fab-file object', async () => {
+    await handler(makeBucketReq('b4m-fab-file', 'u1/doc.md'), makeRes());
+    expect(findOneMock).toHaveBeenCalled();
+    expect(historyDispatchMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a record with no bucket name as fab-file, preserving existing behaviour', async () => {
+    await handler(makeBucketReq(undefined, 'u1/doc.md'), makeRes());
+    expect(findOneMock).toHaveBeenCalled();
+  });
+
+  it('ignores a bucket it has no handler for rather than guessing', async () => {
+    await handler(makeBucketReq('b4m-slack-export', 'exports-x/dump.json'), makeRes());
+    expect(findOneMock).not.toHaveBeenCalled();
+    expect(historyDispatchMock).not.toHaveBeenCalled();
+    expect(notebookDispatchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/internal/s3/object-created.ts
+++ b/apps/client/pages/api/internal/s3/object-created.ts
@@ -4,7 +4,10 @@ import { FabFile, adminSettingsRepository } from '@bike4mind/database';
 import { decodeS3Key, findWithRetry } from '@server/s3/utils';
 import { sendToQueue } from '@server/utils/sqs';
 import { recomputeStatsForUploadedFile } from '@server/dataLakes/recomputeStatsForUploadedFile';
+import { dispatch as historyUploadComplete } from '@server/s3/historyUploadComplete';
+import { dispatch as notebookImportComplete } from '@server/s3/notebookImportComplete';
 import { Resource } from 'sst';
+import type { Context, S3Event } from 'aws-lambda';
 import crypto from 'crypto';
 
 /**
@@ -23,8 +26,26 @@ import crypto from 'crypto';
  */
 
 interface MinioS3Record {
-  s3?: { object?: { key?: string } };
+  s3?: { bucket?: { name?: string }; object?: { key?: string } };
 }
+
+/**
+ * Hosted wires a separate ObjectCreated notification per bucket (infra/buckets.ts). Self-host has
+ * exactly one webhook for all of them, so the bucket has to be read off the record and routed
+ * here, or every event lands in the fab-file logic below. That is what happened: history-import
+ * and notebook-import objects were uploaded and then silently never processed, because this
+ * route was the only consumer and it only ever spoke fab-file.
+ *
+ * The handlers are the SAME ones hosted invokes, called with the record re-wrapped as the S3
+ * event shape they already parse - no second copy of the logic, and their existing idempotency
+ * (keyed on the S3 key) covers a redelivered notification.
+ */
+const selfHostLambdaContext = (functionName: string) =>
+  ({
+    awsRequestId: `selfhost-webhook-${functionName}`,
+    functionName,
+    functionVersion: '$LATEST',
+  }) as unknown as Context;
 
 const secretOk = (authorizationHeader: string | string[] | undefined): boolean => {
   const expected = process.env.INTERNAL_S3_WEBHOOK_SECRET;
@@ -61,9 +82,45 @@ const handler = baseApi({ auth: false }).post(
       key.startsWith('cc-bridge-downloads/');
 
     const records = ((req.body as { Records?: MinioS3Record[] } | undefined)?.Records ?? []) as MinioS3Record[];
-    const enableAutoChunk = await adminSettingsRepository.getSettingsValue('enableAutoChunk');
+
+    // Route each record to the handler its bucket owns before any fab-file work happens. A record
+    // with no bucket name keeps the historical behaviour (fab-file), so this cannot regress the
+    // one path that already worked.
+    const fabFileRecords: MinioS3Record[] = [];
+    const forHandler: Array<{ name: string; run: (e: S3Event, c: Context) => Promise<unknown>; record: MinioS3Record }> =
+      [];
 
     for (const record of records) {
+      const bucket = record.s3?.bucket?.name;
+      if (!bucket || bucket === Resource.fabFileBucket.name) {
+        fabFileRecords.push(record);
+        continue;
+      }
+      if (bucket === Resource.historyImportBucket.name) {
+        // One bucket, two handlers, split by prefix - exactly how hosted filters it.
+        const key = decodeS3Key(record.s3?.object?.key ?? '');
+        forHandler.push(
+          key.startsWith('notebooks/')
+            ? { name: 'notebookImportComplete', run: notebookImportComplete, record }
+            : { name: 'historyUploadComplete', run: historyUploadComplete, record }
+        );
+        continue;
+      }
+      req.logger.info(`No self-host handler for bucket ${bucket}; ignoring object ${record.s3?.object?.key}`);
+    }
+
+    for (const { name, run, record } of forHandler) {
+      // Deliberately not awaited: an import runs for minutes and hosted invokes these as an async
+      // Lambda, so blocking MinIO's webhook here would time it out and provoke a redelivery. The
+      // job row is written early inside the handler, so progress is still visible.
+      void run({ Records: [record] } as unknown as S3Event, selfHostLambdaContext(name)).catch(err =>
+        req.logger.error(`[${name}] self-host dispatch failed: ${err instanceof Error ? err.message : String(err)}`)
+      );
+    }
+
+    const enableAutoChunk = await adminSettingsRepository.getSettingsValue('enableAutoChunk');
+
+    for (const record of fabFileRecords) {
       const rawKey = record.s3?.object?.key;
       if (!rawKey) continue;
       // MinIO URL-encodes the key like S3 does.

--- a/apps/client/pages/api/notebooks/import.ts
+++ b/apps/client/pages/api/notebooks/import.ts
@@ -3,6 +3,7 @@ import { Session } from '@bike4mind/database/auth';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { S3Storage } from '@bike4mind/fab-pipeline';
+import { resolveBrowserNotebookImportUploadUrl } from '@server/utils/browserUploadUrl';
 import { Resource } from 'sst';
 import { z } from 'zod';
 
@@ -57,9 +58,10 @@ const handler = baseApi().post(
       optionsKey,
     });
 
+    // Self-host gets the same-origin proxy below; hosted keeps the presign untouched.
     return res.json({
       success: true,
-      uploadUrl,
+      uploadUrl: resolveBrowserNotebookImportUploadUrl(String(timestamp), uploadUrl),
       importId: timestamp,
     });
   })

--- a/apps/client/pages/api/notebooks/import/__tests__/upload.test.ts
+++ b/apps/client/pages/api/notebooks/import/__tests__/upload.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { UploadTooLargeError } from '@server/utils/spoolRequestToFile';
+import { MAX_NOTEBOOK_IMPORT_UPLOAD_BYTES } from '../upload';
+
+type RouteHandler = (req: Request, res: Response) => Promise<unknown>;
+
+const { uploadMock, spoolMock, captured } = vi.hoisted(() => ({
+  uploadMock: vi.fn(),
+  spoolMock: vi.fn(),
+  captured: {} as {
+    put?: (req: unknown, res: unknown) => Promise<unknown>;
+  },
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const router = {
+      put(h: RouteHandler) {
+        captured.put = h as (req: unknown, res: unknown) => Promise<unknown>;
+        return router;
+      },
+    };
+    return router;
+  },
+}));
+vi.mock('@server/middlewares/asyncHandler', () => ({ asyncHandler: (h: RouteHandler) => h }));
+vi.mock('@bike4mind/common', () => ({ Permission: { create: 'create' } }));
+vi.mock('@bike4mind/database/auth', () => ({ Session: class Session {} }));
+vi.mock('@bike4mind/fab-pipeline', () => ({
+  S3Storage: class {
+    upload = uploadMock;
+  },
+}));
+vi.mock('sst', () => ({ Resource: { historyImportBucket: { name: 'history-bucket' } } }));
+// Wraps the real spool by default so every other case still exercises real streaming on a few
+// bytes; only the cap case is stubbed, so the 413 assertion costs no disk.
+vi.mock('@server/utils/spoolRequestToFile', async importOriginal => {
+  const actual = await importOriginal<typeof import('@server/utils/spoolRequestToFile')>();
+  spoolMock.mockImplementation(actual.spoolRequestToFile);
+  return { ...actual, spoolRequestToFile: spoolMock };
+});
+
+await import('../upload');
+
+const makeRes = () => {
+  const res = {} as Response & { statusCode: number; body: unknown };
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((payload: unknown) => {
+    res.body = payload;
+    res.listeners.finish?.forEach(fn => fn());
+    return res;
+  }) as unknown as Response['json'];
+  res.listeners = {} as Record<string, Array<() => void>>;
+  res.on = vi.fn((event: string, fn: () => void) => {
+    (res.listeners[event] ??= []).push(fn);
+    return res;
+  }) as unknown as Response['on'];
+  return res;
+};
+
+const makeReq = (
+  opts: { query?: Record<string, unknown>; userId?: string; chunks?: string[]; canCreate?: boolean } = {}
+) => {
+  const chunks = opts.chunks ?? ['notebook-json-bytes'];
+  return {
+    query: opts.query ?? { importId: '1700000000000' },
+    user: { id: opts.userId ?? 'user-1' },
+    ability: { can: () => opts.canCreate ?? true },
+    destroy: vi.fn(),
+    socket: { end: vi.fn() },
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield Buffer.from(c);
+    },
+  } as unknown as Request;
+};
+
+describe('PUT /api/notebooks/import/upload (self-host proxy)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.B4M_SELF_HOST = 'true';
+    uploadMock.mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('404s when not in self-host mode, so hosted keeps its direct-to-S3 upload', async () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const res = makeRes();
+    await captured.put!(makeReq(), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an importId that is not digits-only', async () => {
+    const res = makeRes();
+    await captured.put!(makeReq({ query: { importId: 'abc' } }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a traversal-shaped importId', async () => {
+    const res = makeRes();
+    await captured.put!(makeReq({ query: { importId: '../../etc/passwd' } }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty importId', async () => {
+    const res = makeRes();
+    await captured.put!(makeReq({ query: {} }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('403s when the ability check fails', async () => {
+    const res = makeRes();
+    await captured.put!(makeReq({ canCreate: false }), res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('writes under notebooks/<userId>/<importId>.json, ignoring anything else client-supplied', async () => {
+    const res = makeRes();
+    await captured.put!(makeReq({ userId: 'user-1', query: { importId: '1700000000000' } }), res);
+
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    const key = uploadMock.mock.calls[0][1] as string;
+    expect(key).toBe('notebooks/user-1/1700000000000.json');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('413s a body over the cap without uploading anything', async () => {
+    // The cap-crossing byte math is proven on real bytes in spoolRequestToFile.test.ts. Feeding
+    // a real 101 MB here would only re-prove that, at the cost of writing it to the runner's
+    // temp disk on every shard - so the route's error translation is what gets asserted.
+    spoolMock.mockRejectedValueOnce(new UploadTooLargeError(MAX_NOTEBOOK_IMPORT_UPLOAD_BYTES));
+    const res = makeRes();
+    await captured.put!(makeReq(), res);
+    expect(res.status).toHaveBeenCalledWith(413);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ maxBytes: MAX_NOTEBOOK_IMPORT_UPLOAD_BYTES }));
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('tears the socket down with a FIN after the 413 flushes, never an RST', async () => {
+    // Measured against real sockets: destroying the request discards the queued response, so the
+    // client gets ECONNRESET instead of the size message. Ending after 'finish' delivers it.
+    spoolMock.mockRejectedValueOnce(new UploadTooLargeError(MAX_NOTEBOOK_IMPORT_UPLOAD_BYTES));
+    const res = makeRes();
+    const req = makeReq();
+    await captured.put!(req, res);
+    expect(req.destroy).not.toHaveBeenCalled();
+    expect(req.socket.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/notebooks/import/upload.ts
+++ b/apps/client/pages/api/notebooks/import/upload.ts
@@ -1,0 +1,86 @@
+import { Permission } from '@bike4mind/common';
+import { Session } from '@bike4mind/database/auth';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { baseApi } from '@server/middlewares/baseApi';
+import { S3Storage } from '@bike4mind/fab-pipeline';
+import { UploadTooLargeError, spoolRequestToFile } from '@server/utils/spoolRequestToFile';
+import { Resource } from 'sst';
+import type { Request, Response } from 'express';
+
+/**
+ * Ceiling for a proxied notebook import upload. A notebook export is JSON (sessions, artifacts,
+ * tools), not the archive a ChatGPT/Claude history export is, so it does not need the
+ * history-import proxy's 1 GB allowance - 100 MB comfortably covers even a large workspace
+ * exported as JSON.
+ */
+export const MAX_NOTEBOOK_IMPORT_UPLOAD_BYTES = 100 * 1024 * 1024; // 100 MB
+
+/**
+ * importId is the only client-supplied part of the key: pages/api/notebooks/import.ts already
+ * wrote the sibling `<importId>.options.json` using this same timestamp, so it must round-trip
+ * unchanged. It is validated as digits-only so it can never carry a path segment out of the
+ * caller's own prefix.
+ */
+const isValidImportId = (importId: string): boolean => /^\d+$/.test(importId);
+
+const notebookImportKey = (userId: string, importId: string): string => `notebooks/${userId}/${importId}.json`;
+
+const handler = baseApi({ maxBodySize: MAX_NOTEBOOK_IMPORT_UPLOAD_BYTES })
+  /**
+   * Self-host upload proxy (PUT). MinIO is not browser-reachable and its presign is blocked by
+   * the CSP connect-src allow-list, so the browser PUTs here instead and the bytes are written
+   * to storage server-side under the same key shape import.ts already computed.
+   *
+   * Self-host only (404 otherwise).
+   */
+  .put(
+    asyncHandler(async (req: Request, res: Response) => {
+      if (process.env.B4M_SELF_HOST !== 'true') {
+        return res.status(404).json({ error: 'Not found' });
+      }
+
+      const importId = String((req.query as { importId?: string }).importId ?? '');
+      if (!isValidImportId(importId)) {
+        return res.status(400).json({ error: 'Invalid importId' });
+      }
+      // Same gate the POST applies, re-checked here: this route accepts bytes on its own, so it
+      // cannot rely on the presign step having happened.
+      if (!req.ability?.can(Permission.create, Session)) {
+        return res.status(403).json({ error: 'Cannot create session' });
+      }
+
+      let spooled;
+      try {
+        spooled = await spoolRequestToFile(req, MAX_NOTEBOOK_IMPORT_UPLOAD_BYTES, { filename: 'notebook-import.json' });
+      } catch (err) {
+        if (err instanceof UploadTooLargeError) {
+          // Same teardown as import-history/upload.ts: FIN after the body flushes, never an RST.
+          res.on('finish', () => req.socket?.end());
+          return res
+            .status(413)
+            .json({ error: 'Notebook import exceeds the maximum upload size', maxBytes: err.maxBytes });
+        }
+        throw err;
+      }
+
+      try {
+        const key = notebookImportKey(String(req.user.id), importId);
+        await new S3Storage(Resource.historyImportBucket.name).upload(spooled.path, key);
+        req.logger?.info(
+          `[notebooks/import] proxied upload user=${req.user.id} importId=${importId} bytes=${spooled.bytes}`
+        );
+        return res.status(200).json({ success: true });
+      } finally {
+        await spooled.cleanup();
+      }
+    })
+  );
+
+export const config = {
+  api: {
+    bodyParser: false,
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/server/s3/historyUploadComplete.test.ts
+++ b/apps/client/server/s3/historyUploadComplete.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Covers the abandoned-upload cleanup on the "user already has an active import" bail: hosted
+ * relies on an S3 lifecycle rule to reap that object, but self-host has no equivalent for the
+ * history-import bucket, so the handler must delete it itself. A failed delete must not turn
+ * into a failed webhook - no job was ever created on this path, so there is nothing to mark
+ * failed either.
+ */
+
+const h = vi.hoisted(() => ({
+  getMetadata: vi.fn(),
+  deleteMock: vi.fn(),
+  findByS3Key: vi.fn(),
+  hasActiveImport: vi.fn(),
+  jobCreate: vi.fn(),
+  createInboxMessage: vi.fn(),
+  importHistory: vi.fn(),
+}));
+
+vi.mock('@server/s3/utils', () => ({ withContext: (fn: unknown) => fn }));
+vi.mock('@bike4mind/fab-pipeline', () => ({
+  S3Storage: class {
+    getMetadata = h.getMetadata;
+    delete = h.deleteMock;
+  },
+}));
+vi.mock('sst', () => ({ Resource: { historyImportBucket: { name: 'history-bucket' } } }));
+vi.mock('@bike4mind/database', () => ({
+  inboxRepository: { createInboxMessage: h.createInboxMessage },
+  importHistoryJobRepository: {
+    findByS3Key: h.findByS3Key,
+    hasActiveImport: h.hasActiveImport,
+    create: h.jobCreate,
+    update: vi.fn(),
+  },
+  sessionRepository: {},
+  Quest: { bulkWrite: vi.fn() },
+  User: { findById: vi.fn() },
+  withTransaction: (fn: (session: unknown) => Promise<unknown>) => fn(undefined),
+}));
+vi.mock('@bike4mind/services', () => ({
+  importHistoryService: {
+    ImportSource: { OPENAI: 'OpenAI', CLAUDE: 'Claude' },
+    importHistory: h.importHistory,
+  },
+}));
+vi.mock('@bike4mind/common', () => ({ InboxType: { COMMON: 'common' } }));
+vi.mock('@server/utils/importHistoryProgress', () => ({
+  updateImportProgress: vi.fn(),
+  markImportComplete: vi.fn(),
+  markImportFailed: vi.fn(),
+}));
+
+import { dispatch } from './historyUploadComplete';
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+const event = {
+  Records: [
+    {
+      s3: {
+        bucket: { name: 'history-bucket' },
+        object: { key: 'user-1/OpenAI/1700000000000.zip' },
+      },
+    },
+  ],
+};
+
+const run = () => (dispatch as unknown as (e: unknown, c: unknown, l: unknown) => Promise<void>)(event, {}, logger);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getMetadata.mockResolvedValue({ size: 1234 });
+  h.findByS3Key.mockResolvedValue(null);
+  h.hasActiveImport.mockResolvedValue(false);
+  h.createInboxMessage.mockResolvedValue(undefined);
+  h.deleteMock.mockResolvedValue(undefined);
+});
+
+describe('historyUploadComplete abandoned-import cleanup', () => {
+  it('deletes the uploaded object when the user already has an active import', async () => {
+    h.hasActiveImport.mockResolvedValue(true);
+
+    await run();
+
+    expect(h.deleteMock).toHaveBeenCalledWith('user-1/OpenAI/1700000000000.zip');
+    expect(h.jobCreate).not.toHaveBeenCalled();
+    expect(h.createInboxMessage).toHaveBeenCalledWith(expect.objectContaining({ title: 'Import Already in Progress' }));
+  });
+
+  it('does not fail the webhook when the cleanup delete itself fails', async () => {
+    h.hasActiveImport.mockResolvedValue(true);
+    h.deleteMock.mockRejectedValue(new Error('minio down'));
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(h.createInboxMessage).toHaveBeenCalledWith(expect.objectContaining({ title: 'Import Already in Progress' }));
+    // No job exists on this path, so a cleanup failure must not be reported as a failed import.
+    expect(h.createInboxMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'LLM history import Failed' })
+    );
+  });
+});

--- a/apps/client/server/s3/historyUploadComplete.ts
+++ b/apps/client/server/s3/historyUploadComplete.ts
@@ -141,6 +141,15 @@ export const dispatch = withContext(async (event, context, logger) => {
         const hasActiveImport = await importHistoryJobRepository.hasActiveImport(userId);
         if (hasActiveImport) {
           logger.info(`User ${userId} already has an active import, skipping`);
+          // Hosted relies on an S3 lifecycle rule to reap this abandoned upload; self-host has
+          // no equivalent for this bucket, so it must be deleted here or it sits in MinIO
+          // forever. A failed delete must not fail the webhook - the job never got created, so
+          // there is nothing to mark failed either.
+          try {
+            await s3.delete(key);
+          } catch (deleteErr) {
+            logger.error(`Failed to delete abandoned upload ${key}:`, deleteErr);
+          }
           await inboxRepository.createInboxMessage({
             type: InboxType.COMMON,
             title: 'Import Already in Progress',

--- a/apps/client/server/utils/browserUploadUrl.test.ts
+++ b/apps/client/server/utils/browserUploadUrl.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { resolveBrowserAppFileUploadUrl, resolveBrowserUploadUrl } from './browserUploadUrl';
+import {
+  resolveBrowserAppFileUploadUrl,
+  resolveBrowserHistoryImportUploadUrl,
+  resolveBrowserUploadUrl,
+} from './browserUploadUrl';
 
 describe('resolveBrowserUploadUrl', () => {
   afterEach(() => {
@@ -48,5 +52,39 @@ describe('resolveBrowserAppFileUploadUrl', () => {
     delete process.env.B4M_SELF_HOST;
     const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/logo.png?sig=x';
     expect(resolveBrowserAppFileUploadUrl('af1', presigned)).toBe(presigned);
+  });
+});
+
+describe('resolveBrowserHistoryImportUploadUrl', () => {
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('returns the same-origin proxy route in self-host, carrying only the source', () => {
+    // No file id and no storage key in the URL: the proxy recomputes the key from the
+    // authenticated user, because historyUploadComplete reads the owner OUT of that key.
+    process.env.B4M_SELF_HOST = 'true';
+    expect(
+      resolveBrowserHistoryImportUploadUrl('OpenAI', 'http://b4m-history.localhost:9000/u1/OpenAI/1.zip?sig=x')
+    ).toBe('/api/import-history/upload?source=OpenAI');
+  });
+
+  it('percent-encodes the source so it cannot smuggle extra query parameters', () => {
+    process.env.B4M_SELF_HOST = 'true';
+    expect(resolveBrowserHistoryImportUploadUrl('a&b=c', 'http://x/y?sig=1')).toBe(
+      '/api/import-history/upload?source=a%26b%3Dc'
+    );
+  });
+
+  it('returns the direct S3 presigned URL when hosted', () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/u1/OpenAI/1.zip?sig=x';
+    expect(resolveBrowserHistoryImportUploadUrl('OpenAI', presigned)).toBe(presigned);
+  });
+
+  it('treats an unset B4M_SELF_HOST as hosted (returns the presign unchanged)', () => {
+    delete process.env.B4M_SELF_HOST;
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/u1/OpenAI/1.zip?sig=x';
+    expect(resolveBrowserHistoryImportUploadUrl('OpenAI', presigned)).toBe(presigned);
   });
 });

--- a/apps/client/server/utils/browserUploadUrl.test.ts
+++ b/apps/client/server/utils/browserUploadUrl.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   resolveBrowserAppFileUploadUrl,
   resolveBrowserHistoryImportUploadUrl,
+  resolveBrowserNotebookImportUploadUrl,
   resolveBrowserUploadUrl,
 } from './browserUploadUrl';
 
@@ -86,5 +87,33 @@ describe('resolveBrowserHistoryImportUploadUrl', () => {
     delete process.env.B4M_SELF_HOST;
     const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/u1/OpenAI/1.zip?sig=x';
     expect(resolveBrowserHistoryImportUploadUrl('OpenAI', presigned)).toBe(presigned);
+  });
+});
+
+describe('resolveBrowserNotebookImportUploadUrl', () => {
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('returns the same-origin proxy route in self-host, carrying only the importId', () => {
+    process.env.B4M_SELF_HOST = 'true';
+    expect(
+      resolveBrowserNotebookImportUploadUrl(
+        '1234567890',
+        'http://b4m-history.localhost:9000/notebooks/u1/1234567890.json?sig=x'
+      )
+    ).toBe('/api/notebooks/import/upload?importId=1234567890');
+  });
+
+  it('returns the direct S3 presigned URL when hosted', () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/notebooks/u1/1234567890.json?sig=x';
+    expect(resolveBrowserNotebookImportUploadUrl('1234567890', presigned)).toBe(presigned);
+  });
+
+  it('treats an unset B4M_SELF_HOST as hosted (returns the presign unchanged)', () => {
+    delete process.env.B4M_SELF_HOST;
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/notebooks/u1/1234567890.json?sig=x';
+    expect(resolveBrowserNotebookImportUploadUrl('1234567890', presigned)).toBe(presigned);
   });
 });

--- a/apps/client/server/utils/browserUploadUrl.ts
+++ b/apps/client/server/utils/browserUploadUrl.ts
@@ -42,3 +42,19 @@ export const resolveBrowserHistoryImportUploadUrl = (source: string, directPresi
   process.env.B4M_SELF_HOST === 'true'
     ? `/api/import-history/upload?source=${encodeURIComponent(source)}`
     : directPresignedUrl;
+
+/**
+ * The same rewrite for the notebook import (notebooks/import/upload.ts), which uploads the
+ * exported notebook JSON to the history-import bucket under a `notebooks/` prefix.
+ *
+ * importId is the one piece the client supplies, and that is safe only because it is not what
+ * scopes the write: the key is `notebooks/<userId>/<importId>.json`, and the userId segment
+ * comes from the authenticated request, so a caller can only ever write under their own prefix.
+ * importId exists solely to pair this data object with the server-written
+ * `<importId>.options.json` sibling that pages/api/notebooks/import.ts already wrote - it is an
+ * identifier, not a permission.
+ */
+export const resolveBrowserNotebookImportUploadUrl = (importId: string, directPresignedUrl: string): string =>
+  process.env.B4M_SELF_HOST === 'true'
+    ? `/api/notebooks/import/upload?importId=${encodeURIComponent(importId)}`
+    : directPresignedUrl;

--- a/apps/client/server/utils/browserUploadUrl.ts
+++ b/apps/client/server/utils/browserUploadUrl.ts
@@ -26,3 +26,19 @@ export const resolveBrowserUploadUrl = (fileId: string, directPresignedUrl: stri
  */
 export const resolveBrowserAppFileUploadUrl = (appFileId: string, directPresignedUrl: string): string =>
   process.env.B4M_SELF_HOST === 'true' ? `/api/app-files/${appFileId}/upload` : directPresignedUrl;
+
+/**
+ * The same rewrite for the LLM history import (import-history/upload.ts), which uploads a zip to
+ * the history-import bucket rather than a per-file bucket.
+ *
+ * Unlike the two above there is no id to name, because there is no owning DB record - the key is
+ * `<userId>/<source>/<timestamp>.zip`, chosen entirely server-side. That is deliberate and
+ * load-bearing: server/s3/historyUploadComplete.ts parses the userId and source back OUT of the
+ * key to decide whose import this is, so a client-supplied key would let a caller attribute an
+ * import to another user. The proxy therefore takes only the source and recomputes the key from
+ * the authenticated request; nothing about the destination is client-controlled.
+ */
+export const resolveBrowserHistoryImportUploadUrl = (source: string, directPresignedUrl: string): string =>
+  process.env.B4M_SELF_HOST === 'true'
+    ? `/api/import-history/upload?source=${encodeURIComponent(source)}`
+    : directPresignedUrl;

--- a/apps/client/server/utils/spoolRequestToFile.test.ts
+++ b/apps/client/server/utils/spoolRequestToFile.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { UploadTooLargeError, spoolRequestToFile } from './spoolRequestToFile';
+
+/** A request body as the route sees it: an async iterable of Buffers. */
+const bodyOf = (...chunks: string[]): AsyncIterable<Buffer> => ({
+  async *[Symbol.asyncIterator]() {
+    for (const c of chunks) yield Buffer.from(c);
+  },
+});
+
+describe('spoolRequestToFile', () => {
+  it('writes the whole body to a temp file and reports its size', async () => {
+    const spooled = await spoolRequestToFile(bodyOf('hello ', 'world'), 1024);
+    try {
+      expect(readFileSync(spooled.path, 'utf8')).toBe('hello world');
+      expect(spooled.bytes).toBe(11);
+    } finally {
+      await spooled.cleanup();
+    }
+  });
+
+  it('rejects a body that exceeds the cap, reporting the cap', async () => {
+    // The point of spooling: never hold the whole upload in memory, and stop the moment the
+    // cap is passed rather than after the client has finished sending.
+    await expect(spoolRequestToFile(bodyOf('12345', '67890'), 6)).rejects.toBeInstanceOf(UploadTooLargeError);
+  });
+
+  it('leaves no temp file behind when it aborts over the cap', async () => {
+    let leaked: string | undefined;
+    try {
+      await spoolRequestToFile(bodyOf('12345', '67890'), 6, { onPath: p => (leaked = p) });
+    } catch {
+      /* expected */
+    }
+    expect(leaked, 'test needs the path to check for a leak').toBeDefined();
+    expect(existsSync(leaked!)).toBe(false);
+  });
+
+  it('cleanup removes the file and is safe to call twice', async () => {
+    const spooled = await spoolRequestToFile(bodyOf('data'), 1024);
+    await spooled.cleanup();
+    expect(existsSync(spooled.path)).toBe(false);
+    await expect(spooled.cleanup()).resolves.toBeUndefined();
+  });
+});

--- a/apps/client/server/utils/spoolRequestToFile.ts
+++ b/apps/client/server/utils/spoolRequestToFile.ts
@@ -1,0 +1,78 @@
+import { createWriteStream } from 'fs';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
+
+/** Thrown when a body passes the byte cap. The route turns this into a 413. */
+export class UploadTooLargeError extends Error {
+  constructor(public readonly maxBytes: number) {
+    super(`Upload exceeds the maximum size of ${maxBytes} bytes`);
+    this.name = 'UploadTooLargeError';
+  }
+}
+
+export interface SpooledUpload {
+  /** Absolute path to the spooled file. */
+  path: string;
+  bytes: number;
+  /** Remove the temp file and its directory. Safe to call more than once. */
+  cleanup: () => Promise<void>;
+}
+
+interface SpoolOptions {
+  /** File name to spool under; only its extension matters (S3Storage sniffs the destination). */
+  filename?: string;
+  /** Test seam: receives the temp path as soon as it is known, so an aborted spool can be
+   *  checked for leaks. Not used in production code. */
+  onPath?: (path: string) => void;
+}
+
+/**
+ * Stream a request body to a temp file, refusing anything over `maxBytes`.
+ *
+ * Spooled rather than buffered because this backs the LLM history import, where a real export
+ * is routinely 100MB+ and the sibling proxy routes' buffer-into-an-array approach would hold all
+ * of it in the app pod at once. S3Storage.upload already accepts a path and turns it into a read
+ * stream, so the bytes never need to be resident.
+ *
+ * The cap is enforced mid-stream, so an oversized upload stops on the chunk that crosses the
+ * line rather than after the client has finished sending. A body that aborts for any reason
+ * takes its partial file with it; a successful one is the caller's to clean up.
+ */
+export async function spoolRequestToFile(
+  body: AsyncIterable<Buffer>,
+  maxBytes: number,
+  options: SpoolOptions = {}
+): Promise<SpooledUpload> {
+  const dir = await mkdtemp(join(tmpdir(), 'b4m-upload-'));
+  const path = join(dir, options.filename ?? 'upload.bin');
+  options.onPath?.(path);
+
+  let removed = false;
+  const cleanup = async (): Promise<void> => {
+    if (removed) return;
+    removed = true;
+    await rm(dir, { recursive: true, force: true });
+  };
+
+  let bytes = 0;
+  try {
+    // Count inside the pipeline so the cap trips on the crossing chunk; throwing here tears the
+    // pipeline down and closes the write stream, so the partial file is never left open.
+    const counted = async function* () {
+      for await (const chunk of body) {
+        bytes += chunk.length;
+        if (bytes > maxBytes) throw new UploadTooLargeError(maxBytes);
+        yield chunk;
+      }
+    };
+    await pipeline(Readable.from(counted()), createWriteStream(path));
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+
+  return { path, bytes, cleanup };
+}

--- a/compose.selfhost.yaml
+++ b/compose.selfhost.yaml
@@ -94,15 +94,20 @@ services:
       retries: 10
 
   # One-shot: create the buckets the app expects (names come from .env.selfhost),
-  # register the FabFile bucket's put-event webhook (drives self-host upload
-  # chunking), then set a MinIO lifecycle rule that expires abandoned publish drafts. finalize.ts
+  # register the put-event webhook on the FabFile bucket (drives self-host upload
+  # chunking) and on the history-import bucket (without it the LLM history import and
+  # the notebook import upload successfully and are then never processed), then set a
+  # MinIO lifecycle rule that expires abandoned publish drafts. finalize.ts
   # deletes a draft on success, so the drafts/ prefix only lingers when a publish is
   # started but never finalized; the rule reaps those after 7 days. Scoped to the
   # drafts/ prefix so promoted bundles (stored under tier/scope/slug) are never
-  # touched. Idempotent (skips the add if a lifecycle config already exists) and
-  # best-effort (an mc build without ilm support just skips it). Hosted gets the same
-  # cleanup from an S3 lifecycle rule; this is the MinIO equivalent. If you point
-  # object storage at a different S3 backend, add an equivalent drafts/ rule there.
+  # touched. The history-import bucket gets an unprefixed 7-day rule, matching the hosted
+  # lifecycle on that bucket: an archive whose import is abandoned (a second import was
+  # already running) is otherwise never deleted, and self-host had no equivalent reaper.
+  # Both rules are idempotent (skipped if a lifecycle config already exists) and
+  # best-effort (an mc build without ilm support just skips them). Hosted gets the same
+  # cleanup from S3 lifecycle rules; this is the MinIO equivalent. If you point object
+  # storage at a different S3 backend, add equivalent rules there.
   createbuckets:
     image: minio/mc
     depends_on:
@@ -119,10 +124,9 @@ services:
           [ -n "$$b" ] && mc mb -p "local/$$b" || true;
         done;
         [ -n "$$FAB_FILE_BUCKET" ] && mc event add "local/$$FAB_FILE_BUCKET" arn:minio:sqs::primary:webhook --event put --ignore-existing || true;
-        # Same webhook, second bucket: without it the LLM history import and the notebook
-        # import upload successfully and are then never processed.
         [ -n "$$HISTORY_IMPORT_BUCKET" ] && mc event add "local/$$HISTORY_IMPORT_BUCKET" arn:minio:sqs::primary:webhook --event put --ignore-existing || true;
-        { [ -n "$$PUBLISHED_ARTIFACTS_BUCKET" ] && { mc ilm rule ls "local/$$PUBLISHED_ARTIFACTS_BUCKET" >/dev/null 2>&1 || mc ilm rule add --expire-days 7 --prefix "drafts/" "local/$$PUBLISHED_ARTIFACTS_BUCKET"; }; }; true
+        { [ -n "$$PUBLISHED_ARTIFACTS_BUCKET" ] && { mc ilm rule ls "local/$$PUBLISHED_ARTIFACTS_BUCKET" >/dev/null 2>&1 || mc ilm rule add --expire-days 7 --prefix "drafts/" "local/$$PUBLISHED_ARTIFACTS_BUCKET"; }; };
+        { [ -n "$$HISTORY_IMPORT_BUCKET" ] && { mc ilm rule ls "local/$$HISTORY_IMPORT_BUCKET" >/dev/null 2>&1 || mc ilm rule add --expire-days 7 "local/$$HISTORY_IMPORT_BUCKET"; }; }; true
 
   # SQS-compatible queue. Queues are predeclared in elasticmq.conf; the URL
   # format there matches the *_QUEUE URLs in .env.selfhost.example.

--- a/compose.selfhost.yaml
+++ b/compose.selfhost.yaml
@@ -119,6 +119,9 @@ services:
           [ -n "$$b" ] && mc mb -p "local/$$b" || true;
         done;
         [ -n "$$FAB_FILE_BUCKET" ] && mc event add "local/$$FAB_FILE_BUCKET" arn:minio:sqs::primary:webhook --event put --ignore-existing || true;
+        # Same webhook, second bucket: without it the LLM history import and the notebook
+        # import upload successfully and are then never processed.
+        [ -n "$$HISTORY_IMPORT_BUCKET" ] && mc event add "local/$$HISTORY_IMPORT_BUCKET" arn:minio:sqs::primary:webhook --event put --ignore-existing || true;
         { [ -n "$$PUBLISHED_ARTIFACTS_BUCKET" ] && { mc ilm rule ls "local/$$PUBLISHED_ARTIFACTS_BUCKET" >/dev/null 2>&1 || mc ilm rule add --expire-days 7 --prefix "drafts/" "local/$$PUBLISHED_ARTIFACTS_BUCKET"; }; }; true
 
   # SQS-compatible queue. Queues are predeclared in elasticmq.conf; the URL

--- a/packages/scripts/src/checkComposeFoldedComments.test.ts
+++ b/packages/scripts/src/checkComposeFoldedComments.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * A `#` line inside a folded (`>`) block scalar is not a comment.
+ *
+ * YAML joins same-indentation lines of a folded block with a SPACE, so a `#` line lands
+ * inline in the shell command it sits next to and comments out the rest of that line.
+ * Every command after it silently stops running while the container still exits 0. A
+ * literal (`|`) block is safe, because it preserves the newlines that make each `#` a
+ * real comment - so this only flags folded blocks.
+ *
+ * Put the prose above the `- >` line instead, where the YAML parser really does treat it
+ * as a comment.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+interface Offence {
+  file: string;
+  line: number;
+  text: string;
+}
+
+/** Lines beginning a `>` block, then any `#` line at that block's own indentation. */
+const foldedBlockComments = (source: string, file: string): Offence[] => {
+  const lines = source.split('\n');
+  const offences: Offence[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    // `key: >`, `- >`, `>-`, `>+` - the chomping/indent indicators may follow.
+    if (!/^\s*(?:-\s+|[\w.-]+:\s+)?>[-+0-9]*\s*$/.test(lines[i])) continue;
+
+    const introIndent = lines[i].search(/\S/);
+    let baseIndent: number | null = null;
+
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (line.trim() === '') continue;
+      const indent = line.search(/\S/);
+      if (indent <= introIndent) break; // block ended
+      if (baseIndent === null) baseIndent = indent;
+      // A more-indented line keeps its own newlines, so a `#` there is a real comment.
+      if (indent === baseIndent && line.trimStart().startsWith('#')) {
+        offences.push({ file, line: j + 1, text: line.trim() });
+      }
+    }
+  }
+
+  return offences;
+};
+
+describe('compose files', () => {
+  const files = readdirSync(REPO_ROOT).filter(f => /^compose.*\.ya?ml$/.test(f));
+
+  it('finds compose files to scan, proving the scan is not vacuous', () => {
+    expect(files).toContain('compose.selfhost.yaml');
+  });
+
+  it('has no comment line inside a folded block scalar', () => {
+    const offences = files.flatMap(f => foldedBlockComments(readFileSync(path.join(REPO_ROOT, f), 'utf8'), f));
+
+    expect(
+      offences.map(o => `${o.file}:${o.line}  ${o.text}`),
+      'A "#" line at the base indentation of a "> " block folds into the previous line and comments out the commands after it. Move the prose above the "- >" line.'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Two independent breaks, one on each side of the upload. Neither errored, so on a self-hosted install the LLM history import simply did nothing.

Closes #1365.

## Break 1: the upload never reached storage

The PUT went straight at a presigned URL, which on self-host targets the internal MinIO host - unresolvable from a browser and blocked by the CSP `connect-src` allow-list. This is the same failure as the fab-file (#855) and data-lake batch (#1062) uploads before it, so it now takes the same same-origin proxy route those already use.

**No DB record and no capability token**, though the issue offers both as options. The key is `<userId>/<source>/<timestamp>.zip`, derivable entirely from the authenticated request, so the proxy recomputes it and accepts nothing about the destination from the client.

That is the security fix as much as the simplification. `server/s3/historyUploadComplete.ts` parses userId and source back **out** of the key to decide whose import it is, and there is no owning row to validate a client-supplied key against - so trusting one would let a caller attribute an import to another user.

It spools to a temp file rather than buffering like the sibling proxies do. They cap at the 20MB `MaxFileSize` setting; a real ChatGPT export is far larger, so reusing that cap would have silently broken the feature. This carries its own 1GB ceiling whose job is bounding disk, not policing content, and `S3Storage.upload` already accepts a path so the bytes never sit in the app process. The client hands the `File` to `uploadFileToUrl` instead of reading it into an `ArrayBuffer` first, which keeps a whole export out of browser memory too.

## Break 2: nothing consumed the upload

Fixing the first one exposed the second. Hosted wires an ObjectCreated notification **per bucket**: app-files, history-import, and history-import again filtered to the `notebooks/` prefix. Self-host has ONE webhook endpoint for all buckets, its body only ever did fab-file work, and only the fab-file bucket had an `mc event add` at all.

So the upload landed correctly and nothing consumed it - for the LLM history import **and** the notebook import. App-files escapes this only because its proxy route marks the AppFile complete itself.

The webhook now reads the bucket off the record and dispatches to the same handlers hosted invokes, re-wrapping the record as the S3 event shape they already parse. No second copy of the logic, and their existing key-based idempotency covers a redelivered notification. A record with no bucket name keeps the historical fab-file behaviour, so the one path that already worked cannot regress.

Dispatch is deliberately not awaited: an import runs for minutes and hosted invokes these asynchronously, so blocking MinIO's webhook would time it out and provoke a redelivery. The job row is written early inside the handler, so progress stays visible.

## Hosted behaviour is unchanged

The resolver returns the presign untouched when `B4M_SELF_HOST` is unset (asserted in `browserUploadUrl.test.ts`), and both the new PUT and the entire webhook route 404 outside self-host. No new conditional lands on a hosted code path - `browserUploadUrl.ts` already carries two identical resolvers from the PRs above, and the webhook route was already self-host-only in full.

## Verification

The drill this section used to describe was not valid, and finding out why is most of what this round is about. It reported the handler logging the history-import bucket, which proves the event was registered on that cluster. But `mc event add --ignore-existing` is idempotent, and the event had been added by hand during debugging. That registration persisted, so the committed compose path looked correct while doing nothing.

Re-drilled on virgin state instead: fresh volumes, and a bucket name that has never existed anywhere (`p0drill-history-import-neverseen`), so no leftover registration can explain a pass. Same committed `compose.selfhost.yaml`, MinIO's real webhook wired to a sink that records what arrives.

| | `main` | before this commit | after |
|---|---|---|---|
| `mc event add` on the history bucket | not registered | **not registered** | registered |
| `mc ilm rule` on published-artifacts | applied | **not applied** | applied |
| webhook delivered for a PUT into the history bucket | no | **no** | yes |

Before: the object PUTs successfully, no webhook fires, and `createbuckets` exits `0`. After: the notification arrives carrying `s3.bucket.name` set to the history bucket, which is also what re-confirms the record shape the dispatch keys off. The middle column is a regression against `main`, not just a missing fix.

Two things that check the checks rather than the code. The first stub I wrote for this sent `mc` output to stdout, which `>/dev/null 2>&1` then swallowed, so the lifecycle rule looked absent on `main` too; the numbers above come from the corrected instrument. And the pre-commit ASCII guard reported clean against `--changed origin/main` because that mode diffs `base...HEAD` and never sees the working tree - it is `--staged` that scans what is about to be committed, confirmed by planting an em-dash and watching it fail.

## What changed

**The compose fix never ran.** Two `#` prose lines sat at the base indentation of a folded (`>`) scalar. YAML folds same-indentation lines with spaces, so both landed inline in one shell line and everything after the first `#` became a shell comment. The new `mc event add` never ran, and neither did the pre-existing `mc ilm rule` for published-artifacts, which is why the middle column above is a regression. The prose now sits above the `- >` line. `packages/scripts/src/checkComposeFoldedComments.test.ts` fails on a `#` at the base indentation of any folded scalar in any compose file, and deliberately does not flag a literal (`|`) block, where the newlines survive and the `#` really is a comment - `imagegen-pull` relies on that. Mutation-proved three ways: it catches the exact lines removed here, catches a planted one in a different compose file, and stays green on the literal block.

**The notebook import is fixed rather than recorded.** The previous commit widened the scan and listed `NotebookImportModal.tsx` as a known live bypass so the hole was at least visible. I have taken the other option: the call site now goes through `uploadFileToUrl` against a same-origin proxy (`pages/api/notebooks/import/upload.ts`), mirroring the history-import proxy - self-host only, digits-only `importId`, the same ability re-check, spooled to disk, key computed from `req.user.id`. The exemption is gone, and the scan passing with it gone is what proves the call site no longer raw-PUTs. That also makes the `notebookImportComplete` dispatch this PR adds reachable, where before it could only ever see the `.options.json` object it skips by design. So criterion 5 is met and `Closes #1365` stands rather than needing to be narrowed.

**The 413 is now delivered.** Worth reading past the finding, because both proposed fixes on this PR also fail. Measured against real sockets on Node v24, 100 trials per variant, with the client still writing:

| | delivery |
|---|---|
| `req.destroy()` then send (what shipped) | 0/100 |
| send then `req.destroy()` (suggested in the thread) | 0/100 |
| send, never destroy | 100/100 |
| send, then `req.socket.end()` after `finish` | 100/100 |

Reordering does not help because the RST discards the queued response either way. The variant shipped here closes after `'finish'` with `socket.end()`, which sends a FIN and flushes what is already queued - documented semantics rather than a timing margin. That distinction earned its keep: a `setImmediate`-after-`finish` variant measured 100/100 under gentle conditions and collapsed to 0/100 once the writer was tight and the reader slow, and a synchronous `req.socket.end()` collapses to 0/20 behind response-buffering middleware. The reachable window stays narrow either way, since `baseApi` pre-checks `Content-Length` first.

**Orphan retention.** `historyUploadComplete` now deletes the object when it bails on `hasActiveImport`, and self-host gets the unprefixed 7-day lifecycle rule the hosted history-import bucket already has. Both became reachable because this PR is what finally makes self-host uploads land there.

Also folded: the presign that self-host minted and discarded, and the presign GET that sat outside the `try`. The oversize test no longer writes a real gigabyte to the runner's temp disk - measured at 1,029,520 KB before and 108 KB (noise) after.

## Still open

`pages/api/files/[id]/upload.ts` and `pages/api/app-files/[id]/upload.ts` both `req.destroy()` before their 413, so they have the delivery problem measured above. They are left alone here: they buffer through a `for await` loop rather than the spool helper, so removing the destroy has different consequences and wants its own look. Naming them so the list is complete - the repro is four sites, not the two the review found.

The blog-image call site stays out of scope, as a third-party host's presign with no B4M proxy to route through and a CSP limitation that applies regardless of self-host. That decision previously lived only in the exemption reason in test source; recording it here so it is not invisible when #1365 closes.

## The durable half

`browserUploadCallSites.test.ts` fails on any raw PUT in client code outside `uploadFileToUrl`, with per-file exemptions that carry a reason and are themselves checked for going stale in both directions. It covers `axios.put`, a `fetch` init and `XMLHttpRequest.open`, each mutation-proved by planting the syntax and watching the guard name the file. This bug has now shipped four times counting the notebook call site this round turned up, and the scan is what makes a fifth fail in CI instead of in someone's data lake.
