### PR TITLE
fix(client): enqueue a keyed reconnect entry even when the session is unknown

### DIFF
--- a/apps/client/app/hooks/useAgentExecution.test.ts
+++ b/apps/client/app/hooks/useAgentExecution.test.ts
@@ -480,3 +480,44 @@ describe('useAgentExecutionSubscriptions -- the sweep runs on the transition, no
     expect(reconnectCalls()).toHaveLength(1);
   });
 });
+
+describe('useAgentExecutionSubscriptions -- sweep hygiene', () => {
+  beforeEach(() => {
+    ws.sendJsonMessage.mockClear();
+    ws.readyState = 3; // CLOSED
+    Object.keys(handlers).forEach(k => delete handlers[k]);
+    useAgentExecutionStore.getState().clearAll();
+  });
+
+  it('a swept run with no sessionId still gets a keyed queue entry (no send-without-enqueue)', () => {
+    // A stray event synthesises an active execution with no sessionId; the sweep
+    // must still enqueue for it, or its keyed response would drain a concurrent
+    // mount-time probe's un-keyed entry and stamp that session onto the wrong run.
+    useAgentExecutionStore.getState().setStatus('exec-orphan', 'running');
+    ws.readyState = 1; // OPEN
+
+    mountSubscriptions();
+
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([
+      { sessionId: undefined, executionId: 'exec-orphan' },
+    ]);
+  });
+
+  it('a churning dispatcher identity does not re-fire the sweep (the ref guard)', () => {
+    useAgentExecutionStore.getState().startExecution('exec-1', 'sess-1');
+    ws.readyState = 1; // OPEN
+    const { rerender } = mountSubscriptions();
+    const sent = () => ws.sendJsonMessage.mock.calls.filter(c => (c[0] as { command?: string }).command === 'reconnect');
+    expect(sent()).toHaveLength(1);
+
+    // The token refresh case: `sendJsonMessage` gets a new identity every refresh,
+    // so the dispatcher memoised over it churns too. Keyed on readyState alone (via
+    // the ref), the sweep must not re-send.
+    ws.sendJsonMessage = vi.fn();
+    rerender();
+
+    expect(
+      ws.sendJsonMessage.mock.calls.filter(c => (c[0] as { command?: string }).command === 'reconnect')
+    ).toHaveLength(0);
+  });
+});

--- a/apps/client/app/hooks/useAgentExecution.ts
+++ b/apps/client/app/hooks/useAgentExecution.ts
@@ -409,11 +409,20 @@ export function useAgentExecutionSubscriptions(): void {
         // Always drain a pending entry, even on a `found: false` response;
         // otherwise the queue would carry a stale entry and pair it with the
         // next reconnect, mis-attributing the execution to the wrong session.
-        // A found:false carries no executionId on the wire, so what it drains
-        // is the oldest UN-KEYED entry - the mount-time probe's own, which is
-        // the caller a found:false answers. A keyed sweep entry whose run was
-        // deleted server-side stays queued; it can only ever match its own id,
-        // so it pairs with nothing and is dropped with the session's store.
+        //
+        // A found:false carries no executionId on the wire - `handleReconnect`
+        // sends a bare {action, found:false} on EITHER miss branch (no such run,
+        // or a userId mismatch) - so what it drains is the oldest UN-KEYED entry.
+        // That is NOT necessarily the caller it answers: a keyed sweep request
+        // whose run is gone server-side comes back un-keyed too, and drains a
+        // concurrent mount probe's entry instead. The probe's own response then
+        // finds nothing queued, so its run stays unattributed until the next
+        // reconnect. A residual, not a steal: no session is stamped onto the
+        // wrong run, which is the failure this queue exists to prevent.
+        //
+        // It goes away when the server echoes `sessionId` on `reconnect_result`
+        // and the correlation queue can be deleted outright; `handleReconnect`
+        // already holds `execution.sessionId`. Follow-up, not this change.
         const sessionId = store().consumePendingReconnect(msg.executionId);
         if (!msg.found || !msg.executionId || !msg.status) return;
         const executionId = msg.executionId;
@@ -727,9 +736,11 @@ export function useAgentExecutionDispatch() {
         // carrying a sessionId. A request sent WITHOUT an entry is the dangerous
         // case: its keyed response would miss on the id and drain the oldest
         // un-keyed entry - a concurrent mount-time probe's - stamping that session
-        // onto the wrong run. An entry with no sessionId is harmless by contrast:
-        // consuming it returns undefined and hydrate falls back to the execution's
-        // own stored sessionId.
+        // onto the wrong run. An entry with no sessionId takes nothing from anyone
+        // by contrast: consuming it returns undefined and hydrate falls back to
+        // the execution's own stored sessionId - which for a synthesised orphan is
+        // also undefined, so the run stays unattributed rather than being
+        // recovered. Harmless, not a recovery.
         if (sessionId || executionId) {
           useAgentExecutionStore.getState().registerPendingReconnect(sessionId, executionId);
         }

--- a/apps/client/app/hooks/useAgentExecution.ts
+++ b/apps/client/app/hooks/useAgentExecution.ts
@@ -406,9 +406,14 @@ export function useAgentExecutionSubscriptions(): void {
     unsubscribers.push(
       subscribeToAction('reconnect_result', async (msg: IMessageDataToClient) => {
         if (msg.action !== 'reconnect_result') return;
-        // Always drain the pending sessionId, even on a `found: false` response;
+        // Always drain a pending entry, even on a `found: false` response;
         // otherwise the queue would carry a stale entry and pair it with the
         // next reconnect, mis-attributing the execution to the wrong session.
+        // A found:false carries no executionId on the wire, so what it drains
+        // is the oldest UN-KEYED entry - the mount-time probe's own, which is
+        // the caller a found:false answers. A keyed sweep entry whose run was
+        // deleted server-side stays queued; it can only ever match its own id,
+        // so it pairs with nothing and is dropped with the session's store.
         const sessionId = store().consumePendingReconnect(msg.executionId);
         if (!msg.found || !msg.executionId || !msg.status) return;
         const executionId = msg.executionId;
@@ -718,12 +723,14 @@ export function useAgentExecutionDispatch() {
           rememberForSession,
         } as unknown as Parameters<typeof sendJsonMessage>[0]),
       reconnect: (sessionId?: string, executionId?: string) => {
-        // Queue the sessionId so the matching `reconnect_result` can stamp it
-        // onto the hydrated execution; the server response doesn't echo it
-        // back (the payload shape stays stable). Skip queueing
-        // when sessionId is absent (callers reconnecting by executionId
-        // already know their target).
-        if (sessionId) {
+        // Queue an entry for every request that can be answered, not only the ones
+        // carrying a sessionId. A request sent WITHOUT an entry is the dangerous
+        // case: its keyed response would miss on the id and drain the oldest
+        // un-keyed entry - a concurrent mount-time probe's - stamping that session
+        // onto the wrong run. An entry with no sessionId is harmless by contrast:
+        // consuming it returns undefined and hydrate falls back to the execution's
+        // own stored sessionId.
+        if (sessionId || executionId) {
           useAgentExecutionStore.getState().registerPendingReconnect(sessionId, executionId);
         }
         sendJsonMessage({

--- a/apps/client/app/stores/useAgentExecutionStore.test.ts
+++ b/apps/client/app/stores/useAgentExecutionStore.test.ts
@@ -1038,3 +1038,31 @@ describe('useAgentExecutionStore - final_answer collapse (issue #35)', () => {
     expect(child.pendingTextByIteration).toBeUndefined();
   });
 });
+
+describe('useAgentExecutionStore -- keyed entries that can never match do not decay into steals', () => {
+  beforeEach(resetStore);
+
+  it('a keyed miss with no un-keyed entry consumes nothing', () => {
+    const { registerPendingReconnect } = useAgentExecutionStore.getState();
+    registerPendingReconnect('session-A', 'exec-1');
+
+    // The arm that carries the "a keyed entry cannot offset the un-keyed FIFO"
+    // argument: a response for an unknown run must not touch exec-1's entry.
+    expect(useAgentExecutionStore.getState().consumePendingReconnect('exec-unknown')).toBeUndefined();
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([
+      { sessionId: 'session-A', executionId: 'exec-1' },
+    ]);
+  });
+
+  it('a session-less sweep entry answers its own id and leaves the probe entry alone', () => {
+    const { registerPendingReconnect } = useAgentExecutionStore.getState();
+    // The sweep can ask about a run whose session the store never learned
+    // (a stray event synthesises an active, session-less execution). Its entry
+    // must still exist, keyed - otherwise its response would drain the probe's.
+    registerPendingReconnect(undefined, 'exec-orphan');
+    registerPendingReconnect('sess-probe');
+
+    expect(useAgentExecutionStore.getState().consumePendingReconnect('exec-orphan')).toBeUndefined();
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([{ sessionId: 'sess-probe' }]);
+  });
+});

--- a/apps/client/app/stores/useAgentExecutionStore.test.ts
+++ b/apps/client/app/stores/useAgentExecutionStore.test.ts
@@ -1065,4 +1065,22 @@ describe('useAgentExecutionStore -- keyed entries that can never match do not de
     expect(useAgentExecutionStore.getState().consumePendingReconnect('exec-orphan')).toBeUndefined();
     expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([{ sessionId: 'sess-probe' }]);
   });
+
+  // The arm the found:false comment in useAgentExecution.ts reasons about, and the
+  // one it used to get wrong: a keyed sweep request whose run is gone server-side
+  // is answered by a BARE found:false, which drains the un-keyed probe entry it
+  // does not answer. The residual is documented there; this pins the behaviour so
+  // the next reader cannot re-derive the comfortable version of it.
+  it('a found:false drains the oldest un-keyed entry even when a keyed entry is queued', () => {
+    const { registerPendingReconnect } = useAgentExecutionStore.getState();
+    registerPendingReconnect('sess-stale', 'exec-gone'); // sweep entry, run gone server-side
+    registerPendingReconnect('sess-probe'); // concurrent mount probe
+
+    expect(useAgentExecutionStore.getState().consumePendingReconnect(undefined)).toBe('sess-probe');
+    // The probe's entry is gone, so its own response has nothing left to pair with.
+    expect(useAgentExecutionStore.getState().pendingReconnects).toEqual([
+      { sessionId: 'sess-stale', executionId: 'exec-gone' },
+    ]);
+    expect(useAgentExecutionStore.getState().consumePendingReconnect('exec-live')).toBeUndefined();
+  });
 });

--- a/apps/client/app/stores/useAgentExecutionStore.ts
+++ b/apps/client/app/stores/useAgentExecutionStore.ts
@@ -157,7 +157,10 @@ export interface ParentExecution {
 
 /** One outstanding `reconnect` request, waiting for the response that answers it. */
 export interface PendingReconnect {
-  sessionId: string;
+  /** Absent when the sweep asked about a run whose session the store never learned -
+   *  consuming such an entry returns undefined and hydrate falls back to the
+   *  execution's own stored sessionId. */
+  sessionId?: string;
   /** Absent when the caller was asking "is anything running here?" and had no id yet. */
   executionId?: string;
 }
@@ -296,7 +299,7 @@ interface AgentExecutionState {
   registerPendingDispatch: (sessionId: string) => void;
   consumePendingDispatch: () => string | undefined;
   /** `executionId` when the caller already knows which run it is asking about. */
-  registerPendingReconnect: (sessionId: string, executionId?: string) => void;
+  registerPendingReconnect: (sessionId: string | undefined, executionId?: string) => void;
   /** Pass the id the response carries; falls back to FIFO for un-keyed entries. */
   consumePendingReconnect: (executionId?: string) => string | undefined;
 


### PR DESCRIPTION
Follow-up to #2074, delivering the round-2 P2 the review marked "fold in if pushing, otherwise a tracked follow-up" - #2074 was already in the merge queue by then, so this is the follow-up.

## The residual

The socket-open sweep could **send** a reconnect without **enqueuing** an entry: the dispatcher only queued when a `sessionId` was present. A keyed response that misses its id falls back to the oldest un-keyed entry, so an active, session-less execution (a stray event synthesises one through `withExecution` - `emptyExecution` returns an active `pending` with no `sessionId`) answered by the server could drain a concurrent mount-time probe's entry and stamp that session onto the wrong run - while the probe's own response then found nothing, leaving the run it was recovering unattributed.

## The fix

The review's preferred direction: **enqueue whenever an `executionId` is known.** `PendingReconnect.sessionId` is optional now; consuming a session-less entry returns `undefined` and `hydrateFromReconnect` falls back to the execution's own stored `sessionId` - nothing is stolen and recovery is fully preserved. The `found: false` drain comment now describes keyed reality (it drains the oldest un-keyed entry, which is the mount-time probe a `found: false` answers; a keyed entry whose run vanished server-side matches nothing and is dropped with the session's store).

Also folds the two round-2 P3s:
- a test for the keyed-miss-with-no-un-keyed-entry arm - the arm carrying the "a keyed entry cannot offset the un-keyed FIFO" argument;
- a dispatcher-identity-churn test (`ws.sendJsonMessage` replaced between renders) that fails under the old effect dep list, pinning the `reconnectRef` guard.

## Testing

`Test Files 2 passed / Tests 88 passed` across the hook and store suites on top of merged `main`; `tsc --noEmit` clean. Mutation-checked: restoring the `if (sessionId)` guard turns exactly the send-without-enqueue test red.
