### PR TITLE
fix(publish): let a published artifact link off-origin

### DIFF
--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -33,6 +33,7 @@ import {
   usercontentHostFor,
   publicIdFromUsercontentHost,
   isAppWrapperHost,
+  VIEWER_SANDBOX,
 } from '@server/services/publish/viewerSecurity';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
 import {
@@ -73,7 +74,7 @@ import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
  *
  * Bundles are served inside a sandboxed iframe: the `/p/...` HTML response
  * is a minimal trusted wrapper page whose only content is an
- * `<iframe sandbox="allow-scripts" srcdoc=...>` (NO `allow-same-origin`). The
+ * `<iframe sandbox={VIEWER_SANDBOX} srcdoc=...>` (NO `allow-same-origin`). The
  * bundle therefore runs on an opaque (`null`) origin - author inline JS executes,
  * but it cannot read the app origin's localStorage/cookies or call `/api/*` with
  * the viewer's credentials. The visibility check still runs on the app origin
@@ -90,7 +91,7 @@ import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
  * script reads the app's localStorage JWT and re-fetches this same route with
  * `?raw=1` + Authorization: Bearer, then injects the rendered srcdoc into the
  * sandboxed iframe client-side. The opaque-origin model is unchanged: the
- * bundle still runs in `sandbox="allow-scripts"` with NO allow-same-origin, the
+ * bundle still runs in `sandbox={VIEWER_SANDBOX}` with NO allow-same-origin, the
  * token is read only by the trusted shell on the app origin (never the iframe),
  * and the visibility gate still runs for the HTML AND every asset. `?raw=1` is
  * served as inert text/plain so direct navigation can't execute it on the app origin.
@@ -98,10 +99,14 @@ import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
  * The loader shell covers bundles AND reply/fabfile. A gated reply/fabfile navigated with no
  * credential gets the same shell, which re-fetches `?raw=1` and injects the rendered page as the
  * iframe srcdoc; `renderViewerPage` carries a `script-src 'none'` CSP meta so it stays
- * script-free inside the shell's `allow-scripts` iframe. Tradeoff: inside the shelled (gated)
- * render, links obey the iframe sandbox (no `allow-popups`/`allow-top-navigation`), so
- * `target=_blank`/top-nav links won't open - acceptable versus the prior hard 401, and the
- * direct (public, non-shelled) render is unaffected (its links work normally).
+ * script-free inside the shell's sandboxed iframe.
+ *
+ * Outbound links: a framed render (shelled or not, public or gated) obeys the iframe sandbox,
+ * and framing another origin stays refused by `frame-src`. So `VIEWER_SANDBOX` carries
+ * `allow-popups`/`allow-popups-to-escape-sandbox` and `renderSandboxedBundle` retargets a
+ * bundle's off-origin `<a href>`s to a new tab. Two things are still framed-only breakage:
+ * author JS that assigns `location` off-origin, and a plain (no `target`) off-origin link in
+ * a reply/fabfile body, which renders as markdown rather than through the bundle path.
  */
 
 // Bearer-JWT first (browser/client loader), then X-API-Key (programmatic). apiKeyAuth
@@ -925,8 +930,8 @@ function liveryBarMark(brandName: string): string {
  *     `{publicId}.usercontent.app.<domain>`. The separate origin is the isolation boundary;
  *     `allow-same-origin` is SAFE here (resolves to the usercontent origin, not the app).
  *   - Fallback (no isolatedSrc - SERVER_DOMAIN unset): the same-origin sandboxed
- *     `srcdoc` model - `sandbox="allow-scripts"` WITHOUT `allow-same-origin` (opaque
- *     origin; NEVER add allow-same-origin here - it would reclaim the app origin -> ATO).
+ *     `srcdoc` model - `VIEWER_SANDBOX` WITHOUT `allow-same-origin` (opaque origin;
+ *     NEVER add allow-same-origin here - it would reclaim the app origin -> ATO).
  */
 function renderBundleWrapper(
   artifact: PublishedArtifactLean,
@@ -952,13 +957,14 @@ function renderBundleWrapper(
   const srcdocAttr = srcdoc.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
   // Approach B: cross-origin src. `allow-same-origin` is REQUIRED (and safe) here - it keeps
   // the framed doc on its usercontent origin (isolated from the app by SOP), which is what
-  // lets the bundle load its own `<base>`-relative assets same-origin. The sandbox is kept
-  // minimal otherwise: NO allow-forms (the isolated CSP sets `form-action 'none'`, so it'd be
-  // dead capability) and NO allow-popups (matches the Approach A `allow-scripts`-only posture).
+  // lets the bundle load its own `<base>`-relative assets same-origin. Still NO allow-forms
+  // (the isolated CSP sets `form-action 'none'`, so it'd be dead capability).
   // Fallback: opaque-origin srcdoc (no allow-same-origin - that would reclaim the app origin).
   const iframeTag = isolatedSrc
-    ? `<iframe sandbox="allow-scripts allow-same-origin" title="${titleHtml}" src="${escapeHtml(isolatedSrc)}"></iframe>`
-    : `<iframe sandbox="allow-scripts" title="${titleHtml}" srcdoc="${srcdocAttr}"></iframe>`;
+    ? `<iframe sandbox="${VIEWER_SANDBOX} allow-same-origin" title="${titleHtml}" src="${escapeHtml(
+        isolatedSrc
+      )}"></iframe>`
+    : `<iframe sandbox="${VIEWER_SANDBOX}" title="${titleHtml}" srcdoc="${srcdocAttr}"></iframe>`;
   // Hash bridge (srcdoc mode only): forwards the page fragment into the sandboxed
   // bundle (initial deep link + hashchange) and mirrors in-bundle fragment jumps
   // back into the address bar. Approach B's wrapper CSP drops 'unsafe-inline', so
@@ -1198,8 +1204,8 @@ function buildWrapperCsp(req: Request, artifactHost?: string, embedOrigins: stri
 
 /**
  * CSP for a reply's embedded-artifact sub-document (`/p/r/{publicId}?a={i}`). Author inline JS
- * is ALLOWED here (an HTML/SVG artifact is meant to run), but the `sandbox allow-scripts`
- * directive forces an OPAQUE origin with NO `allow-same-origin` - so even a DIRECT navigation
+ * is ALLOWED here (an HTML/SVG artifact is meant to run), but the `sandbox` directive
+ * forces an OPAQUE origin with NO `allow-same-origin` - so even a DIRECT navigation
  * to this URL can never read the app origin's token/cookies (the sandbox, not script-src, is the
  * ATO boundary, exactly as on the bundle path). Blessed libs load from their absolute app-host
  * URLs (renderSandboxedBundle absolutizes them); everything else is self-contained/data:.
@@ -1218,7 +1224,7 @@ function buildReplyArtifactCsp(req: Request): string {
     "form-action 'none'",
     "frame-ancestors 'self'",
     // Opaque origin even on direct navigation; allow-scripts re-enables the artifact's own JS.
-    'sandbox allow-scripts',
+    `sandbox ${VIEWER_SANDBOX}`,
   ].join('; ');
 }
 
@@ -1425,7 +1431,7 @@ function cleanViewerTitle(rawTitle: string | undefined, artifacts: ParsedArtifac
  * same parseArtifactsWithFallback result the `?a` handler indexes into.
  *
  * `standalone` (the `?export=html` download) has no `?a=` route to point at, so an html/svg
- * artifact is inlined as an iframe `srcdoc` instead - same `sandbox="allow-scripts"` opaque-origin
+ * artifact is inlined as an iframe `srcdoc` instead - same `VIEWER_SANDBOX` opaque-origin
  * posture, but self-contained, so the saved file renders offline.
  */
 function renderArtifactBlock(
@@ -1441,11 +1447,11 @@ function renderArtifactBlock(
     // `<`/`>` are literal data. Escaping them would corrupt the framed document (see the
     // identical note in renderBundleWrapper). `&` first so it can't double-escape `&quot;`.
     const doc = artifact.content.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-    return `<iframe class="b4m-artifact" sandbox="allow-scripts" title="${title}" srcdoc="${doc}"></iframe>`;
+    return `<iframe class="b4m-artifact" sandbox="${VIEWER_SANDBOX}" title="${title}" srcdoc="${doc}"></iframe>`;
   }
   if (canFrame && selfPath && (artifact.type === 'html' || artifact.type === 'svg')) {
     const src = escapeHtml(`${selfPath}?a=${index}`);
-    return `<iframe class="b4m-artifact" sandbox="allow-scripts" loading="lazy" title="${title}" src="${src}"></iframe>`;
+    return `<iframe class="b4m-artifact" sandbox="${VIEWER_SANDBOX}" loading="lazy" title="${title}" src="${src}"></iframe>`;
   }
   return `<div class="b4m-artifact-card"><strong>${title}</strong><span>${escapeHtml(
     artifact.type

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
+import { VIEWER_SANDBOX } from '@server/services/publish/viewerSecurity';
 
 const { mockArtifactFindOne, mockProjectFindOne, mockDownload, mockUpdateOne, mockUserFindById } = vi.hoisted(() => ({
   mockArtifactFindOne: vi.fn(),
@@ -132,10 +133,10 @@ describe('GET /api/publish/serve - sandboxed bundle', () => {
     expect(data).toContain('src="https://pub1.usercontent.app.bike4mind.com/uc/u/scope123/my-slug"');
     expect(data).not.toContain('srcdoc=');
     expect(data).not.toContain('console.log(42)'); // author JS lives on the isolated origin
-    // Minimal sandbox: allow-scripts + allow-same-origin only (no forms/popups).
-    expect(data).toContain('sandbox="allow-scripts allow-same-origin"');
+    // The shared viewer sandbox plus allow-same-origin (safe here: it resolves to the
+    // isolated usercontent origin). Popups are how off-origin links open; forms stay out.
+    expect(data).toContain(`sandbox="${VIEWER_SANDBOX} allow-same-origin"`);
     expect(data).not.toContain('allow-forms');
-    expect(data).not.toContain('allow-popups');
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("frame-src 'self' https://pub1.usercontent.app.bike4mind.com"); // can embed it
     // Wrapper has no inline scripts / bundle libs in Approach B -> tightened script-src.
@@ -164,6 +165,24 @@ describe('GET /api/publish/serve - sandboxed bundle', () => {
     expect(csp).toContain("script-src 'unsafe-inline'"); // srcdoc inherits -> must permit bundle inline JS
     expect(data).toContain("b4m:'hash'"); // srcdoc mode carries the wrapper hash bridge
     expect(data).toContain("b4m:'fragment'"); // and the srcdoc carries the fragment-nav helper
+  });
+
+  it('retargets an off-origin link to a new tab on the isolated origin', async () => {
+    // An in-frame off-origin link is refused by the wrapper's frame-src and replaces the
+    // artifact with the browser's "content is blocked" page; a popup is what the sandbox allows.
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(
+      Buffer.from('<html><body><a href="https://github.com/o/r/issues/1">issue</a></body></html>')
+    );
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { uc: 'pub1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('target="_blank"');
+    expect(data).toContain('rel="noopener"');
+    expect(data).not.toContain('noreferrer'); // outbound referral attribution is kept
   });
 
   it('isolated origin serves the bundle AS the page with inline JS + unsafe-inline CSP', async () => {
@@ -335,7 +354,7 @@ describe('GET /api/publish/serve - gated-bundle loader shell', () => {
     expect(res._getStatusCode()).toBe(200);
     expect(res.getHeader('Content-Type')).toBe('text/html; charset=utf-8');
     const data = res._getData() as string;
-    expect(data).toContain('<iframe id="b4m-frame" sandbox="allow-scripts"');
+    expect(data).toContain(`<iframe id="b4m-frame" sandbox="${VIEWER_SANDBOX}"`);
     expect(data).not.toContain('allow-same-origin');
     expect(data).toContain("fetch('/api/auth/refreshToken'");
     expect(data).toContain("'raw=1'");
@@ -525,7 +544,7 @@ describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
 
     expect(res._getStatusCode()).toBe(200);
     const data = res._getData() as string;
-    expect(data).toContain('sandbox="allow-scripts"');
+    expect(data).toContain(`sandbox="${VIEWER_SANDBOX}"`);
     expect(data).toContain('src="/p/r/rhtml?a=0"');
     // The artifact's inner markup must NOT leak into the reply page as text.
     expect(data).not.toContain('<label>Bill</label>');
@@ -557,7 +576,7 @@ describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
     expect(data).toContain('Bill');
     const csp = res.getHeader('Content-Security-Policy') as string;
     // Opaque origin even on direct nav; author inline JS allowed only inside the sandbox.
-    expect(csp).toContain('sandbox allow-scripts');
+    expect(csp).toContain(`sandbox ${VIEWER_SANDBOX}`);
     expect(csp).toContain("script-src 'unsafe-inline'");
     expect(csp).not.toContain("script-src 'none'");
   });
@@ -725,7 +744,7 @@ describe('GET /api/publish/serve - fabfile embedded HTML artifact (#722)', () =>
 
     expect(res._getStatusCode()).toBe(200);
     const data = res._getData() as string;
-    expect(data).toContain('sandbox="allow-scripts"');
+    expect(data).toContain(`sandbox="${VIEWER_SANDBOX}"`);
     expect(data).toContain('src="/p/f/fhtml?a=0"');
     // Non-artifact text stays literal in a <pre>: the markdown heading is NOT rendered to <h1>.
     expect(data).toContain('<pre class="b4m-pre">');
@@ -747,7 +766,7 @@ describe('GET /api/publish/serve - fabfile embedded HTML artifact (#722)', () =>
     expect(res.getHeader('Content-Type')).toContain('text/html');
     expect(res._getData() as string).toContain('window.fab=1');
     const csp = res.getHeader('Content-Security-Policy') as string;
-    expect(csp).toContain('sandbox allow-scripts');
+    expect(csp).toContain(`sandbox ${VIEWER_SANDBOX}`);
     expect(csp).not.toContain("script-src 'none'");
   });
 
@@ -893,7 +912,7 @@ describe('GET /api/publish/serve - reply/fabfile organization visibility', () =>
     const { res, promise } = run(['r', 'r-org']);
     await promise;
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getData() as string).toContain('<iframe id="b4m-frame" sandbox="allow-scripts"');
+    expect(res._getData() as string).toContain(`<iframe id="b4m-frame" sandbox="${VIEWER_SANDBOX}"`);
   });
 
   it('serves an org fabfile to a same-org member (200)', async () => {
@@ -942,7 +961,7 @@ describe('GET /api/publish/serve - gated reply/fabfile loader shell', () => {
     await promise;
     expect(res._getStatusCode()).toBe(200);
     const data = res._getData() as string;
-    expect(data).toContain('<iframe id="b4m-frame" sandbox="allow-scripts"');
+    expect(data).toContain(`<iframe id="b4m-frame" sandbox="${VIEWER_SANDBOX}"`);
     expect(data).not.toContain('allow-same-origin');
     expect(data).toContain("fetch('/api/auth/refreshToken'");
     expect(data).toContain("'raw=1'");
@@ -957,7 +976,7 @@ describe('GET /api/publish/serve - gated reply/fabfile loader shell', () => {
     const { res, promise } = run(['f', 'f-gated']);
     await promise;
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getData() as string).toContain('<iframe id="b4m-frame" sandbox="allow-scripts"');
+    expect(res._getData() as string).toContain(`<iframe id="b4m-frame" sandbox="${VIEWER_SANDBOX}"`);
   });
 
   it('does NOT return the shell for a gated reply ?raw=1 with no credential (stays 401, no loop)', async () => {
@@ -2067,7 +2086,7 @@ describe('GET /api/publish/serve - ?export= content export (issue #1142)', () =>
     expect(data).toContain('srcdoc=');
     expect(data).not.toContain('?a=0');
     // Same opaque-origin posture as the served page; the artifact's own JS travels with it.
-    expect(data).toContain('sandbox="allow-scripts"');
+    expect(data).toContain(`sandbox="${VIEWER_SANDBOX}"`);
     expect(data).toContain('window.ok=1');
   });
 

--- a/apps/client/server/services/publish/renderBundleLoaderShell.test.ts
+++ b/apps/client/server/services/publish/renderBundleLoaderShell.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { renderBundleLoaderShell } from './renderBundleLoaderShell';
+import { VIEWER_SANDBOX } from './viewerSecurity';
 
 describe('renderBundleLoaderShell', () => {
   const shell = renderBundleLoaderShell();
 
-  it('uses a sandbox="allow-scripts" iframe with NO allow-same-origin', () => {
-    expect(shell).toContain('<iframe id="b4m-frame" sandbox="allow-scripts"');
+  it('uses the shared viewer sandbox with NO allow-same-origin', () => {
+    expect(shell).toContain(`<iframe id="b4m-frame" sandbox="${VIEWER_SANDBOX}"`);
+    expect(shell).toContain('allow-scripts');
     expect(shell).not.toContain('allow-same-origin'); // CRITICAL opaque-origin invariant
   });
 

--- a/apps/client/server/services/publish/renderBundleLoaderShell.ts
+++ b/apps/client/server/services/publish/renderBundleLoaderShell.ts
@@ -20,7 +20,7 @@
  * session transport and cannot notice on its own when that transport changes.
  *
  * The opaque-origin model is preserved: the bundle still runs in
- * `<iframe sandbox="allow-scripts">` with NO `allow-same-origin`, so it can't read the
+ * `<iframe sandbox={VIEWER_SANDBOX}>` with NO `allow-same-origin`, so it can't read the
  * app's localStorage/cookies. The token is held only by THIS trusted shell on the app
  * origin and sent only as a fetch header - it is never placed into the iframe or srcdoc.
  *
@@ -38,6 +38,7 @@
  * business in a search index. Mirrors the header the serve route already sets.
  */
 import { HASH_BRIDGE_JS } from './fragmentNav';
+import { VIEWER_SANDBOX } from './viewerSecurity';
 
 export function renderBundleLoaderShell(): string {
   // Bootstrap script: no server-interpolated values.
@@ -115,7 +116,7 @@ export function renderBundleLoaderShell(): string {
   authenticate();
 })();`;
 
-  // SECURITY: `sandbox="allow-scripts"` WITHOUT `allow-same-origin` - identical to the
+  // SECURITY: `VIEWER_SANDBOX` WITHOUT `allow-same-origin` - identical to the
   // wrapped render. The bundle runs on an opaque origin; never add `allow-same-origin`.
   // The iframe starts hidden so a slow `?raw=1` round-trip shows "Loading..." instead of a
   // blank viewport; it's revealed once srcdoc is set. Title is a constant (see header).
@@ -140,7 +141,7 @@ export function renderBundleLoaderShell(): string {
 </style>
 </head>
 <body>
-<iframe id="b4m-frame" sandbox="allow-scripts" title="${sharedTitle}" style="display:none"></iframe>
+<iframe id="b4m-frame" sandbox="${VIEWER_SANDBOX}" title="${sharedTitle}" style="display:none"></iframe>
 <div id="b4m-msg"></div>
 <noscript><div style="max-width:540px;margin:18vh auto 0;padding:0 1.25rem;text-align:center;font-family:system-ui,sans-serif">This is a private item. <a href="/login">Sign in</a> to view it.</div></noscript>
 <script>${bootstrap}</script>

--- a/apps/client/server/services/publish/renderSandboxedBundle.test.ts
+++ b/apps/client/server/services/publish/renderSandboxedBundle.test.ts
@@ -189,6 +189,42 @@ describe('renderSandboxedBundle', () => {
     });
   });
 
+  describe('off-origin links', () => {
+    const render = (body: string) =>
+      renderSandboxedBundle({
+        indexHtml: `<html><head></head><body>${body}</body></html>`,
+        urlBase: URL_BASE,
+        origin: ORIGIN,
+        visibility: 'public',
+      }).srcdoc;
+
+    it('retargets an off-origin link to a new tab with rel=noopener', () => {
+      const srcdoc = render(`<a href="https://github.com/o/r/issues/1">issue</a>`);
+      expect(srcdoc).toContain('target="_blank"');
+      expect(srcdoc).toContain('rel="noopener"');
+    });
+
+    it('keeps the author rel tokens and does not add noreferrer', () => {
+      const srcdoc = render(`<a href="https://example.com/" rel="nofollow">x</a>`);
+      expect(srcdoc).toContain('rel="nofollow noopener"');
+      expect(srcdoc).not.toContain('noreferrer');
+    });
+
+    it('retargets a protocol-relative off-origin link', () => {
+      const srcdoc = render(`<a href="//example.com/x">x</a>`);
+      expect(srcdoc).toContain('target="_blank"');
+    });
+
+    it('leaves same-origin, relative, fragment and non-http links alone', () => {
+      const srcdoc = render(
+        `<a href="${ORIGIN}/p/u/s/other">a</a><a href="page2.html">b</a><a href="#tldr">c</a>` +
+          `<a href="mailto:x@example.com">d</a>`
+      );
+      expect(srcdoc).not.toContain('target="_blank"');
+      expect(srcdoc).not.toContain('rel="noopener"');
+    });
+  });
+
   describe('fragment-nav helper', () => {
     const html = `<html><head></head><body><a href="#tldr">jump</a></body></html>`;
 

--- a/apps/client/server/services/publish/renderSandboxedBundle.ts
+++ b/apps/client/server/services/publish/renderSandboxedBundle.ts
@@ -7,7 +7,7 @@ import { buildFragmentNavScriptTag } from './fragmentNav';
  * Publish - sandboxed-bundle serializer.
  *
  * Re-enables author inline JS by preparing a bundle's `index.html` to be hosted
- * inside a `<iframe sandbox="allow-scripts">` (NO `allow-same-origin`) on the
+ * inside a `<iframe sandbox={VIEWER_SANDBOX}>` (NO `allow-same-origin`) on the
  * `/p/...` viewer page. The sandbox gives the bundle an opaque (`null`) origin:
  * its inline scripts run, but they cannot read the app origin's `localStorage`/
  * cookies, and any `fetch('/api/*')` goes out with no credentials. Author JS is
@@ -36,6 +36,9 @@ import { buildFragmentNavScriptTag } from './fragmentNav';
  * rewritten to absolute `{origin}{path}` URLs - a root-relative path would not
  * resolve against the opaque `about:srcdoc` document, and they load fine
  * cross-origin from the app host without credentials.
+ *
+ * Off-origin `<a href>`s are retargeted to a new tab (see `retargetOffOriginLinks`),
+ * which is the only outbound navigation the viewer sandbox permits.
  */
 
 export interface SandboxAsset {
@@ -145,6 +148,8 @@ export function renderSandboxedBundle(input: RenderSandboxedBundleInput): Render
     }
   }
 
+  retargetOffOriginLinks($, origin);
+
   if (input.pagePaths?.length) {
     // After author content so author click handlers run first (the helper skips
     // defaultPrevented events); the pin bridge appends after this, order-independent.
@@ -158,6 +163,33 @@ export function renderSandboxedBundle(input: RenderSandboxedBundleInput): Render
   }
 
   return { srcdoc: $.html(), droppedAssets };
+}
+
+/**
+ * Force off-origin links into a new tab. Framing another origin is refused by the viewer's
+ * `frame-src`, which replaces the whole artifact with the browser's "content is blocked"
+ * page; a popup is what `VIEWER_SANDBOX` permits instead. `noopener` is added, but NOT
+ * `noreferrer`: outbound referral attribution is deliberately kept (share links suppress
+ * the Referer separately via the wrapper's referrer policy, which the framed document
+ * inherits). Author JS that assigns `location` off-origin is still blocked - only the
+ * link forms are covered.
+ */
+function retargetOffOriginLinks($: cheerio.CheerioAPI, origin: string): void {
+  const sameOrigin = new Set([origin, PUBLISH_HOST ? `https://${PUBLISH_HOST}` : ''].filter(Boolean));
+  $('a[href]').each((_i, el) => {
+    let url: URL;
+    try {
+      // Resolved against the doc origin so relative and protocol-relative hrefs classify too.
+      url = new URL($(el).attr('href') ?? '', origin);
+    } catch {
+      return;
+    }
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') || sameOrigin.has(url.origin)) return;
+    $(el).attr('target', '_blank');
+    const rel = new Set(($(el).attr('rel') ?? '').split(/\s+/).filter(Boolean));
+    rel.add('noopener');
+    $(el).attr('rel', [...rel].join(' '));
+  });
 }
 
 /** Insert (or update) a single `<base href>` as the first child of `<head>`. */

--- a/apps/client/server/services/publish/viewerSecurity.test.ts
+++ b/apps/client/server/services/publish/viewerSecurity.test.ts
@@ -6,6 +6,7 @@ import {
   isAppWrapperHost,
   isUsercontentHost,
   usercontentHostFor,
+  VIEWER_SANDBOX,
 } from './viewerSecurity';
 import { BLESSED_SCRIPT_PATHS, PUBLISH_HOST } from './validateBundle';
 
@@ -286,5 +287,13 @@ describe('buildBundleScriptSrc hosted regression (byte-identical, B4M_SELF_HOST 
     const expected =
       'https://app.pr5.preview.bike4mind.com/static/lib/chart.js@4.x.js https://app.pr5.preview.bike4mind.com/static/b4m-client.js@1.x.js https://app.pr5.preview.bike4mind.com/static/lib/react@18.x.js https://app.pr5.preview.bike4mind.com/static/lib/react-dom@18.x.js https://app.pr5.preview.bike4mind.com/static/lib/prop-types@15.x.js https://app.pr5.preview.bike4mind.com/static/lib/recharts@2.x.js https://app.pr5.preview.bike4mind.com/static/lib/lucide@1.x.js https://app.pr5.preview.bike4mind.com/static/lib/d3@7.x.js https://app.pr5.preview.bike4mind.com/static/lib/lodash@4.x.js https://app.pr5.preview.bike4mind.com/static/lib/mathjs@11.x.js https://app.pr5.preview.bike4mind.com/static/lib/papaparse@5.x.js https://app.pr5.preview.bike4mind.com/static/lib/xlsx@0.18.x.js https://app.bike4mind.com/static/lib/chart.js@4.x.js https://app.bike4mind.com/static/b4m-client.js@1.x.js https://app.bike4mind.com/static/lib/react@18.x.js https://app.bike4mind.com/static/lib/react-dom@18.x.js https://app.bike4mind.com/static/lib/prop-types@15.x.js https://app.bike4mind.com/static/lib/recharts@2.x.js https://app.bike4mind.com/static/lib/lucide@1.x.js https://app.bike4mind.com/static/lib/d3@7.x.js https://app.bike4mind.com/static/lib/lodash@4.x.js https://app.bike4mind.com/static/lib/mathjs@11.x.js https://app.bike4mind.com/static/lib/papaparse@5.x.js https://app.bike4mind.com/static/lib/xlsx@0.18.x.js';
     expect(buildBundleScriptSrc('app.pr5.preview.bike4mind.com', 'https')).toBe(expected);
+  });
+});
+
+describe('VIEWER_SANDBOX', () => {
+  it('grants scripts + escaping popups and never allow-same-origin', () => {
+    expect(VIEWER_SANDBOX).toBe('allow-scripts allow-popups allow-popups-to-escape-sandbox');
+    // The opaque-origin invariant: reclaiming the app origin here is an ATO.
+    expect(VIEWER_SANDBOX.split(' ')).not.toContain('allow-same-origin');
   });
 });

--- a/apps/client/server/services/publish/viewerSecurity.ts
+++ b/apps/client/server/services/publish/viewerSecurity.ts
@@ -197,3 +197,23 @@ export function buildBundleScriptSrc(hostHeader?: string, forwardedProtoHeader?:
   }
   return Array.from(new Set(tokens)).join(' ');
 }
+
+/**
+ * Sandbox token list for every viewer iframe that hosts a bundle (wrapper srcdoc,
+ * Approach-B cross-origin embed, loader shell, reply `?a=` frames) and for the CSP
+ * `sandbox` directive on the documents those frames load.
+ *
+ * `allow-popups` is what lets an artifact link off-origin at all: the wrapper's
+ * `frame-src` refuses to frame another origin, so an in-frame off-origin link replaces
+ * the artifact with the browser's "content is blocked" page. `allow-popups-to-escape-sandbox`
+ * makes the opened tab a NORMAL browsing context - without it the popup inherits these
+ * flags and lands on an opaque origin, where the linked site has no cookies or storage
+ * and is unusable. The escaped tab is a plain top-level navigation the viewer could have
+ * typed themselves; the bundle cannot script it (opaque origin -> cross-origin), and
+ * `renderSandboxedBundle` adds `rel="noopener"` on top.
+ *
+ * `allow-same-origin` is NEVER part of this list - the srcdoc/reply frames must stay on an
+ * opaque origin. Approach B adds it at its own call site, where it resolves to the isolated
+ * usercontent origin rather than the app's.
+ */
+export const VIEWER_SANDBOX = 'allow-scripts allow-popups allow-popups-to-escape-sandbox';


### PR DESCRIPTION
## Description

Closes #2052.

A published artifact could not link off its own origin. Both link forms failed in every render path, so an artifact whose value is partly its outbound references (a report citing sources, an index pointing at tickets or docs) could not link at all:

| link form | before |
|---|---|
| `<a href="https://host/x">` | refused by the wrapper's `frame-src`, and the iframe is replaced by "This content is blocked" - the artifact is gone until the reader reloads |
| `<a href="https://host/x" target="_blank">` | `Blocked opening '...' in a new window because the request was made in a sandboxed frame whose 'allow-popups' permission is not set` - nothing opens |

`window.open(url, '_blank')` from a trusted click handler returned `null`, so authors had no workaround either. Ctrl/cmd+click did work, because that is the browser's own "open link in new tab" UI rather than a page-initiated popup, and the sandbox popup restriction does not gate it - but it is not discoverable and a plain click is what readers do.

This takes option 1 from the issue: grant the viewer iframes `allow-popups allow-popups-to-escape-sandbox` and retarget a bundle's off-origin `<a href>`s to a new tab, so both link forms open the linked page. The opaque origin, `frame-src`, and `allow-same-origin` posture are untouched, so the isolation boundary is exactly what it was.

The escape flag is what makes the opened tab useful: without it the popup inherits the sandbox and lands on an opaque origin, where the linked site has no cookies or storage. The escaped tab is a plain top-level navigation the reader could have typed themselves, the bundle cannot script it (opaque origin, so cross-origin), and the retarget adds `rel="noopener"` on top. `noreferrer` is deliberately NOT added: outbound referral attribution stays intact for authors, and a share link's capability token is already kept out of the Referer by the wrapper's referrer policy, which the framed document inherits.

No allowlist. The issue's comment asked for "at least a whitelist allowing links to trusted sites like github.com"; letting every off-origin link open covers that and does not need a list to maintain, and a link the reader chooses to click is the reader's navigation, not the artifact's.

`apps/client/pages/api/publish/serve/[...path].ts` recorded this as limited to the shelled gated render and claimed "the direct (public, non-shelled) render is unaffected (its links work normally)". That was wrong - a public ungated artifact fails identically - so the note is rewritten to describe what actually holds.

## Changes

- `viewerSecurity.ts`: new `VIEWER_SANDBOX` constant (`allow-scripts allow-popups allow-popups-to-escape-sandbox`), the one place the viewer's sandbox tokens are defined, with the reasoning for each and the standing "never `allow-same-origin`" invariant.
- Every viewer iframe now uses it: the wrapper's srcdoc frame, the Approach-B cross-origin embed (which still adds its own `allow-same-origin`), the gated loader shell, and the reply/fabfile `?a=` artifact frames - plus the `sandbox` directive in the `?a=` sub-document CSP, since the CSP and the frame attribute intersect.
- `renderSandboxedBundle.ts`: `retargetOffOriginLinks` sets `target="_blank"` and adds `noopener` on every `<a>` resolving to an http(s) origin that is neither the document origin nor the app host. Relative, fragment, same-origin and non-http hrefs are untouched, and existing author `rel` tokens are preserved.
- Corrected the stale tradeoff note in the serve handler, and named the two cases that are still framed-only breakage: author JS assigning `location` off-origin (still refused by `frame-src`), and a plain no-`target` off-origin link in a reply/fabfile body, which renders as markdown rather than through the bundle path.

## Guide for Testers

1. Sign in at `app.bike4mind.com` (or the PR preview URL once a maintainer posts one).
2. Publish an artifact whose body contains both link forms, for example `<a href="https://github.com/">plain</a>` and `<a href="https://github.com/" target="_blank" rel="noopener noreferrer">blank</a>`. Set its visibility to public.
3. Open the artifact's `/p/u/...` URL in a normal tab. Expected: the artifact renders as before.
4. Open the browser devtools console, then left-click the "blank" link. Expected: `github.com` opens in a new tab, the artifact tab stays on the artifact, and no `allow-popups` error is logged.
5. Go back to the artifact tab and left-click the "plain" link. Expected: same as step 4 - it opens in a new tab rather than replacing the frame. Before this change the frame showed "This content is blocked" and no `frame-src` refusal is expected in the console now.
6. In the new tab, confirm the site is fully functional (sign in to `github.com`, or check that an already-signed-in session shows). Expected: it behaves as a normal tab, not a stripped-down opaque-origin page.
7. Click a same-page anchor link (`#section`) inside the artifact. Expected: it scrolls in place, still in the same tab, and the address bar fragment follows.

### Regression Checks

1. Open a passphrase-gated artifact while signed out. Expected: the passphrase prompt appears and unlocks as before.
2. Open an org-visibility artifact by pasting its `/p/...` URL into a fresh tab while signed in. Expected: the loading shell resolves to the artifact, not a sign-in message.
3. Open a `/a/<shareToken>` link. Expected: the artifact renders, and its assets (images, stylesheets) load.
4. Open a published reply that embeds an HTML artifact. Expected: the embedded artifact renders in its frame and its own JS runs.
5. Use "Save as HTML" on a public artifact and open the downloaded file from disk. Expected: it renders offline.

### What NOT to test

Nothing here changes publish/finalize, visibility gating, quotas, comments, or the embed allowlist. A published artifact still cannot navigate its own frame to another origin - only links open, and they open in a new tab.

## Additional Information

Verified the mechanism in Chrome against two local iframes, one per sandbox string: with `sandbox="allow-scripts"` an anchor click logs the `allow-popups` block and no tab opens; with `VIEWER_SANDBOX` the tab opens and reports its real origin rather than `null`, confirming the escape flag is what makes the opened page usable. Ctrl+click opened a normal tab in both, which is the pre-existing behavior noted above.

Tests: `renderSandboxedBundle` covers the retarget (off-origin, protocol-relative, preserved `rel` tokens, no `noreferrer`, and the untouched same-origin/relative/fragment/`mailto:` cases); `viewerSecurity` pins the constant's exact value and its no-`allow-same-origin` invariant; the serve-handler suite asserts the sandbox string on every frame it emits plus an end-to-end retarget on the isolated origin. 137 serve tests and 30 publish-service files pass. The pre-existing `normalizePublishTag` failures in `publishTags`/`buildListQuery` are unrelated (stale `@bike4mind/common` build) and reproduce on a clean tree.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
