### PR TITLE
chore(common): spell the vendor "Black Forest Labs" consistently

### DIFF
--- a/b4m-core/common/src/schemas/bfl.ts
+++ b/b4m-core/common/src/schemas/bfl.ts
@@ -31,7 +31,7 @@ export const BFLSafetyToleranceSchema = z
   .transform(value => Math.min(value, BFL_SAFETY_TOLERANCE.MAX));
 
 /**
- * List of image models supported by BlackForest Labs
+ * List of image models supported by Black Forest Labs
  */
 export const BFL_IMAGE_MODELS = [
   ImageModels.FLUX_PRO_1_1, // Current standard model

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -589,3 +589,16 @@ describe('AbstentionPrompt default carries the anti-invention licence', () => {
     expect(settingsMap.AbstentionPrompt.defaultValue).toBe(ABSTENTION_PROMPT);
   });
 });
+
+describe('bflApiKey spells the vendor the way the rest of the app does', () => {
+  // The vendor's own name is three words, and two client surfaces already render it that way
+  // (ApiKeysSection.tsx's PROVIDER_LABELS, ModelSelection.tsx's FLUX section header). This admin
+  // label is a third independent hardcoding of the same string with nothing forcing it to agree,
+  // so pin the spelling here rather than let it drift back.
+  for (const field of ['name', 'description'] as const) {
+    it(`${field} says "Black Forest Labs", not "BlackForest"`, () => {
+      expect(settingsMap.bflApiKey[field]).toContain('Black Forest Labs');
+      expect(settingsMap.bflApiKey[field]).not.toContain('BlackForest');
+    });
+  }
+});

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3215,9 +3215,9 @@ export const settingsMap = {
   }),
   bflApiKey: makeStringSetting({
     key: 'bflApiKey',
-    name: 'BlackForest Labs API Key',
+    name: 'Black Forest Labs API Key',
     defaultValue: '',
-    description: 'The API Key for BlackForest Labs image generation service.',
+    description: 'The API Key for Black Forest Labs image generation service.',
     isSensitive: true,
     category: 'AI',
     group: API_SERVICE_GROUPS.IMAGE_GENERATION.id,

--- a/b4m-core/common/src/utils/modelHelpers.ts
+++ b/b4m-core/common/src/utils/modelHelpers.ts
@@ -32,7 +32,7 @@ export function isGeminiImageModel(model?: string | null): boolean {
   return (GEMINI_IMAGE_MODELS as readonly string[]).includes(model);
 }
 
-/** Returns true for BlackForest Labs image models; derives from BFL_IMAGE_MODELS so it never drifts. */
+/** Returns true for Black Forest Labs image models; derives from BFL_IMAGE_MODELS so it never drifts. */
 export function isBflImageModel(model: string): model is BFLImageModel;
 export function isBflImageModel(model?: string | null): boolean;
 export function isBflImageModel(model?: string | null): boolean {


### PR DESCRIPTION
## Description

Closes #2063 

The vendor "Black Forest Labs" was spelled two ways in the repo. The admin settings screen labelled the API key "BlackForest Labs API Key" while the profile API-keys screen and the model-picker section header both already said "Black Forest Labs" - same vendor, two spellings, three screens.

The cause is that there is no shared constant: `settings.ts`, `ApiKeysSection.tsx`, and `ModelSelection.tsx` each hardcode the display string independently, so nothing forced them to agree and the admin one drifted. Two code comments carried the same misspelling.

This normalizes the admin label and description plus the two comments to the vendor's own three-word name, which also matches the model catalog's `black-forest-labs` vendor slug.

The label and description are pure presentation and safe to rename: every `bflApiKey` call site addresses the setting by its `key`, and neither field is persisted, seeded, or hydrated. No test, snapshot, seed, or script matches on the text.

Deliberately left alone: `BFL` as an identifier (`bflBackend.ts`, `BFL_IMAGE_MODELS`, `ModelBackend.BFL`, the `bfl` API-key field) - those are stable identifiers, not human-readable names.

## Changes

- `b4m-core/common/src/schemas/settings.ts` - `bflApiKey` `name` and `description` now say "Black Forest Labs"
- `b4m-core/common/src/utils/modelHelpers.ts` - comment on `isBflImageModel`
- `b4m-core/common/src/schemas/bfl.ts` - comment on `BFL_IMAGE_MODELS`
- `b4m-core/common/src/schemas/settings.test.ts` - new test pinning the admin-facing spelling so it cannot drift back

## Guide for Testers

1. Go to `app.staging.bike4mind.com` and sign in as a user with admin access. Expected: the app loads and the sidebar shows an Admin entry.
2. Navigate to Sidebar -> Admin -> Settings. Expected: the admin settings page loads with category tabs including AI.
3. Select the AI category, then find the Image Generation group. Expected: the group renders with an API-key field for this vendor.
4. Read the label of that API-key field. Expected: it reads exactly `Black Forest Labs API Key` - with a space between "Black" and "Forest". It must NOT read `BlackForest Labs API Key`.
5. Read the helper text under that field. Expected: it reads exactly `The API Key for Black Forest Labs image generation service.`
6. Confirm the field still behaves as a secret field: it is masked and does not display a stored key in plain text. Expected: masked value, unchanged from before this PR.
7. Open your avatar menu -> Profile -> Settings -> API Keys. Expected: the provider list includes an entry labelled `Black Forest Labs`.
8. Compare step 4 and step 7. Expected: both spell the vendor identically as `Black Forest Labs`.
9. Open a chat session and open the model picker. Scroll to the FLUX models. Expected: the section header reads `Black Forest Labs` - unchanged by this PR, and now matching the other two screens.

### Regression Checks

10. In Admin -> Settings -> AI -> Image Generation, enter any non-empty value in the Black Forest Labs API Key field and save. Expected: the save succeeds with a success toast and no error.
11. Reload the page and return to the same field. Expected: the saved value persists and renders masked. This confirms the rename did not affect storage, which is keyed by `bflApiKey`, not by the label.
12. Generate an image with a FLUX model from a chat session. Expected: generation works exactly as before - the renamed label is display-only and does not touch the request path.

### What NOT to test

- No API, request, or response shape changes. The setting is still addressed by the key `bflApiKey` everywhere.
- Docs-site and in-app help still contain the old spelling in places; those are tracked separately (see Additional Information) and are out of scope here.

## Additional Information

Scoped to `b4m-core/common` on purpose. Three further occurrences - `docs-site/docs/features/image-processing-generation.md`, `packages/database/src/seeds/modelCatalog.seed.json`, and `b4m-core/llm-adapters/src/bflBackend.ts` - are already handled by the open PR #2061, which strips the prefix from those descriptions outright. There is no file overlap between that PR and this one, so the two can land in either order with no conflict.

One gap belongs to neither PR: `apps/client/app/generated/help-index.json` is a committed build artifact generated from `docs-site/docs/**` by `pnpm --filter @bike4mind/scripts help:build-index`, and it backs in-app help search. PR #2061 edits the source heading `#### Flux (BlackForest Labs)` but does not regenerate the index, and neither `help:build-index` nor `help:validate` is wired into CI, so nothing catches the drift. If #2061 merges as-is, the docs will say "Black Forest Labs" while the shipped in-app help index still says "BlackForest Labs". Regenerating also moves the anchor from `flux-blackforest-labs` to `flux-black-forest-labs`; there are zero in-repo references to either, so only external bookmarks to that docs heading would break. Flagging it for whoever owns #2061.

Separately, and unrelated to this change: the `.husky/pre-commit` deprecated-model step runs `npx tsx packages/scripts/src/checkDeprecatedModelUsage.ts` from the repo root, but `tsx` is declared only in `packages/scripts/package.json`, so `npx tsx` fails with `sh: tsx: command not found` in any clone or worktree without a global `tsx`. Pre-existing; worth its own ticket.

## Developer Notes (Optional)

The real root cause of the drift is the missing shared constant - three independent hardcodings of one vendor name. Fixing that properly means introducing a shared vendor-label source spanning `b4m-core/common` and two client components, which is a refactor rather than a spelling fix, so it is not attempted here. The new test is the cheap stand-in: it pins the admin-facing string so this particular surface cannot regress while the underlying duplication stands.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
