### PR TITLE
fix(data-lakes): stop reporting a complete access history as truncated

### DIFF
--- a/b4m-core/services/src/dataLakeService/assembleLakeAccessView.test.ts
+++ b/b4m-core/services/src/dataLakeService/assembleLakeAccessView.test.ts
@@ -264,20 +264,47 @@ describe('assembleLakeAccessView', () => {
 
   it('aggregates history, marks truncation, and carries the window start when the read hits the cap', async () => {
     const older = new Date('2026-08-12T00:00:00Z');
-    const newer = new Date('2026-08-13T00:00:00Z');
-    // Events arrive newest-first (as listByLake returns them), so the oldest fetched is the window start.
-    const events = [event({ principalId: 'u1', createdAt: newer }), event({ principalId: 'u1', createdAt: older })];
+    const middle = new Date('2026-08-13T00:00:00Z');
+    const newer = new Date('2026-08-14T00:00:00Z');
+    // Events arrive newest-first (as listByLake returns them), so the oldest RETURNED event is the
+    // window start. Three come back against a cap of 2: the third is the probe row, which proves
+    // truncation and must NOT reach the aggregates or the window date.
+    const events = [
+      event({ principalId: 'u1', createdAt: newer }),
+      event({ principalId: 'u1', createdAt: middle }),
+      event({ principalId: 'u1', createdAt: older }),
+    ];
     const { adapters, spies } = makeAdapters({ events, users: [{ id: 'u1', name: 'Alice' }] });
     const view = await assembleLakeAccessView(lakeDoc(), {
       ...(adapters as object),
       historyLimit: 2,
       now: NOW,
     } as never);
-    expect(spies.listByLakeEvents).toHaveBeenCalledWith('lake1', { limit: 2 });
+    // limit + 1: the probe. Asking for exactly the cap cannot tell a full window from a complete one.
+    expect(spies.listByLakeEvents).toHaveBeenCalledWith('lake1', { limit: 3 });
     expect(view.history).toHaveLength(1);
+    // 2, not 3: the probe row is sliced off before aggregation, so it cannot inflate readCount.
     expect(view.history[0]).toMatchObject({ principalName: 'Alice', readCount: 2 });
     expect(view.historyTruncated).toBe(true);
-    expect(view.windowStartsAt).toEqual(older);
+    expect(view.windowStartsAt).toEqual(middle);
+  });
+
+  it('reports a complete trail of exactly the cap as untruncated, with no window start (#2092)', async () => {
+    // The boundary the old `events.length >= historyLimit` got wrong. listByLake applies the limit,
+    // so a lake with exactly `historyLimit` reads used to report truncated with a windowStartsAt -
+    // captioning its ENTIRE audit trail as "reads since <date>" and implying older reads were dropped.
+    const older = new Date('2026-08-12T00:00:00Z');
+    const newer = new Date('2026-08-13T00:00:00Z');
+    const events = [event({ principalId: 'u1', createdAt: newer }), event({ principalId: 'u1', createdAt: older })];
+    const { adapters } = makeAdapters({ events, users: [{ id: 'u1', name: 'Alice' }] });
+    const view = await assembleLakeAccessView(lakeDoc(), {
+      ...(adapters as object),
+      historyLimit: 2,
+      now: NOW,
+    } as never);
+    expect(view.history[0]).toMatchObject({ readCount: 2 });
+    expect(view.historyTruncated).toBe(false);
+    expect(view.windowStartsAt).toBeUndefined();
   });
 
   it('does not mark truncation, and omits the window start, when fewer events than the cap come back', async () => {

--- a/b4m-core/services/src/dataLakeService/assembleLakeAccessView.ts
+++ b/b4m-core/services/src/dataLakeService/assembleLakeAccessView.ts
@@ -150,10 +150,18 @@ export async function assembleLakeAccessView(
   { db, historyLimit = LAKE_ACCESS_VIEW_HISTORY_LIMIT, now = new Date() }: AssembleLakeAccessViewAdapters
 ): Promise<LakeAccessView> {
   // All-grants read (no activeAsOf): the view must render lapsed rows too, tagging each active/expired.
-  const [grantRows, events] = await Promise.all([
+  // One event MORE than the window, purely as a probe: fetching exactly `historyLimit` cannot
+  // distinguish "this lake has exactly that many reads" from "there are more behind the window", and
+  // captioning a COMPLETE audit trail as partial is the one thing a compliance surface must not do.
+  // The extra row is sliced off below and never reaches the aggregates. Same technique, and the same
+  // reasoning, as assembleLakeConfigHistory.
+  const [grantRows, fetchedEvents] = await Promise.all([
     db.dataLakeAccessGrants.listByLake(lake.id),
-    db.lakeAccessEvents.listByLake(lake.id, { limit: historyLimit }),
+    db.lakeAccessEvents.listByLake(lake.id, { limit: historyLimit + 1 }),
   ]);
+
+  const historyTruncated = fetchedEvents.length > historyLimit;
+  const events = historyTruncated ? fetchedEvents.slice(0, historyLimit) : fetchedEvents;
 
   const history = aggregateAccessHistory(events);
   const channels = deriveAccessChannels(lake);
@@ -205,8 +213,9 @@ export async function assembleLakeAccessView(
 
   // When the audit read hit the cap, the per-row aggregates only cover the fetched window. Events
   // come back newest-first, so the oldest fetched event is the window's start - carried so a consumer
-  // can qualify readCount/firstAccessedAt rather than present them as all-time.
-  const historyTruncated = events.length >= historyLimit;
+  // can qualify readCount/firstAccessedAt rather than present them as all-time. `historyTruncated` is
+  // decided by the probe row above, so a complete trail of exactly `historyLimit` reads reports
+  // untruncated and carries no window date.
   const windowStartsAt = historyTruncated ? events[events.length - 1]?.createdAt : undefined;
 
   const grants: LakeAccessGrantView[] = grantRows.map((g: IDataLakeAccessGrantDocument) => ({


### PR DESCRIPTION
## Description

Closes #2092.

`assembleLakeAccessView` could not tell a full window from a complete one:

```ts
const historyTruncated = events.length >= historyLimit;
const windowStartsAt = historyTruncated ? events[events.length - 1]?.createdAt : undefined;
```

`listByLake` applies `query.limit(opts.limit)` and was called with `{ limit: historyLimit }`, so `events.length` can never exceed `historyLimit` and `>=` is always satisfied at the boundary. A lake with exactly `historyLimit` access events (2000 by default) reported `historyTruncated: true` with a `windowStartsAt` of its oldest event -- so the compliance JSON and the CSV export captioned a COMPLETE audit trail as a partial window, and a reader would reasonably conclude older accesses had been dropped.

For a surface whose whole purpose is answering "who read this lake", misreporting completeness is the one failure it cannot afford.

The sibling `assembleLakeConfigHistory` already solves this with a probe row and documents why. This applies the same technique.

## Changes

- Fetch `historyLimit + 1` events as a probe; `historyTruncated` is now `fetched.length > historyLimit`.
- Slice the probe row off **before** aggregation, so `readCount`, `firstAccessedAt` and `windowStartsAt` are computed over the real window and the extra row can never inflate them.

No API shape change. The only behaviour difference is at the exact boundary, plus one additional event read per request.

## Test coverage

- The existing truncation test asserted the buggy boundary (2 events against a cap of 2 -> truncated), so it is rewritten to supply the probe row: 3 events against a cap of 2 now proves truncation, and it pins that `readCount` stays 2 and `windowStartsAt` is the oldest RETURNED event, not the probe.
- New test for the boundary itself: exactly `historyLimit` events reports `historyTruncated: false` with no `windowStartsAt`.
- `lakeAccessViewCsv` consumer tests re-run green (14), as do all 27 data-lake route suites (245 tests).

## Guide for Testers

Backend-only; the visible effect is a caption on the access view.

1. Sign in as the owner of a data lake that has been queried at least once.
2. Go to Sidebar -> Data Lakes, open that lake, and open its Access / Membership view.
3. Confirm the read history renders and each row shows a principal and a read count. Expected: no error, same rows as before this change.
4. Click Export CSV. Expected: the file downloads and the rows match what step 3 showed.
5. Confirm that for a lake with a modest number of reads, the view does NOT claim the history is truncated or show a "reads since <date>" qualifier.

**What NOT to test:** the 2000-event boundary itself. Generating exactly 2000 access events by hand is impractical; that case is covered by the unit test.

## Additional Information

Found during a directed review of the data lake subsystem. Sibling of #2086 in the same review batch, but independent of it -- no shared files.
