### PR TITLE
fix(data-lakes): emit retrieval_unavailable on the semantic-search empty-scope exit

### DIFF
--- a/apps/client/pages/api/data-lakes/__tests__/semantic-search.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/semantic-search.test.ts
@@ -86,6 +86,9 @@ vi.mock('@bike4mind/services', async () => ({
     emptyEmbeddingMismatchReport: (
       await import('../../../../../../b4m-core/services/src/dataLakeService/embeddingMismatch')
     ).emptyEmbeddingMismatchReport,
+    emptyRetrievalUnavailableReport: (
+      await import('../../../../../../b4m-core/services/src/dataLakeService/retrievalUnavailable')
+    ).emptyRetrievalUnavailableReport,
     // Real implementations (pure, already unit-tested on their own) so this suite can assert on
     // the actual lakeAccessEventRepository.record call args rather than a reimplementation.
     attributeAccessedLakeIds: (
@@ -345,6 +348,11 @@ describe('POST /api/data-lakes/semantic-search lake scoping', () => {
         // The short-circuit must carry the SAME shape as the success path: the RLM loopback
         // forwards this JSON verbatim, so a missing `scan` would be an inconsistent contract.
         scan: expect.objectContaining({ truncated: false, files_matching: 0, chunks_scanned: 0 }),
+        // Same contract, and the field #2096 was missing here: the RLM prompt documents
+        // `retrieval_unavailable` as always present, so REPL code reading
+        // `retrieval_unavailable.indexing_files` TypeErrored for any caller with no lakes - the
+        // most likely state for a new user.
+        retrieval_unavailable: { indexing_files: 0, paused_files: 0, partial: false },
       })
     );
     // Without these the test still passes with the short-circuit deleted.

--- a/apps/client/pages/api/data-lakes/semantic-search.ts
+++ b/apps/client/pages/api/data-lakes/semantic-search.ts
@@ -126,6 +126,21 @@ const toMismatchPayload = (report: dataLakeService.EmbeddingMismatchReport) => (
   query_embedding_failed: report.queryEmbeddingFailed,
 });
 
+/**
+ * Flatten the retrieval-unavailable report to the wire shape. Shared by BOTH exits for the same
+ * reason as `toScanPayload` and `toMismatchPayload`: the RLM tool forwards this JSON verbatim and its
+ * prompt documents the field as always present, so a path that omits it TypeErrors REPL code that
+ * reads `retrieval_unavailable.indexing_files`. Flat counts rather than the whole report - a caller
+ * needs to know how much is temporarily unsearchable, and the file names are already in `warning`.
+ */
+const toRetrievalUnavailablePayload = (report: dataLakeService.RetrievalUnavailableReport) => ({
+  indexing_files: report.indexing.count,
+  // Counted apart from `indexing_files` because waiting does not fix these - see the report type. A
+  // caller that adds them together would tell the user to retry and be wrong.
+  paused_files: report.paused.count,
+  partial: report.partial,
+});
+
 const toScanPayload = (scan: dataLakeService.SemanticSearchScanAccounting) => ({
   truncated: scan.truncated,
   file_budget_hit: scan.fileBudgetHit,
@@ -245,6 +260,7 @@ const handler = baseApi()
           chunks_scored: 0,
           partial_results: false,
           embedding_mismatch: toMismatchPayload(dataLakeService.emptyEmbeddingMismatchReport()),
+          retrieval_unavailable: toRetrievalUnavailablePayload(dataLakeService.emptyRetrievalUnavailableReport()),
           scan: toScanPayload(dataLakeService.emptyScanAccounting(budgets)),
         });
       }
@@ -436,15 +452,7 @@ const handler = baseApi()
         // everything" signal.
         partial_results: dataLakeService.isPartialSearch(search),
         embedding_mismatch: toMismatchPayload(search.embeddingMismatch),
-        // Flat counts rather than the whole report: a caller needs to know how much is temporarily
-        // unsearchable, and the file names are already in `warning`.
-        retrieval_unavailable: {
-          indexing_files: search.retrievalUnavailable.indexing.count,
-          // Counted apart from `indexing_files` because waiting does not fix these - see the report
-          // type. A caller that adds them together would tell the user to retry and be wrong.
-          paused_files: search.retrievalUnavailable.paused.count,
-          partial: search.retrievalUnavailable.partial,
-        },
+        retrieval_unavailable: toRetrievalUnavailablePayload(search.retrievalUnavailable),
         // Spread rather than `warning: warning ?? undefined`, so the key is genuinely absent on a
         // healthy search instead of present-and-undefined.
         ...(warning ? { warning } : {}),


### PR DESCRIPTION
## Description

Closes #2096.

The zero-accessible-lakes short-circuit in `semantic-search` omitted `retrieval_unavailable`, which the success path always sends. The file states the very invariant this broke:

```ts
/**
 * ... Used by BOTH the no-lakes short-circuit and the success path so
 * the response shape never varies between them - the RLM tool forwards this JSON verbatim.
 */
```

and `dataLakeReplPrompts.ts:24` tells the model the field is always present. So REPL code written against that instruction -- `r.retrieval_unavailable.indexing_files` -- threw a `TypeError` instead of seeing an empty result set and reporting "nothing to search".

The zero-lakes case is the most likely state for a new user, which makes this a first-run failure mode.

## Changes

- Extracted `toRetrievalUnavailablePayload`, alongside the existing `toScanPayload` and `toMismatchPayload` helpers, and routed **both** exits through it. The success path previously inlined this shape, which is how the two drifted; sharing one helper is what stops it recurring.
- Fed the empty exit `dataLakeService.emptyRetrievalUnavailableReport()`.

No change to the success-path payload -- the extracted helper produces byte-identical output to the inlined object it replaces.

## Test coverage

- The existing "returns an empty payload with no embedding spend when no lakes are accessible" test now also asserts `retrieval_unavailable: { indexing_files: 0, paused_files: 0, partial: false }`, so the omission cannot come back.
- 44 tests in the semantic-search suite pass; `pnpm turbo:typecheck` clean (40/40).

## Guide for Testers

1. Sign in as a user who has **no** data lakes and belongs to no org that shares one (a fresh account is easiest).
2. `POST` to `app.staging.bike4mind.com/api/data-lakes/semantic-search` with body `{"query": "anything"}`.
3. Expected: HTTP 200. The JSON contains `"results": []` and a `"retrieval_unavailable": {"indexing_files": 0, "paused_files": 0, "partial": false}` object. Before this change the field was absent entirely.
4. Confirm `scan` and `embedding_mismatch` are also present, so all three accounting blocks appear on the empty path.
5. Now sign in as a user WITH an accessible lake and repeat step 2. Expected: results come back and `retrieval_unavailable` is still present with the same three keys -- confirming the success path is unchanged.

**What NOT to test:** the RLM REPL tool end to end. The bug is a response-shape contract; step 3 is the whole observable surface.

## Additional Information

Found during a directed review of the data lake subsystem. Independent of the sibling PRs in that batch (#2097, #2098) -- no shared files.
