### PR TITLE
fix(data-lakes): narrow repeated query params on the articles and access routes

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/__tests__/access.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/access.test.ts
@@ -121,6 +121,16 @@ describe('GET /api/data-lakes/[id]/access', () => {
     expect(body).toContain('"user","u2","Bob","reader","active"');
   });
 
+  it('still streams CSV when format is repeated, rather than 500ing on the array (#2095)', async () => {
+    // `?format=csv&format=csv` arrives as an array. `(format ?? '').toLowerCase()` threw a TypeError
+    // on it - a 500 raised AFTER the manage gate and the whole access aggregation had already run,
+    // so the work was done and then thrown away.
+    const { res, send, setHeader } = makeRes();
+    await call(req({ id: 'lake1', format: ['csv', 'csv'] }), res);
+    expect(setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv; charset=utf-8');
+    expect(send.mock.calls[0][0] as string).toContain('# Members and grants');
+  });
+
   it('applies the identical manage gate to the CSV path (403 before assembling, no attachment)', async () => {
     h.canManageLake.mockReturnValue(false);
     const { res, send, setHeader } = makeRes();

--- a/apps/client/pages/api/data-lakes/[id]/access.ts
+++ b/apps/client/pages/api/data-lakes/[id]/access.ts
@@ -12,6 +12,7 @@ import { ForbiddenError } from '@server/utils/errors';
 import { Request } from 'express';
 import { toAccessContext } from '@server/dataLakes/toAccessContext';
 import { lakeAccessViewToCsv, lakeAccessViewCsvFilename } from '@server/dataLakes/lakeAccessViewCsv';
+import { firstQueryValue } from '@server/dataLakes/firstQueryValue';
 
 /**
  * GET /api/data-lakes/:id/access[?format=csv]
@@ -34,11 +35,21 @@ import { lakeAccessViewToCsv, lakeAccessViewCsvFilename } from '@server/dataLake
  * the view, because the view is the exported compliance artifact: a per-viewer capability is not a
  * fact about the lake's access and must not appear in the CSV.
  */
+/** `format` is `string[]` for a repeated query param - see firstQueryValue. */
+interface AccessQuery {
+  id: string;
+  format?: string | string[];
+}
+
 const handler = baseApi()
   .use(requireFeatureEnabled('EnableDataLakes'))
-  .get(async (req: Request<{ id: string }, unknown, unknown, { id: string; format?: string }>, res) => {
-    // Next merges the [id] route param into req.query alongside the ?format= query string.
-    const { id, format } = req.query;
+  .get(async (req: Request<{ id: string }, unknown, unknown, AccessQuery>, res) => {
+    // Next merges the [id] route param into req.query alongside the ?format= query string, so `id` is
+    // always a string. `format` is a genuine query param and arrives as an array for
+    // `?format=csv&format=csv`, where `(format ?? '').toLowerCase()` threw a TypeError - a 500 raised
+    // AFTER the manage gate and the whole access aggregation had already run.
+    const { id } = req.query;
+    const format = firstQueryValue(req.query.format);
     const ctx = await toAccessContext(req);
 
     const lake = await dataLakeService.assertLakeAccess(id, ctx, {

--- a/apps/client/server/dataLakes/index.ts
+++ b/apps/client/server/dataLakes/index.ts
@@ -80,7 +80,9 @@ export async function resolveAccessibleLakes(req: EntitlementRequest): Promise<D
 }
 
 export interface DataLakeArticlesQuery {
-  id?: string;
+  // `string[]` for the same reason as `tags`/`search` below: /api/data-lakes/articles has no `[id]`
+  // route segment, so `id` comes purely from the query string and is repeatable.
+  id?: string | string[];
   tags?: string | string[];
   search?: string | string[];
   page?: string;
@@ -135,8 +137,12 @@ export async function queryDataLakeArticles(
   // lakes safely - membership IS the meta-tag) OR a static-registry (open) prefix.
   // A dynamic lake's user-controlled prefix is deliberately NOT a grant here - that
   // was the cross-tenant hole; dynamic-lake files are reached via the meta-tag.
-  if (query.id) {
-    const file = await fabFileRepository.findById(query.id);
+  // Narrowed like `search`/`tags` below: an array reaching findById casts to a Mongoose CastError
+  // and 500s the deep-link read. /api/data-lakes/articles has no `[id]` route segment, so nothing
+  // else overwrites this with a single value.
+  const articleId = firstQueryValue(query.id);
+  if (articleId) {
+    const file = await fabFileRepository.findById(articleId);
     const grantedLakeIds = file && !file.deletedAt ? grantingLakes(lakes, file.tags?.map(t => t.name) ?? []) : [];
     if (!file || grantedLakeIds.length === 0) {
       return { data: [], total: 0, hasMore: false };

--- a/apps/client/server/dataLakes/queryDataLakeArticles.test.ts
+++ b/apps/client/server/dataLakes/queryDataLakeArticles.test.ts
@@ -147,6 +147,18 @@ describe('queryDataLakeArticles deep-link (?id=) branch', () => {
     findById.mockReset();
   });
 
+  it('narrows a repeated ?id= to its first value instead of casting an array into findById (#2095)', async () => {
+    // /api/data-lakes/articles has no `[id]` route segment, so `?id=a&id=b` reaches here as an
+    // array. Passing that to findById produced a Mongoose CastError and a 500; `search` and `tags`
+    // on the same query were already narrowed, `id` was not.
+    findById.mockResolvedValue({ id: 'f1', tags: [{ name: 'datalake:opti-knowledge' }], moderationStatus: 'clean' });
+
+    const result = await queryDataLakeArticles(req, [STATIC_LAKE], { id: ['f1', 'f2'] } as any);
+
+    expect(findById).toHaveBeenCalledWith('f1');
+    expect(result.total).toBe(1);
+  });
+
   it('grants via meta-tag and surfaces the grantor id for the caller to reuse in its own attribution', async () => {
     findById.mockResolvedValue({ id: 'f1', tags: [{ name: 'datalake:opti-knowledge' }], moderationStatus: 'clean' });
 


### PR DESCRIPTION
## Description

Closes #2095.

Two data-lake read routes passed a repeated query param straight into code that assumes a single string, turning a malformed request into a server error. Both already had `firstQueryValue` sitting in the same server module, written for precisely this hazard.

**1. `GET /api/data-lakes/articles?id=...`**

```ts
if (query.id) {
  const file = await fabFileRepository.findById(query.id);
```

This route has no `[id]` path segment, so `id` comes purely from the query string and arrives as `string[]` when repeated. `search` and `tags` on the following lines are both narrowed; `id` was not. `?id=a&id=b` gave `findById(['a','b'])` -> Mongoose `CastError` -> 500.

**2. `GET /api/data-lakes/:id/access?format=csv`**

```ts
if ((format ?? '').toLowerCase() === 'csv') {
```

`format` is a genuine query param -- unlike `id`, which Next overwrites with the route param -- so it can be an array, and `??` does not defend against that. `?format=csv&format=csv` gave `['csv','csv'].toLowerCase is undefined` -> `TypeError` -> 500, raised **after** the manage gate and the whole `assembleLakeAccessView` aggregation had already run. The work was done and then discarded.

## Changes

- `queryDataLakeArticles`: narrow `id` through `firstQueryValue`. `DataLakeArticlesQuery.id` is now typed `string | string[]`, matching its siblings -- the old `string` claimed a guarantee the route cannot make.
- `access.ts`: narrow `format` through `firstQueryValue`, and move the query shape to a named `AccessQuery` interface so the array case is declared rather than implied.

Neither is a security issue: the access gates run correctly in both cases, and the narrowing does not widen what either route returns. `?id=a&id=b` now behaves as `?id=a`, which is standard Express semantics for the rest of this query.

## Test coverage

- `queryDataLakeArticles`: new test passing `{ id: ['f1','f2'] }`, asserting `findById` is called with `'f1'` and the read still resolves.
- `access.ts`: new test calling with `format: ['csv','csv']`, asserting the CSV attachment still streams instead of throwing.
- All 27 data-lake route suites pass (246 tests, up from 245); `pnpm turbo:typecheck` clean (40/40).

## Guide for Testers

1. Sign in and note the id of a file that belongs to a data lake you can read.
2. Request `app.staging.bike4mind.com/api/data-lakes/articles?id=<fileId>`. Expected: HTTP 200 with that one article.
3. Request the same URL with the param repeated: `?id=<fileId>&id=<fileId>`. Expected: HTTP 200 with the same single article. Before this change: HTTP 500.
4. As the owner of a data lake, request `/api/data-lakes/<lakeId>/access?format=csv`. Expected: a CSV file downloads.
5. Repeat step 4 with `?format=csv&format=csv`. Expected: the same CSV downloads. Before this change: HTTP 500.
6. Request `/api/data-lakes/<lakeId>/access` with no `format`. Expected: JSON, not CSV -- confirms the default path is unchanged.

**Regression checks:** open Sidebar -> Data Lakes, click into a lake, open a file from the tree, and export the access CSV. All three should behave exactly as before.

## Additional Information

Found during a directed review of the data lake subsystem. Independent of the sibling PRs in that batch (#2097, #2098, #2099).
