### PR TITLE
feat(slack): announce a new paid subscription on first charge

### DIFF
--- a/apps/client/server/analytics/analyticsMiddleware.ts
+++ b/apps/client/server/analytics/analyticsMiddleware.ts
@@ -82,7 +82,21 @@ export function analyticsMiddleware() {
     }
     emitted.set(pseudoUserId, today);
 
-    // Deterministic sessionId: forensic-only; downstream never groups on it
+    // Deterministic sessionId: sha256 of the pseudonymous id plus the UTC date, so it is
+    // stable for a whole day rather than scoped to a visit.
+    //
+    // It IS grouped on downstream: a consumer of OverwatchRawEvent counts distinct
+    // sessionIds per product. An earlier version of this comment said "forensic-only;
+    // downstream never groups on it" - true when written, false once that consumer
+    // shipped, and it went uncorrected long enough to be quoted elsewhere as evidence
+    // the value was not used. Describe what this is, not what nothing does with it: a
+    // claim about the absence of consumers rots the moment one appears, and unlike a
+    // claim about the value itself, nothing here fails when it does.
+    //
+    // Consequence worth knowing before relying on that grouping: because the input is
+    // (user, day) rather than (user, visit), a distinct-sessionId count is a count of
+    // distinct user-days for this emitter, and of real sessions for a product supplying
+    // its own. The two are not comparable.
     const sessionId = crypto.createHash('sha256').update(`${pseudoUserId}:${today}`).digest('hex');
 
     const userType = resolveUserType({ level: req.user.level, subscribedUntil: req.user.subscribedUntil });

--- a/apps/client/server/events/stripe/invoicePaymentSucceeded.ts
+++ b/apps/client/server/events/stripe/invoicePaymentSucceeded.ts
@@ -9,6 +9,7 @@ import { stripe } from '@server/integrations/stripe/stripe';
 import { Config } from '@server/utils/config';
 import { emitMetric } from '@server/utils/cloudwatch';
 import { withEventContext } from '../utils';
+import { postNewSubscriptionToSlack } from '@server/integrations/slack/slack';
 
 export const handler = withEventContext(async (event, logger) => {
   const { invoiceId, subscriptionId } = StripeEvents.InvoicePaymentSucceeded.schema.parse(event.properties);
@@ -67,4 +68,25 @@ export const handler = withEventContext(async (event, logger) => {
     subscriptionId,
     ownerType: metadata.ownerType || 'User (legacy)',
   });
+
+  // Announce first charges only. `subscription_create` is Stripe's own marker for
+  // the invoice that opens a subscription; `subscription_cycle` is a renewal and
+  // would post monthly per customer. Placed after the work above so the message
+  // means the subscription and credits actually landed.
+  //
+  // Awaited but non-throwing by construction (postNewSubscriptionToSlack swallows
+  // its own errors): this handler retrying would re-run credit granting, so a
+  // Slack outage must not be able to cause that.
+  if (invoice.billing_reason === 'subscription_create') {
+    const lineItem = invoice.lines?.data?.[0];
+    await postNewSubscriptionToSlack({
+      planName: lineItem?.description ?? 'Subscription',
+      // Stripe reports minor units; en-US currency formatting expects major.
+      amount: (invoice.amount_paid ?? 0) / 100,
+      currency: invoice.currency ?? 'usd',
+      invoiceId,
+      email: invoice.customer_email ?? undefined,
+      ownerType: metadata.ownerType,
+    });
+  }
 });

--- a/apps/client/server/integrations/slack/slack.ts
+++ b/apps/client/server/integrations/slack/slack.ts
@@ -213,6 +213,65 @@ export async function postEmailMirrorToSlack(payload: EmailMirrorPayload): Promi
   }
 }
 
+/**
+ * Announce a NEW paid subscription (first charge only) to Slack.
+ *
+ * Called from the invoice.payment_succeeded subscriber AFTER the subscription and
+ * credits are recorded, so the message means "this actually completed", not "Stripe
+ * said something".
+ *
+ * First charge only: the caller gates on Stripe's `billing_reason ===
+ * 'subscription_create'`. Renewals (`subscription_cycle`) would otherwise post every
+ * month per customer and drown the signal this exists to give.
+ *
+ * No enable flag: an unset webhook URL is the off switch, matching the convention
+ * used for the analytics ids. Add a SettingKey gate if the channel is configured but
+ * the announcements should be pausable separately.
+ *
+ * Never throws. Its caller is an event subscriber whose failure would be retried,
+ * and a retry re-runs credit granting - so a Slack outage must not turn into
+ * double-granted credits.
+ */
+export async function postNewSubscriptionToSlack(payload: {
+  planName: string;
+  amount: number;
+  currency: string;
+  /** Stripe invoice id - the natural dedupe key if this is ever redelivered. */
+  invoiceId: string;
+  email?: string;
+  ownerType?: string;
+  organizationName?: string;
+}): Promise<void> {
+  try {
+    // A paid signup is a business event, not an operational alert -> general channel.
+    const settings = await getSettingsMap({ adminSettings: adminSettingsRepository });
+    const slackWebhookUrl = resolveSlackWebhookUrl('SlackGeneralWebhookUrl', settings);
+    if (!slackWebhookUrl) {
+      // Debug, not error: unconfigured is a valid state (the feature is simply off),
+      // unlike the low-credits alert where a missing URL loses an operational signal.
+      Logger.debug('Skipping new-subscription Slack post: no SlackGeneralWebhookUrl / SlackDefaultWebhookUrl set');
+      return;
+    }
+
+    const formattedAmount = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: payload.currency.toUpperCase(),
+    }).format(payload.amount);
+
+    const lines = [
+      `:tada: *New paid subscription* - ${payload.planName} (${formattedAmount})`,
+      payload.email ? `*Customer:* ${payload.email}` : undefined,
+      payload.organizationName ? `*Organization:* ${payload.organizationName}` : undefined,
+      payload.ownerType ? `*Type:* ${payload.ownerType}` : undefined,
+      `*Invoice:* ${payload.invoiceId}`,
+    ].filter(Boolean);
+
+    await axios.post(slackWebhookUrl, { text: lines.join('\n') }, { headers: { 'Content-Type': 'application/json' } });
+  } catch (error) {
+    Logger.error('Error posting new subscription notification to Slack:', error);
+  }
+}
+
 export async function postLowCreditsNotificationToSlack(
   userId: string,
   username: string,


### PR DESCRIPTION
Posts to Slack when someone starts paying for B4M. **First charge only.** Came in at the lower end of the half-day estimate, because everything needed already existed.

## Where it hooks, and why not the webhook

`pages/api/stripe/webhook.ts` only **publishes** `invoice.payment_succeeded` to the event bus — it does no work inline. A notification placed there would fire before the subscription and credits exist, announcing "Stripe said something" rather than "this completed".

Hooking the **subscriber** (`server/events/stripe/invoicePaymentSucceeded.ts`) means the message fires after the work lands, and it gets failure isolation for free: Stripe already has its 2xx by then.

## The gate

`billing_reason === 'subscription_create'` — Stripe's own marker for the invoice that opens a subscription. `subscription_cycle` is a renewal; announcing those would post monthly per customer and drown exactly the signal this exists to give.

Renewal visibility later is a second branch here, not a second project. But it should stay out of any **ad-platform** conversion event — attributing recurring revenue to the original click inflates apparent ROAS.

## Reused rather than built

`server/integrations/slack/slack.ts` already has `resolveSlackWebhookUrl` / `getSettingsMap`, with `postLowCreditsNotificationToSlack` as a near-exact template. I used that rather than the `SlackClient`/bot-token/workspace-model path, which is heavier and aimed at ops tooling.

A paid signup is a business event, so it routes to `SlackGeneralWebhookUrl` with the existing fallback to `SlackDefaultWebhookUrl`.

**No new SettingKey.** An unset webhook URL is the off switch, matching the convention the analytics ids use. Worth a separate enable flag only if the channel is configured but announcements need pausing independently — say so and I'll add one.

## Safety

`postNewSubscriptionToSlack` never throws. That's load-bearing rather than defensive: its caller is an event subscriber whose failure gets retried, and a retry **re-runs credit granting**. A Slack outage must not be able to cause double-granted credits.

Unconfigured logs at `debug`, not `error` — unlike the low-credits alert, where a missing URL loses an operational signal. Here it just means the feature is off.

## One gap, deliberately left

**No test asserting the renewal gate.** The existing suite's fixtures don't expose the invoice mock it needs. I tried, guessed the harness wrong, and reverted rather than leave broken tests in the diff. It's the most valuable test here — a regression means monthly spam per customer — so it shouldn't sit unwritten long. Happy to add it as a follow-up, or here if you'd rather not merge without it.

## Verification

Client typecheck 0 errors. 188 tests passing across 7 files in `server/events/stripe` and `server/integrations/slack`. All pre-commit hooks pass.

## To turn it on

Set `SlackGeneralWebhookUrl` (or `SlackDefaultWebhookUrl`) in admin settings to a Slack incoming-webhook URL. Until then this is inert.