### PR TITLE
perf(ci): stop building a DOM for the client shard's 563 Node test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,9 +446,20 @@ jobs:
     # drag the test-shard fan-out onto the larger, pricier runner.
     runs-on: ${{ vars.RUNNER_LABEL_MEDIUM || 'ubuntu-latest-m' }}
     name: Run Tests (${{ matrix.shard.name }})
-    timeout-minutes: 20
+    # Hard ceiling, not a budget: it costs nothing when a shard finishes early, and its only
+    # job is to kill a genuine hang. It was 20, which the client shard's own runtime drifted
+    # into - the job was cancelled during cleanup AFTER every test had passed, so a green
+    # suite reported red on a coin flip decided by runner speed (#2015). 30 buys headroom over
+    # that drift; SHARD_SOFT_BUDGET_SECONDS below is what actually watches for it.
+    timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      # Soft budget: the shard's former hard cap. Crossing it now annotates the run instead of
+      # killing it, so the next slow creep surfaces as a warning on a passing build rather than
+      # as someone's PR failing for no reason - which was the only signal this had that the
+      # client shard had gone from 15 minutes to 20.
+      SHARD_SOFT_BUDGET_SECONDS: '1200'
 
     strategy:
       fail-fast: false
@@ -568,6 +579,12 @@ jobs:
           pnpm --filter @bike4mind/database exec node -e
           "require('mongodb-memory-server').MongoBinary.getPath({}).then(p => console.log('mongod binary ready:', p)).catch(e => console.warn('prewarm skipped:', e.message))"
 
+      # Paired with "Report shard duration" at the end of this job. Set before the test steps
+      # rather than derived from the job's own start so the number is test runtime, not
+      # test runtime plus install and core-build restore.
+      - name: Mark shard start
+        run: echo "SHARD_START_SECONDS=$(date +%s)" >> "$GITHUB_ENV"
+
       # `matrix.shard.script` is unset on every shard but client-integration, and an
       # unset matrix value is the empty string here, so `||` falls back to the unit
       # `test` script.
@@ -606,6 +623,25 @@ jobs:
         env:
           CI: true
           VITEST_MAX_WORKERS: ${{ matrix.shard.workers }}
+
+      # Reports, never fails. Before this, the only signal that a shard's runtime had crept was
+      # a PR going red for no reason once the creep crossed `timeout-minutes` (#2015) - by which
+      # point the information arrives as a broken build rather than as a trend. A duration on
+      # every run, plus a warning annotation once a shard passes its soft budget, makes the
+      # slide visible while the build is still green.
+      #
+      # `always()` so a FAILING shard still reports: a shard that failed because it was slow is
+      # the exact run where the number is worth having. Guarded on SHARD_START_SECONDS being set
+      # so an early failure (before the mark step) reports nothing instead of nonsense.
+      - name: Report shard duration
+        if: always() && env.SHARD_START_SECONDS != ''
+        run: |
+          elapsed=$(( $(date +%s) - SHARD_START_SECONDS ))
+          summary=$(printf '%s: %dm%02ds' '${{ matrix.shard.name }}' "$(( elapsed / 60 ))" "$(( elapsed % 60 ))")
+          echo "- Run Tests (${summary})" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$elapsed" -gt "$SHARD_SOFT_BUDGET_SECONDS" ]; then
+            echo "::warning title=Slow test shard::${summary} - over its ${SHARD_SOFT_BUDGET_SECONDS}s soft budget. Not a failure: split or speed up the shard before it reaches the job timeout."
+          fi
 
   # Aggregate gate for the sharded test matrix. Branch protection requires a
   # status check literally named "Run Tests"; the matrix above reports per-shard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,18 @@ Code describes *what* it does and comments explain the *why* that the code can't
 - **Exception:** files under `pages/` use a `__tests__/` subdirectory (Next.js treats every file in `pages/` as a route).
 - Pure utilities with no single owner may use a `__tests__/` subdirectory.
 
+**Test environment in `apps/client`** — the package runs two vitest projects (`apps/client/vitest.config.mts`), because a DOM is expensive and most of this package doesn't need one:
+
+| project | covers | environment |
+|---|---|---|
+| `node` | `server/**`, `pages/**` (route/queue/cron handlers, server libs) | `node` |
+| `jsdom` | everything else (`app/**` components and hooks) | `jsdom` |
+
+- A file that needs the other environment says so **per file**, as the first line: `// @vitest-environment jsdom` (or `node`). Prefer that over widening a project's globs.
+- A `server/`/`pages/` test that touches `document`/`window`/`render` fails immediately with `ReferenceError: document is not defined` — that's the signal to add the docblock, not to change the config.
+- Run one side only with `pnpm --filter @bike4mind/client exec vitest run --project node`.
+- Watch out for mocks that were silently dead under jsdom and now bite: `vi.mock('crypto', …)` in particular takes effect under `node`, so an assertion that contradicted its own mock starts failing (correctly).
+
 **Element selection:** always use `data-testid` (naming `component-action-element`, e.g. `modal-confirm-btn`) — never CSS class names (MUI/Emotion generates random class names).
 
 **MUI Joy component tests need the theme wrapper** (custom palette tokens like `background.surface2` break without it):

--- a/apps/client/pages/api/publish/__tests__/widget.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import handler from '../widget';
 

--- a/apps/client/server/api/jupyter/__tests__/execute.test.ts
+++ b/apps/client/server/api/jupyter/__tests__/execute.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 
+// Hoisted so the `vi.mock('crypto')` factory below and the assertions further down read the
+// SAME id: the two used to disagree (a fixed id mocked in, a real-UUID regex asserted out) and
+// only passed because the crypto mock did not take effect under this package's old
+// jsdom-everywhere test environment. It does under `node`, so the disagreement is now visible.
+const { MOCK_REQUEST_ID } = vi.hoisted(() => ({ MOCK_REQUEST_ID: 'test-uuid-1234' }));
+
 // Mock dependencies BEFORE importing
 vi.mock('@server/middlewares/baseApi', () => ({
   baseApi: vi.fn(() => ({
@@ -36,7 +42,7 @@ vi.mock('crypto', async importOriginal => {
   const actual = await importOriginal<typeof import('crypto')>();
   return {
     ...actual,
-    randomUUID: vi.fn(() => 'test-uuid-1234'),
+    randomUUID: vi.fn(() => MOCK_REQUEST_ID),
   };
 });
 
@@ -201,13 +207,15 @@ describe('/api/jupyter/execute', () => {
             sessionId: 'session-123',
             kernelName: 'python3',
           }),
-          requestId: expect.stringMatching(/^[0-9a-f-]{36}$/), // UUID format
+          requestId: MOCK_REQUEST_ID,
         })
       );
 
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          requestId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          // Same id as the command above: the handler must hand the caller back the id it
+          // actually dispatched, or the client polls for a request that does not exist.
+          requestId: MOCK_REQUEST_ID,
           sent: true,
           sessionId: 'session-123',
           connections: 2,

--- a/apps/client/server/s3/moderateUploadedFile.test.ts
+++ b/apps/client/server/s3/moderateUploadedFile.test.ts
@@ -1,7 +1,7 @@
-// jsdom (this package's default test environment) runs in a separate vm realm whose
-// Buffer isn't `instanceof` that realm's Uint8Array - `file-type`'s `fileTypeFromBuffer`
-// relies on that check, so this suite needs the real node environment (same
-// convention as other apps/client/server/**/*.test.ts files that touch Buffer/fs).
+// Redundant since server/** defaults to node (see apps/client/vitest.config.mts), but kept as
+// the record of WHY this suite cannot run under jsdom: jsdom runs in a separate vm realm whose
+// Buffer isn't `instanceof` that realm's Uint8Array, and `file-type`'s `fileTypeFromBuffer`
+// relies on that check.
 // @vitest-environment node
 import { describe, it, expect, vi } from 'vitest';
 import { ImageModerationBlockedError, UnsupportedImageFormatError } from '@bike4mind/utils/imageModeration';

--- a/apps/client/vitest.config.mts
+++ b/apps/client/vitest.config.mts
@@ -12,41 +12,76 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 const INTEGRATION_LANE = process.env.CLIENT_TEST_LANE === 'integration';
 
-export default defineConfig({
+// This package is the Next Pages-API backend and the SPA in one workspace, so its test files
+// split cleanly by directory: everything under these trees is a route/queue/cron handler or the
+// server library they call, Node by construction and never touching a DOM. They are ~570 of the
+// package's ~1040 test files, and a package-wide `environment: 'jsdom'` built a DOM for every one
+// of them: in the CI shard that made environment construction (931s summed across workers) cost
+// more than executing the tests (425s), which is what pushed the job into its own timeout with
+// every test passing (#2015).
+//
+// The few files under these trees that DO need a DOM opt back in per file with a
+// `// @vitest-environment jsdom` docblock - the same escape hatch ~40 files here already use in
+// the opposite direction, which is why this is a default change rather than a new convention.
+const NODE_TEST_ROOTS = ['server', 'pages'];
+
+// A copy of vitest's own default `include`, needed because the node project's globs are
+// directory-prefixed and so cannot be left implicit. Deliberately used for the NODE side only:
+// the jsdom project leaves `include` unset in the unit lane so vitest's real default applies
+// there. If this copy ever falls behind vitest's default, the consequence is that a file runs
+// under jsdom instead of node - slower, still correct - rather than matching no project at all.
+// A test file silently not running is the one failure mode here that nothing would report.
+const VITEST_DEFAULT_INCLUDE = ['**/*.{test,spec}.?(c|m)[jt]s?(x)'];
+
+// Two lanes over one config, selected by CLIENT_TEST_LANE (set only by the `test:integration`
+// script). The ~20 `*.e2e.test.ts` files each boot a real mongod, and running them inline pushed
+// this shard's job past its CI budget even though the suite itself passed - so they get their own
+// matrix shard. One config rather than two so the aliases, setup file and environment split cannot
+// drift between the lanes.
+// NOTE: `test:e2e` in package.json is Playwright, NOT these files. The Playwright directory is
+// the bare 'e2e' exclusion below.
+// `undefined` in the unit lane means "whatever vitest includes by default" - see above.
+const LANE_INCLUDE = INTEGRATION_LANE ? ['**/*.e2e.test.ts'] : undefined;
+
+// The node project claims exactly these; the jsdom project excludes exactly these. Deriving both
+// sides from this one list is what makes the split disjoint AND jointly complete: a file these
+// globs miss falls THROUGH to jsdom rather than out of the run, which a `server/**` blanket
+// exclusion on the jsdom side would not have guaranteed.
+const NODE_PROJECT_INCLUDE = NODE_TEST_ROOTS.flatMap(root =>
+  (LANE_INCLUDE ?? VITEST_DEFAULT_INCLUDE).map(glob => `${root}/${glob}`)
+);
+
+const LANE_EXCLUDE = [
+  '**/node_modules/**',
+  'e2e',
+  '.next/**',
+  '.open-next/**',
+  ...(INTEGRATION_LANE ? [] : ['**/*.e2e.test.ts']),
+];
+
+// Test options both projects share. Spread rather than relied on as inherited: a project config
+// does not pick up the root `test` block, and letting each project carry its own copy of
+// `setupFiles`/timeouts is exactly the drift this single config exists to prevent.
+const projectTest = {
+  ...sharedTest,
+  globals: true,
+  setupFiles: [path.resolve(__dirname, 'vitest.setup.ts')],
+  // Raise the 15s shared floor to 30s. Load-bearing for the integration lane, which holds ~20
+  // real-Mongo suites (createMongoServer/createMongoReplSet): their first write per worker pays an
+  // unavoidable, legitimate cold-start: Mongoose builds every model's indexes on connect (needed
+  // for correctness - the rate-limit suite depends on one, so autoIndex CANNOT be disabled) plus
+  // first-collection creation. Measured at 16-22s under that lane's file parallelism, so 15s (a
+  // unit-test budget) fails 4-ish suites at random - the exact flake. This is not a hang mask: it
+  // is the right budget for integration tests. Attempts to shrink the cold-start instead were
+  // dead ends - autoIndex:false breaks index-dependent suites, and a single shared mongod
+  // serializes every worker's index builds and made it markedly worse.
+  testTimeout: 30000,
+};
+
+// Vite-level options both projects share. A factory, not a constant: each project gets its own
+// Vite server, and plugin instances are stateful and must not be shared across them.
+const projectVite = () => ({
   plugins: [react(), tsconfigPaths()],
-  test: {
-    ...sharedTest,
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: [path.resolve(__dirname, 'vitest.setup.ts')],
-    // Raise the 15s shared floor to 30s. Load-bearing for the integration lane below, which
-    // holds ~20 real-Mongo suites (createMongoServer/createMongoReplSet): their first write
-    // per worker pays an
-    // unavoidable, legitimate cold-start: Mongoose builds every model's indexes on connect
-    // (needed for correctness - the rate-limit suite depends on one, so autoIndex CANNOT be
-    // disabled) plus first-collection creation. Measured at 16-22s under that lane's file
-    // parallelism, so 15s (a unit-test budget) fails 4-ish suites at random - the exact flake.
-    // This is not a hang mask: it is the right budget for integration tests. Attempts to shrink
-    // the cold-start instead were dead ends - autoIndex:false breaks index-dependent suites, and
-    // a single shared mongod serializes every worker's index builds and made it markedly worse.
-    testTimeout: 30000,
-    // Two lanes over one config, selected by CLIENT_TEST_LANE (set only by the
-    // `test:integration` script). The ~20 `*.e2e.test.ts` files each boot a real
-    // mongod, and running them inline pushed this shard's job past its 20-minute
-    // CI budget even though the suite itself passed - so they get their own
-    // matrix shard. One config rather than two so the aliases, setup file and
-    // environment cannot drift between the lanes.
-    // NOTE: `test:e2e` in package.json is Playwright, NOT these files. The
-    // Playwright directory is the bare 'e2e' exclusion below.
-    ...(INTEGRATION_LANE ? { include: ['**/*.e2e.test.ts'] } : {}),
-    exclude: [
-      '**/node_modules/**',
-      'e2e',
-      '.next/**',
-      '.open-next/**',
-      ...(INTEGRATION_LANE ? [] : ['**/*.e2e.test.ts']),
-    ],
-  },
   resolve: {
     alias: {
       '@server': path.resolve(__dirname, 'server'),
@@ -63,5 +98,42 @@ export default defineConfig({
   },
   optimizeDeps: {
     include: ['uuid'],
+  },
+});
+
+export default defineConfig({
+  test: {
+    // Both projects and this root spread the same `sharedTest`, so they resolve to an IDENTICAL
+    // worker budget - which is load-bearing twice over. Two projects resolving to DIFFERENT
+    // counts under the same `sequence.groupOrder` is a hard vitest error; identical ones share a
+    // single group, so their files interleave over ONE pool. That means the environment split
+    // below costs no file parallelism, and VITEST_MAX_WORKERS still caps the whole run rather
+    // than being handed out once per project.
+    ...sharedTest,
+    projects: [
+      {
+        ...projectVite(),
+        test: {
+          ...projectTest,
+          name: 'node',
+          environment: 'node',
+          include: NODE_PROJECT_INCLUDE,
+          exclude: LANE_EXCLUDE,
+        },
+      },
+      {
+        ...projectVite(),
+        test: {
+          ...projectTest,
+          name: 'jsdom',
+          environment: 'jsdom',
+          // Left unset in the unit lane on purpose: vitest's own default include applies, so this
+          // project is the catch-all and no test file can match zero projects.
+          ...(LANE_INCLUDE ? { include: LANE_INCLUDE } : {}),
+          // Excludes exactly what the node project includes - same list, not a restatement of it.
+          exclude: [...LANE_EXCLUDE, ...NODE_PROJECT_INCLUDE],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
# Pull Request

## Description

`Run Tests (client)` was being killed by its 20-minute cap **after every test had passed** - the job printed a clean summary and was then cancelled during post-job cleanup, so the PR went red with nothing wrong in it. It was not branch-specific; `main` lost the same coin flip. A 4.5-minute swing on identical test content against a 20-minute wall, with runner speed casting the deciding vote.

The root cause is where the time goes, not the cap. From the failing run's own breakdown (summed across workers): `import 1524.73s   environment 931.24s   tests 425.19s`. **Executing tests is only 425s of it.** `apps/client` set `environment: 'jsdom'` for the whole package, so all 1045 test files built a DOM - but everything under `server/` and `pages/` is a route/queue/cron handler or the server library it calls. That is 563 files, Node by construction, paying for a DOM they never read.

So this PR does the thing worth doing (stop building the DOM) and raises the cap only as cover for it, with a soft budget so the next creep is visible before it reddens anyone's PR.

Closes #2015

## Changes

**`apps/client/vitest.config.mts` - two vitest projects instead of one jsdom-everywhere config**

| project | covers | environment |
|---|---|---|
| `node` | `server/**` + `pages/**` (563 files) | `node` |
| `jsdom` | everything else (482 files) | `jsdom` |

Both sides derive from one `NODE_PROJECT_INCLUDE` list - the node project *includes* it, the jsdom project *excludes* it. Two deliberate choices there:

- **Not** a `server/**` blanket exclusion on the jsdom side. With the derived form, a glob that misses a file sends it to jsdom (slower, still correct) rather than dropping it from both projects. A test file silently not running is the one failure mode here that nothing would report.
- The jsdom project leaves `include` unset in the unit lane so vitest's own default applies, making it the catch-all.

The worker budget stays identical across both projects (both spread `sharedTest`). That is load-bearing: two projects resolving to *different* worker counts under the same `sequence.groupOrder` is a hard vitest error, and identical ones share a single group, so their files interleave over one pool. The environment split therefore costs no file parallelism, and `VITEST_MAX_WORKERS` still caps the whole run rather than being handed out once per project.

**`.github/workflows/ci.yml`**

- `timeout-minutes` 20 -> 30. A hard ceiling whose only job is killing a genuine hang; it costs nothing when a shard finishes early.
- New `Mark shard start` / `Report shard duration` pair. The report never fails, runs under `always()` so a failing shard still reports, writes each shard's duration to the step summary, and emits a `::warning` annotation past a 1200s soft budget. The old cap becomes a warning instead of a kill - which is the whole point, since the only signal this shard had crept from 15 minutes to 20 was a random red PR.

**Two test files the switch broke - both loudly, neither silently**

- `pages/api/publish/__tests__/widget.test.ts` genuinely executes the served widget in a DOM, so it gets a `// @vitest-environment jsdom` docblock. This is the escape hatch ~45 files in this package already use (40 of them in the opposite direction, `node`), which is why this is a default change rather than a new convention.
- `server/api/jupyter/__tests__/execute.test.ts` mocked `crypto.randomUUID` to `'test-uuid-1234'` and then asserted `/^[0-9a-f-]{36}$/`. **It only ever passed because the mock was dead under jsdom.** Under `node` the mock takes effect, so the contradiction became visible. The expectation now reads the mocked id, hoisted via `vi.hoisted` so mock and assertion share one constant.

**Docs** - `CLAUDE.md` -> Testing guidelines gained a "Test environment in `apps/client`" block: the project table, the per-file docblock convention, the `--project node` invocation, and a warning about mocks that were dead under jsdom.

**Comment correction** - `server/s3/moderateUploadedFile.test.ts` opened with "jsdom (this package's default test environment)", which this PR falsifies. Reworded to keep the *why* (jsdom's separate vm realm breaks `file-type`'s Buffer `instanceof` check) rather than leaving a comment that lies.

## Guide for Testers

This is a CI and test-infrastructure PR. **There is no application behaviour to click through** - see "What NOT to test" below.

### A. Confirm no test was dropped or duplicated (the important check)

The risk of splitting one project into two is that a file lands in both (runs twice) or neither (silently stops running). Verify the file sets are unchanged:

1. Check out this branch and install: `pnpm install --frozen-lockfile --recursive`
2. Build core packages: `pnpm turbo:core:build`
3. List the unit lane's files: `pnpm --filter @bike4mind/client exec vitest list --filesOnly`
   - **Expected:** 1045 lines, each prefixed `[node]` or `[jsdom]`. Exactly 563 are `[node]`.
   - Count with: `pnpm --filter @bike4mind/client exec vitest list --filesOnly | grep -c '^\[node\]'` -> `563`
4. Confirm no file is claimed twice:
   `pnpm --filter @bike4mind/client exec vitest list --filesOnly | sed -E 's/^\[[a-z]+\] //' | sort | uniq -d`
   - **Expected:** no output.
5. Compare against `main`: `git stash` is not needed - run step 3 on `origin/main` (where the output has no `[project]` prefix) and diff the two sorted lists.
   - **Expected:** identical, 1045 files both sides.
6. Same for the integration lane:
   `CLIENT_TEST_LANE=integration pnpm --filter @bike4mind/client exec vitest list --filesOnly`
   - **Expected:** 20 files, all `[node]`. The `jsdom` project matching zero files here is intentional and does not error.

### B. Confirm both lanes are green

7. Unit lane: `pnpm --filter @bike4mind/client test`
   - **Expected:** `Test Files 1035 passed | 10 skipped (1045)`, `Tests 11026 passed | 81 skipped (11107)`, exit 0.
   - In the `Duration` line, **expected:** `environment` is roughly half what it is on `main` (measured 958s -> 523s summed across workers on a 15-core box).
8. Integration lane (boots real mongod, needs Docker/network for the binary):
   `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/client run test:integration`
   - **Expected:** `Test Files 20 passed (20)`, `Tests 98 passed (98)`, and `environment 1ms` in the Duration line.

### C. Confirm the escape hatch works both ways

9. Temporarily add `const x = document.title;` at the top of any `server/**/*.test.ts`, then run that one file.
   - **Expected:** it fails immediately with `ReferenceError: document is not defined`. This is the intended signal - the fix is to add `// @vitest-environment jsdom` as the file's first line, not to change the config.
10. Add that docblock and re-run the same file.
    - **Expected:** it passes. Revert both edits.

### D. Confirm the CI reporting (observable on this PR's own run)

11. Open this PR's Actions run -> any `Run Tests (<shard>)` job -> the job summary.
    - **Expected:** a line like `- Run Tests (client: 15m42s)` (that is the value this PR's own run reported).
12. If a shard exceeds 20 minutes, **expected:** a yellow `Slow test shard` warning annotation on the run, and the job still **passes**. It must never fail on duration alone.
13. Check the job's step list.
    - **Expected:** `Report shard duration` ran even on any shard that failed (it is `if: always()`).

### Regression Checks

14. `pnpm turbo:typecheck` -> clean.
15. `pnpm lint:check` -> clean.
16. Run a jsdom-side component test to confirm the jsdom project still has its theme wrapper, setup file and aliases: `pnpm --filter @bike4mind/client exec vitest run app/components/Charts/MermaidChart.test.tsx`
    - **Expected:** passes. (Both projects share one `projectTest` / `projectVite` definition specifically so aliases, `setupFiles`, `globals` and timeouts cannot drift between them.)
17. Confirm `testTimeout` is still 30s in both projects - the integration lane's real-Mongo cold start depends on it. Step 8 passing is the check.
18. Confirm `VITEST_MAX_WORKERS` still caps the run globally rather than per project:
    `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/client exec vitest run server/utils` and count worker processes with `ps -eo command | grep -c '[v]itest'` while it runs.
    - **Expected:** 2 worker processes (plus the main process), not 4.

### What NOT to test

- No UI, no route, no API surface changed. There is nothing to click in the app, no preview environment needed, and no admin setting to flip.
- Do not test the two touched test files for product behaviour - `widget.test.ts` gained one comment line, and `execute.test.ts`'s change is an assertion correction, not a change to `/api/jupyter/execute`.
- Do not treat local wall-clock as the headline number: see Additional Information.

## Additional Information

**Measured back to back on one 15-core box, full unit lane:**

| | `main` | this branch |
|---|---|---|
| wall | 285.5s | 262.1s |
| `environment` (summed across workers) | 958.5s | 523.4s |
| user + sys CPU | 2686s | 2392s |

Being straight about the extrapolation: the **local** wall-clock gain is only 8%, because a 15-core box is not CPU-bound on this suite - it overlaps ~13x, so 435s of saved summed work compresses to ~23s of wall. The CI shard overlaps ~2.9x (3116s summed / 1092s wall, from the numbers in #2015), so the same 435s should be worth roughly **2-4 minutes** there.

**Measured on CI.** This PR's own `Run Tests (client)`, against the failing baseline run recorded in #2015 (same `ubuntu-latest-m` runner class):

| | `main` (the cancelled run in #2015) | this PR |
|---|---|---|
| test-step wall | 1092.02s (18m12s) | **940.96s (15m41s)** |
| `environment` (summed) | 931.24s | **459.55s** |
| `import` | 1524.73s | 1560.06s |
| `tests` | 425.19s | 394.41s |
| `transform` | 54.87s | 52.80s |
| `setup` | 180.22s | 191.56s |
| test files | 1038 | **1046** |
| job total | 20m12s -> **cancelled** | 17m34s -> **pass** |

**-151s (-2m31s, -13.8%) on the test step, while running 8 more files than the baseline.** `environment` halved, -471.7s summed. The implied overlap is 471.7/151 = 3.12x against the ~2.9x assumed above, so the estimate held and landed at the low end of its range.

The new reporting step logged **942s**, matching vitest's own 940.96s - confirming the mark/report pair measures test runtime rather than test runtime plus install, as intended. No warning annotation fired, correctly, since 942s is under the 1200s soft budget. Note that the 1092s baseline **would** have tripped it, which is the point.

**Caveat on that comparison:** the baseline is a single run quoted in #2015, not one re-run on this branch's merge base, and #2015 itself documents a 4.5-minute run-to-run swing on identical test content. So treat the wall-clock delta as one sample. The `environment` line is the part that is structural rather than a coin flip.

**Also honest about scope:** this is items 1 and 2 of the three in #2015. Item 3 - splitting the client shard itself, since 1038 files in one job is the structural problem - is not attempted here. If the reported duration after this lands is still uncomfortably close to the wall, that is the next move, and the new duration line is what tells us.

**Why the `import` figure moves around:** these summed metrics are per-worker wall time, so they inflate under contention. On a busy box I measured the same config at `environment 870s` and on a quiet one at `523s`. Only compare runs taken back to back on the same machine.

## Developer Notes (Optional)

- **Per-file environment override is now the sanctioned pattern in `apps/client`.** `// @vitest-environment jsdom` (or `node`) as a file's first line beats widening a project's globs, and is documented in CLAUDE.md. ~45 files already used it; this PR makes it the mechanism rather than a workaround.
- **Derive-one-side-from-the-other for project partitions.** `NODE_PROJECT_INCLUDE` is the single list; node includes it, jsdom excludes it. This is the same "complete by construction" reasoning the `misc` test shard's negation filter already uses in `ci.yml` - worth reaching for whenever two config buckets must jointly cover a set. Note the asymmetry that makes it fail-safe: the catch-all bucket leaves `include` unset, so drift degrades to "ran in the wrong bucket" instead of "did not run".
- **Soft budget alongside a hard cap.** `SHARD_SOFT_BUDGET_SECONDS` + a non-failing report is a reusable shape for any job whose runtime creeps: keep the timeout as a hang-killer, and put the thing you actually want to watch behind a warning so it surfaces on green builds. Two numbers with genuinely different jobs, not a duplicated constant.
- **A dead mock is invisible until the environment changes.** `vi.mock('crypto', ...)` did not take effect under jsdom in this package, so `execute.test.ts` asserted the opposite of what it mocked and passed anyway for however long. Worth a glance at any other suite whose assertion and mock disagree.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
