### PR TITLE
fix(services): thread the turn abort signal into tool sub-calls

### DIFF
--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -116,6 +116,10 @@ const ToolContainer = ({ children, sx, toolId }: ToolContainerProps) => {
   const content = (
     <Box
       className="tool-container"
+      // Every gated tool row is addressable by its own id. Hand-added per-tool testids drifted
+      // (image/music/audio had one, deep_research did not), which is exactly the tool an e2e run
+      // for a cancellation change needs to reach.
+      data-testid={toolId ? `tool-row-${toolId}` : undefined}
       sx={theme => {
         const baseStyles = {
           // The row needs its own frame colour, distinct from the surface behind it. Dark mode

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -3046,7 +3046,13 @@ async function processSubagentDispatch(
       toolAvailability
     );
 
+    // Created here rather than alongside its watchdog below because the tools built on the next
+    // line need its signal: a tool that runs its own llm.complete (deep_research, blog_draft, ...)
+    // otherwise keeps generating past both abort triggers. See ToolContext.getAbortSignal.
+    const abortController = new AbortController();
+
     const tools = buildSharedTools({ ...toolDeps, optInTools: subagentLatticeTools }, toolCallbacks, {
+      getAbortSignal: () => abortController.signal,
       config: subagentToolConfig,
       mcpToolsByServer,
       // Empty on purpose: buildSharedTools RETURNS only `tools` (agent-only MCP
@@ -3123,7 +3129,6 @@ async function processSubagentDispatch(
     // LIMITATION: 0..5s window where an aborted child keeps running before
     // the next poll tick. Acceptable - the agent stops at the next iteration
     // boundary inside the LLM call.
-    const abortController = new AbortController();
     const abortPoller = setInterval(() => {
       // Cheap synchronous check first - no DB roundtrip if we're already done.
       if (context.getRemainingTimeInMillis() < PARENT_DEADLINE_BUFFER_MS && !abortController.signal.aborted) {

--- a/b4m-core/services/src/llm/sharedToolBuilder.ts
+++ b/b4m-core/services/src/llm/sharedToolBuilder.ts
@@ -311,6 +311,7 @@ export function buildSharedTools(
       suppressLakeArms,
       sessionRetrievalTags,
       questId: callbacks.questId,
+      getAbortSignal,
     },
     storage,
     imageGenerateStorage,

--- a/b4m-core/services/src/llm/tools/ToolBuilder.abortSignal.test.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.abortSignal.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ToolBuilder, type ToolBuilderConfig, type BuildToolsArgs } from './ToolBuilder';
+import type { ToolDefinition, ToolContext } from './base/types';
+
+// Same stub rationale as ToolBuilder.inlinedAttachmentIds.test.ts: b4mTools drags in every real
+// tool implementation, and only the probe below matters here. generateTools stays real - the point
+// is to exercise the actual ToolBuilder -> buildSharedTools -> generateTools chain.
+vi.mock('./index', async importOriginal => {
+  const actual = await importOriginal<typeof import('./index')>();
+  return { ...actual, b4mTools: {} };
+});
+
+/**
+ * Proves the turn's cancellation signal reaches ToolContext, so a tool that runs its own
+ * llm.complete can be stopped. Before this was threaded, the signal stopped at
+ * delegate_to_agent / coordinate_task and every generic tool got a ToolContext with no
+ * cancellation field at all - a Stop settled the chat turn while the tool's nested generation
+ * kept billing.
+ *
+ * The laziness case is the load-bearing one. Tools are built during tool setup, before the
+ * turn's AbortController exists, so the contract has to be a getter over a holder the host
+ * fills in later. A captured AbortSignal would type-check, pass a naive "is it defined" test
+ * at invocation time, and still be a permanent undefined in production.
+ */
+describe('ToolBuilder threads getAbortSignal into ToolContext', () => {
+  function probeTool(): { tool: ToolDefinition; getContext: () => ToolContext | undefined } {
+    let seen: ToolContext | undefined;
+    const tool: ToolDefinition = {
+      name: 'probe',
+      implementation: context => {
+        seen = context as ToolContext;
+        return {
+          toolFn: async () => '',
+          toolSchema: { name: 'probe', description: 'test probe', parameters: { type: 'object', properties: {} } },
+        };
+      },
+    };
+    return { tool, getContext: () => seen };
+  }
+
+  function makeBuilder(): ToolBuilder {
+    const deps = {
+      user: { id: 'u1' },
+      db: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), updateMetadata: vi.fn() },
+      storage: {},
+      imageGenerateStorage: {},
+      toolCreditsMap: new Map(),
+      subagentTelemetryData: [],
+      sendStatusUpdate: vi.fn(),
+    } as unknown as ToolBuilderConfig;
+    return new ToolBuilder(deps);
+  }
+
+  function callBuildTools(tool: ToolDefinition, getAbortSignal?: () => AbortSignal | undefined): void {
+    makeBuilder().buildTools({
+      enabledTools: ['probe'],
+      externalTools: { probe: tool },
+      getAbortSignal,
+      quest: {} as never,
+      saveQuest: vi.fn() as never,
+      llm: {} as never,
+      config: {},
+    } as unknown as BuildToolsArgs);
+  }
+
+  it('resolves the signal at tool-invocation time, not at build time', () => {
+    // Mirrors the real host: the holder is empty while tools are built and only filled in once
+    // the turn's AbortController is created, several hundred lines later.
+    const holder: { signal?: AbortSignal } = {};
+    const { tool, getContext } = probeTool();
+
+    callBuildTools(tool, () => holder.signal);
+    expect(getContext()?.getAbortSignal).toBeTypeOf('function');
+    expect(getContext()?.getAbortSignal?.()).toBeUndefined();
+
+    const controller = new AbortController();
+    holder.signal = controller.signal;
+
+    expect(getContext()?.getAbortSignal?.()).toBe(controller.signal);
+  });
+
+  it('surfaces the aborted state through the same getter once the turn is stopped', () => {
+    const controller = new AbortController();
+    const { tool, getContext } = probeTool();
+
+    callBuildTools(tool, () => controller.signal);
+    expect(getContext()?.getAbortSignal?.()?.aborted).toBe(false);
+
+    controller.abort();
+    expect(getContext()?.getAbortSignal?.()?.aborted).toBe(true);
+  });
+
+  it('leaves getAbortSignal undefined on hosts that supply no controller', () => {
+    const { tool, getContext } = probeTool();
+    callBuildTools(tool, undefined);
+    expect(getContext()?.getAbortSignal).toBeUndefined();
+  });
+});

--- a/b4m-core/services/src/llm/tools/base/types.ts
+++ b/b4m-core/services/src/llm/tools/base/types.ts
@@ -259,7 +259,18 @@ export interface ToolContext {
    * Hosts supply a closure over a mutable holder they fill in later - the shape the
    * delegate_to_agent / coordinate_task path already uses.
    *
-   * Absent on hosts that have no per-turn controller to hand over - among them the top-level
+   * IT CAN RETURN UNDEFINED EVEN WHEN THE HOST PASSED A GETTER, so treat a missing signal as
+   * normal rather than as a bug. Three cases, and the third is the surprising one:
+   *   - the host wires no controller at all (see below);
+   *   - the holder is not filled yet (a tool somehow invoked during tool setup);
+   *   - ChatCompletionProcess's Research Mode branch, which returns before it ever assigns
+   *     the holder, yet hands `allTools` - these same tool instances - to ResearchModeService.
+   *     That service takes no signal today and the cancellation watcher starts after the
+   *     branch returns, so Research Mode has no cancellation of any kind; tool sub-calls on
+   *     that path stay uninterruptible across every parallel configuration. Fixing it means
+   *     giving Research Mode a controller and a watcher of its own, not changing this contract.
+   *
+   * Absent entirely on hosts with no per-turn controller to hand over - the top-level
    * agent-executor loop, which cancels via a polled `AgentExecution` abort flag rather than an
    * AbortSignal, and the headless deep-agent runner. Those paths get nothing until they grow a
    * controller of their own; the dispatched-subagent path already has one and passes it.

--- a/b4m-core/services/src/llm/tools/base/types.ts
+++ b/b4m-core/services/src/llm/tools/base/types.ts
@@ -247,6 +247,24 @@ export interface ToolContext {
   allowedDirectories?: string[];
   /** Optional code minifier for `file_read`'s opt-in `minified` mode. See CodeMinifier. */
   codeMinifier?: CodeMinifier;
+  /**
+   * Cancellation signal for the turn that invoked this tool, for tools that run their own
+   * `llm.complete()` (deep_research, blog_draft, edit_file, jupyter_notebook, ...). Pass the
+   * result as `abortSignal` on those sub-calls, or pressing Stop settles the chat turn while
+   * the tool's nested generation keeps billing until the provider finishes on its own.
+   *
+   * A getter, not an `AbortSignal`: tools are built before the turn's AbortController exists
+   * (ChatCompletionProcess builds tools during `tool_setup` and only creates the controller
+   * once it is about to call the model), so a captured value would be a permanent `undefined`.
+   * Hosts supply a closure over a mutable holder they fill in later - the shape the
+   * delegate_to_agent / coordinate_task path already uses.
+   *
+   * Absent on hosts that have no per-turn controller to hand over - among them the top-level
+   * agent-executor loop, which cancels via a polled `AgentExecution` abort flag rather than an
+   * AbortSignal, and the headless deep-agent runner. Those paths get nothing until they grow a
+   * controller of their own; the dispatched-subagent path already has one and passes it.
+   */
+  getAbortSignal?: () => AbortSignal | undefined;
 }
 
 export interface ToolDefinition {

--- a/b4m-core/services/src/llm/tools/implementation/blogDraft/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/blogDraft/index.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ClaudeArtifactMimeTypes } from '@bike4mind/common';
-import { sanitizeJsonString, parseTransformationResult, wrapDraftAsArtifact } from './index';
+import { sanitizeJsonString, parseTransformationResult, wrapDraftAsArtifact, blogDraftTool } from './index';
+import type { ToolContext } from '../../base/types';
 
 // Mirror the production artifact-parsing regexes (sharedToolBuilder.ts / client artifactParser.ts)
 const ARTIFACT_RE = /<artifact\s+([^>]*)>([\s\S]*?)<\/artifact>/i;
@@ -303,5 +304,50 @@ Line 3",
       expect(JSON.parse(parsed.body)).toEqual(tricky);
       expect(JSON.parse(parsed.body).content).toContain('</artifact>');
     });
+  });
+});
+
+/**
+ * Consumer half of the cancellation seam (the producer half is
+ * ToolBuilder.abortSignal.test.ts). A tool that never forwards
+ * `context.getAbortSignal()` into its own llm.complete keeps generating - and billing - after
+ * the user presses Stop, because the turn's controller only reaches the outer completion.
+ *
+ * blog_draft stands in for all four tools that run their own generation (blog_draft,
+ * deep_research, edit_file, jupyter_notebook); each opts in with the same one-liner.
+ */
+describe('blogDraftTool forwards the turn abort signal to its own llm.complete', () => {
+  function runTool(getAbortSignal?: () => AbortSignal | undefined) {
+    const complete = vi.fn(async (_model, _messages, _options, callback) => {
+      await callback([JSON.stringify({ title: 'T', content: 'C', summary: 'S', suggestedTags: [] })], undefined);
+    });
+    const context = {
+      userId: 'u1',
+      user: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      db: {},
+      llm: { complete },
+      model: 'test-model',
+      getAbortSignal,
+    } as unknown as ToolContext;
+
+    const run = blogDraftTool
+      .implementation(context, undefined)
+      .toolFn({ sourceContent: 'hello', outputFormat: 'blog' }, {} as never);
+
+    return { run, optionsOf: () => complete.mock.calls[0]?.[2] };
+  }
+
+  it('passes the live signal through as abortSignal', async () => {
+    const controller = new AbortController();
+    const { run, optionsOf } = runTool(() => controller.signal);
+    await run;
+    expect(optionsOf()?.abortSignal).toBe(controller.signal);
+  });
+
+  it('sends no signal when the host supplies no getter', async () => {
+    const { run, optionsOf } = runTool(undefined);
+    await run;
+    expect(optionsOf()?.abortSignal).toBeUndefined();
   });
 });

--- a/b4m-core/services/src/llm/tools/implementation/blogDraft/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/blogDraft/index.test.ts
@@ -350,4 +350,55 @@ describe('blogDraftTool forwards the turn abort signal to its own llm.complete',
     await run;
     expect(optionsOf()?.abortSignal).toBeUndefined();
   });
+
+  // Making the sub-call cancellable means this tool now sees AbortError for the first time, and
+  // the pre-existing catch logged everything at error level - so every Stop would read as a
+  // blog_draft fault in the logs.
+  it('does not log a user Stop as a fault, and still rethrows', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const context = {
+      userId: 'u1',
+      user: {},
+      logger,
+      db: {},
+      llm: {
+        complete: vi.fn(async () => {
+          throw abortError;
+        }),
+      },
+      model: 'test-model',
+      getAbortSignal: () => controller.signal,
+    } as unknown as ToolContext;
+
+    await expect(
+      blogDraftTool.implementation(context, undefined).toolFn({ sourceContent: 'x', outputFormat: 'blog' }, {} as never)
+    ).rejects.toBe(abortError);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('still logs a genuine failure at error level', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const context = {
+      userId: 'u1',
+      user: {},
+      logger,
+      db: {},
+      llm: {
+        complete: vi.fn(async () => {
+          throw new Error('provider exploded');
+        }),
+      },
+      model: 'test-model',
+      getAbortSignal: () => new AbortController().signal,
+    } as unknown as ToolContext;
+
+    await expect(
+      blogDraftTool.implementation(context, undefined).toolFn({ sourceContent: 'x', outputFormat: 'blog' }, {} as never)
+    ).rejects.toThrow(/provider exploded/);
+    expect(logger.error).toHaveBeenCalled();
+  });
 });

--- a/b4m-core/services/src/llm/tools/implementation/blogDraft/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/blogDraft/index.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@bike4mind/observability';
 import { randomUUID } from 'crypto';
 import type { CompletionInfo } from '@bike4mind/llm-adapters';
-import { ChatModels, ClaudeArtifactMimeTypes } from '@bike4mind/common';
+import { ChatModels, ClaudeArtifactMimeTypes, isUserInitiatedAbort } from '@bike4mind/common';
 import { ToolDefinition } from '../../base/types';
 import { recordToolOperationalUsage } from '../../base/recordToolOperationalUsage';
 import { sanitizeJsonString } from '../../utils/jsonSanitize';
@@ -274,6 +274,9 @@ export const blogDraftTool: ToolDefinition = {
           {
             temperature: 0.7,
             stream: false,
+            // Without this the turn's Stop settles the chat but leaves this sub-call
+            // generating (and billing) until the provider finishes. See ToolContext.getAbortSignal.
+            abortSignal: context.getAbortSignal?.(),
           },
           async (texts, info) => {
             llmResponse = texts.filter(t => t !== null && t !== undefined).join('');
@@ -299,7 +302,14 @@ export const blogDraftTool: ToolDefinition = {
         // drafts created in the same millisecond can't collide.
         return wrapDraftAsArtifact(result, `blog-draft-${randomUUID()}`);
       } catch (error) {
-        logger.error('Blog draft creation failed:', error);
+        // Now that the sub-call above is cancellable, a user Stop lands here as an AbortError.
+        // That is the request working as intended, so keep it out of the error logs - otherwise
+        // every Stop looks like a blog_draft fault. The caller still needs the throw.
+        if (error instanceof Error && isUserInitiatedAbort(error, context.getAbortSignal?.())) {
+          logger.debug('Blog draft cancelled by the caller');
+        } else {
+          logger.error('Blog draft creation failed:', error);
+        }
         throw error;
       }
     },

--- a/b4m-core/services/src/llm/tools/implementation/deepResearch/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/deepResearch/index.test.ts
@@ -26,9 +26,22 @@ const ANALYSIS_STOP = JSON.stringify({
   analysis: { summary: 'done', gaps: [], nextSteps: [], shouldContinue: false },
 });
 
-function makeContext() {
+// Planner output that keeps the research loop fed: a gap, shouldContinue, and a follow-up query.
+// Needed to prove the loop is stopped by cancellation rather than by simply running dry.
+const ANALYSIS_CONTINUE = JSON.stringify({
+  analysis: {
+    summary: 'more to do',
+    gaps: ['gap'],
+    nextSteps: ['next'],
+    shouldContinue: true,
+    nextSearchTopic: 'follow-up query',
+  },
+});
+
+function makeContext(getAbortSignal?: () => AbortSignal | undefined) {
   const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() };
   return {
+    getAbortSignal,
     userId: 'user-1',
     user: { organizationId: undefined },
     logger,
@@ -127,5 +140,76 @@ describe('performDeepResearch discovery precedence', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/web search provider|Firecrawl/i);
+  });
+});
+
+/**
+ * Cancellation has to end the research LOOP, not just the in-flight analysis sub-call.
+ * Every phase of an iteration (searcher calls, content extraction, analysis) is separately
+ * billable and each one's catch swallows its own error, so a run that only threaded the signal
+ * into llm.complete would keep searching to maxDepth after Stop - each analysis aborting
+ * instantly while the web searches around it still burned real quota.
+ */
+describe('performDeepResearch honors the turn abort signal', () => {
+  it('does no search work at all when the turn is already aborted', async () => {
+    const provider = searchProvider();
+    createFirecrawlApp.mockReturnValue(null);
+    resolveWebSearchProvider.mockResolvedValue(provider);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await performDeepResearch(
+      makeContext(() => controller.signal),
+      { topic: 'quantum computing' },
+      { maxDepth: 3, duration: 1 }
+    );
+
+    expect(result.success).toBe(true);
+    expect(provider.search).not.toHaveBeenCalled();
+  });
+
+  it('stops after the in-flight iteration instead of running to maxDepth', async () => {
+    const controller = new AbortController();
+    // Stop pressed while the first iteration's search is in flight.
+    const provider = {
+      name: 'searxng' as const,
+      search: vi.fn(async () => {
+        controller.abort();
+        return [{ url: 'https://sx.example/1', title: 'SX', snippet: 's' }];
+      }),
+    };
+    createFirecrawlApp.mockReturnValue(null);
+    resolveWebSearchProvider.mockResolvedValue(provider);
+
+    const context = makeContext(() => controller.signal);
+    // The planner must keep feeding the loop work, or it would run out of queries after the
+    // first iteration and this would pass with no abort handling at all.
+    (context.llm.complete as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_model: string, _msgs: unknown, _opts: unknown, cb: (c: string[], i?: unknown) => void) => {
+        await cb([ANALYSIS_CONTINUE], undefined);
+      }
+    );
+
+    await performDeepResearch(context, { topic: 'quantum computing' }, { maxDepth: 5, duration: 1 });
+
+    expect(provider.search).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the signal into its own analysis sub-call', async () => {
+    const provider = searchProvider();
+    createFirecrawlApp.mockReturnValue(null);
+    resolveWebSearchProvider.mockResolvedValue(provider);
+
+    const controller = new AbortController();
+    const context = makeContext(() => controller.signal);
+
+    await performDeepResearch(context, { topic: 'quantum computing' }, { maxDepth: 1, duration: 1 });
+
+    const complete = context.llm.complete as unknown as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalled();
+    for (const call of complete.mock.calls) {
+      expect((call[2] as { abortSignal?: AbortSignal }).abortSignal).toBe(controller.signal);
+    }
   });
 });

--- a/b4m-core/services/src/llm/tools/implementation/deepResearch/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/deepResearch/index.ts
@@ -306,7 +306,8 @@ export async function performDeepResearch(
     await analysisLlm.complete(
       analysisModel,
       [{ role: 'user', content: prompt }],
-      { temperature: 0.1, stream: false },
+      // abortSignal: see ToolContext.getAbortSignal - Stop must reach nested generation too.
+      { temperature: 0.1, stream: false, abortSignal: context.getAbortSignal?.() },
       async (chunks, info) => {
         result += chunks[0] || '';
         if (info) completionInfo = info;
@@ -365,6 +366,15 @@ export async function performDeepResearch(
     while (state.depth < maxDepth && !state.completed) {
       const timeElapsed = Date.now() - startTime;
       if (timeElapsed >= timeLimit) {
+        break;
+      }
+
+      // Threading the signal into the analysis sub-call above is not enough on its own: every
+      // phase below (searcher calls, content extraction, analysis) is separately billable, and
+      // each one's catch swallows its error, so an aborted run would otherwise keep iterating
+      // to maxDepth doing real work. End the loop instead.
+      if (context.getAbortSignal?.()?.aborted) {
+        log('🔬 Deep Research: aborted by the caller - ending the research loop');
         break;
       }
 

--- a/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { editFileTool } from './index';
+import type { ToolContext } from '../../base/types';
+
+/**
+ * edit_file runs its own llm.complete, so it has to forward `context.getAbortSignal()` as
+ * `abortSignal` or a user Stop leaves that sub-call generating (and billing). See
+ * ToolContext.getAbortSignal.
+ *
+ * The catch block matters as much as the forwarding here. Making the sub-call cancellable means
+ * this tool now sees AbortError for the first time, and the pre-existing handler both logged it
+ * at error level (so every Stop reads as an edit_file fault) and rewrapped it in a fresh Error
+ * (destroying the identity isUserInitiatedAbort needs upstream). Both branches are pinned below.
+ */
+describe('editFileTool cancellation handling', () => {
+  // moderationStatus must be 'clean': isImageServeable fail-closes on EVERY mime type, not just
+  // images, so a fixture without it is refused before the LLM call this test is about.
+  const FILE = {
+    fileName: 'a.txt',
+    mimeType: 'text/plain',
+    fileUrl: 'https://files.example/a.txt',
+    moderationStatus: 'clean',
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, statusText: 'OK', text: async () => 'original content' }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function makeContext(
+    getAbortSignal: (() => AbortSignal | undefined) | undefined,
+    complete: ReturnType<typeof vi.fn>
+  ) {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const context = {
+      userId: 'u1',
+      user: {},
+      logger,
+      db: { fabFiles: { findById: vi.fn(async () => FILE) } },
+      llm: { complete },
+      statusUpdate: vi.fn(),
+      model: 'test-model',
+      getAbortSignal,
+    } as unknown as ToolContext;
+    return { context, logger };
+  }
+
+  function run(context: ToolContext) {
+    return editFileTool
+      .implementation(context, undefined)
+      .toolFn({ fileId: 'f1', instruction: 'uppercase it' }, {} as never);
+  }
+
+  it('passes the live signal through as abortSignal', async () => {
+    const controller = new AbortController();
+    const complete = vi.fn(async (_m, _msgs, _o, cb) => cb(['edited'], undefined));
+    const { context } = makeContext(() => controller.signal, complete);
+
+    await run(context);
+
+    expect(complete.mock.calls[0][2].abortSignal).toBe(controller.signal);
+  });
+
+  it('sends no signal when the host supplies no getter', async () => {
+    const complete = vi.fn(async (_m, _msgs, _o, cb) => cb(['edited'], undefined));
+    const { context } = makeContext(undefined, complete);
+
+    await run(context);
+
+    expect(complete.mock.calls[0][2].abortSignal).toBeUndefined();
+  });
+
+  it('rethrows a user Stop unwrapped and does not log it as a fault', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    const complete = vi.fn(async () => {
+      throw abortError;
+    });
+    const { context, logger } = makeContext(() => controller.signal, complete);
+
+    // The ORIGINAL error object, not a `Failed to edit file: ...` rewrap - upstream
+    // isUserInitiatedAbort checks match on the AbortError identity.
+    await expect(run(context)).rejects.toBe(abortError);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('still reports a genuine failure as an error, wrapped as before', async () => {
+    const complete = vi.fn(async () => {
+      throw new Error('provider exploded');
+    });
+    const { context, logger } = makeContext(() => new AbortController().signal, complete);
+
+    await expect(run(context)).rejects.toThrow(/Failed to edit file: provider exploded/);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
@@ -2,7 +2,7 @@ import { ToolDefinition } from '../../base/types';
 import { recordToolOperationalUsage } from '../../base/recordToolOperationalUsage';
 import { z } from 'zod';
 import { NotFoundError } from '@bike4mind/utils';
-import { isImageServeable } from '@bike4mind/common';
+import { isImageServeable, isUserInitiatedAbort } from '@bike4mind/common';
 import type { CompletionInfo } from '@bike4mind/llm-adapters';
 import { diffLines, type Change } from 'diff';
 
@@ -178,7 +178,9 @@ Return only the edited content without any markdown code blocks or explanations.
             { role: 'system', content: systemPrompt },
             { role: 'user', content: userPrompt },
           ],
-          { temperature: 0.3, stream: false }, // Lower temperature for more consistent edits
+          // Lower temperature for more consistent edits. abortSignal: see
+          // ToolContext.getAbortSignal - Stop must reach nested generation too.
+          { temperature: 0.3, stream: false, abortSignal: context.getAbortSignal?.() },
           async (texts, info) => {
             editedContent = texts.filter(t => t !== null && t !== undefined).join('');
             if (info) completionInfo = info;
@@ -230,6 +232,13 @@ Return only the edited content without any markdown code blocks or explanations.
 
         return JSON.stringify(result, null, 2);
       } catch (error) {
+        // A user Stop reaches this catch now that the edit sub-call is cancellable. Log it as
+        // the intended outcome rather than a fault, and rethrow the original so the AbortError
+        // identity survives for isUserInitiatedAbort checks upstream.
+        if (error instanceof Error && isUserInitiatedAbort(error, context.getAbortSignal?.())) {
+          context.logger.debug(`📝 Edit File Tool: edit cancelled by the caller`);
+          throw error;
+        }
         context.logger.error(`📝 Edit File Tool: Error editing file`, error);
         const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
         throw new Error(`Failed to edit file: ${errorMessage}`);

--- a/b4m-core/services/src/llm/tools/implementation/jupyterNotebook/abortSignal.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/jupyterNotebook/abortSignal.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { jupyterNotebookTool } from './index';
+import type { ToolContext } from '../../base/types';
+
+const NOTEBOOK_JSON = JSON.stringify({
+  title: 'T',
+  cells: [{ type: 'markdown', content: '# hi' }],
+});
+
+/**
+ * generate_jupyter_notebook runs its own llm.complete, so it has to forward
+ * `context.getAbortSignal()` as `abortSignal` or a user Stop leaves that sub-call generating
+ * (and billing) until the provider finishes. See ToolContext.getAbortSignal.
+ *
+ * Worth having its own test rather than trusting the blog_draft one: the opt-in is a per-call-site
+ * one-liner with nothing structural forcing it, so an unthreaded site fails open silently.
+ */
+describe('jupyterNotebookTool forwards the turn abort signal to its own llm.complete', () => {
+  function runTool(getAbortSignal?: () => AbortSignal | undefined) {
+    const complete = vi.fn(async (_model, _messages, _options, callback) => {
+      await callback([NOTEBOOK_JSON], undefined);
+    });
+    const context = {
+      userId: 'u1',
+      user: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      db: {},
+      llm: { complete },
+      model: 'test-model',
+      getAbortSignal,
+    } as unknown as ToolContext;
+
+    const run = jupyterNotebookTool
+      .implementation(context, undefined)
+      .toolFn({ analysisDescription: 'plot something' }, {} as never);
+
+    return { run, optionsOf: () => complete.mock.calls[0]?.[2] };
+  }
+
+  it('passes the live signal through as abortSignal', async () => {
+    const controller = new AbortController();
+    const { run, optionsOf } = runTool(() => controller.signal);
+    await run;
+    expect(optionsOf()?.abortSignal).toBe(controller.signal);
+  });
+
+  it('sends no signal when the host supplies no getter', async () => {
+    const { run, optionsOf } = runTool(undefined);
+    await run;
+    expect(optionsOf()?.abortSignal).toBeUndefined();
+  });
+});

--- a/b4m-core/services/src/llm/tools/implementation/jupyterNotebook/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/jupyterNotebook/index.ts
@@ -149,7 +149,8 @@ Please generate a complete, well-structured notebook that performs this analysis
           { role: 'system', content: NOTEBOOK_GENERATION_PROMPT },
           { role: 'user', content: userPrompt },
         ],
-        { maxTokens: 4000, temperature: 0.7 },
+        // abortSignal: see ToolContext.getAbortSignal - Stop must reach nested generation too.
+        { maxTokens: 4000, temperature: 0.7, abortSignal: context.getAbortSignal?.() },
         async (texts, info) => {
           responseText = texts.filter(t => t !== null && t !== undefined).join('');
           if (info) completionInfo = info;

--- a/b4m-core/services/src/llm/tools/toolGenerators.ts
+++ b/b4m-core/services/src/llm/tools/toolGenerators.ts
@@ -41,6 +41,7 @@ export const generateTools = (
     suppressLakeArms,
     sessionRetrievalTags,
     questId,
+    getAbortSignal,
   }: {
     db: ToolContext['db'];
     retrievalFilter?: ToolContext['retrievalFilter'];
@@ -50,6 +51,7 @@ export const generateTools = (
     suppressLakeArms?: ToolContext['suppressLakeArms'];
     sessionRetrievalTags?: ToolContext['sessionRetrievalTags'];
     questId?: ToolContext['questId'];
+    getAbortSignal?: ToolContext['getAbortSignal'];
   },
   storage: BaseStorage,
   imageGenerateStorage: BaseStorage,
@@ -98,6 +100,7 @@ export const generateTools = (
     codeMinifier,
     availableModels,
     onToolLlmUsage,
+    getAbortSignal,
   };
 
   return Object.entries(tools).reduce(


### PR DESCRIPTION
# Pull Request

## Description

Pressing Stop settled the chat turn but did not cancel generation running **inside** an LLM tool. A tool-internal `llm.complete()` kept producing tokens until the provider finished on its own. On a metered backend that is spend continuing after the user said stop.

Both ends of the plumbing already existed; the middle did not.

- **The sink existed.** `ICompletionOptions.abortSignal?: AbortSignal` (`b4m-core/llm-adapters/src/backend.ts:149`).
- **The source existed and was plumbed most of the way.** `ChatCompletionProcess` declares an `abortSignalHolder`, assigns the live controller's signal to it, and passes `getAbortSignal: () => abortSignalHolder.signal` into `buildTools`; `ToolBuilder` forwards it to `buildSharedTools`.
- **The break.** `buildSharedTools` used `getAbortSignal` at exactly two places - the `getSignal` argument of `createDelegateToAgentTool` and `createCoordinateTaskTool`. It was **not** among the arguments to the `generateTools(...)` call in the same function. `generateTools` builds the single `ToolContext` handed to `tool.implementation(...)` for every tool, and `ToolContext` declared no `abortSignal`, no signal getter, and no cancellation field of any kind. Subagent delegation was special-cased; generic tools were never given the capability.

The signal does not exist when `buildTools` runs (the controller is created several hundred lines later), so this is a lazy `getAbortSignal?: () => AbortSignal | undefined` on `ToolContext`, not a captured `AbortSignal` - the same holder-plus-closure shape the subagent path already used.

### Scope note

The originating report named a second, independent defect: `OllamaBackend.runChatRound` never attached `options.abortSignal` to the transport. **That has since been fixed separately** - `ollamaBackend.ts` now binds the signal via `createClient(options.abortSignal)` and treats a user-initiated abort as an expected outcome rather than an error. This PR is only the `ToolContext` half, which is the half that costs money (it is what fixes the metered backends).

## Status

What this PR closes, and what it deliberately does not.

**Landed here**

- [x] `ToolContext.getAbortSignal` seam, threaded through `generateTools` and passed from `buildSharedTools`
- [x] `blog_draft` forwards it to its own `llm.complete`
- [x] `deep_research` forwards it
- [x] `edit_file` forwards it
- [x] `jupyter_notebook` forwards it
- [x] `deep_research` also breaks its research loop on abort (the signal alone leaves the surrounding search/extract phases burning quota)
- [x] `blog_draft` / `edit_file` stop logging a user Stop as a fault; `edit_file` rethrows unwrapped so the `AbortError` identity survives
- [x] Dispatched-subagent path builds its `AbortController` before its tools, so its watchdog reaches tool sub-calls
- [x] Tests for all four opt-ins plus both new error-handling branches, each confirmed load-bearing by reverting its fix
- [x] `data-testid="tool-row-<toolId>"` on every gated tool row, so tool rows are addressable without hand-added per-tool ids

**Landed previously, on `main`**

- [x] `OllamaBackend` binds `options.abortSignal` to its transport (the other half of the original report)

**NOT covered by this PR - tracked separately**

- [ ] **Host-injected tools opt in.** Tools supplied through `buildSharedTools`' `externalTools` that run their own `llm.complete` still need the same one-line `abortSignal:` at their call site. This PR only makes that possible - it does not wire them, and a host whose tools share a single completion helper needs exactly one line. **Gated on this PR merging**, since the field does not exist on `ToolContext` until then.
- [ ] **Research Mode gains cancellation.** It has none today: `ChatCompletionProcess` returns from that branch before assigning the abort holder, and the watcher starts after. Pre-existing; needs its own controller + watcher.
- [ ] **Top-level agent-executor loop grows an `AbortSignal`.** It cancels via a polled `AgentExecution` flag, so there is nothing to hand tools.
- [ ] **Live verification of Test 1 on staging.** Not done - see "What the preview run did and did not establish" below. The preview cannot run it.

## Changes

- **`ToolContext.getAbortSignal?: () => AbortSignal | undefined`** (`tools/base/types.ts`), threaded through `generateTools`' deps-object argument (`toolGenerators.ts`) and passed from `sharedToolBuilder.ts`.
- **All four tools that run their own generation forward it**: `blog_draft`, `deep_research`, `edit_file`, `jupyter_notebook`. Enumerated via `recordToolOperationalUsage` - the marker every tool-internal LLM call carries - and cross-checked with a `.complete(` sweep of the tool tree; both give the same four.
- **`deep_research` also breaks its research loop on abort.** Threading the signal into the analysis sub-call is not sufficient there: each iteration's searcher calls and content extraction are separately billable, and every phase's `catch` swallows its own error. Without a loop-head guard, an aborted run would have kept iterating to `maxDepth`, with each analysis aborting instantly while the web searches around it still burned real quota - trading LLM spend for search-quota spend.
- **`blog_draft` and `edit_file` no longer report a user Stop as a fault.** Both catches now see `AbortError` for the first time; they route a user-initiated abort to `debug`, and `edit_file` rethrows the original error instead of rewrapping it so the `AbortError` identity survives for `isUserInitiatedAbort` upstream. Same reasoning already applied in `ollamaBackend`.
- **The dispatched-subagent path builds its `AbortController` before its tools** (`agentExecutor.ts` `processSubagentDispatch`), so its watchdog - abort flag plus Lambda deadline - reaches tool sub-calls too. Previously the controller was created after `buildSharedTools`.
- **`ToolContainer` stamps `data-testid="tool-row-<toolId>"` on every gated tool row.** Per-tool testids had been added by hand, so image/music/audio had one and `deep_research` did not - the one tool an e2e run for this change needs to reach.

### Where cancellation still does not reach

Stated explicitly because the first draft of this PR got the list wrong.

- **Research Mode** (`ChatCompletionProcess`) returns from its branch *before* assigning `abortSignalHolder.signal`, yet hands `allTools` - these same tool instances, already carrying the closure - to `ResearchModeService`. That service takes no signal, and the cancellation watcher starts *after* the branch returns. So Research Mode has no cancellation of any kind and its tool sub-calls stay uninterruptible across every parallel configuration. Pre-existing; fixing it means giving Research Mode its own controller and watcher, which is not this PR. The `getAbortSignal` doc now says so.
- **The top-level agent-executor loop**, which cancels via a polled `AgentExecution` abort flag rather than an `AbortSignal`, and **the headless deep-agent runner**. Neither has a per-turn controller to hand over; both pass nothing and behave exactly as before.

## Guide for Testers

**Precondition, read first.** The tools this PR affects all run their own LLM generation, and the clearest one (`deep_research`) additionally needs a web-search provider. On an environment without one its toggle is **hard-gated off** with the tooltip *"Requires Firecrawl (API key or URL) or a web search provider (Serper key or local SearXNG), configured in Admin > API Keys."* Check that first - if you see that tooltip, Test 1 and Test 2 cannot run on that environment. This is the case on this PR's own preview (Anthropic and Gemini keys present; no Firecrawl/Serper/SearXNG), so use **staging** or any environment with a search provider configured.

**Setup**

1. Log in to an environment with a web-search provider configured (see precondition).
2. Open a new notebook session.
3. In the composer, click **Tools**, turn on the **Smart tools -> Enable** master switch, then enable **Deep Research**. If the Deep Research card is dimmed, stop - see the precondition.

**Test 1 - Stop cancels generation inside a tool (the fix)**

4. Type `Research the history of pipe organ construction in northern Germany` and send it.
5. Wait until the status line shows research activity (search/analyze steps appearing) - roughly 10-20 seconds.
6. Press **Stop** while research is still in progress.
7. Expected: the turn settles within a few seconds, the Stop button disappears, and the response stops growing.
8. Expected: **no further search or analyze activity appears after the Stop.** This is the actual fix - before it, the tool's nested generation and its surrounding search loop kept running.

**Test 2 - Regression: an un-aborted run is not truncated**

9. In a new session, send the same prompt and let it run to completion without pressing Stop.
10. Expected: a normal research result with sources. The new abort guard must not cut short a run nobody cancelled.

**Test 3 - No collateral**

11. In a new session with no tools enabled, send `Reply with exactly the word: PONG`.
12. Expected: a normal streamed response, no console errors.

**Regression Checks**

13. Send a message using a tool that does **not** self-generate (Web Search, Knowledge Base). Expected: unchanged - these never call `llm.complete` and are untouched.
14. Press Stop during an ordinary long response with no tools enabled. Expected: unchanged - the turn settles promptly.
15. Run an agent-mode execution that delegates to a subagent. Expected: unchanged - `delegate_to_agent` already carried the signal and its wiring is not modified.

**What NOT to test**

- Ollama/local-model cancellation. Separate transport-level defect, already fixed in `ollamaBackend`, not part of this diff.
- Research Mode cancellation. Known not to work, pre-existing, explicitly out of scope (see above).
- The top-level agent-executor abort flow. Cancels via a polled DB flag, intentionally unchanged.
- Credit/billing totals. This PR stops spend earlier; it does not change how spend is priced or recorded.

## Additional Information

Every new test was confirmed load-bearing by reverting the corresponding fix and watching it fail. That caught one vacuous test of my own: the "stops after the in-flight iteration" case initially passed *without* the guard, because the mock planner never returned a `nextSearchTopic`, so the research loop ran dry after one iteration regardless. It now uses an `ANALYSIS_CONTINUE` fixture that keeps feeding the loop work.

Verification run locally:

- `pnpm turbo:typecheck` and `pnpm turbo:typecheck:fast` (tsgo): green
- `@bike4mind/services`: 5408 passed
- `apps/client` `AISettings` (98) and `server/queueHandlers` (642): passed
- `pnpm lint:check`, control-byte and smart-punctuation guards, deprecated-model check: clean
- `@bike4mind/scripts` (424), `@bike4mind/database` (1995), `@bike4mind/client` (11038): all pass in isolation. A combined `turbo:test` run failed in these three from CPU oversubscription, not from this diff.

### What the preview run did and did not establish

A preview was deployed for this PR and driven with Playwright. Being straight about the result, because it is weaker than "verified live":

- **Verified:** plain chat unaffected (`PONG`, 0 console errors). Pressing Stop on a long ordinary generation settled the turn cleanly - Stop button gone, **0 characters of growth over the following 10 seconds**. That confirms the upstream `AbortController` and cancellation watcher this fix hangs off are alive on this build, and that the `agentExecutor` controller hoist did not break normal cancellation.
- **Could not test:** the headline behavior. **None of the four affected tools are reachable on the preview** - `deep_research` is hard-gated off for lack of a search provider, and `blog_draft` / `edit_file` / `jupyter_notebook` are not in the session tool picker at all. So the live run exercised the scaffolding around the fix, not the fix.

The cancellation of a tool sub-call is therefore covered by unit tests only. A reviewer wanting live confirmation should run Test 1 on **staging**, where a search provider is configured.

## Developer Notes

- **New extension point**: `ToolContext.getAbortSignal` is now available to every tool, not just the subagent delegation path. Any tool that runs its own `llm.complete` opts in with one line at the call site. The contract is deliberately a getter, not a value - tools are constructed before the turn's `AbortController` exists, so a captured signal would type-check and still be a permanent `undefined` in production. The field's doc comment spells this out, including the cases where the getter legitimately returns `undefined`.
- **Enumeration technique worth reusing**: `recordToolOperationalUsage` is the marker every tool-internal LLM call already carries for billing, so grepping it yields the set of "tools that generate" more reliably than grepping `.complete(` call shapes. Caveat worth stating: it is only sound while every generating tool also records usage - a tool that generated without billing would be invisible to it, which is why this was cross-checked a second way.
- **Cancellation is two problems, not one**: threading a signal into a sub-call only helps if the surrounding control flow also stops. `deep_research` is the cautionary case - its per-phase catches swallow errors, so a cancelled sub-call silently became "no result" and the loop carried on doing billable work. Any future loop-shaped tool needs the same loop-head guard, not just the signal.
- **Per-item testids belong in the shared container**, not on individual rows. `ToolContainer` already knew each row's `toolId`; hand-adding testids per tool is what let `deep_research` end up unaddressable.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no user-visible UI change (the only client edit is a test hook)
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a, internal seam
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a

