### PR TITLE
fix(data-lakes): finish the batch rescue sweep when one enqueue fails

### DIFF
--- a/apps/client/server/cron/dataLakeBatchReconcile.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.test.ts
@@ -131,6 +131,7 @@ describe('dataLakeBatchReconcile cron handler', () => {
       taxonomyCandidates: 0,
       taxonomyForced: 0,
       rescuedChunkFiles: 0,
+      rescueFailures: 0,
     });
   });
 
@@ -145,6 +146,7 @@ describe('dataLakeBatchReconcile cron handler', () => {
       taxonomyCandidates: 0,
       taxonomyForced: 0,
       rescuedChunkFiles: 0,
+      rescueFailures: 0,
     });
   });
 
@@ -245,6 +247,56 @@ describe('dataLakeBatchReconcile cron handler', () => {
         userId: 'u1',
       });
       expect(JSON.parse(res.body).rescuedChunkFiles).toBe(2);
+    });
+
+    it('finishes the sweep when one enqueue fails, and reports the partial result (#2117)', async () => {
+      // The sweep is the safety net for files the chunk pipeline lost, so it matters most under the
+      // cluster/queue stress that makes a transient send failure likely. It used to reject out of the
+      // loop on the first failure: every candidate behind it was abandoned, and because the caller
+      // turns a throw into 0 it also reported a sweep that HAD rescued files as having rescued none.
+      h.getSettingsValue.mockResolvedValue(true);
+      h.fabFileFind.mockReturnValue({
+        select: () => ({
+          limit: () => ({
+            lean: async () => [
+              { _id: 'ff1', userId: 'u1' },
+              { _id: 'ff2', userId: 'u2' },
+              { _id: 'ff3', userId: 'u3' },
+            ],
+          }),
+        }),
+      });
+      // The MIDDLE one fails, so the assertion below distinguishes "kept going" from "stopped early".
+      h.sendToQueue.mockImplementation(async (_url: unknown, msg: { fabFileId: string }) => {
+        if (msg.fabFileId === 'ff2') throw new Error('SQS throttled');
+      });
+
+      const res = await handler();
+
+      // All three attempted - the one behind the failure is not abandoned.
+      expect(h.sendToQueue).toHaveBeenCalledTimes(3);
+      expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', { fabFileId: 'ff3', userId: 'u3' });
+      // And the counts are honest: two really were rescued, one really was not.
+      const body = JSON.parse(res.body);
+      expect(body.rescuedChunkFiles).toBe(2);
+      expect(body.rescueFailures).toBe(1);
+    });
+
+    it('does not let a rescue failure take down the batch reconciliation around it', async () => {
+      // The isolation the caller's catch already provided must survive the per-item catch: the
+      // stuck-batch sweep above it still reports, and the handler still returns 200.
+      h.getSettingsValue.mockResolvedValue(true);
+      h.fabFileFind.mockReturnValue({
+        select: () => ({ limit: () => ({ lean: async () => [{ _id: 'ff1', userId: 'u1' }] }) }),
+      });
+      h.sendToQueue.mockRejectedValue(new Error('queue unreachable'));
+
+      const res = await handler();
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.rescuedChunkFiles).toBe(0);
+      expect(body.rescueFailures).toBe(1);
     });
 
     it('does nothing when auto-chunk is disabled', async () => {

--- a/apps/client/server/cron/dataLakeBatchReconcile.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.test.ts
@@ -12,6 +12,10 @@ const h = vi.hoisted(() => ({
   getSettingsValue: vi.fn(),
   fabFileFind: vi.fn(),
   sendToQueue: vi.fn(),
+  // Hoisted rather than left inside the observability mock's closure: an SST cron's return value is
+  // discarded by EventBridge, so this log line is the only actionable output the rescue sweep's
+  // per-file catch produces. Unexposed, deleting that logger.error call is undetectable.
+  loggerError: vi.fn(),
   // Spied (not a bare stub) so a test can assert the cron passes BOTH the age cutoff and the
   // stale-claim cutoff: a one-arg call silently turns the stale-claim rescue arm back off.
   buildScanFilter: vi.fn((cutoff: Date, _staleClaimBefore: Date) => ({ chunkCount: 0, createdAt: { $lt: cutoff } })),
@@ -43,7 +47,7 @@ vi.mock('@bike4mind/services', () => ({
   },
 }));
 vi.mock('@bike4mind/observability', () => {
-  const mockLogger: Record<string, unknown> = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() };
+  const mockLogger: Record<string, unknown> = { info: vi.fn(), warn: vi.fn(), error: h.loggerError, log: vi.fn() };
   mockLogger.withMetadata = vi.fn(() => mockLogger);
   return {
     Logger: vi.fn(function () {
@@ -83,8 +87,11 @@ describe('dataLakeBatchReconcile cron handler', () => {
     h.findStuckTaxonomy.mockResolvedValue([]);
     h.reconcileTaxonomy.mockResolvedValue([]);
     h.enqueueTaxonomyAnalysisIfWanted.mockResolvedValue(undefined);
-    // Rescue sweep defaults: auto-chunk off, no candidates.
+    // Rescue sweep defaults: auto-chunk off, no candidates, sends succeed. The send stub is reset
+    // explicitly because clearAllMocks() clears calls but NOT implementations - without this a test
+    // that makes sendToQueue reject leaks that into every test after it in file order.
     h.getSettingsValue.mockResolvedValue(false);
+    h.sendToQueue.mockResolvedValue(undefined);
     h.fabFileFind.mockReturnValue({
       select: () => ({ limit: () => ({ lean: async () => [] }) }),
     });
@@ -262,24 +269,35 @@ describe('dataLakeBatchReconcile cron handler', () => {
               { _id: 'ff1', userId: 'u1' },
               { _id: 'ff2', userId: 'u2' },
               { _id: 'ff3', userId: 'u3' },
+              { _id: 'ff4', userId: 'u4' },
             ],
           }),
         }),
       });
-      // The MIDDLE one fails, so the assertion below distinguishes "kept going" from "stopped early".
+      // TWO fail, and neither is first or last: the middle placement distinguishes "kept going" from
+      // "stopped early", and the second failure is what forces `failed` to accumulate - a counter
+      // pinned to 1 would satisfy a single-failure fixture.
       h.sendToQueue.mockImplementation(async (_url: unknown, msg: { fabFileId: string }) => {
-        if (msg.fabFileId === 'ff2') throw new Error('SQS throttled');
+        if (msg.fabFileId === 'ff2' || msg.fabFileId === 'ff3') throw new Error('SQS throttled');
       });
 
       const res = await handler();
 
-      // All three attempted - the one behind the failure is not abandoned.
-      expect(h.sendToQueue).toHaveBeenCalledTimes(3);
-      expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', { fabFileId: 'ff3', userId: 'u3' });
-      // And the counts are honest: two really were rescued, one really was not.
+      // All four attempted - the ones behind a failure are not abandoned.
+      expect(h.sendToQueue).toHaveBeenCalledTimes(4);
+      expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', { fabFileId: 'ff4', userId: 'u4' });
+      // And the counts are honest: two really were rescued, two really were not.
       const body = JSON.parse(res.body);
       expect(body.rescuedChunkFiles).toBe(2);
-      expect(body.rescueFailures).toBe(1);
+      expect(body.rescueFailures).toBe(2);
+      // Each failure names its file. The cron's return value goes nowhere (EventBridge discards it),
+      // so without this line an operator has no way to tell WHICH files were not enqueued.
+      for (const fabFileId of ['ff2', 'ff3']) {
+        expect(h.loggerError).toHaveBeenCalledWith(
+          expect.stringContaining('failed to enqueue'),
+          expect.objectContaining({ fabFileId, error: 'SQS throttled' })
+        );
+      }
     });
 
     it('does not let a rescue failure take down the batch reconciliation around it', async () => {
@@ -316,7 +334,12 @@ describe('dataLakeBatchReconcile cron handler', () => {
 
       expect(h.recordRun).toHaveBeenCalledTimes(1);
       expect(res.statusCode).toBe(200);
-      expect(JSON.parse(res.body).rescuedChunkFiles).toBe(0);
+      // BOTH counts, not just the rescued one: the outer catch has to return a whole
+      // {enqueued, failed}, and a fallback that omits `failed` reports nothing at all here -
+      // JSON.stringify drops the undefined key, so the field silently vanishes from the body.
+      const body = JSON.parse(res.body);
+      expect(body.rescuedChunkFiles).toBe(0);
+      expect(body.rescueFailures).toBe(0);
     });
   });
 });

--- a/apps/client/server/cron/dataLakeBatchReconcile.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.ts
@@ -42,6 +42,17 @@ const MAX_PER_RUN = 500;
 const CHUNK_RESCUE_MAX_PER_RUN = 500;
 
 /**
+ * How many rescue sends are in flight at once, matching driveLakeResyncPoll's sweep. The bound is
+ * what makes the per-file catch below safe: sendToQueue builds a fresh SQSClient per call
+ * (server/utils/sqs.ts), so its retry token bucket never throttles down across the loop and every
+ * failed send pays its full attempt budget with no back-off. Run one-at-a-time, a degraded queue
+ * could take CHUNK_RESCUE_MAX_PER_RUN of those past this cron's 10-minute Lambda (infra/cron.ts) -
+ * and a timeout costs the heartbeat and these counts entirely, which is worse than the abandonment
+ * the catch fixes. This sweep also runs LAST, after two other up-to-500 sequential loops.
+ */
+const ENQUEUE_CONCURRENCY = 10;
+
+/**
  * Hosted counterpart of the self-host worker's fabFileChunkScan (worker/main.ts): re-enqueue
  * files that completed upload but were never chunked, so they stop being silently unsearchable
  * (#1420 - e.g. uploads that landed while enableAutoChunk was off, or whose S3 event was lost).
@@ -66,17 +77,20 @@ async function rescueUnchunkedFiles(): Promise<{ enqueued: number; failed: numbe
   const userById = new Map(candidates.map(f => [String(f._id), String(f.userId)]));
   const batchById = new Map(candidates.map(f => [String(f._id), f.batchId]));
 
-  // PER-FILE catch. A throttled or unroutable send used to reject out of this loop and abandon every
-  // candidate behind it, and because the caller turns a throw into 0 it also reported a sweep that
-  // had already rescued files as having rescued none. This sweep is the safety net for files the
-  // chunk pipeline lost, so it matters most under exactly the cluster/queue stress that makes a
-  // transient send failure likely - the failure mode was to give up when it was needed most.
-  // Same shape, and the same reasoning, as driveLakeResyncPoll's enqueue sweep.
+  // Bounded-concurrency fan-out with a PER-FILE catch. A throttled or unroutable send used to reject
+  // out of a sequential loop and abandon every candidate behind it, and because the caller turns a
+  // throw into 0 it also reported a sweep that had already rescued files as having rescued none.
+  // This sweep is the safety net for files the chunk pipeline lost, so it matters most under exactly
+  // the cluster/queue stress that makes a transient send failure likely - the failure mode was to
+  // give up when it was needed most. See ENQUEUE_CONCURRENCY for why removing that early exit
+  // required bounding the wall-clock too.
+  // Read the queue URL once: an unlinked-resource fault is one config error, not 500 identical logs.
+  const queueUrl = Resource.fabFileChunkQueue.url;
   let enqueued = 0;
   let failed = 0;
-  for (const id of userById.keys()) {
+  const enqueueOne = async (id: string) => {
     try {
-      await sendToQueue(Resource.fabFileChunkQueue.url, {
+      await sendToQueue(queueUrl, {
         fabFileId: id,
         userId: userById.get(id)!,
         ...(batchById.get(id) ? { origin: CONVERGENCE_ORIGIN } : {}),
@@ -89,10 +103,17 @@ async function rescueUnchunkedFiles(): Promise<{ enqueued: number; failed: numbe
         error: e instanceof Error ? e.message : String(e),
       });
     }
+  };
+  const ids = [...userById.keys()];
+  for (let i = 0; i < ids.length; i += ENQUEUE_CONCURRENCY) {
+    await Promise.all(ids.slice(i, i + ENQUEUE_CONCURRENCY).map(id => enqueueOne(id)));
   }
 
-  // A failed send changes nothing about the file, so it still matches the scan filter and the next
-  // run retries it - `failed` is the operator's signal, not a lost-work marker.
+  // A failed send changes nothing about the file, so it still matches the scan filter and a later run
+  // retries it. Not necessarily the NEXT one: the candidate query has no sort, so while the backlog
+  // exceeds CHUNK_RESCUE_MAX_PER_RUN a given file is only eventually reached. `failed` is a signal
+  // that sends are being lost, not a marker of work dropped for good. It currently reaches operators
+  // through the sweep's log line only - there is no metric or alarm on it yet.
   return { enqueued, failed };
 }
 

--- a/apps/client/server/cron/dataLakeBatchReconcile.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.ts
@@ -48,8 +48,8 @@ const CHUNK_RESCUE_MAX_PER_RUN = 500;
  * The shared filter excludes terminal outcomes (no-text note, chunk error), so a file is swept
  * at most once per cause; a repeat appearance means the queue message itself was lost.
  */
-async function rescueUnchunkedFiles(): Promise<number> {
-  if (!(await adminSettingsRepository.getSettingsValue('enableAutoChunk'))) return 0;
+async function rescueUnchunkedFiles(): Promise<{ enqueued: number; failed: number }> {
+  if (!(await adminSettingsRepository.getSettingsValue('enableAutoChunk'))) return { enqueued: 0, failed: 0 };
 
   const now = Date.now();
   const cutoff = new Date(now - CHUNK_SCAN_MIN_AGE_MS);
@@ -65,14 +65,35 @@ async function rescueUnchunkedFiles(): Promise<number> {
   // file is not re-sent every pass.
   const userById = new Map(candidates.map(f => [String(f._id), String(f.userId)]));
   const batchById = new Map(candidates.map(f => [String(f._id), f.batchId]));
+
+  // PER-FILE catch. A throttled or unroutable send used to reject out of this loop and abandon every
+  // candidate behind it, and because the caller turns a throw into 0 it also reported a sweep that
+  // had already rescued files as having rescued none. This sweep is the safety net for files the
+  // chunk pipeline lost, so it matters most under exactly the cluster/queue stress that makes a
+  // transient send failure likely - the failure mode was to give up when it was needed most.
+  // Same shape, and the same reasoning, as driveLakeResyncPoll's enqueue sweep.
+  let enqueued = 0;
+  let failed = 0;
   for (const id of userById.keys()) {
-    await sendToQueue(Resource.fabFileChunkQueue.url, {
-      fabFileId: id,
-      userId: userById.get(id)!,
-      ...(batchById.get(id) ? { origin: CONVERGENCE_ORIGIN } : {}),
-    });
+    try {
+      await sendToQueue(Resource.fabFileChunkQueue.url, {
+        fabFileId: id,
+        userId: userById.get(id)!,
+        ...(batchById.get(id) ? { origin: CONVERGENCE_ORIGIN } : {}),
+      });
+      enqueued++;
+    } catch (e) {
+      failed++;
+      logger.error('[DataLakeBatchReconcile] failed to enqueue un-chunked file for rescue', {
+        fabFileId: id,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
   }
-  return userById.size;
+
+  // A failed send changes nothing about the file, so it still matches the scan filter and the next
+  // run retries it - `failed` is the operator's signal, not a lost-work marker.
+  return { enqueued, failed };
 }
 
 /**
@@ -130,9 +151,9 @@ export async function handler() {
   });
 
   // Isolated so a rescue failure never blocks the batch reconciliation above.
-  const rescuedChunkFiles = await rescueUnchunkedFiles().catch(err => {
+  const { enqueued: rescuedChunkFiles, failed: rescueFailures } = await rescueUnchunkedFiles().catch(err => {
     logger.error(`[DataLakeBatchReconcile] un-chunked rescue sweep failed: ${err}`);
-    return 0;
+    return { enqueued: 0, failed: 0 };
   });
 
   // Heartbeat every run (even zero-work) so a stopped/broken cron alarms on absence of data.
@@ -144,6 +165,7 @@ export async function handler() {
     taxonomyCandidates: stuckTaxonomy.length,
     taxonomyForced: forcedTaxonomy.length,
     rescuedChunkFiles,
+    rescueFailures,
   });
   return {
     statusCode: 200,
@@ -153,6 +175,7 @@ export async function handler() {
       taxonomyCandidates: stuckTaxonomy.length,
       taxonomyForced: forcedTaxonomy.length,
       rescuedChunkFiles,
+      rescueFailures,
     }),
   };
 }


### PR DESCRIPTION
## Description

Closes #2117.

The un-chunked rescue sweep enqueued sequentially with no per-item error handling:

```ts
for (const id of userById.keys()) {
  await sendToQueue(Resource.fabFileChunkQueue.url, { fabFileId: id, userId: ..., ... });
}
return userById.size;
```

One rejected `sendToQueue` - an SQS throttle, a transient network fault - threw out of the loop, so every candidate behind it in the iteration order was abandoned. And because the caller turns a throw into `0`:

```ts
const rescuedChunkFiles = await rescueUnchunkedFiles().catch(err => { ...; return 0; });
```

a sweep that had already rescued files reported having rescued none.

## Why this one matters more than its size suggests

This sweep is the safety net for files the chunk pipeline lost - including the strand in #2115, whose end state nothing else will ever select. So it matters most under exactly the cluster or queue stress that makes a transient send failure likely, and where stranded files are most numerous. Giving up on the first error is the wrong behaviour precisely when the sweep is needed.

The twin cron next door already had this bug and fixed it, and its comment describes the failure in almost the same words:

```ts
// driveLakeResyncPoll.ts:54
// throttle) used to reject out of a sequential loop and abandon every connection behind it, so a
// single bad row could stall the whole sweep tick after tick. Now it costs only itself.
```

`dataLakeBatchReconcile` never received the same treatment.

## Changes

- Per-file `try`/`catch` around the send, counting `enqueued` and `failed` and logging the failing `fabFileId`.
- `rescueUnchunkedFiles` returns `{ enqueued, failed }` instead of a bare total, and both surface in the sweep log line and the response body as `rescuedChunkFiles` / `rescueFailures`. A partially-failing tick is now visible instead of looking like a small sweep.

A failed send changes nothing about the file, so it still matches the scan filter and the next run retries it - `failed` is an operator signal, not a lost-work marker.

**Left sequential deliberately.** The sibling batches at `ENQUEUE_CONCURRENCY = 10`, and copying that too was tempting, but the abandonment is the defect and the pace is not: 500 sends in a daily cron is not a latency problem worth coupling to this fix. Easy to add later if the backlog ever justifies it.

## Test coverage

- **New:** one enqueue fails *in the middle* of three - asserts all three are attempted (so the test distinguishes "kept going" from "stopped early"), and that the counts are honest: `rescuedChunkFiles: 2`, `rescueFailures: 1`.
- **New:** every send fails - the handler still returns 200 and the batch reconciliation around it still reports, confirming the caller's isolation survives the per-item catch.
- Two existing tests assert the exact response body with `toEqual`; both extended with `rescueFailures: 0` rather than loosened to `objectContaining`, since pinning the whole shape is the point of those assertions.

Verified both new tests fail against the original loop. 9 tests green in the suite; `pnpm turbo:typecheck` clean (40/40).

## Guide for Testers

Backend cron with no UI surface. The observable effect is in the sweep's own log line and response.

1. Trigger the `dataLakeBatchReconcile` cron (or wait for the daily run) on an environment with at least one un-chunked file older than the scan cutoff.
2. Find the `[DataLakeBatchReconcile] Sweep complete` log entry. Expected: it now carries a `rescueFailures` field alongside `rescuedChunkFiles`.
3. On a healthy environment, expect `rescueFailures: 0` and `rescuedChunkFiles` equal to the number of candidates the filter selected.
4. Confirm the files that were enqueued do get chunked shortly afterwards, and that the batch they belong to progresses.

**Regression checks:** the stuck-batch and stuck-taxonomy sweeps in the same handler still report their own counts, and the handler still returns 200 and records its heartbeat on a zero-work run.

**What NOT to test:** forcing an SQS failure mid-sweep by hand. That needs a throttle at a precise moment; it is covered by the unit tests.

## Additional Information

From the second directed review of the data lake async surface. Complements #2115 (assigned separately) rather than overlapping it - that one stops files being stranded, this one makes the sweep that rescues them reliable. Different files, independently mergeable.
