### PR TITLE
perf(ci): split the client test shard three ways with vitest --shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,8 +416,13 @@ jobs:
 
   # Tests run as a matrix of shards so wall time is the slowest shard, not the
   # serial sum. The heavy suites are isolated onto their own runners:
-  #   - client: the large apps/client suite (thousands of fast unit files) - alone
-  #     so it keeps the whole box for file parallelism.
+  #   - client 1/3, 2/3, 3/3: the large apps/client unit suite (over a thousand files), split
+  #     across three runners by vitest's own `--shard`. Each leg owns its whole box
+  #     for file parallelism. Splitting by `--shard` rather than by directory is the
+  #     point: vitest slices a hash-sorted list of the resolved file paths, so the
+  #     legs tile the file set EXACTLY for any count - no hand-maintained bucket
+  #     lists, and a newly added test file cannot land in two legs or in none. The
+  #     leg count is pinned by checkClientTestShards.test.ts.
   #   - client-integration: the SAME package and filter as `client`, selected onto
   #     its real-Mongo `*.e2e.test.ts` files by a different script. apps/client is
   #     therefore the one package that appears in two legs; the two lanes are
@@ -455,20 +460,43 @@ jobs:
     permissions:
       contents: read
     env:
-      # Soft budget: the shard's former hard cap. Crossing it now annotates the run instead of
-      # killing it, so the next slow creep surfaces as a warning on a passing build rather than
-      # as someone's PR failing for no reason - which was the only signal this had that the
-      # client shard had gone from 15 minutes to 20.
-      SHARD_SOFT_BUDGET_SECONDS: '1200'
+      # Soft budget: crossing it annotates the run instead of killing it, so the next slow creep
+      # surfaces as a warning on a passing build rather than as someone's PR failing for no
+      # reason - which was the only signal this had that the client shard had gone from 15
+      # minutes to 20.
+      #
+      # 600, retuned down from the 1200 that matched the client shard's old pre-split runtime.
+      # With the client suite split three ways, no leg in this matrix is expected to approach 10
+      # minutes - the heaviest non-client leg was 4m51s on the pre-split run - so 1200 could no
+      # longer fire for anything and had stopped being an early warning. At 600 it also catches
+      # the specific way this split can silently break: if a leg stops sharding it runs the WHOLE
+      # suite (~942s in CI) and trips this, rather than just quietly costing 3x for no speedup.
+      SHARD_SOFT_BUDGET_SECONDS: '600'
 
     strategy:
       fail-fast: false
       matrix:
         shard:
           # Single-package shards own the whole runner, so no worker cap.
-          - name: client
+          #
+          # `args` is appended to the test command WITHOUT a `--` separator, and that matters:
+          # `pnpm ... test -- --shard=1/3` forwards the literal `--` on to vitest, which then
+          # reads everything after it as positional path filters. The shard flag is silently
+          # IGNORED and the leg runs the whole suite - measured, it is not a theory. Nothing
+          # errors, so all three legs would quietly do the full suite at 3x the cost. Keep the
+          # args bare. SHARD_SOFT_BUDGET_SECONDS above is the backstop if this regresses.
+          - name: client 1/3
             filter: '--filter @bike4mind/client'
             workers: ''
+            args: '--shard=1/3'
+          - name: client 2/3
+            filter: '--filter @bike4mind/client'
+            workers: ''
+            args: '--shard=2/3'
+          - name: client 3/3
+            filter: '--filter @bike4mind/client'
+            workers: ''
+            args: '--shard=3/3'
           # The client package's ~20 real-Mongo suites (`*.e2e.test.ts`), split off
           # the shard above. Each boots a mongod, and inline they pushed that job
           # past `timeout-minutes` even on runs where the suite itself passed - the
@@ -587,9 +615,11 @@ jobs:
 
       # `matrix.shard.script` is unset on every shard but client-integration, and an
       # unset matrix value is the empty string here, so `||` falls back to the unit
-      # `test` script.
+      # `test` script. `matrix.shard.args` is likewise empty on every leg but the three
+      # client ones, where it carries `--shard=i/3` - deliberately with no `--` separator
+      # before it, see the matrix entries above for why that is load-bearing.
       - name: Run Tests (${{ matrix.shard.name }})
-        run: pnpm --recursive --workspace-concurrency=4 ${{ matrix.shard.filter }} ${{ matrix.shard.script || 'test' }}
+        run: pnpm --recursive --workspace-concurrency=4 ${{ matrix.shard.filter }} ${{ matrix.shard.script || 'test' }} ${{ matrix.shard.args }}
         env:
           CI: true
           VITEST_MAX_WORKERS: ${{ matrix.shard.workers }}
@@ -645,7 +675,7 @@ jobs:
 
   # Aggregate gate for the sharded test matrix. Branch protection requires a
   # status check literally named "Run Tests"; the matrix above reports per-shard
-  # names ("Run Tests (client)", …), so this job re-exposes the exact required
+  # names ("Run Tests (client 1/3)", …), so this job re-exposes the exact required
   # context and passes only when every shard succeeded.
   test:
     name: Run Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,12 @@ Code describes *what* it does and comments explain the *why* that the code can't
 - Run one side only with `pnpm --filter @bike4mind/client exec vitest run --project node`.
 - Watch out for mocks that were silently dead under jsdom and now bite: `vi.mock('crypto', …)` in particular takes effect under `node`, so an assertion that contradicted its own mock starts failing (correctly).
 
+**The `apps/client` unit suite is sharded in CI** across three `test-shards` legs (`Run Tests (client 1/3)` …), each running `--shard=i/3`. vitest slices a hash-sorted list of file paths, so the legs tile the file set exactly and a new test file lands in exactly one of them — nothing to update when you add a test.
+
+- Reproduce one leg locally: `pnpm --filter @bike4mind/client test --shard=2/3`.
+- **Never add a `--` before test-command args in CI.** `pnpm … test -- --shard=2/3` forwards the literal `--` to vitest, which reads the rest as positional path filters: the shard is ignored, the leg silently runs the whole suite, and nothing errors. `packages/scripts/src/checkClientTestShards.test.ts` fails the build if that separator or a leg goes missing.
+- Balance is by file **count**, not duration, so the legs are not equally long. The per-shard duration in each job's summary is how you spot one drifting.
+
 **Element selection:** always use `data-testid` (naming `component-action-element`, e.g. `modal-confirm-btn`) — never CSS class names (MUI/Emotion generates random class names).
 
 **MUI Joy component tests need the theme wrapper** (custom palette tokens like `background.surface2` break without it):

--- a/packages/scripts/src/checkClientTestShards.test.ts
+++ b/packages/scripts/src/checkClientTestShards.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Guard on how CI splits the apps/client unit suite across runners (#2015).
+ *
+ * The suite is over a thousand files and was the whole workflow's critical path, so it runs as N legs of
+ * the `test-shards` matrix, each passing vitest's `--shard=i/N`. vitest slices a hash-sorted
+ * list of resolved file paths, so for a COMPLETE set of legs the partition tiles the file set
+ * exactly. The danger is the set not being complete: drop `--shard=3/3` and roughly a third of
+ * the suite stops running, with every remaining leg green and no count anywhere to contradict
+ * it. Duplicate a leg and those files run twice while another third never runs at all.
+ *
+ * Nothing else can catch that. The per-leg duration report would barely move, and the "Run
+ * Tests" fan-in gate only checks that the legs it was given passed - not that they covered
+ * everything. So the invariant gets pinned here: the indices present must be exactly 1..N with
+ * no gaps and no repeats.
+ *
+ * Text-matched rather than YAML-parsed on purpose - the repo has no YAML parser dependency, and
+ * a regex over the literal `--shard=i/N` strings is precisely the assertion wanted.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const CI_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+
+/**
+ * Every shard leg declared as a matrix `args:` value, in file order.
+ *
+ * Anchored to the `args:` key rather than matching `--shard=` anywhere, because the workflow's
+ * own comments quote the flag while explaining it. A looser regex counts that prose as a leg -
+ * it did, on the first run of this guard - which both inflates the count and would let a comment
+ * mentioning `--shard=3/3` satisfy the completeness check after the real leg was deleted.
+ */
+function readShardLegs(contents: string): Array<{ index: number; count: number }> {
+  return [...contents.matchAll(/^\s*args:\s*'--shard=(\d+)\/(\d+)'\s*$/gm)].map(match => ({
+    index: Number(match[1]),
+    count: Number(match[2]),
+  }));
+}
+
+describe('apps/client test-shard legs in ci.yml', () => {
+  const contents = fs.readFileSync(CI_WORKFLOW, 'utf8');
+  const legs = readShardLegs(contents);
+
+  it('declares at least two legs (otherwise the flag is pointless overhead)', () => {
+    expect(legs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('agrees on a single leg count', () => {
+    expect([...new Set(legs.map(leg => leg.count))]).toHaveLength(1);
+  });
+
+  it('covers every index exactly once, with no gaps and no duplicates', () => {
+    // Explicit rather than letting `legs[0]` throw a bare TypeError: deleting every leg is a
+    // plausible edit, and "no shard legs declared" is the message that explains it.
+    expect(legs, 'no --shard legs declared in ci.yml').not.toHaveLength(0);
+    const { count } = legs[0];
+    const indices = legs.map(leg => leg.index).sort((a, b) => a - b);
+    // The count in `i/N` IS the promise about how many legs exist, so it has to match how many
+    // are actually declared - `--shard=1/3` and `--shard=2/3` alone is a silently missing third.
+    expect(legs).toHaveLength(count);
+    expect(indices).toEqual(Array.from({ length: count }, (_, i) => i + 1));
+  });
+
+  // `pnpm ... test -- --shard=1/3` forwards the literal `--` to vitest, which then reads the
+  // rest as positional path filters: the shard is ignored and the leg runs the WHOLE suite, at
+  // 3x the total cost, without erroring. Measured, not hypothetical. Pin the bare form.
+  it('appends the shard args with no `--` separator', () => {
+    const runLine = contents
+      .split('\n')
+      .find(line => line.includes('matrix.shard.script') && line.includes('matrix.shard.args'));
+    expect(runLine, 'the sharded test command should reference matrix.shard.args').toBeDefined();
+    expect(runLine).not.toMatch(/\s--\s/);
+  });
+});
+
+describe('readShardLegs', () => {
+  it('rejects a set with a missing index', () => {
+    const legs = readShardLegs("  args: '--shard=1/3'\n  args: '--shard=2/3'\n");
+    expect(legs).toHaveLength(2);
+    expect(legs[0].count).toBe(3);
+    // 2 declared against a promised 3 is the silent-drop shape this guard exists to fail on.
+    expect(legs).not.toHaveLength(legs[0].count);
+  });
+
+  it('spots a duplicated index', () => {
+    const legs = readShardLegs("  args: '--shard=1/3'\n  args: '--shard=2/3'\n  args: '--shard=2/3'\n");
+    const indices = legs.map(leg => leg.index);
+    expect(new Set(indices).size).not.toBe(indices.length);
+  });
+
+  it('spots legs disagreeing on the total', () => {
+    const legs = readShardLegs("  args: '--shard=1/3'\n  args: '--shard=2/2'\n");
+    expect([...new Set(legs.map(leg => leg.count))]).toHaveLength(2);
+  });
+
+  it('finds nothing when no legs are declared', () => {
+    expect(readShardLegs('name: client\nfilter: --filter @bike4mind/client\n')).toEqual([]);
+  });
+
+  // The regression that produced this guard's own first red run: a comment quoting the flag is
+  // prose, not a declared leg, and must not be counted as one.
+  it('ignores the flag quoted inside a comment', () => {
+    const legs = readShardLegs(
+      ['          # `pnpm ... test -- --shard=1/3` silently ignores it.', "            args: '--shard=1/3'"].join('\n')
+    );
+    expect(legs).toEqual([{ index: 1, count: 3 }]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #2113, and the last of the three items in #2015.

#2113 cut the `apps/client` unit shard from 18m12s to 15m41s by dropping jsdom for its Node tests. That stopped the false reds, but left the structural problem the issue actually named: **one job owning a thousand-file suite.** It was the critical path for the entire workflow at 17m34s, while the next-slowest job (`Build amd64`) finished in 7m0s. Everything else in CI was waiting on one runner.

The suite now runs as three matrix legs on vitest's `--shard=i/3`.

Splitting with `--shard` rather than by directory is the whole point. vitest slices a hash-sorted list of the resolved file paths, so the legs **tile the file set exactly for any count** - there is no hand-maintained bucket list to keep in step, and a newly added test file lands in exactly one leg without anyone touching this workflow. That is the same "complete by construction" property the `misc` leg's negation filter already relies on, and the opposite of the drift hazard the existing matrix comment warns about ("Moving a package into one of the named buckets requires adding it there AND excluding it here, or it will run twice").

Refs #2015

## Changes

**Three client legs instead of one** (`ci.yml`) - `client 1/3`, `client 2/3`, `client 3/3`, each carrying `args: '--shard=i/3'`. Verified with the exact CI command:

| leg | files | passed | skipped | local duration |
|---|---|---|---|---|
| 1/3 | 352 | 349 | 3 | 63.8s |
| 2/3 | 352 | 348 | 4 | 41.3s |
| 3/3 | 351 | 348 | 3 | 89.5s |
| **sum** | **1055** | **1045** | **10** | |

That matches the unsharded run exactly (`1045 passed | 10 skipped (1055)`) - nothing dropped, nothing doubled.

**The args are appended with NO `--` separator, and that is load-bearing.** `pnpm ... test -- --shard=1/3` forwards the literal `--` on to vitest, which then reads everything after it as positional path filters. The shard flag is **silently ignored and the leg runs the whole suite** - measured, not hypothetical; it ran all 1045 files and exited 0. Written the intuitive way, all three legs would each have done the full suite: 3x the runner cost, no speedup, and nothing failing to say so.

**`SHARD_SOFT_BUDGET_SECONDS` 1200 -> 600.** 1200 was calibrated to the shard's pre-split runtime, so after this split it could no longer fire for any leg in the matrix and had quietly stopped being an early warning - the exact "guard that no longer guards" trap. At 600 it also becomes the backstop for the failure above: a leg that stops sharding takes ~942s and trips the warning.

**New guard: `packages/scripts/src/checkClientTestShards.test.ts`.** This pins the one invariant nothing else can catch. Drop `--shard=3/3` and roughly a third of the suite stops running, with every remaining leg green and no count anywhere to contradict it. Duplicate a leg and those files run twice while another third never runs at all. The `Run Tests` fan-in gate only checks that the legs it was *given* passed - not that they covered everything. The guard asserts the indices present are exactly 1..N with no gaps or repeats, that the legs agree on N, and that no `--` separator has crept back in.

I mutation-tested it rather than trusting it: deleting the `3/3` leg fails `covers every index exactly once`, and re-adding the `--` fails `appends the shard args with no separator`. Both confirmed red.

**Docs** - `CLAUDE.md` gains how to reproduce one leg locally (`pnpm --filter @bike4mind/client test --shard=2/3`), the `--` trap with a pointer to the guard, and the note that balance is by file count rather than duration.

## Guide for Testers

CI/test-infrastructure only. **Nothing in the app changed** - see "What NOT to test".

### A. Confirm the three legs tile the suite (the important check)

The risk of sharding is a leg going missing: the remaining legs stay green while a third of the suite silently stops running.

1. Check out this branch, then `pnpm install --frozen-lockfile --recursive`
2. `pnpm turbo:core:build`
3. Get the unsharded total: `pnpm --filter @bike4mind/client test`
   - **Expected:** `Test Files 1045 passed | 10 skipped (1055)`. Note the numbers; they grow as tests are added, so use your own run as the baseline rather than the table above.
4. Run each leg and record its `Test Files` line:
   - `pnpm --filter @bike4mind/client test --shard=1/3`
   - `pnpm --filter @bike4mind/client test --shard=2/3`
   - `pnpm --filter @bike4mind/client test --shard=3/3`
   - **Expected:** each reports ~351-352 files, all green.
5. Add the three totals up.
   - **Expected:** exactly the step-3 total (1055), with passed and skipped each summing to the step-3 figures (1045 and 10). Any other number means the partition leaks.

### B. Confirm the `--` trap is real (worth seeing once)

6. Run `pnpm --filter @bike4mind/client test -- --shard=1/3` (note the extra `--`).
   - **Expected:** it prints `> vitest run -- --shard=1/3` and then runs **the whole suite** (~1055 files), exiting 0. This is the silent failure the workflow comments and the guard exist to prevent. It is why CI appends the args bare.

### C. Confirm the guard actually fails

7. `pnpm --filter @bike4mind/scripts exec vitest run src/checkClientTestShards.test.ts`
   - **Expected:** 9 tests pass.
8. Delete the `- name: client 3/3` block (all four lines) from `.github/workflows/ci.yml`, re-run step 7.
   - **Expected:** fails on `covers every index exactly once, with no gaps and no duplicates`. Restore the block.
9. In the `run:` line of the `Run Tests` step, insert `--` before `${{ matrix.shard.args }}`, re-run step 7.
   - **Expected:** fails on `appends the shard args with no \`--\` separator`. Revert.

### D. Confirm on this PR's own CI run

10. Open this PR's Actions run.
    - **Expected:** three separate `Run Tests (client 1/3 | 2/3 | 3/3)` checks, all green, plus the unchanged `Run Tests (client-integration)`.
11. Open each client leg's job summary.
    - **Expected:** a `- Run Tests (client N/3: XmYYs)` line in each, each well under 10 minutes, and **no** `Slow test shard` warning.
12. Confirm the required aggregate still reports.
    - **Expected:** a single `Run Tests` check passes. Branch protection requires that name (plus `validate`, `CI Complete`, `preview gate`) and not the per-shard names, so renaming the legs does not orphan a required check - verified against the repo rulesets.

### Regression Checks

13. `pnpm turbo:typecheck` -> clean.
14. `pnpm lint:check` -> clean.
15. `pnpm --filter @bike4mind/scripts test` -> green. (Note: `20260825000000_feedback-derived-keys-and-text-split.integration.test.ts` is a known real-DB flake under parallel load - it passes in isolation and is untouched by this PR.)
16. Integration lane unchanged: `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/client run test:integration`
    - **Expected:** `Test Files 20 passed (20)`. It carries no `args`, so its command is byte-identical to before apart from a trailing space.
17. Check the non-client legs are unaffected: `matrix.shard.args` is empty for them, so `Run Tests (services | data | misc | cli-slack)` should all still pass on this PR's run.
18. Confirm the `misc` leg still runs the out-of-workspace tests (`--dir infra`, `--dir scripts/codemods`) - it is still pinned by `matrix.shard.name == 'misc'`, which this PR does not touch.

### What NOT to test

- No product surface changed. No UI, route, API, admin setting, or preview environment is involved.
- Do not chase per-leg duration differences as a bug - see below, that is expected.
- `apps/client/vitest.config.mts` is **not** touched by this PR; the node/jsdom project split landed in #2113.

## Additional Information

**Projected effect.** Pre-split the client shard was 941s of test time + ~113s of fixed setup = 17m34s, against a next-slowest job of 7m0s. Three legs put each at roughly 314s + 113s, so the client lane should stop being the critical path and `Build amd64` (7m0s) becomes it. That is also why three and not four: past this point the workflow's wall time is bounded by `Build amd64` regardless, so a fourth leg would buy runner cost and no end-to-end gain.

**Honest caveat on balance.** Hash sharding balances file **count**, not duration. The legs came out at 352/352/351 files but 64s/41s/89s locally - a 2.2x spread. Some of that is measurement noise (the three ran sequentially with different CPU availability), but not all: leg 2 spent 62s in `tests` against leg 3's 271s, which is real. So expect the CI legs to be uneven, and the slowest to land above the naive 314s estimate. There is no built-in duration-balanced sharding to reach for - vitest's duration cache is per-machine and not shared across CI jobs - so the position here is to accept the unevenness and rely on the per-shard duration report to surface a leg that drifts badly. The 600s soft budget is the tripwire.

**Cost.** This adds two runners per CI run for the client lane. The setup overhead (~113s of install + core-build restore) is now paid three times instead of once; the test work itself is unchanged in total.

**Follow-up.** Two P3 review findings on the guard itself are tracked in #2161 rather than fixed here: the `--` separator check locates the run line with a `.find()` that a reflowed comment could shadow, and `readShardLegs` claims every `--shard=i/N` in the workflow, so sharding a second package later would be a false red. Neither affects the split; both are about hardening the guard.

## Developer Notes (Optional)

- **Prefer a tool's own partitioning over hand-maintained buckets.** `--shard` gives an exact tiling for free; the alternative (a directory list per leg) is the drift hazard this matrix already warns about elsewhere. Reach for the built-in whenever a job needs splitting.
- **`--` in a `pnpm run` passthrough is a silent-failure generator.** pnpm forwards the separator itself, and the receiving CLI may reinterpret everything after it as positional args. Any flag added to a CI test command through a script indirection deserves a check that it actually took effect - a "faster" command that silently does more work looks identical in a green build.
- **A guard calibrated to old numbers stops being a guard.** `SHARD_SOFT_BUDGET_SECONDS` at 1200 would have gone permanently silent after this split. Worth re-reading any threshold in the same PR that changes what it measures.
- **Mutation-test workflow guards.** This one was written, then broken two ways on purpose to confirm it goes red. Its first run also caught a real bug in itself - the regex counted a `--shard=1/3` quoted inside a workflow comment as a real leg, which is exactly how a guard ends up satisfied by prose after the thing it guards is deleted.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc

