### PR TITLE
fix(waf): put production's rate limits in Count for one measurement week

### DIFF
--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -369,21 +369,51 @@ describe('wafPolicy', () => {
       expect(rateBased.Limit).toBeGreaterThan(apiLimit);
     });
 
-    // Nothing else pins this. #1893's parity guard deep-equals Statement only, so flipping a
-    // production limit to Count is invisible to every other test in this file. When these do go
-    // to Count for a first week of measurement, this assertion is what makes coming back to
-    // Block something the build demands rather than something someone remembers.
-    it('enforces, rather than counts, every production rate limit', () => {
+    // Production's rate limits are in Count for one measurement week, deliberately, and this
+    // assertion is the thing that makes going back to Block a build requirement rather than
+    // something someone remembers. Nothing else in the file would notice: #1893's parity guard
+    // deep-equals Statement and never the rule object.
+    //
+    // What has to be true before each rule flips back to Block:
+    //   api-rate-limit         a week of CountedRequests on production traffic, not staging's,
+    //                          since the January 0.7% was measured on the old blanket shape
+    //   default-rate-limit     5000 has no measurement under it anywhere yet
+    //   image-rate-limit       1000 likewise, and it is the one expensive non-API path
+    //   ai-route, register     both shadows have read zero on staging for weeks, so a Count week
+    //                          is the first real signal either has produced
+    //   static-asset           a DoS backstop, so the reading matters least of the six
+    //
+    // Flip the rule and this assertion together, per rule, as each reading justifies it.
+    // emergency-ip-block and the managed rule groups are untouched and stay enforcing.
+    it('counts, rather than blocks, every production rate limit during the measurement week', () => {
       const rules: WafRule[] = JSON.parse(
         buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
       );
 
-      // any: see above
+      // any: RateBasedStatement shape is deeply nested and varies by statement type
       const limits = rules.filter(r => (r.Statement as any).RateBasedStatement);
       expect(limits.length).toBeGreaterThan(0);
 
       for (const rule of limits) {
-        expect(rule.Action, `${rule.Name} must Block, not Count`).toEqual({ Block: {} });
+        expect(rule.Action, `${rule.Name} is in Count for the measurement week`).toEqual({ Count: {} });
+      }
+    });
+
+    // The break-glass control and the managed rule groups are not part of the measurement week.
+    // If Count ever spreads to these, production has no enforcing rule left at all.
+    it('keeps the emergency IP block enforcing throughout', () => {
+      const rules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      const emergency = rules.find(r => r.Name === 'emergency-ip-block');
+      expect(emergency).toBeDefined();
+      expect(emergency!.Action).toEqual({ Block: {} });
+
+      for (const rule of rules.filter(r => (r.Statement as any).ManagedRuleGroupStatement)) {
+        expect(rule.OverrideAction, `${rule.Name} must not be overridden to Count wholesale`).toEqual({
+          None: {},
+        });
       }
     });
   });

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -325,7 +325,12 @@ describe('wafPolicy', () => {
         for (const rule of scopedRateLimits(stage)) {
           for (const byteMatch of rateLimitByteMatches(rule)) {
             expect(byteMatch.FieldToMatch.UriPath, `${rule.Name} must match on UriPath`).toBeDefined();
-            expect(byteMatch.PositionalConstraint, `${rule.Name} must be prefix-anchored`).toBe('STARTS_WITH');
+            // EXACTLY is accepted alongside STARTS_WITH because it is strictly tighter: it is what
+            // single files such as /version.json use, so the match cannot creep to /version.jsonx.
+            // What this rejects is CONTAINS and ENDS_WITH, neither anchored at the path root.
+            expect(['STARTS_WITH', 'EXACTLY'], `${rule.Name} must be anchored at the path root`).toContain(
+              byteMatch.PositionalConstraint
+            );
           }
         }
       });
@@ -344,8 +349,8 @@ describe('wafPolicy', () => {
 
       // any: see above
       const rateBased = (image!.Statement as any).RateBasedStatement;
-      const staticRule = rules.find(r => r.Name === 'static-asset-rate-limit');
-      const staticLimit = (staticRule!.Statement as any).RateBasedStatement.Limit;
+      const assetRule = rules.find(r => r.Name === 'static-asset-rate-limit');
+      const staticLimit = (assetRule!.Statement as any).RateBasedStatement.Limit;
 
       expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/image');
       expect(rateBased.Limit).toBeLessThan(staticLimit);
@@ -367,18 +372,29 @@ describe('wafPolicy', () => {
       const rateBased = (fallback!.Statement as any).RateBasedStatement;
       const apiLimit = (rules.find(r => r.Name === 'api-rate-limit')!.Statement as any).RateBasedStatement.Limit;
 
-      // Excludes only real assets. /_next/static/ is the sole prefix CloudFront routes to the
-      // bucket, so /_next/data, /_next/image and any case variant stay function-backed and must
-      // fall through to this ceiling rather than into the 50000 asset bucket.
-      // Excludes every bucket-served prefix, each confirmed by probing staging for an AmazonS3
-      // server header. /_next/static/ alone was not enough: in the worst 5-minute window, 84% of
-      // what this rule counted was /icons/, /images/, /scripts/, /version.json and /app-config/,
-      // so the fall-through budget was being spent on cache-cheap files rather than on the
-      // function-backed paths this ceiling exists to bound.
-      const excluded = rateLimitByteMatches(fallback!).map(m => m.SearchString);
-      expect(excluded).toEqual(
-        expect.arrayContaining(['/_next/static/', '/icons/', '/images/', '/scripts/', '/app-config/'])
-      );
+      // Every prefix this rule excludes has to be picked up by the asset backstop instead. Taking
+      // paths out of one ceiling without putting them into another is what image-rate-limit was
+      // created to fix for /_next/image, and the first version of this exclusion repeated that
+      // mistake six times over. Comparing the two sets keeps the partition total rather than
+      // trusting it stays that way. Each prefix was confirmed bucket-served by probing staging
+      // for an AmazonS3 server header rather than inferred from its name.
+      const key = (m: { PositionalConstraint: string; SearchString: string }) =>
+        `${m.PositionalConstraint} ${m.SearchString}`;
+      const assetRule = rules.find(r => r.Name === 'static-asset-rate-limit');
+      const excluded = rateLimitByteMatches(fallback!).map(key).sort();
+      const covered = rateLimitByteMatches(assetRule!).map(key).sort();
+
+      expect(excluded, 'every excluded prefix must land in the asset backstop').toEqual(covered);
+      // Pinned as well, so the set cannot quietly shrink to nothing and still match.
+      expect(excluded).toEqual([
+        'EXACTLY /favicon.ico',
+        'EXACTLY /version.json',
+        'STARTS_WITH /_next/static/',
+        'STARTS_WITH /app-config/',
+        'STARTS_WITH /icons/',
+        'STARTS_WITH /images/',
+        'STARTS_WITH /scripts/',
+      ]);
       // Pinned, not bounded: this number is about to be retuned off a shadow reading, and a
       // greater-than assertion would pass a 10x loosening while failing a tightening.
       expect(rateBased.Limit).toBe(5000);
@@ -485,7 +501,9 @@ describe('wafPolicy', () => {
       // Only /_next/static/ is routed to the assets bucket: probed staging, /_next/static/x answers
       // from AmazonS3 while /_next/x and /_NEXT/static/x both come from the default origin. So the
       // carve-out stops here and everything else under /_next/ stays function-backed.
-      expect(rateBased.ScopeDownStatement.ByteMatchStatement.SearchString).toBe('/_next/static/');
+      // Covers every bucket-served prefix, the same set default-rate-limit excludes, so asserting
+      // one prefix here would go stale the moment that set changes. The partition test owns it.
+      expect(rateLimitByteMatches(assetRule!).length).toBeGreaterThan(1);
     });
 
     it('includes the ai-route-rate-limit rule at Priority 4', () => {

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -266,11 +266,19 @@ describe('wafPolicy', () => {
     });
   });
 
-  // The scope-down of a rate limit, whether asserted directly or negated with NotStatement.
-  // any: WAF statements nest differently per type; this reaches the ByteMatch in either shape.
-  function rateLimitByteMatch(rule: WafRule): any {
-    const scopeDown = (rule.Statement as any).RateBasedStatement?.ScopeDownStatement;
-    return scopeDown?.ByteMatchStatement ?? scopeDown?.NotStatement?.Statement?.ByteMatchStatement;
+  // Every path match in a rate limit's scope-down, at any nesting depth. A limit may assert one
+  // prefix directly, or negate a whole set of them with NotStatement wrapping an OrStatement, so
+  // returning a list is what lets one assertion cover both shapes.
+  // any: WAF statements nest differently per type and the tree is not usefully typed here.
+  function rateLimitByteMatches(rule: WafRule): any[] {
+    const found: any[] = [];
+    const walk = (node: any): void => {
+      if (!node || typeof node !== 'object') return;
+      if (node.ByteMatchStatement) found.push(node.ByteMatchStatement);
+      Object.values(node).forEach(walk);
+    };
+    walk((rule.Statement as any).RateBasedStatement?.ScopeDownStatement);
+    return found;
   }
 
   /** Every rate-based rule in a stage that narrows itself with a scope-down. */
@@ -296,27 +304,29 @@ describe('wafPolicy', () => {
         expect(limits.length).toBeGreaterThan(0);
 
         for (const rule of limits) {
-          const byteMatch = rateLimitByteMatch(rule);
-          expect(byteMatch, `${rule.Name} scope-down must match on a path`).toBeDefined();
+          const matches = rateLimitByteMatches(rule);
+          expect(matches.length, `${rule.Name} scope-down must match on a path`).toBeGreaterThan(0);
 
-          const ordered = [...(byteMatch.TextTransformations ?? [])]
-            .sort((a: { Priority: number }, b: { Priority: number }) => a.Priority - b.Priority)
-            .map((t: { Type: string }) => t.Type);
+          for (const byteMatch of matches) {
+            const ordered = [...(byteMatch.TextTransformations ?? [])]
+              .sort((a: { Priority: number }, b: { Priority: number }) => a.Priority - b.Priority)
+              .map((t: { Type: string }) => t.Type);
 
-          expect(ordered, `${rule.Name} must decode, then normalize, then lowercase`).toEqual([
-            'URL_DECODE',
-            'NORMALIZE_PATH',
-            'LOWERCASE',
-          ]);
+            expect(ordered, `${rule.Name} must decode, then normalize, then lowercase`).toEqual([
+              'URL_DECODE',
+              'NORMALIZE_PATH',
+              'LOWERCASE',
+            ]);
+          }
         }
       });
 
       it(`anchors every ${stage} rate limit to a URI path prefix`, () => {
         for (const rule of scopedRateLimits(stage)) {
-          const byteMatch = rateLimitByteMatch(rule);
-
-          expect(byteMatch.FieldToMatch.UriPath, `${rule.Name} must match on UriPath`).toBeDefined();
-          expect(byteMatch.PositionalConstraint, `${rule.Name} must be prefix-anchored`).toBe('STARTS_WITH');
+          for (const byteMatch of rateLimitByteMatches(rule)) {
+            expect(byteMatch.FieldToMatch.UriPath, `${rule.Name} must match on UriPath`).toBeDefined();
+            expect(byteMatch.PositionalConstraint, `${rule.Name} must be prefix-anchored`).toBe('STARTS_WITH');
+          }
         }
       });
     }
@@ -360,8 +370,14 @@ describe('wafPolicy', () => {
       // Excludes only real assets. /_next/static/ is the sole prefix CloudFront routes to the
       // bucket, so /_next/data, /_next/image and any case variant stay function-backed and must
       // fall through to this ceiling rather than into the 50000 asset bucket.
-      expect(rateBased.ScopeDownStatement.NotStatement.Statement.ByteMatchStatement.SearchString).toBe(
-        '/_next/static/'
+      // Excludes every bucket-served prefix, each confirmed by probing staging for an AmazonS3
+      // server header. /_next/static/ alone was not enough: in the worst 5-minute window, 84% of
+      // what this rule counted was /icons/, /images/, /scripts/, /version.json and /app-config/,
+      // so the fall-through budget was being spent on cache-cheap files rather than on the
+      // function-backed paths this ceiling exists to bound.
+      const excluded = rateLimitByteMatches(fallback!).map(m => m.SearchString);
+      expect(excluded).toEqual(
+        expect.arrayContaining(['/_next/static/', '/icons/', '/images/', '/scripts/', '/app-config/'])
       );
       // Pinned, not bounded: this number is about to be retuned off a shadow reading, and a
       // greater-than assertion would pass a 10x loosening while failing a tightening.

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -455,26 +455,170 @@
           "EvaluationWindowSec": 300,
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
-            "ByteMatchStatement": {
-              "SearchString": "/_next/static/",
-              "FieldToMatch": {
-                "UriPath": {}
-              },
-              "TextTransformations": [
+            "OrStatement": {
+              "Statements": [
                 {
-                  "Priority": 0,
-                  "Type": "URL_DECODE"
+                  "ByteMatchStatement": {
+                    "SearchString": "/_next/static/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
                 },
                 {
-                  "Priority": 1,
-                  "Type": "NORMALIZE_PATH"
+                  "ByteMatchStatement": {
+                    "SearchString": "/icons/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
                 },
                 {
-                  "Priority": 2,
-                  "Type": "LOWERCASE"
+                  "ByteMatchStatement": {
+                    "SearchString": "/images/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/scripts/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/app-config/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/version.json",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "EXACTLY"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/favicon.ico",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "EXACTLY"
+                  }
                 }
-              ],
-              "PositionalConstraint": "STARTS_WITH"
+              ]
             }
           }
         }
@@ -846,7 +990,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -869,7 +1013,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     }
                   ]
@@ -897,26 +1041,170 @@
           "EvaluationWindowSec": 300,
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
-            "ByteMatchStatement": {
-              "SearchString": "/_next/static/",
-              "FieldToMatch": {
-                "UriPath": {}
-              },
-              "TextTransformations": [
+            "OrStatement": {
+              "Statements": [
                 {
-                  "Priority": 0,
-                  "Type": "URL_DECODE"
+                  "ByteMatchStatement": {
+                    "SearchString": "/_next/static/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
                 },
                 {
-                  "Priority": 1,
-                  "Type": "NORMALIZE_PATH"
+                  "ByteMatchStatement": {
+                    "SearchString": "/icons/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
                 },
                 {
-                  "Priority": 2,
-                  "Type": "LOWERCASE"
+                  "ByteMatchStatement": {
+                    "SearchString": "/images/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/scripts/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/app-config/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/version.json",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "EXACTLY"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/favicon.ico",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "EXACTLY"
+                  }
                 }
-              ],
-              "PositionalConstraint": "STARTS_WITH"
+              ]
             }
           }
         }

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -709,26 +709,170 @@
           "ScopeDownStatement": {
             "NotStatement": {
               "Statement": {
-                "ByteMatchStatement": {
-                  "SearchString": "/_next/static/",
-                  "FieldToMatch": {
-                    "UriPath": {}
-                  },
-                  "TextTransformations": [
+                "OrStatement": {
+                  "Statements": [
                     {
-                      "Priority": 0,
-                      "Type": "URL_DECODE"
+                      "ByteMatchStatement": {
+                        "SearchString": "/_next/static/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
                     },
                     {
-                      "Priority": 1,
-                      "Type": "NORMALIZE_PATH"
+                      "ByteMatchStatement": {
+                        "SearchString": "/icons/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
                     },
                     {
-                      "Priority": 2,
-                      "Type": "LOWERCASE"
+                      "ByteMatchStatement": {
+                        "SearchString": "/images/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/scripts/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/app-config/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/version.json",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/favicon.ico",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
                     }
-                  ],
-                  "PositionalConstraint": "STARTS_WITH"
+                  ]
                 }
               }
             }

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -447,26 +447,170 @@
           "EvaluationWindowSec": 300,
           "AggregateKeyType": "IP",
           "ScopeDownStatement": {
-            "ByteMatchStatement": {
-              "SearchString": "/_next/static/",
-              "FieldToMatch": {
-                "UriPath": {}
-              },
-              "TextTransformations": [
+            "OrStatement": {
+              "Statements": [
                 {
-                  "Priority": 0,
-                  "Type": "URL_DECODE"
+                  "ByteMatchStatement": {
+                    "SearchString": "/_next/static/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
                 },
                 {
-                  "Priority": 1,
-                  "Type": "NORMALIZE_PATH"
+                  "ByteMatchStatement": {
+                    "SearchString": "/icons/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
                 },
                 {
-                  "Priority": 2,
-                  "Type": "LOWERCASE"
+                  "ByteMatchStatement": {
+                    "SearchString": "/images/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/scripts/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/app-config/",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "STARTS_WITH"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/version.json",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "EXACTLY"
+                  }
+                },
+                {
+                  "ByteMatchStatement": {
+                    "SearchString": "/favicon.ico",
+                    "FieldToMatch": {
+                      "UriPath": {}
+                    },
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "URL_DECODE"
+                      },
+                      {
+                        "Priority": 1,
+                        "Type": "NORMALIZE_PATH"
+                      },
+                      {
+                        "Priority": 2,
+                        "Type": "LOWERCASE"
+                      }
+                    ],
+                    "PositionalConstraint": "EXACTLY"
+                  }
                 }
-              ],
-              "PositionalConstraint": "STARTS_WITH"
+              ]
             }
           }
         }
@@ -670,7 +814,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -693,7 +837,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     }
                   ]

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -533,26 +533,170 @@
           "ScopeDownStatement": {
             "NotStatement": {
               "Statement": {
-                "ByteMatchStatement": {
-                  "SearchString": "/_next/static/",
-                  "FieldToMatch": {
-                    "UriPath": {}
-                  },
-                  "TextTransformations": [
+                "OrStatement": {
+                  "Statements": [
                     {
-                      "Priority": 0,
-                      "Type": "URL_DECODE"
+                      "ByteMatchStatement": {
+                        "SearchString": "/_next/static/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
                     },
                     {
-                      "Priority": 1,
-                      "Type": "NORMALIZE_PATH"
+                      "ByteMatchStatement": {
+                        "SearchString": "/icons/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
                     },
                     {
-                      "Priority": 2,
-                      "Type": "LOWERCASE"
+                      "ByteMatchStatement": {
+                        "SearchString": "/images/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/scripts/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/app-config/",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/version.json",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/favicon.ico",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "URL_DECODE"
+                          },
+                          {
+                            "Priority": 1,
+                            "Type": "NORMALIZE_PATH"
+                          },
+                          {
+                            "Priority": 2,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
                     }
-                  ],
-                  "PositionalConstraint": "STARTS_WITH"
+                  ]
                 }
               }
             }

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -160,7 +160,7 @@
         }
       },
       "Action": {
-        "Block": {}
+        "Count": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,
@@ -202,7 +202,7 @@
         }
       },
       "Action": {
-        "Block": {}
+        "Count": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,
@@ -430,7 +430,7 @@
         }
       },
       "Action": {
-        "Block": {}
+        "Count": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,
@@ -472,7 +472,7 @@
         }
       },
       "Action": {
-        "Block": {}
+        "Count": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,
@@ -514,7 +514,7 @@
         }
       },
       "Action": {
-        "Block": {}
+        "Count": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,
@@ -560,7 +560,7 @@
         }
       },
       "Action": {
-        "Block": {}
+        "Count": {}
       },
       "VisibilityConfig": {
         "SampledRequestsEnabled": true,


### PR DESCRIPTION
The step between Bike4Mind/bike4mind#1959 and actually enabling the firewall. Every production rate limit goes to `Count`; the emergency IP block and the AWS managed rule groups are deliberately untouched and stay enforcing.

## Why not straight to Block

When this rule set was last live on production it blocked **2,021 of 279,554** requests in a month, nobody explained them, and the production WAF log group has since aged to **zero stored bytes**, so nobody can. Producing that explanation before enforcing is the only way not to repeat it.

Four of the six ceilings have no measurement under them at all:

| rule | ceiling | evidence today |
| --- | --- | --- |
| `api-rate-limit` | 2000 | staging measured the old **blanket** shape, which no longer exists |
| `default-rate-limit` | 5000 | none, the rule is new |
| `image-rate-limit` | 1000 | none, the rule is new |
| `ai-route-rate-limit` | 300 | shadow has read **zero** on staging for weeks |
| `register-rate-limit` | 100 | shadow has read **zero** on staging for weeks |
| `static-asset-rate-limit` | 50000 | a DoS backstop, so it matters least |

**Count is not a week without protection.** `ENABLE_WAF` is unset on the deployer's production environment, so production has no firewall attached today either way. The comparison is Count against nothing, not Count against Block.

## The guard flips in this same commit

That was the condition attached to the Count recommendation in review, and it is the point of the change as much as the flip is. With the assertion now pinning `Count`, going back to `Block` is something the build demands rather than something someone remembers. Nothing else in the file would notice: Bike4Mind/bike4mind#1893's parity guard deep-equals `Statement` and never the rule object.

The per-rule evidence needed before each flip back is written into the comment above the assertion, so the next person does not have to reconstruct it from PR history. Rules flip back one at a time, each with its own reading.

## What stays enforcing

`emergency-ip-block` and the five managed rule groups. Added a guard for that too, because the failure mode is quiet: if `Count` spread to those, production would have a WAF with no enforcing rule in it at all and a dashboard that still looked busy.

## Retuned mid-review off the first staging reading

Staging deployed the scoped policy this morning, and the first hours changed one of these numbers before the PR merged.

**The scope fix worked.** `api-rate-limit-prod-shadow`, hourly, with the deploy at ~06:53 UTC: 25,164 then 26,921 on the old blanket shape, then **zero every hour** once scoped to `/api/`. So 2000 scoped is comfortable and that is now measured rather than argued.

**The problem moved to the fall-through.** `default-rate-limit-prod-shadow` counted up to 26,782 in an hour, with a per-IP peak of **8,191 in one 5-minute window** against its 5000 ceiling.

The composition of that peak window is what decided the fix: **84% was cache-cheap static files** - `/icons/`, `/images/`, `/scripts/`, `/version.json`, `/app-config/` - and only `/new`, at 289 requests, was function-backed. So the ceiling was not too low. It was spending a budget meant for function-backed paths on static ones, which is the same mistake the original blanket rule made one level up.

So the exclusion now covers every bucket-served prefix, each confirmed by probing staging for an `AmazonS3` server header rather than inferred from its name. `/serwist/sw.js`, `/new` and `/auth/success` answer from the default origin and are deliberately still counted. Excluding those prefixes takes the peak from ~8,191 to roughly 1,300, comfortably under the ceiling.

**Worth knowing about this list.** There was no routing table to derive it from - the distribution has a single default origin and no path-pattern cache behaviours, so the S3 split happens behind CloudFront. That makes the exclusion a duplication of logic living elsewhere, and it will need revisiting whenever a static prefix is added. A test cannot catch that drift, since the routing is not in this repo.

## Verification

- AWS accepts both policies: **prod 1318 WCU, dev 1342**, against the **1500** basic-tier boundary, so headroom is now about 182 and 158.
- **34 tests** pass in `infra/__tests__`, which gate the build.
- The test helper now walks every path match in a scope-down rather than the first. It previously read one `ByteMatch`, so against a seven-entry exclusion set the order and anchoring guards would have checked one and passed on the other six. Confirmed by mutation: breaking one entry's transformation order now fails.
- Each guard fails on its own mutation: leaving one rule on `Block` (an incomplete flip), flipping `emergency-ip-block` to `Count`, and overriding a managed group to `Count` wholesale each fail exactly one assertion.

## After this

Setting `ENABLE_WAF=true` on the deployer's **production** environment is the next step and the first one with a live effect. It is a variable change rather than a code change, so it does not belong in this PR. Two checks belong with it, both about output rather than configuration, since a control that is enabled and producing nothing is what started this whole thread: `AllowedRequests` appearing in CloudWatch for the new ACL, and sending `/%2e/api/...` at staging to confirm the reordered transformations actually count a normalized path.

