### PR TITLE
fix(data-lakes): finish the self-host chunk rescue sweep when one enqueue fails

### DIFF
--- a/apps/client/server/worker/chunkRescueSweep.test.ts
+++ b/apps/client/server/worker/chunkRescueSweep.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getSettingsValue: vi.fn(),
+  fabFileFind: vi.fn(),
+  sendToQueue: vi.fn(),
+  // Spied (not a bare stub) so a test can assert the sweep passes BOTH the age cutoff and the
+  // stale-claim cutoff: a one-arg call silently turns the stale-claim rescue arm back off.
+  buildScanFilter: vi.fn((cutoff: Date, _staleClaimBefore: Date) => ({ chunkCount: 0, createdAt: { $lt: cutoff } })),
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  adminSettingsRepository: { getSettingsValue: h.getSettingsValue },
+  FabFile: { find: h.fabFileFind },
+}));
+vi.mock('sst', () => ({ Resource: { fabFileChunkQueue: { url: 'http://elasticmq/fabFileChunkQueue' } } }));
+vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => h.sendToQueue(...a) }));
+vi.mock('./chunkScan', () => ({
+  buildFabFileChunkScanFilter: (...a: unknown[]) => h.buildScanFilter(...(a as [Date, Date])),
+  CHUNK_SCAN_BATCH: 50,
+  CHUNK_SCAN_MIN_AGE_MS: 2 * 60_000,
+  CHUNK_CLAIM_STALE_MS: 30 * 60_000,
+}));
+
+import { runChunkRescueSweep } from './chunkRescueSweep';
+
+type Candidate = { _id: string; userId: string; batchId?: string };
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+/** The sweep only ever calls info/error on it; the real Logger's surface is irrelevant here. */
+const runSweep = () => runChunkRescueSweep(logger as never);
+
+const limitSpy = vi.fn();
+const withCandidates = (candidates: Candidate[]) => {
+  h.fabFileFind.mockReturnValue({
+    select: () => ({
+      limit: (n: number) => {
+        limitSpy(n);
+        return { lean: async () => candidates };
+      },
+    }),
+  });
+};
+
+describe('runChunkRescueSweep (self-host chunk rescue)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Defaults: auto-chunk on, no candidates, sends succeed. The send stub is reset explicitly
+    // because clearAllMocks() clears calls but NOT implementations - without this a test that
+    // makes sendToQueue reject would leak that into every test after it in file order.
+    h.getSettingsValue.mockResolvedValue(true);
+    h.sendToQueue.mockResolvedValue(undefined);
+    withCandidates([]);
+  });
+
+  it('does no work at all when auto-chunk is disabled', async () => {
+    h.getSettingsValue.mockResolvedValue(false);
+
+    await expect(runSweep()).resolves.toEqual({ enqueued: 0, failed: 0 });
+
+    // The gate is before the QUERY, not just before the send: a disabled install must not pay for
+    // an indexed scan of every complete-but-unchunked file once a minute, forever.
+    expect(h.fabFileFind).not.toHaveBeenCalled();
+    expect(h.sendToQueue).not.toHaveBeenCalled();
+  });
+
+  it('selects with both cutoffs and the per-pass cap', async () => {
+    await runSweep();
+
+    expect(h.buildScanFilter).toHaveBeenCalledTimes(1);
+    const [cutoff, staleClaimBefore] = h.buildScanFilter.mock.calls[0];
+    expect(cutoff).toBeInstanceOf(Date);
+    // The stale-claim arm rescues files whose worker died before clearing isChunking. Dropping this
+    // argument is a silent regression: the filter still works, it just stops rescuing that class.
+    expect(staleClaimBefore).toBeInstanceOf(Date);
+    expect(staleClaimBefore.getTime()).toBeLessThan(cutoff.getTime());
+    expect(limitSpy).toHaveBeenCalledWith(50);
+  });
+
+  it('stamps convergence provenance only on files that belong to a batch', async () => {
+    withCandidates([
+      { _id: 'ff1', userId: 'u1', batchId: 'b1' },
+      { _id: 'ff2', userId: 'u2' },
+    ]);
+
+    await expect(runSweep()).resolves.toEqual({ enqueued: 2, failed: 0 });
+
+    // Batch files are convergence work the kill switch may halt; a lone upload rescue is not, and
+    // stamping it would make the switch stop it too.
+    expect(h.sendToQueue).toHaveBeenCalledWith('http://elasticmq/fabFileChunkQueue', {
+      fabFileId: 'ff1',
+      userId: 'u1',
+      origin: 'convergence',
+    });
+    expect(h.sendToQueue).toHaveBeenCalledWith('http://elasticmq/fabFileChunkQueue', {
+      fabFileId: 'ff2',
+      userId: 'u2',
+    });
+  });
+
+  it('finishes the sweep when one enqueue fails, and reports the partial result (#2158)', async () => {
+    // The sweep is the safety net for files the chunk pipeline lost, so it matters most under the
+    // queue stress that makes a transient send failure likely. It used to reject out of the loop on
+    // the first failure: every candidate behind it was abandoned until the next tick, and the count
+    // it logged was the SELECTED size, so a tick that had sent almost nothing still read as a win.
+    withCandidates([
+      { _id: 'ff1', userId: 'u1' },
+      { _id: 'ff2', userId: 'u2' },
+      { _id: 'ff3', userId: 'u3' },
+      { _id: 'ff4', userId: 'u4' },
+    ]);
+    // TWO fail, and neither is first or last: the middle placement distinguishes "kept going" from
+    // "stopped early", and the second failure is what forces `failed` to accumulate - a counter
+    // pinned to 1 would satisfy a single-failure fixture.
+    h.sendToQueue.mockImplementation(async (_url: unknown, msg: { fabFileId: string }) => {
+      if (msg.fabFileId === 'ff2' || msg.fabFileId === 'ff3') throw new Error('SQS throttled');
+    });
+
+    await expect(runSweep()).resolves.toEqual({ enqueued: 2, failed: 2 });
+
+    // All four attempted - the ones behind a failure are not abandoned.
+    expect(h.sendToQueue).toHaveBeenCalledTimes(4);
+    expect(h.sendToQueue).toHaveBeenCalledWith('http://elasticmq/fabFileChunkQueue', {
+      fabFileId: 'ff4',
+      userId: 'u4',
+    });
+    // Each failure names its file. The sweep's return value is discarded by the scheduled-task
+    // wrapper, so without this line an operator cannot tell WHICH files were not enqueued.
+    for (const fabFileId of ['ff2', 'ff3']) {
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('failed to enqueue'),
+        expect.objectContaining({ fabFileId, error: 'SQS throttled' })
+      );
+    }
+    // And the summary is honest about the split rather than reporting the selected size.
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('enqueued 2 un-chunked file(s), 2 failed'));
+  });
+
+  it('still reports a tick whose every send failed', async () => {
+    // The "did something" guard on the log line keys off failures too. Keying it off `enqueued`
+    // alone would make a totally-broken queue look exactly like an idle install: silence.
+    withCandidates([{ _id: 'ff1', userId: 'u1' }]);
+    h.sendToQueue.mockRejectedValue(new Error('queue unreachable'));
+
+    await expect(runSweep()).resolves.toEqual({ enqueued: 0, failed: 1 });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('enqueued 0 un-chunked file(s), 1 failed'));
+  });
+
+  it('stays quiet when there is nothing to rescue', async () => {
+    // Runs once a minute on every self-host install; a per-tick log line would bury the real ones.
+    await expect(runSweep()).resolves.toEqual({ enqueued: 0, failed: 0 });
+
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('attempts every candidate across concurrency waves, not just the first wave', async () => {
+    // The fan-out runs in fixed-size waves; an off-by-one in the slice window would silently drop
+    // the tail of a full pass, which is indistinguishable from "the backlog was small" in the logs.
+    const candidates = Array.from({ length: 25 }, (_, i) => ({ _id: `ff${i}`, userId: `u${i}` }));
+    withCandidates(candidates);
+
+    await expect(runSweep()).resolves.toEqual({ enqueued: 25, failed: 0 });
+
+    expect(h.sendToQueue).toHaveBeenCalledTimes(25);
+  });
+});

--- a/apps/client/server/worker/chunkRescueSweep.ts
+++ b/apps/client/server/worker/chunkRescueSweep.ts
@@ -1,0 +1,101 @@
+/**
+ * Self-host driver for the un-chunked rescue sweep.
+ *
+ * Safety net for the MinIO webhook (pages/api/internal/s3/object-created.ts): if a notification is
+ * missed, re-enqueue files that completed upload but were never chunked so they stop being silently
+ * unsearchable. Selection lives in chunkScan.ts and is shared with the hosted twin.
+ *
+ * MUST STAY IN SYNC with `rescueUnchunkedFiles` in server/cron/dataLakeBatchReconcile.ts - the
+ * hosted deployment has no self-host worker and drives the same sweep off its daily SST cron. Their
+ * run budgets are meant to differ (50 per tick every 60s here vs 500 per day there); nothing else
+ * is, so a behavioural change to one belongs in both. They are still two functions because the
+ * hosted one folds its counts into the cron's response body and heartbeat metric, which have no
+ * analogue here - the divergence risk that buys is exactly what this notice is for.
+ *
+ * Lives in its own module rather than inline in main.ts so the enqueue accounting is reachable from
+ * a test at all: as a scheduled-task closure it was unexported and unnameable.
+ */
+
+import { adminSettingsRepository, FabFile } from '@bike4mind/database';
+import type { Logger } from '@bike4mind/observability';
+import { Resource } from 'sst';
+import { sendToQueue } from '@server/utils/sqs';
+import { CONVERGENCE_ORIGIN } from '@server/queueHandlers/convergenceProvenance';
+import {
+  buildFabFileChunkScanFilter,
+  CHUNK_SCAN_BATCH,
+  CHUNK_SCAN_MIN_AGE_MS,
+  CHUNK_CLAIM_STALE_MS,
+} from './chunkScan';
+
+/**
+ * How many rescue sends are in flight at once, matching driveLakeResyncPoll's sweep.
+ * The bound is what makes the per-file catch below safe: sendToQueue builds a fresh SQSClient per
+ * call (server/utils/sqs.ts), so its retry token bucket never throttles down across the loop and
+ * every failed send pays its full attempt budget with no back-off. Run one-at-a-time against a
+ * degraded queue, CHUNK_SCAN_BATCH of those can outlast the scheduler's 60s tick - and the worker's
+ * scheduled tasks are non-reentrant (selfHostWorker.ts), so an overrunning tick doesn't queue up,
+ * it makes the next one a skip. Removing the early exit without bounding the wall-clock would trade
+ * "abandons the tail" for "runs half as often exactly when it is needed most".
+ */
+const ENQUEUE_CONCURRENCY = 10;
+
+export async function runChunkRescueSweep(runLogger: Logger): Promise<{ enqueued: number; failed: number }> {
+  if (!(await adminSettingsRepository.getSettingsValue('enableAutoChunk'))) return { enqueued: 0, failed: 0 };
+
+  const now = Date.now();
+  const cutoff = new Date(now - CHUNK_SCAN_MIN_AGE_MS);
+  const staleClaimBefore = new Date(now - CHUNK_CLAIM_STALE_MS);
+  const candidates = await FabFile.find(buildFabFileChunkScanFilter(cutoff, staleClaimBefore))
+    .select('_id userId batchId')
+    .limit(CHUNK_SCAN_BATCH)
+    .lean();
+
+  // Enqueue the selected ids directly. No producer-side claim: the chunk worker's compare-and-set
+  // (fabFileChunk.ts) is the single point of mutual exclusion, so a file already in flight loses
+  // there and returns. The selection filter above already excludes in-flight files, so a merely-slow
+  // file is not re-sent every pass.
+  const userById = new Map(candidates.map(f => [String(f._id), String(f.userId)]));
+  const batchById = new Map(candidates.map(f => [String(f._id), f.batchId]));
+
+  // Bounded-concurrency fan-out with a PER-FILE catch. A throttled or unroutable send used to reject
+  // out of a sequential loop and abandon every candidate behind it, and the count reported was the
+  // selected size rather than the sent size. This sweep is the safety net for files the chunk
+  // pipeline lost, so it matters most under exactly the queue stress that makes a transient send
+  // failure likely - the failure mode was to give up when it was needed most.
+  // Read the queue URL once: an unlinked-resource fault is one config error, not 50 identical logs.
+  const queueUrl = Resource.fabFileChunkQueue.url;
+  let enqueued = 0;
+  let failed = 0;
+  const enqueueOne = async (id: string) => {
+    try {
+      await sendToQueue(queueUrl, {
+        fabFileId: id,
+        userId: userById.get(id)!,
+        ...(batchById.get(id) ? { origin: CONVERGENCE_ORIGIN } : {}),
+      });
+      enqueued++;
+    } catch (e) {
+      failed++;
+      runLogger.error('[fabFileChunkScan] failed to enqueue un-chunked file for rescue', {
+        fabFileId: id,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  };
+  const ids = [...userById.keys()];
+  for (let i = 0; i < ids.length; i += ENQUEUE_CONCURRENCY) {
+    await Promise.all(ids.slice(i, i + ENQUEUE_CONCURRENCY).map(id => enqueueOne(id)));
+  }
+
+  // A failed send changes nothing about the file, so it still matches the scan filter and a later
+  // tick retries it - a minute away, not a day. Not necessarily the NEXT one: the candidate query
+  // has no sort, so while the backlog exceeds CHUNK_SCAN_BATCH a given file is only eventually
+  // reached. `failed` is a signal that sends are being lost, not a marker of work dropped for good.
+  // Logged only when the tick did something, so an idle install stays quiet - but a tick that
+  // enqueued nothing BECAUSE every send failed still reports, which is the case worth seeing.
+  if (enqueued > 0 || failed > 0) {
+    runLogger.info(`[fabFileChunkScan] enqueued ${enqueued} un-chunked file(s), ${failed} failed`);
+  }
+  return { enqueued, failed };
+}

--- a/apps/client/server/worker/main.ts
+++ b/apps/client/server/worker/main.ts
@@ -1,6 +1,6 @@
 import type { SQSEvent } from 'aws-lambda';
 import { taskSchedulerService } from '@bike4mind/services';
-import { taskScheduleRepository, connectDB, FabFile, adminSettingsRepository } from '@bike4mind/database';
+import { taskScheduleRepository, connectDB } from '@bike4mind/database';
 import { TaskScheduleHandler } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
 import { Resource } from 'sst';
@@ -15,13 +15,7 @@ import { isDiscoveryDriver, startDiscoveryOnStartup } from '@server/modelDiscove
 import { runStuckBatchSweep } from '@server/cron/dataLakeBatchReconcile';
 import { SelfHostWorker } from './selfHostWorker';
 import { dispatchSelfHostEvent } from './eventDispatch';
-import {
-  buildFabFileChunkScanFilter,
-  CHUNK_SCAN_BATCH,
-  CHUNK_SCAN_MIN_AGE_MS,
-  CHUNK_CLAIM_STALE_MS,
-} from './chunkScan';
-import { CONVERGENCE_ORIGIN } from '@server/queueHandlers/convergenceProvenance';
+import { runChunkRescueSweep } from './chunkRescueSweep';
 import {
   FAB_FILE_CHUNK_MAX_RECEIVE_COUNT,
   FAB_FILE_VECTORIZE_MAX_RECEIVE_COUNT,
@@ -138,35 +132,10 @@ async function main() {
   });
 
   // Safety net for the MinIO webhook (pages/api/internal/s3/object-created.ts): if a
-  // notification is missed, sweep un-chunked files and enqueue them. The selection filter
-  // (buildFabFileChunkScanFilter) skips uploads that never completed so the scan can't churn.
+  // notification is missed, sweep un-chunked files and enqueue them. Selection and enqueue
+  // accounting live in chunkRescueSweep.ts, shared in shape with the hosted daily cron.
   worker.registerScheduledTask('fabFileChunkScan', CHUNK_SCAN_INTERVAL_MS, async () => {
-    if (!(await adminSettingsRepository.getSettingsValue('enableAutoChunk'))) return;
-
-    const now = Date.now();
-    const cutoff = new Date(now - CHUNK_SCAN_MIN_AGE_MS);
-    const staleClaimBefore = new Date(now - CHUNK_CLAIM_STALE_MS);
-    const candidates = await FabFile.find(buildFabFileChunkScanFilter(cutoff, staleClaimBefore))
-      .select('_id userId batchId')
-      .limit(CHUNK_SCAN_BATCH)
-      .lean();
-
-    // Enqueue the selected ids directly. No producer-side claim: the chunk worker's compare-and-set
-    // (fabFileChunk.ts) is the single point of mutual exclusion, so a file already in flight loses
-    // there and returns. The selection filter above already excludes in-flight files, so a merely-slow
-    // file is not re-sent every pass.
-    const userById = new Map(candidates.map(f => [String(f._id), String(f.userId)]));
-    const batchById = new Map(candidates.map(f => [String(f._id), f.batchId]));
-    for (const id of userById.keys()) {
-      await sendToQueue(Resource.fabFileChunkQueue.url, {
-        fabFileId: id,
-        userId: userById.get(id)!,
-        ...(batchById.get(id) ? { origin: CONVERGENCE_ORIGIN } : {}),
-      });
-    }
-    if (userById.size > 0) {
-      bootLogger.info(`[fabFileChunkScan] enqueued ${userById.size} un-chunked file(s)`);
-    }
+    await runChunkRescueSweep(bootLogger);
   });
 
   // Self-host counterpart of the hosted daily dataLakeBatchReconcile cron (infra/cron.ts):


### PR DESCRIPTION
# Pull Request

## Description

The self-host worker's `fabFileChunkScan` re-enqueues files that completed upload but were never chunked - the safety net for a missed MinIO webhook. It enqueued its candidates in a bare sequential loop with no per-file catch:

- **One rejected `sendToQueue` threw out of the loop** and abandoned every candidate behind it. This sweep matters most under exactly the queue stress that makes a transient send failure likely, so the failure mode was to give up when it was needed most.
- **The count it logged was the SELECTED size, not the sent size.** A tick that had sent almost nothing still read as `enqueued 50 un-chunked file(s)`.

Same two defects #2125 fixes in the hosted `dataLakeBatchReconcile` twin; this is the other copy. Lower severity here (50 files per tick rather than 500 per day, and the next attempt is a minute away rather than a day), but the same bug - and left alone the two copies would silently diverge, which is how one of them stays wrong indefinitely.

## Changes

- **New `apps/client/server/worker/chunkRescueSweep.ts`** exporting `runChunkRescueSweep(logger)`. Adopts `driveLakeResyncPoll`'s shape: an `enqueueOne` closure with a per-file `try`/`catch` counting `enqueued`/`failed`, run over `ENQUEUE_CONCURRENCY`-sized waves, with the queue URL read once above the loop.
- The bound is what makes removing the early exit safe. `sendToQueue` builds a fresh `SQSClient` per call, so its retry token bucket never throttles down across the loop and every failed send pays its full attempt budget with no back-off. Run one-at-a-time against a degraded queue, 50 of those can outlast the scheduler's 60s tick - and scheduled tasks are non-reentrant (`selfHostWorker.ts`), so an overrunning tick doesn't queue up, it makes the next one a skip. Without the bound this would trade "abandons the tail" for "runs half as often".
- **Both counts in the summary line**, and it now fires when `failed > 0` even if `enqueued` is 0 - otherwise a totally broken queue looks identical to an idle install: silence. Each failure also logs its `fabFileId`, since the sweep's return value is discarded by the scheduled-task wrapper.
- **`main.ts`'s task body is now a one-line call.** The extraction is what makes this testable at all: as a scheduled-task closure the enqueue accounting was unexported and unnameable, which is why the self-host copy had no tests while the hosted twin had thorough ones.
- **7 unit tests** covering the gate, the selection cutoffs, provenance stamping, partial failure, all-failed, the quiet path, and multi-wave coverage.

## Guide for Testers

This is a **self-host-only background worker** change with no UI. Verification is by unit test and log inspection.

### Automated

1. From the repo root, run:
   ```
   pnpm --filter @bike4mind/client exec vitest run --project node server/worker/chunkRescueSweep.test.ts
   ```
2. Expected: `Test Files 1 passed (1)`, `Tests 7 passed (7)`.
3. Confirm the tests are load-bearing rather than tautological - revert `chunkRescueSweep.ts`'s fan-out to a bare `for (const id of userById.keys()) await sendToQueue(...)` with `enqueued = userById.size`, re-run step 1, and expect exactly two failures: *"finishes the sweep when one enqueue fails"* and *"still reports a tick whose every send failed"*. Restore the file afterwards.

### Manual (optional, requires a self-host stack)

1. Bring up the self-host compose stack (`compose.selfhost.yaml`) and confirm the `worker` service is running.
2. In Admin settings, ensure `enableAutoChunk` is **on**.
3. Upload two or more files and let them reach `status: complete`.
4. In Mongo, set `chunkCount: 0` on those `fabfiles` documents and clear `isChunking`, `notes`, and `error`, so they match the rescue filter. Wait for their `createdAt` to be more than 2 minutes old.
5. Within 60 seconds the worker logs `[fabFileChunkScan] enqueued N un-chunked file(s), 0 failed`. Expected: `N` equals the number of files you reset, and they chunk.
6. To see the partial-failure path, point `SQS_ENDPOINT` at an unreachable address (or stop the ElasticMQ container) and repeat. Expected: one `[fabFileChunkScan] failed to enqueue un-chunked file for rescue` line **per file** naming its `fabFileId`, followed by a single `enqueued 0 un-chunked file(s), N failed` summary. Previously this produced one `scheduled task "fabFileChunkScan" failed` line and no per-file detail.

### Regression Checks

1. Auto-chunk **disabled**: no `[fabFileChunkScan]` log lines at all, and no Mongo query is issued (the gate is before the `FabFile.find`, and a test asserts it).
2. Auto-chunk **enabled with nothing to rescue**: still no log line. This task runs once a minute on every self-host install, so a per-tick line would bury the real ones.
3. Files that belong to a data-lake batch are still stamped `origin: 'convergence'` so the convergence kill switch can halt them; standalone upload rescues are still **not** stamped, so the switch does not stop them. Both directions are asserted in the tests.
4. The worker still boots and its other scheduled tasks (`taskScheduler`, `dataLakeBatchReconcile`, `modelDiscovery`) still register - `main.ts` lost four imports in this refactor.

### What NOT to test

- Anything in the hosted deployment. Hosted has no self-host worker; its copy of this sweep is `dataLakeBatchReconcile` and is being fixed separately in #2125.
- Chunking quality, embeddings, or search results. This PR only changes which messages get **enqueued** and what gets **logged** - the chunk handler itself is untouched.
- Any UI surface. There is none.

## Additional Information

**Deliberately NOT deduplicated with the hosted twin.** `server/cron/dataLakeBatchReconcile.ts` is currently being rewritten by #2125 in exactly the function that would be extracted, and is also touched by #2126 and #2143. Collapsing the two now would put this in direct conflict with all three for what is a P3 fix. Instead the new module carries a `MUST STAY IN SYNC` header naming its twin, and this is the natural home to move the hosted copy into once that queue clears. Worth doing as a follow-up - flagging it rather than leaving it implicit.

`main.ts` is also touched by #2126 and #2143, but this PR *shrinks* its footprint there (41 lines to 5), so the conflict surface is smaller than the line count suggests.

**A failed send is not lost work.** It changes nothing about the file, so it still matches the scan filter and a later tick retries it. Not necessarily the next one - the candidate query has no sort, so while the backlog exceeds `CHUNK_SCAN_BATCH` a given file is only eventually reached. `failed` is a signal that sends are being lost, not a marker of work dropped for good. There is no metric or alarm on it yet; it reaches operators through the log line only.

Closes #2158
