### PR TITLE
fix(data-lakes): page the lake-memory extraction scan instead of hydrating every member

### DIFF
--- a/apps/client/server/dataLakes/extractLakeMemory.ts
+++ b/apps/client/server/dataLakes/extractLakeMemory.ts
@@ -176,21 +176,16 @@ export async function extractLakeMemoryForBatch(
     const claimedLake = await dataLakeRepository.findById(lake.id).catch(() => null);
     const cursor = (claimedLake ?? lake).lakeMemoryCursor ?? null;
 
-    // ONE read for the slice this run will actually work on: live members only, ordered by id, bounded
-    // to the cap, and projected down to the three fields used below. Live-only matters beyond the byte
-    // count: its lifecycle sibling `findIdsByDataLakeTag` reports tombstones too (it must - the chunk
-    // sweep needs them), and a tombstone that reaches this loop consumes a cap slot, so a lake of 40
-    // tombstones and 10 live docs would fold nothing. This used to enumerate every id the
-    // lake had ever held and then hydrate all of them UNPROJECTED - `content`, `chunks` and `vector`
-    // included - before slicing to the cap, so a lake of a few thousand ~1MB documents pulled GBs into
-    // the Lambda and was killed before the deadline guard below ever got to yield. Every SQS redelivery
-    // was killed the same way, so the run never progressed and never stopped costing, which is the exact
-    // outcome that guard exists to prevent. Filtering and bounding in the database is what keeps the
-    // guard reachable.
+    // One bounded, projected, keyset-paged read of the slice this run will work on. LIVE-only because a
+    // tombstone reaching the loop below would consume a cap slot (its lifecycle sibling
+    // `findIdsByDataLakeTag` reports tombstones on purpose), and the cap has to bound real work.
     //
-    // The extra row past the cap is a PROBE: it distinguishes "the lake continues past this slice" from
-    // "the slice happened to fill exactly", which is what the continuation bookkeeping below needs, and
-    // is cheaper than a second count query. It is dropped from `docs` and never processed.
+    // The extra row past the cap is a PROBE: it separates "the lake continues past this slice" from "the
+    // slice happened to fill exactly", which is what the continuation bookkeeping below needs and is
+    // cheaper than a count query. It is dropped from `docs` and never processed.
+    //
+    // See `findLakeMemoryExtractionMembers` for why the filter, the ordering and the bound must all stay
+    // in the database - that is where the constraint has to be honoured.
     const page = await fabFileRepository.findLakeMemoryExtractionMembers(dataLakeService.lakeMembershipScope(lake), {
       after: cursor,
       limit: MAX_DOCS_PER_RUN + 1,
@@ -272,6 +267,10 @@ export async function extractLakeMemoryForBatch(
     // non-empty, since the read is bounded rather than counted - hence "at least" in the logs.
     const unattemptedInSlice = docs.length - docsAttempted;
     const hasUncovered = unattemptedInSlice > 0 || moreBeyondThisSlice;
+    // Lower bound, not a count: the probe row proves at least one more doc exists without saying how
+    // many. Both warns below report the same quantity, so it lives here rather than being spelled out
+    // at each of them.
+    const atLeastUncovered = unattemptedInSlice + (moreBeyondThisSlice ? 1 : 0);
     let hasMore = false;
     if (docsAttempted > 0 && hasUncovered && lastAttemptedId) {
       try {
@@ -285,7 +284,7 @@ export async function extractLakeMemoryForBatch(
         // from the top; failing loudly here rather than papering over it.
         logger.warn(
           `[lakeMemory] lake ${datalakeTag} could not persist the continuation cursor; the remaining ` +
-            `doc(s) (at least ${unattemptedInSlice + (moreBeyondThisSlice ? 1 : 0)}) will be picked up on ` +
+            `doc(s) (at least ${atLeastUncovered}) will be picked up on ` +
             `the next finalize: ${err instanceof Error ? err.message : String(err)}`
         );
       }
@@ -310,8 +309,7 @@ export async function extractLakeMemoryForBatch(
       // or re-enqueuing here would be a no-progress loop, so do neither - the next finalize retries.
       logger.warn(
         `[lakeMemory] lake ${datalakeTag} made no progress before the deadline; at least ` +
-          `${unattemptedInSlice + (moreBeyondThisSlice ? 1 : 0)} doc(s) still uncovered, not enqueuing a ` +
-          `continuation (would loop)`
+          `${atLeastUncovered} doc(s) still uncovered, not enqueuing a continuation (would loop)`
       );
     }
 

--- a/apps/client/server/dataLakes/extractLakeMemory.ts
+++ b/apps/client/server/dataLakes/extractLakeMemory.ts
@@ -163,16 +163,6 @@ export async function extractLakeMemoryForBatch(
     }
 
     const extractor = new LakeMemoryExtractionService(logger);
-    const allDocIds = await fabFileRepository.findIdsByDataLakeTag(dataLakeService.lakeMembershipScope(lake));
-    // Drop tombstones BEFORE applying the cap, and sort by id so the continuation cursor is a stable
-    // keyset boundary. `findIdsByDataLakeTag` includes soft-deleted/archived ids (it must, for
-    // lifecycle), so filtering first keeps tombstones from consuming cap slots and pushing live docs out
-    // (a lake of 40 tombstones + 10 live would otherwise fold nothing). FabFile ids are ObjectId hex,
-    // whose lexicographic order is creation order, so a new upload sorts AFTER the cursor and is picked
-    // up on a later run rather than shifting the window under an in-progress scan.
-    const liveDocs = (await fabFileRepository.findAllByIds(allDocIds))
-      .filter(f => !f.deletedAt && !f.archivedAt)
-      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
     // Bounded continuation: resume AFTER the last document a prior interrupted run attempted (the
     // persisted cursor), not from the cap boundary - the deadline guard can end a run mid-slice, so the
@@ -185,12 +175,32 @@ export async function extractLakeMemoryForBatch(
     // lease exists to prevent. Falls back to the pre-claim value if the re-read fails.
     const claimedLake = await dataLakeRepository.findById(lake.id).catch(() => null);
     const cursor = (claimedLake ?? lake).lakeMemoryCursor ?? null;
-    const remainingDocs = cursor ? liveDocs.filter(f => f.id > cursor) : liveDocs;
-    const docs = remainingDocs.slice(0, MAX_DOCS_PER_RUN);
-    if (remainingDocs.length > docs.length) {
+
+    // ONE read for the slice this run will actually work on: live members only, ordered by id, bounded
+    // to the cap, and projected down to the three fields used below. Live-only matters beyond the byte
+    // count: its lifecycle sibling `findIdsByDataLakeTag` reports tombstones too (it must - the chunk
+    // sweep needs them), and a tombstone that reaches this loop consumes a cap slot, so a lake of 40
+    // tombstones and 10 live docs would fold nothing. This used to enumerate every id the
+    // lake had ever held and then hydrate all of them UNPROJECTED - `content`, `chunks` and `vector`
+    // included - before slicing to the cap, so a lake of a few thousand ~1MB documents pulled GBs into
+    // the Lambda and was killed before the deadline guard below ever got to yield. Every SQS redelivery
+    // was killed the same way, so the run never progressed and never stopped costing, which is the exact
+    // outcome that guard exists to prevent. Filtering and bounding in the database is what keeps the
+    // guard reachable.
+    //
+    // The extra row past the cap is a PROBE: it distinguishes "the lake continues past this slice" from
+    // "the slice happened to fill exactly", which is what the continuation bookkeeping below needs, and
+    // is cheaper than a second count query. It is dropped from `docs` and never processed.
+    const page = await fabFileRepository.findLakeMemoryExtractionMembers(dataLakeService.lakeMembershipScope(lake), {
+      after: cursor,
+      limit: MAX_DOCS_PER_RUN + 1,
+    });
+    const docs = page.slice(0, MAX_DOCS_PER_RUN);
+    const moreBeyondThisSlice = page.length > docs.length;
+    if (moreBeyondThisSlice) {
       logger.info(
-        `[lakeMemory] lake ${datalakeTag}: ${remainingDocs.length} docs remain this scan, extracting ` +
-          `${docs.length} now; a continuation run will cover the rest`
+        `[lakeMemory] lake ${datalakeTag}: extracting ${docs.length} docs now (the per-run cap) and ` +
+          `more remain; a continuation run will cover the rest`
       );
     }
 
@@ -205,7 +215,7 @@ export async function extractLakeMemoryForBatch(
     let factsWritten = 0;
     let docsAttempted = 0;
     let lastAttemptedId: string | null = null;
-    for (const file of docs) {
+    for (const doc of docs) {
       // Yield rather than get killed. Checked BEFORE starting a doc, since the expensive, unresumable
       // part (the LLM call) is at the start of one. Unlike before, the uncovered docs are NOT lost: the
       // cursor bookkeeping below persists progress and a continuation run picks them up.
@@ -218,9 +228,9 @@ export async function extractLakeMemoryForBatch(
         break;
       }
       docsAttempted++;
-      lastAttemptedId = file.id;
+      lastAttemptedId = doc.fabFileId;
       try {
-        const chunks = await fabFileChunkRepository.findTextsByFabFileId(file.id, { limit: CHUNK_PAGE_LIMIT });
+        const chunks = await fabFileChunkRepository.findTextsByFabFileId(doc.fabFileId, { limit: CHUNK_PAGE_LIMIT });
         const text = chunks
           .map(c => c.text)
           .join('\n')
@@ -230,16 +240,19 @@ export async function extractLakeMemoryForBatch(
         docsProcessed++;
         const facts = await extractor.evaluate({
           apiKeyTable,
-          docTitle: file.fileName,
+          // The id as a last-resort title: the projected row types `fileName` as optional (legacy rows
+          // can lack it, as the sibling lake readers assume), and handing the extractor `undefined`
+          // would put the literal string in the prompt.
+          docTitle: doc.fileName ?? doc.fabFileId,
           docText: text,
           endUserId: ownerUserId,
         });
         if (!facts?.length) continue;
 
-        const tier = evidenceTierForDoc((file.tags ?? []).map(t => t.name));
+        const tier = evidenceTierForDoc((doc.tags ?? []).map(t => t.name));
         for (const { fact } of facts) {
           const embedding = await embed(fact).catch(() => undefined);
-          await session.append({ summary: fact, evidenceTier: tier, sources: [file.id], embedding });
+          await session.append({ summary: fact, evidenceTier: tier, sources: [doc.fabFileId], embedding });
           factsWritten++;
         }
       } catch (err) {
@@ -248,16 +261,19 @@ export async function extractLakeMemoryForBatch(
         // precedes the ledger de-dup), it throws again, and the run DLQs - docs after it never fold. Skip
         // + log so the rest of the lake still folds; a re-scan retries the bad doc.
         logger.warn(
-          `[lakeMemory] doc ${file.id} failed; skipping it this run: ${err instanceof Error ? err.message : String(err)}`
+          `[lakeMemory] doc ${doc.fabFileId} failed; skipping it this run: ${err instanceof Error ? err.message : String(err)}`
         );
       }
     }
 
-    // Continuation bookkeeping. `uncovered` counts docs in THIS scan not yet attempted, whether the run
-    // stopped at the cap or the deadline.
-    const uncovered = remainingDocs.length - docsAttempted;
+    // Continuation bookkeeping. Two independent ways this scan can leave work behind, and both must
+    // count: the deadline stopped the loop partway through the slice, or the probe row showed the lake
+    // continues past it. `unattemptedInSlice` is exact; what lies beyond the slice is only known to be
+    // non-empty, since the read is bounded rather than counted - hence "at least" in the logs.
+    const unattemptedInSlice = docs.length - docsAttempted;
+    const hasUncovered = unattemptedInSlice > 0 || moreBeyondThisSlice;
     let hasMore = false;
-    if (docsAttempted > 0 && uncovered > 0 && lastAttemptedId) {
+    if (docsAttempted > 0 && hasUncovered && lastAttemptedId) {
       try {
         // Resume from what was ATTEMPTED, not the cap: persist the last attempted id as the cursor.
         await dataLakeRepository.setLakeMemoryCursor(lake.id, lastAttemptedId);
@@ -269,12 +285,11 @@ export async function extractLakeMemoryForBatch(
         // from the top; failing loudly here rather than papering over it.
         logger.warn(
           `[lakeMemory] lake ${datalakeTag} could not persist the continuation cursor; the remaining ` +
-            `${uncovered} doc(s) will be picked up on the next finalize: ${
-              err instanceof Error ? err.message : String(err)
-            }`
+            `doc(s) (at least ${unattemptedInSlice + (moreBeyondThisSlice ? 1 : 0)}) will be picked up on ` +
+            `the next finalize: ${err instanceof Error ? err.message : String(err)}`
         );
       }
-    } else if (uncovered === 0) {
+    } else if (!hasUncovered) {
       // Whole scan covered. Clear the cursor so the next batch finalize does a fresh full re-scan, which
       // re-asserts existing facts and keeps their ACT-R salience hot (the idempotency contract above).
       // Best-effort: a failed clear self-heals - the next run resumes from a cursor past the last doc,
@@ -294,8 +309,9 @@ export async function extractLakeMemoryForBatch(
       // uncovered > 0 but nothing attempted: the deadline hit before the first doc. Advancing the cursor
       // or re-enqueuing here would be a no-progress loop, so do neither - the next finalize retries.
       logger.warn(
-        `[lakeMemory] lake ${datalakeTag} made no progress before the deadline; ${uncovered} doc(s) still ` +
-          `uncovered, not enqueuing a continuation (would loop)`
+        `[lakeMemory] lake ${datalakeTag} made no progress before the deadline; at least ` +
+          `${unattemptedInSlice + (moreBeyondThisSlice ? 1 : 0)} doc(s) still uncovered, not enqueuing a ` +
+          `continuation (would loop)`
       );
     }
 
@@ -303,6 +319,10 @@ export async function extractLakeMemoryForBatch(
       dataLakeId: params.dataLakeId,
       docsProcessed,
       factsWritten,
+      // Where the slice started. The read ignores a cursor it cannot parse and pages from the top
+      // instead of throwing the run into the DLQ, so without this in the summary that rewind would be
+      // invisible - it would just look like an unexplained full re-scan.
+      resumedFromCursor: cursor,
       // `docsAttempted < docs.length` is the deadline-stop signal; `hasMore` is whether a continuation
       // was enqueued (cap or deadline left docs uncovered and we made progress).
       docsAttempted,

--- a/apps/client/server/dataLakes/extractLakeMemoryDeadline.test.ts
+++ b/apps/client/server/dataLakes/extractLakeMemoryDeadline.test.ts
@@ -12,8 +12,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const findByIdMock = vi.fn();
-const findIdsByDataLakeTagMock = vi.fn();
-const findAllByIdsMock = vi.fn();
+const findLakeMemoryExtractionMembersMock = vi.fn();
 const findTextsByFabFileIdMock = vi.fn();
 const evaluateMock = vi.fn();
 const appendMock = vi.fn();
@@ -32,8 +31,17 @@ vi.mock('@bike4mind/database', () => ({
   },
   fabFileChunkRepository: { findTextsByFabFileId: (...a: unknown[]) => findTextsByFabFileIdMock(...a) },
   fabFileRepository: {
-    findIdsByDataLakeTag: (...a: unknown[]) => findIdsByDataLakeTagMock(...a),
-    findAllByIds: (...a: unknown[]) => findAllByIdsMock(...a),
+    findLakeMemoryExtractionMembers: (...a: unknown[]) => findLakeMemoryExtractionMembersMock(...a),
+    // The two unbounded readers this producer used to use, kept here as THROWING stubs. Between them
+    // they resolved every id the lake had ever held and hydrated all of them unprojected, which is what
+    // OOMed the extraction Lambda before its own deadline guard could yield. Reaching for either again
+    // fails the test loudly instead of only showing up as a DLQ on a large lake.
+    findIdsByDataLakeTag: () => {
+      throw new Error('unbounded read: lake-memory extraction must page via findLakeMemoryExtractionMembers');
+    },
+    findAllByIds: () => {
+      throw new Error('unprojected read: lake-memory extraction must page via findLakeMemoryExtractionMembers');
+    },
   },
 }));
 vi.mock('@bike4mind/common', () => ({
@@ -64,12 +72,27 @@ const { extractLakeMemoryForBatch } = await import('./extractLakeMemory');
 
 const makeLogger = () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), log: vi.fn(), debug: vi.fn() });
 
+/**
+ * Stand in for the repository's paged member read over an in-memory id list, honoring the keyset
+ * `after` and the `limit` FOR REAL (sorted, as the database returns them). A fixed-array stub would
+ * leave the two things this producer actually decides on untested: where a continuation resumes, and
+ * whether the one-past-the-cap probe row correctly says "the lake continues".
+ */
+const seedMembers = (ids: string[]) => {
+  findLakeMemoryExtractionMembersMock.mockImplementation(
+    async (_scope: unknown, { after, limit }: { after?: string | null; limit: number }) =>
+      [...ids]
+        .sort()
+        .filter(id => !after || id > after)
+        .slice(0, limit)
+        .map(id => ({ fabFileId: id, fileName: `${id}.md`, tags: [] }))
+  );
+};
+
 /** N live docs, each with readable text and one extractable fact. */
 const seedLake = (docCount: number) => {
   findByIdMock.mockResolvedValue({ id: 'lake-1', createdByUserId: 'owner-1', datalakeTag: 'datalake:test' });
-  const ids = Array.from({ length: docCount }, (_, i) => `doc-${i}`);
-  findIdsByDataLakeTagMock.mockResolvedValue(ids);
-  findAllByIdsMock.mockResolvedValue(ids.map(id => ({ id, fileName: `${id}.md`, tags: [] })));
+  seedMembers(Array.from({ length: docCount }, (_, i) => `doc-${String(i).padStart(3, '0')}`));
   findTextsByFabFileIdMock.mockResolvedValue([{ text: 'some durable reference text' }]);
   evaluateMock.mockResolvedValue([{ fact: 'the X-200 ships with 36 units' }]);
 };
@@ -120,7 +143,7 @@ describe('extractLakeMemoryForBatch deadline guard (#1440)', () => {
     expect(appendMock).toHaveBeenCalledTimes(2);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('ran out of time after 2/10 docs'));
     // The cursor resumes from the last doc ATTEMPTED (doc index 1), not the cap boundary.
-    expect(setLakeMemoryCursorMock).toHaveBeenCalledWith('lake-1', 'doc-1');
+    expect(setLakeMemoryCursorMock).toHaveBeenCalledWith('lake-1', 'doc-001');
   });
 
   it('falls back to the wall clock when the Lambda clock reports a non-finite value', async () => {
@@ -208,13 +231,7 @@ describe('extractLakeMemoryForBatch continuation + concurrency guard (#1501)', (
   });
 
   it('signals hasMore and persists the 100th doc as the cursor when the doc cap is hit', async () => {
-    // Zero-padded ids so lexicographic order == numeric order, making the keyset boundary deterministic.
-    findByIdMock.mockResolvedValue({ id: 'lake-1', createdByUserId: 'owner-1', datalakeTag: 'datalake:test' });
-    const ids = Array.from({ length: 150 }, (_, i) => `doc-${String(i).padStart(3, '0')}`);
-    findIdsByDataLakeTagMock.mockResolvedValue(ids);
-    findAllByIdsMock.mockResolvedValue(ids.map(id => ({ id, fileName: `${id}.md`, tags: [] })));
-    findTextsByFabFileIdMock.mockResolvedValue([{ text: 'durable reference text' }]);
-    evaluateMock.mockResolvedValue([{ fact: 'a durable fact' }]);
+    seedLake(150);
     const logger = makeLogger();
 
     const result = await extractLakeMemoryForBatch(
@@ -226,6 +243,45 @@ describe('extractLakeMemoryForBatch continuation + concurrency guard (#1501)', (
     expect(result.hasMore).toBe(true);
     expect(setLakeMemoryCursorMock).toHaveBeenCalledWith('lake-1', 'doc-099');
     expect(releaseLakeMemoryExtractionMock).toHaveBeenCalledTimes(1);
+    // The 101st row is the probe that reported "more remain"; it is never processed.
+    expect(evaluateMock).toHaveBeenCalledTimes(100);
+  });
+
+  it('asks the database for the slice - cap plus one probe row, from the cursor - and nothing wider', async () => {
+    // The regression this whole change is about: the run must never materialize the lake to find out
+    // how big it is. One bounded, cursor-anchored read, and the bound is the cap plus the probe row.
+    seedLake(150);
+    findByIdMock.mockResolvedValue({
+      id: 'lake-1',
+      createdByUserId: 'owner-1',
+      datalakeTag: 'datalake:test',
+      lakeMemoryCursor: 'doc-004',
+    });
+
+    await extractLakeMemoryForBatch(
+      { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 },
+      makeLogger() as never
+    );
+
+    expect(findLakeMemoryExtractionMembersMock).toHaveBeenCalledTimes(1);
+    expect(findLakeMemoryExtractionMembersMock).toHaveBeenCalledWith('datalake:test', { after: 'doc-004', limit: 101 });
+  });
+
+  it('does not ask for a continuation when the slice fills the cap exactly and the lake ends there', async () => {
+    // The probe row is what tells these apart. Without it, a lake of exactly 100 live docs would look
+    // identical to a truncated one and chain a continuation run that finds nothing - and, because the
+    // cursor would have been advanced to the last doc, would keep the lake from ever re-scanning clean.
+    seedLake(100);
+    const logger = makeLogger();
+
+    const result = await extractLakeMemoryForBatch(
+      { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 },
+      logger as never
+    );
+
+    expect(result.docsProcessed).toBe(100);
+    expect(result.hasMore).toBe(false);
+    expect(setLakeMemoryCursorMock).not.toHaveBeenCalledWith('lake-1', 'doc-099');
   });
 
   it('resumes from the persisted cursor and clears it once the scan reaches the end', async () => {
@@ -237,9 +293,7 @@ describe('extractLakeMemoryForBatch continuation + concurrency guard (#1501)', (
       datalakeTag: 'datalake:test',
       lakeMemoryCursor: 'doc-1',
     });
-    const ids = ['doc-0', 'doc-1', 'doc-2', 'doc-3', 'doc-4'];
-    findIdsByDataLakeTagMock.mockResolvedValue(ids);
-    findAllByIdsMock.mockResolvedValue(ids.map(id => ({ id, fileName: `${id}.md`, tags: [] })));
+    seedMembers(['doc-0', 'doc-1', 'doc-2', 'doc-3', 'doc-4']);
     findTextsByFabFileIdMock.mockResolvedValue([{ text: 'durable reference text' }]);
     evaluateMock.mockResolvedValue([{ fact: 'a durable fact' }]);
     const logger = makeLogger();
@@ -261,9 +315,7 @@ describe('extractLakeMemoryForBatch continuation + concurrency guard (#1501)', (
     // cursor in the window before this run wins the claim. Resuming from the stale value would re-scan
     // (and re-bill) an already-covered slice. Pre-claim read reports cursor doc-0; the post-claim read
     // reports the advanced doc-3, and the run must honor the latter.
-    const ids = ['doc-0', 'doc-1', 'doc-2', 'doc-3', 'doc-4'];
-    findIdsByDataLakeTagMock.mockResolvedValue(ids);
-    findAllByIdsMock.mockResolvedValue(ids.map(id => ({ id, fileName: `${id}.md`, tags: [] })));
+    seedMembers(['doc-0', 'doc-1', 'doc-2', 'doc-3', 'doc-4']);
     findTextsByFabFileIdMock.mockResolvedValue([{ text: 'durable reference text' }]);
     evaluateMock.mockResolvedValue([{ fact: 'a durable fact' }]);
     findByIdMock

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -1017,6 +1017,21 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
     }>
   >;
   /**
+   * One page of a lake's live members for the lake-memory extraction producer, ascending by `_id`.
+   * Projects ONLY the three fields that producer reads - it replaced a
+   * `findIdsByDataLakeTag` + `findAllByIds` pair that hydrated every member's `content`, `chunks` and
+   * `vector` before the producer's per-run cap applied, which OOMed the extraction Lambda on any large
+   * lake and re-OOMed on every SQS redelivery.
+   *
+   * `after` is a keyset boundary (ObjectId order is creation order, so a mid-scan upload sorts after it
+   * and waits for a later run); an unparseable value is ignored rather than throwing. Ask for one row
+   * past the cap to tell "the lake continues" from "the slice filled exactly" without a count query.
+   */
+  findLakeMemoryExtractionMembers(
+    scope: DataLakeMembershipScope,
+    options: { after?: string | null; limit: number }
+  ): Promise<Array<{ fabFileId: string; fileName?: string; tags: { name: string }[] }>>;
+  /**
    * One page of file ids that have chunks but no `chunkedCharCount` (missing or nulled by a
    * content rewrite), ascending by `_id` - the char-length backfill's phase-2 cursor.
    */

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -1017,15 +1017,13 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
     }>
   >;
   /**
-   * One page of a lake's live members for the lake-memory extraction producer, ascending by `_id`.
-   * Projects ONLY the three fields that producer reads - it replaced a
-   * `findIdsByDataLakeTag` + `findAllByIds` pair that hydrated every member's `content`, `chunks` and
-   * `vector` before the producer's per-run cap applied, which OOMed the extraction Lambda on any large
-   * lake and re-OOMed on every SQS redelivery.
+   * One page of a lake's LIVE members for the lake-memory extraction producer, ascending by `_id`,
+   * projecting only the three fields that producer reads. Live-only and bounded in the database, unlike
+   * `findIdsByDataLakeTag` above, which reports every member the lake ever had.
    *
-   * `after` is a keyset boundary (ObjectId order is creation order, so a mid-scan upload sorts after it
-   * and waits for a later run); an unparseable value is ignored rather than throwing. Ask for one row
-   * past the cap to tell "the lake continues" from "the slice filled exactly" without a count query.
+   * `after` is a keyset boundary, and an unparseable one is ignored rather than throwing. Ask for one
+   * row past the cap to tell "the lake continues" from "the slice filled exactly" without a count
+   * query. See the implementation for why each of those is load-bearing.
    */
   findLakeMemoryExtractionMembers(
     scope: DataLakeMembershipScope,

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -93,6 +93,7 @@ export const createMockFabFileRepository = (): IFabFileRepository => ({
   computeDataLakeStats: vi.fn(),
   findDataLakeHealthMembers: vi.fn(),
   findLakeConvergenceMembers: vi.fn(),
+  findLakeMemoryExtractionMembers: vi.fn(),
   findFileIdsMissingChunkedCharCount: vi.fn(),
   setChunkedCharCount: vi.fn(),
   findFileIdsMissingChunkRollups: vi.fn(),

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -891,6 +891,76 @@ describe('FabFile data lake lifecycle membership', () => {
     });
   });
 
+  /**
+   * The read the lake-memory extraction producer pages the lake with. It exists because the producer
+   * used to resolve every id the lake had ever held and then hydrate all of them UNPROJECTED, so
+   * `content`/`chunks`/`vector` reached the Lambda before the per-run cap applied - GBs on a large
+   * lake, killed before its own deadline guard could yield, and killed again on every redelivery.
+   * These pin the three properties that fix rests on: metadata only, live only, and bounded.
+   */
+  describe('findLakeMemoryExtractionMembers', () => {
+    const page = (options: { after?: string | null; limit: number }) =>
+      fabFileRepository.findLakeMemoryExtractionMembers(scope, options);
+
+    it('returns both membership arms and no stranger-owned prefix match', async () => {
+      const rows = await seedLakeRows();
+
+      const members = await page({ limit: 100 });
+
+      expect(members.map(m => m.fabFileId).sort()).toEqual([...rows.memberIds].sort());
+    });
+
+    it('projects the three fields the producer reads and NONE of the heavy payload', async () => {
+      const rows = await seedLakeRows();
+      // A member carrying every field the old unprojected read would have pulled into the Lambda.
+      await FabFile.updateOne(
+        { _id: rows.metaTagged._id },
+        { $set: { content: 'x'.repeat(50_000), chunks: ['a', 'b'], vector: [0.1, 0.2, 0.3] } }
+      );
+
+      const [member] = await page({ limit: 1 });
+
+      expect(Object.keys(member).sort()).toEqual(['fabFileId', 'fileName', 'tags']);
+      expect(member.tags).toEqual([{ name: DATALAKE_TAG }]);
+    });
+
+    it('excludes soft-deleted and archived members in the DATABASE, not after hydration', async () => {
+      const rows = await seedLakeRows();
+      await FabFile.updateOne({ _id: rows.metaTagged._id }, { $set: { deletedAt: new Date() } });
+      await FabFile.updateOne({ _id: rows.prefixOwned._id }, { $set: { archivedAt: new Date() } });
+
+      // Contrast with its lifecycle sibling, which deliberately reports both (the chunk sweep needs
+      // them). A tombstone must never consume one of the producer's capped run slots.
+      expect(await page({ limit: 100 })).toEqual([]);
+      expect((await fabFileRepository.findIdsByDataLakeTag(scope)).sort()).toEqual([...rows.memberIds].sort());
+    });
+
+    it('pages forward from the keyset cursor in _id order and honors the limit', async () => {
+      const rows = await seedLakeRows();
+      const ascending = [...rows.memberIds].sort();
+
+      const first = await page({ limit: 1 });
+      expect(first.map(m => m.fabFileId)).toEqual([ascending[0]]);
+
+      const second = await page({ after: first[0].fabFileId, limit: 1 });
+      expect(second.map(m => m.fabFileId)).toEqual([ascending[1]]);
+
+      // Past the last member: an exhausted page is empty, which is how the producer learns the scan
+      // is complete and clears its cursor.
+      expect(await page({ after: ascending[1], limit: 1 })).toEqual([]);
+    });
+
+    it('ignores an unparseable cursor instead of throwing the run into the DLQ', async () => {
+      const rows = await seedLakeRows();
+
+      // A re-scan is merely wasteful (the producer's ledger append de-dups); a cast error would fail
+      // the invocation, and SQS would redeliver it to the same cast error.
+      const members = await page({ after: 'not-an-objectid', limit: 100 });
+
+      expect(members.map(m => m.fabFileId).sort()).toEqual([...rows.memberIds].sort());
+    });
+  });
+
   describe('hardDeleteByIds', () => {
     it('destroys exactly the ids given, soft-deleted included, and nothing a re-resolve would add', async () => {
       const rows = await seedLakeRows();

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -913,7 +913,14 @@ describe('FabFile data lake lifecycle membership', () => {
     it('projects the three fields the producer reads and NONE of the heavy payload', async () => {
       const rows = await seedLakeRows();
       // A member carrying every field the old unprojected read would have pulled into the Lambda.
-      await FabFile.updateOne(
+      //
+      // The RAW DRIVER, not `FabFile.updateOne`: none of `content`, `chunks` or `vector` is a declared
+      // path on FabFileSchema, so mongoose strict mode drops all three from the update silently (the
+      // same footgun the `sourceType` comment at the schema's provenance block records). Seeding through
+      // mongoose leaves the document with no heavy payload at all, which makes the assertion below pass
+      // for the wrong reason - it would still pass with `content: 1` added to the projection. The raw
+      // driver is also how these fields reach production documents in the first place.
+      await FabFile.collection.updateOne(
         { _id: rows.metaTagged._id },
         { $set: { content: 'x'.repeat(50_000), chunks: ['a', 'b'], vector: [0.1, 0.2, 0.3] } }
       );

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -1343,6 +1343,64 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   }
 
   /**
+   * One page of a lake's live members for the lake-memory extraction producer
+   * (`extractLakeMemoryForBatch`), ascending by `_id`.
+   *
+   * Deliberately NOT `findIdsByDataLakeTag` + `findAllByIds`, which is what this replaced. That pair
+   * returned every id the lake had ever held (tombstones included, by design - lifecycle sweeps need
+   * them) and then hydrated all of them UNPROJECTED, so `content`, `chunks` and `vector` all landed in
+   * the Lambda before the producer's own per-run cap applied. A lake of a few thousand ~1MB documents
+   * pulled GBs into one invocation and was killed before the deadline guard could yield, and every SQS
+   * redelivery was killed the same way until the message reached the DLQ.
+   *
+   * So the liveness filter, the ordering and the bound all run in the DATABASE, and the projection is
+   * an inclusion list of exactly the three fields the producer reads: the id to fetch chunks by and to
+   * persist as its continuation cursor, the file name as the extractor's doc title, and the tag names
+   * that decide the evidence tier. The document text comes separately from `fabFileChunkRepository`, so
+   * none of the heavy fields are wanted here at all.
+   *
+   * `after` is a KEYSET boundary, not an offset: ObjectId order is creation order, so a document
+   * uploaded mid-scan sorts after the cursor and is picked up by a later run rather than shifting the
+   * window under an in-progress one. An `after` that is not a valid ObjectId is ignored (the page
+   * starts from the top) rather than throwing a cast error - the producer's ledger append de-dups, so
+   * an over-broad re-scan is merely wasteful, whereas a throw would fail the run into the DLQ.
+   *
+   * `limit` is the caller's bound verbatim; the producer asks for one row past its cap and uses that
+   * probe row to tell "the lake continues" from "the slice happened to fill exactly", which is cheaper
+   * than a second count query.
+   */
+  async findLakeMemoryExtractionMembers(
+    scope: DataLakeMembershipScope,
+    options: { after?: string | null; limit: number }
+  ): Promise<Array<{ fabFileId: string; fileName?: string; tags: { name: string }[] }>> {
+    const after = options.after && mongoose.Types.ObjectId.isValid(options.after) ? convertId(options.after) : null;
+    return this.fabFileModel.aggregate([
+      {
+        // buildDataLakeMembershipQuery, NOT a spread - see findDataLakeHealthMembers. An aggregate is
+        // outside the soft-delete plugin's query middleware, so `deletedAt` is filtered here
+        // explicitly rather than by default.
+        $match: buildDataLakeMembershipQuery(scope, {
+          deletedAt: null,
+          archivedAt: null,
+          ...(after ? { _id: { $gt: after } } : {}),
+        }),
+      },
+      { $sort: { _id: 1 } },
+      { $limit: options.limit },
+      {
+        $project: {
+          _id: 0,
+          fabFileId: { $toString: '$_id' },
+          fileName: 1,
+          // Only the tag NAME, as in findLakeConvergenceMembers: a lake member can carry many tags and
+          // the tier decision reads nothing else off them.
+          tags: { $map: { input: { $ifNull: ['$tags', []] }, as: 't', in: { name: '$$t.name' } } },
+        },
+      },
+    ]);
+  }
+
+  /**
    * One page of file ids that have chunks but no `chunkedCharCount` (missing or nulled by a
    * content rewrite), ascending by `_id` - the char-length backfill's phase-2 cursor.
    */


### PR DESCRIPTION
# Pull Request

Closes #2088

## Description

`extractLakeMemoryForBatch` caps its LLM work at `MAX_DOCS_PER_RUN = 100`, but the cap was applied
**after** every member document in the lake had already been hydrated into the Lambda:

- `findIdsByDataLakeTag` has no limit and deliberately sets `includeDeleted: true`, so it returned
  every id the lake had ever held, tombstones included. That is correct for the lifecycle sweeps it
  was written for, and wrong here.
- `findAllByIds` is `find({ _id: { $in: ids } })` with **no projection**, so `content`, `chunks` and
  `vector` all loaded in full - while every neighbouring read in `FabFileModel.ts` excludes exactly
  those three.

This call site only ever reads the id, the file name and the tag names off those documents; the
chunk text comes separately from `fabFileChunkRepository`. So a lake of a few thousand documents
averaging ~1MB of extracted text pulled GBs into one `find()` before `.slice(0, 100)` ran. The
Lambda OOMed or timed out, SQS redelivered, and it died the same way on every redelivery until the
message reached the DLQ - the exact never-progressing, re-billing outcome the deadline guard at
`extractLakeMemory.ts:212` exists to prevent. The guard never got the chance to run.

The fix replaces both reads with one bounded, projected, keyset-paged read. The membership filter,
the liveness filter, the `_id` ordering and the run cap all execute in the database, so what reaches
the Lambda is at most 101 rows of three fields each - regardless of lake size.

## Changes

- **`FabFileRepository.findLakeMemoryExtractionMembers(scope, { after, limit })`** (new). Aggregate
  with `buildDataLakeMembershipQuery` (not a spread - the prefix arm is itself a top-level `$or`),
  `deletedAt: null` + `archivedAt: null`, a `_id > after` keyset boundary, `$sort: { _id: 1 }`,
  `$limit`, and an **inclusion** `$project` of `fabFileId` / `fileName` / `tags.name` only. Declared
  on `IFabFileRepository` and mirrored into the services testUtils mock.
  - An `after` that is not a valid ObjectId is ignored (the page starts from the top) rather than
    throwing: the producer's ledger append de-dups, so an over-broad re-scan is merely wasteful,
    whereas a cast error would fail the invocation into the DLQ. The run then writes a fresh valid
    cursor, so it self-heals.
- **`extractLakeMemory.ts`**: the cursor is now resolved before the member read (it parameterizes
  it), and the run asks for `MAX_DOCS_PER_RUN + 1` rows. The extra row is a **probe** that
  distinguishes "the lake continues past this slice" from "the slice happened to fill exactly" -
  which is what `hasMore` and the continuation cursor need, and is cheaper than a second count query.
  Continuation bookkeeping moves from an exact `remainingDocs.length - docsAttempted` to
  `unattemptedInSlice > 0 || moreBeyondThisSlice`; the logs say "at least N" where the count is now a
  lower bound rather than exact.
- The run summary gains `resumedFromCursor`, so a cursor rewind is visible in logs instead of looking
  like an unexplained full re-scan.
- **Tests**: five new repository tests against a real Mongo (projection shape, both membership arms,
  tombstone/archive exclusion in the database, keyset paging + limit, unparseable cursor). The
  projection test seeds `content`/`chunks`/`vector` through the **raw driver**, not
  `FabFile.updateOne` - none of the three is a declared path on `FabFileSchema`, so mongoose strict
  mode drops them from the update silently and the assertion would otherwise pass because there is
  nothing heavy on the document rather than because the projection excludes it. Mutation-checked:
  adding `content: 1` inside `findLakeMemoryExtractionMembers` fails that test by name. The
  producer's deadline/continuation suite now runs against a paging fake that honours `after` and
  `limit` for real, plus new cases for the probe row and for a lake that fills the cap exactly. The
  two unbounded readers are left in that file's mock as **throwing stubs**, so reaching for either
  again fails the suite instead of only showing up as a DLQ on a large lake.

No behaviour change to what gets extracted, what gets written to the ledger, how the continuation
chain terminates, or the queue handler.

## Guide for Testers

This is a backend-only change to an SQS-driven extraction Lambda. There is no UI surface, and the
observable outcome is in CloudWatch logs, not in the app.

**Setup**

1. Go to `app.staging.bike4mind.com` and sign in as an admin.
2. Navigate to **Sidebar -> Admin -> Admin Settings** and confirm `EnableLakeMemory` is **on**. If it
   is off, turn it on and save. (With it off, the handler drops the queued message and nothing below
   will run.)

**Happy path - a small lake still folds normally**

3. Navigate to **Sidebar -> Data Lakes** and click **Create Data Lake**. Name it `pr-2088-small`.
4. Upload 3 text or PDF files into that lake and wait for the batch to finish ingesting (each file
   shows a completed status; give it up to 2 minutes).
5. In CloudWatch, open the `lakeMemoryExtraction` Lambda log group and find the newest invocation.
6. **Expected:** one `[lakeMemory] extraction complete` line with `docsProcessed: 3`, `hasMore:
   false`, `docsAvailableThisRun: 3`, and `resumedFromCursor: null`. No `ran out of time` warning, no
   error, no DLQ message.

**The fix itself - a lake larger than the per-run cap**

7. Create a second lake named `pr-2088-large` the same way.
8. Upload **more than 100** files into it. They should be large enough to be non-trivial - PDFs or
   text files of a few hundred KB each are ideal, since the point is that document *bodies* must no
   longer reach the Lambda.
9. Wait for the batch to finalize, then open the `lakeMemoryExtraction` log group.
10. **Expected on the first invocation:** an info line reading
    `[lakeMemory] lake datalake:...: extracting 100 docs now (the per-run cap) and more remain; a
    continuation run will cover the rest`, followed by `extraction complete` with `docsProcessed:
    100`, `hasMore: true`, and then
    `[lakeMemory] enqueued continuation run for the remaining docs` with `slice: 1`.
11. **Expected on the next invocation:** `resumedFromCursor` is set to the id the previous run
    stopped at (not `null`), and it processes the remaining documents rather than re-doing the first
    100.
12. **Expected overall:** no invocation reports an out-of-memory error or a task timeout, and the
    `lakeMemory` DLQ receives no messages. Check **Sidebar -> Admin -> DLQ Management** and confirm
    the lake-memory queue is empty.
13. Also check `Max Memory Used` in each invocation's `REPORT` line - it should stay flat across the
    chain and be unrelated to the size of the uploaded files. Before this change it scaled with the
    lake's total extracted text.

**Regression Checks**

14. Soft-delete one file from `pr-2088-small` (Files list -> the file's overflow menu -> Delete),
    then re-trigger extraction by uploading one new file into that lake.
15. **Expected:** the deleted file is not extracted, and `docsProcessed` counts only live documents.
    A lake whose members are mostly tombstones must still fold its live documents rather than
    reporting zero.
16. Confirm the lake's memory profile still gains facts: open the lake and confirm the extracted
    facts/beliefs surface as they did before this PR. The set of facts should be unchanged - this PR
    changes only how the member list is read.
17. Confirm the ordinary Data Lakes surfaces are untouched: lake stats/file counts, the lake health
    panel, archive and delete a throwaway lake. All of those use different repository reads and
    should behave exactly as before.

**What NOT to test**

- There is no new or changed UI. Nothing in this PR adds a button, route, setting, or panel.
- No API contract, request/response shape, or public endpoint changed.
- No database migration and no new index. The new read uses the existing data-lake membership
  indexes.
- Local `pnpm dev` will not exercise this: the extraction only runs on the deployed SQS-driven
  Lambda, so verification has to happen on staging or a preview.

## Additional Information

The two reads this replaces are both still in use and still correct for their own callers -
`findIdsByDataLakeTag` for the lifecycle sweeps that genuinely need tombstones, and `findAllByIds`
for the session/project/sharing paths. Neither was changed; this adds a purpose-built read next to
`findDataLakeHealthMembers` and `findLakeConvergenceMembers` and follows their shape.

Worth noting for a follow-up: `findAllByIds` being unprojected is a wider pattern than this one call
site (`listBySession` and `projectService.listFiles` reach it too), but auditing those is out of
scope here.

## Developer Notes (Optional)

- **Reusable pattern**: `findLakeMemoryExtractionMembers` is the third member of the
  "purpose-built, projected, `_id`-sorted lake member read" family. A future lake-wide scan should
  add a sibling rather than reach for `findIdsByDataLakeTag` + a hydrate - the pair reads as
  convenient and is a latent OOM on any lake big enough to matter.
- **The probe row**: asking for `cap + 1` and treating the extra row as a signal is how a
  keyset-paged job keeps exact `hasMore` semantics without paying for a `countDocuments` on every
  run. Applicable to any of the other cursor-paged sweeps in this codebase.
- **Gotcha worth knowing repo-wide** (thanks @choyno for catching it here): a test that seeds an
  **undeclared** schema path through mongoose seeds nothing - strict mode drops it from the update
  with no error, so the assertion built on it passes for the wrong reason. `content`, `chunks` and
  `vector` are all undeclared on `FabFileSchema` despite being the exact fields
  `METADATA_ONLY_PROJECTION` exists to exclude. Seed those through `Model.collection.updateOne`,
  which is also how production writes them. The schema's own provenance block records the same
  footgun biting `sourceType` in production, so this is worth a look in any projection test that
  asserts a heavy field is absent.

