### PR TITLE
fix(waf): stop the admin prefix bypassing every protection in production

### DIFF
--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -450,6 +450,80 @@ describe('wafPolicy', () => {
     });
   });
 
+  // A terminating Allow evaluated before emergency-ip-block exempts its paths from the
+  // break-glass control and from every managed rule group, not just from a rate limit. Production
+  // used to carry two of them; /api/admin/ has been removed in favour of the pattern staging has
+  // run since July, and the surviving one is deliberate and documented below.
+  describe('terminating Allow rules', () => {
+    it('leaves only the completions endpoint exempted ahead of the emergency IP block', () => {
+      const rules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      const emergency = rules.find(r => r.Name === 'emergency-ip-block');
+      const allowsBefore = rules
+        .filter(r => r.Action && 'Allow' in r.Action && r.Priority < emergency!.Priority)
+        .map(r => r.Name);
+
+      // The completions path is a long-lived SSE POST carrying user prompt text, which the SQLi
+      // and XSS signatures false-positive on, so this exemption stays until there is evidence for
+      // removing it - and staging cannot supply that, since it runs the same rule.
+      expect(allowsBefore).toEqual(['Allow-LLM-API']);
+    });
+
+    // /api/admin/ was exempted from everything by a terminating Allow at priority 1. Staging has
+    // never had that rule and handles the same traffic surgically instead: the specific ingest
+    // paths are excluded from CommonRuleSet and AdminProtection_URIPATH is set to Count. Measured
+    // before porting it: 10,981 /api/admin/ requests over 14 days on staging, every one ALLOW via
+    // Default_Action, none blocked by any rule.
+    it('subjects /api/admin/ to the managed rules rather than exempting it', () => {
+      const rules: WafRule[] = JSON.parse(
+        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
+      );
+
+      expect(rules.find(r => r.Name === 'allow-admin-endpoints')).toBeUndefined();
+
+      const exemptedPaths = rules
+        .filter(r => r.Action && 'Allow' in r.Action)
+        .flatMap(r => uriPathMatches(r.Statement).map(m => m.searchString));
+      expect(exemptedPaths.some(p => p.startsWith('/api/admin'))).toBe(false);
+    });
+
+    // The security-dashboard ingest endpoints post scanner output, which CommonRuleSet reads as an
+    // attack payload. They are the reason the blunt Allow existed, so they need naming explicitly
+    // or removing it just moves the breakage.
+    it('exempts the scanner ingest paths from CommonRuleSet, which is what the blunt Allow covered', () => {
+      const excluded = uriPathMatches(commonRuleSetScopeDown('production')).map(m => m.searchString);
+
+      for (const path of [
+        '/api/admin/security-dashboard/web-owasp-ingest',
+        '/api/admin/security-dashboard/code-semgrep-ingest',
+        '/api/admin/security-dashboard/packages-ingest',
+        '/api/admin/security-dashboard/secrets-ingest',
+        '/api/admin/security-dashboard/cloud-prowler-ingest',
+        '/api/admin/security-dashboard/attack-simulation-ingest',
+      ]) {
+        expect(excluded, `${path} must stay exempt from CommonRuleSet`).toContain(path);
+      }
+    });
+
+    // STARTS_WITH also exempted /api/ai/v1/completions-extra, which probing shows serves the SPA
+    // shell rather than the endpoint. Both forms that do route - bare and trailing slash, each
+    // confirmed answering text/event-stream - are matched exactly instead.
+    it('matches the completions endpoint exactly, not by prefix', () => {
+      for (const stage of ['dev', 'production']) {
+        const rules: WafRule[] = JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
+        const allow = rules.find(r => r.Name === 'Allow-LLM-API');
+        const matches = uriPathMatches(allow!.Statement);
+
+        expect(matches.map(m => m.searchString).sort()).toEqual(['/api/ai/v1/completions', '/api/ai/v1/completions/']);
+        for (const m of matches) {
+          expect(m.positionalConstraint, `${stage} completions allow must not be a prefix`).toBe('EXACTLY');
+        }
+      }
+    });
+  });
+
   describe('buildDevWafRuleJson — production stage', () => {
     it('pins Allow-LLM-API at Priority 0 so completions endpoint is not counted by ai-route-rate-limit', () => {
       const ruleJson = buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' });

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -66,7 +66,7 @@ function uriPathMatches(scopeDown: any): UriPathMatch[] {
     // A pattern set keeps its patterns in a separate AWS resource, so nothing in this repo can
     // read them. Returning silently would read as a pass, which is the failure mode this whole
     // walker exists to prevent - so refuse to answer instead.
-    if (node.RegexPatternSetReferenceStatement) {
+    if (node.RegexPatternSetReferenceStatement?.FieldToMatch?.UriPath) {
       throw new Error(
         'RegexPatternSetReferenceStatement: patterns live in a separate AWS resource and cannot be ' +
           'inspected from this repo, so path assertions here cannot cover it. Assert on the pattern ' +
@@ -496,44 +496,76 @@ describe('wafPolicy', () => {
     // paths are excluded from CommonRuleSet and AdminProtection_URIPATH is set to Count. Measured
     // before porting it: 10,981 /api/admin/ requests over 14 days on staging, every one ALLOW via
     // Default_Action, none blocked by any rule.
+    // Both stages: the dev policy is what staging and every preview stage actually run, and this
+    // guard being production-only meant a blanket /api/admin/ Allow could be re-added to dev and
+    // pass. The sibling test above deliberately stays production-only, because dev carries
+    // Allow-ZAP-Scanner ahead of the emergency block and that is tracked separately.
     it('subjects /api/admin/ to the managed rules rather than exempting it', () => {
-      const rules: WafRule[] = JSON.parse(
-        buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage: 'production' })
-      );
+      for (const stage of ['dev', 'production']) {
+        const rules: WafRule[] = JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
 
-      expect(rules.find(r => r.Name === 'allow-admin-endpoints')).toBeUndefined();
+        expect(
+          rules.find(r => r.Name === 'allow-admin-endpoints'),
+          stage
+        ).toBeUndefined();
 
-      // Matched with includes rather than startsWith on purpose: a regex spelling carries an
-      // anchor, so '^/api/admin/' does not start with '/api/admin' and the obvious check reads as
-      // a pass. Any Allow rule mentioning the admin prefix at all is what needs flagging here.
-      const exemptedPaths = rules
-        .filter(r => r.Action && 'Allow' in r.Action)
-        .flatMap(r => uriPathMatches(r.Statement).map(m => m.searchString));
-      const adminExemptions = exemptedPaths.filter(p => p.includes('/api/admin'));
-      expect(adminExemptions, 'no Allow rule may reference the admin prefix').toEqual([]);
-    });
-
-    // The security-dashboard ingest endpoints post scanner output, which CommonRuleSet reads as an
-    // attack payload. They are the reason the blunt Allow existed, so they need naming explicitly
-    // or removing it just moves the breakage.
-    it('exempts the scanner ingest paths from CommonRuleSet, which is what the blunt Allow covered', () => {
-      const excluded = uriPathMatches(commonRuleSetScopeDown('production')).map(m => m.searchString);
-
-      for (const path of [
-        '/api/admin/security-dashboard/web-owasp-ingest',
-        '/api/admin/security-dashboard/code-semgrep-ingest',
-        '/api/admin/security-dashboard/packages-ingest',
-        '/api/admin/security-dashboard/secrets-ingest',
-        '/api/admin/security-dashboard/cloud-prowler-ingest',
-        '/api/admin/security-dashboard/attack-simulation-ingest',
-      ]) {
-        expect(excluded, `${path} must stay exempt from CommonRuleSet`).toContain(path);
+        // Matched with includes rather than startsWith on purpose: a regex spelling carries an
+        // anchor, so '^/api/admin/' does not start with '/api/admin' and the obvious check reads
+        // as a pass. Any Allow rule mentioning the admin prefix at all is what needs flagging.
+        const exemptedPaths = rules
+          .filter(r => r.Action && 'Allow' in r.Action)
+          .flatMap(r => uriPathMatches(r.Statement).map(m => m.searchString));
+        const adminExemptions = exemptedPaths.filter(path => path.includes('/api/admin'));
+        expect(adminExemptions, `${stage}: no Allow rule may reference the admin prefix`).toEqual([]);
       }
     });
 
-    // STARTS_WITH also exempted /api/ai/v1/completions-extra, which probing shows serves the SPA
-    // shell rather than the endpoint. Both forms that do route - bare and trailing slash, each
-    // confirmed answering text/event-stream - are matched exactly instead.
+    it('exempts the scanner ingest paths from CommonRuleSet on both stages', () => {
+      for (const stage of ['dev', 'production']) {
+        const excluded = uriPathMatches(commonRuleSetScopeDown(stage)).map(m => m.searchString);
+
+        for (const path of [
+          '/api/admin/security-dashboard/web-owasp-ingest',
+          '/api/admin/security-dashboard/code-semgrep-ingest',
+          '/api/admin/security-dashboard/packages-ingest',
+          '/api/admin/security-dashboard/secrets-ingest',
+          '/api/admin/security-dashboard/cloud-prowler-ingest',
+          '/api/admin/security-dashboard/attack-simulation-ingest',
+        ]) {
+          expect(excluded, `${stage}: ${path} must stay exempt from CommonRuleSet`).toContain(path);
+        }
+      }
+    });
+
+    // (4) The claim the whole change rests on: production now runs the same surgical managed-rule
+    // configuration staging has run since July, which is what makes 10,981 measured staging
+    // requests evidence about production. The -prod-shadow parity guard covers rate limits only,
+    // so without this a future edit to one policy re-opens exactly the drift being closed here.
+    it('runs the same managed rule group configuration on both stages', () => {
+      const forStage = (stage: string): WafRule[] =>
+        JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
+      const dev = forStage('dev');
+      const prod = forStage('production');
+
+      // any: ManagedRuleGroupStatement is deeply nested and not usefully typed here
+      const managed = (rules: WafRule[]) => rules.filter(r => (r.Statement as any).ManagedRuleGroupStatement);
+      expect(
+        managed(prod)
+          .map(r => r.Name)
+          .sort()
+      ).toEqual(
+        managed(dev)
+          .map(r => r.Name)
+          .sort()
+      );
+
+      for (const rule of managed(prod)) {
+        const twin = dev.find(r => r.Name === rule.Name);
+        expect(twin, `${rule.Name} must exist on both stages`).toBeDefined();
+        expect(rule.Statement, `${rule.Name} must be configured identically on both stages`).toEqual(twin!.Statement);
+      }
+    });
+
     it('matches the completions endpoint exactly, not by prefix', () => {
       for (const stage of ['dev', 'production']) {
         const rules: WafRule[] = JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
@@ -543,6 +575,10 @@ describe('wafPolicy', () => {
         expect(matches.map(m => m.searchString).sort()).toEqual(['/api/ai/v1/completions', '/api/ai/v1/completions/']);
         for (const m of matches) {
           expect(m.positionalConstraint, `${stage} completions allow must not be a prefix`).toBe('EXACTLY');
+          // On an Allow, a transform inverts polarity: every form it folds in becomes exempt from
+          // all five managed rule groups. Asserted because the data was fixed and the guard was
+          // not, so reverting the transforms passed every test in this file.
+          expect(m.textTransformations, `${stage} completions allow transformations`).toEqual(['NONE']);
         }
       }
     });

--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -53,6 +53,26 @@ function uriPathMatches(scopeDown: any): UriPathMatch[] {
         textTransformations: (byteMatch.TextTransformations ?? []).map((t: { Type: string }) => t.Type),
       });
     }
+    // A regex exemption has the same effect on traffic as a byte match and was invisible here, so
+    // the same bypass spelled as a RegexMatchStatement passed every assertion in this file.
+    const regexMatch = node.RegexMatchStatement;
+    if (regexMatch?.FieldToMatch?.UriPath && typeof regexMatch.RegexString === 'string') {
+      found.push({
+        searchString: regexMatch.RegexString,
+        positionalConstraint: 'REGEX',
+        textTransformations: (regexMatch.TextTransformations ?? []).map((t: { Type: string }) => t.Type),
+      });
+    }
+    // A pattern set keeps its patterns in a separate AWS resource, so nothing in this repo can
+    // read them. Returning silently would read as a pass, which is the failure mode this whole
+    // walker exists to prevent - so refuse to answer instead.
+    if (node.RegexPatternSetReferenceStatement) {
+      throw new Error(
+        'RegexPatternSetReferenceStatement: patterns live in a separate AWS resource and cannot be ' +
+          'inspected from this repo, so path assertions here cannot cover it. Assert on the pattern ' +
+          'set directly, or do not use one in a policy these tests are meant to guard.'
+      );
+    }
     Object.values(node).forEach(walk);
   };
   walk(scopeDown);
@@ -483,10 +503,14 @@ describe('wafPolicy', () => {
 
       expect(rules.find(r => r.Name === 'allow-admin-endpoints')).toBeUndefined();
 
+      // Matched with includes rather than startsWith on purpose: a regex spelling carries an
+      // anchor, so '^/api/admin/' does not start with '/api/admin' and the obvious check reads as
+      // a pass. Any Allow rule mentioning the admin prefix at all is what needs flagging here.
       const exemptedPaths = rules
         .filter(r => r.Action && 'Allow' in r.Action)
         .flatMap(r => uriPathMatches(r.Statement).map(m => m.searchString));
-      expect(exemptedPaths.some(p => p.startsWith('/api/admin'))).toBe(false);
+      const adminExemptions = exemptedPaths.filter(p => p.includes('/api/admin'));
+      expect(adminExemptions, 'no Allow rule may reference the admin prefix').toEqual([]);
     });
 
     // The security-dashboard ingest endpoints post scanner output, which CommonRuleSet reads as an

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -9,18 +9,55 @@
       "Name": "Allow-LLM-API",
       "Priority": 0,
       "Statement": {
-        "ByteMatchStatement": {
-          "SearchString": "/api/ai/v1/completions",
-          "FieldToMatch": {
-            "UriPath": {}
-          },
-          "TextTransformations": [
+        "OrStatement": {
+          "Statements": [
             {
-              "Priority": 0,
-              "Type": "NONE"
+              "ByteMatchStatement": {
+                "SearchString": "/api/ai/v1/completions",
+                "FieldToMatch": {
+                  "UriPath": {}
+                },
+                "TextTransformations": [
+                  {
+                    "Priority": 0,
+                    "Type": "URL_DECODE"
+                  },
+                  {
+                    "Priority": 1,
+                    "Type": "NORMALIZE_PATH"
+                  },
+                  {
+                    "Priority": 2,
+                    "Type": "LOWERCASE"
+                  }
+                ],
+                "PositionalConstraint": "EXACTLY"
+              }
+            },
+            {
+              "ByteMatchStatement": {
+                "SearchString": "/api/ai/v1/completions/",
+                "FieldToMatch": {
+                  "UriPath": {}
+                },
+                "TextTransformations": [
+                  {
+                    "Priority": 0,
+                    "Type": "URL_DECODE"
+                  },
+                  {
+                    "Priority": 1,
+                    "Type": "NORMALIZE_PATH"
+                  },
+                  {
+                    "Priority": 2,
+                    "Type": "LOWERCASE"
+                  }
+                ],
+                "PositionalConstraint": "EXACTLY"
+              }
             }
-          ],
-          "PositionalConstraint": "STARTS_WITH"
+          ]
         }
       },
       "Action": {

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -20,15 +20,7 @@
                 "TextTransformations": [
                   {
                     "Priority": 0,
-                    "Type": "URL_DECODE"
-                  },
-                  {
-                    "Priority": 1,
-                    "Type": "NORMALIZE_PATH"
-                  },
-                  {
-                    "Priority": 2,
-                    "Type": "LOWERCASE"
+                    "Type": "NONE"
                   }
                 ],
                 "PositionalConstraint": "EXACTLY"
@@ -43,15 +35,7 @@
                 "TextTransformations": [
                   {
                     "Priority": 0,
-                    "Type": "URL_DECODE"
-                  },
-                  {
-                    "Priority": 1,
-                    "Type": "NORMALIZE_PATH"
-                  },
-                  {
-                    "Priority": 2,
-                    "Type": "LOWERCASE"
+                    "Type": "NONE"
                   }
                 ],
                 "PositionalConstraint": "EXACTLY"

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -20,15 +20,7 @@
                 "TextTransformations": [
                   {
                     "Priority": 0,
-                    "Type": "URL_DECODE"
-                  },
-                  {
-                    "Priority": 1,
-                    "Type": "NORMALIZE_PATH"
-                  },
-                  {
-                    "Priority": 2,
-                    "Type": "LOWERCASE"
+                    "Type": "NONE"
                   }
                 ],
                 "PositionalConstraint": "EXACTLY"
@@ -43,15 +35,7 @@
                 "TextTransformations": [
                   {
                     "Priority": 0,
-                    "Type": "URL_DECODE"
-                  },
-                  {
-                    "Priority": 1,
-                    "Type": "NORMALIZE_PATH"
-                  },
-                  {
-                    "Priority": 2,
-                    "Type": "LOWERCASE"
+                    "Type": "NONE"
                   }
                 ],
                 "PositionalConstraint": "EXACTLY"

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -9,18 +9,55 @@
       "Name": "Allow-LLM-API",
       "Priority": 0,
       "Statement": {
-        "ByteMatchStatement": {
-          "SearchString": "/api/ai/v1/completions",
-          "FieldToMatch": {
-            "UriPath": {}
-          },
-          "TextTransformations": [
+        "OrStatement": {
+          "Statements": [
             {
-              "Priority": 0,
-              "Type": "NONE"
+              "ByteMatchStatement": {
+                "SearchString": "/api/ai/v1/completions",
+                "FieldToMatch": {
+                  "UriPath": {}
+                },
+                "TextTransformations": [
+                  {
+                    "Priority": 0,
+                    "Type": "URL_DECODE"
+                  },
+                  {
+                    "Priority": 1,
+                    "Type": "NORMALIZE_PATH"
+                  },
+                  {
+                    "Priority": 2,
+                    "Type": "LOWERCASE"
+                  }
+                ],
+                "PositionalConstraint": "EXACTLY"
+              }
+            },
+            {
+              "ByteMatchStatement": {
+                "SearchString": "/api/ai/v1/completions/",
+                "FieldToMatch": {
+                  "UriPath": {}
+                },
+                "TextTransformations": [
+                  {
+                    "Priority": 0,
+                    "Type": "URL_DECODE"
+                  },
+                  {
+                    "Priority": 1,
+                    "Type": "NORMALIZE_PATH"
+                  },
+                  {
+                    "Priority": 2,
+                    "Type": "LOWERCASE"
+                  }
+                ],
+                "PositionalConstraint": "EXACTLY"
+              }
             }
-          ],
-          "PositionalConstraint": "STARTS_WITH"
+          ]
         }
       },
       "Action": {
@@ -30,33 +67,6 @@
         "SampledRequestsEnabled": true,
         "CloudWatchMetricsEnabled": true,
         "MetricName": "Allow-LLM-API"
-      }
-    },
-    {
-      "Name": "allow-admin-endpoints",
-      "Priority": 1,
-      "Statement": {
-        "ByteMatchStatement": {
-          "SearchString": "/api/admin/",
-          "FieldToMatch": {
-            "UriPath": {}
-          },
-          "TextTransformations": [
-            {
-              "Priority": 0,
-              "Type": "LOWERCASE"
-            }
-          ],
-          "PositionalConstraint": "STARTS_WITH"
-        }
-      },
-      "Action": {
-        "Allow": {}
-      },
-      "VisibilityConfig": {
-        "SampledRequestsEnabled": true,
-        "CloudWatchMetricsEnabled": true,
-        "MetricName": "allow-admin-endpoints"
       }
     },
     {
@@ -250,6 +260,96 @@
                           }
                         ],
                         "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/web-owasp-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/code-semgrep-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/packages-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/secrets-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/cloud-prowler-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/attack-simulation-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "STARTS_WITH"
                       }
                     }
                   ]


### PR DESCRIPTION
Closes the first finding of the internal WAF findings issue for the admin half, and narrows it for the other. This is the last change before `ENABLE_WAF` is set on production, because the managed rule groups are the only thing that enforces on day one and these two rules were exempting traffic from them.

## The problem

Production carried two terminating `Allow` rules **ahead of** `emergency-ip-block`:

```
P0  Allow-LLM-API          Allow   <- terminating
P1  allow-admin-endpoints  Allow   <- terminating
P2  emergency-ip-block     Block
P6-10  five managed rule groups
```

Anything matching those skipped the break-glass control and all five managed rule groups, not merely a rate limit. Enabling the firewall with them in place would have shipped a WAF that does not inspect `/api/admin/` at all.

## The admin half, closed

The rule existed for a reason: the security-dashboard ingest endpoints post scanner output that CommonRuleSet reads as an attack payload. Removing it alone would just move the breakage.

Staging has never had that rule. It handles the same traffic surgically instead - the six ingest paths excluded from CommonRuleSet, and `AdminProtection_URIPATH` set to `Count`. Production already had the override and was missing the exclusions, which is why it needed the blunt rule.

**Measured before porting rather than after:** 10,981 requests to `/api/admin/` on staging over 14 days, **every one `ALLOW` via `Default_Action`**, none blocked by any rule. So the surgical configuration demonstrably carries this traffic without the bypass.

## The completions half, narrowed rather than removed

`Allow-LLM-API` stays, deliberately. It fronts a long-lived SSE `POST` carrying user prompt text, which the SQLi and XSS signatures false-positive on, and staging cannot supply evidence for removing it because staging runs the same rule. Removing it belongs behind its own measurement, not this PR.

What did change is the match. `STARTS_WITH` also exempted `/api/ai/v1/completions-extra`, which probing shows serves the SPA shell rather than the endpoint. Both forms that actually route are now matched `EXACTLY`:

| path | probe result | exempt now |
| --- | --- | --- |
| `/api/ai/v1/completions` | `200 text/event-stream` | yes |
| `/api/ai/v1/completions/` | `200 text/event-stream` | yes |
| `/api/ai/v1/completions-extra` | `200 text/html`, SPA shell | **no** |

The trailing-slash form matters: matching only the bare path would have pushed a live route outside the exemption and into the managed rules.

## Why the staging measurement is evidence about production

The 10,981-request reading only transfers if production runs the same configuration staging does. It now does: all five managed rule groups are configured identically across the dev and prod policies, including all eight CommonRuleSet exclusions, `SizeRestrictions_BODY` on Count and `AdminProtection_URIPATH` on Count. That parity is the load-bearing half of this argument and a guard now holds it - the `-prod-shadow` pairs cover rate-limit rules only, so nothing kept the managed groups in step before.

## What still enforces, and what does not

After this, exactly one terminating Allow precedes the emergency IP block, and there is a test asserting that rather than a comment hoping for it. `allow-overwatch-ingest` is also a terminating Allow and sits at priority 3: after the emergency block, so it does not bypass the break-glass control, but still ahead of all five managed rule groups, which it does bypass. That is pre-existing, untouched here, and tracked separately.

## Verification

- AWS accepts both policies: **prod 1342 WCU, dev 1368**, against the **1500** basic-tier boundary.
- **39 tests** pass, and the admin and scanner-ingest guards now run over both stages rather than production alone - the dev policy is what staging and every preview stage actually run.
- The completions Allow is pinned on its transformations (`NONE`) as well as its match, so the widening removed in review cannot walk back in. All `-prod-shadow` rate-limit pairs still byte-match.
- Each guard fails on its own mutation: reintroducing the blunt admin Allow on either stage, reverting the completions match to a prefix, reverting the transform stack, dropping a scanner ingest exclusion from either stage, and drifting a managed rule group between stages.

## Out of scope, deliberately

The scanner bypass token in the dev policy is the third finding of that issue and is tracked separately. It does not appear in the production policy at all - confirmed, zero occurrences - so it has no bearing on enabling production.

