### PR TITLE
fix(data-lake): report an owner's own rung, not platform-admin, in the config trail

### DIFF
--- a/b4m-core/services/src/dataLakeService/lakeConfigChangeWiring.test.ts
+++ b/b4m-core/services/src/dataLakeService/lakeConfigChangeWiring.test.ts
@@ -78,6 +78,28 @@ describe('updateDataLake', () => {
     });
   });
 
+  // The rung is left to resolveLakeManageRung on this path (as on archive/unarchive/delete/restore),
+  // so a dual-role owner's routine rename recorded `platform-admin` too - the same false alarm as
+  // the visibility rows, on every resolver-driven action.
+  it('attributes a rename by an admin who owns the lake to their ownership', async () => {
+    const existing = lake({ name: 'Lake' });
+    const audit = auditSpy();
+    await updateDataLake(
+      { userId: 'owner', isAdmin: true },
+      'lake1',
+      { name: 'Renamed' },
+      {
+        db: {
+          dataLakes: { findById: vi.fn().mockResolvedValue(existing), update: echoUpdate(existing) },
+          dataLakeAccessGrants: noGrants,
+          ...audit.db,
+        },
+      }
+    );
+
+    expect(audit.only().manageRung).toBe('creator');
+  });
+
   // A concurrent writer's change must never be attributed to THIS caller. `BaseModel.update` is a
   // `findOneAndUpdate` with `new: true`, so its result carries whatever else landed on the document
   // between our read and our write. Diffing that result would put another principal's field change
@@ -362,8 +384,32 @@ describe('setLakeVisibility', () => {
     expect(audit.only().manageRung).toBe('creator');
   });
 
-  // The other half of the same rule: DEMOTION to private stays full canManageLake, so an admin
-  // demoting a lake they do not own is genuinely acting as admin and must still record that.
+  // Both directions of one owner's own edit must name the same authority: un-publishing recorded
+  // `platform-admin` for a dual-role (platform admin + owner) account while publishing recorded
+  // ownership, so the History tab flagged half of the same account's own visibility edits as an
+  // outside intervention. Restoring the admin-first arm in resolveLakeManageRung makes this red.
+  it('records ownership in BOTH directions when an admin who owns the lake publishes then un-publishes', async () => {
+    const dualRole = { userId: 'owner', isAdmin: true, organizationId: 'org-1' };
+    const published = lake({ isPublic: true });
+    const audit = auditSpy();
+    const db = (existing: IDataLakeDocument) => ({
+      dataLakes: {
+        findById: vi.fn().mockResolvedValue(existing),
+        update: echoUpdate(existing),
+        find: vi.fn().mockResolvedValue([]),
+      },
+      dataLakeAccessGrants: noGrants,
+      ...audit.db,
+    });
+
+    await setLakeVisibility(dualRole, 'lake1', 'public', { db: db(lake()) });
+    await setLakeVisibility(dualRole, 'lake1', 'private', { db: db(published) });
+
+    expect(audit.events().map(e => e.manageRung)).toEqual(['creator', 'creator']);
+  });
+
+  // The other half of the same rule: an admin acting on a lake they have NO relationship to is
+  // genuinely acting as admin, in either direction, and must still record that.
   it('still records platform-admin when an admin makes a lake private', async () => {
     const existing = lake({ isPublic: true });
     const audit = auditSpy();
@@ -445,6 +491,29 @@ describe('transferLakeOwnership', () => {
     );
 
     expect(audit.only().manageRung).toBe('org-admin');
+  });
+
+  // Same false alarm as the visibility rows, through the other hand-written override: this gate's
+  // own ternary checked actor.isAdmin FIRST, so a dual-role owner handing off their own lake was
+  // recorded as a platform admin doing it to them. The two overrides now agree with the resolver.
+  it('records ownership, not platform-admin, when an admin transfers a lake they own', async () => {
+    const existing = lake();
+    const audit = auditSpy();
+    await transferLakeOwnership({ userId: 'owner', isAdmin: true }, 'lake1', 'newOwner', {
+      db: { ...transferDb(existing), ...audit.db },
+    });
+
+    expect(audit.only().manageRung).toBe('creator');
+  });
+
+  it('records platform-admin when an admin transfers a lake they do NOT own', async () => {
+    const existing = lake();
+    const audit = auditSpy();
+    await transferLakeOwnership({ userId: 'root', isAdmin: true }, 'lake1', 'newOwner', {
+      db: { ...transferDb(existing), ...audit.db },
+    });
+
+    expect(audit.only().manageRung).toBe('platform-admin');
   });
 
   it('records nothing when the named owner already solely owns the lake', async () => {

--- a/b4m-core/services/src/dataLakeService/manageRule.test.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.test.ts
@@ -172,15 +172,27 @@ describe('resolveLakeManageRung', () => {
     expect(resolveLakeManageRung(lake('creator'), actor({ userId: 'creator' }), grants)).toBe('grant-curator');
   });
 
-  it('reports the MOST privileged rung when several apply - what actually let them do it', () => {
-    // A platform admin who also owns the lake could have acted either way; the admin rung is the
-    // one worth surfacing, because it is the one with no standing relationship to the lake.
-    const rung = resolveLakeManageRung(lake('creator', 'org-1'), {
-      userId: 'creator',
-      isAdmin: true,
-      administeredOrgIds: ['org-1'],
-    });
-    expect(rung).toBe('platform-admin');
+  // Reverses an earlier rule that reported the MOST privileged applicable rung. That rung feeds a
+  // history surface where `platform-admin` renders as a warning ("changed by somebody outside this
+  // lake's own people"), so it fired on a dual-role account's routine edits to a lake it owns.
+  // `platform-admin` now means what the warning claims: no lake-side relationship authorized this.
+  it("reports the actor's own relationship to the lake, not platform-admin, when both apply", () => {
+    const dualRole: ManageActor = { userId: 'creator', isAdmin: true, administeredOrgIds: ['org-1'] };
+    expect(resolveLakeManageRung(lake('creator', 'org-1'), dualRole)).toBe('creator');
+    expect(
+      resolveLakeManageRung(lake('someoneElse'), { ...dualRole, userId: 'newOwner' }, [
+        grant('user', 'newOwner', 'owner'),
+      ])
+    ).toBe('grant-owner');
+    expect(
+      resolveLakeManageRung(lake('someoneElse'), { ...dualRole, userId: 'cur' }, [grant('user', 'cur', 'curator')])
+    ).toBe('grant-curator');
+    // Only an admin with no relationship of their own to the lake still reports the admin rung.
+    expect(resolveLakeManageRung(lake('creator', 'org-1'), actor({ userId: 'root', isAdmin: true }))).toBe(
+      'platform-admin'
+    );
+    // ...as does an admin acting with no principal at all (a script running under admin rights).
+    expect(resolveLakeManageRung(lake('creator'), actor({ userId: '', isAdmin: true }))).toBe('platform-admin');
   });
 
   // The two functions must agree in BOTH directions, or a new rung added to canManageLake without

--- a/b4m-core/services/src/dataLakeService/manageRule.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.ts
@@ -134,22 +134,27 @@ export function canManageLake(
  * `null` for an actor who cannot manage the lake at all, so it is exactly `canManageLake` with the
  * winning rung named instead of collapsed to `true`.
  *
- * Reports the FIRST rung that grants, in `canManageLake`'s own short-circuit order, so several
- * applicable rungs report the most privileged one - which is the honest answer to "what let them
- * do this": a platform admin who also happens to own the lake could have done it either way, and
- * the admin rung is the one worth surfacing.
+ * Reports the rungs in `canManageLake`'s order with ONE deliberate departure: `platform-admin` is
+ * checked LAST, so it is reported only when no lake-side relationship of the actor's own would have
+ * authorized the write. The rung feeds a history surface that renders `platform-admin` as a warning
+ * ("somebody outside this lake's own people changed it"), so reporting the most privileged
+ * applicable rung fired that warning on a dual-role account's routine edits to a lake it owns -
+ * technically true, but a false alarm on the one surface whose whole purpose is trust. Ownership,
+ * curatorship and the org rungs are standing relationships to THIS lake and are the more
+ * informative answer whenever one of them applies.
  *
  * MUST stay in sync with `canManageLake` above; a test pins agreement across both directions
  * (a rung implies manage, and no-rung implies no-manage), so a new rung added there without one
- * here fails rather than silently recording every write under an older rung.
+ * here fails rather than silently recording every write under an older rung. The reordering is safe
+ * for that agreement precisely because it only changes WHICH of several granting rungs is named.
  */
 export function resolveLakeManageRung(
   lake: Pick<IDataLakeDocument, 'createdByUserId' | 'organizationId'>,
   actor: ManageActor,
   grants: readonly LakeGrant[] = []
 ): LakeManageRung | null {
-  if (actor.isAdmin) return 'platform-admin';
-  if (!actor.userId) return null;
+  // A principal-less actor has no lake-side relationship to find, so admin is the only answer left.
+  if (!actor.userId) return actor.isAdmin ? 'platform-admin' : null;
 
   // Split where isEffectiveOwner does not: an `owner` USER grant supersedes the creator, so the two
   // arms answer different questions after a transfer (who it was moved to vs. the original author
@@ -173,5 +178,7 @@ export function resolveLakeManageRung(
       (g.role === 'owner' || g.role === 'curator') &&
       administeredOrgIds.includes(g.principalId)
   );
-  return hasOrgGrant ? 'org-grant' : null;
+  if (hasOrgGrant) return 'org-grant';
+
+  return actor.isAdmin ? 'platform-admin' : null;
 }

--- a/b4m-core/services/src/dataLakeService/setLakeVisibility.ts
+++ b/b4m-core/services/src/dataLakeService/setLakeVisibility.ts
@@ -168,21 +168,14 @@ export const setLakeVisibility = async (
         organizationId: targetOrg ?? undefined,
         isPublic: targetIsPublic,
       }),
-      // An EXPOSING write was authorized by ownership and nothing else: the gate above is
-      // deliberately `isEffectiveOwner`, "WITHOUT the admin / curator / org-admin bypasses this must
-      // exclude". Left to `resolveLakeManageRung`, its first branch (`if (actor.isAdmin) return
-      // 'platform-admin'`) would record admin for an admin who is ALSO the owner - naming an
-      // authority that could not have passed this particular gate. The rung is an authorization
-      // fact, so it must name the branch that actually let the call through. Same reasoning, and the
-      // same shape, as transferLakeOwnership's override.
-      //
-      // Demotion to private is NOT overridden: that path stays full `canManageLake`, so the
-      // resolver's wider ladder is the honest answer there.
-      manageRung: exposes
-        ? grants.some(g => g.principalType === 'user' && g.principalId === actor.userId && g.role === 'owner')
-          ? 'grant-owner'
-          : 'creator'
-        : undefined,
+      // No `manageRung` override, either direction. An EXPOSING write is gated on
+      // `isEffectiveOwner` alone ("WITHOUT the admin / curator / org-admin bypasses this must
+      // exclude"), and `resolveLakeManageRung` now checks the admin rung LAST, so for an actor who
+      // cleared that gate it reports `grant-owner`/`creator` on its own - the branch that actually
+      // let the call through. Demotion to private stays full `canManageLake`, where the resolver's
+      // wider ladder is the honest answer. Overriding here would have to restate the resolver to
+      // stay right, and the two drifting apart is exactly how one direction of the SAME edit by the
+      // SAME owner came to record a different authority than the other.
     },
     { db, logger }
   );

--- a/b4m-core/services/src/dataLakeService/transferLakeOwnership.ts
+++ b/b4m-core/services/src/dataLakeService/transferLakeOwnership.ts
@@ -211,12 +211,15 @@ export const transferLakeOwnership = async (
   // so a creator who is also an org admin ends up holding exactly that grant. `manageRung` is an
   // authorization fact, so it must come from the branch that actually authorized the call - which is
   // `resolveLakeTransferAuthority` above, the one rule this gate and the transfer picker share.
-  const manageRung = actor.isAdmin
-    ? 'platform-admin'
-    : authority.isOwner
-      ? grants.some(g => g.principalType === 'user' && g.principalId === actor.userId && g.role === 'owner')
-        ? 'grant-owner'
-        : 'creator'
+  // Ownership is checked BEFORE the admin bypass, matching `resolveLakeManageRung`: an owner who
+  // also happens to be a platform admin transferred their OWN lake, and naming the admin rung there
+  // reads as an outside intervention on the history surface.
+  const manageRung = authority.isOwner
+    ? grants.some(g => g.principalType === 'user' && g.principalId === actor.userId && g.role === 'owner')
+      ? 'grant-owner'
+      : 'creator'
+    : actor.isAdmin
+      ? 'platform-admin'
       : 'org-admin';
 
   await recordLakeConfigChange(

--- a/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.test.ts
+++ b/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.test.ts
@@ -315,10 +315,9 @@ describe('updateFallbackLakeSettings - config-change audit', () => {
     const event = record.mock.calls[0][0];
     expect(event.dataLakeId).toBe('opti-knowledge');
     expect(event.action).toBe('update');
-    // Resolved, not overridden: resolveLakeManageRung's first arm is isAdmin -> platform-admin,
-    // and this route's gate guarantees isAdmin, so the resolver already names the only rung that
-    // can authorize this call. Asserted here so a widened gate shows up as a changed rung rather
-    // than silently recording an admin who was not involved.
+    // Overridden, not resolved: this route's gate is `ctx.isAdmin` and nothing else, while
+    // resolveLakeManageRung checks the admin rung LAST and would name `org-admin` on an
+    // org-scoped registry lake. Asserted here so a widened gate has to revisit the literal.
     expect(event.manageRung).toBe('platform-admin');
     expect(event.principalId).toBe('admin-1');
   });

--- a/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.ts
+++ b/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.ts
@@ -109,13 +109,14 @@ export const updateFallbackLakeSettings = async (
       // explicit rung below.
       action: 'update',
       changes: diffLakeConfig(before, projected),
-      // No `manageRung` override, deliberately. This route's gate is `ctx.isAdmin` directly (see
-      // assertFallbackLakeSettingsWriteAccess), and `resolveLakeManageRung`'s FIRST arm is
-      // `isAdmin -> 'platform-admin'`, so it already returns the one rung that can ever authorize
-      // this call. Hardcoding it would be redundant today and a LIE tomorrow: were the gate ever
-      // widened, the resolver would name the new rung while a literal kept reporting an admin who
-      // was not involved - and the rung is an authorization fact, not a label (see the override's
-      // own doc comment).
+      // Overridden, because this route's gate is `ctx.isAdmin` directly (see
+      // assertFallbackLakeSettingsWriteAccess) and nothing else: `resolveLakeManageRung` checks the
+      // admin rung LAST, so on an ORG-SCOPED registry lake (overlay-contributed entries may carry
+      // `organizationId`) it would name `org-admin` for an admin who also administers that org - a
+      // rung that cannot pass this gate at all, since an org admin who is not a platform admin is
+      // refused here. The rung is an authorization fact, so it must name the branch that let the
+      // call through. If this gate is ever widened, this literal must be revisited with it.
+      manageRung: 'platform-admin',
     },
     { db, logger }
   );


### PR DESCRIPTION
Closes #1941

## Description

In a data lake's **History** tab, an account that is both a platform admin AND the lake's own owner saw the orange **Platform admin** warning chip against its own routine edits. That chip means "somebody outside this lake's own people changed it", so firing it for the owner's own edit is a false alarm on a surface whose whole purpose is trust.

It was most visible on visibility, where the two directions disagreed one row apart:

| Action | Rung recorded before | Rendered as |
|---|---|---|
| Publish (`isPublic false -> true`) | `grant-owner` / `creator` | Owner / Creator (primary) |
| Un-publish (`isPublic true -> false`) | `platform-admin` | **Platform admin (warning)** |

**Root cause.** The two directions pass through different gates, and each row honestly named whichever gate ran. Exposing a lake is gated on `isEffectiveOwner` alone (deliberately excluding the admin/curator/org-admin bypasses so a platform admin cannot expose someone else's lake for them), and because that gate is narrower than `canManageLake`, `setLakeVisibility` overrode the recorded rung to `grant-owner`/`creator`. Demotion to private took neither the narrow gate nor the override, so the rung fell through to `resolveLakeManageRung`, whose first arm was `if (actor.isAdmin) return 'platform-admin'`.

The asymmetry was the override doing its job on one branch and nothing doing it on the other - but the false alarm was wider than publish-vs-un-publish. Six further call sites (`updateDataLake`, `archiveDataLake`, `unarchiveDataLake`, `deleteDataLake`, `restoreDeletedDataLake`, `acceptDataLakePurge`) left the rung to the same admin-first resolver, so a dual-role owner renaming, archiving or deleting their own lake got the same chip. `transferLakeOwnership` has its own hand-written rung and also checked `actor.isAdmin` first, so it did too.

**Fix.** `resolveLakeManageRung` now checks `platform-admin` LAST, so it is reported only when no lake-side relationship of the actor's own would have authorized the write - which is exactly what the warning chip claims. This reverses the resolver's earlier "report the MOST privileged applicable rung" rule; that was a deliberate design decision, so the reversal is recorded in the doc comment and its test is replaced with the reversal (with reasoning) rather than dropped. A platform admin who is NOT the lake's owner still records `platform-admin`, and gets the warning chip, for every action.

With the admin rung no longer first, the two hand-written overrides collapse toward the resolver instead of disagreeing with each other.

The chip colour mapping is untouched: rendering `platform-admin` as a warning is correct; the problem was which writes recorded that rung. No stored history row is rewritten either - none of them is false, they named the branch that actually ran at the time.

Not a regression: latent since the rung was first recorded in #1845, with nothing rendering it until the History tab's warning chip landed in #1917.

## Changes

- `manageRule.ts` - `resolveLakeManageRung` checks the `platform-admin` arm last, after the owner / curator / org rungs; a principal-less actor short-circuits to `platform-admin` (or `null`) since it has no lake-side relationship to find. Doc comment records the reversed precedence and why.
- `setLakeVisibility.ts` - drops its `manageRung` override entirely. With the admin rung no longer first, the resolver names `grant-owner`/`creator` on its own for any actor who cleared the narrow expose gate, and the override was the reason the two directions could disagree at all.
- `transferLakeOwnership.ts` - its hand-written rung checks `authority.isOwner` before `actor.isAdmin`, matching the resolver. The org-admin-vs-curator reasoning that made this rung explicit in the first place is unchanged.
- `updateFallbackLakeSettings.ts` - gains a `manageRung: 'platform-admin'` override it previously did not need. Its gate is `ctx.isAdmin` and nothing else, so with the admin rung checked last the resolver would name `org-admin` on an org-scoped registry lake - a rung that cannot pass that gate at all.
- Tests: `manageRule.test.ts` replaces the most-privileged-rung case with its reversal; `lakeConfigChangeWiring.test.ts` adds a dual-role publish-then-un-publish case pinning both directions, a dual-role rename (the resolver-driven class), and both transfer cases (owner -> ownership rung, non-owner admin -> `platform-admin`).

Mutation-verified: restoring the admin-first arm in the resolver and the admin-first ternary in `transferLakeOwnership` turns 5 tests red, including the pre-existing "records ownership ... when an admin who owns the lake exposes it" (which the resolver now carries on its own).

## Guide for Testers

Requires an account that is BOTH a platform admin AND the effective owner (creator, or the holder of an `owner` user grant) of a data lake. A platform admin who does not own the lake will not show the bug.

1. Sign in to the preview environment as that dual-role account.
2. Open a data lake you own -> **Settings** -> **Visibility**, set it to **Public**, and confirm the dialog. Expected: the change saves with no error.
3. Set **Visibility** back to **Private**. Expected: the change saves with no error.
4. Reopen **Settings** and go to the **History** tab. Expected: two visibility rows, both attributed to **Owner** or **Creator** (primary chip). Expected: NO orange **Platform admin** warning chip on either row. Before this change, the un-publish row carried that chip.
5. Rename the same lake (**Settings** -> name field -> save), then reopen **History**. Expected: the rename row is attributed to Owner/Creator, not Platform admin.
6. Still on the same lake, use **Transfer ownership** to hand it to another user. Expected: the transfer row in **History** is attributed to Owner/Creator, consistent with the visibility rows above it.

### Regression Checks

7. Sign in as a platform admin who does NOT own some other lake, and archive or rename that lake. Open its **History** tab. Expected: the row IS attributed to **Platform admin**, with the orange warning chip. This is the case the chip exists for and it must still fire.
8. As an ordinary (non-admin) lake owner, publish and un-publish a lake you own. Expected: both History rows attributed to Owner/Creator, unchanged from before.
9. As an org admin who is not the lake's owner, rename an org-scoped lake. Expected: the History row is attributed to the org-admin rung, unchanged.

### What NOT to test

The chip colours and the rung vocabulary are untouched, as is any history row recorded before this change (nothing is backfilled, and no stored row is false - each named the branch that actually ran at the time).

## Additional Information

`pnpm turbo:typecheck`, `pnpm turbo:test` and `pnpm lint:check` are green locally. Three packages (`scripts`, `client`, `database`) failed on the first full `turbo:test` run with 30s+ timeouts on real-DB/integration tests; re-run one package at a time with a capped worker pool they all pass (`scripts` 424/424, `database` 1994/1994, `client` 11021/11021), so those were CPU oversubscription, not this change.

Consumers of the stored `manageRung` field were swept: `assembleLakeConfigHistory.ts` and `LakeConfigHistorySection.tsx` are the only two in this repo, and neither depends on admin-first ordering. Worth a reviewer's eye if support tooling outside this repo queries the field.

## Developer Notes

- **Architecture decision:** `resolveLakeManageRung` now answers "what relationship of the actor's own authorized this?" rather than "what is the most privileged thing they could have used?". The platform-admin rung means "no lake-side relationship applied", which is what makes it safe for a UI to render as a warning. Any new rung added to `canManageLake` should be placed ahead of the admin arm here for the same reason.
- Because the resolver now agrees with the narrow expose gate, `setLakeVisibility` no longer restates it. The two remaining explicit rungs (`transferLakeOwnership`, `updateFallbackLakeSettings`) are the sites whose gates are genuinely narrower than the resolver's ladder, and both say so in a comment.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a, the reasoning lives in the resolver's doc comment
