### PR TITLE
fix(overwatch): let upsertProduct callers omit fields they do not own

### DIFF
--- a/packages/database/src/__tests__/OverwatchProductPartialUpsert.test.ts
+++ b/packages/database/src/__tests__/OverwatchProductPartialUpsert.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OverwatchProduct, overwatchProductRepository } from '../models/infra/ops/OverwatchProductModel';
+import { setupMongoTest } from '../__test__/utils';
+
+setupMongoTest();
+
+beforeEach(async () => {
+  await OverwatchProduct.deleteMany({});
+  await OverwatchProduct.syncIndexes();
+});
+
+/**
+ * `upsertProduct` writes `{ $set: data }`, so omitting a key preserves the stored value
+ * and supplying an empty one overwrites it. These tests pin the omission half for every
+ * field that is optional on the write path: a caller that does not know about a field
+ * must not be able to destroy it, and the only way to express that is to leave the key
+ * out entirely.
+ *
+ * The distinction is invisible in the return value of a single call, which is why each
+ * test writes a value, writes again without it, and then reads the document back.
+ */
+
+/** The minimum a caller must supply: everything else is optional on this path. */
+const identity = { productId: 'vibeswire', name: 'VibesWire' };
+
+const socialLink = { platform: 'x', url: 'https://x.com/vibeswire', handle: '@vibeswire' };
+const customEvent = { name: 'signup_completed', label: 'Signup completed' };
+const campaignLink = { label: 'Launch', url: 'https://vibeswire.com/?utm_campaign=launch' };
+const postingChannel = {
+  label: 'r/selfhosted',
+  url: 'https://reddit.com/r/selfhosted',
+  platform: 'reddit',
+  notes: 'Self-promo limited to 1 in 10 posts.',
+};
+
+describe('upsertProduct partial updates', () => {
+  it('creates a product from identity fields alone', async () => {
+    // If any of the five were still required this call would not compile, which is the
+    // property the rest of these tests depend on.
+    const saved = await overwatchProductRepository.upsertProduct(identity);
+
+    expect(saved).toMatchObject({ productId: 'vibeswire', name: 'VibesWire' });
+    // Schema defaults apply on the upsert-insert, so a caller that supplied nothing still
+    // gets a document every reader can iterate unconditionally.
+    expect(saved.socialLinks).toEqual([]);
+    expect(saved.customEvents).toEqual([]);
+    expect(saved.campaignLinks).toEqual([]);
+    expect(saved.postingChannels).toEqual([]);
+    expect(saved.status).toBe('active');
+  });
+
+  describe('omitting a field preserves it', () => {
+    it('preserves socialLinks', async () => {
+      await overwatchProductRepository.upsertProduct({ ...identity, socialLinks: [socialLink] });
+      await overwatchProductRepository.upsertProduct({ ...identity, name: 'VibesWire Renamed' });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.socialLinks).toHaveLength(1);
+      expect(doc?.name).toBe('VibesWire Renamed');
+    });
+
+    it('preserves customEvents', async () => {
+      await overwatchProductRepository.upsertProduct({ ...identity, customEvents: [customEvent] });
+      await overwatchProductRepository.upsertProduct({ ...identity, name: 'VibesWire Renamed' });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.customEvents).toHaveLength(1);
+    });
+
+    it('preserves campaignLinks', async () => {
+      await overwatchProductRepository.upsertProduct({ ...identity, campaignLinks: [campaignLink] });
+      await overwatchProductRepository.upsertProduct({ ...identity, name: 'VibesWire Renamed' });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.campaignLinks).toHaveLength(1);
+    });
+
+    it('preserves postingChannels', async () => {
+      await overwatchProductRepository.upsertProduct({ ...identity, postingChannels: [postingChannel] });
+      await overwatchProductRepository.upsertProduct({ ...identity, name: 'VibesWire Renamed' });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.postingChannels).toHaveLength(1);
+    });
+
+    it('preserves an inactive status', async () => {
+      // The sharpest of the five. The other four empty a list; this one silently returns a
+      // product to service. A caller editing an unrelated field has no reason to send a
+      // status, and before this was optional it had no way to avoid sending one.
+      await overwatchProductRepository.upsertProduct({ ...identity, status: 'inactive' });
+      await overwatchProductRepository.upsertProduct({ ...identity, name: 'VibesWire Renamed' });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.status).toBe('inactive');
+    });
+
+    it('preserves every field across an identity-only write', async () => {
+      // All five at once: a partial update touching nothing but the name must leave the
+      // whole rest of the document standing.
+      await overwatchProductRepository.upsertProduct({
+        ...identity,
+        socialLinks: [socialLink],
+        customEvents: [customEvent],
+        campaignLinks: [campaignLink],
+        postingChannels: [postingChannel],
+        status: 'inactive',
+      });
+
+      await overwatchProductRepository.upsertProduct({ ...identity, name: 'VibesWire Renamed' });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc).toMatchObject({
+        name: 'VibesWire Renamed',
+        status: 'inactive',
+      });
+      expect(doc?.socialLinks).toHaveLength(1);
+      expect(doc?.customEvents).toHaveLength(1);
+      expect(doc?.campaignLinks).toHaveLength(1);
+      expect(doc?.postingChannels).toHaveLength(1);
+    });
+  });
+
+  describe('supplying a field still overwrites it', () => {
+    // The other half of the contract. Optional must not become unwritable: clearing a list
+    // deliberately, or deactivating a product, has to keep working.
+    it('clears a list when an empty array is supplied', async () => {
+      await overwatchProductRepository.upsertProduct({ ...identity, socialLinks: [socialLink] });
+      await overwatchProductRepository.upsertProduct({ ...identity, socialLinks: [] });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.socialLinks).toEqual([]);
+    });
+
+    it('deactivates a product when a status is supplied', async () => {
+      await overwatchProductRepository.upsertProduct(identity);
+      await overwatchProductRepository.upsertProduct({ ...identity, status: 'inactive' });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.status).toBe('inactive');
+    });
+
+    it('replaces a list rather than merging into it', async () => {
+      await overwatchProductRepository.upsertProduct({ ...identity, customEvents: [customEvent] });
+      await overwatchProductRepository.upsertProduct({
+        ...identity,
+        customEvents: [{ name: 'purchase', label: 'Purchase' }],
+      });
+
+      const doc = await OverwatchProduct.findOne({ productId: 'vibeswire' }).lean();
+      expect(doc?.customEvents).toHaveLength(1);
+      expect(doc?.customEvents[0].name).toBe('purchase');
+    });
+  });
+});

--- a/packages/database/src/models/infra/ops/OverwatchProductModel.ts
+++ b/packages/database/src/models/infra/ops/OverwatchProductModel.ts
@@ -169,18 +169,49 @@ export const overwatchProductRepository = {
   },
 
   /**
-   * `postingChannels` is optional on the write path even though it is required on the
-   * document, because reads normalize it to `[]` (see withPostingChannels).
+   * Five fields that are required on the document are optional here: `postingChannels`,
+   * `socialLinks`, `customEvents`, `campaignLinks` and `status`.
    *
-   * Deliberate: adding it as a required member of this parameter would break every
-   * existing caller at compile time - the exact drift that left two overlay routes
-   * uncompilable when core made an adapter field required. Omitting it also leaves any
-   * stored value untouched, since `$set` never sees the key, so a caller that doesn't
-   * know about this field cannot wipe it.
+   * This method issues `findOneAndUpdate(..., { $set: data }, { upsert: true })`, so the
+   * two states a caller can express are not "a value" and "empty" - they are "a value"
+   * and "absent". A key present as `[]` or `'active'` overwrites whatever is stored. A key
+   * absent from `data` is never mentioned by `$set`, so the stored value survives.
+   *
+   * Requiring these fields forces every caller to supply a value for every field on every
+   * write, including fields it knows nothing about. A caller making a partial update has
+   * no correct value to send: it must either invent one, which silently destroys the
+   * stored data and still returns success, or fail to compile. Optional is what lets
+   * omission mean "leave this alone" - the only safe meaning for a field the caller does
+   * not own.
+   *
+   * Safe on insert: the schema defaults all five (`[]` for the four array fields,
+   * `'active'` for `status`), and those defaults apply on the upsert-insert. Reads
+   * normalize `postingChannels` for documents written before that field existed, since
+   * schema defaults never run on them - see withPostingChannels.
+   *
+   * Adding any of these back as required would break every existing caller at compile
+   * time - the same drift that left downstream callers uncompilable when core last made
+   * an established field required.
    */
   async upsertProduct(
-    data: Omit<IOverwatchProductDoc, '_id' | 'createdAt' | 'updatedAt' | 'postingChannels'> & {
+    data: Omit<
+      IOverwatchProductDoc,
+      | '_id'
+      | 'createdAt'
+      | 'updatedAt'
+      | 'postingChannels'
+      | 'socialLinks'
+      | 'customEvents'
+      | 'campaignLinks'
+      | 'status'
+    > & {
       postingChannels?: IPostingChannel[];
+      socialLinks?: ISocialLink[];
+      customEvents?: ICustomEvent[];
+      campaignLinks?: ICampaignLink[];
+      // Indexed off the document type rather than restating the union, so a new status
+      // value cannot be accepted here while being unrepresentable on the document.
+      status?: IOverwatchProductDoc['status'];
     }
   ): Promise<IOverwatchProductDoc> {
     const result = await OverwatchProduct.findOneAndUpdate(


### PR DESCRIPTION
## Description

`overwatchProductRepository.upsertProduct` issues:

```ts
findOneAndUpdate({ productId: data.productId }, { $set: data }, { upsert: true, new: true, lean: true })
```

With `$set`, the two states a caller can express are **"a value"** and **"absent"** — not "a value" and "empty". A key absent from `data` is never mentioned by the update, so the stored value survives. A key present as `[]` or `'active'` overwrites it.

Four fields that are required on the document were therefore required on the write path too: `socialLinks`, `customEvents`, `campaignLinks` and `status`. That forces every caller to supply a value for every field on every write, **including fields it knows nothing about**. A caller making a partial update has no correct value to send: it must either invent one — which silently destroys the stored data and still returns success — or fail to compile.

`status` is the sharpest of the four. The others empty a list; that one returns a product to service. Any caller updating an unrelated field had to send a status, and the only value it could reasonably invent is the schema default `'active'`, so a partial update could reactivate a deactivated product with no error and no signal.

This is the same problem `postingChannels` already had, and it gets the same treatment — the existing carve-out and its docblock were the model for this change.

## Changes

- `upsertProduct` accepts `socialLinks`, `customEvents`, `campaignLinks` and `status` as **optional**, joining `postingChannels` in the `Omit` carve-out.
- `status` is typed as `IOverwatchProductDoc['status']` rather than restating the union, so a value cannot be accepted here that is unrepresentable on the document.
- Docblock rewritten to explain the `$set` semantics that make omission meaningful, rather than describing one field.
- New test file covering **both halves** of the contract for each field.

**Safe on insert:** the schema defaults all four (`[]` for the three lists, `'active'` for `status`) and those defaults apply on the upsert-insert. There is no path where a field ends up undefined on a new document.

**Not a behaviour change for existing callers:** supplying a value still overwrites exactly as before. Clearing a list with `[]` and deactivating a product with `'inactive'` both keep working, and are tested. The only thing that changes is that omission becomes expressible.

The sole in-repo caller is the test suite, so nothing else needed updating.

## Guide for Testers

**Backend type/contract change with no UI surface.** Verification is the test suite:

1. Run `pnpm --filter @bike4mind/database test` (or `cd packages/database && pnpm test`).
2. Expect `src/__tests__/OverwatchProductPartialUpsert.test.ts` — 10 tests — to pass.
3. Expect `src/__tests__/OverwatchProductPostingChannels.test.ts` — 11 tests — to pass unchanged. This is the regression check: `postingChannels` already had this treatment and its behaviour must be identical.

**Regression checks**

4. Confirm no other call site needed changing: `grep -rn "upsertProduct" --exclude-dir=node_modules .` should return only the model and the two test files.
5. Confirm the widened type still rejects a bad status: adding `status: 'archived'` to any `upsertProduct` call in a test should fail typecheck.

**What NOT to test**

- No UI, route, or API surface changes here. There is nothing to click.
- No migration and no schema change — the document shape is untouched. Existing documents are unaffected.

## Additional Information

**Verified by mutation rather than by the tests merely passing.** Six mutants, all killed:

| Mutant | Result |
|---|---|
| Re-add defaults for all four fields in `$set` | killed |
| Default `status` on every write | killed |
| Default `socialLinks` on every write | killed |
| Default `campaignLinks` on every write | killed |
| `upsert: false` | killed |
| `new: false` | killed |

The first four matter most: they are what a well-meaning "restore the defaults" edit would look like, and each one silently re-introduces the omission-deletes behaviour. Each test writes a value, writes again without it, then reads the document back — a single call's return value cannot distinguish preserved from overwritten.

**Pre-existing typecheck errors:** `pnpm --filter @bike4mind/database typecheck:native` reports 23 errors on this branch. It reports the same 23 on a pristine `origin/main`, all in `src/models/ai/DataLakeModel.ts`, none in any file touched here. Checked both ways rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)