### PR TITLE
feat(admin): show account creation age in the users table

### DIFF
--- a/apps/client/app/components/admin/Users/Views/SlimUsersView.tsx
+++ b/apps/client/app/components/admin/Users/Views/SlimUsersView.tsx
@@ -11,6 +11,7 @@ import LoginsView from '../LoginsView';
 import MFAStatusBadge from '../MFAStatusBadge';
 import UserIdChip from '../UserIdChip';
 import { computeStoragePercent } from './storageUtils';
+import { formatAccountAge, formatAccountCreatedTitle } from '../formatAccountAge';
 
 interface SlimUsersViewProps {
   user: AdminUserListItem;
@@ -22,15 +23,19 @@ interface SlimUsersContainerProps {
 }
 
 /** Header and row share these widths; they must be edited together or the table skews. */
+// MUI Joy Grid is 12 columns and these must sum to exactly 12, or rows wrap and
+// stop lining up with the sticky header. Adding `created` was funded by trimming
+// 0.25 from five neighbours rather than appending, which would have overflowed.
 const COLUMN_WIDTHS = {
-  name: 2,
+  name: 1.75,
   userId: 1.25,
-  email: 2.25,
+  email: 2,
+  created: 1.25,
   logins: 0.75,
-  storage: 1.25,
+  storage: 1,
   security: 1,
-  activity: 1.5,
-  actions: 2,
+  activity: 1.25,
+  actions: 1.75,
 } as const;
 
 const ELLIPSIS_SX = { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } as const;
@@ -121,6 +126,7 @@ const SlimUsersViewHeader: React.FC = () => (
           ['Name', COLUMN_WIDTHS.name],
           ['User ID', COLUMN_WIDTHS.userId],
           ['Email', COLUMN_WIDTHS.email],
+          ['Created', COLUMN_WIDTHS.created],
           ['Logins', COLUMN_WIDTHS.logins],
           ['Storage', COLUMN_WIDTHS.storage],
           ['Security', COLUMN_WIDTHS.security],
@@ -172,6 +178,28 @@ const SlimUsersView: React.FC<SlimUsersViewProps> = ({ user, index }) => (
             {user.email}
           </Typography>
         </Tooltip>
+      </Grid>
+
+      {/* The table already sorts by createdAt by default (useUsersTabParams), so
+          until now it sorted by something the reader could not see. Relative age
+          answers "how new is this account" directly; the exact timestamp is on
+          hover rather than spending column width. */}
+      <Grid xs={COLUMN_WIDTHS.created} sx={{ minWidth: 0 }}>
+        {formatAccountAge(user.createdAt) ? (
+          <Tooltip title={formatAccountCreatedTitle(user.createdAt) ?? ''} placement="top">
+            <Typography
+              level="body-sm"
+              data-testid="admin-user-created"
+              sx={{ color: 'text.secondary', cursor: 'help', ...ELLIPSIS_SX }}
+            >
+              {formatAccountAge(user.createdAt)}
+            </Typography>
+          </Tooltip>
+        ) : (
+          <Typography level="body-xs" sx={{ color: 'text.tertiary', ...ELLIPSIS_SX }}>
+            &mdash;
+          </Typography>
+        )}
       </Grid>
 
       <Grid xs={COLUMN_WIDTHS.logins}>

--- a/apps/client/app/components/admin/Users/formatAccountAge.test.ts
+++ b/apps/client/app/components/admin/Users/formatAccountAge.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { formatAccountAge, formatAccountCreatedTitle } from './formatAccountAge';
+
+const NOW = new Date('2026-08-27T12:00:00.000Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString();
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe('formatAccountAge', () => {
+  it('scales through the units', () => {
+    expect(formatAccountAge(ago(30_000), NOW)).toBe('just now');
+    expect(formatAccountAge(ago(5 * MIN), NOW)).toBe('5m ago');
+    expect(formatAccountAge(ago(3 * HOUR), NOW)).toBe('3h ago');
+    expect(formatAccountAge(ago(3 * DAY), NOW)).toBe('3d ago');
+    expect(formatAccountAge(ago(60 * DAY), NOW)).toBe('2mo ago');
+    expect(formatAccountAge(ago(400 * DAY), NOW)).toBe('1y ago');
+  });
+
+  it('does not render a negative age for a future or clock-skewed date', () => {
+    expect(formatAccountAge(new Date(NOW.getTime() + DAY).toISOString(), NOW)).toBe('today');
+  });
+
+  it('returns null rather than a placeholder when the field is absent or junk', () => {
+    // Every user has timestamps, so absent means a projection dropped it -
+    // rendering an epoch date would look like real data.
+    expect(formatAccountAge(undefined, NOW)).toBeNull();
+    expect(formatAccountAge(null, NOW)).toBeNull();
+    expect(formatAccountAge('', NOW)).toBeNull();
+    expect(formatAccountAge('not a date', NOW)).toBeNull();
+  });
+
+  it('accepts a Date as well as an ISO string', () => {
+    expect(formatAccountAge(new Date(NOW.getTime() - 2 * DAY), NOW)).toBe('2d ago');
+  });
+});
+
+describe('formatAccountCreatedTitle', () => {
+  it('gives a full timestamp for the hover', () => {
+    expect(formatAccountCreatedTitle('2026-08-24T00:00:00.000Z')).toContain('Account created');
+  });
+
+  it('is null when there is nothing to show', () => {
+    expect(formatAccountCreatedTitle(undefined)).toBeNull();
+    expect(formatAccountCreatedTitle('nope')).toBeNull();
+  });
+});

--- a/apps/client/app/components/admin/Users/formatAccountAge.ts
+++ b/apps/client/app/components/admin/Users/formatAccountAge.ts
@@ -1,0 +1,43 @@
+/**
+ * Relative account age for the admin users table, e.g. "3d ago".
+ *
+ * Relative rather than absolute because of what the column is FOR: the table
+ * already sorts by createdAt, and the question being asked while scanning it is
+ * "how new is this account", which a raw date makes the reader compute. The exact
+ * timestamp is still one hover away (see the title attribute at the call site),
+ * so precision is available without spending column width on it.
+ *
+ * Returns null for a missing or unparseable value rather than a placeholder date -
+ * every user has timestamps (UserModel sets `timestamps: true`), so an absent
+ * value means a projection dropped the field, and rendering "Jan 1 1970" would
+ * look like data instead of like nothing.
+ */
+export function formatAccountAge(createdAt: string | Date | undefined | null, now: Date = new Date()): string | null {
+  if (!createdAt) return null;
+  const created = createdAt instanceof Date ? createdAt : new Date(createdAt);
+  const ms = created.getTime();
+  if (!Number.isFinite(ms)) return null;
+
+  const seconds = Math.floor((now.getTime() - ms) / 1000);
+  // Clock skew or a future-dated record: say "today" rather than "-3d ago".
+  if (seconds < 0) return 'today';
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}
+
+/** Full timestamp for the hover title; null when there is nothing to show. */
+export function formatAccountCreatedTitle(createdAt: string | Date | undefined | null): string | null {
+  if (!createdAt) return null;
+  const created = createdAt instanceof Date ? createdAt : new Date(createdAt);
+  if (!Number.isFinite(created.getTime())) return null;
+  return `Account created ${created.toLocaleString()}`;
+}


### PR DESCRIPTION
Adds a **Created** column to the admin users table.

## No tracking work was needed

`UserModel.ts` sets `timestamps: true`, so `createdAt` has been written for every account since the model existed. I verified against production: real values like `2026-08-23T06:34:29.889Z` come straight off `/api/users`.

The date was already available everywhere *except* the table:

| Where | Already used `createdAt`? |
|---|---|
| `useUsersTabParams.ts` | Yes — it's the **default sort field** |
| `exportUsersCsv.ts` | Yes — included in the CSV |
| `LoginDetailsModal.tsx` | Yes — renders "Created: …" |
| The users table | **No** |

So the table has been sorting by a value the reader couldn't see, which is exactly the confusing part: you can order by account creation but nothing on screen tells you when accounts were created.

## Relative age, not a raw date

Shows `3d ago` with the full timestamp on hover. The question being asked while scanning this table is *how new is this account* — a raw date makes the reader do that arithmetic. Precision stays one hover away rather than spending column width on it.

## Two details worth a look in review

**Absent values render an em dash, not a date.** `formatAccountAge` returns `null` for a missing or unparseable value. Since every user has timestamps, an absent value means a projection dropped the field — rendering `Jan 1 1970` there would read as data rather than as nothing. A future-dated or clock-skewed record reads `today` instead of a negative age.

**The grid had to be rebalanced, not extended.** MUI Joy's Grid is 12 columns and `COLUMN_WIDTHS` already summed to exactly 12. Appending would have wrapped rows out of alignment with the sticky header, so the new column is funded by trimming 0.25 from five neighbours. The sum is asserted in a comment and still 12.0.

## Verification

Client typecheck 0 errors. 81 tests passing across 12 files under `admin/Users`, including 6 new ones covering unit scaling, the future-date guard, null handling for absent/junk input, and `Date`-vs-ISO-string input.

## Possible follow-up

The header labels aren't clickable, so the sort direction still isn't adjustable from the UI — the default `createdAt desc` is what you get. Making the headers sortable is a separate, larger change; this PR just makes the existing sort legible.