### PR TITLE
test(fab-pipeline): import real opensearch predicates instead of re-implementing them (#2130)

### DIFF
--- a/b4m-core/fab-pipeline/src/dataLake/selfHostSearchIndex.test.ts
+++ b/b4m-core/fab-pipeline/src/dataLake/selfHostSearchIndex.test.ts
@@ -8,15 +8,14 @@ const mockOsClient = {
   deleteDocumentByQuery: vi.fn(),
 };
 
-vi.mock('./opensearchClient', () => ({
+// Fake only the OpenSearchClient; keep the real pure predicates
+// (isIndexAlreadyExistsError / isIndexNotFoundError) so these tests exercise the
+// shipped logic rather than a hand-copied fork that can drift (#2130).
+vi.mock('./opensearchClient', async importActual => ({
+  ...(await importActual<typeof import('./opensearchClient')>()),
   OpenSearchClient: vi.fn(function MockOpenSearchClient() {
     return mockOsClient;
   }),
-  isIndexAlreadyExistsError: (error: Error & { statusCode?: number; body?: { error?: { type?: string } } }) =>
-    error.statusCode === 400 && error.body?.error?.type === 'resource_already_exists_exception',
-  isIndexNotFoundError: (error: Error & { statusCode?: number; body?: { error?: { type?: string } } }) =>
-    (error.statusCode === 404 && error.body?.error?.type === 'index_not_found_exception') ||
-    (error.message ?? '').toLowerCase().includes('index_not_found_exception'),
 }));
 
 import { FabFileChunkSearchIndex, selfHostVectorIndexName } from './selfHostSearchIndex';


### PR DESCRIPTION
## What & why

Fixes #2130.

`selfHostSearchIndex.test.ts` mocked the **entire** `./opensearchClient` module and hand-reimplemented the two pure predicates (`isIndexAlreadyExistsError` / `isIndexNotFoundError`). The tests were therefore asserting against a **copy** of the logic — the shipped predicate could break and this file would stay fully green. The copy had in fact already drifted: it omitted the real `isIndexAlreadyExistsError` message fallback.

## The fix

Mock **only** `OpenSearchClient` via `importActual`, keeping the real pure predicates so the tests exercise the shipped code:

```ts
vi.mock('./opensearchClient', async importActual => ({
  ...(await importActual<typeof import('./opensearchClient')>()),
  OpenSearchClient: vi.fn(function MockOpenSearchClient() {
    return mockOsClient;
  }),
}));
```

## Verification

- `selfHostSearchIndex.test.ts` + `opensearchClient.test.ts`: **73 tests pass**; lint + `tsc --noEmit` clean.
- **Mutation check (the point of the fix):** neutering the real `isIndexNotFoundError` to `return false` now **fails** the `#2087` test ("treats a missing index as a satisfied removal, so the purge is not wedged"). Before this change that same mutation left the file green. Reverted after.
- **Grep of sibling `dataLake` tests:** only this file had the anti-pattern; `opensearchClient.test.ts` already tests the real functions directly.

Test-only change, one file. `tidy` / `P3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)