### PR TITLE
refactor(client): drop dead options.fields param on useSubscribeCollection

### DIFF
--- a/apps/client/app/contexts/UserContext.test.tsx
+++ b/apps/client/app/contexts/UserContext.test.tsx
@@ -189,7 +189,8 @@ describe('shouldRevokeForTokenVersion — JWT kill switch (legacy-token gap fix)
 
 describe('applyUserPush - merge a users WS push onto the store user (#1632)', () => {
   it('preserves fields absent from the push (the projection-wipe bug)', () => {
-    // A full document from /api/identify, then a push carrying only the projected subset.
+    // A full document from /api/identify, then a push that omits some of its fields (the real
+    // push carries the full user doc minus the server's security exclusions).
     const existing = fakeUser({
       lastNotebookId: 'nb-1',
       blogIntegration: { enabled: true },
@@ -199,9 +200,9 @@ describe('applyUserPush - merge a users WS push onto the store user (#1632)', ()
 
     const merged = applyUserPush(existing, pushed) as unknown as Record<string, unknown>;
 
-    // Projected field updates...
+    // Pushed field updates...
     expect(merged.currentCredits).toBe(42);
-    // ...while every non-projected field survives instead of being wiped to undefined.
+    // ...while every field absent from the push survives instead of being wiped to undefined.
     expect(merged.lastNotebookId).toBe('nb-1');
     expect(merged.blogIntegration).toEqual({ enabled: true });
     expect(merged.isBanned).toBe(true);
@@ -209,7 +210,7 @@ describe('applyUserPush - merge a users WS push onto the store user (#1632)', ()
 
   it('lets a field present in the push win, so server-side clears still propagate', () => {
     const existing = fakeUser({ lastNotebookId: 'nb-1' } as Partial<IUserDocument>);
-    // The field is in the projection and was cleared server-side: present-as-null overwrites.
+    // The field is present in the push and was cleared server-side: present-as-null overwrites.
     const pushed = { id: 'u1', lastNotebookId: null } as unknown as IUserDocument;
 
     const merged = applyUserPush(existing, pushed) as unknown as Record<string, unknown>;
@@ -226,7 +227,7 @@ describe('applyUserPush - merge a users WS push onto the store user (#1632)', ()
   });
 
   it('keeps store-derived flags (isBanned/isModerated) intact when the push omits them', () => {
-    // The blast-radius trap: these flags are not in the projection, so a replace reset them to
+    // The blast-radius trap: these flags are absent from the push, so a replace reset them to
     // false. Fed through setCurrentUser, the merged object must keep the real values.
     useUser.setState({ currentUser: null, isHydrated: false });
     const existing = fakeUser({ isBanned: true, isModerated: true } as Partial<IUserDocument>);

--- a/apps/client/app/contexts/UserContext.tsx
+++ b/apps/client/app/contexts/UserContext.tsx
@@ -379,11 +379,11 @@ export function resolveIdentifyEffect(params: {
 export const shouldAdoptIdentifyToken = (heldToken: string | null | undefined): boolean => !heldToken;
 
 /**
- * Merge a `users` WebSocket push onto the existing store user. The push carries only the
- * subscription's projected fields, so replacing would wipe every non-projected field (integration
- * settings, lastNotebookId, isBanned/isModerated, ...); merging updates the projected fields and
- * preserves the rest. `existing` may be null (no user yet), in which case the pushed subset is
- * adopted as-is. Exported for unit testing.
+ * Merge a `users` WebSocket push onto the existing store user. The push carries the full user
+ * document minus the server's security exclusions (password, stripeCustomerId, resetPasswordToken -
+ * see resolveFieldLimits), so replacing would wipe those excluded fields from the store; merging
+ * applies the pushed fields and preserves the excluded ones. `existing` may be null (no user yet),
+ * in which case the pushed document is adopted as-is. Exported for unit testing.
  */
 export const applyUserPush = (existing: IUserDocument | null, pushed: IUserDocument): IUserDocument =>
   ({ ...(existing ?? {}), ...pushed }) as IUserDocument;
@@ -407,12 +407,11 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       (_type: string, data: IUserDocument) => {
         if (data && data.id === userId) {
           try {
-            // The 'users' push carries only the projected `fields` (see the options below), so
-            // replacing the store user would wipe every field outside that projection (integration
-            // settings, lastNotebookId, isBanned/isModerated, ...). Merge onto the existing user so
-            // a push updates the projected fields and leaves the rest intact. Tradeoff: a field
-            // cleared server-side but absent from the projection keeps its stale value until the
-            // next refreshUser()/identify.
+            // The 'users' push carries the full user document minus the server's security
+            // exclusions (password, stripeCustomerId, resetPasswordToken), so replacing the store
+            // user would wipe those excluded fields. Merge onto the existing user so a push applies
+            // its fields and leaves the excluded ones intact. Tradeoff: a field cleared server-side
+            // but absent from the push keeps its stale value until the next refreshUser()/identify.
             setCurrentUser(applyUserPush(useUser.getState().currentUser, data));
             // Real-time kill switch: if the user's tokenVersion has advanced
             // past the version embedded in this tab's access token, the session
@@ -446,43 +445,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       },
       [setCurrentUser, userId, accessToken]
     ),
-    {
-      fetchInitialData: true,
-      fields: {
-        currentCredits: 1,
-        lastCreditsPurchasedAt: 1,
-        id: 1,
-        tokenVersion: 1,
-        emailVerified: 1,
-        name: 1,
-        email: 1,
-        username: 1,
-        systemFiles: 1,
-        showCreditsUsed: 1,
-        atlassianConnect: 1,
-        googleDrive: 1,
-        authProviders: 1,
-        // Critical fields for modal filtering and UI
-        tags: 1,
-        isAdmin: 1,
-        level: 1,
-        photoUrl: 1,
-        organizationId: 1,
-        // User presence fields
-        isOnline: 1,
-        lastActiveAt: 1,
-        // Additional user preferences
-        preferredVoice: 1,
-        preferences: 1,
-        // Security and permissions
-        mfa: 1,
-        groups: 1,
-        // Integration settings: projected so a real-time slackSettings change reaches this tab.
-        // The handler now merges rather than replaces, so a field absent here is no longer wiped -
-        // it just doesn't update in real time and refreshes on the next refreshUser()/identify.
-        slackSettings: 1,
-      },
-    }
+    { fetchInitialData: true }
   );
 
   // Fetch the current user's data and access token when the component mounts.

--- a/apps/client/app/utils/react-query.ts
+++ b/apps/client/app/utils/react-query.ts
@@ -331,7 +331,6 @@ export const useSubscribeCollection = <T>(
   callbackFn?: SubscriptionCallbackFunction<T>,
   options?: {
     fetchInitialData?: boolean;
-    fields?: Partial<Record<keyof T, boolean | number>>;
   }
 ) => {
   const [subscriptionId] = useState(() => Math.random().toString(36).substring(2, 9));
@@ -401,6 +400,11 @@ export const useSubscribeCollection = <T>(
           collectionName,
           query: mongoQuery,
           subscriptionId,
+          // Always empty: the server owns the projection (it merges in exclusion-based
+          // fieldLimits per collection, e.g. password/stripeCustomerId for `users`). A
+          // client-supplied inclusion projection can't be honored on those collections -
+          // it would mix inclusions with the server's exclusions and be dropped - so we
+          // don't offer one. `fields` is still required by the wire schema.
           fields: {},
           fetchInitialData: options?.fetchInitialData ?? true,
         };


### PR DESCRIPTION
## Description

Tidy-up from #1785. `useSubscribeCollection` accepted an `options.fields` param, but `subscribe()` hardcodes `fields: {}` on the wire, so the param was never used. The only caller passing it (`UserContext`) was requesting an inclusion projection for the `users` collection that was silently ignored.

For the `users` collection the server always merges in exclusion-based `fieldLimits` (`password`, `stripeCustomerId`, `resetPasswordToken` - see `resolveFieldLimits`). A client-supplied inclusion projection could therefore never be honored on that path: it would mix inclusions with the server's exclusions and be dropped. The dead param implied an inclusion-projection capability the `users` path can't offer, so it's removed rather than wired up.

The server-side exclusion merge and the drop-inclusions guard in `dataSubscribeRequest.ts` are correct and stay: the guard is defensively useful for overlay callers and is already covered by tests, and the `deletedAt: true` it carries on the pure-inclusion branch is required for soft-delete detection. Item #1's original "throws / can never deliver a data_update" was already resolved on `main` (the guard now drops-and-warns instead of throwing).

## Changes

- Remove the unused `fields?` param from `useSubscribeCollection`'s `options` type (`react-query.ts`), and document why the wire payload is always `fields: {}`.
- Remove the dead `fields: { ... }` projection object from the `users` subscription in `UserContext.tsx`.
- Fix the two `applyUserPush` comments that claimed the push "carries only the projected fields" - it carries the full user document minus the server's security exclusions; the merge preserves those excluded fields.

**No runtime change:** the wire payload was already `fields: {}`, so what the server receives, projects, and pushes is identical. This is pure dead-surface removal + comment accuracy.

## Guide for Testers

This is a no-runtime-change refactor; validation is via the existing automated suites and a quick smoke check.

### Regression Checks
1. Sign in to the app. Confirm the current-user data loads (credits, name, avatar all populated).
2. In another session/tab, change a user field that flows through the `users` subscription (e.g. purchase/adjust credits, or update Slack integration settings). Confirm the change appears in the first tab in real time without a full refresh.
3. Confirm fields NOT sent by the push (e.g. integration settings, `lastNotebookId`) are still present after a push lands - i.e. the merge still preserves them (they are not wiped to undefined).
4. Trigger a server-side session revocation (password reset / MFA change) and confirm the real-time kill switch still forces re-auth.

### What NOT to test
- No UI changes. No new capability. No backend/schema changes - the WebSocket payload is byte-identical to before.

## Verification

- `pnpm --filter @bike4mind/client typecheck` - clean
- `apps/client/app/contexts/UserContext.test.tsx` + `server/websocket/__tests__/dataSubscribeRequest.test.ts` - 38 passed
- `apps/client/app/utils/react-query` tests - 8 passed
- eslint on both changed files - 0 errors (only pre-existing `any` warnings on unrelated lines)

Closes #1785

🤖 Generated with [Claude Code](https://claude.com/claude-code)