### PR TITLE
fix(data-lakes): give the stranded-vectorize sweep a stale-claim recovery arm

### DIFF
--- a/apps/client/server/cron/dataLakeBatchReconcile.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.test.ts
@@ -19,6 +19,9 @@ const h = vi.hoisted(() => ({
   // Spied (not a bare stub) so a test can assert the cron passes BOTH the age cutoff and the
   // stale-claim cutoff: a one-arg call silently turns the stale-claim rescue arm back off.
   buildScanFilter: vi.fn((cutoff: Date, _staleClaimBefore: Date) => ({ chunkCount: 0, createdAt: { $lt: cutoff } })),
+  buildStrandedFilter: vi.fn((cutoff: Date, _staleClaimBefore?: Date) => ({
+    vectorizeEnqueueFailedAt: { $lt: cutoff },
+  })),
 }));
 
 vi.mock('@bike4mind/database', () => ({
@@ -62,7 +65,7 @@ vi.mock('sst', () => ({
 vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => h.sendToQueue(...a) }));
 vi.mock('@server/worker/chunkScan', () => ({
   buildFabFileChunkScanFilter: (...a: unknown[]) => h.buildScanFilter(...(a as [Date, Date])),
-  buildStrandedVectorizeScanFilter: (cutoff: Date) => ({ vectorizeEnqueueFailedAt: { $lt: cutoff } }),
+  buildStrandedVectorizeScanFilter: (...a: unknown[]) => h.buildStrandedFilter(...(a as [Date, Date])),
   CHUNK_SCAN_MIN_AGE_MS: 2 * 60_000,
   CHUNK_CLAIM_STALE_MS: 30 * 60_000,
   VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS: 15 * 60_000,
@@ -354,6 +357,13 @@ describe('dataLakeBatchReconcile cron handler', () => {
 
       expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', { fabFileId: 'ff9', userId: 'u9' });
       expect(JSON.parse(res.body).rescuedVectorizeFiles).toBe(1);
+
+      // Both cutoffs, same as the un-chunked sweep: a one-arg call drops the stale-claim arm, and a
+      // file left claimed by a worker killed inside resumeVectorizeEnqueue would have no way back.
+      const [cutoff, staleClaimBefore] = h.buildStrandedFilter.mock.calls[0] as [Date, Date];
+      expect(cutoff).toBeInstanceOf(Date);
+      expect(staleClaimBefore).toBeInstanceOf(Date);
+      expect(staleClaimBefore.getTime()).toBeLessThan(cutoff.getTime());
     });
 
     it('a failed send costs only itself: the candidates behind it still go out', async () => {

--- a/apps/client/server/cron/dataLakeBatchReconcile.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.ts
@@ -130,8 +130,10 @@ async function rescueUnchunkedFiles(): Promise<{ enqueued: number; failed: numbe
  * re-chunks. Not gated on enableAutoChunk: these files were already chunked.
  */
 async function rescueStrandedVectorizeFiles(): Promise<number> {
-  const cutoff = new Date(Date.now() - VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS);
-  const candidates = await FabFile.find(buildStrandedVectorizeScanFilter(cutoff))
+  const now = Date.now();
+  const cutoff = new Date(now - VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS);
+  const staleClaimBefore = new Date(now - CHUNK_CLAIM_STALE_MS);
+  const candidates = await FabFile.find(buildStrandedVectorizeScanFilter(cutoff, staleClaimBefore))
     .select('_id userId batchId')
     .limit(CHUNK_RESCUE_MAX_PER_RUN)
     .lean();

--- a/apps/client/server/worker/chunkScan.e2e.test.ts
+++ b/apps/client/server/worker/chunkScan.e2e.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
+import { FabFile } from '@bike4mind/database';
+import {
+  buildStrandedVectorizeScanFilter,
+  CHUNK_CLAIM_STALE_MS,
+  VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS,
+} from './chunkScan';
+
+/**
+ * Real-Mongo guard for the stranded-vectorize sweep's stale-claim arm, driving THIS builder rather
+ * than a copy of its output. packages/database/src/__tests__/fabFileVectorizeStranded.test.ts also
+ * covers the shape against a real mongod, but hand-writes the filter literal (it cannot import
+ * apps/client), so it cannot notice the arms here changing; chunkScan.test.ts drives the real
+ * builder but matches documents in JS, so it cannot notice Mongo disagreeing with that matcher.
+ * This file is the one place both halves are real at once.
+ */
+
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+});
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+const now = Date.now();
+const cutoff = new Date(now - VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS);
+const staleClaimBefore = new Date(now - CHUNK_CLAIM_STALE_MS);
+
+/** Every seeded file is a genuine stranded-vectorize candidate; only the claim state varies. */
+async function seedClaimStates() {
+  const stranded = {
+    userId: 'u1',
+    type: 'FILE',
+    chunked: true,
+    chunkCount: 7,
+    vectorizeEnqueueFailedAt: new Date(now - VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS - 60_000),
+  };
+  await FabFile.create([
+    { ...stranded, fileName: 'free.pdf', isChunking: false },
+    { ...stranded, fileName: 'no-claim-field.pdf' },
+    {
+      ...stranded,
+      fileName: 'hardkill-stale.pdf',
+      isChunking: true,
+      chunkClaimedAt: new Date(now - CHUNK_CLAIM_STALE_MS - 60_000),
+    },
+    { ...stranded, fileName: 'hardkill-no-stamp.pdf', isChunking: true, chunkClaimedAt: null },
+    { ...stranded, fileName: 'live-claim.pdf', isChunking: true, chunkClaimedAt: new Date(now - 60_000) },
+  ]);
+}
+
+const select = async (filter: ReturnType<typeof buildStrandedVectorizeScanFilter>) =>
+  (await FabFile.find(filter).select('fileName').lean()).map(f => f.fileName).sort();
+
+describe('buildStrandedVectorizeScanFilter against a real mongod', () => {
+  it('rescues a claim a hard-killed worker left behind, and never a live one', async () => {
+    // The failure the arm exists for: resumeVectorizeEnqueue holds isChunking across real work, so
+    // an OOM/timeout/deploy kill inside that window never runs the finally that clears it.
+    await seedClaimStates();
+
+    expect(await select(buildStrandedVectorizeScanFilter(cutoff, staleClaimBefore))).toEqual([
+      'free.pdf',
+      'hardkill-no-stamp.pdf',
+      'hardkill-stale.pdf',
+      'no-claim-field.pdf',
+    ]);
+  });
+
+  it('without the cutoff selects only unclaimed files - the gap this arm closes', async () => {
+    await seedClaimStates();
+
+    expect(await select(buildStrandedVectorizeScanFilter(cutoff))).toEqual(['free.pdf', 'no-claim-field.pdf']);
+  });
+
+  it('keeps the partial vectorizeEnqueueFailedAt index leading the plan', async () => {
+    // A three-way $or is exactly the shape that can tip the planner into subplanning and a
+    // collection scan across every FabFile - see the comment on the residual $or in chunkScan.ts.
+    // The decoy population is load-bearing: on a handful of documents every index costs the same
+    // and the planner picks arbitrarily, so an explain assertion over a bare 5-doc collection
+    // proves nothing. These 2000 unstamped files are outside the partial index entirely, which is
+    // what makes choosing it the only cheap plan.
+    await seedClaimStates();
+    await FabFile.createIndexes();
+    await FabFile.collection.insertMany(
+      Array.from({ length: 2000 }, (_, i) => ({
+        userId: 'u1',
+        fileName: `decoy-${i}.pdf`,
+        type: 'FILE',
+        chunked: true,
+        deletedAt: null,
+        vectorizeEnqueueFailedAt: null,
+      }))
+    );
+
+    const plan = await FabFile.collection
+      .find(buildStrandedVectorizeScanFilter(cutoff, staleClaimBefore) as never)
+      .explain('queryPlanner');
+
+    const winning = JSON.stringify(plan.queryPlanner.winningPlan);
+    expect(winning).toContain('"indexName":"vectorizeEnqueueFailedAt_1"');
+    expect(winning).not.toContain('"stage":"COLLSCAN"');
+  });
+
+  it('still excludes a deleted or un-chunked file when the arm is on', async () => {
+    // The arm widens the claim predicate only; it must not open a door for files that are some
+    // other sweep's business.
+    const stranded = {
+      userId: 'u1',
+      type: 'FILE',
+      isChunking: true,
+      chunkClaimedAt: new Date(now - CHUNK_CLAIM_STALE_MS - 60_000),
+      vectorizeEnqueueFailedAt: new Date(now - VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS - 60_000),
+    };
+    await FabFile.create([
+      { ...stranded, fileName: 'unchunked.pdf', chunked: false },
+      { ...stranded, fileName: 'deleted.pdf', chunked: true, deletedAt: new Date() },
+      { ...stranded, fileName: 'keeper.pdf', chunked: true },
+    ]);
+
+    expect(await select(buildStrandedVectorizeScanFilter(cutoff, staleClaimBefore))).toEqual(['keeper.pdf']);
+  });
+});

--- a/apps/client/server/worker/chunkScan.test.ts
+++ b/apps/client/server/worker/chunkScan.test.ts
@@ -228,6 +228,50 @@ describe('buildStrandedVectorizeScanFilter', () => {
     expect(matches(doc, filter)).toBe(false);
   });
 
+  describe('stale-claim arm', () => {
+    // resumeVectorizeEnqueue holds the claim across real work (a vectorless-chunk read plus N
+    // sends), so a hard-killed worker leaves isChunking:true with no finally to clear it. Every
+    // other automatic door is shut on that file - hence the same three arms the un-chunked sweep
+    // carries, with the same chunkClaimedAt cutoff.
+    const claimCutoff = new Date('2026-01-01T00:00:00Z');
+    const withStale = buildStrandedVectorizeScanFilter(cutoff, claimCutoff);
+    const base = { chunked: true, vectorizeEnqueueFailedAt: stale, deletedAt: null };
+
+    it('still selects a file that is not claimed at all', () => {
+      expect(matches({ ...base, isChunking: false }, withStale)).toBe(true);
+    });
+
+    it('selects a claim older than the stale cutoff', () => {
+      expect(matches({ ...base, isChunking: true, chunkClaimedAt: stale }, withStale)).toBe(true);
+    });
+
+    it('selects an in-flight file with no claim stamp - the pre-chunkClaimedAt backfill', () => {
+      expect(matches({ ...base, isChunking: true, chunkClaimedAt: null }, withStale)).toBe(true);
+      expect(matches({ ...base, isChunking: true }, withStale)).toBe(true);
+    });
+
+    it('leaves a genuinely in-flight claim alone', () => {
+      expect(matches({ ...base, isChunking: true, chunkClaimedAt: fresh }, withStale)).toBe(false);
+    });
+
+    it('uses the same claim cutoff the un-chunked sweep does', () => {
+      const claimed = { isChunking: true, chunkClaimedAt: fresh };
+      expect(matches({ ...base, ...claimed }, withStale)).toBe(
+        matches(
+          {
+            status: 'complete',
+            chunkCount: 0,
+            createdAt: stale,
+            deletedAt: null,
+            mimeType: 'application/pdf',
+            ...claimed,
+          },
+          buildFabFileChunkScanFilter(cutoff, claimCutoff)
+        )
+      );
+    });
+  });
+
   it('skips a deleted file', () => {
     const doc = { chunked: true, vectorizeEnqueueFailedAt: stale, isChunking: false, deletedAt: new Date() };
     expect(matches(doc, filter)).toBe(false);

--- a/apps/client/server/worker/chunkScan.test.ts
+++ b/apps/client/server/worker/chunkScan.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import {
   buildFabFileChunkScanFilter,
   buildStrandedVectorizeScanFilter,
@@ -299,4 +301,29 @@ describe('buildStrandedVectorizeScanFilter', () => {
     expect(matches(doc, buildFabFileChunkScanFilter(cutoff))).toBe(false);
     expect(matches(doc, filter)).toBe(true);
   });
+});
+
+describe('production call sites pass the stale-claim cutoff', () => {
+  // Source-shape guard, because the regression is silent: staleClaimBefore is optional (the arm is
+  // opt-in), so dropping it type-checks, passes every other test, and just quietly turns the
+  // recovery arm back off. The cron's call is covered behaviourally in dataLakeBatchReconcile.test.ts;
+  // the self-host worker's is inside an unexported main(), so this is what watches it.
+  const sources = {
+    'server/worker/main.ts': 'main.ts',
+    'server/cron/dataLakeBatchReconcile.ts': '../cron/dataLakeBatchReconcile.ts',
+  } as const;
+
+  for (const [label, rel] of Object.entries(sources)) {
+    it(`${label} calls buildStrandedVectorizeScanFilter with both cutoffs`, async () => {
+      const src = await readFile(resolve(__dirname, rel), 'utf8');
+      const call = src.match(/buildStrandedVectorizeScanFilter\(([^)]*)\)/);
+      expect(call, 'call site vanished - move or delete this guard with it').not.toBeNull();
+      expect(
+        call![1]
+          .split(',')
+          .map(a => a.trim())
+          .filter(Boolean)
+      ).toHaveLength(2);
+    });
+  }
 });

--- a/apps/client/server/worker/chunkScan.ts
+++ b/apps/client/server/worker/chunkScan.ts
@@ -144,8 +144,16 @@ export const VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS = 15 * 60_000;
  * chunks that still lack a vector, clearing the stamp when it succeeds. Deliberately NOT gated on
  * enableAutoChunk (unlike the un-chunked sweep): that setting governs whether new uploads get
  * chunked, and this only finishes handing off work that was already chunked.
+ *
+ * `staleClaimBefore` carries the same three-arm stale-claim semantics as
+ * buildFabFileChunkScanFilter, and for the same reason: resumeVectorizeEnqueue does real work under
+ * the claim (a vectorless-chunk read plus N sends), so a worker hard-killed inside that window never
+ * runs the finally that clears isChunking. Without the arm every automatic door is shut on that file
+ * - the un-chunked sweep needs chunkCount: 0, findConvergencePausedFilesByScope excludes in-flight,
+ * and the reprocess endpoint refuses a file being chunked - leaving only SQS redelivery and, past
+ * the retry ladder, a manual DLQ replay.
  */
-export const buildStrandedVectorizeScanFilter = (cutoff: Date) => ({
+export const buildStrandedVectorizeScanFilter = (cutoff: Date, staleClaimBefore?: Date) => ({
   // $type is load-bearing, not decoration, but not for narrowing: `$lt` is type-bracketed, so a bare
   // `$lt: cutoff` already excludes the null default and a missing field. $type is here because it
   // matches the partial index's own predicate (FabFileModel.ts) and is therefore what lets the
@@ -157,6 +165,20 @@ export const buildStrandedVectorizeScanFilter = (cutoff: Date) => ({
   // whichever writer happens to have cleared the marker: an un-chunked file is the other sweep's
   // business whatever stamps it carries.
   chunked: true,
-  isChunking: { $ne: true },
   deletedAt: null,
+  // Normally exclude in-flight files. When a stale-claim cutoff is supplied, ALSO rescue a claim
+  // older than it, including the `chunkClaimedAt: null` backfill arm for files stuck claimed from
+  // before that stamp existed - see buildFabFileChunkScanFilter, whose arms these mirror exactly.
+  // Kept as a residual `$or` beside the stamp predicate rather than folded into it, so the partial
+  // vectorizeEnqueueFailedAt index still leads the plan (fabFileVectorizeStranded.test.ts asserts
+  // the IXSCAN).
+  ...(staleClaimBefore
+    ? {
+        $or: [
+          { isChunking: { $ne: true } },
+          { isChunking: true, chunkClaimedAt: { $lt: staleClaimBefore } },
+          { isChunking: true, chunkClaimedAt: null },
+        ],
+      }
+    : { isChunking: { $ne: true } }),
 });

--- a/apps/client/server/worker/main.ts
+++ b/apps/client/server/worker/main.ts
@@ -15,7 +15,12 @@ import { isDiscoveryDriver, startDiscoveryOnStartup } from '@server/modelDiscove
 import { runStuckBatchSweep } from '@server/cron/dataLakeBatchReconcile';
 import { SelfHostWorker } from './selfHostWorker';
 import { dispatchSelfHostEvent } from './eventDispatch';
-import { buildStrandedVectorizeScanFilter, CHUNK_SCAN_BATCH, VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS } from './chunkScan';
+import {
+  buildStrandedVectorizeScanFilter,
+  CHUNK_CLAIM_STALE_MS,
+  CHUNK_SCAN_BATCH,
+  VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS,
+} from './chunkScan';
 import { CONVERGENCE_ORIGIN } from '@server/queueHandlers/convergenceProvenance';
 import { runChunkRescueSweep } from './chunkRescueSweep';
 import {
@@ -142,8 +147,10 @@ async function main() {
     // Second pass, same queue: files whose chunks landed but whose vectorize hand-off failed.
     // Ungated (these files were already chunked, so enableAutoChunk has nothing left to gate) and
     // separately capped - see buildStrandedVectorizeScanFilter.
-    const strandedCutoff = new Date(Date.now() - VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS);
-    const stranded = await FabFile.find(buildStrandedVectorizeScanFilter(strandedCutoff))
+    const strandedNow = Date.now();
+    const strandedCutoff = new Date(strandedNow - VECTORIZE_ENQUEUE_RESCUE_MIN_AGE_MS);
+    const strandedStaleClaimBefore = new Date(strandedNow - CHUNK_CLAIM_STALE_MS);
+    const stranded = await FabFile.find(buildStrandedVectorizeScanFilter(strandedCutoff, strandedStaleClaimBefore))
       .select('_id userId batchId')
       .limit(CHUNK_SCAN_BATCH)
       .lean();

--- a/packages/database/src/__tests__/fabFileVectorizeStranded.test.ts
+++ b/packages/database/src/__tests__/fabFileVectorizeStranded.test.ts
@@ -91,6 +91,20 @@ describe('stranded vectorize hand-off recovery', () => {
         { userId: 'u1', fileName: 'healthy.pdf', type: 'FILE', chunked: true },
       ]);
       await FabFile.createIndexes();
+      // Load-bearing, not padding: on a two-document collection every index costs the same and the
+      // planner picks arbitrarily - a real mongod answers this very query from
+      // deletedAt_1_filePath_1 at that size. These unstamped files sit outside the partial index,
+      // which is what makes choosing it the only cheap plan and the assertion below able to fail.
+      await FabFile.collection.insertMany(
+        Array.from({ length: 2000 }, (_, i) => ({
+          userId: 'u1',
+          fileName: `decoy-${i}.pdf`,
+          type: 'FILE',
+          chunked: true,
+          deletedAt: null,
+          vectorizeEnqueueFailedAt: null,
+        }))
+      );
 
       const plan = await FabFile.collection
         .find({
@@ -106,8 +120,9 @@ describe('stranded vectorize hand-off recovery', () => {
         .explain('queryPlanner');
 
       const winning = JSON.stringify(plan.queryPlanner.winningPlan);
-      expect(winning).toContain('IXSCAN');
-      expect(winning).toContain('vectorizeEnqueueFailedAt');
+      // The index NAME, not the field name: the field appears in the residual FETCH filter of any
+      // plan, so a bare substring check on it passes even when another index won.
+      expect(winning).toContain('"indexName":"vectorizeEnqueueFailedAt_1"');
       expect(winning).not.toContain('"stage":"COLLSCAN"');
     });
 

--- a/packages/database/src/__tests__/fabFileVectorizeStranded.test.ts
+++ b/packages/database/src/__tests__/fabFileVectorizeStranded.test.ts
@@ -76,6 +76,82 @@ describe('stranded vectorize hand-off recovery', () => {
       expect(winning).not.toContain('"stage":"COLLSCAN"');
     });
 
+    it('still uses the index when the sweep carries its stale-claim $or', async () => {
+      // The stale-claim recovery arm (buildStrandedVectorizeScanFilter) adds a three-way $or on
+      // isChunking, which is exactly the shape that can tip the planner into subplanning and a
+      // collection scan. The stamp predicate has to stay the one leading the plan.
+      await FabFile.create([
+        {
+          userId: 'u1',
+          fileName: 'stranded.pdf',
+          type: 'FILE',
+          chunked: true,
+          vectorizeEnqueueFailedAt: new Date('2026-01-01'),
+        },
+        { userId: 'u1', fileName: 'healthy.pdf', type: 'FILE', chunked: true },
+      ]);
+      await FabFile.createIndexes();
+
+      const plan = await FabFile.collection
+        .find({
+          vectorizeEnqueueFailedAt: { $type: 'date', $lt: new Date('2026-02-01') },
+          chunked: true,
+          deletedAt: null,
+          $or: [
+            { isChunking: { $ne: true } },
+            { isChunking: true, chunkClaimedAt: { $lt: new Date('2026-01-15') } },
+            { isChunking: true, chunkClaimedAt: null },
+          ],
+        })
+        .explain('queryPlanner');
+
+      const winning = JSON.stringify(plan.queryPlanner.winningPlan);
+      expect(winning).toContain('IXSCAN');
+      expect(winning).toContain('vectorizeEnqueueFailedAt');
+      expect(winning).not.toContain('"stage":"COLLSCAN"');
+    });
+
+    it('rescues a file whose claim went stale, and leaves a live claim alone', async () => {
+      // The failure the arm exists for: a worker hard-killed inside resumeVectorizeEnqueue leaves
+      // isChunking:true with nothing to clear it, and no other automatic door selects the file.
+      const staleClaimBefore = new Date('2026-01-15');
+      await FabFile.create([
+        {
+          userId: 'u1',
+          fileName: 'stale-claim.pdf',
+          type: 'FILE',
+          chunked: true,
+          isChunking: true,
+          chunkClaimedAt: new Date('2026-01-01'),
+          vectorizeEnqueueFailedAt: new Date('2026-01-01'),
+        },
+        {
+          userId: 'u1',
+          fileName: 'in-flight.pdf',
+          type: 'FILE',
+          chunked: true,
+          isChunking: true,
+          chunkClaimedAt: new Date('2026-01-20'),
+          vectorizeEnqueueFailedAt: new Date('2026-01-01'),
+        },
+      ]);
+
+      const selected = await FabFile.collection
+        .find({
+          vectorizeEnqueueFailedAt: { $type: 'date', $lt: new Date('2026-02-01') },
+          chunked: true,
+          deletedAt: null,
+          $or: [
+            { isChunking: { $ne: true } },
+            { isChunking: true, chunkClaimedAt: { $lt: staleClaimBefore } },
+            { isChunking: true, chunkClaimedAt: null },
+          ],
+        })
+        .toArray();
+
+      expect(selected.map(f => f.fileName)).toEqual(['stale-claim.pdf']);
+    });
+
     it('selects the stamped file only, never the unstamped default', async () => {
       // The field defaults to null on every file, and null sorts BEFORE any date. What keeps the
       // sweep from selecting the whole collection is that $lt matches within a BSON type bracket


### PR DESCRIPTION
# Pull Request

> **Stacked on #2143.** Base branch is `fix/vectorize-enqueue-strand`, not `main` --
> `buildStrandedVectorizeScanFilter` only exists on that branch. Merge #2143 first, or fold this in.

Closes #2188.

## Description

`buildStrandedVectorizeScanFilter` excluded in-flight files with a flat `isChunking: { $ne: true }`,
while its sibling `buildFabFileChunkScanFilter` deliberately carries a three-arm `$or` with a
stale-claim escape hatch: a hard worker kill (OOM / timeout / deploy) never runs the `finally` that
clears `isChunking`, so without that arm the file stays claimed and invisible.

That gap matters more now that `resumeVectorizeEnqueue` does real work under the claim (a
`findVectorlessChunkIds` read plus N `sendToQueue` calls) rather than returning immediately. A worker
killed inside that window leaves `isChunking: true` with every *automatic* door shut:

| door | selects it? | why not |
|---|---|---|
| stranded sweep | no | flat `isChunking: { $ne: true }` |
| un-chunked sweep | no | requires `chunkCount: 0`; the file has chunks |
| `findConvergencePausedFilesByScope` | no | `isChunking: { $ne: true }` |
| `POST /api/files/reprocess` | no | throws `FabFile is currently being chunked` |

SQS redelivery still recovers it for up to three receives via the chunk handler's own CAS stale arm,
and the DLQ is replayable from admin, so this needs a hard kill *plus* an exhausted retry ladder
*plus* nobody replaying the DLQ. Thin -- but every automatic door being shut is exactly the failure
class the parent PR exists to close.

## Changes

- `apps/client/server/worker/chunkScan.ts` -- `buildStrandedVectorizeScanFilter(cutoff, staleClaimBefore?)`
  now carries the same three-arm `$or` as `buildFabFileChunkScanFilter` (claim free / claim older than
  `staleClaimBefore` / `chunkClaimedAt: null` backfill). Kept as a residual `$or` beside the stamp
  predicate so the partial `vectorizeEnqueueFailedAt` index still leads the plan.
- `apps/client/server/cron/dataLakeBatchReconcile.ts` and `apps/client/server/worker/main.ts` -- thread
  the `CHUNK_CLAIM_STALE_MS` cutoff each already computes for its first pass into the stranded call.
- Tests:
  - `chunkScan.test.ts` -- stale-claim arm cases, one asserting the cutoff matches the un-chunked
    sweep's, plus a source-shape guard that both production call sites pass two args (the parameter is
    optional, so dropping it type-checks and silently turns the arm back off; `worker/main.ts`'s call
    sits inside an unexported `main()` with no other coverage).
  - NEW `chunkScan.e2e.test.ts` -- integration lane (real mongod, picked up by the `client-integration`
    CI leg). The only place the builder and Mongo are both real. Covers stale-claim rescue vs. a live
    claim, the pre-change gap, the query plan, and that the new arm opens no door for deleted or
    un-chunked files.
  - `packages/database/src/__tests__/fabFileVectorizeStranded.test.ts` -- tightened a vacuous explain
    assertion. `toContain('vectorizeEnqueueFailedAt')` matches the field name in any plan's residual
    FETCH filter, and on a 2-document collection mongod answered from `deletedAt_1_filePath_1`, so it
    passed while asserting nothing. Now asserts `"indexName":"vectorizeEnqueueFailedAt_1"` over a
    2000-doc decoy population that puts the partial index genuinely in contention (confirmed it fails
    without the decoys).

The chunk handler's own CAS uses identical arms and the same constant, so a file selected by the new
arm is re-claimed and resumed end to end.

## Guide for Testers

Backend-only. No UI surface.

**What NOT to test:** there is nothing to click. The behaviour only fires when a chunking worker is
killed mid-claim, which is not reproducible from the app.

Verified instead against a live Mongo, driving the real builder and the real `FabFile` model across
five seeded claim states:

1. One-arg call (the filter as it shipped before this change) selects `free` only.
2. Two-arg call (as the cron and worker now call it) selects `free`, `hardkill-stale` and
   `hardkill-nostamp`, and never `live-claim`.
3. `explain()` reports `IXSCAN` on `vectorizeEnqueueFailedAt_1` with no `COLLSCAN`.

All three are asserted by the new `chunkScan.e2e.test.ts`.

## Additional Information

Gate: `pnpm turbo:typecheck` clean, `pnpm lint:check` clean, ASCII guards exit 0. Per-package suites
green in isolation -- `@bike4mind/client` 11263 passed (1054 files), client integration lane 102
passed (21 files), `@bike4mind/database` and `@bike4mind/scripts` exit 0.

Under `pnpm turbo:test`'s full package parallelism on this machine, `@bike4mind/scripts` fails: 16
real-mongod migration `*.integration.test.ts` files abort on the 30s timeout while taking 90-108s
each. `@bike4mind/database` showed the same contention class (a `DataLakeProposalModel.test.ts`
`createdAt` tie-ordering failure that passes in isolation). Both packages are untouched by this
branch and pass on their own -- flagging it as local CPU contention, not a regression here.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
