### PR TITLE
fix(data-lakes): gate /rechunk on the convergence kill switch before it resets

### DIFF
--- a/apps/client/app/hooks/data/dataLakes.test.ts
+++ b/apps/client/app/hooks/data/dataLakes.test.ts
@@ -641,6 +641,51 @@ describe('useRechunkDataLake cache invalidation', () => {
   });
 });
 
+describe('useRechunkDataLake paused refusal (#2223)', () => {
+  // The toast spies are module-level and shared across this file, so both assertions below
+  // ("the other toast was NOT called") need a clean slate.
+  beforeEach(() => {
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.warning).mockClear();
+  });
+
+  const mount = () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+    return renderHook(() => useRechunkDataLake('lake1'), { wrapper });
+  };
+
+  it('warns that nothing was rebuilt, instead of a green success claiming the opposite', async () => {
+    // The paused arm also returns enqueued: 0, so on the counts alone it is indistinguishable from
+    // "nothing to do" - and it fell through to toast.success('All files are already chunked into
+    // passages.'). That claim is not merely uninformative but FALSE: the server-side gate only runs
+    // when at least one file was detected, so `detected` is always >= 1 here.
+    apiPost.mockResolvedValueOnce({ data: { detected: 12, enqueued: 0, remaining: 12, outcome: 'paused' } });
+
+    const { result } = mount();
+    await act(async () => {
+      await result.current.mutateAsync(undefined);
+    });
+
+    expect(toast.warning).toHaveBeenCalledWith(expect.stringContaining('paused'));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('still reports a genuine nothing-to-do as a success', async () => {
+    // The arm the paused case used to be confused with must keep its own wording.
+    apiPost.mockResolvedValueOnce({ data: { detected: 0, enqueued: 0, remaining: 0 } });
+
+    const { result } = mount();
+    await act(async () => {
+      await result.current.mutateAsync(undefined);
+    });
+
+    expect(toast.success).toHaveBeenCalledWith('All files are already chunked into passages.');
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+});
+
 describe('useTransferLakeOwnership cache invalidation', () => {
   it('refreshes the access view, the picker and the lake LIST - ownership decides canManage', async () => {
     // The list matters as much as the view: once the actor is no longer the owner, controls that

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -881,18 +881,34 @@ export function useRechunkDataLake(dataLakeId: string | null) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (limit?: number) => {
-      const res = await api.post<{ detected: number; enqueued: number; remaining: number }>(
-        `/api/data-lakes/${dataLakeId}/rechunk`,
-        limit ? { limit } : {}
-      );
+      const res = await api.post<{
+        detected: number;
+        enqueued: number;
+        remaining: number;
+        // Present only on the refusal arm. Typed optional because the success arm omits it entirely,
+        // and read FIRST below: a paused run also returns `enqueued: 0`, which is indistinguishable
+        // from "nothing to do" on the counts alone.
+        outcome?: 'paused';
+      }>(`/api/data-lakes/${dataLakeId}/rechunk`, limit ? { limit } : {});
       return res.data;
     },
     onSuccess: data => {
-      toast.success(
-        data.enqueued > 0
-          ? `Rebuilding ${data.enqueued} file(s) into passages - ${data.remaining} remaining.`
-          : 'All files are already chunked into passages.'
-      );
+      if (data.outcome === 'paused') {
+        // A warning, not a success: the server refused and changed nothing. Without this arm the
+        // refusal fell through to "All files are already chunked into passages" as a GREEN success -
+        // which is not merely uninformative but false, since the gate only runs when at least one
+        // file was detected. Wording mirrors useConvergeDataLake's paused arm below.
+        toast.warning(
+          'Background lake work is paused, so nothing was rebuilt. No files were changed - re-run this ' +
+            'once an administrator turns convergence back on.'
+        );
+      } else {
+        toast.success(
+          data.enqueued > 0
+            ? `Rebuilding ${data.enqueued} file(s) into passages - ${data.remaining} remaining.`
+            : 'All files are already chunked into passages.'
+        );
+      }
       if (dataLakeId) {
         queryClient.invalidateQueries({ queryKey: dataLakeKeys.rebuildStatus(dataLakeId) });
         queryClient.invalidateQueries({ queryKey: dataLakeKeys.filesOf(dataLakeId) });

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/rechunk.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/rechunk.test.ts
@@ -66,7 +66,11 @@ const invoke = async (method: 'GET' | 'POST', body: unknown = {}) => {
   return { res, json };
 };
 
-const lake = { id: 'lake1', datalakeTag: 'datalake:acme', createdByUserId: 'u1' };
+// Deliberately NOT the same string as the route param ('lake1'): assertLakeAccess resolves by id
+// THEN slug, so req.query.id may be a slug while lake.id is the resolved document id. With both
+// 'lake1', an assertion on the lakeId the handler forwards cannot tell which one it used - and
+// forwarding the slug is precisely what defeats the per-lake override downstream.
+const lake = { id: 'lakeDoc1', datalakeTag: 'datalake:acme', createdByUserId: 'u1' };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -115,7 +119,7 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
       fabFileId: 'f1',
       userId: 'u1',
       origin: 'convergence',
-      lakeId: 'lake1',
+      lakeId: 'lakeDoc1',
     });
     // The skipped file is not enqueued and is still outstanding, so it must remain countable.
     expect(json).toHaveBeenCalledWith({ detected: 2, enqueued: 1, remaining: 1 });
@@ -134,13 +138,13 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
       fabFileId: 'f1',
       userId: 'u1',
       origin: 'convergence',
-      lakeId: 'lake1',
+      lakeId: 'lakeDoc1',
     });
     expect(h.sendToQueue).toHaveBeenCalledWith('https://sqs.example.com/fab-file-chunk', {
       fabFileId: 'f2',
       userId: 'u2',
       origin: 'convergence',
-      lakeId: 'lake1',
+      lakeId: 'lakeDoc1',
     });
     expect(json).toHaveBeenCalledWith({ detected: 2, enqueued: 2, remaining: 0 });
   });
@@ -206,9 +210,9 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
     expect(h.resetChunkStateByIds).not.toHaveBeenCalled();
     expect(h.sendToQueue).not.toHaveBeenCalled();
     // And the caller is told, rather than shown a silent zero-count success.
-    expect(json).toHaveBeenCalledWith(
-      expect.objectContaining({ outcome: 'paused', enqueued: 0, detected: 2, remaining: 2 })
-    );
+    // Exact, not objectContaining: this response shape is brand new, so an unintended extra field is
+    // exactly the drift worth catching - the same argument that keeps the success arms exact below.
+    expect(json).toHaveBeenCalledWith({ detected: 2, enqueued: 0, remaining: 2, outcome: 'paused' });
   });
 
   it('asks the kill switch about THIS lake, so a per-lake override is honoured', async () => {
@@ -216,7 +220,7 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
     await invoke('POST', {});
 
     // First argument only: the third is req.logger, which this harness's fake request does not carry.
-    expect(h.isConvergenceHalted.mock.calls[0][0]).toEqual({ origin: 'convergence', lakeId: 'lake1' });
+    expect(h.isConvergenceHalted.mock.calls[0][0]).toEqual({ origin: 'convergence', lakeId: 'lakeDoc1' });
   });
 
   it('stamps convergence provenance on every message, so an in-flight wave halts too', async () => {
@@ -227,7 +231,7 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
 
     expect(h.sendToQueue).toHaveBeenCalledWith(
       'https://sqs.example.com/fab-file-chunk',
-      expect.objectContaining({ fabFileId: 'f1', userId: 'u1', origin: 'convergence', lakeId: 'lake1' })
+      expect.objectContaining({ fabFileId: 'f1', userId: 'u1', origin: 'convergence', lakeId: 'lakeDoc1' })
     );
   });
 

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/rechunk.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/rechunk.test.ts
@@ -9,6 +9,7 @@ const h = vi.hoisted(() => ({
   sendToQueue: vi.fn(),
   getSourceQueueUrl: vi.fn(() => 'https://sqs.example.com/fab-file-chunk'),
   toAccessContext: vi.fn(async () => ({ userId: 'u1', isAdmin: false })),
+  isConvergenceHalted: vi.fn(async () => false),
 }));
 
 vi.mock('@server/middlewares/baseApi', () => ({
@@ -40,10 +41,14 @@ vi.mock('@bike4mind/database', () => ({
     resetChunkStateByIds: h.resetChunkStateByIds,
   },
   fabFileChunkRepository: {},
+  adminSettingsRepository: {},
+  scopedSettingsRepository: {},
 }));
 vi.mock('@server/dataLakes/toAccessContext', () => ({ toAccessContext: h.toAccessContext }));
 vi.mock('@server/utils/sqs', () => ({ sendToQueue: h.sendToQueue }));
 vi.mock('@server/utils/dlqRegistry', () => ({ getSourceQueueUrl: h.getSourceQueueUrl }));
+vi.mock('@server/queueHandlers/convergenceProvenance', () => ({ CONVERGENCE_ORIGIN: 'convergence' }));
+vi.mock('@server/queueHandlers/convergenceKillSwitch', () => ({ isConvergenceHalted: h.isConvergenceHalted }));
 
 import handler from '../rechunk';
 
@@ -73,6 +78,8 @@ beforeEach(() => {
   // Returns the ids actually reset - a file a worker is mid-run on is skipped (round-8 P1).
   h.resetChunkStateByIds.mockImplementation(async (ids: string[]) => ids);
   h.sendToQueue.mockResolvedValue(undefined);
+  // Switch OFF by default; the paused cases below opt in.
+  h.isConvergenceHalted.mockResolvedValue(false);
 });
 
 describe('GET /api/data-lakes/[id]/rechunk', () => {
@@ -107,6 +114,8 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
     expect(h.sendToQueue).toHaveBeenCalledWith('https://sqs.example.com/fab-file-chunk', {
       fabFileId: 'f1',
       userId: 'u1',
+      origin: 'convergence',
+      lakeId: 'lake1',
     });
     // The skipped file is not enqueued and is still outstanding, so it must remain countable.
     expect(json).toHaveBeenCalledWith({ detected: 2, enqueued: 1, remaining: 1 });
@@ -124,10 +133,14 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
     expect(h.sendToQueue).toHaveBeenCalledWith('https://sqs.example.com/fab-file-chunk', {
       fabFileId: 'f1',
       userId: 'u1',
+      origin: 'convergence',
+      lakeId: 'lake1',
     });
     expect(h.sendToQueue).toHaveBeenCalledWith('https://sqs.example.com/fab-file-chunk', {
       fabFileId: 'f2',
       userId: 'u2',
+      origin: 'convergence',
+      lakeId: 'lake1',
     });
     expect(json).toHaveBeenCalledWith({ detected: 2, enqueued: 2, remaining: 0 });
   });
@@ -176,6 +189,54 @@ describe('POST /api/data-lakes/[id]/rechunk', () => {
     expect(h.resetChunkStateByIds).not.toHaveBeenCalled();
     expect(h.sendToQueue).not.toHaveBeenCalled();
     expect(json).toHaveBeenCalledWith({ detected: 0, enqueued: 0, remaining: 0 });
+  });
+
+  it('refuses BEFORE the reset when the convergence kill switch is on (#2223)', async () => {
+    // The producer-side gate is the whole point: the consumer's check only drops messages already
+    // on the queue, and by then resetChunkStateByIds has deleted this wave's passages and nulled its
+    // health rollups. A consumer-side stamp cannot protect a route that destroys before it enqueues.
+    h.isConvergenceHalted.mockResolvedValue(true);
+    h.detectUnderChunkedFiles.mockResolvedValue([
+      { fabFileId: 'f1', userId: 'u1' },
+      { fabFileId: 'f2', userId: 'u1' },
+    ]);
+    const { json } = await invoke('POST', {});
+
+    // Nothing touched - this is what "before the reset" means.
+    expect(h.resetChunkStateByIds).not.toHaveBeenCalled();
+    expect(h.sendToQueue).not.toHaveBeenCalled();
+    // And the caller is told, rather than shown a silent zero-count success.
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'paused', enqueued: 0, detected: 2, remaining: 2 })
+    );
+  });
+
+  it('asks the kill switch about THIS lake, so a per-lake override is honoured', async () => {
+    h.detectUnderChunkedFiles.mockResolvedValue([{ fabFileId: 'f1', userId: 'u1' }]);
+    await invoke('POST', {});
+
+    // First argument only: the third is req.logger, which this harness's fake request does not carry.
+    expect(h.isConvergenceHalted.mock.calls[0][0]).toEqual({ origin: 'convergence', lakeId: 'lake1' });
+  });
+
+  it('stamps convergence provenance on every message, so an in-flight wave halts too', async () => {
+    // The producer gate protects the passages; the stamp is what stops the consumer continuing to
+    // re-embed if the switch is turned on after these messages were already sent.
+    h.detectUnderChunkedFiles.mockResolvedValue([{ fabFileId: 'f1', userId: 'u1' }]);
+    await invoke('POST', {});
+
+    expect(h.sendToQueue).toHaveBeenCalledWith(
+      'https://sqs.example.com/fab-file-chunk',
+      expect.objectContaining({ fabFileId: 'f1', userId: 'u1', origin: 'convergence', lakeId: 'lake1' })
+    );
+  });
+
+  it('does not consult the kill switch when there is nothing to rechunk', async () => {
+    // The gate sits inside the wave.length > 0 branch, so an empty detection costs no settings read.
+    h.detectUnderChunkedFiles.mockResolvedValue([]);
+    await invoke('POST', {});
+
+    expect(h.isConvergenceHalted).not.toHaveBeenCalled();
   });
 
   it('gates on rebuild access - a rejected assert never resets or enqueues', async () => {

--- a/apps/client/pages/api/data-lakes/[id]/rechunk.ts
+++ b/apps/client/pages/api/data-lakes/[id]/rechunk.ts
@@ -6,12 +6,16 @@ import {
   dataLakeAccessGrantRepository,
   fabFileRepository,
   fabFileChunkRepository,
+  adminSettingsRepository,
+  scopedSettingsRepository,
 } from '@bike4mind/database';
 import { Request } from 'express';
 import { z } from 'zod';
 import { toAccessContext } from '@server/dataLakes/toAccessContext';
 import { sendToQueue } from '@server/utils/sqs';
 import { getSourceQueueUrl } from '@server/utils/dlqRegistry';
+import { CONVERGENCE_ORIGIN } from '@server/queueHandlers/convergenceProvenance';
+import { isConvergenceHalted } from '@server/queueHandlers/convergenceKillSwitch';
 
 /**
  * GET  /api/data-lakes/:id/rechunk           -> { underChunkedCount, failedCount }
@@ -72,6 +76,39 @@ const handler = baseApi()
 
     let enqueued = 0;
     if (wave.length > 0) {
+      // Kill switch BEFORE the reset, for the reason /converge documents at the same point: the
+      // consumer's check only drops messages already on the queue, and by then
+      // `resetChunkStateByIds` has deleted this wave's passages and nulled its health rollups. A
+      // consumer-side stamp alone cannot protect this route - the destruction happens on the
+      // producer side.
+      //
+      // Gated even though this door repairs rather than converges: it deletes and re-embeds a whole
+      // wave at full spend, which is exactly what an operator turning the switch on is trying to
+      // stop. Refusing is also recoverable in a way the alternative is not - the files stay
+      // searchable and the admin can retry once the switch is off, whereas a wave halted mid-flight
+      // leaves them with no passages at all.
+      if (
+        await isConvergenceHalted(
+          { origin: CONVERGENCE_ORIGIN, lakeId: lake.id },
+          {
+            adminSettings: adminSettingsRepository,
+            scopedSettings: scopedSettingsRepository,
+            dataLakes: dataLakeRepository,
+          },
+          req.logger
+        )
+      ) {
+        req.logger?.log?.(
+          `[convergence] lake ${lake.id}: background lake work is paused; rechunk refused before touching ${wave.length} member(s)`
+        );
+        return res.json({
+          detected: detected.length,
+          enqueued: 0,
+          remaining: detected.length,
+          outcome: 'paused',
+        });
+      }
+
       const queueUrl = getSourceQueueUrl('fabFileChunkQueue');
       if (!queueUrl) throw new Error('Chunk queue URL not found');
       // Reset the wave, then enqueue exactly what the reset changed. The reset is preconditioned on
@@ -96,7 +133,17 @@ const handler = baseApi()
       // is run once. Documented for owners in knowledge-management.md. Retrieval first, conformance
       // second - a wrong-sized searchable file still answers; an unsearchable one does not.
       const results = await Promise.allSettled(
-        resetIds.map(id => sendToQueue(queueUrl, { fabFileId: id, userId: userById.get(id)! }))
+        resetIds.map(id =>
+          sendToQueue(queueUrl, {
+            fabFileId: id,
+            userId: userById.get(id)!,
+            // Provenance for the #1676 kill switch, matching /converge. The producer gate above is
+            // what protects the passages; this is what stops an in-flight wave from continuing to
+            // re-embed if the switch is turned on after the messages were sent.
+            origin: CONVERGENCE_ORIGIN,
+            lakeId: lake.id,
+          })
+        )
       );
       const failed = results.filter(r => r.status === 'rejected').length;
       const skipped = userById.size - resetIds.length;

--- a/apps/client/server/queueHandlers/convergenceKillSwitch.test.ts
+++ b/apps/client/server/queueHandlers/convergenceKillSwitch.test.ts
@@ -39,9 +39,9 @@ describe('provenancePayloadShape (fail-soft to user)', () => {
   });
 
   it('preserves a valid origin and lakeId', () => {
-    expect(schema.parse({ origin: 'convergence', lakeId: 'lake-1' })).toEqual({
+    expect(schema.parse({ origin: 'convergence', lakeId: LAKE_OID })).toEqual({
       origin: 'convergence',
-      lakeId: 'lake-1',
+      lakeId: LAKE_OID,
     });
   });
 
@@ -49,6 +49,13 @@ describe('provenancePayloadShape (fail-soft to user)', () => {
     expect(schema.parse({ origin: 'garbage' }).origin).toBeUndefined();
   });
 });
+
+/**
+ * A real 24-char hex id. The per-lake arm only runs for an id that can address a row - a static
+ * registry lake's id is a human slug, and passing one to findById is what used to CastError and fail
+ * the whole switch open (see the guard in resolvePauseFlag).
+ */
+const LAKE_OID = '0123456789abcdef01234567';
 
 describe('isConvergenceHalted', () => {
   const makeDeps = () => ({
@@ -92,14 +99,14 @@ describe('isConvergenceHalted', () => {
   });
 
   it('halts per-lake convergence work when the lake override resolves to paused', async () => {
-    deps.dataLakes.findById.mockResolvedValue({ id: 'lake-1', createdByUserId: 'u1' });
+    deps.dataLakes.findById.mockResolvedValue({ id: LAKE_OID, createdByUserId: 'u1' });
     resolveScopedSetting.mockResolvedValue({ value: true, source: 'Lake' } as never);
 
-    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: 'lake-1' }, deps)).toBe(true);
-    expect(scopeForLake).toHaveBeenCalledWith({ id: 'lake-1', createdByUserId: 'u1' });
+    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: LAKE_OID }, deps)).toBe(true);
+    expect(scopeForLake).toHaveBeenCalledWith({ id: LAKE_OID, createdByUserId: 'u1' });
     expect(resolveScopedSetting).toHaveBeenCalledWith(
       'PauseLakeConvergence',
-      { lakeId: 'lake-1' },
+      { lakeId: LAKE_OID },
       expect.objectContaining({ adminSettings: deps.adminSettings, scopedSettings: deps.scopedSettings }),
       expect.anything()
     );
@@ -108,15 +115,35 @@ describe('isConvergenceHalted', () => {
   });
 
   it('lets per-lake convergence work run when the lake override resolves to not-paused', async () => {
-    deps.dataLakes.findById.mockResolvedValue({ id: 'lake-1', createdByUserId: 'u1' });
+    deps.dataLakes.findById.mockResolvedValue({ id: LAKE_OID, createdByUserId: 'u1' });
     resolveScopedSetting.mockResolvedValue({ value: false, source: 'Platform' } as never);
-    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: 'lake-1' }, deps)).toBe(false);
+    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: LAKE_OID }, deps)).toBe(false);
+  });
+
+  it('reads the PLATFORM switch for a static registry lake, whose id is a slug not an ObjectId', async () => {
+    // The whole switch used to fail open here: BaseModel.findById passes the slug straight to
+    // Mongoose, the CastError lands in resolvePauseFlag's catch, and it returns false WITHOUT ever
+    // reading the platform value - so a paused platform did not halt the one lake class the
+    // "Rebuild passages" door is deliberately kept open for.
+    deps.adminSettings.getSettingsValue.mockResolvedValue(true);
+
+    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: 'opti-knowledge' }, deps)).toBe(true);
+
+    // No lookup attempted at all - a lake with no document has nowhere to carry a scoped override.
+    expect(deps.dataLakes.findById).not.toHaveBeenCalled();
+    expect(resolveScopedSetting).not.toHaveBeenCalled();
+    expect(deps.adminSettings.getSettingsValue).toHaveBeenCalledWith('PauseLakeConvergence');
+  });
+
+  it('lets a static registry lake run when the platform switch is off', async () => {
+    deps.adminSettings.getSettingsValue.mockResolvedValue(false);
+    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: 'opti-knowledge' }, deps)).toBe(false);
   });
 
   it('falls back to the platform switch when the lake was deleted between enqueue and handling', async () => {
     deps.dataLakes.findById.mockResolvedValue(null);
     deps.adminSettings.getSettingsValue.mockResolvedValue(true);
-    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: 'gone' }, deps)).toBe(true);
+    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: LAKE_OID }, deps)).toBe(true);
     expect(resolveScopedSetting).not.toHaveBeenCalled();
   });
 

--- a/apps/client/server/queueHandlers/convergenceKillSwitch.ts
+++ b/apps/client/server/queueHandlers/convergenceKillSwitch.ts
@@ -1,3 +1,4 @@
+import { isObjectIdOrHexString } from 'mongoose';
 import { IAdminSettingsRepository, IDataLakeRepository, IScopedSettingsRepository } from '@bike4mind/common';
 import { scopedSettingsService } from '@bike4mind/services';
 import { Logger } from '@bike4mind/observability';
@@ -25,7 +26,14 @@ async function resolvePauseFlag(
   logger?: Logger
 ): Promise<boolean> {
   try {
-    if (lakeId) {
+    // A STATIC registry lake's id is a human slug, not an ObjectId (see isFallbackLake), and
+    // BaseModel.findById passes it straight to Mongoose - which raises a CastError, lands in the
+    // catch below, and returns `false` WITHOUT ever reading the platform switch. So the whole kill
+    // switch failed open for exactly the lake class "Rebuild passages" is deliberately kept open
+    // for. Skipping the lookup instead falls through to the platform read, which is the correct
+    // answer for a lake that has no document to carry a scoped override in the first place.
+    // Guarded rather than caught, so a genuine lookup failure still reaches the catch.
+    if (lakeId && isObjectIdOrHexString(lakeId)) {
       const lake = await deps.dataLakes.findById(lakeId);
       if (lake) {
         const { value } = await scopedSettingsService.resolveScopedSetting(

--- a/docs-site/docs/features/knowledge-management.md
+++ b/docs-site/docs/features/knowledge-management.md
@@ -110,6 +110,13 @@ Check these in order, all of them visible in the plan the button reads:
   (the request was recorded but the work never ran), the file keeps reporting as re-indexing rather
   than vanishing, and **Rebuild passages** picks it up once the request is a couple of hours old.
 
+  **Rebuild passages is refused while the pause is on, and says so.** The rebuild door deletes and
+  re-embeds a whole wave, so it is gated the same way convergence is: starting it while background
+  lake work is paused changes nothing at all - no passages are removed and nothing is queued - and the
+  toast says the run was refused rather than reporting success. The "to rebuild" count beside the
+  button therefore stays where it was. This is the same pause described above, so the remedy is the
+  same: an administrator turns convergence back on, then run it again.
+
   **A rebuild restores searchability, not conformance.** "Rebuild passages" deliberately rebuilds at
   the owner's default passage size rather than the lake's declared target, because it has to work on
   any lake - including one with no policy at all - and because a file can belong to several lakes that


### PR DESCRIPTION
## Description

Closes #2223 - fully, including static registry lakes (see the last two bullets under Changes).

`/api/data-lakes/[id]/rechunk` consulted the convergence kill switch **nowhere**, and the messages it sent carried no `origin` - so `isConvergenceHalted` defaulted them to `user` work and never halted them either. With `PauseLakeConvergence` ON, an admin using that door re-chunked and re-embedded every member of the lake at full spend.

## Why the gate has to be producer-side

`/converge` already documents the reason at exactly this point in its own flow:

> Kill switch BEFORE the reset, not only in the consumer (#1676). The consumer's check drops messages that are already on the queue - by which point `resetChunkStateByIds` has cleared `chunked`, zeroed the counts and nulled all four health rollups for the whole wave.

`/rechunk` has the same shape: `resetChunkStateByIds` at `:82`, then the sends. So a consumer-side stamp alone cannot protect this route - by the time a halt runs, the lake's passages are already gone. That is what makes this worse than the sweep cases in #2169, which enqueue without destroying first.

## Changes

- **Producer-side gate before the reset**, mirroring `/converge`, returning `outcome: 'paused'` rather than a silent zero-count success.
- **`origin`/`lakeId` stamped on every message.** The gate protects the passages; the stamp is what stops an already-enqueued wave continuing to re-embed if the switch is flipped after the sends landed.
- **The refusal is rendered.** `useRechunkDataLake` now reads `outcome` and shows the paused warning instead of a green success. Without this the server-side gate was invisible: a paused run returns `enqueued: 0`, which the hook could not tell apart from "nothing to do".
- **The gate no longer fails open on a static registry lake.** A built-in lake's id is a human slug, not an ObjectId, so the unguarded `findById` in `resolvePauseFlag` raised a `CastError` that landed in the catch and returned `false` **without ever reading the platform switch**. Guarded with `isObjectIdOrHexString`. This defect predates this PR and `/converge` inherited it identically; fixing it in the shared helper closes both doors.

### The judgement call

I gated this even though `/rechunk` **repairs** rather than converges - the route's own comment is emphatic that it "restores RETRIEVABILITY and is deliberately policy-independent", so halting a repair is not self-evidently right.

Two reasons it is:

- It deletes and re-embeds a whole wave at full spend. That is precisely what an operator turning the switch on is trying to stop, whatever the door is called.
- **Refusing is the recoverable choice.** A refused rechunk leaves the files searchable and the admin can retry once the switch is off. A wave halted *mid-flight* leaves them with no passages at all - the reset has run and nothing will rebuild them until someone notices.

If the team would rather `/rechunk` stay exempt as an explicit repair escape hatch, that is a coherent position and this is the commit to argue it on - but then the reset needs to be the thing that is gated, not the enqueue.

## Test coverage

- **Paused:** neither `resetChunkStateByIds` nor any send runs, and the response carries `outcome: 'paused'` with the detection count intact. "Before the reset" is the assertion that matters.
- **Per-lake:** the switch is asked about *this* lake, so a scoped override is honoured rather than only the platform flag.
- **Provenance:** every message carries `origin` and `lakeId`.
- **Empty detection consults nothing** - the gate sits inside the wave-non-empty branch, so a no-op costs no settings read.

Two pre-existing exact-shape message assertions were **extended** with the new provenance rather than loosened to `objectContaining`, since pinning the whole payload is the point of those.

Verified the first two fail with the gate removed. 12 tests in the route suite; all 31 data-lake route suites green (279 tests); `pnpm turbo:typecheck` 40/40; eslint clean.

## Guide for Testers

Requires admin access to the convergence kill switch.

> **Read this first - a clean environment cannot produce the state step 1 used to assume.** The
> original version of this guide said "open a lake with several members that are under-chunked". On a
> fresh install no such lake exists, and none can be created: `detectUnderChunkedFiles` selects
> chunks over `OVERSIZED_PASSAGE_TOKEN_THRESHOLD` (**1500** tokens) while the current chunker targets
> `DEFAULT_PASSAGE_TOKEN_TARGET` (**512**), so a correctly chunked file is ~3x below the bar by
> construction. That population is legacy data, not a reachable state. Changing the lake's
> **Required passage size** does not help either - that grades *health*, and the rebuild threshold is
> a constant. Thanks to @gsreyson for finding this the hard way.
>
> So seed the **stranded** population instead, which is the one this PR is actually about.

### Setup: give the lake one stranded member

1. Create a private lake and upload one multi-passage text file. Wait for chunking to finish.
2. Confirm the file has no vectors yet (`GET /api/data-lakes/:id/health` shows `coverage.measuredMembers: 0`, or check `vectorizedChunkCount`). This is the normal state on an environment with no embedding worker, and it satisfies two of the three stranded conditions already.
3. Set that file's `notes` to the exact value of `CONVERGENCE_PAUSED_CHUNK_NOTE` (`b4m-core/common/src/constants/chunking.ts`). Copy the string from source - the query is an exact `$in` match, so a paraphrase silently selects nothing.
4. `GET /api/data-lakes/:id/rechunk`. Expected: `underChunkedCount: 1`, and the **Rebuild passages** control now renders.

Seeding rather than doing it through the product is deliberate: the marker is written by the chunk handler when it halts, and the switch does not halt ordinary uploads - only convergence-origin work, whose doors both refuse while the switch is on. The only unseeded route is a few-seconds race between starting convergence and flipping the switch, which is not a test procedure.

### The actual test

5. Confirm `Data Lakes: Pause background convergence work` is **OFF**. Click **Rebuild passages**. Expected: it reports the file enqueued and re-chunks normally.
6. Re-seed step 3, then turn the pause switch **ON**.
7. Click **Rebuild passages**. Expected: **an amber warning** saying background lake work is paused and nothing was rebuilt - not a green "All files are already chunked into passages", which is what shipped before this change. The response carries `outcome: 'paused'` with `enqueued: 0` and the detected count unchanged.
8. Confirm the file's passages are **untouched** - it keeps its chunks and stays searchable. Before this change the whole wave was deleted and re-embedded.
9. Turn the switch back **OFF** and click **Rebuild passages**. Expected: it works normally, so the refusal was not sticky.
10. ~~With the switch ON, click **Rebuild passages** on a **built-in** lake.~~ **Not testable through the UI - covered by unit test instead. Please skip.**

    The registry-lake fix is real and is what this PR's second commit is about (the switch used to fail OPEN there: `BaseModel.findById` passed the human slug to Mongoose, the CastError landed in `resolvePauseFlag`'s catch, and it returned `false` without ever reading the setting). But it cannot be reached from the UI: the kill-switch check sits inside `if (wave.length > 0)` in `rechunk.ts`, and the built-in lakes carry no meta-tagged members, so detection returns an empty wave and the POST short-circuits before the gate is consulted. That is deliberate - the gate protects the destructive reset, and with no wave there is nothing to refuse - and it is pinned by `rechunk.test.ts`, *"does not consult the kill switch when there is nothing to rechunk"*.

    Covered instead by `convergenceKillSwitch.test.ts` (the platform switch for a registry lake whose id is a slug, both switch-on and switch-off), and by `rechunk.test.ts` asserting the gate is asked about the resolved **document id** rather than the slug.

    Thanks to @gsreyson for catching that this step could not pass, and for establishing that a built-in lake IS seedable via its `datalake:<slug>` meta-tag. That last point surfaced a separate bug - rebuild resolves a registry lake through an *owned* scope, so its prefix-arm members are invisible to it - tracked as #2377 and out of scope here.

### Regression checks

11. With the switch OFF, confirm `/converge` behaves exactly as before - it was already gated and this PR does not touch it.
12. Confirm an ordinary file upload still chunks with the switch **ON**. User work must never be halted by it.

### What NOT to test

The under-chunked (oversized-chunk) arm, unless you have an environment carrying legacy pre-512 chunks - see the note above. The gate is identical for both populations, so the stranded arm exercises it fully.

