### PR TITLE
test(scripts): pin the clock in the api-key reactivation migration tests

### DIFF
--- a/packages/scripts/migrate/migrations/20260731000000_reactivate-collateral-deactivated-api-keys.test.ts
+++ b/packages/scripts/migrate/migrations/20260731000000_reactivate-collateral-deactivated-api-keys.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 type Filter = Record<string, unknown>;
 
@@ -130,6 +130,19 @@ describe('reactivate-collateral-deactivated-api-keys migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpdateMany.mockResolvedValue({ modifiedCount: 1 });
+    // `up()` reads the real clock (`selectKeysToReactivate(keys, new Date())`) while these
+    // fixtures date their `expiresAt` off the frozen NOW. Without pinning the clock the suite is
+    // a time bomb: it passed for 30 days and went red at 2026-08-29T00:00:00Z, the instant
+    // `day(30)` fell into the past, because every fixture key then read as expired and the
+    // migration returned before `updateMany`. Nothing in the migration had changed.
+    // `toFake: ['Date']` pins the calendar ONLY - timers and promise scheduling stay real, so the
+    // mocked awaits below resolve normally.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('reads only live keys of owners who hold an inactive one, then reactivates the selection', async () => {


### PR DESCRIPTION
## Description

**`main` is currently red, and has been since 2026-08-29T00:00:00Z. Nobody changed any code.** This unblocks the queue.

`Run Tests (misc)` fails on `20260731000000_reactivate-collateral-deactivated-api-keys.test.ts`, 2 failed / 16 passed, with `updateMany` never called.

The migration resolves candidates against the **real** clock:

```ts
const ids = selectKeysToReactivate(keys, new Date());
```

The two `migration.up()` tests build fixtures whose `expiresAt` is `day(30)` from a frozen `NOW = 2026-07-30T00:00:00Z`. That evaluates to **2026-08-29T00:00:00Z**. At that instant every fixture key started reading as expired, `selectKeysToReactivate` returned `[]`, and `up()` hit its early return before `updateMany` -- so both assertions failed on a call count of 0.

A 30-day fuse, lit the day the migration landed in #1207. The 16 pure `selectKeysToReactivate` unit tests kept passing throughout because they pass `NOW` in explicitly; only the two that route through `up()` touch the real clock.

## Changes

- Pin the clock in the `migration.up()` describe block: `vi.useFakeTimers({ toFake: ['Date'] })` + `vi.setSystemTime(NOW)`, released in `afterEach`.
- `toFake: ['Date']` is deliberate -- it pins the calendar **only**. Timers and promise scheduling stay real, so the mocked `await`s in `up()` resolve normally. Faking everything would risk hanging the async path for no benefit.
- Comment records the failure mode so the next person does not re-light the fuse.

No production code changed. The migration's real-clock read is correct behavior for a migration; the test was the thing making a claim about time.

## Verification

- Target file: **18/18 pass** (was 2 failed / 16 passed).
- Full package: **453 passed / 42 files** (was 2 failed / 451 passed).
- **Proved time-invariant**, not just green today: re-pinned `NOW` to `2020-01-01` and to `2031-06-15` and ran both -- 18/18 in each. Before this change the suite depended on the real date being earlier than 2026-08-29.
- `pnpm --filter @bike4mind/scripts typecheck` clean, eslint clean on the touched file.
- Audited the sibling migration tests that carry hardcoded dates (`fix-project-live-unique-name-index`, `audit-fabfile-session-owner-mismatch`). Neither compares a fixture against the clock -- the first only stamps `deletedAt: new Date()` on a write, the second reads no clock at all -- so this was the only live fuse of this shape.

## Guide for Testers

Backend test-only change; nothing to exercise in the app.

1. Confirm `Run Tests (misc)` is green on this PR.
2. Confirm the same leg is red on any other open PR branched from current `main`, which is the bug this fixes.

### What NOT to test

No runtime, UI, or migration behavior changes. The migration itself is untouched, and it has already run.

## Additional Information

Found while investigating CI on #2230, which was blocked by this and is otherwise green.
