### PR TITLE
chore(scripts): add pre-merge census for dynamic-lake prefix-only members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,9 @@ craftpix-zips/
 
 # Output from local one-off scripts (e.g. packages/scripts/testKnowledgeToolRefusal.ts)
 packages/scripts/out/
+
+# Belt for the data-lake census artifact. It is written to os.tmpdir() with mode 0600, but
+# DATALAKE_CENSUS_OUT_DIR can override that, and the file carries cross-tenant identity data
+# that must never reach this repo's permanent, public history. Unanchored on purpose so it
+# matches wherever an operator lands it.
+datalake-prefix-only-census-*.json

--- a/packages/scripts/migrate/check-datalake-prefix-only-members.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-only-members.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
-import { connectDB, DataLakeModel, FabFile, buildDataLakeMembershipQuery } from '@bike4mind/database';
+import { connectDB, DataLakeModel, FabFile, buildDataLakeMembershipQuery, mongoose } from '@bike4mind/database';
 import { DATA_LAKES, normalizeTagPrefix, isReservedTagPrefix } from '@bike4mind/common';
 import { escapeRegex } from '@bike4mind/utils/escapeRegex';
 import pLimit from 'p-limit';
@@ -10,6 +11,7 @@ import {
   classifyDynamicLakeMode,
   reconcilePrefixOnly,
   renderCensusReport,
+  type ExampleFileListing,
   type LakeReport,
 } from './prefixOnlyMembersReport';
 
@@ -18,8 +20,10 @@ import {
  * the lake-membership-retrieval-parity PR). Its own PR, merged and RUN before that fix, because
  * the fix changes which files retrieval reaches - this must measure the PRE-change world.
  *
- * `buildDataLakeMembershipFilter` (@bike4mind/database) is `metaTag OR (fileTagPrefix AND
- * lake.creatorUserId)`. Retrieval today only ever sees the caller-anchored prefix arm, never the
+ * `buildDataLakeMembershipFilter` (@bike4mind/database) is, for an OWNED lake, `metaTag OR
+ * (fileTagPrefix AND lake.creatorUserId)`. Every lake this census routes through the builder is
+ * owned (registry lakes are counted separately, below). Retrieval today only ever sees the
+ * caller-anchored prefix arm, never the
  * creator-anchored one, so a creator-owned file carrying a lake's prefix but no meta-tag is
  * listed/counted/graded-healthy by membership and unreachable by retrieval for anyone but the
  * creator. This script sizes that population per lake, BOTH directions:
@@ -35,11 +39,14 @@ import {
  *    so anyone "fixes" it.
  *
  * `buildDataLakeMembershipFilter` fails closed to the meta-tag arm alone on three different
- * conditions (no prefix, reserved prefix, no creator), all of which collapse to a bare
- * `prefixOnly = 0`. Only one of those is a genuine zero, so every lake is classified into an
+ * conditions (no prefix, reserved prefix, no creator), all of which would collapse to a bare
+ * `prefixOnly = 0`. Only ONE of those is a genuine zero, so every lake is classified into an
  * explicit arm mode first (see prefixOnlyMembersReport.ts) rather than printing that bare zero.
- * A dynamic lake with no creator on record is a data-quality defect and escalates on its own,
- * separately from the widening/narrowing counts.
+ * Two of the three escalate on their own, separately from the widening/narrowing counts:
+ *  - no creator on record: a data-quality defect in the row itself.
+ *  - RESERVED prefix: retrieval honours such a prefix today and the fix drops it, so the lake
+ *    loses its whole prefix arm. This is the largest movement the census can see and the one a
+ *    collapsed zero would have hidden entirely, so it is its own arm mode, not a footnote.
  *
  * Registry (static) lakes have no creator to anchor to and use the OPEN arm at retrieval - already
  * fully reachable today - so they get one informational, un-anchored count and never escalate. A
@@ -51,7 +58,11 @@ import {
  * mechanically enforced by checkDatalakeCensusReadOnly.test.ts. One lake per query (never a
  * cross-lake $or); counts never materialise documents except a capped example listing for an
  * anchored finding (a `+1` probe to detect truncation). The JSON artifact this script writes
- * contains cross-tenant file names - split it per owner before any of it leaves the operator.
+ * carries cross-tenant identity data - per-file owner ids and file names, plus each lake's name,
+ * fileTagPrefix and creator id. Split it per owner before any of it leaves the operator; the
+ * per-file `userId` is projected precisely so that split is possible. It is written to the OS
+ * temp dir with mode 0600, NOT into the repo (override with DATALAKE_CENSUS_OUT_DIR, but never
+ * point that at a git working tree - this is a public repo and history is permanent).
  *
  * Exit codes so CI/an operator can tell "found things" from "crashed": 0 clean, 2 findings need
  * owner sign-off (not an error), 1 the census itself failed (including a RECONCILE mismatch,
@@ -67,6 +78,18 @@ const LIVE_CONJUNCT = { deletedAt: null, archivedAt: null };
 const FILE_LISTING_CAP = 500;
 /** Small, so a large tenant does not put the whole lake table under concurrent scan at once. */
 const LAKE_CONCURRENCY = 4;
+/**
+ * Server-side cap per query. The connection-wide socketTimeoutMS (db-core mongo.ts) is
+ * CLIENT-side and does not stop work already running on the server, and `narrowingFilter`'s
+ * leading `{userId: {$ne: ...}}` cannot be bounded to an index range - it relies on the planner
+ * picking the `tags.name` index and applying the negation as a residual. Nothing pins that, and
+ * this is a tool pointed at production.
+ */
+const QUERY_TIMEOUT_MS = 30_000;
+
+const countLive = (filter: Record<string, unknown>) => FabFile.countDocuments(filter, { maxTimeMS: QUERY_TIMEOUT_MS });
+
+const EMPTY_LISTING: ExampleFileListing = { files: [], truncated: false };
 
 interface DataLakeRow {
   _id: unknown;
@@ -79,12 +102,19 @@ interface DataLakeRow {
 const prefixRegexArm = (prefix: string) => ({ 'tags.name': { $regex: new RegExp(`^${escapeRegex(prefix)}`) } });
 const notMetaTag = (datalakeTag: string) => ({ 'tags.name': { $ne: datalakeTag } });
 
-async function listExampleFiles(filter: Record<string, unknown>): Promise<{ fileNames: string[]; truncated: boolean }> {
-  const docs = await FabFile.find(filter, { fileName: 1 })
+async function listExampleFiles(filter: Record<string, unknown>): Promise<ExampleFileListing> {
+  // userId is projected, not just fileName, because the docblock's mitigation ("split it per
+  // owner") is otherwise unperformable on the half that needs it: the narrowing set is by
+  // definition NOT the creator's, so with names alone there is no owner to split on.
+  const docs = await FabFile.find(filter, { fileName: 1, userId: 1 })
     .limit(FILE_LISTING_CAP + 1)
-    .lean<{ fileName: string }[]>();
+    .maxTimeMS(QUERY_TIMEOUT_MS)
+    .lean<{ fileName: string; userId: string }[]>();
   const truncated = docs.length > FILE_LISTING_CAP;
-  return { fileNames: docs.slice(0, FILE_LISTING_CAP).map(d => d.fileName), truncated };
+  return {
+    files: docs.slice(0, FILE_LISTING_CAP).map(d => ({ userId: d.userId, fileName: d.fileName })),
+    truncated,
+  };
 }
 
 async function buildDynamicLakeReport(row: DataLakeRow): Promise<LakeReport> {
@@ -93,11 +123,20 @@ async function buildDynamicLakeReport(row: DataLakeRow): Promise<LakeReport> {
   const datalakeTag = row.datalakeTag ?? '';
   const mode = classifyDynamicLakeMode(row);
 
-  const scope = { datalakeTag, fileTagPrefix: row.fileTagPrefix, creatorUserId: row.createdByUserId };
+  // `kind` is required on DataLakeMembershipScope once the predicate expresses registry lakes;
+  // every lake reaching this function came from the DataLake collection, so it is always owned.
+  // `as const` is load-bearing: `scope` is a standalone const, so without it `kind` widens to
+  // `string` and no longer matches the union member.
+  const scope = {
+    kind: 'owned' as const,
+    datalakeTag,
+    fileTagPrefix: row.fileTagPrefix,
+    creatorUserId: row.createdByUserId,
+  };
   const [total, totalExcludingPending, metaTagged] = await Promise.all([
-    FabFile.countDocuments(buildDataLakeMembershipQuery(scope, LIVE_CONJUNCT)),
-    FabFile.countDocuments(buildDataLakeMembershipQuery(scope, { ...LIVE_CONJUNCT, status: { $ne: 'pending' } })),
-    FabFile.countDocuments({ 'tags.name': datalakeTag, ...LIVE_CONJUNCT }),
+    countLive(buildDataLakeMembershipQuery(scope, LIVE_CONJUNCT)),
+    countLive(buildDataLakeMembershipQuery(scope, { ...LIVE_CONJUNCT, status: { $ne: 'pending' } })),
+    countLive({ 'tags.name': datalakeTag, ...LIVE_CONJUNCT }),
   ]);
 
   const base: LakeReport = {
@@ -114,8 +153,8 @@ async function buildDynamicLakeReport(row: DataLakeRow): Promise<LakeReport> {
     reconcileMismatch: false,
     narrowingUpperBound: null,
     unanchoredCount: null,
-    prefixOnlyFiles: { fileNames: [], truncated: false },
-    narrowingFiles: { fileNames: [], truncated: false },
+    prefixOnlyFiles: { files: [], truncated: false },
+    narrowingFiles: { files: [], truncated: false },
   };
 
   if (mode === 'no-prefix') return base;
@@ -123,8 +162,11 @@ async function buildDynamicLakeReport(row: DataLakeRow): Promise<LakeReport> {
   const prefix = normalizeTagPrefix(row.fileTagPrefix);
   if (!prefix) return base; // classifier already routed this to no-prefix; defensive only.
 
-  if (mode === 'creator-less') {
-    const unanchoredCount = await FabFile.countDocuments({
+  // Both fail-closed modes get the same un-anchored reach figure. For `reserved-prefix` it is
+  // heavily inflated by construction (a `datalake:` regex matches every OTHER lake's membership
+  // meta-tag), which is why renderLakeLines labels it over-match rather than narrowing.
+  if (mode === 'creator-less' || mode === 'reserved-prefix') {
+    const unanchoredCount = await countLive({
       $and: [prefixRegexArm(prefix), notMetaTag(datalakeTag)],
       ...LIVE_CONJUNCT,
     });
@@ -142,14 +184,14 @@ async function buildDynamicLakeReport(row: DataLakeRow): Promise<LakeReport> {
     ...LIVE_CONJUNCT,
   };
   const [prefixOnlyDirect, narrowingUpperBound] = await Promise.all([
-    FabFile.countDocuments(prefixOnlyFilter),
-    FabFile.countDocuments(narrowingFilter),
+    countLive(prefixOnlyFilter),
+    countLive(narrowingFilter),
   ]);
   const reconcile = reconcilePrefixOnly(total, metaTagged, prefixOnlyDirect);
 
   const [prefixOnlyFiles, narrowingFiles] = await Promise.all([
-    prefixOnlyDirect > 0 ? listExampleFiles(prefixOnlyFilter) : Promise.resolve({ fileNames: [], truncated: false }),
-    narrowingUpperBound > 0 ? listExampleFiles(narrowingFilter) : Promise.resolve({ fileNames: [], truncated: false }),
+    prefixOnlyDirect > 0 ? listExampleFiles(prefixOnlyFilter) : Promise.resolve(EMPTY_LISTING),
+    narrowingUpperBound > 0 ? listExampleFiles(narrowingFilter) : Promise.resolve(EMPTY_LISTING),
   ]);
 
   return {
@@ -177,13 +219,13 @@ async function buildRegistryLakeReport(lake: (typeof DATA_LAKES)[number]): Promi
     reconcileMismatch: false,
     narrowingUpperBound: null,
     unanchoredCount: null,
-    prefixOnlyFiles: { fileNames: [], truncated: false },
-    narrowingFiles: { fileNames: [], truncated: false },
+    prefixOnlyFiles: { files: [], truncated: false },
+    narrowingFiles: { files: [], truncated: false },
   };
   const prefix = normalizeTagPrefix(lake.fileTagPrefix);
   if (!prefix || isReservedTagPrefix(prefix)) return base;
 
-  const unanchoredCount = await FabFile.countDocuments({
+  const unanchoredCount = await countLive({
     $and: [prefixRegexArm(prefix), notMetaTag(lake.datalakeTag)],
     ...LIVE_CONJUNCT,
   });
@@ -198,9 +240,9 @@ async function main() {
 
   console.log(`Checking dynamic-lake prefix-only membership on stage="${stage}"...`);
 
-  const dbLakes = await DataLakeModel.find({}, { name: 1, fileTagPrefix: 1, datalakeTag: 1, createdByUserId: 1 }).lean<
-    DataLakeRow[]
-  >();
+  const dbLakes = await DataLakeModel.find({}, { name: 1, fileTagPrefix: 1, datalakeTag: 1, createdByUserId: 1 })
+    .maxTimeMS(QUERY_TIMEOUT_MS)
+    .lean<DataLakeRow[]>();
   console.log(`Scanned ${dbLakes.length} dynamic data lake(s).`);
 
   // A DB row can shadow a registry entry's datalakeTag; that row is still classified as dynamic
@@ -219,13 +261,27 @@ async function main() {
   const { lines, exitCode, findingsCount, reconcileMismatchCount } = renderCensusReport(lakes, stage);
   for (const line of lines) console.log(line);
 
-  const artifactPath = path.resolve(process.cwd(), `datalake-prefix-only-census-${stage}-${Date.now()}.json`);
+  // Deliberately NOT the working directory: under the documented `pnpm --filter scripts ...`
+  // invocation that is packages/scripts, i.e. inside a PUBLIC repo's tree, where nothing in the
+  // commit chain would stop `git add -A` from making tenant file names permanent. The temp dir is
+  // world-readable on Linux (1777 /tmp), so the 0600 is load-bearing rather than decoration.
+  // checkDatalakeCensusReadOnly.test.ts fails the build if this regresses.
+  const outDir = process.env.DATALAKE_CENSUS_OUT_DIR ?? os.tmpdir();
+  const artifactPath = path.resolve(outDir, `datalake-prefix-only-census-${stage}-${Date.now()}.json`);
+  // `lines` and `exitCode` are serialized too: stdout is the only place the rendered ESCALATE /
+  // RECONCILE lines and the sign-off summary exist, and it is the surface most likely to be lost.
   fs.writeFileSync(
     artifactPath,
-    JSON.stringify({ stage, generatedAt: new Date().toISOString(), findingsCount, lakes }, null, 2)
+    JSON.stringify({ stage, generatedAt: new Date().toISOString(), exitCode, findingsCount, lines, lakes }, null, 2),
+    { mode: 0o600 }
   );
-  console.log(`\nFull per-lake detail written to ${artifactPath}.`);
-  console.log('That file contains cross-tenant file names - split it per owner before any of it leaves the operator.');
+  console.log(`\nFull per-lake detail written to ${artifactPath} (mode 0600).`);
+  console.log(
+    'That file carries cross-tenant identity data - per-file owner ids and file names, plus each ' +
+      "lake's name, fileTagPrefix and creator id. Split it per owner (the per-file userId is there " +
+      'for exactly that) before any of it leaves the operator. Tmp reaping can remove it, so copy ' +
+      'it deliberately if it is needed for sign-off.'
+  );
 
   if (reconcileMismatchCount > 0) {
     throw new Error(
@@ -233,10 +289,24 @@ async function main() {
     );
   }
 
-  process.exit(exitCode);
+  return exitCode;
 }
 
-main().catch(e => {
-  console.error(e);
-  process.exit(1);
-});
+/**
+ * `process.exitCode` + an explicit disconnect, never `process.exit()`. Node's stdout is
+ * asynchronous when it is a pipe - which the documented `sst shell`/`pnpm` invocation guarantees -
+ * and `process.exit()` does not drain it. The exposure is worst exactly where it matters most:
+ * exit 2 is the findings case and also the longest output, and the last lines printed are the
+ * artifact path and the cross-tenant-data warning. The same applies to the failure path, where
+ * truncating console.error costs the operator the REASON the census could not be trusted.
+ */
+void (async () => {
+  try {
+    process.exitCode = await main();
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect().catch(() => {});
+  }
+})();

--- a/packages/scripts/migrate/check-datalake-prefix-only-members.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-only-members.ts
@@ -1,0 +1,242 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { connectDB, DataLakeModel, FabFile, buildDataLakeMembershipQuery } from '@bike4mind/database';
+import { DATA_LAKES, normalizeTagPrefix, isReservedTagPrefix } from '@bike4mind/common';
+import { escapeRegex } from '@bike4mind/utils/escapeRegex';
+import pLimit from 'p-limit';
+import { Resource } from 'sst';
+import { Config } from '../utils/config';
+import {
+  classifyDynamicLakeMode,
+  reconcilePrefixOnly,
+  renderCensusReport,
+  type LakeReport,
+} from './prefixOnlyMembersReport';
+
+/**
+ * READ-ONLY pre-merge census for the dynamic-lake prefix-only-member gap (the defect fixed by
+ * the lake-membership-retrieval-parity PR). Its own PR, merged and RUN before that fix, because
+ * the fix changes which files retrieval reaches - this must measure the PRE-change world.
+ *
+ * `buildDataLakeMembershipFilter` (@bike4mind/database) is `metaTag OR (fileTagPrefix AND
+ * lake.creatorUserId)`. Retrieval today only ever sees the caller-anchored prefix arm, never the
+ * creator-anchored one, so a creator-owned file carrying a lake's prefix but no meta-tag is
+ * listed/counted/graded-healthy by membership and unreachable by retrieval for anyone but the
+ * creator. This script sizes that population per lake, BOTH directions:
+ *
+ *  - WIDENING: the prefix-only population the fix makes newly reachable (three cross-checked
+ *    counts: total, total-minus-metaTagged, and a direct prefix-regex-and-creator count, with a
+ *    loud RECONCILE line if the cross-check disagrees).
+ *  - NARROWING: the population the fix makes newly UNREACHABLE - a file carrying the lake's
+ *    prefix that the lake's CREATOR DOES NOT OWN and that carries no meta-tag. Today it counts as
+ *    lake content for whoever owns or is shared on it; after the fix it does not. This is an
+ *    UPPER BOUND (the census cannot see per-caller reachability), and a nonzero value is CORRECT
+ *    behaviour under the new predicate, not a defect - it exists so an owner is not surprised, not
+ *    so anyone "fixes" it.
+ *
+ * `buildDataLakeMembershipFilter` fails closed to the meta-tag arm alone on three different
+ * conditions (no prefix, reserved prefix, no creator), all of which collapse to a bare
+ * `prefixOnly = 0`. Only one of those is a genuine zero, so every lake is classified into an
+ * explicit arm mode first (see prefixOnlyMembersReport.ts) rather than printing that bare zero.
+ * A dynamic lake with no creator on record is a data-quality defect and escalates on its own,
+ * separately from the widening/narrowing counts.
+ *
+ * Registry (static) lakes have no creator to anchor to and use the OPEN arm at retrieval - already
+ * fully reachable today - so they get one informational, un-anchored count and never escalate. A
+ * DB row is classified as dynamic by PROVENANCE (it came from the DataLake collection), never by
+ * whether its id/tag also happens to appear in the static registry (a "shadowed" row) - getting
+ * that backwards would drop a shadowed row's user-controlled prefix out of the gate entirely.
+ *
+ * Shape: raw models only (FabFile, DataLakeModel), no repository import, no write method -
+ * mechanically enforced by checkDatalakeCensusReadOnly.test.ts. One lake per query (never a
+ * cross-lake $or); counts never materialise documents except a capped example listing for an
+ * anchored finding (a `+1` probe to detect truncation). The JSON artifact this script writes
+ * contains cross-tenant file names - split it per owner before any of it leaves the operator.
+ *
+ * Exit codes so CI/an operator can tell "found things" from "crashed": 0 clean, 2 findings need
+ * owner sign-off (not an error), 1 the census itself failed (including a RECONCILE mismatch,
+ * which means the two widening queries disagree and the output cannot be trusted). Never merge on
+ * a 1 - an unrun census reads the same as a clean one.
+ *
+ * Usage:
+ *   ./for-env <env> pnpm sst shell --stage <stage> -- pnpm --filter scripts datalake:check-prefix-only-members
+ */
+
+const LIVE_CONJUNCT = { deletedAt: null, archivedAt: null };
+/** Per-lake example-file listing cap; the (cap+1)-th result flips `truncated`. */
+const FILE_LISTING_CAP = 500;
+/** Small, so a large tenant does not put the whole lake table under concurrent scan at once. */
+const LAKE_CONCURRENCY = 4;
+
+interface DataLakeRow {
+  _id: unknown;
+  name?: string;
+  fileTagPrefix?: string | null;
+  datalakeTag?: string;
+  createdByUserId?: string | null;
+}
+
+const prefixRegexArm = (prefix: string) => ({ 'tags.name': { $regex: new RegExp(`^${escapeRegex(prefix)}`) } });
+const notMetaTag = (datalakeTag: string) => ({ 'tags.name': { $ne: datalakeTag } });
+
+async function listExampleFiles(filter: Record<string, unknown>): Promise<{ fileNames: string[]; truncated: boolean }> {
+  const docs = await FabFile.find(filter, { fileName: 1 })
+    .limit(FILE_LISTING_CAP + 1)
+    .lean<{ fileName: string }[]>();
+  const truncated = docs.length > FILE_LISTING_CAP;
+  return { fileNames: docs.slice(0, FILE_LISTING_CAP).map(d => d.fileName), truncated };
+}
+
+async function buildDynamicLakeReport(row: DataLakeRow): Promise<LakeReport> {
+  const id = String(row._id);
+  const name = row.name ?? '(unnamed)';
+  const datalakeTag = row.datalakeTag ?? '';
+  const mode = classifyDynamicLakeMode(row);
+
+  const scope = { datalakeTag, fileTagPrefix: row.fileTagPrefix, creatorUserId: row.createdByUserId };
+  const [total, totalExcludingPending, metaTagged] = await Promise.all([
+    FabFile.countDocuments(buildDataLakeMembershipQuery(scope, LIVE_CONJUNCT)),
+    FabFile.countDocuments(buildDataLakeMembershipQuery(scope, { ...LIVE_CONJUNCT, status: { $ne: 'pending' } })),
+    FabFile.countDocuments({ 'tags.name': datalakeTag, ...LIVE_CONJUNCT }),
+  ]);
+
+  const base: LakeReport = {
+    id,
+    name,
+    datalakeTag,
+    fileTagPrefix: row.fileTagPrefix,
+    createdByUserId: row.createdByUserId,
+    mode,
+    total,
+    totalExcludingPending,
+    metaTagged,
+    prefixOnlyDirect: null,
+    reconcileMismatch: false,
+    narrowingUpperBound: null,
+    unanchoredCount: null,
+    prefixOnlyFiles: { fileNames: [], truncated: false },
+    narrowingFiles: { fileNames: [], truncated: false },
+  };
+
+  if (mode === 'no-prefix') return base;
+
+  const prefix = normalizeTagPrefix(row.fileTagPrefix);
+  if (!prefix) return base; // classifier already routed this to no-prefix; defensive only.
+
+  if (mode === 'creator-less') {
+    const unanchoredCount = await FabFile.countDocuments({
+      $and: [prefixRegexArm(prefix), notMetaTag(datalakeTag)],
+      ...LIVE_CONJUNCT,
+    });
+    return { ...base, unanchoredCount };
+  }
+
+  // mode === 'anchored'
+  const creatorUserId = row.createdByUserId as string;
+  const prefixOnlyFilter = {
+    $and: [prefixRegexArm(prefix), { userId: creatorUserId }, notMetaTag(datalakeTag)],
+    ...LIVE_CONJUNCT,
+  };
+  const narrowingFilter = {
+    $and: [prefixRegexArm(prefix), { userId: { $ne: creatorUserId } }, notMetaTag(datalakeTag)],
+    ...LIVE_CONJUNCT,
+  };
+  const [prefixOnlyDirect, narrowingUpperBound] = await Promise.all([
+    FabFile.countDocuments(prefixOnlyFilter),
+    FabFile.countDocuments(narrowingFilter),
+  ]);
+  const reconcile = reconcilePrefixOnly(total, metaTagged, prefixOnlyDirect);
+
+  const [prefixOnlyFiles, narrowingFiles] = await Promise.all([
+    prefixOnlyDirect > 0 ? listExampleFiles(prefixOnlyFilter) : Promise.resolve({ fileNames: [], truncated: false }),
+    narrowingUpperBound > 0 ? listExampleFiles(narrowingFilter) : Promise.resolve({ fileNames: [], truncated: false }),
+  ]);
+
+  return {
+    ...base,
+    prefixOnlyDirect,
+    reconcileMismatch: !reconcile.matches,
+    narrowingUpperBound,
+    prefixOnlyFiles,
+    narrowingFiles,
+  };
+}
+
+async function buildRegistryLakeReport(lake: (typeof DATA_LAKES)[number]): Promise<LakeReport> {
+  const base: LakeReport = {
+    id: lake.id,
+    name: lake.name,
+    datalakeTag: lake.datalakeTag,
+    fileTagPrefix: lake.fileTagPrefix,
+    createdByUserId: null,
+    mode: 'open',
+    total: null,
+    totalExcludingPending: null,
+    metaTagged: null,
+    prefixOnlyDirect: null,
+    reconcileMismatch: false,
+    narrowingUpperBound: null,
+    unanchoredCount: null,
+    prefixOnlyFiles: { fileNames: [], truncated: false },
+    narrowingFiles: { fileNames: [], truncated: false },
+  };
+  const prefix = normalizeTagPrefix(lake.fileTagPrefix);
+  if (!prefix || isReservedTagPrefix(prefix)) return base;
+
+  const unanchoredCount = await FabFile.countDocuments({
+    $and: [prefixRegexArm(prefix), notMetaTag(lake.datalakeTag)],
+    ...LIVE_CONJUNCT,
+  });
+  return { ...base, unanchoredCount };
+}
+
+async function main() {
+  const dbUri = Config.MONGODB_URI;
+  if (!dbUri) throw new Error('MONGODB_URI is required');
+  const stage = Resource.App.stage;
+  await connectDB(dbUri.replace('%STAGE%', stage));
+
+  console.log(`Checking dynamic-lake prefix-only membership on stage="${stage}"...`);
+
+  const dbLakes = await DataLakeModel.find({}, { name: 1, fileTagPrefix: 1, datalakeTag: 1, createdByUserId: 1 }).lean<
+    DataLakeRow[]
+  >();
+  console.log(`Scanned ${dbLakes.length} dynamic data lake(s).`);
+
+  // A DB row can shadow a registry entry's datalakeTag; that row is still classified as dynamic
+  // (see the docblock above) and is already covered by the loop below, so drop it from the
+  // registry-only set to avoid reporting the same lake twice under two different modes.
+  const dbDatalakeTags = new Set(dbLakes.map(l => l.datalakeTag).filter((t): t is string => !!t));
+  const registryOnlyLakes = DATA_LAKES.filter(l => !dbDatalakeTags.has(l.datalakeTag));
+  console.log(`Plus ${registryOnlyLakes.length} registry-only (static) lake(s), informational only.`);
+
+  const limit = pLimit(LAKE_CONCURRENCY);
+  const lakes = await Promise.all([
+    ...dbLakes.map(row => limit(() => buildDynamicLakeReport(row))),
+    ...registryOnlyLakes.map(lake => limit(() => buildRegistryLakeReport(lake))),
+  ]);
+
+  const { lines, exitCode, findingsCount, reconcileMismatchCount } = renderCensusReport(lakes, stage);
+  for (const line of lines) console.log(line);
+
+  const artifactPath = path.resolve(process.cwd(), `datalake-prefix-only-census-${stage}-${Date.now()}.json`);
+  fs.writeFileSync(
+    artifactPath,
+    JSON.stringify({ stage, generatedAt: new Date().toISOString(), findingsCount, lakes }, null, 2)
+  );
+  console.log(`\nFull per-lake detail written to ${artifactPath}.`);
+  console.log('That file contains cross-tenant file names - split it per owner before any of it leaves the operator.');
+
+  if (reconcileMismatchCount > 0) {
+    throw new Error(
+      `${reconcileMismatchCount} lake(s) failed the RECONCILE cross-check - the census cannot be trusted on this run.`
+    );
+  }
+
+  process.exit(exitCode);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/scripts/migrate/check-datalake-prefix-only-members.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-only-members.ts
@@ -1,7 +1,14 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { connectDB, DataLakeModel, FabFile, buildDataLakeMembershipQuery, mongoose } from '@bike4mind/database';
+import {
+  connectDB,
+  DataLakeModel,
+  FabFile,
+  buildDataLakeMembershipQuery,
+  whenCatalogSeeded,
+  mongoose,
+} from '@bike4mind/database';
 import { DATA_LAKES, normalizeTagPrefix, isReservedTagPrefix } from '@bike4mind/common';
 import { escapeRegex } from '@bike4mind/utils/escapeRegex';
 import pLimit from 'p-limit';
@@ -68,6 +75,13 @@ import {
  * owner sign-off (not an error), 1 the census itself failed (including a RECONCILE mismatch,
  * which means the two widening queries disagree and the output cannot be trusted). Never merge on
  * a 1 - an unrun census reads the same as a clean one.
+ *
+ * BUT DO NOT READ $? THROUGH THE INVOCATION BELOW. Measured 2026-09-01 against stage production:
+ * `sst shell` collapses every non-zero child code to 1 (0 survives), so a findings run (2) and a
+ * crashed run (1) are indistinguishable from the shell - the exact confusion the codes exist to
+ * prevent. `pnpm --filter` collapses them too, one layer earlier. The AUTHORITATIVE signal is the
+ * `exitCode` field in the JSON artifact, and the CENSUS RESULT line printed last on stdout. Read
+ * one of those, not `$?`, until something reads this process's code directly.
  *
  * Usage:
  *   ./for-env <env> pnpm sst shell --stage <stage> -- pnpm --filter scripts datalake:check-prefix-only-members
@@ -289,6 +303,13 @@ async function main() {
     );
   }
 
+  // Printed last and stated in words because `$?` cannot carry it: see the exit-code note above.
+  console.log(
+    `\nCENSUS RESULT: exitCode=${exitCode} - ${
+      exitCode === 0 ? 'CLEAN, no lake needs owner sign-off' : `${findingsCount} lake(s) NEED OWNER SIGN-OFF`
+    }. The shell will report 1 for any non-zero; trust this line and the artifact, not $?.`
+  );
+
   return exitCode;
 }
 
@@ -307,6 +328,10 @@ void (async () => {
     console.error(e);
     process.exitCode = 1;
   } finally {
+    // connectDB (priceCatalogBootstrap) kicks off a fire-and-forget catalog seed. Disconnecting
+    // under it throws MongoExpiredSessionError and dumps a stack trace AFTER the report - burying
+    // the very lines this exit path exists to preserve. whenCatalogSeeded never rejects.
+    await whenCatalogSeeded().catch(() => {});
     await mongoose.disconnect().catch(() => {});
   }
 })();

--- a/packages/scripts/migrate/check-datalake-prefix-only-members.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-only-members.ts
@@ -17,6 +17,7 @@ import { Config } from '../utils/config';
 import {
   classifyDynamicLakeMode,
   reconcilePrefixOnly,
+  censusResultLine,
   renderCensusReport,
   type ExampleFileListing,
   type LakeReport,
@@ -61,8 +62,14 @@ import {
  * whether its id/tag also happens to appear in the static registry (a "shadowed" row) - getting
  * that backwards would drop a shadowed row's user-controlled prefix out of the gate entirely.
  *
- * Shape: raw models only (FabFile, DataLakeModel), no repository import, no write method -
- * mechanically enforced by checkDatalakeCensusReadOnly.test.ts. One lake per query (never a
+ * Shape: raw models only (FabFile, DataLakeModel), no repository import, and no write method OF
+ * ITS OWN - the latter mechanically enforced by checkDatalakeCensusReadOnly.test.ts. Read that
+ * claim narrowly, because the guard is a source grep over this file and prefixOnlyMembersReport.ts
+ * and structurally cannot see a transitive one: the shared `connectDB` wrapper
+ * (packages/database/src/priceCatalogBootstrap.ts) builds unique indexes on three collections -
+ * including the DataLake collection this script audits - and seeds the model catalog. Those are
+ * idempotent, touch no audited DOCUMENT, and are how every script in this audit family connects,
+ * but "READ-ONLY" here means this script issues no writes, not that the process issues none. One lake per query (never a
  * cross-lake $or); counts never materialise documents except a capped example listing for an
  * anchored finding (a `+1` probe to detect truncation). The JSON artifact this script writes
  * carries cross-tenant identity data - per-file owner ids and file names, plus each lake's name,
@@ -177,8 +184,9 @@ async function buildDynamicLakeReport(row: DataLakeRow): Promise<LakeReport> {
   if (!prefix) return base; // classifier already routed this to no-prefix; defensive only.
 
   // Both fail-closed modes get the same un-anchored reach figure. For `reserved-prefix` it is
-  // heavily inflated by construction (a `datalake:` regex matches every OTHER lake's membership
-  // meta-tag), which is why renderLakeLines labels it over-match rather than narrowing.
+  // inflated by construction - a `datalake:`-namespace regex can match OTHER lakes' membership
+  // meta-tags, a bare `datalake:` matching all of them and a longer `datalake:acme:` only those
+  // beneath it - which is why renderLakeLines labels it over-match rather than narrowing.
   if (mode === 'creator-less' || mode === 'reserved-prefix') {
     const unanchoredCount = await countLive({
       $and: [prefixRegexArm(prefix), notMetaTag(datalakeTag)],
@@ -286,7 +294,11 @@ async function main() {
   // RECONCILE lines and the sign-off summary exist, and it is the surface most likely to be lost.
   fs.writeFileSync(
     artifactPath,
-    JSON.stringify({ stage, generatedAt: new Date().toISOString(), exitCode, findingsCount, lines, lakes }, null, 2),
+    JSON.stringify(
+      { stage, generatedAt: new Date().toISOString(), exitCode, findingsCount, reconcileMismatchCount, lines, lakes },
+      null,
+      2
+    ),
     { mode: 0o600 }
   );
   console.log(`\nFull per-lake detail written to ${artifactPath} (mode 0600).`);
@@ -297,18 +309,17 @@ async function main() {
       'it deliberately if it is needed for sign-off.'
   );
 
+  // BEFORE the throw, not after. `$?` cannot carry the verdict (see the exit-code note above), so
+  // this line and the artifact are the only authoritative signals - and the RECONCILE path is
+  // exactly the one where the operator most needs them. renderCensusReport has already folded the
+  // mismatch into `exitCode`, so this cannot announce CLEAN on a run that is about to abort.
+  console.log(censusResultLine(exitCode, findingsCount, reconcileMismatchCount));
+
   if (reconcileMismatchCount > 0) {
     throw new Error(
       `${reconcileMismatchCount} lake(s) failed the RECONCILE cross-check - the census cannot be trusted on this run.`
     );
   }
-
-  // Printed last and stated in words because `$?` cannot carry it: see the exit-code note above.
-  console.log(
-    `\nCENSUS RESULT: exitCode=${exitCode} - ${
-      exitCode === 0 ? 'CLEAN, no lake needs owner sign-off' : `${findingsCount} lake(s) NEED OWNER SIGN-OFF`
-    }. The shell will report 1 for any non-zero; trust this line and the artifact, not $?.`
-  );
 
   return exitCode;
 }

--- a/packages/scripts/migrate/prefixOnlyMembersReport.test.ts
+++ b/packages/scripts/migrate/prefixOnlyMembersReport.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyDynamicLakeMode,
+  reconcilePrefixOnly,
+  isFinding,
+  renderCensusReport,
+  type LakeReport,
+} from './prefixOnlyMembersReport';
+
+const baseLake = (overrides: Partial<LakeReport>): LakeReport => ({
+  id: 'lake-1',
+  name: 'Test Lake',
+  datalakeTag: 'datalake:test-lake',
+  fileTagPrefix: 'acme:',
+  createdByUserId: 'user-1',
+  mode: 'anchored',
+  total: 10,
+  totalExcludingPending: 9,
+  metaTagged: 8,
+  prefixOnlyDirect: 2,
+  reconcileMismatch: false,
+  narrowingUpperBound: 0,
+  unanchoredCount: null,
+  prefixOnlyFiles: { fileNames: [], truncated: false },
+  narrowingFiles: { fileNames: [], truncated: false },
+  ...overrides,
+});
+
+describe('classifyDynamicLakeMode', () => {
+  it('classifies a valid prefix + creator as anchored', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'acme:', createdByUserId: 'user-1' })).toBe('anchored');
+  });
+
+  it('classifies a missing prefix as no-prefix', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: undefined, createdByUserId: 'user-1' })).toBe('no-prefix');
+  });
+
+  it('classifies a colon-less prefix as no-prefix', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'acme', createdByUserId: 'user-1' })).toBe('no-prefix');
+  });
+
+  it('classifies a reserved (datalake:) prefix as no-prefix', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'datalake:acme:', createdByUserId: 'user-1' })).toBe('no-prefix');
+  });
+
+  it('classifies a missing creator as creator-less', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'acme:', createdByUserId: undefined })).toBe('creator-less');
+  });
+
+  it('classifies an empty-string creator as creator-less, not anchored', () => {
+    // createdByUserId: '' is a real stored value in this codebase (a synthetic registry
+    // fallback), and '' is falsy - the classifier must test truthiness, not `!= null`.
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'acme:', createdByUserId: '' })).toBe('creator-less');
+  });
+
+  it('prefers no-prefix over creator-less when both conditions hold', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: undefined, createdByUserId: '' })).toBe('no-prefix');
+  });
+});
+
+describe('reconcilePrefixOnly', () => {
+  it('matches when total - metaTagged equals the direct count', () => {
+    expect(reconcilePrefixOnly(10, 8, 2)).toEqual({ expected: 2, actual: 2, matches: true });
+  });
+
+  it('flags a mismatch when the two counts disagree', () => {
+    expect(reconcilePrefixOnly(10, 8, 3)).toEqual({ expected: 2, actual: 3, matches: false });
+  });
+});
+
+describe('isFinding', () => {
+  it('does not escalate an anchored lake with zero widening and zero narrowing', () => {
+    expect(isFinding(baseLake({ prefixOnlyDirect: 0, narrowingUpperBound: 0 }))).toBe(false);
+  });
+
+  it('escalates an anchored lake with a nonzero widening count', () => {
+    expect(isFinding(baseLake({ prefixOnlyDirect: 1, narrowingUpperBound: 0 }))).toBe(true);
+  });
+
+  it('escalates an anchored lake with a nonzero narrowing count even if widening is zero', () => {
+    expect(isFinding(baseLake({ prefixOnlyDirect: 0, narrowingUpperBound: 1 }))).toBe(true);
+  });
+
+  it('never escalates a no-prefix lake', () => {
+    expect(isFinding(baseLake({ mode: 'no-prefix', prefixOnlyDirect: null, narrowingUpperBound: null }))).toBe(false);
+  });
+
+  it('never escalates an open (registry) lake', () => {
+    expect(
+      isFinding(baseLake({ mode: 'open', prefixOnlyDirect: null, narrowingUpperBound: null, unanchoredCount: 50 }))
+    ).toBe(false);
+  });
+
+  it('always escalates a creator-less lake, even with a zero unanchored count', () => {
+    expect(
+      isFinding(
+        baseLake({ mode: 'creator-less', prefixOnlyDirect: null, narrowingUpperBound: null, unanchoredCount: 0 })
+      )
+    ).toBe(true);
+  });
+});
+
+describe('renderCensusReport', () => {
+  it('exits 0 with no findings when every lake is clean', () => {
+    const result = renderCensusReport([baseLake({ prefixOnlyDirect: 0, narrowingUpperBound: 0 })], 'dev');
+    expect(result.exitCode).toBe(0);
+    expect(result.findingsCount).toBe(0);
+  });
+
+  it('exits 2 and names the lake when a finding exists', () => {
+    const result = renderCensusReport([baseLake({ prefixOnlyDirect: 3 })], 'dev');
+    expect(result.exitCode).toBe(2);
+    expect(result.findingsCount).toBe(1);
+    expect(result.lines.some(l => l.includes('Test Lake'))).toBe(true);
+  });
+
+  it('never prints a bare "0" for a creator-less lake', () => {
+    const result = renderCensusReport(
+      [
+        baseLake({
+          mode: 'creator-less',
+          prefixOnlyDirect: null,
+          narrowingUpperBound: null,
+          unanchoredCount: 0,
+          total: null,
+          totalExcludingPending: null,
+          metaTagged: null,
+        }),
+      ],
+      'dev'
+    );
+    const memberLine = result.lines.find(l => l.includes('prefix-only members:'));
+    expect(memberLine).toContain('n/a (fails closed)');
+    expect(memberLine).not.toBe('  prefix-only members: 0');
+  });
+
+  it('labels the narrowing count as an upper bound and states a nonzero value is correct', () => {
+    const result = renderCensusReport([baseLake({ prefixOnlyDirect: 0, narrowingUpperBound: 5 })], 'dev');
+    expect(result.lines.some(l => l.includes('narrowing upper bound') && l.includes('5'))).toBe(true);
+    expect(result.lines.some(l => l.toLowerCase().includes('not a defect'))).toBe(true);
+  });
+
+  it('surfaces a RECONCILE line when the two widening counts disagree', () => {
+    const result = renderCensusReport(
+      [baseLake({ reconcileMismatch: true, total: 10, metaTagged: 8, prefixOnlyDirect: 3 })],
+      'dev'
+    );
+    expect(result.lines.some(l => l.startsWith('  RECONCILE:'))).toBe(true);
+    expect(result.reconcileMismatchCount).toBe(1);
+  });
+});

--- a/packages/scripts/migrate/prefixOnlyMembersReport.test.ts
+++ b/packages/scripts/migrate/prefixOnlyMembersReport.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  censusResultLine,
   classifyDynamicLakeMode,
   reconcilePrefixOnly,
   isFinding,
@@ -247,11 +248,78 @@ describe('renderCensusReport', () => {
     expect(result.lines.some(l => l.includes('fileTagPrefix="acme: "'))).toBe(true);
   });
 
+  // A RECONCILE mismatch used to leave exitCode at 0 and the summary at "No lake needs owner
+  // sign-off." while main() aborted the run - so the two signals the docblock calls authoritative
+  // both said CLEAN on a census that had just declared itself untrustworthy.
+  it('exits 1 on a RECONCILE mismatch even when NO lake escalates', () => {
+    const result = renderCensusReport(
+      [baseLake({ reconcileMismatch: true, total: 1, metaTagged: 0, prefixOnlyDirect: 0, narrowingUpperBound: 0 })],
+      'production'
+    );
+    expect(result.findingsCount).toBe(0);
+    expect(result.reconcileMismatchCount).toBe(1);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('never prints a clean summary on a RECONCILE mismatch', () => {
+    const result = renderCensusReport(
+      [baseLake({ reconcileMismatch: true, total: 1, metaTagged: 0, prefixOnlyDirect: 0, narrowingUpperBound: 0 })],
+      'production'
+    );
+    expect(result.lines).not.toContain('No lake needs owner sign-off.');
+    expect(result.lines.some(l => l.includes('DO NOT MERGE'))).toBe(true);
+  });
+
+  it('a mismatch outranks a findings verdict rather than sitting beside it', () => {
+    const result = renderCensusReport([baseLake({ reconcileMismatch: true, prefixOnlyDirect: 3 })], 'production');
+    expect(result.findingsCount).toBe(1);
+    expect(result.exitCode).toBe(1);
+    expect(result.lines.some(l => l.includes('need owner sign-off before'))).toBe(false);
+  });
+
+  it('surfaces the missing creator even when the lake is ALSO reserved-prefix', () => {
+    // classifyDynamicLakeMode short-circuits on the reserved prefix, so keying the ESCALATE line
+    // off `mode === 'creator-less'` hid the data-quality defect entirely on stdout.
+    const result = renderCensusReport(
+      [baseLake({ mode: 'reserved-prefix', fileTagPrefix: 'datalake:acme:', createdByUserId: '', unanchoredCount: 4 })],
+      'production'
+    );
+    expect(result.lines.some(l => l.includes('no creator on record'))).toBe(true);
+  });
+
+  it('does not claim a missing creator for a registry (open) lake', () => {
+    const result = renderCensusReport(
+      [baseLake({ mode: 'open', createdByUserId: null, total: null, totalExcludingPending: null, metaTagged: null })],
+      'production'
+    );
+    expect(result.lines.some(l => l.includes('no creator on record'))).toBe(false);
+  });
+
   it('marks the widening listing as truncated, not just the narrowing one', () => {
     const result = renderCensusReport(
       [baseLake({ prefixOnlyDirect: 501, prefixOnlyFiles: { files: [], truncated: true } })],
       'dev'
     );
     expect(result.lines.find(l => l.includes('prefix-only members:'))).toContain('(truncated listing)');
+  });
+});
+
+describe('censusResultLine', () => {
+  it('reports CENSUS FAILED, not a verdict, when the census could not be trusted', () => {
+    const line = censusResultLine(1, 0, 2);
+    expect(line).toContain('CENSUS FAILED');
+    expect(line).toContain('2 lake(s) failed the RECONCILE');
+    expect(line).not.toContain('CLEAN');
+  });
+
+  it('reports CLEAN only on 0 and the sign-off count on 2', () => {
+    expect(censusResultLine(0, 0, 0)).toContain('CLEAN, no lake needs owner sign-off');
+    expect(censusResultLine(2, 3, 0)).toContain('3 lake(s) NEED OWNER SIGN-OFF');
+  });
+
+  it('always tells the operator not to trust the shell exit code', () => {
+    for (const code of [0, 1, 2] as const) {
+      expect(censusResultLine(code, 1, 1)).toContain('not $?');
+    }
   });
 });

--- a/packages/scripts/migrate/prefixOnlyMembersReport.test.ts
+++ b/packages/scripts/migrate/prefixOnlyMembersReport.test.ts
@@ -21,8 +21,8 @@ const baseLake = (overrides: Partial<LakeReport>): LakeReport => ({
   reconcileMismatch: false,
   narrowingUpperBound: 0,
   unanchoredCount: null,
-  prefixOnlyFiles: { fileNames: [], truncated: false },
-  narrowingFiles: { fileNames: [], truncated: false },
+  prefixOnlyFiles: { files: [], truncated: false },
+  narrowingFiles: { files: [], truncated: false },
   ...overrides,
 });
 
@@ -39,8 +39,21 @@ describe('classifyDynamicLakeMode', () => {
     expect(classifyDynamicLakeMode({ fileTagPrefix: 'acme', createdByUserId: 'user-1' })).toBe('no-prefix');
   });
 
-  it('classifies a reserved (datalake:) prefix as no-prefix', () => {
-    expect(classifyDynamicLakeMode({ fileTagPrefix: 'datalake:acme:', createdByUserId: 'user-1' })).toBe('no-prefix');
+  it('classifies a reserved (datalake:) prefix as its OWN mode, never no-prefix', () => {
+    // Folding this into no-prefix is the false zero the census exists to catch: retrieval honours
+    // a reserved prefix today and the fix drops it, so the lake loses its whole prefix arm while
+    // "0 (no prefix arm)" claims nothing moves.
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'datalake:acme:', createdByUserId: 'user-1' })).toBe(
+      'reserved-prefix'
+    );
+  });
+
+  it('prefers reserved-prefix over creator-less when both conditions hold', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'datalake:acme:', createdByUserId: '' })).toBe('reserved-prefix');
+  });
+
+  it('still classifies an unusable (colon-less) prefix as no-prefix, not reserved', () => {
+    expect(classifyDynamicLakeMode({ fileTagPrefix: 'datalake', createdByUserId: 'user-1' })).toBe('no-prefix');
   });
 
   it('classifies a missing creator as creator-less', () => {
@@ -91,6 +104,14 @@ describe('isFinding', () => {
     ).toBe(false);
   });
 
+  it('always escalates a reserved-prefix lake, even with a zero unanchored count', () => {
+    expect(
+      isFinding(
+        baseLake({ mode: 'reserved-prefix', prefixOnlyDirect: null, narrowingUpperBound: null, unanchoredCount: 0 })
+      )
+    ).toBe(true);
+  });
+
   it('always escalates a creator-less lake, even with a zero unanchored count', () => {
     expect(
       isFinding(
@@ -107,11 +128,16 @@ describe('renderCensusReport', () => {
     expect(result.findingsCount).toBe(0);
   });
 
-  it('exits 2 and names the lake when a finding exists', () => {
+  it('exits 2 and names the lake IN THE SUMMARY when a finding exists', () => {
     const result = renderCensusReport([baseLake({ prefixOnlyDirect: 3 })], 'dev');
     expect(result.exitCode).toBe(2);
     expect(result.findingsCount).toBe(1);
-    expect(result.lines.some(l => l.includes('Test Lake'))).toBe(true);
+    // Must assert against the summary line specifically. A bare `lines.some(includes('Test Lake'))`
+    // is vacuous: renderLakeLines emits a `Lake "Test Lake" (...)` header for EVERY lake, so it
+    // passes even with the whole summary block deleted.
+    const summary = result.lines.find(l => l.includes('need owner sign-off before'));
+    expect(summary).toBeDefined();
+    expect(summary).toContain('Test Lake');
   });
 
   it('never prints a bare "0" for a creator-less lake', () => {
@@ -147,5 +173,85 @@ describe('renderCensusReport', () => {
     );
     expect(result.lines.some(l => l.startsWith('  RECONCILE:'))).toBe(true);
     expect(result.reconcileMismatchCount).toBe(1);
+  });
+
+  it('tells the operator a RECONCILE mismatch may just be a concurrent write', () => {
+    // The three counts are unsynchronized countDocuments calls, so a mismatch does NOT prove the
+    // queries diverged. Without this the operator reads a hard "do not trust" and stops.
+    const result = renderCensusReport([baseLake({ reconcileMismatch: true })], 'dev');
+    const line = result.lines.find(l => l.startsWith('  RECONCILE:'));
+    expect(line).toMatch(/[Rr]e-run/);
+    expect(line).toMatch(/unsynchronized/);
+  });
+
+  // The next two cover modeColumn branches that no test reached before: both could be replaced
+  // with arbitrary strings and the whole suite stayed green.
+  it('renders a no-prefix lake without escalating it', () => {
+    const result = renderCensusReport(
+      [baseLake({ mode: 'no-prefix', fileTagPrefix: 'acme', prefixOnlyDirect: null, narrowingUpperBound: null })],
+      'dev'
+    );
+    expect(result.lines.find(l => l.includes('prefix-only members:'))).toContain('0 (no prefix arm)');
+    expect(result.exitCode).toBe(0);
+    expect(result.findingsCount).toBe(0);
+  });
+
+  it('renders an open (registry) lake with its unanchored count, without escalating it', () => {
+    const result = renderCensusReport(
+      [
+        baseLake({
+          mode: 'open',
+          prefixOnlyDirect: null,
+          narrowingUpperBound: null,
+          unanchoredCount: 50,
+          total: null,
+          totalExcludingPending: null,
+          metaTagged: null,
+        }),
+      ],
+      'dev'
+    );
+    const memberLine = result.lines.find(l => l.includes('prefix-only members:'));
+    expect(memberLine).toContain('50');
+    expect(memberLine).toContain('OPEN arm');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('escalates a reserved-prefix lake and labels its number over-match, not narrowing', () => {
+    const result = renderCensusReport(
+      [
+        baseLake({
+          mode: 'reserved-prefix',
+          fileTagPrefix: 'datalake:acme:',
+          prefixOnlyDirect: null,
+          narrowingUpperBound: null,
+          unanchoredCount: 900,
+        }),
+      ],
+      'dev'
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.findingsCount).toBe(1);
+    expect(result.lines.some(l => l.includes('ESCALATE') && l.includes('reserved'))).toBe(true);
+    // The figure is inflated by construction (a `datalake:` regex matches other lakes' meta-tags),
+    // so it must never be presented as a narrowing/member count.
+    const memberLine = result.lines.find(l => l.includes('prefix-only members:'));
+    expect(memberLine).toContain('over-match');
+    expect(memberLine).not.toContain('narrowing');
+    expect(result.lines.some(l => l.includes('NOT a member count'))).toBe(true);
+  });
+
+  it('prints fileTagPrefix so a malformed or reserved value is visible', () => {
+    const result = renderCensusReport([baseLake({ fileTagPrefix: 'acme: ' })], 'dev');
+    // JSON-quoted on purpose: bare printing hides the trailing space that made it unusable.
+    expect(result.lines.some(l => l.includes('fileTagPrefix="acme: "'))).toBe(true);
+  });
+
+  it('marks the widening listing as truncated, not just the narrowing one', () => {
+    const result = renderCensusReport(
+      [baseLake({ prefixOnlyDirect: 501, prefixOnlyFiles: { files: [], truncated: true } })],
+      'dev'
+    );
+    expect(result.lines.find(l => l.includes('prefix-only members:'))).toContain('(truncated listing)');
   });
 });

--- a/packages/scripts/migrate/prefixOnlyMembersReport.ts
+++ b/packages/scripts/migrate/prefixOnlyMembersReport.ts
@@ -119,8 +119,9 @@ const modeColumn = (lake: LakeReport): string => {
     case 'no-prefix':
       return '0 (no prefix arm)';
     case 'reserved-prefix':
-      // NOT a member count: a `datalake:`-namespace regex matches every OTHER lake's
-      // membership meta-tag, so this figure is inflated by design. See renderLakeLines.
+      // NOT a member count: a `datalake:`-namespace regex can match OTHER lakes' membership
+      // meta-tags, so this figure is inflated. How much depends on prefix length - a bare
+      // `datalake:` matches every one of them, a longer `datalake:acme:` only those beneath it.
       return `n/a (reserved prefix - whole arm dropped by the fix) - prefix over-match: ${lake.unanchoredCount ?? 0}`;
     case 'creator-less':
       return `n/a (fails closed) - unanchored: ${lake.unanchoredCount ?? 0}`;
@@ -175,13 +176,17 @@ export function renderLakeLines(lake: LakeReport): string[] {
         'collapsed "0 (no prefix arm)" would have hidden. Only meta-tagged files stay reachable.'
     );
     lines.push(
-      '    The over-match figure above is NOT a member count and is inflated by design: a "datalake:" regex ' +
-        "matches every other lake's membership meta-tag. Treat it as reach, not as narrowing. Note the arm " +
-        'being dropped is also an ownership leak, so removing it is a fix - review what this lake loses, not ' +
-        'whether the drop is correct.'
+      '    The over-match figure above is NOT a member count and is inflated: a "datalake:" regex can match ' +
+        'OTHER lakes\' membership meta-tags, and how much depends on prefix length - a bare "datalake:" ' +
+        'matches every one of them, a longer "datalake:acme:" only those beneath it. Treat it as reach, not ' +
+        'as narrowing. Note the arm being dropped is also an ownership leak, so removing it is a fix - ' +
+        'review what this lake loses, not whether the drop is correct.'
     );
   }
-  if (lake.mode === 'creator-less') {
+  // Keyed off the FIELD, not the mode: classifyDynamicLakeMode short-circuits on a reserved prefix
+  // before it ever looks at the creator, so a lake that is both would otherwise show no trace of
+  // the missing creator on stdout. `open` (registry) lakes have no creator by construction.
+  if (!lake.createdByUserId && lake.mode !== 'open') {
     lines.push('  ESCALATE: dynamic lake with no creator on record - legacy row or bad ingest, review before merge.');
   }
   return lines;
@@ -189,7 +194,13 @@ export function renderLakeLines(lake: LakeReport): string[] {
 
 export interface CensusRenderResult {
   lines: string[];
-  exitCode: 0 | 2;
+  /**
+   * 0 clean, 2 findings need owner sign-off, 1 the census cannot be trusted. A RECONCILE mismatch
+   * OUTRANKS a findings verdict and is why this is not just `isFinding`-derived: the two widening
+   * queries disagreed, so no number in the report is trustworthy - including a `0` that would
+   * otherwise announce "nothing needs sign-off" on a run main() is about to abort.
+   */
+  exitCode: 0 | 1 | 2;
   findingsCount: number;
   reconcileMismatchCount: number;
 }
@@ -201,15 +212,43 @@ export function renderCensusReport(lakes: LakeReport[], stage: string): CensusRe
   }
   const findings = lakes.filter(isFinding);
   const reconcileMismatches = lakes.filter(l => l.reconcileMismatch);
-  lines.push(
-    findings.length === 0
-      ? 'No lake needs owner sign-off.'
-      : `${findings.length} lake(s) need owner sign-off before #2254 merges: ${findings.map(l => l.name).join(', ')}`
-  );
+  if (reconcileMismatches.length > 0) {
+    // Deliberately REPLACES the clean/findings summary rather than sitting beside it. On a mismatch
+    // there is no verdict to report: "No lake needs owner sign-off." would be the most dangerous
+    // line in the file, since it reads as a green light on a run whose own numbers disagree.
+    lines.push(
+      `${reconcileMismatches.length} lake(s) failed the RECONCILE cross-check - DO NOT MERGE on this run. ` +
+        'No verdict is available: the two widening queries disagree, so neither a sign-off list nor a ' +
+        'clean result can be trusted. Re-run; a concurrent write does not reproduce, a real divergence does.'
+    );
+  } else {
+    lines.push(
+      findings.length === 0
+        ? 'No lake needs owner sign-off.'
+        : `${findings.length} lake(s) need owner sign-off before #2254 merges: ${findings.map(l => l.name).join(', ')}`
+    );
+  }
   return {
     lines,
-    exitCode: findings.length === 0 ? 0 : 2,
+    exitCode: reconcileMismatches.length > 0 ? 1 : findings.length === 0 ? 0 : 2,
     findingsCount: findings.length,
     reconcileMismatchCount: reconcileMismatches.length,
   };
+}
+
+/**
+ * The operator-facing verdict line. Pure and exported, rather than built inline in main(), because
+ * `$?` is unreliable through the documented invocation - which makes this line and the artifact's
+ * `exitCode` the only authoritative signals, and an untested authoritative signal is exactly how
+ * the RECONCILE case came to announce CLEAN.
+ */
+export function censusResultLine(exitCode: 0 | 1 | 2, findingsCount: number, reconcileMismatchCount: number): string {
+  const verdict =
+    exitCode === 1
+      ? `CENSUS FAILED - ${reconcileMismatchCount} lake(s) failed the RECONCILE cross-check. These numbers ` +
+        'cannot be trusted and nothing may merge on them'
+      : exitCode === 0
+        ? 'CLEAN, no lake needs owner sign-off'
+        : `${findingsCount} lake(s) NEED OWNER SIGN-OFF`;
+  return `\nCENSUS RESULT: exitCode=${exitCode} - ${verdict}. The shell will report 1 for any non-zero; trust this line and the artifact, not $?.`;
 }

--- a/packages/scripts/migrate/prefixOnlyMembersReport.ts
+++ b/packages/scripts/migrate/prefixOnlyMembersReport.ts
@@ -7,20 +7,35 @@ import { isReservedTagPrefix, normalizeTagPrefix } from '@bike4mind/common';
  * without a Mongo connection.
  */
 
-export type ArmMode = 'anchored' | 'no-prefix' | 'creator-less' | 'open';
+export type ArmMode = 'anchored' | 'no-prefix' | 'reserved-prefix' | 'creator-less' | 'open';
 
 /**
- * The same three fail-closed conditions `buildDataLakeMembershipFilter`
- * (`@bike4mind/database`) collapses to a bare meta-tag arm, kept separate here so the
- * census can tell "genuinely no prefix arm" from "fails closed for a data-quality
- * reason" - both would otherwise print as an indistinguishable `prefixOnly = 0`.
+ * The fail-closed conditions that make an owned-lake membership filter collapse to a bare
+ * meta-tag arm, kept separate here so the census can tell "genuinely no prefix arm" from
+ * "fails closed for a data-quality reason" - all would otherwise print as an
+ * indistinguishable `prefixOnly = 0`.
+ *
+ * `reserved-prefix` is deliberately NOT folded into `no-prefix`, because the two move in
+ * opposite directions across the retrieval-parity fix:
+ *  - A prefix that fails `normalizeTagPrefix` (no trailing ":") is dropped by retrieval
+ *    TODAY (fabFileSearchQuery normalizes and filters nulls) and by the membership filter
+ *    after the fix, so nothing moves - a genuine zero.
+ *  - A RESERVED (`datalake:`-namespace) prefix is live at retrieval today and is dropped by
+ *    `buildDataLakeMembershipFilter` after the fix, so such a lake loses its whole prefix
+ *    arm while a collapsed `0 (no prefix arm)` would report that nothing moves. That is the
+ *    exact false zero this census exists to catch, so it escalates on its own.
+ *
+ * Note that `fileTagPrefix` is `required: true` on DataLakeModel, so for a DYNAMIC lake
+ * `no-prefix` still means a malformed stored value, not an absent one. It does not escalate
+ * (nothing moves), but the prefix is printed so an operator can see it.
  */
 export function classifyDynamicLakeMode(row: {
   fileTagPrefix?: string | null;
   createdByUserId?: string | null;
-}): 'anchored' | 'no-prefix' | 'creator-less' {
+}): 'anchored' | 'no-prefix' | 'reserved-prefix' | 'creator-less' {
   const prefix = normalizeTagPrefix(row.fileTagPrefix);
-  if (!prefix || isReservedTagPrefix(prefix)) return 'no-prefix';
+  if (!prefix) return 'no-prefix';
+  if (isReservedTagPrefix(prefix)) return 'reserved-prefix';
   // createdByUserId: '' is a real (if unusual) stored value, not the same as missing -
   // both must fail closed, so test truthiness rather than `!= null`.
   if (!row.createdByUserId) return 'creator-less';
@@ -38,12 +53,26 @@ export interface ReconcileResult {
  * `metaTagged` counts the meta-tag arm alone. By inclusion-exclusion,
  * `total - metaTagged` must equal the count of files that satisfy the prefix arm but
  * NOT the meta arm - exactly what `prefixOnlyDirect` counts directly. The two are
- * expected to always agree; a mismatch means the two queries diverged (e.g. a regex
- * escaping difference), not that the population genuinely differs.
+ * expected to agree. A mismatch has two causes, and the census cannot tell them apart:
+ * the two queries diverged (e.g. a regex escaping difference), OR the population moved
+ * between them - these are three separate unsynchronized `countDocuments` calls with no
+ * session and no snapshot, so a single upload/delete/archive landing mid-run shifts one
+ * count and not the other. Re-run before believing a mismatch; a real divergence is
+ * reproducible and a concurrent write is not.
  */
 export function reconcilePrefixOnly(total: number, metaTagged: number, prefixOnlyDirect: number): ReconcileResult {
   const expected = total - metaTagged;
   return { expected, actual: prefixOnlyDirect, matches: expected === prefixOnlyDirect };
+}
+
+/**
+ * A capped example listing. `userId` is carried per file so the artifact can be split per owner
+ * before it is shared - the narrowing set is by definition not the lake creator's, so file names
+ * alone leave the cross-tenant half with no owner to split on.
+ */
+export interface ExampleFileListing {
+  files: { userId: string; fileName: string }[];
+  truncated: boolean;
 }
 
 export interface LakeReport {
@@ -64,30 +93,35 @@ export interface LakeReport {
   narrowingUpperBound: number | null;
   /** creator-less | open only - prefix reach with no ownership anchor at all. */
   unanchoredCount: number | null;
-  /** capped example file names for an anchored finding, for owner review. Empty otherwise. */
-  prefixOnlyFiles: { fileNames: string[]; truncated: boolean };
-  narrowingFiles: { fileNames: string[]; truncated: boolean };
+  /** capped example files for an anchored finding, for owner review. Empty otherwise. */
+  prefixOnlyFiles: ExampleFileListing;
+  narrowingFiles: ExampleFileListing;
 }
 
 /**
  * A lake needs owner sign-off. Anchored lakes escalate only on a nonzero widening OR
- * narrowing count; creator-less lakes escalate unconditionally - the fail-closed reason
- * itself (a dynamic lake with no creator) is a data-quality defect regardless of what its
- * unanchored count happens to be, so it belongs on the same escalation path rather than a
- * footnote. `no-prefix` and `open` never escalate: the first is genuinely zero, the second
- * is already retrievable today.
+ * narrowing count; creator-less and reserved-prefix lakes escalate unconditionally - the
+ * fail-closed reason itself is the defect (a dynamic lake with no creator; a lake whose
+ * whole prefix arm disappears across the fix) regardless of what its count happens to be,
+ * so both belong on the escalation path rather than in a footnote. `no-prefix` and `open`
+ * never escalate: the first moves nothing in either direction (see classifyDynamicLakeMode),
+ * the second is already retrievable today.
  */
 export function isFinding(lake: LakeReport): boolean {
   if (lake.mode === 'anchored') {
     return (lake.prefixOnlyDirect ?? 0) > 0 || (lake.narrowingUpperBound ?? 0) > 0;
   }
-  return lake.mode === 'creator-less';
+  return lake.mode === 'creator-less' || lake.mode === 'reserved-prefix';
 }
 
 const modeColumn = (lake: LakeReport): string => {
   switch (lake.mode) {
     case 'no-prefix':
       return '0 (no prefix arm)';
+    case 'reserved-prefix':
+      // NOT a member count: a `datalake:`-namespace regex matches every OTHER lake's
+      // membership meta-tag, so this figure is inflated by design. See renderLakeLines.
+      return `n/a (reserved prefix - whole arm dropped by the fix) - prefix over-match: ${lake.unanchoredCount ?? 0}`;
     case 'creator-less':
       return `n/a (fails closed) - unanchored: ${lake.unanchoredCount ?? 0}`;
     case 'open':
@@ -99,20 +133,27 @@ const modeColumn = (lake: LakeReport): string => {
 
 export function renderLakeLines(lake: LakeReport): string[] {
   const lines: string[] = [];
-  const header = `Lake "${lake.name}" (id=${lake.id}, mode=${lake.mode})`;
+  // fileTagPrefix is JSON-quoted, not bare: a value that only LOOKS fine (stray whitespace,
+  // a missing trailing ":") is what routes a lake to no-prefix, and bare printing hides it.
+  const prefix = lake.fileTagPrefix == null ? '(none)' : JSON.stringify(lake.fileTagPrefix);
+  const header = `Lake "${lake.name}" (id=${lake.id}, mode=${lake.mode}, fileTagPrefix=${prefix})`;
   lines.push(header);
   if (lake.total !== null) {
     lines.push(
       `  total=${lake.total} totalExcludingPending=${lake.totalExcludingPending} metaTagged=${lake.metaTagged}`
     );
   }
-  lines.push(`  prefix-only members: ${modeColumn(lake)}`);
+  lines.push(
+    `  prefix-only members: ${modeColumn(lake)}${lake.prefixOnlyFiles.truncated ? ' (truncated listing)' : ''}`
+  );
   if (lake.mode === 'anchored') {
     if (lake.reconcileMismatch) {
       lines.push(
         `  RECONCILE: total(${lake.total}) - metaTagged(${lake.metaTagged}) = ${
           (lake.total ?? 0) - (lake.metaTagged ?? 0)
-        } but the direct count is ${lake.prefixOnlyDirect} - the two queries disagree, do not trust this lake's numbers.`
+        } but the direct count is ${lake.prefixOnlyDirect} - the two queries disagree, do not trust ` +
+          "this lake's numbers. Re-run before acting: the three counts are unsynchronized, so a write " +
+          'landing mid-run produces this too. A real divergence reproduces; a concurrent write does not.'
       );
     }
     lines.push(
@@ -125,6 +166,19 @@ export function renderLakeLines(lake: LakeReport): string[] {
         'behaviour under the new predicate, not a defect - such a file genuinely is not a member of ' +
         'this lake once the prefix arm is anchored to the creator. It exists so an owner can review ' +
         'the population, not so anyone "fixes" it.'
+    );
+  }
+  if (lake.mode === 'reserved-prefix') {
+    lines.push(
+      '  ESCALATE: this lake\'s fileTagPrefix sits in the reserved "datalake:" namespace. Retrieval honours ' +
+        'that prefix TODAY and the fix drops it, so this lake loses its ENTIRE prefix arm - the one shape a ' +
+        'collapsed "0 (no prefix arm)" would have hidden. Only meta-tagged files stay reachable.'
+    );
+    lines.push(
+      '    The over-match figure above is NOT a member count and is inflated by design: a "datalake:" regex ' +
+        "matches every other lake's membership meta-tag. Treat it as reach, not as narrowing. Note the arm " +
+        'being dropped is also an ownership leak, so removing it is a fix - review what this lake loses, not ' +
+        'whether the drop is correct.'
     );
   }
   if (lake.mode === 'creator-less') {

--- a/packages/scripts/migrate/prefixOnlyMembersReport.ts
+++ b/packages/scripts/migrate/prefixOnlyMembersReport.ts
@@ -1,0 +1,161 @@
+import { isReservedTagPrefix, normalizeTagPrefix } from '@bike4mind/common';
+
+/**
+ * Pure classification/rendering for the pre-merge prefix-only-member census
+ * (check-datalake-prefix-only-members.ts). Kept free of I/O so the arm-mode
+ * classification, the reconcile check and the exit-code decision are unit-testable
+ * without a Mongo connection.
+ */
+
+export type ArmMode = 'anchored' | 'no-prefix' | 'creator-less' | 'open';
+
+/**
+ * The same three fail-closed conditions `buildDataLakeMembershipFilter`
+ * (`@bike4mind/database`) collapses to a bare meta-tag arm, kept separate here so the
+ * census can tell "genuinely no prefix arm" from "fails closed for a data-quality
+ * reason" - both would otherwise print as an indistinguishable `prefixOnly = 0`.
+ */
+export function classifyDynamicLakeMode(row: {
+  fileTagPrefix?: string | null;
+  createdByUserId?: string | null;
+}): 'anchored' | 'no-prefix' | 'creator-less' {
+  const prefix = normalizeTagPrefix(row.fileTagPrefix);
+  if (!prefix || isReservedTagPrefix(prefix)) return 'no-prefix';
+  // createdByUserId: '' is a real (if unusual) stored value, not the same as missing -
+  // both must fail closed, so test truthiness rather than `!= null`.
+  if (!row.createdByUserId) return 'creator-less';
+  return 'anchored';
+}
+
+export interface ReconcileResult {
+  expected: number;
+  actual: number;
+  matches: boolean;
+}
+
+/**
+ * `total` counts the union of the meta-tag arm and the (prefix AND creator) arm;
+ * `metaTagged` counts the meta-tag arm alone. By inclusion-exclusion,
+ * `total - metaTagged` must equal the count of files that satisfy the prefix arm but
+ * NOT the meta arm - exactly what `prefixOnlyDirect` counts directly. The two are
+ * expected to always agree; a mismatch means the two queries diverged (e.g. a regex
+ * escaping difference), not that the population genuinely differs.
+ */
+export function reconcilePrefixOnly(total: number, metaTagged: number, prefixOnlyDirect: number): ReconcileResult {
+  const expected = total - metaTagged;
+  return { expected, actual: prefixOnlyDirect, matches: expected === prefixOnlyDirect };
+}
+
+export interface LakeReport {
+  id: string;
+  name: string;
+  datalakeTag: string;
+  fileTagPrefix: string | null | undefined;
+  createdByUserId: string | null | undefined;
+  mode: ArmMode;
+  /** null where not computed (registry lakes have no DataLake document to count against). */
+  total: number | null;
+  totalExcludingPending: number | null;
+  metaTagged: number | null;
+  /** anchored only. */
+  prefixOnlyDirect: number | null;
+  reconcileMismatch: boolean;
+  /** anchored only - the narrowing UPPER BOUND (Step 7's fourth count). */
+  narrowingUpperBound: number | null;
+  /** creator-less | open only - prefix reach with no ownership anchor at all. */
+  unanchoredCount: number | null;
+  /** capped example file names for an anchored finding, for owner review. Empty otherwise. */
+  prefixOnlyFiles: { fileNames: string[]; truncated: boolean };
+  narrowingFiles: { fileNames: string[]; truncated: boolean };
+}
+
+/**
+ * A lake needs owner sign-off. Anchored lakes escalate only on a nonzero widening OR
+ * narrowing count; creator-less lakes escalate unconditionally - the fail-closed reason
+ * itself (a dynamic lake with no creator) is a data-quality defect regardless of what its
+ * unanchored count happens to be, so it belongs on the same escalation path rather than a
+ * footnote. `no-prefix` and `open` never escalate: the first is genuinely zero, the second
+ * is already retrievable today.
+ */
+export function isFinding(lake: LakeReport): boolean {
+  if (lake.mode === 'anchored') {
+    return (lake.prefixOnlyDirect ?? 0) > 0 || (lake.narrowingUpperBound ?? 0) > 0;
+  }
+  return lake.mode === 'creator-less';
+}
+
+const modeColumn = (lake: LakeReport): string => {
+  switch (lake.mode) {
+    case 'no-prefix':
+      return '0 (no prefix arm)';
+    case 'creator-less':
+      return `n/a (fails closed) - unanchored: ${lake.unanchoredCount ?? 0}`;
+    case 'open':
+      return `${lake.unanchoredCount ?? 0} (OPEN arm - already retrievable)`;
+    case 'anchored':
+      return `${lake.prefixOnlyDirect ?? 0}`;
+  }
+};
+
+export function renderLakeLines(lake: LakeReport): string[] {
+  const lines: string[] = [];
+  const header = `Lake "${lake.name}" (id=${lake.id}, mode=${lake.mode})`;
+  lines.push(header);
+  if (lake.total !== null) {
+    lines.push(
+      `  total=${lake.total} totalExcludingPending=${lake.totalExcludingPending} metaTagged=${lake.metaTagged}`
+    );
+  }
+  lines.push(`  prefix-only members: ${modeColumn(lake)}`);
+  if (lake.mode === 'anchored') {
+    if (lake.reconcileMismatch) {
+      lines.push(
+        `  RECONCILE: total(${lake.total}) - metaTagged(${lake.metaTagged}) = ${
+          (lake.total ?? 0) - (lake.metaTagged ?? 0)
+        } but the direct count is ${lake.prefixOnlyDirect} - the two queries disagree, do not trust this lake's numbers.`
+      );
+    }
+    lines.push(
+      `  narrowing upper bound (files this fix makes UNREACHABLE): ${lake.narrowingUpperBound}${
+        lake.narrowingFiles.truncated ? ' (truncated listing)' : ''
+      }`
+    );
+    lines.push(
+      '    This is an UPPER BOUND, not a per-caller reachability count. A nonzero value is CORRECT ' +
+        'behaviour under the new predicate, not a defect - such a file genuinely is not a member of ' +
+        'this lake once the prefix arm is anchored to the creator. It exists so an owner can review ' +
+        'the population, not so anyone "fixes" it.'
+    );
+  }
+  if (lake.mode === 'creator-less') {
+    lines.push('  ESCALATE: dynamic lake with no creator on record - legacy row or bad ingest, review before merge.');
+  }
+  return lines;
+}
+
+export interface CensusRenderResult {
+  lines: string[];
+  exitCode: 0 | 2;
+  findingsCount: number;
+  reconcileMismatchCount: number;
+}
+
+export function renderCensusReport(lakes: LakeReport[], stage: string): CensusRenderResult {
+  const lines: string[] = [`Prefix-only member census - stage="${stage}"`, `Scanned ${lakes.length} lake(s).`, ''];
+  for (const lake of lakes) {
+    lines.push(...renderLakeLines(lake), '');
+  }
+  const findings = lakes.filter(isFinding);
+  const reconcileMismatches = lakes.filter(l => l.reconcileMismatch);
+  lines.push(
+    findings.length === 0
+      ? 'No lake needs owner sign-off.'
+      : `${findings.length} lake(s) need owner sign-off before #2254 merges: ${findings.map(l => l.name).join(', ')}`
+  );
+  return {
+    lines,
+    exitCode: findings.length === 0 ? 0 : 2,
+    findingsCount: findings.length,
+    reconcileMismatchCount: reconcileMismatches.length,
+  };
+}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -20,6 +20,7 @@
     "datalake:check-slug-dupes": "tsx migrate/check-datalake-slug-dupes.ts",
     "datalake:check-prefix-overlaps": "tsx migrate/check-datalake-prefix-overlaps.ts",
     "datalake:check-prefix-dupes": "tsx migrate/check-datalake-prefix-dupes.ts",
+    "datalake:check-prefix-only-members": "tsx migrate/check-datalake-prefix-only-members.ts",
     "datalake:ingest-pdfs": "tsx datalake/ingest-pdf-datalake.ts",
     "db:create-user": "tsx createUser.ts",
     "db:list-users": "tsx listUsers.ts",

--- a/packages/scripts/src/checkDatalakeCensusReadOnly.test.ts
+++ b/packages/scripts/src/checkDatalakeCensusReadOnly.test.ts
@@ -10,21 +10,46 @@ import path from 'node:path';
  * mutates a lake or a file while an owner is only expecting a report.
  */
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const SCRIPT_PATH = 'packages/scripts/migrate/check-datalake-prefix-only-members.ts';
+const ENTRY_PATH = 'packages/scripts/migrate/check-datalake-prefix-only-members.ts';
+// The census executes BOTH files. Guarding only the entry point would leave a write added to the
+// report module outside the control entirely.
+const SCRIPT_PATHS = [ENTRY_PATH, 'packages/scripts/migrate/prefixOnlyMembersReport.ts'];
 
+// `findByIdAnd*`, `insertOne` (a real Model method since Mongoose 8.9) and `bulkSave` are spelled
+// out rather than folded into the `findOneAnd*` / `insert` alternatives: none of them share a
+// prefix with one, so a looser pattern would still have missed them.
 const WRITE_METHOD_PATTERN =
-  /\.(updateOne|updateMany|deleteOne|deleteMany|findOneAndUpdate|findOneAndDelete|findOneAndReplace|insertMany|bulkWrite|replaceOne|save|create)\s*\(/;
+  /\.(updateOne|updateMany|deleteOne|deleteMany|findOneAndUpdate|findOneAndDelete|findOneAndReplace|findByIdAndUpdate|findByIdAndDelete|findByIdAndRemove|insertOne|insertMany|bulkWrite|bulkSave|replaceOne|remove|save|create)\s*\(/;
+// An aggregation stage is the most plausible way a counting script grows a write path, and it
+// looks nothing like a write method.
+const AGGREGATE_WRITE_PATTERN = /\$out\b|\$merge\b/;
 
 describe('the prefix-only-member census stays read-only', () => {
-  const source = readFileSync(path.join(REPO_ROOT, SCRIPT_PATH), 'utf8');
+  const sources = new Map(SCRIPT_PATHS.map(p => [p, readFileSync(path.join(REPO_ROOT, p), 'utf8')]));
 
-  it('calls no Mongoose write method', () => {
-    expect(WRITE_METHOD_PATTERN.test(source)).toBe(false);
+  it.each(SCRIPT_PATHS)('calls no Mongoose write method: %s', p => {
+    expect(WRITE_METHOD_PATTERN.test(sources.get(p)!)).toBe(false);
+  });
+
+  it.each(SCRIPT_PATHS)('has no write-stage aggregation: %s', p => {
+    expect(AGGREGATE_WRITE_PATTERN.test(sources.get(p)!)).toBe(false);
   });
 
   it('imports only raw models, never a repository', () => {
+    const source = sources.get(ENTRY_PATH)!;
     expect(source).not.toMatch(/fabFileRepository|dataLakeRepository/);
     expect(source).toMatch(/import\s*\{[^}]*\bFabFile\b[^}]*\}\s*from\s*'@bike4mind\/database'/);
     expect(source).toMatch(/import\s*\{[^}]*\bDataLakeModel\b[^}]*\}\s*from\s*'@bike4mind\/database'/);
+  });
+
+  // The census DOES write one file - the JSON artifact - and that is disclosed in its docblock.
+  // What must never come back is resolving it against process.cwd(): under the documented
+  // `pnpm --filter scripts` invocation that is packages/scripts, inside this public repo's working
+  // tree, where the artifact's cross-tenant identity data is one `git add -A` from permanent.
+  it('never resolves the artifact against the working directory', () => {
+    const source = sources.get(ENTRY_PATH)!;
+    expect(source).not.toMatch(/process\.cwd\(\)/);
+    expect(source).toMatch(/os\.tmpdir\(\)/);
+    expect(source).toMatch(/mode:\s*0o600/);
   });
 });

--- a/packages/scripts/src/checkDatalakeCensusReadOnly.test.ts
+++ b/packages/scripts/src/checkDatalakeCensusReadOnly.test.ts
@@ -20,6 +20,10 @@ const SCRIPT_PATHS = [ENTRY_PATH, 'packages/scripts/migrate/prefixOnlyMembersRep
 // prefix with one, so a looser pattern would still have missed them.
 const WRITE_METHOD_PATTERN =
   /\.(updateOne|updateMany|deleteOne|deleteMany|findOneAndUpdate|findOneAndDelete|findOneAndReplace|findByIdAndUpdate|findByIdAndDelete|findByIdAndRemove|insertOne|insertMany|bulkWrite|bulkSave|replaceOne|remove|save|create)\s*\(/;
+// Collection/DDL verbs, separate from the document-write list above. Generic hardening: a Mongoose
+// model has always exposed `.collection` (native Collection) and `.db` (Connection), so this reach
+// is not new - the document-write list simply never named the destructive collection-level verbs.
+const DDL_METHOD_PATTERN = /\.(drop|dropDatabase|dropIndexes?|createCollection|createIndexe?s?|syncIndexes)\s*\(/;
 // An aggregation stage is the most plausible way a counting script grows a write path, and it
 // looks nothing like a write method.
 const AGGREGATE_WRITE_PATTERN = /\$out\b|\$merge\b/;
@@ -35,6 +39,10 @@ describe('the prefix-only-member census stays read-only', () => {
     expect(AGGREGATE_WRITE_PATTERN.test(sources.get(p)!)).toBe(false);
   });
 
+  it.each(SCRIPT_PATHS)('calls no collection-level DDL verb: %s', p => {
+    expect(DDL_METHOD_PATTERN.test(sources.get(p)!)).toBe(false);
+  });
+
   it('imports only raw models, never a repository', () => {
     const source = sources.get(ENTRY_PATH)!;
     expect(source).not.toMatch(/fabFileRepository|dataLakeRepository/);
@@ -43,13 +51,31 @@ describe('the prefix-only-member census stays read-only', () => {
   });
 
   // The census DOES write one file - the JSON artifact - and that is disclosed in its docblock.
-  // What must never come back is resolving it against process.cwd(): under the documented
-  // `pnpm --filter scripts` invocation that is packages/scripts, inside this public repo's working
-  // tree, where the artifact's cross-tenant identity data is one `git add -A` from permanent.
-  it('never resolves the artifact against the working directory', () => {
-    const source = sources.get(ENTRY_PATH)!;
-    expect(source).not.toMatch(/process\.cwd\(\)/);
-    expect(source).toMatch(/os\.tmpdir\(\)/);
-    expect(source).toMatch(/mode:\s*0o600/);
+  // What must never come back is resolving it against the working directory: under the documented
+  // `pnpm --filter scripts` invocation that is packages/scripts, inside this public repo's tree,
+  // where the artifact's cross-tenant identity data is one `git add -A` from permanent.
+  //
+  // Comments are stripped before these run. A comment explaining why the working directory is
+  // avoided would otherwise trip the negative grep - which already happened once during review.
+  const stripComments = (src: string): string => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+  it('resolves the artifact outside the repo tree', () => {
+    const code = stripComments(sources.get(ENTRY_PATH)!);
+    // Every spelling that lands in the repo tree, not just one. `resolve('.'` and the module-dir
+    // global are as repo-local as the working directory and were previously unguarded.
+    expect(code).not.toMatch(/process\.cwd\(\)|__dirname|resolve\(\s*['"`]\.\.?['"`]/);
+    expect(code).toMatch(/const\s+outDir\s*=[^;]*os\.tmpdir\(\)/);
+  });
+
+  // Tied to the CALL, not grepped file-wide: with whole-file `toMatch`, a SECOND unprotected
+  // writeFileSync elsewhere kept every assertion green (verified by mutation during review),
+  // because the first write still supplied both literals.
+  it('gives every file write owner-only permissions', () => {
+    const code = stripComments(sources.get(ENTRY_PATH)!);
+    const calls = [...code.matchAll(/writeFileSync\s*\(/g)];
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(code.slice(call.index, call.index + 600)).toMatch(/mode:\s*0o600/);
+    }
   });
 });

--- a/packages/scripts/src/checkDatalakeCensusReadOnly.test.ts
+++ b/packages/scripts/src/checkDatalakeCensusReadOnly.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * Guards the read-only contract of the pre-merge prefix-only-member census: it audits data lake
+ * membership across every tenant and MUST never be able to write. Mirrors the source-level guard
+ * in checkNoRawS3Client.test.ts - a mechanical check the census cannot regress into a script that
+ * mutates a lake or a file while an owner is only expecting a report.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const SCRIPT_PATH = 'packages/scripts/migrate/check-datalake-prefix-only-members.ts';
+
+const WRITE_METHOD_PATTERN =
+  /\.(updateOne|updateMany|deleteOne|deleteMany|findOneAndUpdate|findOneAndDelete|findOneAndReplace|insertMany|bulkWrite|replaceOne|save|create)\s*\(/;
+
+describe('the prefix-only-member census stays read-only', () => {
+  const source = readFileSync(path.join(REPO_ROOT, SCRIPT_PATH), 'utf8');
+
+  it('calls no Mongoose write method', () => {
+    expect(WRITE_METHOD_PATTERN.test(source)).toBe(false);
+  });
+
+  it('imports only raw models, never a repository', () => {
+    expect(source).not.toMatch(/fabFileRepository|dataLakeRepository/);
+    expect(source).toMatch(/import\s*\{[^}]*\bFabFile\b[^}]*\}\s*from\s*'@bike4mind\/database'/);
+    expect(source).toMatch(/import\s*\{[^}]*\bDataLakeModel\b[^}]*\}\s*from\s*'@bike4mind\/database'/);
+  });
+});


### PR DESCRIPTION
## Description

Adds a read-only pre-merge census script that sizes the population affected by the lake-membership
retrieval-parity fix, per lake, in **both** directions.

**Update: the census has now been RUN against production, and this PR carries the fixes that run
exposed.** Results and per-lake sign-off live in the plan doc, not here. What matters for review:
13 lakes scanned, **0 RECONCILE mismatches** - the instrument's own cross-check held on every
anchored lake against real data, which is the validity property the whole design rests on. Two lakes
were flagged for sign-off and both have been cleared on the file-level evidence.

The stage list question is also answered: **production is the only viable target.** Stage `dev`'s
database is an empty 154-collection shell (0 lakes, 0 files), so a census there scans nothing and
exits 0 - a vacuous clean indistinguishable from a real one.

**Read the dependency direction carefully: it runs the other way from the usual.** This is the
safety gate for the retrieval-parity fix (#2254), not a follow-up to it. The census has to measure
the **pre-change** world, so it merges and runs **before** that PR. #2254 is deliberately on hold
waiting on this.

A data lake decides who its files are twice, against two different people.
`buildDataLakeMembershipFilter` is `metaTag OR (fileTagPrefix AND lake.creatorUserId)`, but retrieval
only ever sees a *caller*-anchored prefix arm and never the creator-anchored one. So a creator-owned
file carrying a lake's prefix but no `datalake:` meta-tag is listed, counted and graded healthy by
membership while being unreachable by retrieval for everyone but the creator. Before changing that
predicate we need to know how many files move, per lake, in each direction.

## Changes

- **`packages/scripts/migrate/check-datalake-prefix-only-members.ts`** - the I/O shell, following the
  established read-only audit family (`check-datalake-prefix-overlaps.ts` as template:
  `Config.MONGODB_URI` + `Resource.App.stage`, `connectDB`, bare `console.log`, docblock ending in
  the literal invocation line). Raw models only, never a repository object, so "this cannot write" is
  mechanically obvious. Bounded: counts never materialise documents, one lake per query (no
  cross-lake `$or`), `p-limit` on the lake loop, and a `+1` truncation probe on the per-lake example
  listing.
- **`packages/scripts/migrate/prefixOnlyMembersReport.ts`** + `.test.ts` - the pure
  classification/rendering half split out with its own unit tests, mirroring the existing
  `ingestPlan.ts` / `ingestPlan.test.ts` idiom.
- **`packages/scripts/src/checkDatalakeCensusReadOnly.test.ts`** - source-level guard test in the
  repo's established `checkNoRawS3Client.test.ts` idiom, asserting the script contains no write path.
- **`packages/scripts/package.json`** - wires `datalake:check-prefix-only-members`.

### Four counts, not two

All use the live conjunct `{deletedAt: null, archivedAt: null}` so `total` reproduces what
`GET /api/data-lakes/{id}/articles` reports, plus the `status: {$ne: 'pending'}` variant that
`computeDataLakeStats` counts - without both, the issue's own worked example does not reconcile and a
reader cannot tell which surface a number came from.

Three size the **widening** (what the fix makes newly reachable): `total`, meta-tagged, and the
prefix-only population computed *directly* (prefix regex AND creator AND not this lake's meta-tag),
cross-checked against `total - metaTagged`. On disagreement it prints a loud `RECONCILE` line and
exits `1` rather than silently picking a number.

### The artifact does not land in the repo

The JSON artifact resolves against `os.tmpdir()` with `mode: 0600`, never the working directory -
under the documented `pnpm --filter scripts` invocation that would be `packages/scripts`, inside
this public repo's tree, where nothing in the commit chain would stop `git add -A` from making
cross-tenant identity data permanent (not gitignored, `lint-staged` globs only `*.{js,ts,tsx}`, and
gitleaks has `generic-api-key` disabled so file names are invisible to it). An unanchored
`.gitignore` pattern is the belt for the `DATALAKE_CENSUS_OUT_DIR` override, and
`checkDatalakeCensusReadOnly.test.ts` fails the build if the `cwd` resolution regresses.

The example listing projects `userId` alongside `fileName`, because the docblock's own mitigation
("split it per owner") is otherwise unperformable on the half that needs it: the narrowing set is by
definition not the creator's, so file names alone leave the cross-tenant half with no owner to split
on. The warning names the identity-bearing fields rather than only file names.

The fourth sizes the **narrowing** (what the fix makes newly *un*reachable): prefix regex AND NOT
creator AND NOT this lake's meta-tag, in `anchored` arm mode only. This one is the reason the gate
exists - without it a lake owner would sign off on a report showing only what their lake gains and
never what it loses. It is labelled an **UPPER BOUND** in the output (the census cannot see per-caller
reachability), it feeds exit `2` rather than an informational column, and the output states in words
that **a nonzero value is correct behaviour under the new predicate, not a defect to fix** - without
that sentence the first owner to see a nonzero files a bug against a working change.

### The false-zero trap

`buildDataLakeMembershipFilter` fails closed to the meta arm on three separate conditions (no prefix,
reserved prefix, no creator), all of which would collapse to a bare `prefixOnly = 0` and only one of
which is a true zero. Every lake is classified into an explicit arm mode first - `anchored` /
`no-prefix` / `reserved-prefix` / `creator-less` / `open`.

**`reserved-prefix` is its own mode, and that is the single most important thing in this PR.**
Folding it into `no-prefix` (as the first draft and the plan's own spec did) produces exactly the
false zero the census exists to catch: retrieval honours a `datalake:`-namespace prefix **today**
(neither `getDynamicDataLakeTags.ts` nor `fabFileSearchQuery.ts` calls `isReservedTagPrefix`) and
the parity fix drops it, so such a lake loses its **entire** prefix arm while the report says
nothing moves. It now escalates unconditionally. `no-prefix` stays non-escalating and that is
correct: an unusable prefix is dropped by retrieval today AND after, so nothing moves for it.

`creator-less`, `reserved-prefix` and `open` get a second **un-anchored** count under a distinct
header so nobody misreads it as a membership count. For `reserved-prefix` that figure is labelled
**over-match**, never narrowing: a `datalake:` regex matches every other lake's membership meta-tag,
so it is inflated by construction and is not a member count. `createdByUserId: ''` is a real reachable
value and `''` is falsy, so the classifier tests truthiness rather than `!= null`. Registry-vs-dynamic
is decided by **provenance** (a DB row shadowing a registry id stays dynamic), matching
`getDynamicDataLakeTags.ts`.

Exit codes are separated so CI can tell "found things" from "crashed": `0` clean, `2` findings needing
owner sign-off (not an error), `1` the census itself failed. A `1` must never be merged on - an unrun
census is indistinguishable from a clean one.

**A RECONCILE mismatch outranks the findings verdict.** `renderCensusReport` emits the exit code,
and a mismatch makes it `1` regardless of what `isFinding` says, replacing the summary line rather
than sitting beside it. Without that, a lake could disagree with itself while no lake escalated -
exit `0`, summary `No lake needs owner sign-off.` - on a run the script then aborts as untrustworthy.
Both signals named authoritative below were wrong at once in that case. It needs no query bug to
reach: `total`/`metaTagged` are counted in one `Promise.all` and the direct count in a later one, so
a concurrent delete/archive/meta-tag produces it. The `CENSUS RESULT` line is now printed BEFORE the
throw and is a pure, unit-tested function, and `reconcileMismatchCount` is serialized into the
artifact.

**But do not read `$?`, and this is measured rather than assumed.** `sst shell` collapses every
non-zero child code to `1` (`0` survives), and `pnpm --filter` does the same one layer earlier - so
through the documented invocation a findings run (`2`) and a crashed run (`1`) are indistinguishable,
the exact confusion the separate codes exist to prevent. Verified with
`sst shell -- node -e 'process.exitCode=2'` returning `1`. The authoritative signal is therefore the
`exitCode` field in the JSON artifact and the `CENSUS RESULT` line printed last on stdout, both of
which this PR adds. This is a property of the invocation, not of the script, and it applies to any
future audit script in this repo that relies on distinct exit codes.

## What this PR does not cover

- **It does not run the census.** That is the actual gate, and it needs the stage list (unanswered)
  plus per-lake owner sign-off.
- No runtime code, no API, no UI. `packages/scripts/` only.
- Issue #2243 stays OPEN when this merges - a further step (aggregate lake browse) remains after
  this and after #2254, so the closing reference belongs on whichever of the three PRs lands last.

## Guide for Testers

Backend/tooling-only. There is no UI surface and nothing to click.

**What NOT to test:** any app surface. This adds a manually-invoked script; nothing in it runs in a
request path, on a schedule, or at deploy.

The script reads a live database and is intended to be run by an operator against a chosen stage as a
deliberate pre-merge step - not as part of reviewing this PR. For a reviewer, the meaningful
verification is source-level:

1. Confirm the script contains no write path. The guard test at `packages/scripts/src/checkDatalakeCensusReadOnly.test.ts` asserts this in CI, now across **both** files the census executes (a write added to the pure report module was previously outside the control), and now covering `findByIdAndUpdate` / `findByIdAndDelete` / `insertOne` (a real `Model` method since Mongoose 8.9; this repo pins `^8.24.1`) / `bulkSave` / `remove`, plus `$out` / `$merge` aggregation stages - the most plausible way a counting script grows a write path.
2. Confirm no repository object is imported - only raw models (`DataLakeModel`, `FabFile`) and the shared filter builder.
3. Confirm no customer, partner, organization or cloud identifier appears in the source; every identifier is read at runtime.
4. Read the docblock's stated JSON artifact caveat: the artifact contains cross-tenant file names and must be split per owner before any of it leaves the operator.

When an operator does run it, the invocation is the literal line in the docblock:
`./for-env <env> pnpm sst shell --stage <stage> -- pnpm --filter scripts datalake:check-prefix-only-members`

## Additional Information

Branched from `origin/main` @ `f19181619`.

**Test-suite disclosure.** `pnpm --filter scripts test` is red in this local checkout, and it is red
without this change too. I established that empirically rather than assuming it, since this PR does
touch `packages/scripts`:

- On this branch: **9** failing files. Eight are `migrate/migrations/*` real-Mongo tests, all
  `Test timed out in 30000ms` / `Hook timed out in 30000ms`. The ninth is
  `src/checkNoRawS3Client.test.ts`, failing **entirely** on `packages/premium/tavern/**` paths - a
  nested overlay checkout that is not tracked in this repo and is therefore invisible to public CI.
  (The original disclosure said 8; re-measured on this branch, it is 9. This branch touches no file
  under `packages/premium/`.)
- On a clean tree with this change removed: 6 failing files on one run and **8 on a second run** - the
  same 8 files, a superset of the branch's set. The failing set is nondeterministic real-Mongo
  timeout flake and this branch touches none of those files.
- This PR's own new tests pass outright: 22/22, matching the exact test-count delta between the two
  runs (470 -> 492).

`pnpm turbo:typecheck` (40/40), `pnpm lint:check`, and both ASCII guards
(`check-no-smart-punctuation.sh`, `check-no-control-bytes.sh`) are clean. A full `pnpm turbo test`
also shows failures in `apps/client` and `packages/database`; both are real-Mongo/`MongoMemoryServer`
timeout-shaped and neither package has a single file changed by this branch. **CI is the arbiter** on
all of the above.

Plan: `2243-membership-retrieval-parity` (Step 7 - the pre-merge census script).

Refs #2243


