### PR TITLE
chore(nix): add git to the dev shell, which macOS needs to avoid a fork loop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,18 +18,23 @@
             packages = [
               pkgs.nodejs_24
               pkgs.pnpm_10
-              # Required on macOS, not a convenience -- omitting it is a fork bomb.
+              # Required on macOS, not a convenience: without it, `git` in this shell is a
+              # fork bomb.
               #
-              # With no git in this shell, `git` falls through to macOS's /usr/bin/git shim. That
-              # shim finds its real binary via DEVELOPER_DIR, NOT via PATH -- and this shell's own
-              # darwin stdenv sets DEVELOPER_DIR to a nix apple-sdk whose `xcrun` is xcbuild's
-              # reimplementation. xcbuild's xcrun does not do developer-dir tool resolution; it
-              # falls back to PATH, finds /usr/bin/git, and the two call each other with no base
-              # case. Any `git` invocation then forks until the machine is unusable (observed:
-              # 5,000+ processes, terminal emulator pegged, shell startup ~60x slower).
+              # /usr/bin/git is not git. It is one of 78 hard links to a single
+              # com.apple.dt.xcode_select.tool-shim binary, which resolves the real tool through
+              # libxcselect.dylib (see `otool -L /usr/bin/git`). That library ships only inside the
+              # dyld shared cache, so how it reacts to this shell's DEVELOPER_DIR -- pointed at a
+              # nix apple-sdk by the darwin stdenv -- cannot be audited from here, only observed:
+              # every `git` call forks without bound. 5,000+ processes, terminal emulator pegged,
+              # shell startup ~60x slower. Do not reproduce it to check.
               #
-              # Providing git here puts a real git ahead of the shim on PATH, so the shim is never
-              # reached. Do not remove without also clearing DEVELOPER_DIR/SDKROOT in a shellHook.
+              # A real git ahead of the shim on PATH means the shim is never reached. Keep it here.
+              #
+              # This closes one hole, not the class: 48 of those 78 shim names still resolve to
+              # /usr/bin inside this shell (gcc, gnumake, m4, libtool, swift, lldb, yacc). The
+              # names a Node build actually reaches -- cc, clang, make, ld, ar, nm, strip -- come
+              # from stdenv, which is why git is the one that has bitten.
               pkgs.git
               pkgs.mongosh
               pkgs.ollama

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,19 @@
             packages = [
               pkgs.nodejs_24
               pkgs.pnpm_10
+              # Required on macOS, not a convenience -- omitting it is a fork bomb.
+              #
+              # With no git in this shell, `git` falls through to macOS's /usr/bin/git shim. That
+              # shim finds its real binary via DEVELOPER_DIR, NOT via PATH -- and this shell's own
+              # darwin stdenv sets DEVELOPER_DIR to a nix apple-sdk whose `xcrun` is xcbuild's
+              # reimplementation. xcbuild's xcrun does not do developer-dir tool resolution; it
+              # falls back to PATH, finds /usr/bin/git, and the two call each other with no base
+              # case. Any `git` invocation then forks until the machine is unusable (observed:
+              # 5,000+ processes, terminal emulator pegged, shell startup ~60x slower).
+              #
+              # Providing git here puts a real git ahead of the shim on PATH, so the shim is never
+              # reached. Do not remove without also clearing DEVELOPER_DIR/SDKROOT in a shellHook.
+              pkgs.git
               pkgs.mongosh
               pkgs.ollama
               pkgs.stripe-cli


### PR DESCRIPTION
## Description

The nix dev shell ships no `git`. On macOS that is not a missing convenience — it makes **any `git` invocation inside the shell fork without bound.**

The loop:

1. With no git in the shell, `git` falls through to macOS's `/usr/bin/git` shim.
2. That shim locates its real binary via **`DEVELOPER_DIR`, not `PATH`** — and this shell's own darwin stdenv sets `DEVELOPER_DIR` to a nix `apple-sdk`, whose `xcrun` is **xcbuild's** reimplementation rather than Apple's.
3. xcbuild's `xcrun` doesn't implement developer-dir tool resolution. It falls back to `PATH`, finds `/usr/bin/git`, and runs it.
4. → back to step 1. Neither side has a base case.

Observed on an `aarch64-darwin` machine: **5,000+ processes**, the terminal emulator pegged at 192% CPU walking the child-process tree, and interactive shell startup ~60x slower (2.7s vs 0.04s). Recovery required killing the swarm faster than it could respawn — each victim has already forked its replacement and reparents to `launchd`.

The trigger was ordinary: a test run invoking a script that shells out to `git`.

Anyone on macOS with nix who runs `direnv allow` here hits this. It hasn't bitten more people only because the committed `.envrc` sits unapproved by default.

## Changes

- Add `pkgs.git` to the dev shell's `packages`, with a comment explaining why it is load-bearing and what to do if someone wants to remove it.

Providing git puts a real git ahead of the shim on `PATH`, so the shim is never reached. `DEVELOPER_DIR` stays set — that's stdenv's business — but nothing consults it anymore for `git`.

Linux is unaffected (no `/usr/bin/git` shim, no `DEVELOPER_DIR`), but the package is unconditional so every platform gets a pinned git rather than whatever the host happens to have.

## Guide for Testers

Requires macOS with nix installed.

1. Check out this branch.
2. Run `nix develop` in the repo root. Expected: the shell builds and you get a prompt.
3. Run `command -v git`. Expected: a path under `/nix/store/…-git-<version>/bin/git` — **not** `/usr/bin/git`.
4. Run `git --version`. Expected: prints a version and returns immediately.
5. Run `git ls-files -z -- '*.ts' | head -c 100`. Expected: returns immediately.
6. In another terminal, run `pgrep -f 'apple-sdk.*xcrun' | wc -l` during steps 4–5. Expected: **0**. Before this change that number climbs into the thousands within seconds.

To see the old behaviour, do step 3 on `main`: `git` resolves to `/usr/bin/git`. Do **not** then run `git` — that is the fork bomb.

## Verification already done

Built the patched dev shell and ran the above:

```
DEVELOPER_DIR=/nix/store/49rnbvkp…-apple-sdk-14.4    (still set, as expected)
git   -> /nix/store/rfbzyqcy…-git-2.53.0/bin/git      (nix git wins)
xcrun -> /nix/store/4wy2b9di…-xcbuild-…-xcrun/bin/xcrun
git version 2.53.0                                    (returned normally)
git ls-files -z -- '*.ts'                             (returned normally)
```

No process growth; `xcrun` count stayed at baseline throughout.