### PR TITLE
fix(chat): keep a failed quest's own error reply instead of clobbering it

### DIFF
--- a/apps/client/server/chatCompletion/internal/route.ts
+++ b/apps/client/server/chatCompletion/internal/route.ts
@@ -19,6 +19,13 @@ import { processQuest } from '@server/queueHandlers/questProcessor';
  */
 
 /**
+ * Last-resort reply for a quest whose processing threw before anything specific was persisted.
+ * Only ever written when `settleIfUnfinished` finds the quest still unfinished - see the catch in
+ * `registerInternalRoutes`.
+ */
+export const GENERIC_PROCESSING_FAILURE_REPLY = 'Something went wrong while processing your request. Please try again.';
+
+/**
  * Shared-secret bearer check. Both the frontend Lambda and this service link
  * CHAT_COMPLETION_INTERNAL_SECRET (a dedicated internal-dispatch secret, NOT the AES
  * SECRET_ENCRYPTION_KEY), so the caller proves it's the frontend (not arbitrary internet
@@ -78,13 +85,21 @@ export function registerInternalRoutes(app: Express, track: (p: Promise<void>) =
 
     const task = processQuest(params, logger).catch(async err => {
       logger.error('Quest processing failed', { error: err instanceof Error ? err.message : String(err) });
-      // Surface the failure to the client instead of leaving the quest 'running' forever.
+      // Surface the failure to the client instead of leaving the quest 'running' forever - but only
+      // when nothing terminal was written yet. ChatCompletionProcess persists the provider's own
+      // message (`quest.reply = err.message`) and marks the quest terminal before it rethrows, so an
+      // unconditional write here replaces a specific, actionable diagnostic with this generic one.
       try {
-        await questRepository.update({
-          id: params.questId,
+        const settled = await questRepository.settleIfUnfinished(params.questId, {
           status: 'stopped',
-          replies: ['Something went wrong while processing your request. Please try again.'],
+          type: 'error',
+          reply: GENERIC_PROCESSING_FAILURE_REPLY,
         });
+        if (!settled) {
+          logger.info('Quest already settled by the processor; kept its own error reply', {
+            questId: params.questId,
+          });
+        }
       } catch (updateErr) {
         logger.error('Failed to mark quest stopped after processing error', {
           error: updateErr instanceof Error ? updateErr.message : String(updateErr),

--- a/apps/client/server/chatCompletion/server.test.ts
+++ b/apps/client/server/chatCompletion/server.test.ts
@@ -21,14 +21,15 @@ vi.mock('@server/websocket/utils', () => ({ sendToConnection: mockSendToConnecti
 const mockProcessQuest = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock('@server/queueHandlers/questProcessor', () => ({ processQuest: mockProcessQuest }));
 
-// questRepository.update - used in the error path; connectDB/mongoose unused by /process.
-// The remaining repos are pulled in by the completions route (executeCompletion + credit
-// attribution); stubbed so importing the route doesn't drag in real DB models.
-const mockQuestUpdate = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+// questRepository.settleIfUnfinished - the error path's status-guarded terminal write.
+// connectDB/mongoose unused by /process. The remaining repos are pulled in by the completions
+// route (executeCompletion + credit attribution); stubbed so importing the route doesn't drag
+// in real DB models.
+const mockQuestSettleIfUnfinished = vi.hoisted(() => vi.fn().mockResolvedValue(true));
 vi.mock('@bike4mind/database', () => ({
   connectDB: vi.fn().mockResolvedValue(undefined),
   mongoose: { connection: { readyState: 1 } },
-  questRepository: { update: mockQuestUpdate },
+  questRepository: { settleIfUnfinished: mockQuestSettleIfUnfinished },
   userApiKeyRepository: { findById: vi.fn().mockResolvedValue({ id: 'key1', name: 'Test Key' }) },
   adminSettingsRepository: {},
   apiKeyRepository: {},
@@ -87,6 +88,7 @@ vi.mock('@bike4mind/utils', () => ({ registerProcessErrorHandlers: vi.fn() }));
 vi.mock('@server/utils/config', () => ({ Config: { MONGODB_URI: 'mongodb://x/%STAGE%', STAGE: 'test' } }));
 
 import { createApp } from './server';
+import { GENERIC_PROCESSING_FAILURE_REPLY } from './internal/route';
 
 const VALID_BODY = { questId: 'q1', sessionId: 's1', userId: 'u1', message: 'hello' };
 const AUTH = `Bearer ${mockResource.CHAT_COMPLETION_INTERNAL_SECRET.value}`;
@@ -146,6 +148,49 @@ describe('ChatCompletion /process', () => {
     expect(json).toMatchObject({ accepted: true, questId: 'q1' });
     expect(mockProcessQuest).toHaveBeenCalledTimes(1);
     expect(mockProcessQuest.mock.calls[0][0]).toMatchObject(VALID_BODY);
+  });
+
+  it('does not touch the quest when processing succeeds', async () => {
+    mockProcessQuest.mockResolvedValueOnce(undefined);
+    await post(VALID_BODY, { authorization: AUTH });
+    await vi.waitFor(() => expect(mockProcessQuest).toHaveBeenCalledTimes(1));
+    expect(mockQuestSettleIfUnfinished).not.toHaveBeenCalled();
+  });
+
+  // The generic reply must never be written unconditionally: ChatCompletionProcess persists the
+  // provider's own message and marks the quest terminal before rethrowing, so an unguarded write
+  // would replace a specific diagnostic with a useless one. The status predicate lives in
+  // settleIfUnfinished, so the contract this route owns is that it routes through it.
+  it('settles a failed quest through the status-guarded write, not an unconditional update', async () => {
+    mockProcessQuest.mockRejectedValueOnce(new Error('boom'));
+    await post(VALID_BODY, { authorization: AUTH });
+
+    await vi.waitFor(() => expect(mockQuestSettleIfUnfinished).toHaveBeenCalledTimes(1));
+    expect(mockQuestSettleIfUnfinished).toHaveBeenCalledWith('q1', {
+      status: 'stopped',
+      type: 'error',
+      reply: GENERIC_PROCESSING_FAILURE_REPLY,
+    });
+  });
+
+  it('leaves the processor-persisted reply alone when the quest is already settled', async () => {
+    mockProcessQuest.mockRejectedValueOnce(new Error('A maximum of 4 blocks with cache_control may be provided.'));
+    mockQuestSettleIfUnfinished.mockResolvedValueOnce(false);
+
+    await post(VALID_BODY, { authorization: AUTH });
+
+    await vi.waitFor(() => expect(mockQuestSettleIfUnfinished).toHaveBeenCalledTimes(1));
+    // No second, unguarded write once the guarded one reports it did not match.
+    expect(mockQuestSettleIfUnfinished).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a write failure while settling a failed quest', async () => {
+    mockProcessQuest.mockRejectedValueOnce(new Error('boom'));
+    mockQuestSettleIfUnfinished.mockRejectedValueOnce(new Error('mongo down'));
+
+    const res = await post(VALID_BODY, { authorization: AUTH });
+    expect(res.status).toBe(202);
+    await vi.waitFor(() => expect(mockQuestSettleIfUnfinished).toHaveBeenCalledTimes(1));
   });
 });
 


### PR DESCRIPTION
## Description

A quest whose processing threw could show the user a generic error even when the backend had already recorded a specific, actionable one.

`ChatCompletionProcess.process` persists the underlying message (`quest.reply = err.message`) and marks the quest terminal, then rethrows for anything it does not classify (`b4m-core/services/src/llm/ChatCompletionProcess.ts:5299`, `:5311`, `:5363`). The `/process` catch in the ChatCompletion service caught that rethrow and did an `_id`-only `questRepository.update`, overwriting `replies` with:

> Something went wrong while processing your request. Please try again.

`reply` and `replies` are separate fields (`packages/database/src/models/content/QuestModel.ts:392-393`), and the client prefers `replies` when it is non-empty (`apps/client/app/utils/replyUtils.ts:4-8`). So the real message survived on `reply` while the user was shown the generic one -- and diagnosing an incident meant reading the raw Mongo document rather than the reply the product already had.

Observed shape on a real failing turn: `reply` held a provider 400 (the Anthropic `cache_control` block ceiling, capped by #2135), `replies[0]` held the generic string.

This is not a one-off. On staging, **204 of 204 quests showing the generic string were masking a specific reply underneath -- a 100% masking rate**, across 10 distinct underlying errors:

| count | masked message |
|------:|----------------|
| 172 | `OpenAI rejected the embedding request (401 Unauthorized): the OPENAI_API_KEY is invalid or expired` |
| 11 | `A maximum of 4 blocks with cache_control may be provided. Found 5.` |
| 6 | `The text contains a special token that is not allowed: <\|endoftext\|>` |
| 5 | `404 not_found_error: model: claude-opus-4-...` |
| 10 | six others (stream ended without a terminal event, `terminated`, Gemini 404, safety-classifier refusal, ...) |

The top row is the cost in one line: an error that named the exact misconfiguration, and told an operator how to fix it, reached 172 turns as "Something went wrong." (That burst was 2026-07-31 to 08-01 and is long resolved -- it is cited as evidence of the masking, not as a live incident.)

## Changes

- `apps/client/server/chatCompletion/internal/route.ts`
  - Route the failure write through `questRepository.settleIfUnfinished` instead of a raw `_id`-only `update`. Its status predicate no-ops when the processor already settled the quest (preserving that reply) and still writes the fallback when nothing terminal was persisted -- e.g. a throw before or around `process()` such as a failed user lookup or DB connect.
  - Log at `info` when the guarded write does not match, so "kept the processor's reply" is distinguishable from "never ran".
  - Hoist the generic string to an exported `GENERIC_PROCESSING_FAILURE_REPLY` so the test asserts against one source of truth.
  - The fallback now also sets `type: 'error'`, which the previous unconditional write never did, so the bubble renders as an error rather than an untyped reply.
- `apps/client/server/chatCompletion/server.test.ts` -- 4 new `/process` cases and the repository mock updated to the new seam.

No schema change, no API change, no UI change.

### Why `settleIfUnfinished`

It is the existing primitive for this exact hazard, and its docblock already spells the bug out: an `_id`-only write *"would then overwrite a real answer with the abandoned-run error"*. The quest-timeout sweep, the stranded-quest settle, the abandoned-execution sweep and the quest-status endpoint all go through it. This route was the last unguarded writer.

## Guide for Testers

This is a backend error-path change. The user-visible surface is the existing chat reply bubble; there is no new control to click.

### Setup

1. Open `app.pr<N>.preview.bike4mind.com` and sign in.
2. Open a new chat session.

### Happy path (must be unaffected)

3. Type `Write me a haiku about debugging.` in the message input and send.
4. Expected: a normal streamed reply appears within ~15 seconds. No error banner, no generic "Something went wrong" text.
5. Send a second message in the same session: `Now make it about databases.`
6. Expected: a second normal reply. Session history shows both turns.

### Error path still terminates (the behavior this PR must not break)

7. In the same session, click Stop/cancel while a reply is mid-stream.
8. Expected: the turn ends promptly with an interrupted-style message. The spinner does NOT hang indefinitely.
9. Reload the page.
10. Expected: the cancelled turn is still terminal after reload -- it does not revert to a spinner.

### Verifying the actual fix

The fix only differs from old behavior when processing throws *after* the backend already recorded a specific error, which cannot be triggered from the UI on demand. Two ways to confirm:

11. Unit coverage: `pnpm --filter @bike4mind/client exec vitest run --project node server/chatCompletion/server.test.ts` -- 20 passing, including `settles a failed quest through the status-guarded write, not an unconditional update` and `leaves the processor-persisted reply alone when the quest is already settled`.
12. If you can reach the preview DB: find any quest with `type: 'error'` and compare `reply` against `replies[0]`. After this change they should agree, or `replies` should be empty with the specific message on `reply` -- never a specific `reply` masked by the generic `replies[0]`.

### Regression Checks

- Normal chat completion, streaming, and session history: unchanged.
- A quest that fails before the processor starts (bad session, bad user) still ends terminal with the generic message rather than spinning forever.
- Cancelling a turn still works and still persists.
- The `/process` endpoint still 401s without the internal bearer and still 400s on a malformed payload (covered by existing tests in the same file).

### What NOT to test

- No UI, styling, routing, or navigation changes -- do not look for visual differences.
- No admin settings, no feature flags, no migrations.
- Do not try to force the exact provider error from the original incident; it is capped by #2135, its root cause is tracked separately in #2127, and neither is what this PR changes.

## Additional Information

The provider error behind the original incident (`A maximum of 4 blocks with cache_control may be provided. Found 5.`) is **capped** by #2135, but not fixed: the underlying marker accumulation across tool-calling rounds is still open as #2127. The cap absorbs roughly three rounds, so a longer tool loop still arrives over the ceiling. This PR does not touch either -- it fixes the reporting layer that hid the error, so the next such failure is legible from the reply itself instead of requiring a database read.

A note on what this does and does not expose. Preserving `quest.reply` means raw provider text now reaches the user where the generic string previously replaced it, so I checked whether anything operator-only can leak. The embedding-auth message in the table above is exactly that shape (it embeds a masked key fragment, and `OpenAIEmbeddingService.ts:77-79` says explicitly that callers must map it to user-safe copy). It can no longer reach `quest.reply`: both embedding call sites in a chat turn now catch and degrade -- `b4m-core/utils/src/llm/utils.ts:1378` falls back to raw file content, and `ChatCompletionFeatures.ts:2320` returns `noContextMessages('unavailable')`. Of the classes that can still land there, none carry credentials.

## Developer Notes

- `GENERIC_PROCESSING_FAILURE_REPLY` is exported from `internal/route.ts`, so any future caller or test asserts against one constant rather than a copied literal.
- Pattern worth reusing: a terminal quest write from a background/catch context should go through `questRepository.settleIfUnfinished`, never `BaseRepository.update`. The status predicate is what makes a late writer safe against a racing natural completion.
- The `settled` boolean is now logged rather than discarded, which makes "the processor owned this failure" observable without a DB read.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) -- n/a, no UI change
- [ ] I have made corresponding changes to the documentation (if applicable) -- n/a
- [ ] If adding/modifying telemetry fields -- n/a

