### PR TITLE
feat(chat): put the chat left of the knowledge split and frame both panes

### DIFF
--- a/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
@@ -1305,6 +1305,7 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
         borderRadius: '8px',
         background: theme.palette.background.body,
         position: 'relative',
+        overflow: 'hidden', // clips the header and content to the frame's 8px radius
       })}
     >
       <Box
@@ -1316,6 +1317,13 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
           display: 'flex',
           alignItems: 'center',
           gap: '8px',
+          // Same 56px app-chrome band as the chat's SessionTop beside it. minHeight, not
+          // height: on phones the toolbar stacks onto a second row (see the grid below) and
+          // a hard height would clip it.
+          minHeight: '56px',
+          boxSizing: 'border-box',
+          flexShrink: 0,
+          backgroundColor: theme.palette.background.level1,
         })}
       >
         <Box

--- a/apps/client/app/components/Session/ChatPanelControls.tsx
+++ b/apps/client/app/components/Session/ChatPanelControls.tsx
@@ -1,82 +1,152 @@
 'use client';
 
 import React from 'react';
-import { IconButton, Tooltip } from '@mui/joy';
+import { IconButton, Option, Select, Tooltip, Typography } from '@mui/joy';
+import { selectClasses } from '@mui/joy/Select';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import VerticalSplitIcon from '@mui/icons-material/VerticalSplit';
-import HorizontalSplitIcon from '@mui/icons-material/HorizontalSplit';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { menuSurfaceSx } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
+import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 import { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 import { useCopySessionMarkdown } from './useCopySessionMarkdown';
+
+/**
+ * Square chrome button for a panel header. Exported so surfaces that contribute their
+ * own buttons to this header cluster stay the same shape as the ones defined here.
+ */
+export const chatHeaderToolButtonSx = {
+  // Both axes pinned: Joy sizes an IconButton off --IconButton-size through
+  // minWidth/minHeight, which would otherwise win over a bare width/height.
+  width: '32px',
+  height: '32px',
+  minWidth: '32px',
+  minHeight: '32px',
+  borderRadius: '8px',
+} as const;
+
+type LayoutChoice = 'dockRight' | 'dockBottom' | 'floatingChat';
+
+const LAYOUT_LABELS: Record<LayoutChoice, string> = {
+  // 'dockRight' is the persisted layout name, kept because it is stored per user; the split
+  // row renders that pane on the LEFT (see SessionContainer), so the label says left.
+  dockRight: 'Dock left',
+  dockBottom: 'Dock bottom',
+  floatingChat: 'Float',
+};
 
 interface ChatPanelControlsProps {
   /** data-testid prefix, e.g. 'docked-chat' or 'floating-chat' */
   testIdPrefix: string;
-  /** Current docked layout; highlights the matching dock button. Omit in the floating window. */
+  /** Current docked layout; preselected in the menu. Omit in the floating window. */
   activeLayout?: 'dockRight' | 'dockBottom';
-  /** Render the "Float" button (docked panels only). */
+  /** Offer "Float" in the menu (docked panels only - the floating window is already there). */
   showFloat?: boolean;
 }
 
 /**
- * The window-control cluster shared by DockedChatPanel and FloatingChatWindow:
- * copy-as-markdown, optional Float, and the two dock-direction buttons.
- * Panel-specific trailing buttons (Minimize/Close) stay in the panels.
+ * The window-control cluster shared by DockedChatPanel and FloatingChatWindow: the
+ * layout menu (dock directions plus, where the panel offers it, Float) followed by
+ * copy-as-markdown. Panel-specific buttons (Hide chat, Close) stay in the panels.
  */
 const ChatPanelControls: React.FC<ChatPanelControlsProps> = ({ testIdPrefix, activeLayout, showFloat = false }) => {
   const { copyMarkdown, copied } = useCopySessionMarkdown();
 
   return (
     <>
+      <Select
+        size="sm"
+        variant="outlined"
+        color="neutral"
+        value={activeLayout ?? null}
+        onChange={(_, value) => value && setSessionLayout({ layout: value })}
+        // The floating window passes no activeLayout, so nothing matches an Option and Joy
+        // leaves the button blank rather than falling back. Say what the control is.
+        placeholder="Layout"
+        indicator={<ExpandMoreIcon sx={{ fontSize: 18 }} />}
+        renderValue={option => (
+          <Typography noWrap level="body-sm" textColor="inherit" sx={{ minWidth: 0 }}>
+            {option ? LAYOUT_LABELS[option.value as LayoutChoice] : 'Layout'}
+          </Typography>
+        )}
+        slotProps={{
+          button: { 'data-testid': `${testIdPrefix}-layout-select-btn` },
+          listbox: {
+            'data-testid': `${testIdPrefix}-layout-listbox`,
+            sx: theme => ({
+              ...menuSurfaceSx(theme),
+              borderRadius: '8px',
+              // minWidth, not width: Joy's Select popper writes an inline width on this
+              // element from the anchor's own box, and an inline style beats any class.
+              minWidth: 180,
+              maxHeight: 360,
+              overflowY: 'auto',
+              // The app's own 4px thumb (sidenav, Data Lake tree) rather than the platform
+              // bar, which lands a chunky light-grey rail on the dark menu.
+              ...scrollbarStyles,
+              '--List-padding': '8px',
+              '--List-radius': '8px',
+              '--List-gap': '4px',
+              '--ListItem-radius': '8px',
+              // Same hover and selected grounds as the app's other menus instead of Joy's
+              // default primary fill. Joy paints its hover from --variant-plainHoverBg, so
+              // pointing the variable at the colour is what actually wins - a bare :hover
+              // rule does not.
+              '& [role="option"]': {
+                borderRadius: '8px',
+                transition: 'background 0.15s',
+                '--variant-plainHoverBg': theme.palette.notebooklist.hoverBg,
+                '&:hover': { backgroundColor: theme.palette.notebooklist.hoverBg },
+                '&[aria-selected="true"]': {
+                  backgroundColor: theme.palette.notebooklist.focusedBackground,
+                  fontWeight: 600,
+                  // Joy tints a selected Option with the primary palette; the row is already
+                  // marked by its ground, so the text stays ordinary ink.
+                  color: 'inherit',
+                  '&:hover': { backgroundColor: theme.palette.notebooklist.focusedBackground },
+                },
+                '&:focus-visible': {
+                  outline: `2px solid ${theme.palette.primary[500]}`,
+                  outlineOffset: '-2px',
+                },
+              },
+            }),
+          },
+        }}
+        data-testid={`${testIdPrefix}-layout-select`}
+        sx={{
+          maxWidth: 220,
+          fontWeight: 400,
+          gap: '8px',
+          // The chevron points at where the list is: down when it is closed, up while it is
+          // open, turning rather than swapping so the two read as one control.
+          [`& .${selectClasses.indicator}`]: { transition: 'transform 0.2s ease' },
+          [`&.${selectClasses.expanded} .${selectClasses.indicator}`]: { transform: 'rotate(-180deg)' },
+        }}
+      >
+        <Option value="dockRight" data-testid={`${testIdPrefix}-dock-right`}>
+          {LAYOUT_LABELS.dockRight}
+        </Option>
+        <Option value="dockBottom" data-testid={`${testIdPrefix}-dock-bottom`}>
+          {LAYOUT_LABELS.dockBottom}
+        </Option>
+        {showFloat && (
+          <Option value="floatingChat" data-testid={`${testIdPrefix}-float`}>
+            {LAYOUT_LABELS.floatingChat}
+          </Option>
+        )}
+      </Select>
       <Tooltip title={copied ? 'Copied!' : 'Copy chat as Markdown'} disableInteractive>
         <IconButton
-          size="sm"
-          variant="plain"
+          size="md"
+          variant="outlined"
           color={copied ? 'success' : 'neutral'}
           onClick={copyMarkdown}
+          aria-label="Copy chat as Markdown"
           data-testid={`${testIdPrefix}-copy-markdown`}
-          sx={{ '--IconButton-size': '28px' }}
+          sx={chatHeaderToolButtonSx}
         >
-          {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 14 }} />}
-        </IconButton>
-      </Tooltip>
-      {showFloat && (
-        <Tooltip title="Float" disableInteractive>
-          <IconButton
-            size="sm"
-            variant="plain"
-            color="neutral"
-            onClick={() => setSessionLayout({ layout: 'floatingChat' })}
-            data-testid={`${testIdPrefix}-float`}
-            sx={{ '--IconButton-size': '28px' }}
-          >
-            <OpenInNewIcon sx={{ fontSize: 16 }} />
-          </IconButton>
-        </Tooltip>
-      )}
-      <Tooltip title="Dock right" disableInteractive>
-        <IconButton
-          size="sm"
-          variant={activeLayout === 'dockRight' ? 'soft' : 'plain'}
-          color={activeLayout === 'dockRight' ? 'primary' : 'neutral'}
-          onClick={() => setSessionLayout({ layout: 'dockRight' })}
-          data-testid={`${testIdPrefix}-dock-right`}
-          sx={{ '--IconButton-size': '28px' }}
-        >
-          <VerticalSplitIcon sx={{ fontSize: 16 }} />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title="Dock bottom" disableInteractive>
-        <IconButton
-          size="sm"
-          variant={activeLayout === 'dockBottom' ? 'soft' : 'plain'}
-          color={activeLayout === 'dockBottom' ? 'primary' : 'neutral'}
-          onClick={() => setSessionLayout({ layout: 'dockBottom' })}
-          data-testid={`${testIdPrefix}-dock-bottom`}
-          sx={{ '--IconButton-size': '28px' }}
-        >
-          <HorizontalSplitIcon sx={{ fontSize: 16 }} />
+          {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 16 }} />}
         </IconButton>
       </Tooltip>
     </>

--- a/apps/client/app/components/Session/DockedChatPanel.test.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.test.tsx
@@ -7,8 +7,8 @@ import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSession
 import DockedChatPanel from './DockedChatPanel';
 
 // The control cluster reaches SessionsContext/react-query through useCopySessionMarkdown,
-// which is irrelevant to the header's minimize wiring.
-vi.mock('./ChatPanelControls', () => ({ default: () => null }));
+// which is irrelevant to the header's Hide chat wiring.
+vi.mock('./ChatPanelControls', () => ({ default: () => null, chatHeaderToolButtonSx: {} }));
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -20,7 +20,7 @@ describe('DockedChatPanel', () => {
     setSessionLayout({ layout: 'dockRight', floatingChatMinimized: false });
   });
 
-  it('minimizes to the AI Chat launcher instead of switching to the floating window', () => {
+  it('hides to the AI Chat launcher instead of switching to the floating window', () => {
     render(
       <Wrapper>
         <DockedChatPanel>chat</DockedChatPanel>

--- a/apps/client/app/components/Session/DockedChatPanel.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { Box, IconButton, Typography, Tooltip } from '@mui/joy';
+import { Box, IconButton, Tooltip, Typography } from '@mui/joy';
 import CloseIcon from '@mui/icons-material/Close';
 import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
-import ChatPanelControls from './ChatPanelControls';
+import ChatPanelControls, { chatHeaderToolButtonSx } from './ChatPanelControls';
 
 interface DockedChatPanelProps {
   children: React.ReactNode;
@@ -16,9 +16,9 @@ interface DockedChatPanelProps {
 const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActions, title }) => {
   const layout = useSessionLayout(s => s.layout);
 
-  // Dismiss the panel down to the bottom-right "AI Chat" launcher (the minimized
-  // FloatingChatWindow pill) rather than opening the floating window.
-  const handleMinimize = useCallback(() => {
+  // "Hide chat": dismiss the panel down to the bottom-right "AI Chat" launcher (the
+  // minimized FloatingChatWindow pill) rather than opening the floating window.
+  const handleHide = useCallback(() => {
     setSessionLayout({
       layout: 'floatingChat',
       floatingChatMinimized: true,
@@ -33,7 +33,11 @@ const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActio
         flexDirection: 'column',
         height: '100%',
         width: '100%',
+        // overflow:hidden is what makes the radius actually clip the header bar's corners.
         overflow: 'hidden',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: '8px',
       }}
     >
       {/* Header bar */}
@@ -65,23 +69,24 @@ const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActio
           )}
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          {/* Session actions first (headerActions leads with the primary New Chat),
-              then window controls. */}
-          {headerActions}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          {/* Layout menu leads the cluster, then the surface's own actions (headerActions),
+              with Hide chat last as the control nearest the pane edge. */}
           <ChatPanelControls
             testIdPrefix="docked-chat"
             activeLayout={layout === 'dockRight' || layout === 'dockBottom' ? layout : undefined}
             showFloat
           />
-          <Tooltip title="Minimize" disableInteractive>
+          {headerActions}
+          <Tooltip title="Hide chat" disableInteractive>
             <IconButton
-              size="sm"
-              variant="plain"
+              size="md"
+              variant="outlined"
               color="neutral"
-              onClick={handleMinimize}
+              onClick={handleHide}
               data-testid="docked-chat-close"
-              sx={{ '--IconButton-size': '28px' }}
+              aria-label="Hide chat"
+              sx={chatHeaderToolButtonSx}
             >
               <CloseIcon sx={{ fontSize: 16 }} />
             </IconButton>

--- a/apps/client/app/components/Session/ResizableSplitter.tsx
+++ b/apps/client/app/components/Session/ResizableSplitter.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState, useTransition } from 'react';
-import { Box, Tooltip } from '@mui/joy';
-import { DragIndicator } from '@mui/icons-material';
+import { Box } from '@mui/joy';
 import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 
 interface ResizableSplitterProps {
@@ -54,7 +53,9 @@ const ResizableSplitter: React.FC<ResizableSplitterProps> = ({ onWidthChange }) 
         const parentRect = parent.getBoundingClientRect();
         const deltaX = e.clientX - dragState.startX;
         const deltaPercent = (deltaX / parentRect.width) * 100;
-        const newWidth = Math.max(20, Math.min(80, dragState.startWidth + deltaPercent));
+        // Minus, not plus: SessionContainer renders the split row-reversed, so the viewer
+        // sits to the RIGHT of this handle and dragging right has to shrink it.
+        const newWidth = Math.max(20, Math.min(80, dragState.startWidth - deltaPercent));
 
         dragState.currentWidth = newWidth;
 
@@ -98,8 +99,10 @@ const ResizableSplitter: React.FC<ResizableSplitterProps> = ({ onWidthChange }) 
   return (
     <Box
       sx={{
-        width: '12px',
-        marginX: '-3px',
+        // Negative margin so the handle overlaps BOTH panes evenly and reads as the boundary
+        // between them rather than as chrome belonging to either pane.
+        width: '8px',
+        marginX: '-6px',
         cursor: 'col-resize',
         display: 'flex',
         alignItems: 'center',
@@ -107,41 +110,30 @@ const ResizableSplitter: React.FC<ResizableSplitterProps> = ({ onWidthChange }) 
         position: 'relative',
         zIndex: 10,
         touchAction: 'none', // Prevent touch scrolling during drag
+        // The visible mark is a short centered bar, not a full-height rule. It lives on
+        // ::before so the element itself stays a full-height 8px grab strip -- a 2px-wide
+        // hit area would be near-impossible to catch with a pointer.
         '&::before': {
           content: '""',
           position: 'absolute',
-          top: 0,
-          bottom: 0,
+          top: '50%',
           left: '50%',
-          transform: 'translateX(-50%)',
-          width: '1px',
+          transform: 'translate(-50%, -50%)',
+          width: '2px',
+          height: '32px',
           backgroundColor: 'divider',
-          transition: 'all 0.2s ease',
+          transition: 'background-color 0.2s ease',
         },
         '&:hover::before, &[data-dragging="true"]::before': {
-          width: '3px',
-          backgroundColor: 'primary.main',
+          // primary.500, not primary.main: Joy's palette has no `main` key (that is Material
+          // UI), so the string falls through as an invalid CSS value and nothing happens.
+          backgroundColor: 'primary.500',
         },
       }}
       onPointerDown={handlePointerDown}
       data-dragging={isDragging}
-    >
-      <Tooltip title="Drag to resize" placement="top">
-        <DragIndicator
-          sx={{
-            fontSize: '16px',
-            color: isDragging ? 'primary.main' : 'text.secondary',
-            opacity: isDragging ? 1 : 0.6,
-            transform: 'rotate(90deg)',
-            transition: 'all 0.2s ease',
-            pointerEvents: 'none',
-            '&:hover': {
-              opacity: 1,
-            },
-          }}
-        />
-      </Tooltip>
-    </Box>
+      aria-label="Drag to resize"
+    />
   );
 };
 

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -522,7 +522,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
           boxShadow: theme.palette.session.boxShadow,
           paddingX: isPWA ? '24px' : '16px',
           pb: isPWA ? '20px' : isMobile ? '10px' : '0px',
-          borderRadius: isCompactLayout || isMobile || isDockedLayout || isFloatingLayout ? 0 : '.625rem',
+          // Bottom corners at 8px to sit inside the chat pane's own 8px frame; the top pair
+          // is free-standing and keeps its looser .625rem.
+          borderRadius:
+            isCompactLayout || isMobile || isDockedLayout || isFloatingLayout ? 0 : '.625rem .625rem 8px 8px',
         })}
       >
         <Box>

--- a/apps/client/app/components/Session/SessionContainer.tsx
+++ b/apps/client/app/components/Session/SessionContainer.tsx
@@ -431,12 +431,35 @@ const SessionContainer: FC<SessionLayoutProps> = ({
     setShowPinnedOnly(false);
   }, [currentSessionId, setShowPinnedOnly]);
 
+  // The side-by-side split (KnowledgeViewer beside the chat). Mobile collapses it to a
+  // stack, so it is not one there.
+  const isVerticalSplit = layout === 'vertical' && !isMobile;
+  // Mirrors the guard on the KnowledgeViewer Box below: where that renders, the chat's own
+  // top bar has a header to line up with, so it joins the app-chrome band (56px, level1
+  // ground, 16px gutters, contents centred vertically). In the default full-width chat it
+  // keeps its original loose 60px header - framing it there moves the Data Lakes button.
+  const isKnowledgeViewerOpen = layout !== 'hide' && layout !== 'dockRight' && layout !== 'dockBottom';
+  // Only the edge FACING the splitter is padded here - the notebook layout already puts an
+  // 8px gutter around the outside of the content, and paying it twice reads as a wide frame.
+  // The row is reversed, so the chat sits left (inner edge = right) and the viewer right
+  // (inner edge = left). Both panes carry their own 1px/8px frame already; this is only the
+  // space between them.
+  const chatPanePadding = isVerticalSplit ? { paddingRight: '8px' } : {};
+  const knowledgePanePadding = isVerticalSplit ? { paddingLeft: '8px' } : {};
+
   return (
     <ChatCompletionProvider sessionId={currentSessionId ?? null}>
       <Box
         sx={{
           display: 'flex',
-          flexDirection: layout === 'horizontal' || (isMobile && layout === 'vertical') ? 'column' : 'row',
+          // row-reverse in the split: the chat sits LEFT and the KnowledgeViewer right.
+          // DOM order stays knowledge -> splitter -> chat, which ResizableSplitter's
+          // children[0]/[2] lookup depends on; it flips the drag sign instead.
+          flexDirection: isVerticalSplit
+            ? 'row-reverse'
+            : layout === 'horizontal' || (isMobile && layout === 'vertical')
+              ? 'column'
+              : 'row',
           rowGap: layout === 'horizontal' || (isMobile && layout === 'vertical') ? '10px' : '0px',
           p: isMobile ? '0px' : '0px',
           height: '100%',
@@ -446,7 +469,10 @@ const SessionContainer: FC<SessionLayoutProps> = ({
         }}
       >
         {layout !== 'hide' && layout !== 'dockRight' && layout !== 'dockBottom' && (
-          <Box ref={knowledgeRef} sx={{ transition: 'all 0.3s ease', ...layoutStyles.knowledge }}>
+          <Box
+            ref={knowledgeRef}
+            sx={{ transition: 'all 0.3s ease', ...layoutStyles.knowledge, ...knowledgePanePadding }}
+          >
             <KnowledgeViewer autoHideOnEmpty={autoHideOnEmpty} />
           </Box>
         )}
@@ -461,6 +487,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
             opacity: 1,
             ...(layout === 'pip' ? {} : layoutStyles.chat),
             ...layoutStyles.session,
+            ...chatPanePadding,
             position: layout === 'pip' ? 'fixed' : 'relative',
           }}
         >
@@ -483,11 +510,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
                 position: 'relative',
                 display: 'flex',
                 flexDirection: 'column',
-                // overflow: 'hidden', // Prevent content from escaping flex container on mobile
-                pt: {
-                  xs: project ? '60px' : 0,
-                  sm: '60px',
-                },
+                overflow: 'hidden', // clips children to the frame's 8px radius
               }}
             >
               {/* SessionTop header. Skipped in floatingChat/dock like the chat content below:
@@ -496,26 +519,30 @@ const SessionContainer: FC<SessionLayoutProps> = ({
               {layout !== 'floatingChat' && layout !== 'dockRight' && layout !== 'dockBottom' && (
                 <Box
                   sx={theme => ({
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
+                    // In flow, not absolute: it is the first row of the column, so it reserves
+                    // its own height instead of needing a matching pt on the parent.
                     width: '100%',
-                    height: '60px',
+                    flexShrink: 0,
+                    // Only in the band: the full-width chat's bar is not a chrome header and
+                    // a rule under it just cuts the pane in two.
+                    borderBottom: isKnowledgeViewerOpen ? '1px solid' : 'none',
                     borderColor: 'divider',
-                    background: transparentTop ? 'transparent' : theme.palette.background.body,
+                    background: transparentTop
+                      ? 'transparent'
+                      : isKnowledgeViewerOpen
+                        ? theme.palette.background.level1
+                        : theme.palette.background.body,
                     zIndex: 1,
-                    padding: 0,
+                    padding: '8px 8px 16px',
                     display: {
-                      xs: project ? 'block' : 'none',
-                      sm: 'block',
+                      xs: project ? (isKnowledgeViewerOpen ? 'flex' : 'block') : 'none',
+                      sm: isKnowledgeViewerOpen ? 'flex' : 'block',
                     },
+                    // Only the band is a fixed 56px; outside it the bar is content-sized.
+                    ...(isKnowledgeViewerOpen ? { height: '56px', alignItems: 'center', px: '16px', pb: '8px' } : {}),
                   })}
                 >
-                  <SessionTop
-                    listClosed={listClosed}
-                    onChatWidthToggle={setIsFullWidth}
-                    transparentTop={transparentTop}
-                  />
+                  <SessionTop listClosed={listClosed} onChatWidthToggle={setIsFullWidth} />
                 </Box>
               )}
               {/* Skip rendering chat content when floatingChat/dock is active — FloatingChatWindow
@@ -691,7 +718,16 @@ const SessionContainer: FC<SessionLayoutProps> = ({
               {/* px aligns the message/status content with the input row (SessionBottom
                   pads 16px) so nothing hugs the narrow docked/floating panel edges. */}
               <Box
-                sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', px: '16px', pb: '24px' }}
+                sx={{
+                  flex: 1,
+                  overflow: 'hidden',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  pl: '16px',
+                  // Narrower on the right: the message list's own scrollbar already sits there.
+                  pr: '8px',
+                  pb: '24px',
+                }}
               >
                 {!currentSessionId ? (
                   customSplash || <NotebookSplash />

--- a/apps/client/app/components/Session/SessionTop.tsx
+++ b/apps/client/app/components/Session/SessionTop.tsx
@@ -32,11 +32,9 @@ type SessionTopProps = {
    */
   enableSearch?: boolean;
   onChatWidthToggle?: (isFullWidth: boolean) => void;
-  /** Render the bar transparent (no solid topbar background) - chat-first Data Lake surface. */
-  transparentTop?: boolean;
 };
 
-const SessionTop: React.FC<SessionTopProps> = ({ enableSearch = true, onChatWidthToggle, transparentTop }) => {
+const SessionTop: React.FC<SessionTopProps> = ({ enableSearch = true, onChatWidthToggle }) => {
   const { currentSession, currentSessionId } = useSessions();
   const { data: cachedSession } = useGetSession(currentSessionId ?? null);
   const layout = useSessionLayout(s => s.layout);
@@ -81,8 +79,6 @@ const SessionTop: React.FC<SessionTopProps> = ({ enableSearch = true, onChatWidt
           alignItems: 'center',
           flexDirection: 'row',
           paddingRight: '0px',
-          height: '0em',
-          backgroundColor: transparentTop ? 'transparent' : 'chatbox.topbarBg',
           color: 'chatbox.topbarText',
           zIndex: 10000,
         })}

--- a/apps/client/app/components/layouts/Notebook/index.tsx
+++ b/apps/client/app/components/layouts/Notebook/index.tsx
@@ -19,7 +19,6 @@ import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { keyframes } from '@mui/system';
 import NotebookHeader from './Header';
 import { gray } from '@client/app/utils/themes/colors';
-import useSessionLayout from '@client/app/hooks/useSessionLayout';
 import useDataLakeMode from '@client/app/hooks/useDataLakeMode';
 
 export interface NotebookLayoutProps {
@@ -71,29 +70,22 @@ const NotebookLayout: FC<PropsWithChildren<NotebookLayoutProps>> = ({ children }
   const openSideNav = useNotebookLayout(s => s.openSideNav);
   const isMobile = useIsMobile();
   const isImpersonating = useAccessToken(s => s.impersonating);
-  const layout = useSessionLayout(s => s.layout);
 
   // Global keyboard shortcuts
   useHelpKeyboardShortcut();
   useCommandPaletteShortcut();
-
-  // Knowledge viewer is open when layout is not 'hide'
-  const isKnowledgeViewerOpen = layout !== 'hide';
 
   // Mirrors useOptiAccess's route check: '/opti' only exists in overlay builds.
   const { pathname } = useLocation();
   const isOptiRoute = pathname.startsWith('/opti');
   const dataLakeModeOn = useDataLakeMode(s => s.enabled);
 
+  // Opti hub / in-chat Data Lake mode own their edge-to-edge layout; the notebook gutter
+  // would double up as a visible frame around the docked chat + splitter. The 36px left is
+  // clearance for the collapsed sidenav's floating expand control, not a gutter.
   const getContentPadding = (): string => {
-    if (isMobile) return '0px';
-    // Opti hub / in-chat Data Lake mode own their edge-to-edge layout; the
-    // notebook gutter would double up as a visible frame around the docked chat + splitter.
-    if (isOptiRoute || dataLakeModeOn) return '0px';
-    if (openSideNav && isKnowledgeViewerOpen) return '12px 12px 12px 12px';
-    if (openSideNav) return '12px 12px 12px 12px';
-    if (isKnowledgeViewerOpen) return '12px 12px 12px 36px';
-    return '12px 12px 12px 36px';
+    if (isMobile || isOptiRoute || dataLakeModeOn) return '0px';
+    return openSideNav ? '8px' : '8px 8px 8px 36px';
   };
 
   return (

--- a/apps/client/app/hooks/useSessionLayout.ts
+++ b/apps/client/app/hooks/useSessionLayout.ts
@@ -92,7 +92,7 @@ interface SessionLayoutControlState {
   floatingChatSize: { width: number; height: number };
   floatingChatMinimized: boolean;
   // Docked chat panel sizing (percentage)
-  dockChatWidth: number; // Width % for dockRight mode (default 35)
+  dockChatWidth: number; // Width % for dockRight mode (default 40)
   dockChatHeight: number; // Height % for dockBottom mode (default 40)
   // Optimistic first-message: holds the user's prompt while the new session is being
   // confirmed by the server. Cleared on session.created. Not persisted.
@@ -119,7 +119,7 @@ const useSessionLayout = create<SessionLayoutControlState>()(
       floatingChatPosition: { x: -1, y: -1 }, // -1 indicates "center on first use"
       floatingChatSize: { width: 450, height: 600 },
       floatingChatMinimized: false,
-      dockChatWidth: 35,
+      dockChatWidth: 40,
       dockChatHeight: 40,
     }),
     {


### PR DESCRIPTION
## Description

The chat and the KnowledgeViewer now read as two framed panes with the chat on the
left, and the controls around them are brought onto one visual system.

Layout-wise nothing moved in the DOM: the split row renders `row-reverse`, because
`ResizableSplitter` finds its two panes positionally (`children[0]` / `children[2]`)
and reordering them would have broken the drag. Only the drag sign flips.

While doing the splitter I found a dead rule: its hover/drag highlight asked for
`primary.main`, a Material UI token that Joy's palette has no key for, so the string
fell through as an invalid CSS value and the colour never changed. It went unnoticed
because the same rule also grew the bar from 1px to 3px. With the size change gone
the highlight simply stopped working, which is how it surfaced.

## Changes

- Split renders reversed: chat left, KnowledgeViewer right. `ResizableSplitter`
  inverts its delta to match.
- Gutters: each pane pads only the edge facing the splitter; the notebook layout
  supplies the 8px around the outside. The collapsed sidenav's 36px left clearance
  stays - that is room for the floating expand control, not a gutter.
- Splitter: drag icon and tooltip removed, leaving a centred 2px x 32px bar on an
  8px grab strip. Hover/drag now only recolours it, and the colour was fixed from
  `primary.main` to `primary.500`.
- The chat's top bar moves into the flow (it was absolutely positioned with a
  matching `pt` on the pane) and joins the 56px chrome band - `background.level1`,
  16px gutters, contents centred - while the viewer is open. In the full-width chat
  it keeps its previous looser shape and no bottom rule.
- `knowledge-viewer-header` matches that band; the viewer clips to its own radius.
- The dock buttons collapse into one layout menu - Dock left / Dock bottom / Float -
  styled like the app's other select menus. Hide chat stays a separate button.
  "Dock right" is only relabelled: the stored `dockRight` layout name is untouched
  because it is persisted per user.
- Default docked chat width 35% -> 40%.

## Guide for Testers

1. Open `app.staging.bike4mind.com` and start any chat.
2. Open a knowledge file so the viewer appears beside the chat (click a file chip on
   a message, or attach one and open it).
   Expected: the chat is on the LEFT, the viewer on the RIGHT.
3. Look at the gap between the two panes.
   Expected: both panes are framed (1px border, 8px radius), separated by an even
   gutter, and neither frame touches the window edge.
4. Hover the divider between the panes.
   Expected: a short vertical bar (about 32px tall) in the middle of the boundary
   turns blue. There is no drag-handle icon and the bar does not change size.
5. Drag that divider to the right, release, then drag it back.
   Expected: dragging right shrinks the viewer and grows the chat; the panes follow
   the pointer, and the width sticks after release.
6. Compare the chat's top bar with the viewer's header.
   Expected: both are 56px tall, share the same background, and their bottom rules
   line up across the split.
7. Close the viewer so the chat is full width again.
   Expected: the chat's top bar loses the panel background and the rule under it, and
   the Data Lakes button sits just inside the frame's top border rather than flush
   against it.
   Correction: this step originally said the button sits where it did before this PR.
   It does not - removing the `height: '0em'` from `SessionTop`'s wrapper is what
   dropped the old flush position. Measured on the preview against `main` with the
   viewer closed (#2306): chat frame top 12px -> 8px, button top 12px -> 16px, so the
   button sits 8px inside the frame instead of straddling its border. The shift was
   not reverted.
8. In a docked chat panel, open the "Dock left" dropdown in the header.
   Expected: three entries - Dock left, Dock bottom, Float - in a menu styled like the
   app's other select menus.
9. Pick Dock bottom, then reopen the menu and pick Dock left.
   Expected: the panel docks below, then back to the left; the menu's trigger always
   names the current layout.
10. Click the X button beside the dropdown.
    Expected: the panel collapses to the "AI Chat" pill in the bottom-right corner.
    Hovering the button reads "Hide chat".

### Regression Checks

Checks 11 and 12 are withdrawn: neither can fail as written.
`dockChatWidth` and `dockChatHeight` are defaulted and persisted but never read and
never written, so the docked panel is just `width: 100%` of whatever the surrounding
layout gives it, and no width was ever dragged into storage to preserve. For the same
reason the "Default docked chat width 35% -> 40%" change listed above has no
observable effect yet. Tracked in #2305.

11. ~~In a browser with no saved layout (or after clearing site data), open a chat and
    dock it left. Expected: the chat pane takes about 40% of the width.~~ Withdrawn.
12. ~~In a browser that already had a docked chat, reload. Expected: your previously
    dragged width is preserved, not reset to 40%.~~ Withdrawn.
13. Collapse the sidenav while the split is open.
    Expected: content still clears the floating expand control at the top-left.
14. Switch the chat to Float and back.
    Expected: the floating window still opens, moves, minimises and closes; its header
    also carries the layout menu (without Float or Hide chat, which it already has).

### What NOT to test

- Message sending, streaming, tools, or attachments - untouched.
- Mobile layout: the split collapses to a stack there and was left alone.

## Additional Information

`Promise.withResolvers` in the pre-push build needs Node >= 24; the repo's engines
field already says so.

## Developer Notes

- `chatHeaderToolButtonSx` is exported from `ChatPanelControls` - any surface that
  contributes buttons to a chat panel header via `headerActions` can import it and
  stay the same 32px square shape instead of restating the sizing.
- `ChatPanelControls` now takes `showFloat` and `activeLayout` and owns the whole
  layout menu, so a new panel type only has to decide which entries it offers.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
