### PR TITLE
fix(ci): guard check-help-content.sh with its own CI trigger

### DIFF
--- a/.github/workflows/check-help-content-guard.yml
+++ b/.github/workflows/check-help-content-guard.yml
@@ -1,0 +1,36 @@
+name: Help Content Guard
+
+# Runs .husky/check-help-content.sh unconditionally on any PR that touches it.
+#
+# check-help-content.sh enforces the Help AI chat's "every indexed article has a
+# vector" invariant, but it is a .husky/ file: the `changes` job's shared filter
+# treats all of .husky/** as non-deployable (hooks aren't runtime app code) and
+# docs-paths only covers docs-site/**, so a diff that touches ONLY this script is
+# both deployable=false and docs-changed=false. Any job gated on either flag
+# (core-build's own invocation of this same script included) skips, and a skipped
+# required check counts as passing - the one file that is itself a CI-enforced
+# guard has no CI path that actually runs it. This workflow is that path,
+# independent of the `changes` job's outputs entirely, following the same pattern
+# as gitleaks-config-guard.yml for .gitleaks.toml.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.husky/check-help-content.sh'
+      - '.github/workflows/check-help-content-guard.yml'
+  # Also run on the merge queue so the check reports there if it later becomes a
+  # required branch-protection check (see semantic-pr-title.yml for why a required
+  # check must run on merge_group).
+  merge_group:
+    branches: [main]
+
+jobs:
+  check:
+    if: github.repository == (vars.CANONICAL_REPO || 'MillionOnMars/lumina5')
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check help content
+        run: sh .husky/check-help-content.sh

--- a/packages/scripts/src/checkHelpContentGuardWired.test.ts
+++ b/packages/scripts/src/checkHelpContentGuardWired.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Guards the CI-wiring gap in #2210: .husky/check-help-content.sh enforces the Help AI chat's
+ * "every indexed article has a vector" invariant, but a diff that touches ONLY that file is
+ * `deployable=false` (`.husky/**` is on changes-filter's exclude list) AND `docs-changed=false`
+ * (docs-paths only covers docs-site/**), so every job gated on either flag skips - and a skipped
+ * required check counts as passing. Nothing in CI would ever run the script on a diff shaped
+ * exactly like an edit to itself.
+ *
+ * check-help-content-guard.yml closes that by running the script unconditionally, gated only on
+ * its own `paths:` filter (the same pattern gitleaks-config-guard.yml uses for .gitleaks.toml).
+ * This test pins that the guard workflow exists, actually watches the script, and runs it with no
+ * `if:` gate tied to the shared changes-filter outputs - so a future edit can't quietly reintroduce
+ * the gap by adding a `needs.changes` condition or dropping the path from the trigger.
+ *
+ * Text-matched rather than YAML-parsed, following checkClientTestShards.test.ts's precedent: the
+ * repo has no YAML parser dependency, and a diff that only touches the guarded script never reaches
+ * a real GitHub Actions run in this test suite anyway - the trigger's own `paths:` list is the thing
+ * under test.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const GUARD_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'check-help-content-guard.yml');
+const GUARDED_SCRIPT = '.husky/check-help-content.sh';
+
+describe('check-help-content-guard.yml', () => {
+  it('exists', () => {
+    expect(fs.existsSync(GUARD_WORKFLOW), `expected ${GUARD_WORKFLOW} to exist`).toBe(true);
+  });
+
+  const contents = fs.existsSync(GUARD_WORKFLOW) ? fs.readFileSync(GUARD_WORKFLOW, 'utf8') : '';
+
+  it('triggers on a pull_request paths filter that names the guarded script', () => {
+    const pullRequestBlock = contents.match(/pull_request:\n(?:[ \t]+.*\n)+/)?.[0] ?? '';
+    expect(pullRequestBlock).toContain('paths:');
+    expect(pullRequestBlock).toContain(GUARDED_SCRIPT);
+  });
+
+  it('also triggers on merge_group, so the check reports there if it becomes required', () => {
+    expect(contents).toMatch(/^\s*merge_group:\s*$/m);
+  });
+
+  it('runs the guarded script with no if: gate on the shared changes-filter outputs', () => {
+    const runLineIndex = contents.split('\n').findIndex(line => line.includes(`sh ${GUARDED_SCRIPT}`));
+    expect(runLineIndex, `expected a run step invoking sh ${GUARDED_SCRIPT}`).toBeGreaterThanOrEqual(0);
+    // The whole point: this must NOT be reachable only through `needs.changes.outputs.deployable`
+    // or `docs-changed` - that is exactly the condition that made the script unreachable before.
+    expect(contents).not.toMatch(/if:.*needs\.changes\.outputs\.(deployable|docs-changed)/);
+  });
+});


### PR DESCRIPTION
## Description

Closes #2210

A diff that touches only `.husky/check-help-content.sh` is invisible to CI: it is `deployable=false` (`.husky/**` is on `changes-filter`'s exclude list) and `docs-changed=false` (`docs-paths` only covers `docs-site/**`), so every job gated on either flag skips - and GitHub counts a skipped required check as passing. The one script that enforces the Help AI chat's "every indexed article has a vector" invariant currently has no CI path that would run it on an edit to itself, so a regression (or removal) of the script can merge silently.

Root cause:
- `.github/actions/changes-filter/action.yml:46` - `.husky/**` is on the `exclude-paths` default, so any `.husky/`-only diff is non-deployable.
- `.github/actions/changes-filter/action.yml:60` - `docs-paths` default is only `docs-site/**`, so a `.husky/`-only diff never sets `docs-changed=true` either.

Both lists are correct for every other `.husky/` file (hooks aren't deployable app code); the gap only bites this one script because nothing else gives it an unconditional CI path.

## Changes

- Add `.github/workflows/check-help-content-guard.yml`: runs `sh .husky/check-help-content.sh` unconditionally on `pull_request` (+ `merge_group`), gated only by its own `paths:` filter (`.husky/check-help-content.sh` and the guard workflow itself) - independent of the shared `changes` job's `deployable`/`docs-changed` outputs. Same pattern `gitleaks-config-guard.yml` uses for `.gitleaks.toml`.
- Add `packages/scripts/src/checkHelpContentGuardWired.test.ts`: pins that the guard workflow exists, triggers on `merge_group` too, and is never gated behind `needs.changes.outputs.deployable`/`docs-changed`. Fails on current `main` (the guard workflow doesn't exist yet); passes once the new file is added.

No change to `deployable`/`docs-changed` output for any other file.

## Guide for Testers

This is a CI-configuration-only change with no user-facing or runtime behavior.

1. Open this PR's "Checks" tab on GitHub.
2. Confirm a check named "Help Content Guard / check" is listed and has run (not skipped), because this PR's own diff touches `.github/workflows/check-help-content-guard.yml`.
3. Expected result: the check passes (the current `.husky/check-help-content.sh` on this branch is not broken).

### What NOT to test

- No app/UI behavior changed. Nothing here touches the Help AI chat feature itself, the help index/embeddings files, or any runtime code path - only how CI schedules one existing script.

## Additional Information

- The new job is not added to branch protection's required-checks list in this PR - that is a repo-settings change outside a PR diff. For this fix to actually block a bad merge (rather than just report status), someone with admin access needs to add "Help Content Guard / check" to the required-checks list.
- This is independent of and does not conflict with PR #2112 (the PR that first wires `check-help-content.sh` into `core-build`/`help-docs`): this workflow touches neither `ci.yml` nor `changes-filter/action.yml`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no user-facing docs affected