### PR TITLE
feat(retrieval): record not_indexed on knowledgeBaseSearch's semantic arm, not ok

### DIFF
--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -352,11 +352,13 @@ export const RetrievalSummarySchema = z.object({
    *   confident-wrong-answer this field exists to catch. Distinct from 'failed' because nothing
    *   broke: the remedy is re-vectorizing, which the corpus owner can do themselves, and a retry
    *   never helps.
-   *   COVERAGE: only forced retrieval records this today. The same condition is reachable through
-   *   knowledgeBaseSearch's semantic arm, which still records 'ok' when every candidate was
-   *   withheld for having no usable vector - so a turn that used only that surface still
-   *   under-reports. Anything cutting on this field should treat 'ok' as "not proven searched"
-   *   until that arm is corrected.
+   *   COVERAGE: recorded by forced retrieval (KnowledgeRetrievalFeature's `scoredCount === 0`
+   *   exit) and by knowledgeBaseSearch, whose semantic arms carry the same verdict through to the
+   *   keyword arm's write - the two agree on "not one passage was compared against the query",
+   *   not on any withholding flag, so a relevance floor that emptied a real search and a partial
+   *   withholding alongside a real search both stay 'ok' on both surfaces.
+   *   knowledgeBaseRetrieve cannot reach this state: it fetches named files rather than ranking
+   *   against a query embedding, so it has no comparison to come up empty.
    * 'failed' - recall did not complete: it threw, OR the retrieval repository is not wired on
    *   this host (the guards in ChatCompletionFeatures / knowledgeBaseSearch / knowledgeBaseRetrieve
    *   record it without anything throwing). What separates it from 'not_indexed' is the remedy,

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
@@ -33,6 +33,7 @@ vi.mock('@bike4mind/utils', async importOriginal => {
 });
 
 import {
+  comparedNoPassages,
   fileScopedSemanticSearch,
   semanticDataLakeSearch,
   type SemanticDataLakeSearchParams,
@@ -1654,5 +1655,44 @@ describe('semanticDataLakeSearch withholds mid-(re)index members (#1681)', () =>
 
     expect(result.retrievalUnavailable.indexing.count).toBe(1);
     expect(result.retrievalUnavailable.paused.count).toBe(0);
+  });
+});
+
+/**
+ * `comparedNoPassages` is the seam that separates "we looked at none of the corpus" from "we
+ * looked and it did not match" - the distinction `results.length` cannot make, and the one a
+ * retrieval outcome is graded on (see proveRetrievalOutcome in knowledgeBaseSearch).
+ *
+ * Both routes have to count, and each was a plausible one-sided implementation: keying on the scan
+ * count alone reports every healthy all-ANN deployment as unsearched, and keying on the ann hits
+ * alone reports every DocumentDB/self-host deployment the same way.
+ */
+describe('comparedNoPassages', () => {
+  const scanOf = (over: Partial<{ annHits: number }> = {}) => ({
+    truncated: false,
+    fileBudgetHit: false,
+    chunkBudgetHit: false,
+    filesMatching: 3,
+    filesScoped: 3,
+    filesScanned: 3,
+    chunksScanned: 0,
+    chunksSkippedDimensionMismatch: 0,
+    annFilesQueried: 0,
+    annHits: 0,
+    annModelsQueried: 0,
+    budgets: { maxFiles: 20000, maxChunks: 100000 },
+    ...over,
+  });
+
+  it('is true only when neither route compared anything', () => {
+    expect(comparedNoPassages({ chunksScored: 0, scan: scanOf() })).toBe(true);
+  });
+
+  it('is false once the scan path scored a chunk, even with no ann hits', () => {
+    expect(comparedNoPassages({ chunksScored: 1, scan: scanOf() })).toBe(false);
+  });
+
+  it('is false once an ann index returned a hit, even with nothing scored on the scan path', () => {
+    expect(comparedNoPassages({ chunksScored: 0, scan: scanOf({ annHits: 1 }) })).toBe(false);
   });
 });

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
@@ -194,6 +194,29 @@ export interface SemanticDataLakeSearchResult {
   alternateModelsEmbedded: string[];
 }
 
+/**
+ * Did this search compare NOTHING against the query - not one passage scored, by the scan path or
+ * by any ANN index? The counterpart of `isPartialSearch`: that one answers "did we return less
+ * than the whole corpus", this one answers "did we look at any of it at all".
+ *
+ * Keyed on `chunksScored`, which `scanAndRank` increments BEFORE the `minScore` filter, so a
+ * relevance floor that emptied a genuinely-ranked result set is correctly NOT "compared nothing" -
+ * the distinction a caller cannot make from `results.length` alone.
+ *
+ * `scan.annHits` (raw hits, pre-scope-filter) is what covers the ANN routes, and it is a sound
+ * "something was compared" signal despite being a HIT count rather than a comparison count only
+ * because of the zero-raw-hits rebucket below: a ready file whose ANN query returned nothing is
+ * moved to `scanEligible` and scanned, so it still reaches `chunksScored`. Without that rebucket
+ * this predicate could not tell an un-indexed ANN file from a genuine topical zero.
+ *
+ * Says nothing about WHY nothing was compared, deliberately - an empty scope, an unvectorized
+ * corpus and a failed query embed all satisfy it, and they carry different remedies. Callers
+ * separate them (see `proveRetrievalOutcome` in knowledgeBaseSearch); this is the raw fact.
+ */
+export function comparedNoPassages(search: Pick<SemanticDataLakeSearchResult, 'chunksScored' | 'scan'>): boolean {
+  return search.chunksScored === 0 && search.scan.annHits === 0;
+}
+
 export interface SemanticDataLakeSearchParams {
   userId: string;
   /** User's groups for org-level file sharing (forwarded to fabfiles.search). */
@@ -899,19 +922,18 @@ async function rankChunksForFiles(args: {
     );
   }
 
-  // Warn only when NOTHING could be compared by ANY path. A few withheld chunks mid-revectorize
-  // are expected and must stay quiet - the same policy the truncation warning above applies, and
-  // the reason unlabeled files and budgets do not raise the flag either. Excludes annResult.hitsReturned
-  // and alternateHitsReturned (not annEligible.length/outcome file counts): a lake fully served by
-  // ANN retrieval - the primary model, an alternate model, or both - legitimately scores zero
-  // chunks on the scan path, and without this the warning would false-fire on every healthy
-  // all-ANN search that also happens to have an unrelated excluded file elsewhere in scope.
-  if (
-    mismatchReport.partial &&
-    scanned.chunksScored === 0 &&
-    annResult.hitsReturned === 0 &&
-    alternateHitsReturned === 0
-  ) {
+  // Warn only when NOTHING could be compared by ANY path - `comparedNoPassages` above owns that
+  // definition, and counting the ann hits (rather than annEligible.length/outcome file counts) is
+  // why: a lake fully served by ANN retrieval - the primary model, an alternate model, or both -
+  // legitimately scores zero chunks on the scan path, and without them the warning would
+  // false-fire on every healthy all-ANN search that also happens to have an unrelated excluded
+  // file elsewhere in scope. The `partial` guard keeps this to a MISMATCH diagnosis: a few
+  // withheld chunks mid-revectorize are expected and must stay quiet, the same policy the
+  // truncation warning above applies, and the reason unlabeled files and budgets do not raise
+  // the flag either. The retrieval-outcome readers deliberately do NOT inherit that guard - see
+  // `proveRetrievalOutcome` in knowledgeBaseSearch, where an unvectorized corpus raises no
+  // mismatch at all and still has to be reported as unsearched.
+  if (mismatchReport.partial && comparedNoPassages({ chunksScored: scanned.chunksScored, scan })) {
     logger?.warn?.('[semanticSearch] nothing could be compared in the query embedding space', {
       queryEmbeddingModel: embeddingModel,
       excludedFiles: mismatchReport.excludedFiles.count,

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
@@ -22,7 +22,11 @@ vi.mock('../../../../dataLakeService/getDynamicDataLakeTags', async () => {
 // without standing up embeddings; both default to no-hit so the keyword arm runs after.
 const semanticDataLakeSearchMock = vi.fn();
 const fileScopedSemanticSearchMock = vi.fn();
-vi.mock('../../../../dataLakeService/semanticDataLakeSearch', () => ({
+// Spread the real module so the pure helpers stay real - `comparedNoPassages` in particular, which
+// the tool imports from here to grade a search. A factory listing only the two entrypoints leaves
+// every other export undefined, and the tool then throws on the first call to one.
+vi.mock('../../../../dataLakeService/semanticDataLakeSearch', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../../dataLakeService/semanticDataLakeSearch')>()),
   semanticDataLakeSearch: (...args: unknown[]) => semanticDataLakeSearchMock(...args),
   fileScopedSemanticSearch: (...args: unknown[]) => fileScopedSemanticSearchMock(...args),
 }));
@@ -2009,6 +2013,214 @@ describe('search_knowledge_base retrieval summary (#1867)', () => {
       surfaces: ['knowledgeBaseSearch'],
       dataLakeTags: [],
     });
+  });
+});
+
+/**
+ * The semantic arm can run to completion having compared NOTHING against the query - every
+ * candidate withheld for carrying no usable vector - and the keyword arm's write is then the only
+ * one this surface makes for the turn. Recording that as 'ok' claims the library was searched and
+ * came up empty, which is the confident-wrong-answer promptMeta.retrieval exists to catch.
+ *
+ * Asserted on the write the surface actually makes, never on the arm's internal verdict: a test
+ * reading the carried field would still pass if the keyword arm went back to a hardcoded 'ok'.
+ */
+describe('search_knowledge_base retrieval outcome when nothing was compared (#2258)', () => {
+  /** filesScoped > 0 and nothing compared - the shape that makes a corpus provably unsearched. */
+  const unsearchedScan = {
+    truncated: false,
+    fileBudgetHit: false,
+    chunkBudgetHit: false,
+    filesMatching: 3,
+    filesScoped: 3,
+    filesScanned: 3,
+    chunksScanned: 0,
+    chunksSkippedDimensionMismatch: 0,
+    annFilesQueried: 0,
+    annHits: 0,
+    annModelsQueried: 0,
+    budgets: { maxFiles: 20000, maxChunks: 100000 },
+  };
+
+  function semanticCtx(overrides: Partial<ToolContext> = {}, keywordHits: unknown[] = []): ToolContext {
+    return makeContext({
+      retrievalFilter: undefined,
+      db: {
+        fabfiles: { search: vi.fn().mockResolvedValue({ data: keywordHits, total: keywordHits.length }) },
+        fabfilechunks: { findVectorsByFabFileIds: vi.fn() },
+        adminSettings: { getSettingsValue: vi.fn().mockResolvedValue(ADA) },
+        apiKeys: {},
+        usageEvents: { record: vi.fn() },
+      } as never,
+      ...overrides,
+    });
+  }
+
+  const outcomesFrom = (ctx: ToolContext) =>
+    (ctx.statusUpdate as ReturnType<typeof vi.fn>).mock.calls
+      .map(c => (c[0] as { promptMeta?: { retrieval?: { outcome?: string } } })?.promptMeta?.retrieval?.outcome)
+      .filter(Boolean);
+
+  beforeEach(() => {
+    getDynamicDataLakeAccessMock.mockResolvedValue({
+      dataLakeTags: ['datalake:x'],
+      dataLakeTagPrefixes: [],
+      scopedTagPrefixes: [],
+      lakes: [{ id: 'lake-x', datalakeTag: 'datalake:x' }],
+    });
+  });
+
+  it('records not_indexed when every candidate was withheld, not a topical zero', async () => {
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      embeddingMismatch: mismatchReport(),
+      scan: unsearchedScan,
+    });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['not_indexed']);
+  });
+
+  it('records not_indexed even when the keyword arm finds files, since only their names were searched', async () => {
+    // The two keyword branches differ in whether anything was FOUND, not in whether anything was
+    // SEARCHED - so a metadata hit must not launder an unsearchable corpus back into 'ok'.
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      embeddingMismatch: mismatchReport(),
+      scan: unsearchedScan,
+    });
+    const ctx = semanticCtx({}, [
+      { id: 'k', fileName: 'Keyword doc.pdf', tags: [], vectorized: true, mimeType: 'application/pdf' },
+    ]);
+
+    const out = await run(ctx);
+
+    expect(out).toContain('Keyword doc.pdf');
+    expect(outcomesFrom(ctx)).toEqual(['not_indexed']);
+  });
+
+  it('records not_indexed from the agent-scoped arm too', async () => {
+    fileScopedSemanticSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      embeddingMismatch: mismatchReport(),
+      scan: unsearchedScan,
+    });
+    const ctx = semanticCtx({ kbScope: { fileIds: ['a'] } });
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['not_indexed']);
+  });
+
+  it('records not_indexed for a lake the kill switch emptied, the withholding family the ticket names', async () => {
+    // Every candidate withheld by retrievalUnavailable rather than by an embedding mismatch: a
+    // convergence wave deleted the passages and the kill switch stopped them being rebuilt. Same
+    // verdict, a different withholding report - which is why the predicate counts comparisons
+    // instead of asking either report whether it withheld anything.
+    const retrievalUnavailable = {
+      indexing: { count: 0, sample: [] },
+      paused: { count: 3, sample: [{ fileId: 'f1', fileName: 'Handbook.pdf' }] },
+      partial: true,
+    };
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      retrievalUnavailable,
+      scan: unsearchedScan,
+    });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['not_indexed']);
+  });
+
+  it('records not_indexed for an unvectorized corpus, which raises no mismatch flag at all', async () => {
+    // The case `partial` cannot see: nothing was withheld for being off-model, the files simply
+    // hold no vector. Gating on a withholding flag would leave this one reporting 'ok' forever.
+    semanticDataLakeSearchMock.mockResolvedValue({ ...emptySemanticResult(), scan: unsearchedScan });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['not_indexed']);
+  });
+
+  it('keeps ok when a relevance floor emptied a genuinely-ranked result set', async () => {
+    // chunksScored counts comparisons BEFORE minScore, so a floor that filtered every survivor
+    // still proves the library was searched. Folding this into not_indexed would trade one
+    // mislabel for another.
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      chunksScored: 9,
+      scan: { ...unsearchedScan, chunksScanned: 9 },
+    });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['ok']);
+  });
+
+  it('keeps ok when SOME content was withheld and the rest was really searched', async () => {
+    // `partial` is true here (a file was withheld) and the outcome is still 'ok' - the reason a
+    // boolean withholding flag cannot decide this and a count has to.
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      chunksScored: 9,
+      embeddingMismatch: mismatchReport(),
+      scan: { ...unsearchedScan, chunksScanned: 9 },
+    });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['ok']);
+  });
+
+  it('keeps ok when an ANN index served the corpus, which scores zero chunks on the scan path', async () => {
+    // A healthy all-ANN lake legitimately reports chunksScored 0. Keying on that alone would
+    // report every Atlas/OpenSearch deployment as unindexed.
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      scan: { ...unsearchedScan, annFilesQueried: 3, annHits: 12, annModelsQueried: 1 },
+    });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['ok']);
+  });
+
+  it('leaves the outcome alone when no document was in scope, an access state rather than an indexing one', async () => {
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      scan: { ...unsearchedScan, filesMatching: 0, filesScoped: 0, filesScanned: 0 },
+    });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['ok']);
+  });
+
+  it('records failed, not not_indexed, when the query itself could not be embedded', async () => {
+    // Nothing was compared here either, but the remedy is fixing the embedder, never re-indexing
+    // content - the line RetrievalSummarySchema draws between the two outcomes.
+    const report = emptyEmbeddingMismatchReport();
+    report.queryEmbeddingFailed = true;
+    report.partial = true;
+    semanticDataLakeSearchMock.mockResolvedValue({
+      ...emptySemanticResult(),
+      embeddingMismatch: report,
+      scan: unsearchedScan,
+    });
+    const ctx = semanticCtx();
+
+    await run(ctx);
+
+    expect(outcomesFrom(ctx)).toEqual(['failed']);
   });
 });
 

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
@@ -30,11 +30,14 @@ import { GROUNDED_NO_INVENTION_RULE } from '../../../prompts';
 import { PARTIAL_RESULTS_STATUS_SUFFIX } from '../../../../dataLakeService/embeddingMismatch';
 import { describeSearchLimitations } from '../../../../dataLakeService/retrievalUnavailable';
 import {
+  comparedNoPassages,
   fileScopedSemanticSearch,
   semanticDataLakeSearch,
   SemanticChunkResult,
+  type SemanticDataLakeSearchResult,
   type SemanticSearchScanAccounting,
 } from '../../../../dataLakeService/semanticDataLakeSearch';
+import type { RetrievalSummary } from '../../retrievalSummaryMerge';
 import { resolveSearchBudgets, type ResolvedSearchBudgets } from '../../../../dataLakeService/resolveSearchBudgets';
 import { scopeForCaller } from '../../../../settings/resolveScopedSetting';
 import { openSearchChunkAdapter } from '../../../../dataLakeService/openSearchChunkAdapter';
@@ -360,9 +363,70 @@ interface SemanticArmResult {
   /** Per-chunk similarity score, index-aligned with `chunkIds` - required (not optional) so
    *  every construction site must supply it, including the empty-result ones below. */
   scores: number[];
+  /**
+   * What this arm PROVED about the corpus for `promptMeta.retrieval.outcome`, or null when it
+   * proved nothing either way. Carried separately for the same reason `skipNotice` is: on a turn
+   * the semantic arm returns no output for, the keyword arm's write is the only one this surface
+   * makes, so a verdict left here would never be recorded.
+   */
+  retrievalOutcome: ProvenRetrievalOutcome | null;
 }
 
-/** Nothing to report: dependency missing, no accessible corpus, or the arm threw. */
+/**
+ * The outcomes a semantic arm can prove, derived from the schema's enum so a new outcome has to be
+ * placed here rather than silently falling outside it. Neither excluded member is reachable: 'ok'
+ * writes itself via emitSemanticCitables when passages come back, and 'no_lakes' is decided by the
+ * no-corpus guards that return before a search runs.
+ */
+type ProvenRetrievalOutcome = Exclude<RetrievalSummary['outcome'], 'ok' | 'no_lakes'>;
+
+/**
+ * The retrieval verdict a completed semantic search proves, or null when it proves nothing and the
+ * keyword arm's 'ok' should stand. Shared by both arms so the taxonomy is decided once rather than
+ * at each of the write sites that ultimately stamp it.
+ *
+ * Only ever called on the zero-results path. Non-empty results imply something was scored, so both
+ * branches below are already false there.
+ *
+ * The optional reads mirror `search.alternateModelsEmbedded ?? []` at the call sites: both fields
+ * are required on the service's return type, so a real caller always supplies them, and the
+ * tolerance only guards a test double built from a partial result object. A double that omits the
+ * counters therefore keeps the pre-existing 'ok' rather than inventing a verdict from absence.
+ */
+function proveRetrievalOutcome(search: SemanticDataLakeSearchResult): ProvenRetrievalOutcome | null {
+  // The embedder failing is not an indexing gap. Nothing was compared either way, but the remedy
+  // is fixing the outage and never re-vectorizing content, which is precisely the line
+  // RetrievalSummarySchema draws between 'failed' and 'not_indexed'. Forced retrieval reaches the
+  // same verdict for free (generateEmbedding throws and its catch records 'failed'); this path
+  // returns an empty-vector report instead of throwing, so it has to be mapped by hand.
+  if (search.embeddingMismatch?.queryEmbeddingFailed) return 'failed';
+  // Files WERE in scope and not one of their passages was compared against the query. Parity with
+  // forced retrieval's `scoredCount === 0` exit, and the same reasoning: whether the cause is an
+  // unvectorized corpus, a wholly foreign-model one or a lake the kill switch emptied, the library
+  // was not searched, and reporting that as a topical zero claims it was.
+  //
+  // The scope guard is what keeps this off the abstain cases. An empty scope also compares nothing,
+  // but "no document was in scope" is an access/config state rather than evidence about the corpus
+  // - forced retrieval buckets it as 'no_lakes', and this surface's own no-corpus guards return
+  // before a search is ever run, so the honest answer here is to leave their verdict alone.
+  //
+  // Deliberately NOT keyed on `skipNotice` or on either report's `partial`, both of which look
+  // right and are not: `skipNotice` folds in the relevance-floor case, where a genuinely-ranked
+  // result set was emptied by a threshold and 'ok' is correct; `partial` means only that SOME
+  // content was withheld (`withheld.length > 0` for retrievalUnavailable), which is equally true
+  // of a withholding whose remainder really was searched. Only "not one passage was compared"
+  // separates those, and only a count can express it.
+  if (search.scan?.filesScoped > 0 && comparedNoPassages(search)) return 'not_indexed';
+  return null;
+}
+
+/**
+ * Nothing to report: dependency missing, no accessible corpus, or the arm threw. `retrievalOutcome`
+ * is null on all of them - no search completed, so none of them proves anything about whether the
+ * corpus is searchable. The throw is the one that does carry a verdict and it records its own
+ * 'failed' before returning this; the rest deliberately leave the write to the keyword arm, which
+ * really does run and complete on those paths.
+ */
 const NO_SEMANTIC_RESULT: SemanticArmResult = {
   output: null,
   skipNotice: null,
@@ -371,6 +435,7 @@ const NO_SEMANTIC_RESULT: SemanticArmResult = {
   lakeIds: [],
   chunkIds: [],
   scores: [],
+  retrievalOutcome: null,
 };
 
 /**
@@ -471,7 +536,16 @@ async function trySemanticKbSearch(
           `📚 [semantic] 0 results at relevance floor ${budgets.kbMinRelevance.toFixed(2)} (candidates existed above 0 but none cleared the floor)`
         );
       }
-      return { output: null, skipNotice, datalakeTags: [], fileHits: [], lakeIds: [], chunkIds: [], scores: [] };
+      return {
+        output: null,
+        skipNotice,
+        datalakeTags: [],
+        fileHits: [],
+        lakeIds: [],
+        chunkIds: [],
+        scores: [],
+        retrievalOutcome: proveRetrievalOutcome(search),
+      };
     }
 
     // Bound by token budget (the primary lever once configured), with the passage ceiling as a
@@ -519,6 +593,9 @@ async function trySemanticKbSearch(
       ),
       chunkIds: ranked.map(r => r.chunkId),
       scores: ranked.map(r => r.score),
+      // Passages were returned, so emitSemanticCitables above already recorded the 'ok' this
+      // arm proved; there is nothing left for the keyword arm to stamp.
+      retrievalOutcome: null,
     };
   } catch (err) {
     context.logger.warn('📚 [semantic] KB search failed, falling back to keyword:', err);
@@ -598,7 +675,16 @@ async function tryScopedSemanticKbSearch(
           `📚 [semantic] 0 scoped results at relevance floor ${budgets.kbMinRelevance.toFixed(2)} (candidates existed above 0 but none cleared the floor)`
         );
       }
-      return { output: null, skipNotice, datalakeTags: [], fileHits: [], lakeIds: [], chunkIds: [], scores: [] };
+      return {
+        output: null,
+        skipNotice,
+        datalakeTags: [],
+        fileHits: [],
+        lakeIds: [],
+        chunkIds: [],
+        scores: [],
+        retrievalOutcome: proveRetrievalOutcome(search),
+      };
     }
 
     const bound = await boundPassagesByTokenBudget(search.results, {
@@ -630,6 +716,8 @@ async function tryScopedSemanticKbSearch(
       lakeIds: [],
       chunkIds: ranked.map(r => r.chunkId),
       scores: ranked.map(r => r.score),
+      // See the matching return in trySemanticKbSearch: the 'ok' is already recorded.
+      retrievalOutcome: null,
     };
   } catch (err) {
     context.logger.warn('📚 [semantic] scoped KB search failed, falling back to scoped keyword:', err);
@@ -1115,6 +1203,20 @@ export const knowledgeBaseSearchTool: ToolDefinition = {
             rankedResults.map((f: IFabFileDocument) => f.fileName)
           );
 
+          // Whatever the semantic arm proved about the corpus outranks this arm's own verdict, on
+          // BOTH branches below. That is not the same claim as "the tool found nothing": this arm
+          // matches on file METADATA, so it can list documents whose text was never compared to
+          // the query, and calling that 'ok' says the library was searched when only its filenames
+          // were. The two branches differ in whether anything was FOUND, not in whether anything
+          // was SEARCHED, so a verdict that turns on the latter has to apply to both or the same
+          // field would mean different things two branches apart.
+          //
+          // 'ok' when the arm proved nothing, which is the same claim this write has always made:
+          // the semantic arm ran to completion (or never ran at all - see NO_SEMANTIC_RESULT) and
+          // this keyword pass then completed too, so retrieval happened and must stay
+          // distinguishable from "never searched" (#1867).
+          const keywordArmOutcome = semantic.retrievalOutcome ?? 'ok';
+
           // Emit citable source chips so search results appear as clickable citations
           if (rankedResults.length > 0) {
             const citables: CitableSource[] = rankedResults.map((file: IFabFileDocument, index: number) => {
@@ -1172,7 +1274,7 @@ export const knowledgeBaseSearchTool: ToolDefinition = {
                   ...(semantic.skipNotice ? { warnings: [semantic.skipNotice] } : {}),
                   retrieval: {
                     attempted: true,
-                    outcome: 'ok',
+                    outcome: keywordArmOutcome,
                     surfaces: ['knowledgeBaseSearch'],
                     dataLakeTags: keywordArmLakes.map(l => l.datalakeTag),
                   },
@@ -1189,11 +1291,12 @@ export const knowledgeBaseSearchTool: ToolDefinition = {
               {
                 promptMeta: {
                   ...(semantic.skipNotice ? { warnings: [semantic.skipNotice] } : {}),
-                  // Ran to completion and legitimately found nothing - must be distinguishable
-                  // from "never searched" (#1867).
+                  // Zero hits, so the outcome is the whole signal this write carries - see
+                  // `keywordArmOutcome` above for why 'ok' here is a claim about the SEARCH and
+                  // not about the empty result.
                   retrieval: {
                     attempted: true,
-                    outcome: 'ok',
+                    outcome: keywordArmOutcome,
                     surfaces: ['knowledgeBaseSearch'],
                     dataLakeTags: keywordArmLakes.map(l => l.datalakeTag),
                   },

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
@@ -377,8 +377,12 @@ interface SemanticArmResult {
  * placed here rather than silently falling outside it. Neither excluded member is reachable: 'ok'
  * writes itself via emitSemanticCitables when passages come back, and 'no_lakes' is decided by the
  * no-corpus guards that return before a search runs.
+ *
+ * NonNullable is not redundant: `outcome` is required today but becomes present-iff-`attempted`
+ * (#1394), and without it this union would silently absorb `undefined` and stop naming only the
+ * outcomes an arm can PROVE. Keep it.
  */
-type ProvenRetrievalOutcome = Exclude<RetrievalSummary['outcome'], 'ok' | 'no_lakes'>;
+type ProvenRetrievalOutcome = Exclude<NonNullable<RetrievalSummary['outcome']>, 'ok' | 'no_lakes'>;
 
 /**
  * The retrieval verdict a completed semantic search proves, or null when it proves nothing and the


### PR DESCRIPTION
# Pull Request

## Description

`search_knowledge_base`'s semantic arm can run to completion having compared **nothing** against the
query - every candidate withheld for carrying no usable vector - and the turn was recorded as
`promptMeta.retrieval.outcome: 'ok'`.

The scenario: a lake whose passages a convergence wave deleted and the kill switch stopped from
being rebuilt. Every candidate is withheld, the semantic arm scores nothing, the metadata-only
keyword arm finds nothing, and the turn reports `ok` - "we looked and your documents do not cover
this" for a library that was never searched. If forced retrieval did not also run that turn,
nothing corrects it.

`not_indexed` exists for exactly this condition and was wired to one of the two surfaces that can
reach it (forced retrieval's `scoredCount === 0` exit). This applies the same verdict to the other.

Not a regression - that write read `ok` before the outcome vocabulary existed, and nothing renders
the field yet. It matters because the field's first consumer will be built against this taxonomy,
and the cost rises once a panel exists and once more rows accumulate mislabelled.

Closes #2258

## Changes

**The grading rule: was any passage compared, not was anything withheld.**

Two obvious fixes are both wrong, and the tests pin each:

- **Branching on `skipNotice`** conflates the withholding family with the relevance-floor case. A
  floor that emptied a genuinely-ranked result set is a legitimate `ok`, and folding it into
  `not_indexed` trades one mislabel for another.
- **`partial` is not sufficient either.** It means only that *some* content was withheld, which is
  equally true of a withholding whose remainder really was searched.

The counter that answers the question already existed: `chunksScored`, which `scanAndRank`
increments *before* the `minScore` filter.

- **`b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts`** - new exported seam
  `comparedNoPassages` (`chunksScored === 0 && scan.annHits === 0`). The pre-existing "nothing could
  be compared in the query embedding space" warn now shares that one definition instead of spelling
  out its own four-term condition. Both counters are load-bearing: keying on the scan count alone
  reports every healthy Atlas/OpenSearch lake as unindexed, and keying on the ann hits alone reports
  every DocumentDB/self-host lake the same way.
- **`.../knowledgeBaseSearch/index.ts`** - `proveRetrievalOutcome` maps a completed search to
  `not_indexed` / `failed` / null, and **both** semantic arms (unscoped and agent-scoped) carry the
  verdict out on `SemanticArmResult` alongside `skipNotice`, for the same reason `skipNotice` is
  carried: on a zero-passage turn the keyword arm's write is the only one this surface makes.
- **`b4m-core/common/src/schemas/promptMeta.ts`** - the COVERAGE caveat telling readers to treat
  `ok` as "not proven searched" is replaced with what the field now actually guarantees.

Three calls that go past the issue's literal line reference, each deliberate:

1. **Both keyword branches**, not only the no-hits one. They differ in whether anything was
   *found*, not in whether anything was *searched* - this arm matches on file **metadata**, so it
   can list documents whose text was never compared to the query. Fixing one branch and not the
   other reproduces the exact split-meaning bug the issue exists to kill, inside a single function.
2. **A failed query embed records `failed`, not `not_indexed`.** Nothing was compared there either,
   but the remedy is the embedder, never re-indexing - the line the schema draws between the two.
   This is parity: forced retrieval gets there for free because `generateEmbedding` throws into its
   catch, while `semanticDataLakeSearch` returns a `queryEmbeddingFailed` report instead of
   throwing, so it has to be mapped by hand.
3. **A `filesScoped > 0` guard**, so an empty scope keeps its existing verdict. An empty scope also
   compares nothing, but "no document was in scope" is an access/config state rather than evidence
   about the corpus - forced retrieval buckets it as `no_lakes`.

**`knowledgeBaseRetrieve` needs no change** (the issue asked this be checked). Its five `ok` sites
fetch named files and search name/tags/notes (`textSearch: true`); it never ranks against a query
embedding, so it has no comparison to come up empty. Recorded in the schema's COVERAGE note rather
than left as an open question.

**13 new tests, mutation-checked rather than merely green:** reverting the keyword-arm wiring fails
5 of them, dropping the `filesScoped` guard fails 3, dropping `annHits` from the seam fails 2.

## Guide for Testers

`promptMeta.retrieval.outcome` has no dedicated UI yet - it is read through the Prompt Meta
Inspector's raw JSON. These steps are how you observe it.

**Read this first - the corpus is wider than the lake.** The semantic arm searches the lake's files
UNION your own and shared files: `collectScopedFiles` hardcodes `includeShared: true` and never sets
`restrictToDataLake`. Attaching a lake narrows which LAKES are searched; it cannot exclude a file you
own. One vectorized file anywhere in your account therefore makes step 7 read `ok` - correctly, since
something really was searched. Use a **fresh account that owns nothing**, or the assertion cannot be
made. (`retrieval.dataLakeTags` will not warn you: it is written from the session's lake list, not
from what was searched. `promptMeta.citables` is what exposes a file from outside the fixture.)

**Setup - an account whose entire corpus has no comparable passage**

1. Register a fresh account on `app.pr<N>.preview.bike4mind.com` (Admin -> Registration Invites for a
   code, then sign up). Upload nothing else to it, ever.
2. **Sidebar -> Data Lakes -> Create Lake**, name it `Unindexed QA`. Expected: the lake appears.
3. Upload an **image** (any `.png`) to that lake and let processing finish.
   Expected: the file lists with **zero** chunks / vectorized passages. An image never yields
   passages, which is a stable form of the state under test - "in scope, nothing comparable", the
   same state a lake stripped of its passages ends in, with no background work to pause and no
   timing to race.

**The assertion**

4. Start a new chat session and attach `Unindexed QA` to it (session knowledge/lake selector).
5. Ask `What does the handbook say about paid time off?`
   Expected: a reply within ~30s; the status line shows a knowledge-base search ran.
6. Hover the assistant message, open its **context menu (`...`)**, click **Prompt Meta**, then the
   **Debug** tab. Expected: a `Prompt Metadata JSON` block.
7. Read the `retrieval` object.
   Expected: **`"outcome": "not_indexed"`**, `"attempted": true`,
   `"surfaces": ["knowledgeBaseSearch"]`, and **`citables` empty** (a non-empty `citables` means a
   file outside the fixture was searched - see the warning above, the run is void).
   **On `main` this reads `"outcome": "ok"` - that is the bug.**

**The negative case - a searchable corpus must stay `ok`**

8. Upload a plain-text document to the **same** lake and let it vectorize (nonzero passage count).
9. In a new session attached to that lake, ask the same question.
   Expected: **`"outcome": "ok"`**, citing the text document. Only the corpus state changed, so this
   is the controlled counterpart of step 7.
10. Ask a question the document does **not** answer (e.g. `What is the company policy on submarine
    maintenance?`). Expected: still **`"outcome": "ok"`**. A topical zero on a searched library is
    `ok`, and is the case that must not regress into `not_indexed`.

### Regression Checks

11. **Partial withholding still reads `ok`.** Step 9's lake holds both the unsearchable image and the
    vectorized document. Expected `ok`: some content was withheld, but the rest was really searched.
12. **The unvectorized case carries no model-facing notice, and that is unchanged.** In the step-5
    session, `promptMeta.warnings` is expected to be **empty** - neither withholding report raises
    `partial` for a corpus that simply has no vectors, so `skipNotice` stays null. That pre-existing
    gap is described under "Two gaps deliberately left" below; this PR fixes the diagnostic, not the
    notice. Do not read the empty array as a regression.
13. **The withheld-content channel itself is untouched.** On a lake that triggers a genuine
    embedding-model mismatch, the partial-results status suffix and the withholding sentence in
    `warnings` must appear exactly as before. This PR does not write to that channel.
14. **A normal KB search is untouched.** Ask a question the documents do answer; passages are cited
    as before and `retrieval.outcome` is `ok`.
15. **Agent-scoped search.** Ask an agent with a curated knowledge-base scope a question. Expected:
    scoped retrieval behaves as before; `ok` when its curated files are indexed.

### What NOT to test

- **There is no new UI.** No control, badge, banner, or setting ships here. The only way to see the
  change is the Prompt Meta Inspector's raw JSON. The panel that will render this field is #1872,
  which this PR is sequenced before.
- **Do not use "Rebuild passages" or the background-work kill switch to build the fixture.** Both
  look like the obvious lever and neither produces the state: the rechunk route only selects
  under-chunked files, so a healthy single-chunk file is skipped, and the pause setting deliberately
  does not stop real-time user uploads from vectorizing. Use the image file in step 3.
- **Do not test forced retrieval's outcome.** That surface already recorded `not_indexed` and is
  untouched here.
- **Do not test `retrieve_knowledge_content`** for this outcome. It cannot reach the state (it
  fetches named files rather than ranking against a query embedding); this PR only documents that.
- **No performance or cost change** to assert - the fix reads counters the search already computed.
- **No credit/billing surface** is involved.

## Additional Information

**Verified live on the PR preview**, against the deployed head (the deploy pinned this branch's
SHA), through the real chat surface with the `search_knowledge_base` tool - one account, one lake,
only the corpus state varying:

| corpus | `retrieval.outcome` | `citables` |
| --- | --- | --- |
| image only, 0 passages | **`not_indexed`** | none |
| same lake + a vectorized document | `ok` | the document |
| same lake, question the document does not answer | `ok` | the document |

Isolation was established before asserting: an unscoped semantic-search probe on that account
reported `files_in_scope: 1, chunks_scored: 0, ann_hits: 0` - exactly the predicate's inputs - and
the empty `citables` on the first row proves no file from outside the fixture was ranked.

Two things this run corrected in the guide above, both worth knowing: an earlier attempt read `ok`
for the unsearchable lake and looked like a failed fix, but the account owned a vectorized file that
the tool searches regardless of lake scope; and neither "Rebuild passages" nor the background-work
kill switch can produce an emptied lake. The zero-results-with-scored-chunks path (a relevance floor
emptying a real search) is **not** reachable live without configuring `kbMinRelevance`, so it is
covered by unit tests only - called out rather than implied.

Note for anyone testing on this preview: its `defaultEmbeddingModel` is set to a Bedrock Titan model
because the environment has no OpenAI key; the default OpenAI embedding model returns a
"key not configured" error there. That is an environment fact, not a change in this PR.

**Merge-order note.** Open PR #2264 (`feat(retrieval): record whether a turn's retrieval was forced
or merely offered`) edits the same `RetrievalSummarySchema` doc block, one line from the COVERAGE
text rewritten here. Whichever lands second will conflict there. It is a comment-only conflict, but
worth sequencing rather than discovering in the merge queue.

**Two gaps deliberately left, both pre-existing:**

- **The model is still not told** in the unvectorized-corpus case. Neither withholding report raises
  `partial` there, so `skipNotice` is null and the model reads a bare metadata listing while the
  diagnostic is now honest. Closing that means adding a model-facing notice - a prompt-behavior
  change with its own risk, and not what this issue asked for.
- **`apps/client/pages/api/data-lakes/semantic-search.ts`** already exposes `chunks_scored` and
  `partial_results` on the wire and could now expose an "unsearched" flag from the new seam. That is
  a different contract with no outcome taxonomy, so it is untouched.

**One observed state, left as-is:** the semantic arm's chunk-repository guard returns without
recording anything and falls through to `ok`. Arguably `failed` under the schema's host-wiring
clause, but on that path the keyword arm genuinely runs and completes, and
`knowledgeBaseSearch/index.test.ts` pins `ok` there on purpose. Not widened here.

## Developer Notes

- **`comparedNoPassages(search)`** is a new export from the data-lake service - the counterpart to
  the existing `isPartialSearch`. `isPartialSearch` answers "did we return less than the whole
  corpus"; this one answers "did we look at any of it at all". Any future surface that has to tell
  an unsearched corpus from a topical zero should call it rather than re-deriving the condition, and
  it correctly covers both retrieval routes (brute-force scan and ANN).
- **`ProvenRetrievalOutcome`** is derived as `Exclude<RetrievalSummary['outcome'], 'ok' | 'no_lakes'>`
  rather than hand-listed, so a new member added to the Zod enum has to be placed rather than
  silently falling outside the type.
- **The "carry the verdict, do not write it here" pattern** now applies to the retrieval outcome the
  same way it already applied to `skipNotice`: an arm that produces no output still has facts the
  turn's only write needs, so it returns them instead of writing. Any third arm added to this tool
  should follow it.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script - N/A, no new settings
- [ ] I have made the UI/UX feel good - N/A, no UI in this PR
- [ ] I have made corresponding changes to the documentation - N/A; the schema's own doc block is
      the documentation for this field and is updated
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no new
      field and no new data captured; an existing field's value is corrected on one surface
