### PR TITLE
docs(data-lake): scope the transitional stall-prose arm to the forward window

### DIFF
--- a/b4m-core/common/src/constants/chunking.ts
+++ b/b4m-core/common/src/constants/chunking.ts
@@ -203,19 +203,21 @@ export function isConvergencePausedNote(notes?: string | null): boolean {
  * has run in every environment. Reads the new field, then falls back to the legacy prose that the
  * pre-migration rows still carry in `notes`.
  *
- * It exists because the migration and the code that reads the new field do not deploy atomically,
- * in EITHER direction:
+ * It exists for the FORWARD window only: `migratorInvocation` is a `dependsOn` of the web stack
+ * only (infra/web.ts); the queue stack has none, so the executor can serve forced retrieval and
+ * `knowledge_base_search` while rows still carry the marker in `notes` and no `chunkStallReason`. A
+ * row stalled by the chunk arm then reads as a plain unindexed file: `isRetrievalExcluded` drops it
+ * upstream of the withhold on a vectorizedOnly lake, and `partitionByIndexAvailability` calls it
+ * servable everywhere else. The turn answers around a passage-less file and reports FULL coverage -
+ * the silent degradation this whole path exists to prevent.
  *
- * - Forward: `migratorInvocation` is a `dependsOn` of the web stack only (infra/web.ts); the queue
- *   stack has none, so the executor can serve forced retrieval and `knowledge_base_search` while
- *   rows still carry the marker in `notes` and no `chunkStallReason`. A row stalled by the chunk arm
- *   then reads as a plain unindexed file: `isRetrievalExcluded` drops it upstream of the withhold on
- *   a vectorizedOnly lake, and `partitionByIndexAvailability` calls it servable everywhere else. The
- *   turn answers around a passage-less file and reports FULL coverage - the silent degradation this
- *   whole path exists to prevent.
- * - Backward: nothing reverts the data. `migratorInvocation` only ever runs `up`, and `migrate down`
- *   is a manual CLI step, so a code rollback leaves rows migrated and pre-#2016 readers looking at an
- *   absent `notes`.
+ * A code ROLLBACK is the mirror image and this arm CANNOT cover it: the rows are already migrated
+ * (`chunkStallReason` set, `notes` unset) and the code restored is pre-#2016, which does not contain
+ * this function. Nothing reverts the data on its own either - `migratorInvocation` only ever runs
+ * `up` and `migrate down` is a manual CLI step - so `migrate down` is a REQUIRED step of any
+ * rollback past #2016, not an optional tidy-up. What this arm does buy is that `down()` is safe to
+ * run FIRST: whichever stack is still new keeps honoring the prose it restores, so a staggered
+ * rollback has no window where a stalled file reads as servable.
  *
  * Deliberately NOT used by the grading/health/UI readers: they are gated behind the web stack, and
  * a legacy row there renders the notice line AND the identical text as the owner's note.

--- a/b4m-core/common/src/constants/chunking.ts
+++ b/b4m-core/common/src/constants/chunking.ts
@@ -217,7 +217,9 @@ export function isConvergencePausedNote(notes?: string | null): boolean {
  * `up` and `migrate down` is a manual CLI step - so `migrate down` is a REQUIRED step of any
  * rollback past #2016, not an optional tidy-up. What this arm does buy is that `down()` is safe to
  * run FIRST: whichever stack is still new keeps honoring the prose it restores, so a staggered
- * rollback has no window where a stalled file reads as servable.
+ * rollback has no window where a restored marker is invisible. `down()` is a PARTIAL restore
+ * though - it skips a row whose owner typed a note after `up()`, and that row grades as unstalled
+ * on both stacks once the field is dropped. See its own comment.
  *
  * Deliberately NOT used by the grading/health/UI readers: they are gated behind the web stack, and
  * a legacy row there renders the notice line AND the identical text as the owner's note.

--- a/b4m-core/services/src/dataLakeService/retrievalUnavailable.test.ts
+++ b/b4m-core/services/src/dataLakeService/retrievalUnavailable.test.ts
@@ -83,11 +83,11 @@ describe('partitionByIndexAvailability (#1681 constraint 1)', () => {
     expect(withheld.map(f => f.id)).toEqual(['f1']);
   });
 
-  // The transitional legacy arm (isChunkStalledFile): between the queue stack's deploy and the
-  // #2016 migration - and after a code ROLLBACK, which nothing reverts the data for - a stalled row
-  // still carries the marker as prose in `notes` and no `chunkStallReason`. Without the fallback it
-  // reads as a plain chunkless file and is SERVED, so the turn answers around a hole and reports
-  // full coverage. Delete with the arm.
+  // The transitional legacy arm (isChunkStalledFile): between the queue stack's deploy and the #2016
+  // migration a stalled row still carries the marker as prose in `notes` and no `chunkStallReason`.
+  // Without the fallback it reads as a plain chunkless file and is SERVED, so the turn answers around
+  // a hole and reports full coverage. Delete with the arm. (A code ROLLBACK is the opposite shape and
+  // is NOT covered here - it needs `migrate down`; see the chunking.ts docblock.)
   it('withholds a pre-migration row carrying the stall marker as legacy prose in notes', () => {
     const legacy = {
       ...settled,

--- a/b4m-core/utils/src/retrievalExclusion.test.ts
+++ b/b4m-core/utils/src/retrievalExclusion.test.ts
@@ -90,9 +90,9 @@ describe('isRetrievalExcluded', () => {
   });
 
   it('keeps a PRE-MIGRATION stranded file, whose marker is still legacy prose in notes', () => {
-    // The queue stack does not wait on #2016's migrator, and a code rollback does not revert the
-    // data, so both windows can hand this reader a row with the marker only in `notes`. Without the
-    // transitional arm it is dropped here - upstream of the withhold - and the hole goes unreported.
+    // The queue stack does not wait on #2016's migrator, so it can hand this reader a row with the
+    // marker only in `notes`. Without the transitional arm it is dropped here - upstream of the
+    // withhold - and the hole goes unreported.
     const legacy = { fileName: 'Report.pdf', vectorized: false, notes: CHUNK_STALL_NOTICES.rechunkPaused };
     expect(isRetrievalExcluded(legacy, { vectorizedOnly: true })).toBe(false);
     // The owner's own prose is not a marker; only the exact handler wording is.

--- a/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts
+++ b/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts
@@ -53,7 +53,10 @@ import { type MigrationFile } from './index';
  * them. A row left migrated reads as unstalled to every pre-#2016 reader - no `abandonedByKillSwitch`
  * health signal, a permanent "still indexing" from `partitionByIndexAvailability`, and no "Rebuild
  * passages" repair from `findConvergencePausedFilesByScope`. Run `down()` FIRST: the transitional
- * arms honor the prose it restores, so the still-new stack keeps working until it is gone.
+ * arms honor the prose it restores, so the still-new stack keeps working until it is gone. It is a
+ * PARTIAL restore by design (see its comment): a row whose owner typed a note after `up()` keeps
+ * that note and loses its marker with the dropped field, so audit those rather than assume `down()`
+ * recovered every row.
  */
 
 /** Applied to the two stall notes only; they are fixed literals but contain a regex metacharacter ('.'). */

--- a/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts
+++ b/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts
@@ -41,13 +41,19 @@ import { type MigrationFile } from './index';
  * Gating the queue stacks on the migrator would not close it: the old handlers keep serving until
  * their own deploy either way.
  *
- * The READ side of both windows - the forward one above, and a code rollback, where nothing reverts
- * the data because `migratorInvocation` only ever runs `up` and `migrate down` is a manual CLI step -
- * is covered by `isChunkStalledFile` (b4m-core/common/src/constants/chunking.ts) and its Mongo mirror
- * in `buildFabFileSearchQuery`. Those transitional arms read the legacy prose alongside the new field,
- * so a retrieval path serving ahead of, or behind, this migration still withholds and NAMES a stalled
- * file. They are what makes rolling the code back safe without also running `down()`, and they are
- * deleted one release after this has landed everywhere - see that docblock.
+ * The READ side of that forward window is covered by `isChunkStalledFile`
+ * (b4m-core/common/src/constants/chunking.ts) and its Mongo mirror in `buildFabFileSearchQuery`.
+ * Those transitional arms read the legacy prose alongside the new field, so a retrieval path serving
+ * AHEAD of this migration still withholds and NAMES a stalled file. They are deleted one release
+ * after this has landed everywhere - see that docblock.
+ *
+ * ROLLING BACK PAST #2016 REQUIRES `migrate down`. Nothing reverts the data on its own
+ * (`migratorInvocation` only ever runs `up`), and the transitional arms above do not help here: they
+ * read prose this migration deleted, and the pre-#2016 code a rollback restores does not contain
+ * them. A row left migrated reads as unstalled to every pre-#2016 reader - no `abandonedByKillSwitch`
+ * health signal, a permanent "still indexing" from `partitionByIndexAvailability`, and no "Rebuild
+ * passages" repair from `findConvergencePausedFilesByScope`. Run `down()` FIRST: the transitional
+ * arms honor the prose it restores, so the still-new stack keeps working until it is gone.
  */
 
 /** Applied to the two stall notes only; they are fixed literals but contain a regex metacharacter ('.'). */


### PR DESCRIPTION
# Pull Request

## Description

`isChunkStalledFile` landed to close the deploy window where the queue stack serves ahead of the `20260828000000_split-chunk-stall-markers-off-notes` migration. It does close that window. But its docblock listed a **second** reason it exists - a code rollback - and the migration docblock turned that into an operator instruction: the transitional arms "are what makes rolling the code back safe without also running `down()`".

That direction is one the arm structurally cannot reach, and the instruction is actively dangerous.

The arm is `isChunkStalled(chunkStallReason) || LEGACY_CHUNK_STALL_NOTES.includes(notes)`. Reading legacy prose out of `notes` is **new code reading un-migrated rows**. A rollback is the mirror image: the rows are **migrated** (`chunkStallReason` set, `notes` unset by the migration's exact arm) and the code restored is pre-#2016, which does not contain `isChunkStalledFile` at all. The function is never on the stack.

**What happens if someone acts on the old wording.** Take a file at `chunkCount: 45, vectorizedChunkCount: 0, error: null, chunkStallReason: 'vectorizePaused'`, `notes` unset. Roll the code back without running `down()`:

- `evaluateMemberHealth` calls `isConvergencePausedNote(undefined)` -> `false`, so `abandonedByKillSwitch` never fires.
- `isMemberIndexingInFlight` finds nothing settled and compares `0 < 45` -> in flight, **permanently**.
- `partitionByIndexAvailability` withholds it as `indexing`, so search prints "they will return on their own" about a file that never will.
- `findConvergencePausedFilesByScope` matches nothing - its `notes: { $in: CONVERGENCE_PAUSED_NOTES }` arm sees an absent field and the stale-pending arm sees `null`. **"Rebuild passages" no longer offers the repair.**

So `migrate down` is a **required** step of any rollback past #2016, not an optional tidy-up.

There is also a real property worth keeping, once stated correctly: the arm makes `down()` safe to run **early**, so a staggered rollback (queue before web, or vice versa) has no window where a *restored* marker is invisible to whichever stack is still new. That is "safe to run `down()` **first**", not "safe **without** `down()`".

**`down()` is a partial restore, and the docs now say so.** Its restore arm is guarded on `notes` still being empty, so a row whose owner typed a note after `up()` is skipped - and then loses `chunkStallReason` with the field drop, ending up unstalled to *every* reader. That carve-out is called out in both docblocks; see the self-review commit below for how it was found.

Comment-only. No behaviour change, no runtime code touched.

Closes #2295

## Changes

**`b2891dc` - the fix**

- **`b4m-core/common/src/constants/chunking.ts`** - scoped the `isChunkStalledFile` docblock to the forward window. The `Forward:` / `Backward:` bullet pair is gone; a rollback is now stated as a hazard the arm explicitly does **not** cover, `migrate down` is named as required, and the property the arm genuinely buys (`down()` safe to run first) is spelled out.
- **`packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts`** - replaced the "safe without also running `down()`" sentence with `ROLLING BACK PAST #2016 REQUIRES migrate down`, plus the three concrete readers that go wrong if it is skipped.
- **`b4m-core/services/src/dataLakeService/retrievalUnavailable.test.ts`** and **`b4m-core/utils/src/retrievalExclusion.test.ts`** - dropped the matching "a code rollback does not revert the data" claims from both test comments.

**`8ef3e9a` - self-review correction**

The first pass replaced one overstatement with another: it claimed a staggered rollback has "no window where a stalled file reads as servable". `down()` does not deliver that, and its own comment says so. Narrowed the claim to *restored* markers and documented the partial restore in both files.

## Guide for Testers

**There is no UI or runtime behaviour in this PR.** It changes four comments and nothing else. Verification is reading the diff and confirming the new prose is true of the code it describes. Any reviewer or agent can run these from a checkout of this branch:

1. Confirm the diff is comment-only. Run:
   ```
   git diff origin/main...HEAD --stat
   git diff origin/main...HEAD | grep -E '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-]\s*(\*|//)'
   ```
   **Expected:** 4 files changed. The second command prints **nothing** - every added and removed line is inside a `/* */` block or a `//` comment.

2. Confirm the retracted claim is gone repo-wide. Run:
   ```
   git grep -i 'without also running' -- '*.ts' '*.md'
   ```
   **Expected:** no output.

3. Confirm the arm genuinely cannot be on a rolled-back stack - the core premise. Run:
   ```
   git grep chunkStallReason 49f96c3ca^ -- b4m-core packages apps
   ```
   **Expected:** no output. `chunkStallReason` and `isChunkStalledFile` do not exist before the commit that introduced them, so pre-#2016 code cannot contain the fallback.

4. Confirm every symbol named in the new failure chain resolves, and that the pre-#2016 versions really did key on `notes`. Run:
   ```
   git show 49f96c3ca^:b4m-core/common/src/constants/lakeHealth.ts | grep -n 'abandonedByKillSwitch'
   git show 49f96c3ca^:b4m-core/services/src/dataLakeService/retrievalUnavailable.ts | grep -n 'isConvergencePausedNote'
   git grep -n 'Rebuild passages' -- apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
   ```
   **Expected:** the first shows `isConvergencePausedNote(member.notes)`, the second shows the same predicate reading `file.notes`, the third hits `LakeInfoPanel.tsx:83`. All three old readers keyed on `notes`, which is why a migrated row is invisible to them.

5. Confirm the migration's exact arm really does unset `notes`, and that `down()`'s restore is guarded. Open the migration around lines 105 and 186.
   **Expected:** `up()` has `{ $set: { chunkStallReason: reason }, $unset: { notes: '' } }`; `down()`'s restore matches only `$or: [{ notes: { $exists: false } }, { notes: '' }]`.

6. Confirm the tests whose comments changed still pass:
   ```
   pnpm --filter @bike4mind/utils test src/retrievalExclusion.test.ts
   pnpm --filter @bike4mind/services test src/dataLakeService/retrievalUnavailable.test.ts
   ```
   **Expected:** 18 passed and 27 passed respectively.

### Optional: prove it against a real database

If you have a local Mongo, the claims can be executed rather than read. Seed two stalled rows carrying the legacy prose, run `migration.up()`, then `migration.down()`, evaluating `isConvergencePausedNote(notes)` (the pre-#2016 reader) and `isChunkStalledFile(row)` (the current one) at each stage. This was run on a local self-host before merge:

| Stage | Row | `chunkStallReason` | `notes` | pre-#2016 reader | current reader |
|---|---|---|---|---|---|
| seeded | A, B | absent | prose | `true` | `true` |
| after `up()` | A, B | set | **absent** | **`false`** | `true` |
| after `down()` | A | absent | **restored** | `true` | `true` |
| after `down()` | B *(owner typed a note after `up()`)* | absent | owner text | **`false`** | **`false`** |

Row A after `up()` is the failure this PR documents: invisible to every old reader. Row B after `down()` is the partial restore - `down()` logged `Restored 0 'vectorizePaused' markers` and the row grades unstalled on both stacks.

### Regression Checks

None apply in the usual sense - no code path changed. The only regression risk a comment carries is that a future reader trusts it, so the check is step 4 above: every symbol the new prose names must still exist. If a later PR renames `findConvergencePausedFilesByScope` or `abandonedByKillSwitch`, these comments need updating with it.

### What NOT to test

- **Do not boot a preview environment.** Nothing observable changes; a preview cannot distinguish this branch from `main`, so a browser pass here proves nothing either way.
- **Do not try to exercise the rollback on a shared environment.** Verifying it end to end means deploying, migrating, then rolling the code back with data left migrated - exactly the state this PR documents as harmful. Use a local/scratch database, as above.
- **Do not test data-lake indexing, the convergence kill switch, "Rebuild passages", or retrieval withholding.** All of that behaviour is unchanged by this PR; it is only *described* more accurately.

## Additional Information

The rollback hazard was raised in review before the original merge. The fix that landed aimed at it but, for the reason above, could not reach it - so what shipped was correct code carrying an incorrect explanation. This PR corrects the explanation only; it deliberately does **not** change the arm, which is still scheduled for deletion one release after the migration has landed everywhere.

A small inaccuracy in the issue for the record: it cites `isChunkStalledFile` at `chunking.ts:201-220`, but that range is the docblock - the function is at `232-234`. The issue's suggested-fix section targets the right range.

Gates: `@bike4mind/utils` 18 passed, `@bike4mind/services` 27 passed, `tsc --noEmit` clean on `common` / `utils` / `services` / `scripts`, `pnpm lint:check` clean, prettier clean, both ASCII guards clean, and the full pre-commit hook ran on both commits with no `--no-verify`.

## Developer Notes (Optional)

- **Doc invariant worth keeping.** The corrected docblocks state the asymmetry explicitly: a legacy-prose fallback can only ever cover the *forward* half of a migration window, because it is by construction new code reading old rows. Any future transitional read-arm added for a data migration inherits the same limit - it is never a rollback story, and the rollback story is always "run `down()`, and run it first".
- **A reversible migration is not necessarily a complete one.** This `down()` deliberately refuses to overwrite owner-authored text to reconstruct a marker, which makes it a partial restore. That is the right trade, but it means "we have a `down()`" does not imply "a rollback is lossless" - worth stating in any migration whose `down()` is guarded.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
