### PR TITLE
feat(retrieval): add a recall probe harness for kb search budgets

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,7 +50,8 @@
     "backfill:pending-free-credits": "tsx backfillPendingFreeCredits.ts",
     "backfill:fabfile-moderation-status": "tsx src/backfill-fabfile-moderation-status.ts",
     "tavern:upload-icons": "tsx src/uploadTavernIcons.ts",
-    "count-tokens-probe": "tsx count-tokens-probe.ts"
+    "count-tokens-probe": "tsx count-tokens-probe.ts",
+    "retrieval:recall-probe": "tsx retrieval/recall-probe.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.111.0",

--- a/packages/scripts/retrieval/auditEvent.test.ts
+++ b/packages/scripts/retrieval/auditEvent.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { readRetrievalStatus, readServedDocuments, type RetrievalStatus } from './auditEvent';
+import { RELEVANCE_FLOOR_NOTICE, readRetrievalStatus, readServedDocuments, type RetrievalStatus } from './auditEvent';
 
 /** The tool ran to completion and put passages in front of the model. */
 const SERVED: RetrievalStatus = { kind: 'served-content' };
 /** The tool ran to completion and had nothing to serve. */
 const EMPTY: RetrievalStatus = { kind: 'no-content' };
+/** The semantic arm ran and the floor under test rejected every candidate. */
+const FLOOR_EMPTIED: RetrievalStatus = { kind: 'floor-emptied' };
+
+/** The notice as the tool actually writes it, prefix-matched by RELEVANCE_FLOOR_NOTICE. */
+const floorWarning = `${RELEVANCE_FLOOR_NOTICE} for this query`;
 
 describe('readRetrievalStatus', () => {
   it('reads a citables write as content having reached the model', () => {
@@ -25,6 +30,52 @@ describe('readRetrievalStatus', () => {
         { retrieval: { outcome: 'ok' } },
       ])
     ).toEqual(SERVED);
+  });
+
+  it('takes the LAST outcome when two writes disagree, in both directions', () => {
+    // The pair above cannot fail if the terminal pick is reversed - both outcomes are 'ok'. These
+    // can. The rule is load-bearing: it is what makes the semantic-then-keyword sequence readable
+    // at all, and what lets a late failure override an earlier apparent success.
+    expect(readRetrievalStatus([{ retrieval: { outcome: 'ok' } }, { retrieval: { outcome: 'failed' } }])).toEqual({
+      kind: 'failed',
+      outcome: 'failed',
+    });
+    expect(readRetrievalStatus([{ retrieval: { outcome: 'failed' } }, { retrieval: { outcome: 'ok' } }])).toEqual(
+      EMPTY
+    );
+  });
+
+  it('reads the relevance-floor notice as the floor emptying an arm that DID run', () => {
+    // The keyword arm carries the semantic arm's skipNotice into promptMeta.warnings. Without
+    // this, a nonzero floor reads as a keyword fallback and aborts the sweep on its first
+    // negative question - the exact rows the floor was added to produce.
+    expect(readRetrievalStatus([{ warnings: [floorWarning], retrieval: { outcome: 'ok' } }])).toEqual(FLOOR_EMPTIED);
+  });
+
+  it('lets the floor notice win over citables the keyword fallback stamped', () => {
+    // The fallback still runs after the floor empties the semantic arm, and its hits become
+    // citables. Counting those would report the keyword arm's behaviour as this configuration's,
+    // and neither knob under test governs that arm.
+    expect(
+      readRetrievalStatus([{ citables: [{ id: 'f1' }], warnings: [floorWarning], retrieval: { outcome: 'ok' } }])
+    ).toEqual(FLOOR_EMPTIED);
+  });
+
+  it('does not read an unrelated warning as the floor', () => {
+    // describeSearchLimitations produces its own notices (e.g. files withheld for a model
+    // mismatch) on the same field. Those mean the corpus was not whole, which is not a clean
+    // measurement - they must keep falling through to the abort.
+    expect(readRetrievalStatus([{ warnings: ['some files were withheld'], retrieval: { outcome: 'ok' } }])).toEqual(
+      EMPTY
+    );
+  });
+
+  it('keeps a non-ok outcome ahead of the floor notice', () => {
+    // A failed retrieval exercised no configuration whether or not a floor was set.
+    expect(readRetrievalStatus([{ warnings: [floorWarning], retrieval: { outcome: 'failed' } }])).toEqual({
+      kind: 'failed',
+      outcome: 'failed',
+    });
   });
 
   it('reports a non-ok outcome rather than reading it as an empty result', () => {
@@ -88,6 +139,13 @@ describe('readServedDocuments', () => {
     // the operator after an embedding credential that is fine.
     expect(readServedDocuments({ fileIds: [], scores: [0.9] }, SERVED)).toMatchObject({ kind: 'unmeasurable' });
     expect(readServedDocuments({ scores: [0.9] }, SERVED)).toMatchObject({ kind: 'unmeasurable' });
+  });
+
+  it('reads a floor-emptied turn as nothing served, whatever the keyword arm recorded', () => {
+    // The keyword fallback writes its own unscored audit row. Reading THAT as keyword-fallback is
+    // what made `--configs 0:0,4000:70` impossible to complete.
+    expect(readServedDocuments({ fileIds: ['f1'] }, FLOOR_EMPTIED)).toEqual({ kind: 'nothing' });
+    expect(readServedDocuments(null, FLOOR_EMPTIED)).toEqual({ kind: 'nothing' });
   });
 
   it('does not treat a zero score as absent', () => {

--- a/packages/scripts/retrieval/auditEvent.test.ts
+++ b/packages/scripts/retrieval/auditEvent.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readServedDocuments } from './auditEvent';
+
+describe('readServedDocuments', () => {
+  it('reads a scored event as the files retrieval served', () => {
+    expect(readServedDocuments({ fileIds: ['f1', 'f2'], scores: [0.81, 0.74] })).toEqual({
+      kind: 'served',
+      fileIds: ['f1', 'f2'],
+    });
+  });
+
+  it('reads no event as having served nothing', () => {
+    // The desired outcome on a negative question: the search produced no output, so the tool
+    // recorded no lake read.
+    expect(readServedDocuments(null)).toEqual({ kind: 'nothing' });
+    expect(readServedDocuments(undefined)).toEqual({ kind: 'nothing' });
+  });
+
+  it('reads a score-less event as the keyword fallback, not as a result', () => {
+    // The keyword arm records the SAME surface with no chunk scores. Scoring it as a real result
+    // would report a keyword-search number as a budget-sweep row, and neither knob applies there.
+    expect(readServedDocuments({ fileIds: ['f1'] })).toEqual({ kind: 'keyword-fallback' });
+    expect(readServedDocuments({ fileIds: ['f1'], scores: [] })).toEqual({ kind: 'keyword-fallback' });
+  });
+
+  it('refuses a scored event that carries no files rather than scoring it as an honest zero', () => {
+    // Should not occur - scores are index-aligned to the chunks those files came from - but reading
+    // it as 'served' with an empty list would silently score a broken run as a zero-recall question.
+    expect(readServedDocuments({ fileIds: [], scores: [0.9] })).toEqual({ kind: 'keyword-fallback' });
+    expect(readServedDocuments({ scores: [0.9] })).toEqual({ kind: 'keyword-fallback' });
+  });
+
+  it('does not treat a zero score as absent', () => {
+    // 0 is a real cosine score. A truthiness check on scores[0] would misread this as the keyword arm.
+    expect(readServedDocuments({ fileIds: ['f1'], scores: [0] })).toEqual({ kind: 'served', fileIds: ['f1'] });
+  });
+});

--- a/packages/scripts/retrieval/auditEvent.test.ts
+++ b/packages/scripts/retrieval/auditEvent.test.ts
@@ -1,37 +1,100 @@
 import { describe, expect, it } from 'vitest';
-import { readServedDocuments } from './auditEvent';
+import { readRetrievalStatus, readServedDocuments, type RetrievalStatus } from './auditEvent';
+
+/** The tool ran to completion and put passages in front of the model. */
+const SERVED: RetrievalStatus = { kind: 'served-content' };
+/** The tool ran to completion and had nothing to serve. */
+const EMPTY: RetrievalStatus = { kind: 'no-content' };
+
+describe('readRetrievalStatus', () => {
+  it('reads a citables write as content having reached the model', () => {
+    expect(readRetrievalStatus([{ citables: [{ id: 'f1' }], retrieval: { outcome: 'ok' } }])).toEqual(SERVED);
+  });
+
+  it('reads an ok write with no citables as a completed search that found nothing', () => {
+    // The keyword arm's no-hit branch: outcome 'ok' precisely so it is distinguishable from
+    // "never searched", but no citables because nothing was served.
+    expect(readRetrievalStatus([{ retrieval: { outcome: 'ok' } }])).toEqual(EMPTY);
+  });
+
+  it('takes the last retrieval write as terminal but keeps citables from any of them', () => {
+    // A semantic arm that found nothing falls through to the keyword arm, which writes again.
+    expect(
+      readRetrievalStatus([
+        { citables: [{ id: 'f1' }], retrieval: { outcome: 'ok' } },
+        { retrieval: { outcome: 'ok' } },
+      ])
+    ).toEqual(SERVED);
+  });
+
+  it('reports a non-ok outcome rather than reading it as an empty result', () => {
+    expect(readRetrievalStatus([{ retrieval: { outcome: 'failed' } }])).toEqual({ kind: 'failed', outcome: 'failed' });
+    expect(readRetrievalStatus([{ retrieval: { outcome: 'no_lakes' } }])).toEqual({
+      kind: 'failed',
+      outcome: 'no_lakes',
+    });
+    // A retrieval block with no outcome at all is still not a completed search.
+    expect(readRetrievalStatus([{ retrieval: {} }])).toEqual({ kind: 'failed', outcome: 'unknown' });
+  });
+
+  it('reports no status writes at all as absent', () => {
+    expect(readRetrievalStatus([])).toEqual({ kind: 'absent' });
+    // A status write that carries no retrieval block does not count as the terminal one.
+    expect(readRetrievalStatus([{ citables: [{ id: 'f1' }] }])).toEqual({ kind: 'absent' });
+  });
+});
 
 describe('readServedDocuments', () => {
   it('reads a scored event as the files retrieval served', () => {
-    expect(readServedDocuments({ fileIds: ['f1', 'f2'], scores: [0.81, 0.74] })).toEqual({
+    expect(readServedDocuments({ fileIds: ['f1', 'f2'], scores: [0.81, 0.74] }, SERVED)).toEqual({
       kind: 'served',
       fileIds: ['f1', 'f2'],
     });
   });
 
-  it('reads no event as having served nothing', () => {
+  it('reads no event as having served nothing when the tool says it served nothing', () => {
     // The desired outcome on a negative question: the search produced no output, so the tool
-    // recorded no lake read.
-    expect(readServedDocuments(null)).toEqual({ kind: 'nothing' });
-    expect(readServedDocuments(undefined)).toEqual({ kind: 'nothing' });
+    // recorded no lake read - and its own status write corroborates that.
+    expect(readServedDocuments(null, EMPTY)).toEqual({ kind: 'nothing' });
+    expect(readServedDocuments(undefined, EMPTY)).toEqual({ kind: 'nothing' });
+  });
+
+  it('refuses a missing event when the tool says content WAS served', () => {
+    // The case a bare null cannot express: a stalled un-awaited audit write, or a hit on something
+    // not attributable to a lake. Scoring it zero would look exactly like the floor working.
+    const reading = readServedDocuments(null, SERVED);
+    expect(reading.kind).toBe('unmeasurable');
+    expect(reading).toMatchObject({ reason: expect.stringContaining('no lake-audit event') });
+  });
+
+  it('refuses a run whose retrieval never completed', () => {
+    expect(readServedDocuments(null, { kind: 'failed', outcome: 'no_lakes' })).toMatchObject({
+      kind: 'unmeasurable',
+      reason: expect.stringContaining('no_lakes'),
+    });
+    expect(readServedDocuments(null, { kind: 'absent' })).toMatchObject({ kind: 'unmeasurable' });
   });
 
   it('reads a score-less event as the keyword fallback, not as a result', () => {
     // The keyword arm records the SAME surface with no chunk scores. Scoring it as a real result
     // would report a keyword-search number as a budget-sweep row, and neither knob applies there.
-    expect(readServedDocuments({ fileIds: ['f1'] })).toEqual({ kind: 'keyword-fallback' });
-    expect(readServedDocuments({ fileIds: ['f1'], scores: [] })).toEqual({ kind: 'keyword-fallback' });
+    expect(readServedDocuments({ fileIds: ['f1'] }, SERVED)).toEqual({ kind: 'keyword-fallback' });
+    expect(readServedDocuments({ fileIds: ['f1'], scores: [] }, SERVED)).toEqual({ kind: 'keyword-fallback' });
   });
 
-  it('refuses a scored event that carries no files rather than scoring it as an honest zero', () => {
-    // Should not occur - scores are index-aligned to the chunks those files came from - but reading
-    // it as 'served' with an empty list would silently score a broken run as a zero-recall question.
-    expect(readServedDocuments({ fileIds: [], scores: [0.9] })).toEqual({ kind: 'keyword-fallback' });
-    expect(readServedDocuments({ scores: [0.9] })).toEqual({ kind: 'keyword-fallback' });
+  it('refuses a scored event that carries no files rather than blaming the keyword arm', () => {
+    // Should not occur - scores are index-aligned to the chunks those files came from - and it is
+    // not the keyword arm either, which writes no scores at all. Diagnosing it as one would send
+    // the operator after an embedding credential that is fine.
+    expect(readServedDocuments({ fileIds: [], scores: [0.9] }, SERVED)).toMatchObject({ kind: 'unmeasurable' });
+    expect(readServedDocuments({ scores: [0.9] }, SERVED)).toMatchObject({ kind: 'unmeasurable' });
   });
 
   it('does not treat a zero score as absent', () => {
     // 0 is a real cosine score. A truthiness check on scores[0] would misread this as the keyword arm.
-    expect(readServedDocuments({ fileIds: ['f1'], scores: [0] })).toEqual({ kind: 'served', fileIds: ['f1'] });
+    expect(readServedDocuments({ fileIds: ['f1'], scores: [0] }, SERVED)).toEqual({
+      kind: 'served',
+      fileIds: ['f1'],
+    });
   });
 });

--- a/packages/scripts/retrieval/auditEvent.ts
+++ b/packages/scripts/retrieval/auditEvent.ts
@@ -13,6 +13,49 @@ export type AuditEventShape = {
   scores?: number[];
 };
 
+/**
+ * What the tool's OWN status write says happened, captured from the `statusUpdate` seam.
+ *
+ * This is what disambiguates an absent audit event. Every terminal path in
+ * `search_knowledge_base` awaits a `statusUpdate` carrying `promptMeta.retrieval` before returning
+ * (the semantic arm via `emitSemanticCitables`, the keyword arm on both its hit and no-hit
+ * branches, and each failure path), so unlike the un-awaited audit write this signal is always
+ * present by the time `toolFn` resolves. `citables` is the tool's own record of what reached the
+ * model, so its presence separates "served content" from "ran and found nothing".
+ */
+export type RetrievalStatus =
+  /** Retrieval ran to completion and put passages in front of the model. */
+  | { kind: 'served-content' }
+  /** Retrieval ran to completion and legitimately had nothing to serve. */
+  | { kind: 'no-content' }
+  /** Retrieval reported a non-ok outcome (`failed`, `no_lakes`). */
+  | { kind: 'failed'; outcome: string }
+  /** No retrieval status was written at all, so the tool did not reach a terminal path. */
+  | { kind: 'absent' };
+
+/** The `promptMeta` fields this reading depends on. The tool writes more; none of the rest matters. */
+export type CapturedPromptMeta = {
+  citables?: unknown[];
+  retrieval?: { outcome?: string };
+};
+
+/**
+ * Collapse the status writes captured across one tool call into the one fact the audit reading
+ * needs.
+ *
+ * The last write carrying `retrieval` is the terminal one: a semantic arm that finds nothing falls
+ * through to the keyword arm, which writes its own. `citables` is checked across every write
+ * because it is the tool's record of what actually reached the model, and the keyword arm's no-hit
+ * branch is the one path that omits it.
+ */
+export function readRetrievalStatus(metas: readonly CapturedPromptMeta[]): RetrievalStatus {
+  const terminal = [...metas].reverse().find(m => m.retrieval)?.retrieval;
+  if (!terminal) return { kind: 'absent' };
+  const outcome = terminal.outcome ?? 'unknown';
+  if (outcome !== 'ok') return { kind: 'failed', outcome };
+  return metas.some(m => (m.citables?.length ?? 0) > 0) ? { kind: 'served-content' } : { kind: 'no-content' };
+}
+
 export type ServedReading =
   /** Retrieval ran and served these files. */
   | { kind: 'served'; fileIds: string[] }
@@ -23,7 +66,12 @@ export type ServedReading =
    * applies there, so the configuration was never exercised and the run must stop rather than
    * report a keyword-search number as a budget-sweep row.
    */
-  | { kind: 'keyword-fallback' };
+  | { kind: 'keyword-fallback' }
+  /**
+   * The probe cannot say what was served. Never scored - a data point the harness could not
+   * observe must surface as an error, not as a zero that reads like a real floor rejection.
+   */
+  | { kind: 'unmeasurable'; reason: string };
 
 /**
  * `search_knowledge_base` records an audit event from two places (`knowledgeBaseSearch/index.ts`,
@@ -33,18 +81,51 @@ export type ServedReading =
  * - semantic arm: carries `chunkIds` and per-chunk `scores`.
  * - keyword arm:  carries `fileIds` only, no scores (it is metadata-only, with no chunk ranking).
  *
- * No event at all means no lake read was recorded, which for a caller who owns no files of their own
- * means the search produced no output. The probe enforces that "owns no files" precondition in its
- * preflight, because without it an unattributable personal-file hit also produces no event and would
- * be misread here as "served nothing".
+ * No event at all is AMBIGUOUS on its own, which is why `status` is required. The tool writes no
+ * audit row when it served nothing, and the probe's wait for that un-awaited write can also simply
+ * time out - the same absence standing for a genuine result and for a harness malfunction. `status`
+ * is the tool's own awaited account of which one it was.
  */
-export function readServedDocuments(event: AuditEventShape | null | undefined): ServedReading {
-  if (!event) return { kind: 'nothing' };
+export function readServedDocuments(event: AuditEventShape | null | undefined, status: RetrievalStatus): ServedReading {
+  if (status.kind === 'absent') {
+    return {
+      kind: 'unmeasurable',
+      reason:
+        'the tool wrote no retrieval status, so it never reached a terminal path. The probe cannot ' +
+        'tell a served result from an empty one without it - check the ToolContext wiring.',
+    };
+  }
+  if (status.kind === 'failed') {
+    return {
+      kind: 'unmeasurable',
+      reason: `retrieval reported outcome "${status.outcome}" rather than running to completion, so no configuration was exercised.`,
+    };
+  }
+
+  if (!event) {
+    // Absence is only trustworthy when the tool itself says it had nothing to serve.
+    if (status.kind === 'served-content') {
+      return {
+        kind: 'unmeasurable',
+        reason:
+          'retrieval served content but no lake-audit event arrived within the wait window. Either ' +
+          'the un-awaited audit write stalled, or nothing served was attributable to a lake (the ' +
+          "preflight's own-files precondition exists to rule the latter out).",
+      };
+    }
+    return { kind: 'nothing' };
+  }
+
   if (!event.scores || event.scores.length === 0) return { kind: 'keyword-fallback' };
   const fileIds = event.fileIds ?? [];
   // A scored event with no files should not occur (scores are index-aligned to the ranked chunks
-  // those files came from), but reading it as 'served' with an empty list would silently score a
-  // zero-recall question as if retrieval had legitimately returned nothing.
-  if (fileIds.length === 0) return { kind: 'keyword-fallback' };
+  // those files came from). It is not the keyword arm either - that arm writes no scores - so
+  // diagnosing it as one would send the operator after an embedding credential that is fine.
+  if (fileIds.length === 0) {
+    return {
+      kind: 'unmeasurable',
+      reason: 'the audit event carried per-chunk scores but no file ids, which the semantic arm cannot produce.',
+    };
+  }
   return { kind: 'served', fileIds };
 }

--- a/packages/scripts/retrieval/auditEvent.ts
+++ b/packages/scripts/retrieval/auditEvent.ts
@@ -1,0 +1,50 @@
+/**
+ * Reading one lake-audit event as "what did retrieval actually serve".
+ *
+ * Pure and separated from the live driver because this is the single decision the whole measurement
+ * rests on: the same absent-event condition means "correctly served nothing" in one case and "the
+ * probe cannot see what was served" in another, and getting that backwards silently reports a
+ * healthy configuration as a total recall failure. It needs to be testable without a stage.
+ */
+
+/** The fields of a captured `RecordLakeAccessEventInput` this reading depends on. */
+export type AuditEventShape = {
+  fileIds?: string[];
+  scores?: number[];
+};
+
+export type ServedReading =
+  /** Retrieval ran and served these files. */
+  | { kind: 'served'; fileIds: string[] }
+  /** Retrieval ran and served nothing. On a negative question this is the desired outcome. */
+  | { kind: 'nothing' }
+  /**
+   * The semantic arm did not run and the keyword fallback answered instead. Neither knob under test
+   * applies there, so the configuration was never exercised and the run must stop rather than
+   * report a keyword-search number as a budget-sweep row.
+   */
+  | { kind: 'keyword-fallback' };
+
+/**
+ * `search_knowledge_base` records an audit event from two places (`knowledgeBaseSearch/index.ts`,
+ * the semantic arm at ~974 and the keyword arm at ~1224). They are told apart by their PAYLOAD, not
+ * their `surface`, which is identical on both:
+ *
+ * - semantic arm: carries `chunkIds` and per-chunk `scores`.
+ * - keyword arm:  carries `fileIds` only, no scores (it is metadata-only, with no chunk ranking).
+ *
+ * No event at all means no lake read was recorded, which for a caller who owns no files of their own
+ * means the search produced no output. The probe enforces that "owns no files" precondition in its
+ * preflight, because without it an unattributable personal-file hit also produces no event and would
+ * be misread here as "served nothing".
+ */
+export function readServedDocuments(event: AuditEventShape | null | undefined): ServedReading {
+  if (!event) return { kind: 'nothing' };
+  if (!event.scores || event.scores.length === 0) return { kind: 'keyword-fallback' };
+  const fileIds = event.fileIds ?? [];
+  // A scored event with no files should not occur (scores are index-aligned to the ranked chunks
+  // those files came from), but reading it as 'served' with an empty list would silently score a
+  // zero-recall question as if retrieval had legitimately returned nothing.
+  if (fileIds.length === 0) return { kind: 'keyword-fallback' };
+  return { kind: 'served', fileIds };
+}

--- a/packages/scripts/retrieval/auditEvent.ts
+++ b/packages/scripts/retrieval/auditEvent.ts
@@ -7,11 +7,30 @@
  * healthy configuration as a total recall failure. It needs to be testable without a stage.
  */
 
-/** The fields of a captured `RecordLakeAccessEventInput` this reading depends on. */
-export type AuditEventShape = {
-  fileIds?: string[];
-  scores?: number[];
-};
+import type { PromptMeta, RecordLakeAccessEventInput } from '@bike4mind/common';
+
+/**
+ * The fields of a captured `RecordLakeAccessEventInput` this reading depends on.
+ *
+ * Derived from the producer's own type rather than restated, so an upstream rename of `fileIds` or
+ * `scores` is a build error here. Restating them structurally would compile clean, make the probe
+ * read `undefined`, and route a healthy semantic result straight into `keyword-fallback` - a
+ * confidently wrong diagnosis, which is the one failure mode this module exists to prevent.
+ */
+export type AuditEventShape = Pick<RecordLakeAccessEventInput, 'fileIds' | 'scores'>;
+
+/**
+ * The tool's own notice when a nonzero relevance floor rejected every candidate passage.
+ *
+ * COUPLED BY TEXT to `knowledgeBaseSearch/index.ts` (both semantic arms build this literal when
+ * `budgets.kbMinRelevance > 0 && search.results.length === 0`), because the tool exposes no
+ * structural signal for it: the floor-emptied turn and a turn where the semantic arm was never
+ * available reach the same keyword-arm status write, and `warnings` is the only field that differs.
+ *
+ * Drift is safe, not silent. If the wording changes, a floor-emptied turn stops matching, reads as
+ * `keyword-fallback`, and ABORTS the sweep with an error - it can never quietly score a wrong row.
+ */
+export const RELEVANCE_FLOOR_NOTICE = 'a configured relevance threshold filtered out every candidate passage';
 
 /**
  * What the tool's OWN status write says happened, captured from the `statusUpdate` seam.
@@ -28,16 +47,39 @@ export type RetrievalStatus =
   | { kind: 'served-content' }
   /** Retrieval ran to completion and legitimately had nothing to serve. */
   | { kind: 'no-content' }
-  /** Retrieval reported a non-ok outcome (`failed`, `no_lakes`). */
+  /**
+   * The semantic arm RAN and the relevance floor under test rejected every candidate. A legitimate
+   * served-nothing measurement of the configuration, not a harness failure - see
+   * `RELEVANCE_FLOOR_NOTICE`.
+   */
+  | { kind: 'floor-emptied' }
+  /**
+   * Retrieval reported a non-ok outcome (`failed`, `no_lakes`, `not_indexed`). Deliberately keyed
+   * on "not ok" rather than enumerating them, so an outcome added upstream is a loud stop here
+   * instead of a silently scored row.
+   */
   | { kind: 'failed'; outcome: string }
   /** No retrieval status was written at all, so the tool did not reach a terminal path. */
   | { kind: 'absent' };
 
-/** The `promptMeta` fields this reading depends on. The tool writes more; none of the rest matters. */
+/**
+ * The `promptMeta` fields this reading depends on. The tool writes more; none of the rest matters.
+ *
+ * `Pick`ed from the real `PromptMeta` rather than restated for the same reason as
+ * `AuditEventShape`: a rename of `citables`, `warnings` or `retrieval` upstream must break the
+ * build here rather than degrade this reading into a wrong diagnosis. `unknown[]` for `citables`
+ * because only its length is read, and `outcome`/`warnings` are widened to what this module
+ * narrows on.
+ */
+type SourcePromptMetaFields = Pick<PromptMeta, 'citables' | 'warnings' | 'retrieval'>;
 export type CapturedPromptMeta = {
   citables?: unknown[];
+  warnings?: string[];
   retrieval?: { outcome?: string };
 };
+// Fails the build if the source fields drift out of the shape this module reads them in.
+const _promptMetaFieldsMatch: (m: SourcePromptMetaFields) => CapturedPromptMeta = m => m;
+void _promptMetaFieldsMatch;
 
 /**
  * Collapse the status writes captured across one tool call into the one fact the audit reading
@@ -47,12 +89,19 @@ export type CapturedPromptMeta = {
  * through to the keyword arm, which writes its own. `citables` is checked across every write
  * because it is the tool's record of what actually reached the model, and the keyword arm's no-hit
  * branch is the one path that omits it.
+ *
+ * The floor notice is checked BEFORE `citables` and wins over it. When the floor empties the
+ * semantic arm, the keyword fallback still runs and may stamp citables of its own - but those are
+ * keyword hits, which neither knob under test governs, so counting them would report the fallback's
+ * behaviour as this configuration's. What the sweep is measuring served nothing.
  */
 export function readRetrievalStatus(metas: readonly CapturedPromptMeta[]): RetrievalStatus {
   const terminal = [...metas].reverse().find(m => m.retrieval)?.retrieval;
   if (!terminal) return { kind: 'absent' };
   const outcome = terminal.outcome ?? 'unknown';
   if (outcome !== 'ok') return { kind: 'failed', outcome };
+  const carriesFloorNotice = metas.some(m => m.warnings?.some(w => w.includes(RELEVANCE_FLOOR_NOTICE)));
+  if (carriesFloorNotice) return { kind: 'floor-emptied' };
   return metas.some(m => (m.citables?.length ?? 0) > 0) ? { kind: 'served-content' } : { kind: 'no-content' };
 }
 
@@ -62,9 +111,13 @@ export type ServedReading =
   /** Retrieval ran and served nothing. On a negative question this is the desired outcome. */
   | { kind: 'nothing' }
   /**
-   * The semantic arm did not run and the keyword fallback answered instead. Neither knob under test
-   * applies there, so the configuration was never exercised and the run must stop rather than
+   * The semantic arm was never AVAILABLE and the keyword fallback answered instead - a wiring or
+   * credential problem, so the configuration was never exercised and the run must stop rather than
    * report a keyword-search number as a budget-sweep row.
+   *
+   * Narrower than "the keyword arm answered": the floor emptying an arm that did run is
+   * `floor-emptied`, and reads as a legitimate `nothing`. Both reach the same keyword-arm audit
+   * row, so only `status` can tell them apart.
    */
   | { kind: 'keyword-fallback' }
   /**
@@ -101,6 +154,12 @@ export function readServedDocuments(event: AuditEventShape | null | undefined, s
       reason: `retrieval reported outcome "${status.outcome}" rather than running to completion, so no configuration was exercised.`,
     };
   }
+
+  // Decided before the event is inspected, because the keyword fallback that runs after a
+  // floor-emptied semantic arm writes an unscored audit row of its own. Reading THAT as
+  // `keyword-fallback` is what made every nonzero floor abort the sweep on its first negative
+  // question - the exact rows the floor was added to produce.
+  if (status.kind === 'floor-emptied') return { kind: 'nothing' };
 
   if (!event) {
     // Absence is only trustworthy when the tool itself says it had nothing to serve.

--- a/packages/scripts/retrieval/corpus.test.ts
+++ b/packages/scripts/retrieval/corpus.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { loadHelpArticles } from '../help/loadHelpArticles';
 import { NEGATIVES, NEVER_SUPPORTING, POSITIVES, PROBE_QUESTIONS, REFERENCED_SLUGS } from './corpus';
@@ -22,6 +25,30 @@ describe('probe ground truth', () => {
       missing,
       `Ground truth cites slugs that are not public help articles (renamed or moved?):\n  ${missing.join('\n  ')}`
     ).toEqual([]);
+  });
+
+  it('references only slugs the help-lake ingest will actually create', () => {
+    // loadHelpArticles reads docs-site; the ingest reads the GENERATED index. They are normally in
+    // step, but the index is what determines what ends up in the lake, so the ground truth has to
+    // hold against that source specifically - a slug present in docs but absent from the index is
+    // an article the probe can never retrieve.
+    const indexPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../../apps/client/app/generated/help-index.json'
+    );
+    // Generated, so a fresh checkout may not have it yet. Absent is not a failure - the docs-site
+    // assertion above still covers the ground truth; this one adds the ingest's own view when built.
+    if (!existsSync(indexPath)) return;
+
+    const entries = JSON.parse(readFileSync(indexPath, 'utf-8')).entries as {
+      slug: string;
+      accessLevel: string;
+    }[];
+    const ingested = new Set(entries.filter(e => e.accessLevel === 'public').map(e => e.slug));
+    const missing = REFERENCED_SLUGS.filter(slug => !ingested.has(slug));
+    expect(missing, `Ground truth cites slugs the ingest will not put in the lake:\n  ${missing.join('\n  ')}`).toEqual(
+      []
+    );
   });
 
   it('never cites the survey and grab-bag articles as supporting', () => {

--- a/packages/scripts/retrieval/corpus.test.ts
+++ b/packages/scripts/retrieval/corpus.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { loadHelpArticles } from '../help/loadHelpArticles';
+import { NEGATIVES, NEVER_SUPPORTING, POSITIVES, PROBE_QUESTIONS, REFERENCED_SLUGS } from './corpus';
+
+/**
+ * CI gate on the probe's ground truth, validated against the REAL help corpus rather than a fixture.
+ *
+ * The failure this exists to prevent is silent and expensive: a docs rename turns a supporting slug
+ * into one no article carries, every question citing it loses recall it should have had, and the
+ * sweep concludes a budget setting is worse than it is. Retrieval would not have changed at all.
+ */
+describe('probe ground truth', () => {
+  it('references only slugs that exist as PUBLIC help articles', async () => {
+    // Public is the operative filter: `ingest-help-datalake.ts` ingests accessLevel === 'public'
+    // only, so an admin-category article is a real doc that is nonetheless not in the lake, and
+    // citing one would be unreachable ground truth.
+    const publicSlugs = new Set((await loadHelpArticles()).filter(a => a.accessLevel === 'public').map(a => a.slug));
+    expect(publicSlugs.size).toBeGreaterThan(0);
+
+    const missing = REFERENCED_SLUGS.filter(slug => !publicSlugs.has(slug));
+    expect(
+      missing,
+      `Ground truth cites slugs that are not public help articles (renamed or moved?):\n  ${missing.join('\n  ')}`
+    ).toEqual([]);
+  });
+
+  it('never cites the survey and grab-bag articles as supporting', () => {
+    const leaked = REFERENCED_SLUGS.filter(slug => (NEVER_SUPPORTING as readonly string[]).includes(slug));
+    expect(leaked, `These are corpus distractors by design and must not be ground truth: ${leaked.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  it('has unique question ids', () => {
+    const ids = PROBE_QUESTIONS.map(q => q.id);
+    expect(new Set(ids).size, `Duplicate question ids: ${ids.join(', ')}`).toBe(ids.length);
+  });
+
+  it('lists no slug twice within one question', () => {
+    const offenders = PROBE_QUESTIONS.filter(q => new Set(q.supporting).size !== q.supporting.length).map(q => q.id);
+    // A repeat would inflate that question's recall denominator against a document served once.
+    expect(offenders, `Repeated supporting slug in: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('carries enough negatives for falsePositiveRate to mean anything', () => {
+    // The relevance floor's whole purpose is serving nothing when nothing fits. With no negatives
+    // the sweep can only ever see the floor's cost (recall lost) and never its benefit.
+    expect(NEGATIVES.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('is mostly multi-document, so the sweep can discriminate between budgets', () => {
+    // A question one article fully answers is satisfied at every setting and cannot separate
+    // configurations. If this ever drops below half, the set has quietly stopped measuring breadth.
+    const multi = POSITIVES.filter(q => q.supporting.length > 1).length;
+    expect(multi / POSITIVES.length).toBeGreaterThan(0.5);
+  });
+
+  it('partitions cleanly into positives and negatives', () => {
+    expect(POSITIVES.length + NEGATIVES.length).toBe(PROBE_QUESTIONS.length);
+  });
+});

--- a/packages/scripts/retrieval/corpus.ts
+++ b/packages/scripts/retrieval/corpus.ts
@@ -1,0 +1,267 @@
+/**
+ * The retrieval-recall probe corpus (#1993): a fixed question set with hand-authored ground truth.
+ *
+ * WHY THE HELP LAKE. The probe needs a real corpus with real embeddings, and this repo is public, so
+ * a corpus built from a customer's lake could not be committed - which would make the baseline
+ * unreproducible, the exact problem #1831's measurement has today. The `system-help` lake
+ * (`packages/scripts/help/ingest-help-datalake.ts`) is the one corpus that is simultaneously real,
+ * already vectorized with the deployment's own embedding model, and public: 51 articles under
+ * `docs-site/docs/features`, close to the 47-document lake #1831 measured. Seed it into any stage
+ * and this file's ground truth applies unchanged.
+ *
+ * WHY HAND-AUTHORED GROUND TRUTH. #1831 derived its supporting set from an IDF-weighted token proxy
+ * over judge-flagged claims and flagged its own 16% as "directional, not precise". A proxy cannot be
+ * committed and cannot be audited. Because the corpus is in-repo, the supporting set can simply be
+ * stated - and then a config sweep is comparing configurations rather than comparing two runs of an
+ * estimator.
+ *
+ * DESIGN RULES, because an easy question set proves nothing:
+ *
+ * 1. MOST QUESTIONS NEED SEVERAL DOCUMENTS. This ticket is about the SIZE of what retrieval serves,
+ *    so a question one article fully answers cannot discriminate one budget from another - it is
+ *    satisfied at every setting. The interesting questions span 2-5 articles.
+ * 2. LOW LEXICAL OVERLAP with the article that answers them. A question phrased in the words of its
+ *    own document is answerable by keyword matching, and would score a retrieval quality this system
+ *    does not have.
+ * 3. NEGATIVES ARE NEAR-MISSES, NOT NONSENSE. Each negative sits adjacent to something the corpus
+ *    genuinely covers (Salesforce against a corpus full of GitHub/Jira/Confluence/Slack; account
+ *    deletion against an article on data retention and "your rights"). A negative nothing resembles
+ *    is free to reject. These are the questions the relevance floor exists for, and the only ones
+ *    where `falsePositiveRate` can move.
+ *
+ * TWO SLUGS ARE DELIBERATELY NEVER CITED AS SUPPORTING. `features/overview` is a survey that touches
+ * every topic, and `features/common-issues` is a troubleshooting grab-bag; both are plausibly
+ * "relevant" to almost any question. Admitting them would inflate recall without retrieval having
+ * found anything a reader could use. They stay in the lake as realistic distractors - which is the
+ * point - but never in a supporting set.
+ */
+
+export type ProbeQuestion = {
+  id: string;
+  question: string;
+  /**
+   * Help slugs that genuinely carry material an answer would rest on, as ingested (`help:<slug>`).
+   * EMPTY means a negative: nothing in the corpus supports this, and the correct behavior is to
+   * serve nothing. Verified against the live corpus by `corpus.test.ts`.
+   */
+  supporting: string[];
+  /** Why this question is hard. Documentation for a future reader; never read by the scorer. */
+  note?: string;
+};
+
+export const PROBE_QUESTIONS: ProbeQuestion[] = [
+  {
+    id: 'q01',
+    question:
+      'Our headcount went from four people to nine last quarter and finance is asking why the monthly charge moved. What drives that number?',
+    supporting: ['features/organizations-teams'],
+    note: 'Seat-based billing with a 4-seat minimum. Phrased in finance vocabulary ("headcount", "monthly charge") with no overlap on "seat" or "subscription".',
+  },
+  {
+    id: 'q02',
+    question:
+      'I want the assistant to answer strictly out of the policy documents my team uploaded, and to show which document each statement came from.',
+    supporting: ['features/data-lakes', 'features/knowledge-management'],
+    note: 'Spans grounding (data-lakes) and the document/search side (knowledge-management). Avoids the words "lake", "retrieval" and "citation".',
+  },
+  {
+    id: 'q03',
+    question: 'What actually happens to a PDF between dropping it in and the assistant being able to use its contents?',
+    supporting: ['features/knowledge-management', 'features/data-lakes'],
+    note: 'The chunk/embed pipeline. "Vectorize" and "embedding" never appear in the question.',
+  },
+  {
+    id: 'q04',
+    question: 'We run everything through Okta. What does the sign-in flow look like for our staff?',
+    supporting: ['features/identity-providers'],
+    note: 'Single-document positive, kept deliberately: a few of these are needed or the set cannot show that narrow questions stay narrow as the budget widens.',
+  },
+  {
+    id: 'q05',
+    question:
+      'In one channel the replies should come from a cheaper model than the rest of the workspace uses. Where is that decided?',
+    supporting: ['features/slack-model-config', 'features/integrations/slack-integration'],
+    note: 'Channel overrides plus org defaults, and the resolution order between them.',
+  },
+  {
+    id: 'q06',
+    question: 'Which of the built-in capabilities can turn a table of numbers into a picture?',
+    supporting: ['features/smart-tools'],
+    note: 'Data and visualization tools. Deliberately avoids "chart", "graph" and "tool".',
+  },
+  {
+    id: 'q07',
+    question: 'I made something in a session and want to hand a colleague outside the company a link to it.',
+    supporting: ['features/publish-and-share', 'features/publish-and-share-cookbook', 'features/artifacts-system'],
+    note: 'Three documents: the visibility model, the recipes, and what an artifact is. A budget that serves one gets a third of the answer.',
+  },
+  {
+    id: 'q08',
+    question:
+      'The bot answered fine this morning and now it has gone quiet and mentions being throttled. Where do I start?',
+    supporting: [
+      'features/integrations/troubleshooting',
+      'features/integrations/slack-integration',
+      'features/integrations/slack-commands',
+    ],
+    note: 'Rate limits are documented per-integration AND in the shared troubleshooting article, so a full answer needs both.',
+  },
+  {
+    id: 'q09',
+    question:
+      'I want to hand over a large piece of work and have it break itself into steps and grind through them without me babysitting each one.',
+    supporting: ['features/quest-master', 'features/subagents'],
+    note: 'Autonomous planning plus delegation. Phrased with no overlap on "quest", "task" or "agent".',
+  },
+  {
+    id: 'q10',
+    question: 'How does it come to remember things about me from one conversation to the next?',
+    supporting: ['features/mementos'],
+  },
+  {
+    id: 'q11',
+    question: 'We are burning through our allowance faster than expected. What levers exist to bring that down?',
+    supporting: ['features/ai-models', 'features/research-mode', 'features/image-processing-generation'],
+    note: 'Cost is documented per-feature rather than in one place: model choice, research runs, and image generation each carry their own section. The single hardest recall case in the set.',
+  },
+  {
+    id: 'q12',
+    question: 'I have years of conversations in another assistant. Can I bring them across, and what gets lost?',
+    supporting: ['features/chat-history-import'],
+  },
+  {
+    id: 'q13',
+    question:
+      'What do I need to switch on before someone can hold a spoken conversation with it, and what does that cost?',
+    supporting: ['features/voice-v2'],
+    note: 'Admin setup and credits live in the same article; a narrow question that should stay narrow.',
+  },
+  {
+    id: 'q14',
+    question:
+      'We have our own model running behind our firewall. Can it be pointed at that instead of the usual providers?',
+    supporting: ['features/private-model-hub', 'features/ai-models'],
+    note: 'Private hub plus the custom-key section of the model article.',
+  },
+  {
+    id: 'q15',
+    question: 'My generated interface renders blank and the browser console complains about a blocked script.',
+    supporting: ['features/react-artifacts-csp', 'features/artifacts-system'],
+    note: 'CSP constraints plus artifact troubleshooting.',
+  },
+  {
+    id: 'q16',
+    question: 'How do I get a line break in the box without firing off the message?',
+    supporting: ['features/keyboard-shortcuts', 'features/notebooks'],
+    note: 'Documented in both the dedicated shortcuts article and the notebook article - a genuine two-document fact.',
+  },
+  {
+    id: 'q17',
+    question: 'What usage information is gathered about me, what is deliberately left out, and can I decline?',
+    supporting: ['features/context-telemetry'],
+  },
+  {
+    id: 'q18',
+    question: 'I am juggling three client engagements and want each one to keep its own files and sessions apart.',
+    supporting: ['features/projects'],
+  },
+  {
+    id: 'q19',
+    question: 'I want a named assistant with a fixed brief and manner that my team can call on.',
+    supporting: ['features/agents', 'features/tavern'],
+    note: 'Agent creation plus the surface agents are created on.',
+  },
+  {
+    id: 'q20',
+    question: 'Can I get a copy of a session out of the product in a form I could put in version control?',
+    supporting: ['features/notebook-export-import'],
+  },
+  {
+    id: 'q21',
+    question: 'When a pull request opens, the right people should hear about it where they already work.',
+    supporting: ['features/github-slack-notifications', 'features/integrations/github-webhooks'],
+    note: 'Subscription management plus the event plumbing underneath. No overlap on "notification" or "webhook".',
+  },
+  {
+    id: 'q22',
+    question: 'Which permissions does the connector ask my administrator to grant, and what does it do with them?',
+    supporting: [
+      'features/integrations/github-integration',
+      'features/integrations/jira-integration',
+      'features/integrations/confluence-integration',
+      'features/integrations',
+    ],
+    note: 'Deliberately unscoped to one vendor: every integration article carries its own scopes section plus the shared matrix. Tests breadth across near-identical documents, which is where ranking crowds one source out.',
+  },
+  {
+    id: 'q23',
+    question: 'Is there a way to drive this from a terminal as part of a build?',
+    supporting: ['features/tavern/cli'],
+  },
+  {
+    id: 'q24',
+    question:
+      'I want it to go away and read broadly around a topic before writing anything, and to tell me what it read.',
+    supporting: ['features/research-mode', 'features/research-engine'],
+    note: 'Two adjacent articles that are easy to conflate; a shallow retrieval returns one and reads as complete.',
+  },
+  {
+    id: 'q25',
+    question: 'Where do I go to see and revoke the tokens my account has handed out to other systems?',
+    supporting: ['features/profile-settings'],
+  },
+
+  // --- Negatives: nothing in the corpus supports these. See design rule 3. ---
+  {
+    id: 'n01',
+    question:
+      'How do I sync our customer records from Salesforce so the assistant can answer questions about accounts?',
+    supporting: [],
+    note: 'Near-miss: the corpus documents GitHub, Jira, Confluence and Slack connectors at length. "Salesforce" appears nowhere in it.',
+  },
+  {
+    id: 'n02',
+    question:
+      'We need to run this inside an air-gapped network with no outbound connectivity. What is the on-premise install path?',
+    supporting: [],
+    note: 'Near-miss: the corpus covers private model endpoints and identity federation, which sound adjacent. No self-hosting or air-gap material exists in it.',
+  },
+  {
+    id: 'n03',
+    question: 'I want my account permanently deleted along with everything it ever stored. How do I trigger that?',
+    supporting: [],
+    note: 'The strongest near-miss in the set: the telemetry article has "Data Retention" and "Your Rights" sections that a floor set too low will happily serve as if they answered this.',
+  },
+  {
+    id: 'n04',
+    question: 'Is there a browser extension that lets me use this on any page I am reading?',
+    supporting: [],
+    note: 'Near-miss to the integrations family. No extension is documented anywhere in the corpus.',
+  },
+  {
+    id: 'n05',
+    question: 'Can it produce a two-host podcast episode with distinct voices from a document I give it?',
+    supporting: [],
+    note: 'Near-miss: the corpus documents spoken conversation (voice) and image generation, so both halves sound covered. Podcast generation is not.',
+  },
+];
+
+/** Questions with a non-empty supporting set. */
+export const POSITIVES = PROBE_QUESTIONS.filter(q => q.supporting.length > 0);
+
+/** Questions nothing in the corpus supports - scored by falsePositiveRate, not recall. */
+export const NEGATIVES = PROBE_QUESTIONS.filter(q => q.supporting.length === 0);
+
+/**
+ * Every slug this ground truth depends on. `corpus.test.ts` asserts each one is a real public help
+ * article, so a docs rename cannot silently turn a supporting document into an unreachable one and
+ * depress recall for a reason that has nothing to do with retrieval.
+ */
+export const REFERENCED_SLUGS = [...new Set(PROBE_QUESTIONS.flatMap(q => q.supporting))].sort();
+
+/**
+ * Survey/grab-bag articles that stay in the lake as distractors but are never ground truth. Asserted
+ * absent from every supporting set by `corpus.test.ts`, so the exclusion cannot erode as questions
+ * are added later.
+ */
+export const NEVER_SUPPORTING = ['features/overview', 'features/common-issues'] as const;

--- a/packages/scripts/retrieval/metrics.test.ts
+++ b/packages/scripts/retrieval/metrics.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { aggregate, hitRate, precision, recall, reciprocalRank, scoreQuestion } from './metrics';
+
+const set = (...ids: string[]) => new Set(ids);
+
+describe('recall', () => {
+  it('is the fraction of the supporting set that was served', () => {
+    expect(recall(['a', 'b'], set('a', 'b', 'c', 'd'))).toBe(0.5);
+  });
+
+  it('does not exceed 1 when extra non-supporting documents are served', () => {
+    expect(recall(['a', 'x', 'y', 'z'], set('a'))).toBe(1);
+  });
+
+  it('is vacuously 1 on a negative question, which is why negatives are scored separately', () => {
+    expect(recall([], set())).toBe(1);
+    expect(recall(['x'], set())).toBe(1);
+  });
+});
+
+describe('precision', () => {
+  it('is the fraction of what was served that supports the answer', () => {
+    expect(precision(['a', 'x', 'y', 'z'], set('a'))).toBe(0.25);
+  });
+
+  it('scores 1 for serving nothing, which is only meaningful next to recall', () => {
+    expect(precision([], set('a'))).toBe(1);
+    expect(recall([], set('a'))).toBe(0);
+  });
+});
+
+describe('hitRate', () => {
+  it('is 1 when any supporting document was served, regardless of how many were missed', () => {
+    // The #1831 shape: finds something, then stops. High hit rate, low recall.
+    expect(hitRate(['a'], set('a', 'b', 'c', 'd', 'e'))).toBe(1);
+    expect(recall(['a'], set('a', 'b', 'c', 'd', 'e'))).toBe(0.2);
+  });
+
+  it('is 0 on a negative question so it cannot inflate the positives-only average', () => {
+    expect(hitRate(['x'], set())).toBe(0);
+  });
+});
+
+describe('reciprocalRank', () => {
+  it('rewards serving a supporting document earlier', () => {
+    expect(reciprocalRank(['a', 'x'], set('a'))).toBe(1);
+    expect(reciprocalRank(['x', 'a'], set('a'))).toBe(0.5);
+    expect(reciprocalRank(['x', 'y', 'a'], set('a'))).toBeCloseTo(1 / 3);
+  });
+
+  it('is 0 when no supporting document was served at all', () => {
+    expect(reciprocalRank(['x', 'y'], set('a'))).toBe(0);
+  });
+});
+
+describe('scoreQuestion', () => {
+  it('counts a document once even when several of its passages were served', () => {
+    // The probe maps passages to their owning document, so repeats are the normal case: a token
+    // budget that admits 5 passages from one file has reached ONE document, not five.
+    const outcome = scoreQuestion(['a', 'a', 'a', 'b'], set('a', 'b'));
+    expect(outcome.documentsServed).toBe(2);
+    expect(outcome.recall).toBe(1);
+    expect(outcome.precision).toBe(1);
+  });
+
+  it('dedupes forward so reciprocal rank reflects first appearance', () => {
+    expect(scoreQuestion(['x', 'a', 'x'], set('a')).rr).toBe(0.5);
+  });
+
+  it('flags a question with no supporting set as a negative', () => {
+    expect(scoreQuestion(['x'], set()).isNegative).toBe(true);
+    expect(scoreQuestion(['x'], set('a')).isNegative).toBe(false);
+  });
+});
+
+describe('aggregate', () => {
+  it('averages positives and negatives separately so negatives cannot inflate recall', () => {
+    const outcomes = [
+      scoreQuestion(['a'], set('a', 'b')), // positive: recall 0.5
+      scoreQuestion(['x'], set()), // negative: recall vacuously 1
+    ];
+    const agg = aggregate(outcomes);
+    expect(agg.positives).toBe(1);
+    expect(agg.negatives).toBe(1);
+    // Pooling would have reported 0.75 here, a number no positive question earned.
+    expect(agg.recall).toBe(0.5);
+  });
+
+  it('reports falsePositiveRate as the share of negatives that served anything', () => {
+    const agg = aggregate([
+      scoreQuestion(['x'], set()), // floor let something through
+      scoreQuestion([], set()), // floor held
+    ]);
+    expect(agg.falsePositiveRate).toBe(0.5);
+  });
+
+  it('averages documentsServed across every question, positives and negatives alike', () => {
+    const agg = aggregate([scoreQuestion(['a', 'b'], set('a')), scoreQuestion(['x'], set())]);
+    expect(agg.meanDocumentsServed).toBe(1.5);
+  });
+
+  it('returns zeroes rather than NaN when a bucket is empty', () => {
+    // A corpus with no negatives must not report NaN for falsePositiveRate: the probe prints these
+    // straight into a results table, and NaN there reads as a broken run rather than an empty bucket.
+    const agg = aggregate([scoreQuestion(['a'], set('a'))]);
+    expect(agg.negatives).toBe(0);
+    expect(agg.falsePositiveRate).toBe(0);
+    expect(agg.recall).toBe(1);
+  });
+
+  it('handles a completely empty run without dividing by zero', () => {
+    const agg = aggregate([]);
+    expect(agg).toMatchObject({ positives: 0, negatives: 0, recall: 0, falsePositiveRate: 0 });
+  });
+});

--- a/packages/scripts/retrieval/metrics.test.ts
+++ b/packages/scripts/retrieval/metrics.test.ts
@@ -99,6 +99,28 @@ describe('aggregate', () => {
     expect(agg.meanDocumentsServed).toBe(1.5);
   });
 
+  it('excludes empty-served positives from precision so a floor cannot inflate it', () => {
+    const agg = aggregate([
+      scoreQuestion(['a', 'x'], set('a')), // served, precision 0.5
+      scoreQuestion([], set('b')), // emptied by the floor: precision vacuously 1
+    ]);
+    // Pooling the vacuous 1 would report 0.75 - precision RISING as the floor empties questions,
+    // which inverts the one metric that exists to price what a floor costs.
+    expect(agg.precision).toBe(0.5);
+    expect(agg.precisionScored).toBe(1);
+    // Recall is where the emptied question is supposed to show up, and still does.
+    expect(agg.recall).toBe(0.5);
+  });
+
+  it('reports precisionScored 0 rather than a precision no question earned', () => {
+    // Every positive emptied. mean([]) is 0, which the table renders as "n/a (n=0)" so it does not
+    // read as a measured collapse.
+    const agg = aggregate([scoreQuestion([], set('a')), scoreQuestion([], set('b'))]);
+    expect(agg.precisionScored).toBe(0);
+    expect(agg.precision).toBe(0);
+    expect(agg.recall).toBe(0);
+  });
+
   it('returns zeroes rather than NaN when a bucket is empty', () => {
     // A corpus with no negatives must not report NaN for falsePositiveRate: the probe prints these
     // straight into a results table, and NaN there reads as a broken run rather than an empty bucket.

--- a/packages/scripts/retrieval/metrics.ts
+++ b/packages/scripts/retrieval/metrics.ts
@@ -94,7 +94,19 @@ export type Aggregate = {
   /** Questions nothing supports - the denominator for falsePositiveRate. */
   negatives: number;
   recall: number;
+  /**
+   * Averaged over the positives that actually SERVED something, not over all of them - read it
+   * next to `precisionScored`, which is that denominator.
+   *
+   * A positive that served nothing scores a vacuous `precision` of 1 (nothing irrelevant was
+   * served). Pooling those in would make precision climb as the floor got more aggressive, since
+   * an emptied question would contribute a 1.0 rather than being excluded - so precision would
+   * reward the very trade it exists to price. Recall still scores those questions 0, which is
+   * where an over-aggressive floor is supposed to show up.
+   */
   precision: number;
+  /** Positives that served at least one document - the denominator `precision` was averaged over. */
+  precisionScored: number;
   hitRate: number;
   mrr: number;
   meanDocumentsServed: number;
@@ -116,15 +128,20 @@ const mean = (xs: number[]): number => (xs.length === 0 ? 0 : xs.reduce((a, b) =
  * negative, so pooling would let a corpus with many negatives report a high recall that no positive
  * question earned. `meanDocumentsServed` spans every question, since "how much did retrieval emit"
  * is meaningful on both.
+ *
+ * Precision narrows the denominator once more, to the positives that served something - see the
+ * field's own comment for why a vacuous 1.0 there would invert the metric's meaning.
  */
 export function aggregate(outcomes: readonly QuestionOutcome[]): Aggregate {
   const positives = outcomes.filter(o => !o.isNegative);
   const negatives = outcomes.filter(o => o.isNegative);
+  const precisionScored = positives.filter(o => o.documentsServed > 0);
   return {
     positives: positives.length,
     negatives: negatives.length,
     recall: mean(positives.map(o => o.recall)),
-    precision: mean(positives.map(o => o.precision)),
+    precision: mean(precisionScored.map(o => o.precision)),
+    precisionScored: precisionScored.length,
     hitRate: mean(positives.map(o => o.hit)),
     mrr: mean(positives.map(o => o.rr)),
     meanDocumentsServed: mean(outcomes.map(o => o.documentsServed)),

--- a/packages/scripts/retrieval/metrics.ts
+++ b/packages/scripts/retrieval/metrics.ts
@@ -1,0 +1,133 @@
+/**
+ * Retrieval metrics for the `search_knowledge_base` recall probe (#1993).
+ *
+ * Pure and dependency-free, deliberately mirroring `b4m-core/memory/src/eval/metrics.ts` so the two
+ * evals speak one vocabulary: they take an ORDERED list of document ids (what retrieval actually
+ * served, best first) plus the ids that genuinely support an answer, and score the outcome. Nothing
+ * here knows about embeddings, Mongo, or the tool - which is what lets the same numbers compare one
+ * budget/floor configuration against another on identical footing.
+ *
+ * The unit is a DOCUMENT (a help slug), not a passage. #1831 measured "3.9 documents of 47" and
+ * "16% of the supporting set", and the whole question this ticket asks - does a wider budget reach
+ * more of the material that could support the answer - is a document-level question. Several
+ * passages from one document are one document reached, not several.
+ */
+
+/**
+ * Fraction of the supporting documents that retrieval actually served. THE headline number: a
+ * document the model never sees cannot support its answer, however well it was ranked.
+ *
+ * A question with an empty supporting set (a NEGATIVE - see the corpus) scores 1: there was nothing
+ * to find, so nothing was missed. Read those questions through `falsePositiveRate` instead, which is
+ * the metric that can actually fail on them.
+ */
+export function recall(served: readonly string[], supporting: ReadonlySet<string>): number {
+  if (supporting.size === 0) return 1;
+  const found = served.filter(id => supporting.has(id)).length;
+  return found / supporting.size;
+}
+
+/**
+ * Fraction of what retrieval served that was actually supporting. The counterweight to recall, and
+ * the reason this ticket cannot just raise the budget until recall peaks: serving every document
+ * scores a perfect recall and a terrible precision, and precision is what governs how much
+ * irrelevant material the model is invited to answer from.
+ *
+ * Serving nothing scores 1 - nothing irrelevant was served. That is only meaningful next to recall,
+ * which scores 0 on the same outcome whenever a supporting set exists.
+ */
+export function precision(served: readonly string[], supporting: ReadonlySet<string>): number {
+  if (served.length === 0) return 1;
+  return served.filter(id => supporting.has(id)).length / served.length;
+}
+
+/**
+ * Did retrieval serve at least one supporting document? #1831's "at-least-one-relevant hit rate"
+ * was 93% against a 16% recall - the finding that retrieval is not blind, it finds something and
+ * then stops. Kept so this probe can state whether that gap still holds.
+ */
+export function hitRate(served: readonly string[], supporting: ReadonlySet<string>): number {
+  if (supporting.size === 0) return 0;
+  return served.some(id => supporting.has(id)) ? 1 : 0;
+}
+
+/**
+ * Reciprocal rank of the FIRST supporting document (1 = served first, 0 = never served). Rewards
+ * ordering, which a token budget silently depends on: a budget keeps a rank-ordered prefix, so a
+ * budget can only be set safely if the ranking puts supporting documents near the front.
+ */
+export function reciprocalRank(served: readonly string[], supporting: ReadonlySet<string>): number {
+  const i = served.findIndex(id => supporting.has(id));
+  return i === -1 ? 0 : 1 / (i + 1);
+}
+
+export type QuestionOutcome = {
+  recall: number;
+  precision: number;
+  hit: number;
+  rr: number;
+  /** Distinct documents served. #1831's headline was this number (3.9) against a 47-document lake. */
+  documentsServed: number;
+  /** True when nothing supports this question - scored by `falsePositiveRate`, not by recall. */
+  isNegative: boolean;
+};
+
+/** Score one question's served documents against its supporting set. */
+export function scoreQuestion(served: readonly string[], supporting: ReadonlySet<string>): QuestionOutcome {
+  // Rank order matters to reciprocalRank, so dedupe forward (keep first occurrence) rather than
+  // through a Set round-trip, which would preserve insertion order only by accident of the input.
+  const seen = new Set<string>();
+  const distinct = served.filter(id => (seen.has(id) ? false : (seen.add(id), true)));
+  return {
+    recall: recall(distinct, supporting),
+    precision: precision(distinct, supporting),
+    hit: hitRate(distinct, supporting),
+    rr: reciprocalRank(distinct, supporting),
+    documentsServed: distinct.length,
+    isNegative: supporting.size === 0,
+  };
+}
+
+export type Aggregate = {
+  /** Questions with a non-empty supporting set - the denominator for recall/precision/hit/mrr. */
+  positives: number;
+  /** Questions nothing supports - the denominator for falsePositiveRate. */
+  negatives: number;
+  recall: number;
+  precision: number;
+  hitRate: number;
+  mrr: number;
+  meanDocumentsServed: number;
+  /**
+   * Fraction of NEGATIVE questions where retrieval served anything at all. The metric the relevance
+   * floor exists to move: with the floor off, a negative question still gets the top-k nearest
+   * chunks, however unrelated. A floor that trades a little recall for a large drop here is the
+   * outcome this ticket is looking for, and no other metric can see it.
+   */
+  falsePositiveRate: number;
+};
+
+const mean = (xs: number[]): number => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length);
+
+/**
+ * Aggregate per-question outcomes into one configuration's row.
+ *
+ * Positives and negatives are averaged SEPARATELY and never pooled: recall is vacuously 1 on a
+ * negative, so pooling would let a corpus with many negatives report a high recall that no positive
+ * question earned. `meanDocumentsServed` spans every question, since "how much did retrieval emit"
+ * is meaningful on both.
+ */
+export function aggregate(outcomes: readonly QuestionOutcome[]): Aggregate {
+  const positives = outcomes.filter(o => !o.isNegative);
+  const negatives = outcomes.filter(o => o.isNegative);
+  return {
+    positives: positives.length,
+    negatives: negatives.length,
+    recall: mean(positives.map(o => o.recall)),
+    precision: mean(positives.map(o => o.precision)),
+    hitRate: mean(positives.map(o => o.hit)),
+    mrr: mean(positives.map(o => o.rr)),
+    meanDocumentsServed: mean(outcomes.map(o => o.documentsServed)),
+    falsePositiveRate: mean(negatives.map(o => (o.documentsServed > 0 ? 1 : 0))),
+  };
+}

--- a/packages/scripts/retrieval/pollEvent.test.ts
+++ b/packages/scripts/retrieval/pollEvent.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pollFor } from './pollEvent';
+
+/** A clock that advances only when the poller sleeps, so no test waits on real wall clock. */
+function fakeClock(startMs = 0) {
+  let t = startMs;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe('pollFor', () => {
+  it('returns a value that is already there without sleeping', async () => {
+    const clock = fakeClock();
+    const sleep = vi.fn(clock.sleep);
+    await expect(pollFor(() => 'ready', { now: clock.now, sleep })).resolves.toBe('ready');
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('returns a value that arrives partway through the wait', async () => {
+    const clock = fakeClock();
+    const buffer: string[] = [];
+    let ticks = 0;
+    const sleep = async (ms: number) => {
+      await clock.sleep(ms);
+      if (++ticks === 3) buffer.push('late');
+    };
+    await expect(pollFor(() => buffer[0], { now: clock.now, sleep, pollIntervalMs: 10 })).resolves.toBe('late');
+    expect(ticks).toBe(3);
+  });
+
+  it('returns null once the deadline passes rather than waiting forever', async () => {
+    const clock = fakeClock();
+    await expect(
+      pollFor(() => undefined, { now: clock.now, sleep: clock.sleep, timeoutMs: 50, pollIntervalMs: 10 })
+    ).resolves.toBeNull();
+  });
+
+  it('still reads a present value at a zero timeout', async () => {
+    // The deadline check runs AFTER the read, so a value already in the buffer is never missed by
+    // a caller that does not want to wait at all.
+    const clock = fakeClock();
+    await expect(pollFor(() => 'here', { now: clock.now, sleep: clock.sleep, timeoutMs: 0 })).resolves.toBe('here');
+    await expect(pollFor(() => undefined, { now: clock.now, sleep: clock.sleep, timeoutMs: 0 })).resolves.toBeNull();
+  });
+
+  it('does not mistake a falsy value for an absent one', async () => {
+    // The audit event is an object today, but a poller that tested truthiness would silently spin
+    // out the full timeout on a legitimate 0 or empty string.
+    const clock = fakeClock();
+    await expect(pollFor(() => 0, { now: clock.now, sleep: clock.sleep, timeoutMs: 0 })).resolves.toBe(0);
+    await expect(pollFor(() => '', { now: clock.now, sleep: clock.sleep, timeoutMs: 0 })).resolves.toBe('');
+  });
+});

--- a/packages/scripts/retrieval/pollEvent.ts
+++ b/packages/scripts/retrieval/pollEvent.ts
@@ -1,0 +1,52 @@
+/**
+ * Waiting out the audit trail's un-awaited write.
+ *
+ * `recordLakeAccessEvent` resolves the audit retention settings before calling `record()`, and
+ * `search_knowledge_base` does not await the result - so the event lands a few microtasks after
+ * `toolFn` returns. Polling beats a fixed sleep: the settings read is cached, so this almost always
+ * succeeds on the first tick.
+ *
+ * Pure and separate from the live driver only so it can be tested at all - `recall-probe.ts` calls
+ * `main()` on import, so nothing that lives there can be unit tested. Timing is injectable for the
+ * same reason.
+ */
+
+export type PollOptions = {
+  /** Total wall clock to wait before giving up. */
+  timeoutMs?: number;
+  /** Macrotask gap between polls, so a pending I/O continuation is not starved by a tight loop. */
+  pollIntervalMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/**
+ * Poll `read` until it yields a value or the deadline passes.
+ *
+ * Returns `null` on timeout rather than throwing, deliberately: `readServedDocuments` is the single
+ * place a missing event is told apart from an honest empty result, and that decision has to stay in
+ * one testable spot rather than being pre-empted by an exception thrown here. The caller only
+ * invokes this once the status seam has already confirmed content WAS served, so a `null` from here
+ * is unambiguously a stalled write.
+ *
+ * Checks once BEFORE sleeping, so a value already present costs no wall clock and a `timeoutMs` of
+ * 0 still reads it.
+ */
+export async function pollFor<T>(read: () => T | undefined, options: PollOptions = {}): Promise<T | null> {
+  const {
+    timeoutMs = 5_000,
+    pollIntervalMs = 5,
+    now = () => Date.now(),
+    sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)),
+  } = options;
+
+  const deadline = now() + timeoutMs;
+  for (;;) {
+    const value = read();
+    if (value !== undefined) return value;
+    if (now() >= deadline) return null;
+    // Drain microtasks first - the un-awaited write usually settles here - then yield a macrotask.
+    await new Promise<void>(resolve => setImmediate(resolve));
+    await sleep(pollIntervalMs);
+  }
+}

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -24,6 +24,11 @@
  * the payload in memory. Same data the audit trail gets, no race, and no parsing of the
  * model-facing string the tool returns.
  *
+ * The probe captures the `statusUpdate` seam alongside it, because the audit trail alone cannot say
+ * whether an absent event means "retrieval served nothing" or "the harness never saw the write".
+ * Unlike the audit write, every terminal path AWAITS its status write, so `promptMeta.retrieval` is
+ * always present by the time `toolFn` resolves. See `auditEvent.ts`, which owns that decision.
+ *
  * CORPUS. The `system-help` lake: 51 public help articles, seeded by
  * `packages/scripts/help/ingest-help-datalake.ts`. See `corpus.ts` for why that corpus and why the
  * ground truth is hand-authored.
@@ -73,7 +78,7 @@ import { Logger } from '@bike4mind/observability';
 import { b4mTools } from '@bike4mind/services/llm/tools';
 import type { ToolContext } from '@bike4mind/services/llm/tools';
 import type { IUserDocument, RecordLakeAccessEventInput, SettingKey } from '@bike4mind/common';
-import { readServedDocuments } from './auditEvent';
+import { readRetrievalStatus, readServedDocuments, type CapturedPromptMeta } from './auditEvent';
 import { PROBE_QUESTIONS, type ProbeQuestion } from './corpus';
 import { aggregate, scoreQuestion, type QuestionOutcome } from './metrics';
 import {
@@ -100,21 +105,29 @@ const logger = new Logger();
 // ---------------------------------------------------------------------------
 
 /**
- * Stands in for the lake-audit repository so the probe reads exactly what the tool reported, at the
- * adapter boundary the ToolContext already exposes. Nothing is persisted.
+ * Stands in for the two seams the probe observes one tool call through, both adapter boundaries the
+ * ToolContext already exposes: the lake-audit repository (WHAT was served) and `statusUpdate` (the
+ * tool's own account of WHETHER it served anything). Nothing is persisted.
  */
 function createCapturingRecorder() {
   const events: RecordLakeAccessEventInput[] = [];
+  const promptMetas: CapturedPromptMeta[] = [];
   return {
     events,
+    promptMetas,
     recorder: {
       record: async (input: RecordLakeAccessEventInput) => {
         events.push(input);
         return undefined as unknown as never;
       },
     },
+    statusUpdate: async (update?: { promptMeta?: CapturedPromptMeta }) => {
+      if (update?.promptMeta) promptMetas.push(update.promptMeta);
+      return undefined;
+    },
     reset: () => {
       events.length = 0;
+      promptMetas.length = 0;
     },
   };
 }
@@ -126,6 +139,11 @@ type Capture = ReturnType<typeof createCapturingRecorder>;
  * tool does not await the result, so the event lands a few microtasks after `toolFn` returns. Poll
  * briefly rather than sleeping a fixed interval: the settings read is cached, so this almost always
  * succeeds on the first tick.
+ *
+ * Only called once the status seam has confirmed content WAS served, so exhausting the timeout is
+ * unambiguously a stalled write and never an honest empty result. Still returns `null` rather than
+ * throwing, to keep `readServedDocuments` the single place the two absences are told apart - the
+ * one decision that has to stay testable without a stage.
  */
 async function waitForEvent(capture: Capture, timeoutMs = 5_000): Promise<RecordLakeAccessEventInput | null> {
   const deadline = Date.now() + timeoutMs;
@@ -168,7 +186,7 @@ function buildToolContext(user: IUserDocument, capture: Capture) {
       scopedSettings: scopedSettingsRepository,
       lakeAccessEvents: capture.recorder,
     },
-    statusUpdate: async () => undefined,
+    statusUpdate: capture.statusUpdate,
     onStart: async () => undefined,
   } as unknown as ToolContext;
 }
@@ -326,7 +344,19 @@ async function runQuestion(question: ProbeQuestion, user: IUserDocument, capture
   const tool = b4mTools.search_knowledge_base.implementation(context, {});
   await tool.toolFn({ query: question.question });
 
-  const reading = readServedDocuments(await waitForEvent(capture));
+  // Awaited by the tool on every terminal path, so it is already captured. Only the un-awaited
+  // audit write needs waiting for, and only when this says one is coming - so a negative question
+  // now costs no wall clock instead of burning the full timeout to learn nothing.
+  const status = readRetrievalStatus(capture.promptMetas);
+  const event = status.kind === 'served-content' ? await waitForEvent(capture) : (capture.events[0] ?? null);
+  const reading = readServedDocuments(event, status);
+
+  if (reading.kind === 'unmeasurable') {
+    throw new Error(
+      `Question ${question.id} produced no measurable result: ${reading.reason} Refusing to score ` +
+        `it as a zero, which would be indistinguishable from the relevance floor doing its job.`
+    );
+  }
 
   if (reading.kind === 'keyword-fallback') {
     throw new Error(

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -183,6 +183,18 @@ async function waitForEvent(capture: Capture, timeoutMs = 5_000): Promise<Record
  * touches - a narrower context than the real one would silently change behavior, a wider one would
  * just be noise.
  */
+/**
+ * The ToolContext the search tool runs on.
+ *
+ * The double cast is deliberate: ToolContext is shaped for a live chat turn and carries many fields
+ * (session, quest, streaming, config) that a headless probe has no analogue for, so satisfying it
+ * honestly would mean fabricating a turn. Only the fields the search path actually reads are wired.
+ *
+ * The cost is that the compiler cannot tell us when a field the search path DOES read is missing -
+ * it silently reads `undefined` and the tool degrades instead of failing. That is exactly how the
+ * lake-access gap produced a clean 0% across every question. The canary search in `preflight` is
+ * the compensating control for this cast; do not remove one without the other.
+ */
 function buildToolContext(user: IUserDocument, capture: Capture) {
   return {
     userId: user.id,
@@ -293,8 +305,13 @@ async function preflight(user: IUserDocument, capture: Capture): Promise<{ lakeI
   //
   // Empirical rather than a re-derivation of the access rules: this is a live end-to-end search, so
   // it also catches an unusable embedding credential, a tag drift, or an unvectorized corpus - any
-  // reason the candidate set comes back empty, not just the one that bit us. Run before any config
-  // is applied, so the stage's own settings cannot be what suppresses it.
+  // reason the candidate set comes back empty, not just the one that bit us.
+  //
+  // It runs at whatever the stage already has configured, since the sweep has not applied anything
+  // yet - so a stage carrying an aggressive floor of its own can fail this check on a lake that is
+  // in fact reachable. That is the right trade: the canary's job is to turn a silent stage-wide
+  // zero into a loud stop, and a false stop costs one legible error message while a false pass
+  // costs a plausible, entirely wrong results table.
   const canary = await runQuestion(CANARY_QUESTION, user, capture);
   if (canary.served.length === 0) {
     throw new Error(
@@ -302,7 +319,9 @@ async function preflight(user: IUserDocument, capture: Capture): Promise<{ lakeI
         `user ${user.id} and every question would score 0% at every configuration.\n` +
         `Most likely cause: no access grant. "${HELP_LAKE_SLUG}" is gateless, org-less and not ` +
         `public, so the only arm that admits anyone is the owner bypass - run as the account in the ` +
-        `lake's createdByUserId, or grant access via isPublic / requiredUserTag / organizationId.`
+        `lake's createdByUserId, or grant access via isPublic / requiredUserTag / organizationId.\n` +
+        `Otherwise check this stage's existing ${MIN_RELEVANCE_SETTING}: the canary runs before the ` +
+        `sweep applies anything, so a floor already set on the stage can suppress it.`
     );
   }
 

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -1,0 +1,421 @@
+#!/usr/bin/env tsx
+/**
+ * Retrieval-recall probe for `search_knowledge_base` (#1993).
+ *
+ * Measures how much of the material that could support an answer actually reaches the model, at
+ * several `kbSearchResultTokenBudget` / `kbSearchMinRelevancePct` settings, so those defaults can be
+ * chosen from a measurement instead of left at the conservative launch values #1955 shipped.
+ *
+ * WHY IT DRIVES THE TOOL RATHER THAN A CHAT TURN. #1831 measured through forced retrieval, and this
+ * ticket inherited that wording - but forced retrieval is a different code path with different
+ * budgets (`ChatCompletionFeatures.ts:1595` states it is NOT routed through semanticDataLakeSearch;
+ * it uses `forcedRetrievalCharBudget` and a hardcoded 0.75 similarity floor). The three kb* knobs
+ * are consumed in exactly one file, `knowledgeBaseSearch/index.ts`. A forced-retrieval probe would
+ * have returned identical numbers at every configuration. Invoking the tool directly also removes
+ * model tool-choice variance entirely, which is the variable forced retrieval was chosen to control,
+ * while still exercising the shipped ranking, ceiling, floor and token-budget code rather than a
+ * reimplementation that could drift from it.
+ *
+ * HOW IT SEES WHAT WAS SERVED. The tool already reports every read to the lake audit trail
+ * (`recordLakeAccessEvent`, `knowledgeBaseSearch/index.ts:974`) carrying the deduped file ids, chunk
+ * ids and per-chunk scores. That write is deliberately un-awaited, so reading the rows back out of
+ * Mongo would race the probe's next question. Instead the probe supplies its own
+ * `db.lakeAccessEvents` recorder - the adapter seam the ToolContext already exposes - and captures
+ * the payload in memory. Same data the audit trail gets, no race, and no parsing of the
+ * model-facing string the tool returns.
+ *
+ * CORPUS. The `system-help` lake: 51 public help articles, seeded by
+ * `packages/scripts/help/ingest-help-datalake.ts`. See `corpus.ts` for why that corpus and why the
+ * ground truth is hand-authored.
+ *
+ * SCOPE. This measures RECALL of the supporting set. The unverifiable-claim rate the ticket also
+ * asks for needs an answer generated from the served passages plus a judge pass over its claims;
+ * that arm is not built here and is required before any default is actually changed, since it is the
+ * metric that can show a wider budget making answers worse rather than better.
+ *
+ * Usage (needs DB + an embedding key, which `sst shell` provides):
+ *   npx sst shell --stage pr<N> -- tsx packages/scripts/retrieval/recall-probe.ts \
+ *     --userId <probeUserId> --configs=0:0
+ *
+ *   --configs   sweep points as `tokenBudget:minRelevancePct`, comma separated.
+ *               Defaults to `0:0`, today's shipped defaults (the baseline row).
+ *   --userId    the principal the searches run as. Use an account with NO personal files: the
+ *               unscoped arm ranks the caller's own library alongside the lake, and personal files
+ *               would enter the corpus without being in the ground truth.
+ *   --out-dir   where the JSON result lands (default ./out).
+ *   --dry-run   run the preflight checks and print the plan without writing settings or searching.
+ *
+ * SIDE EFFECT: the sweep WRITES the two admin settings on the target stage and restores their prior
+ * values in a `finally`. They are stage-wide, so run this against a preview you own, never a stage
+ * other people are using.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { Resource } from 'sst';
+import {
+  AdminSettings,
+  adminSettingsRepository,
+  apiKeyRepository,
+  connectDB,
+  dataLakeRepository,
+  fabFileChunkRepository,
+  fabFileRepository,
+  fallbackLakeSettingsRepository,
+  organizationRepository,
+  scopedSettingsRepository,
+  userRepository,
+} from '@bike4mind/database';
+import { invalidateScopedSettingsCache, invalidateSettingsCache } from '@bike4mind/utils';
+import { Logger } from '@bike4mind/observability';
+import { b4mTools } from '@bike4mind/services/llm/tools';
+import type { ToolContext } from '@bike4mind/services/llm/tools';
+import type { IUserDocument, RecordLakeAccessEventInput } from '@bike4mind/common';
+import { PROBE_QUESTIONS, type ProbeQuestion } from './corpus';
+import { aggregate, scoreQuestion, type QuestionOutcome } from './metrics';
+import {
+  BASELINE_CONFIG,
+  formatConfig,
+  formatSweepTable,
+  parseConfigs,
+  type SweepConfig,
+  type SweepRow,
+} from './sweep';
+
+/** The lake `ingest-help-datalake.ts` creates, and the per-article tag prefix it writes. */
+const HELP_LAKE_SLUG = 'system-help';
+const HELP_TAG_PREFIX = 'help:';
+
+const TOKEN_BUDGET_SETTING = 'kbSearchResultTokenBudget';
+const MIN_RELEVANCE_SETTING = 'kbSearchMinRelevancePct';
+
+const logger = new Logger();
+
+// ---------------------------------------------------------------------------
+// Capture seam
+// ---------------------------------------------------------------------------
+
+/**
+ * Stands in for the lake-audit repository so the probe reads exactly what the tool reported, at the
+ * adapter boundary the ToolContext already exposes. Nothing is persisted.
+ */
+function createCapturingRecorder() {
+  const events: RecordLakeAccessEventInput[] = [];
+  return {
+    events,
+    recorder: {
+      record: async (input: RecordLakeAccessEventInput) => {
+        events.push(input);
+        return undefined as unknown as never;
+      },
+    },
+    reset: () => {
+      events.length = 0;
+    },
+  };
+}
+
+type Capture = ReturnType<typeof createCapturingRecorder>;
+
+/**
+ * `recordLakeAccessEvent` resolves the audit retention settings before calling `record()`, and the
+ * tool does not await the result, so the event lands a few microtasks after `toolFn` returns. Poll
+ * briefly rather than sleeping a fixed interval: the settings read is cached, so this almost always
+ * succeeds on the first tick.
+ */
+async function waitForEvent(capture: Capture, timeoutMs = 5_000): Promise<RecordLakeAccessEventInput | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (capture.events.length > 0) return capture.events[0];
+    await new Promise(resolve => setImmediate(resolve));
+    // Yield to the macrotask queue too, so a pending I/O continuation is not starved by a tight
+    // microtask loop.
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tool context
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble the repository graph `search_knowledge_base` needs. Mirrors the agent executor's wiring
+ * (`apps/client/server/queueHandlers/agentExecutor.ts`), minus every adapter this one tool never
+ * touches - a narrower context than the real one would silently change behavior, a wider one would
+ * just be noise.
+ */
+function buildToolContext(user: IUserDocument, capture: Capture) {
+  return {
+    userId: user.id,
+    user,
+    logger,
+    // No sessionId/questId: this is not a chat turn. They are diagnostic join keys on the audit row
+    // and are never read by the search path itself.
+    db: {
+      apiKeys: apiKeyRepository,
+      adminSettings: adminSettingsRepository,
+      fabfiles: fabFileRepository,
+      fabfilechunks: fabFileChunkRepository,
+      users: userRepository,
+      dataLakes: dataLakeRepository,
+      fallbackLakeSettings: fallbackLakeSettingsRepository,
+      organizations: organizationRepository,
+      scopedSettings: scopedSettingsRepository,
+      lakeAccessEvents: capture.recorder,
+    },
+    statusUpdate: async () => undefined,
+    onStart: async () => undefined,
+  } as unknown as ToolContext;
+}
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+/**
+ * Fail before measuring anything rather than reporting a confidently wrong number.
+ *
+ * Each of these degrades SILENTLY in production, which is correct for a chat turn and ruinous for a
+ * measurement: an unvectorized lake, a missing embedding credential or an unsupported
+ * `defaultEmbeddingModel` all send `search_knowledge_base` down its keyword fallback, which ignores
+ * both knobs this probe exists to sweep. The run would complete and every row would look identical.
+ */
+async function preflight(): Promise<{ lakeId: string; fileCount: number }> {
+  const lake = await dataLakeRepository.findBySlug(HELP_LAKE_SLUG);
+  if (!lake) {
+    throw new Error(
+      `No "${HELP_LAKE_SLUG}" lake on this stage. Seed it first:\n` +
+        `  pnpm --filter @bike4mind/scripts help:regenerate\n` +
+        `  npx sst shell --stage <stage> -- tsx packages/scripts/help/ingest-help-datalake.ts --userId <id>`
+    );
+  }
+  if (lake.status !== 'active') throw new Error(`Lake "${HELP_LAKE_SLUG}" is ${lake.status}, not active.`);
+
+  const fileIds = await fabFileRepository.findIdsByDataLakeTag({
+    kind: 'registry',
+    datalakeTag: lake.datalakeTag,
+  });
+  if (fileIds.length === 0) throw new Error(`Lake "${HELP_LAKE_SLUG}" exists but holds no files. Re-run the ingest.`);
+
+  const embeddingModel = await adminSettingsRepository.getSettingsValue('defaultEmbeddingModel');
+  if (!embeddingModel) {
+    throw new Error(
+      'defaultEmbeddingModel is not configured on this stage, so the semantic arm cannot run and ' +
+        'search_knowledge_base would silently fall back to keyword search.'
+    );
+  }
+
+  // A file with no chunks embeds to nothing and is unreachable by semantic search, so a lake that
+  // ingested but never vectorized would measure as a total recall failure with no other symptom.
+  let vectorized = 0;
+  for (const id of fileIds) {
+    if ((await fabFileChunkRepository.countByFabFileId(id)) > 0) vectorized++;
+  }
+  if (vectorized === 0) {
+    throw new Error(`None of the ${fileIds.length} help files carry chunks. The lake was ingested but not vectorized.`);
+  }
+  if (vectorized < fileIds.length) {
+    logger.warn(
+      `Only ${vectorized}/${fileIds.length} help files are vectorized. Recall is bounded by that, ` +
+        `not by the settings under test - finish the ingest before trusting these numbers.`
+    );
+  }
+
+  logger.log(
+    `Preflight OK: lake "${HELP_LAKE_SLUG}" (${lake.id}), ${fileIds.length} files, ` +
+      `${vectorized} vectorized, embedding model ${embeddingModel}`
+  );
+  return { lakeId: lake.id, fileCount: fileIds.length };
+}
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+async function readSetting(name: string): Promise<string | null> {
+  const row = await AdminSettings.findOne({ settingName: name }).lean<{ settingValue?: string } | null>();
+  return row?.settingValue ?? null;
+}
+
+/**
+ * Write a setting and drop the in-process caches so the next search sees it.
+ *
+ * Both caches must go: `resolveSearchBudgets` reads the platform value through the cached settings
+ * accessor AND consults the scoped-settings overlay, each with its own ~5 minute TTL. Because the
+ * probe invokes the tool in this same process, invalidating here makes a configuration take effect
+ * immediately - an HTTP-driven probe would have to wait out a full TTL on every serving instance.
+ */
+async function writeSetting(name: string, value: string | null): Promise<void> {
+  if (value === null) {
+    await AdminSettings.deleteOne({ settingName: name });
+  } else {
+    await AdminSettings.updateOne({ settingName: name }, { $set: { settingValue: value } }, { upsert: true });
+  }
+  invalidateSettingsCache();
+  invalidateScopedSettingsCache();
+}
+
+async function applyConfig(config: SweepConfig): Promise<void> {
+  await writeSetting(TOKEN_BUDGET_SETTING, String(config.tokenBudget));
+  await writeSetting(MIN_RELEVANCE_SETTING, String(config.minRelevancePct));
+}
+
+// ---------------------------------------------------------------------------
+// One question
+// ---------------------------------------------------------------------------
+
+/**
+ * Map served file ids back to help slugs via the `help:<slug>` tag the ingest writes, which is the
+ * only stable identity a file has across re-ingests (ids are regenerated every run, since the ingest
+ * deletes and recreates the corpus).
+ */
+async function resolveSlugs(fileIds: readonly string[]): Promise<string[]> {
+  const slugs: string[] = [];
+  for (const id of fileIds) {
+    const file = await fabFileRepository.findById(id);
+    // Tags are {name, strength} objects, not bare strings - see IFabFile.tags.
+    const tag = file?.tags?.find(t => t.name.startsWith(HELP_TAG_PREFIX));
+    // A served file with no help tag is a real signal, not noise to drop: it means something outside
+    // the corpus entered the ranking, and the ground truth cannot describe it.
+    slugs.push(tag ? tag.name.slice(HELP_TAG_PREFIX.length) : `UNTAGGED:${id}`);
+  }
+  return slugs;
+}
+
+type QuestionResult = {
+  id: string;
+  question: string;
+  supporting: string[];
+  served: string[];
+  outcome: QuestionOutcome;
+};
+
+async function runQuestion(question: ProbeQuestion, user: IUserDocument, capture: Capture): Promise<QuestionResult> {
+  capture.reset();
+  const context = buildToolContext(user, capture);
+  const tool = b4mTools.search_knowledge_base.implementation(context, {});
+  await tool.toolFn({ query: question.question });
+
+  const event = await waitForEvent(capture);
+
+  // No event at all is the correct reading of "served nothing": the tool only records once the
+  // semantic arm produced output, so a search that found nothing writes no row. That is exactly the
+  // outcome a relevance floor is supposed to produce on a negative question.
+  if (!event) {
+    const outcome = scoreQuestion([], new Set(question.supporting));
+    return { ...question, served: [], outcome };
+  }
+
+  // The keyword fallback records the SAME surface but carries no scores (see the two call sites in
+  // knowledgeBaseSearch/index.ts). Reaching it means neither knob under test applied, so the run
+  // must stop rather than report a keyword-search number as a budget-sweep result.
+  if (!event.scores || event.scores.length === 0) {
+    throw new Error(
+      `Question ${question.id} fell through to KEYWORD search (audit row carried no scores). ` +
+        `The semantic arm did not run, so this configuration was never exercised. Check the ` +
+        `embedding credential and defaultEmbeddingModel on this stage.`
+    );
+  }
+
+  const served = await resolveSlugs(event.fileIds ?? []);
+  return { ...question, served, outcome: scoreQuestion(served, new Set(question.supporting)) };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const argv = await yargs(hideBin(process.argv))
+    .option('userId', { type: 'string', demandOption: true, describe: 'Principal the searches run as' })
+    .option('configs', { type: 'string', default: '0:0', describe: 'tokenBudget:minRelevancePct, comma separated' })
+    .option('out-dir', { type: 'string', default: path.join(process.cwd(), 'out') })
+    .option('dry-run', { type: 'boolean', default: false })
+    .strict()
+    .parse();
+
+  const configs = parseConfigs(argv.configs);
+  if (
+    !configs.some(
+      c => c.tokenBudget === BASELINE_CONFIG.tokenBudget && c.minRelevancePct === BASELINE_CONFIG.minRelevancePct
+    )
+  ) {
+    // Without the off/off row there is nothing to read the other rows against: a recall number means
+    // "better or worse than what ships today", and today is 0/0.
+    logger.warn(
+      `--configs omits the ${formatConfig(BASELINE_CONFIG)} baseline. Rows will have nothing to compare against.`
+    );
+  }
+
+  await connectDB(Resource.MONGODB_URI.value.replace('%STAGE%', Resource.App.stage));
+  logger.log(`Connected (stage: ${Resource.App.stage})`);
+  const { lakeId, fileCount } = await preflight();
+
+  const user = await userRepository.findById(argv.userId);
+  if (!user) throw new Error(`No user ${argv.userId} on this stage.`);
+
+  if (argv['dry-run']) {
+    logger.log(
+      `Dry run. Would sweep ${configs.length} configuration(s) over ${PROBE_QUESTIONS.length} questions ` +
+        `against lake ${lakeId} (${fileCount} files) as ${user.id}:\n  ` +
+        configs.map(formatConfig).join('\n  ')
+    );
+    return;
+  }
+
+  const capture = createCapturingRecorder();
+  const rows: SweepRow[] = [];
+  const detail: Record<string, QuestionResult[]> = {};
+
+  // Captured BEFORE the first write so the finally below restores whatever the stage had, including
+  // "unset" - writing a 0 back would leave a row where there was none and quietly change how a
+  // future reader interprets the stage's configuration.
+  const original = {
+    [TOKEN_BUDGET_SETTING]: await readSetting(TOKEN_BUDGET_SETTING),
+    [MIN_RELEVANCE_SETTING]: await readSetting(MIN_RELEVANCE_SETTING),
+  };
+
+  try {
+    for (const config of configs) {
+      await applyConfig(config);
+      logger.log(`\n=== ${formatConfig(config)} ===`);
+
+      const results: QuestionResult[] = [];
+      for (const question of PROBE_QUESTIONS) {
+        const result = await runQuestion(question, user, capture);
+        results.push(result);
+        logger.log(
+          `  ${result.id}  served ${result.outcome.documentsServed}  recall ${(result.outcome.recall * 100).toFixed(0)}%`
+        );
+      }
+      detail[formatConfig(config)] = results;
+      rows.push({ ...config, aggregate: aggregate(results.map(r => r.outcome)) });
+    }
+  } finally {
+    for (const [name, value] of Object.entries(original)) await writeSetting(name, value);
+    logger.log('\nRestored the original settings values.');
+  }
+
+  const table = formatSweepTable(rows);
+  logger.log(`\n${table}\n`);
+
+  mkdirSync(argv['out-dir'], { recursive: true });
+  const outPath = path.join(argv['out-dir'], 'retrieval-recall-probe.json');
+  writeFileSync(
+    outPath,
+    // No timestamp: the run's provenance is the stage and the corpus, and a timestamp would make two
+    // otherwise-identical runs diff noisily when they are checked into a ticket.
+    JSON.stringify({ lakeId, corpusFiles: fileCount, questions: PROBE_QUESTIONS.length, rows, detail }, null, 2)
+  );
+  logger.log(`Wrote ${outPath}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    logger.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -47,7 +47,7 @@
  *   --userId    the principal the searches run as. Use an account with NO personal files: the
  *               unscoped arm ranks the caller's own library alongside the lake, and personal files
  *               would enter the corpus without being in the ground truth.
- *   --out-dir   where the JSON result lands (default ./out).
+ *   --out-dir   where the JSON result lands (default packages/scripts/out, which is gitignored).
  *   --dry-run   run the preflight checks and print the plan without writing settings or searching.
  *
  * SIDE EFFECT: the sweep WRITES the two admin settings on the target stage and restores their prior
@@ -57,6 +57,7 @@
 
 import { writeFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { Resource } from 'sst';
@@ -90,9 +91,24 @@ import {
   type SweepRow,
 } from './sweep';
 
+/** This file is packages/scripts/retrieval/, so the package root is two levels up. */
+const SCRIPTS_PACKAGE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
 /** The lake `ingest-help-datalake.ts` creates, and the per-article tag prefix it writes. */
 const HELP_LAKE_SLUG = 'system-help';
 const HELP_TAG_PREFIX = 'help:';
+
+/**
+ * A deliberately easy, high-lexical-overlap query used only to prove the search path returns
+ * anything at all. It is NOT part of the measured set - it breaks the corpus design rules on
+ * purpose (see corpus.ts), because a precondition check wants the highest-signal query available,
+ * which is exactly the opposite of what a discriminating probe question wants.
+ */
+const CANARY_QUESTION: ProbeQuestion = {
+  id: 'canary',
+  question: 'data lakes',
+  supporting: ['features/data-lakes'],
+};
 
 // Typed as SettingKey so a typo fails the build rather than writing a row nothing reads.
 const TOKEN_BUDGET_SETTING: SettingKey = 'kbSearchResultTokenBudget';
@@ -203,7 +219,7 @@ function buildToolContext(user: IUserDocument, capture: Capture) {
  * `defaultEmbeddingModel` all send `search_knowledge_base` down its keyword fallback, which ignores
  * both knobs this probe exists to sweep. The run would complete and every row would look identical.
  */
-async function preflight(user: IUserDocument): Promise<{ lakeId: string; fileCount: number }> {
+async function preflight(user: IUserDocument, capture: Capture): Promise<{ lakeId: string; fileCount: number }> {
   const lake = await dataLakeRepository.findBySlug(HELP_LAKE_SLUG);
   if (!lake) {
     throw new Error(
@@ -266,6 +282,27 @@ async function preflight(user: IUserDocument): Promise<{ lakeId: string; fileCou
     throw new Error(
       `Probe user ${user.id} owns ${ownNonLake.length} file(s) outside the help lake. They would ` +
         `enter the ranking without being in the ground truth. Use a dedicated account with no files.`
+    );
+  }
+
+  // THE precondition every other check presupposes: that a search by THIS caller over THIS lake
+  // actually returns candidates. Everything above verifies the corpus exists; none of it verifies
+  // the caller can reach it. That gap is invisible downstream - a caller with no grant makes the
+  // tool search an empty candidate set, report `outcome: 'ok'`, and score a clean 0 on every
+  // question, which is indistinguishable from a relevance floor correctly rejecting everything.
+  //
+  // Empirical rather than a re-derivation of the access rules: this is a live end-to-end search, so
+  // it also catches an unusable embedding credential, a tag drift, or an unvectorized corpus - any
+  // reason the candidate set comes back empty, not just the one that bit us. Run before any config
+  // is applied, so the stage's own settings cannot be what suppresses it.
+  const canary = await runQuestion(CANARY_QUESTION, user, capture);
+  if (canary.served.length === 0) {
+    throw new Error(
+      `Canary search returned no documents, so the ${fileIds.length}-file lake is unreachable for ` +
+        `user ${user.id} and every question would score 0% at every configuration.\n` +
+        `Most likely cause: no access grant. "${HELP_LAKE_SLUG}" is gateless, org-less and not ` +
+        `public, so the only arm that admits anyone is the owner bypass - run as the account in the ` +
+        `lake's createdByUserId, or grant access via isPublic / requiredUserTag / organizationId.`
     );
   }
 
@@ -378,7 +415,9 @@ async function main(): Promise<void> {
   const argv = await yargs(hideBin(process.argv))
     .option('userId', { type: 'string', demandOption: true, describe: 'Principal the searches run as' })
     .option('configs', { type: 'string', default: '0:0', describe: 'tokenBudget:minRelevancePct, comma separated' })
-    .option('out-dir', { type: 'string', default: path.join(process.cwd(), 'out') })
+    // packages/scripts/out/ is gitignored; the repo root's out/ is not, so defaulting to cwd
+    // dropped an untracked result file into the repo whenever this ran from the root.
+    .option('out-dir', { type: 'string', default: path.resolve(SCRIPTS_PACKAGE_DIR, 'out') })
     .option('dry-run', { type: 'boolean', default: false })
     .strict()
     .parse();
@@ -401,7 +440,9 @@ async function main(): Promise<void> {
 
   const user = await userRepository.findById(argv.userId);
   if (!user) throw new Error(`No user ${argv.userId} on this stage.`);
-  const { lakeId, fileCount } = await preflight(user);
+
+  const capture = createCapturingRecorder();
+  const { lakeId, fileCount } = await preflight(user, capture);
 
   if (argv['dry-run']) {
     logger.log(
@@ -412,7 +453,6 @@ async function main(): Promise<void> {
     return;
   }
 
-  const capture = createCapturingRecorder();
   const rows: SweepRow[] = [];
   const detail: Record<string, QuestionResult[]> = {};
 
@@ -441,8 +481,29 @@ async function main(): Promise<void> {
       rows.push({ ...config, aggregate: aggregate(results.map(r => r.outcome)) });
     }
   } finally {
-    for (const [name, value] of Object.entries(original)) await writeSetting(name, value);
-    logger.log('\nRestored the original settings values.');
+    // Restore every setting even if one throws, and never let a restore failure replace the error
+    // that actually ended the run - a mid-run DB outage takes the writes down with it, and an
+    // unguarded `await` here would surface the cleanup's socket timeout while hiding the cause.
+    // The stage is left mutated either way, so the values needed to undo it by hand are printed
+    // rather than merely logged as a failure.
+    const stranded: string[] = [];
+    for (const [name, value] of Object.entries(original)) {
+      try {
+        await writeSetting(name, value);
+      } catch (err) {
+        stranded.push(`${name}=${value ?? '(unset)'}`);
+        logger.warn(`Could not restore ${name}`, err);
+      }
+    }
+    if (stranded.length > 0) {
+      logger.error(
+        `SETTINGS LEFT MODIFIED ON THIS STAGE. Restore by hand: ${stranded.join(', ')} ` +
+          '("(unset)" means delete the row rather than writing a 0 - a 0 row and no row read the ' +
+          'same to the search path today, but not to a human reading the stage config later.)'
+      );
+    } else {
+      logger.log('\nRestored the original settings values.');
+    }
   }
 
   const table = formatSweepTable(rows);

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -27,7 +27,11 @@
  * The probe captures the `statusUpdate` seam alongside it, because the audit trail alone cannot say
  * whether an absent event means "retrieval served nothing" or "the harness never saw the write".
  * Unlike the audit write, every terminal path AWAITS its status write, so `promptMeta.retrieval` is
- * always present by the time `toolFn` resolves. See `auditEvent.ts`, which owns that decision.
+ * always present by the time `toolFn` resolves. `promptMeta.warnings` is captured from the same
+ * seam and carries the tool's relevance-floor notice, which is the only thing separating "the
+ * keyword arm answered because the floor under test emptied the semantic one" (a real measurement)
+ * from "the keyword arm answered because the semantic one was never wired up" (a fatal harness
+ * problem). See `auditEvent.ts`, which owns both decisions.
  *
  * CORPUS. The `system-help` lake: 51 public help articles, seeded by
  * `packages/scripts/help/ingest-help-datalake.ts`. See `corpus.ts` for why that corpus and why the
@@ -48,14 +52,20 @@
  *               unscoped arm ranks the caller's own library alongside the lake, and personal files
  *               would enter the corpus without being in the ground truth.
  *   --out-dir   where the JSON result lands (default packages/scripts/out, which is gitignored).
- *   --dry-run   run the preflight checks and print the plan without writing settings or searching.
+ *   --dry-run   print the plan without writing settings or sweeping. Preflight still RUNS, and it
+ *               ends in a live canary search (a real embedding call) - checking that the corpus is
+ *               reachable is the whole value of a dry run, so it is deliberately not skipped.
  *
  * SIDE EFFECT: the sweep WRITES the two admin settings on the target stage and restores their prior
- * values in a `finally`. They are stage-wide, so run this against a preview you own, never a stage
- * other people are using.
+ * values on the way out - from a `finally`, and from a SIGINT/SIGTERM handler so Ctrl-C does not
+ * strand a mid-sweep configuration on the stage. It also takes a lease row for the duration, so a
+ * second concurrent run refuses to start rather than capturing the first run's mutated values as
+ * its baseline. They are stage-wide settings regardless, so run this against a preview you own,
+ * never a stage other people are using.
  */
 
 import { writeFileSync, mkdirSync } from 'node:fs';
+import { hostname } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import yargs from 'yargs';
@@ -80,6 +90,7 @@ import { b4mTools } from '@bike4mind/services/llm/tools';
 import type { ToolContext } from '@bike4mind/services/llm/tools';
 import type { IUserDocument, RecordLakeAccessEventInput, SettingKey } from '@bike4mind/common';
 import { readRetrievalStatus, readServedDocuments, type CapturedPromptMeta } from './auditEvent';
+import { pollFor } from './pollEvent';
 import { PROBE_QUESTIONS, type ProbeQuestion } from './corpus';
 import { aggregate, scoreQuestion, type QuestionOutcome } from './metrics';
 import {
@@ -151,27 +162,11 @@ function createCapturingRecorder() {
 type Capture = ReturnType<typeof createCapturingRecorder>;
 
 /**
- * `recordLakeAccessEvent` resolves the audit retention settings before calling `record()`, and the
- * tool does not await the result, so the event lands a few microtasks after `toolFn` returns. Poll
- * briefly rather than sleeping a fixed interval: the settings read is cached, so this almost always
- * succeeds on the first tick.
- *
- * Only called once the status seam has confirmed content WAS served, so exhausting the timeout is
- * unambiguously a stalled write and never an honest empty result. Still returns `null` rather than
- * throwing, to keep `readServedDocuments` the single place the two absences are told apart - the
- * one decision that has to stay testable without a stage.
+ * Wait out the tool's un-awaited audit write. See `pollEvent.ts`, which owns the loop and its
+ * timeout semantics; this is only the binding to the capture buffer.
  */
-async function waitForEvent(capture: Capture, timeoutMs = 5_000): Promise<RecordLakeAccessEventInput | null> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (capture.events.length > 0) return capture.events[0];
-    await new Promise(resolve => setImmediate(resolve));
-    // Yield to the macrotask queue too, so a pending I/O continuation is not starved by a tight
-    // microtask loop.
-    await new Promise(resolve => setTimeout(resolve, 5));
-  }
-  return null;
-}
+const waitForEvent = (capture: Capture, timeoutMs?: number): Promise<RecordLakeAccessEventInput | null> =>
+  pollFor(() => capture.events[0], { timeoutMs });
 
 // ---------------------------------------------------------------------------
 // Tool context
@@ -288,12 +283,21 @@ async function preflight(user: IUserDocument, capture: Capture): Promise<{ lakeI
   // personal file is not attributable to any lake - so the tool records no audit event for it and
   // the probe would read a real result as "served nothing". Ground truth cannot describe those
   // files either. Enforce the precondition instead of documenting it.
+  //
+  // PARTIAL BY CONSTRUCTION: `findByUserId` returns OWNED files, while the unscoped arm ranks
+  // owned plus shared plus org-shared. A file shared TO the probe user passes this check and can
+  // still enter the ranking. Low impact rather than unhandled - `resolveSlugs` surfaces it as
+  // `UNTAGGED:<id>` instead of dropping it, so it shows up in the detail as an intruder rather
+  // than corrupting a slug - but a clean account is still the only way to rule the case out, which
+  // is why the message asks for one rather than for an empty owned list.
   const ownFiles = await fabFileRepository.findByUserId(user.id);
   const ownNonLake = ownFiles.filter(f => !f.tags?.some(t => t.name.startsWith(HELP_TAG_PREFIX)));
   if (ownNonLake.length > 0) {
     throw new Error(
       `Probe user ${user.id} owns ${ownNonLake.length} file(s) outside the help lake. They would ` +
-        `enter the ranking without being in the ground truth. Use a dedicated account with no files.`
+        `enter the ranking without being in the ground truth. Use a dedicated account with no files ` +
+        `- note this check sees OWNED files only, so files shared to the account are not covered ` +
+        `and would appear in the results as UNTAGGED:<id>.`
     );
   }
 
@@ -336,6 +340,12 @@ async function preflight(user: IUserDocument, capture: Capture): Promise<{ lakeI
 // Settings
 // ---------------------------------------------------------------------------
 
+/**
+ * Deliberately reads THROUGH the soft-delete filter (see `writeSetting`), so a tombstone left by an
+ * older run of this script reads as "unset" rather than as a baseline. That is the recovering
+ * answer: a tombstone's `settingValue` is whatever the interrupted sweep wrote last, never the
+ * stage's real prior value, and restoring "unset" hard-deletes the row and leaves the stage clean.
+ */
 async function readSetting(name: string): Promise<string | null> {
   const row = await AdminSettings.findOne({ settingName: name }).lean<{ settingValue?: string } | null>();
   return row?.settingValue ?? null;
@@ -348,12 +358,31 @@ async function readSetting(name: string): Promise<string | null> {
  * accessor AND consults the scoped-settings overlay, each with its own ~5 minute TTL. Because the
  * probe invokes the tool in this same process, invalidating here makes a configuration take effect
  * immediately - an HTTP-driven probe would have to wait out a full TTL on every serving instance.
+ *
+ * BOTH BRANCHES FIGHT THE SAME SOFT-DELETE ASYMMETRY, which is invisible at the call site.
+ * `AdminSettingsSchema.plugin(softDeletePlugin)` (`AdminSettingsModel.ts:47`) replaces `deleteOne`
+ * with an `updateOne` that stamps `deletedAt` (`db-core/src/utils/mongo.ts:412`), and the plugin
+ * filters `find`/`findOne` on `deletedAt: null` but hooks NEITHER `updateOne` NOR
+ * `findOneAndUpdate`. A plain `deleteOne` here would therefore leave a tombstoned row that still
+ * carries the sweep's last value: `readSetting` reports it unset, so the next run captures a false
+ * baseline; the upsert below would match the tombstone without clearing `deletedAt`, so every
+ * subsequent configuration writes into a document `AdminSettingsCache` cannot see and every row in
+ * the table silently measures the shipped defaults. It escapes the script too - the settings API
+ * saves through an unfiltered `findOneAndUpdate`, so the setting becomes permanently unsettable
+ * from the admin UI on any stage this ran against.
+ *
+ * `hardDelete` really removes the row; `deletedAt: null` on the upsert recovers one left by an
+ * older run of this script.
  */
 async function writeSetting(name: string, value: string | null): Promise<void> {
   if (value === null) {
-    await AdminSettings.deleteOne({ settingName: name });
+    await AdminSettings.deleteOne({ settingName: name }, { hardDelete: true });
   } else {
-    await AdminSettings.updateOne({ settingName: name }, { $set: { settingValue: value } }, { upsert: true });
+    await AdminSettings.updateOne(
+      { settingName: name },
+      { $set: { settingValue: value, deletedAt: null } },
+      { upsert: true }
+    );
   }
   invalidateSettingsCache();
   invalidateScopedSettingsCache();
@@ -362,6 +391,154 @@ async function writeSetting(name: string, value: string | null): Promise<void> {
 async function applyConfig(config: SweepConfig): Promise<void> {
   await writeSetting(TOKEN_BUDGET_SETTING, String(config.tokenBudget));
   await writeSetting(MIN_RELEVANCE_SETTING, String(config.minRelevancePct));
+}
+
+/**
+ * A row this script owns, not a real setting - `settingsMap` has no entry for it, so every typed
+ * reader ignores it. It exists only so a second concurrent run can see the first.
+ */
+const LEASE_SETTING = '__recallProbeLease';
+
+/**
+ * How long before a lease is reported as abandoned. Longer than any plausible sweep (30 questions x
+ * a handful of configurations, each a live embedding call), so a slow run is never mistaken for a
+ * dead one.
+ */
+const LEASE_STALE_AFTER_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Take exclusive ownership of the two swept settings, and hand back a `restore` that gives them
+ * back exactly once.
+ *
+ * This is the ONLY thing standing between a dev script and a permanently altered shared stage, so
+ * both ways of losing that guarantee are closed here rather than left to the caller:
+ *
+ * - CONCURRENCY. A second run started while a first is in flight would read the FIRST run's mutated
+ *   values as its own baseline and restore those on exit, discarding the stage's real configuration
+ *   with no error anywhere. The lease makes the second run refuse instead. It is a plain row rather
+ *   than a Mongo lock because the two runs may be different processes on different machines.
+ *
+ * - INTERRUPTION. Ctrl-C is the natural reaction to a sweep that is taking too long, and it skips
+ *   `finally` entirely - leaving the stage carrying whichever configuration was mid-flight, which
+ *   is a live change to retrieval behaviour that nobody knows was made. The handlers below restore
+ *   first and then re-raise, so the exit status still reports the signal.
+ *
+ * `restore` is idempotent and single-flight: the signal path and the `finally` path both call it,
+ * and a second Ctrl-C during a slow restore must not start a second one.
+ */
+async function acquireSettingsLease(): Promise<{ restore: () => Promise<void> }> {
+  const holder = `${hostname()}:${process.pid}`;
+  const now = Date.now();
+
+  // Atomic: `upsertedCount` is 1 only for the run that actually created the row. A concurrent
+  // loser either matches the existing row or trips the unique index on settingName - both mean
+  // somebody else holds the lease.
+  let acquired = false;
+  try {
+    const result = await AdminSettings.updateOne(
+      { settingName: LEASE_SETTING },
+      { $setOnInsert: { settingValue: JSON.stringify({ holder, startedAt: now }), deletedAt: null } },
+      { upsert: true }
+    );
+    acquired = result.upsertedCount === 1;
+  } catch {
+    acquired = false;
+  }
+
+  if (!acquired) {
+    const existing = await readSetting(LEASE_SETTING);
+    // Tolerate an unparseable row: the lease still BLOCKS either way, and a SyntaxError here would
+    // replace the message that tells the operator what to do with one that does not.
+    let startedAt = 0;
+    try {
+      startedAt = Number(JSON.parse(existing ?? '{}')?.startedAt ?? 0);
+    } catch {
+      startedAt = 0;
+    }
+    const ageMs = now - startedAt;
+    const age =
+      Number.isFinite(ageMs) && startedAt > 0 ? `${Math.round(ageMs / 60_000)} minute(s) ago` : 'at an unknown time';
+    const staleHint =
+      startedAt > 0 && ageMs > LEASE_STALE_AFTER_MS
+        ? `\nThat lease is older than ${LEASE_STALE_AFTER_MS / 3_600_000}h, so the run holding it probably died. ` +
+          `Confirm no sweep is running, CHECK ${TOKEN_BUDGET_SETTING} and ${MIN_RELEVANCE_SETTING} against ` +
+          `what this stage should have, then clear the "${LEASE_SETTING}" row to release it.`
+        : '';
+    throw new Error(
+      `Another recall probe holds the settings lease on this stage (${existing ?? 'holder unknown'}, taken ${age}). ` +
+        `Refusing to start: this run would capture that run's mutated settings as its baseline and ` +
+        `restore those on exit, permanently discarding the stage's real configuration.${staleHint}`
+    );
+  }
+
+  // Captured AFTER the lease so nothing else can be mid-sweep, and BEFORE the first write so the
+  // restore puts back whatever the stage had, including "unset" - writing a 0 back would leave a
+  // row where there was none and quietly change how a future reader interprets the stage config.
+  const original: Record<string, string | null> = {
+    [TOKEN_BUDGET_SETTING]: await readSetting(TOKEN_BUDGET_SETTING),
+    [MIN_RELEVANCE_SETTING]: await readSetting(MIN_RELEVANCE_SETTING),
+  };
+
+  let inFlight: Promise<void> | null = null;
+  const runRestore = async (): Promise<void> => {
+    // Never let a restore failure replace the error that actually ended the run - a mid-run DB
+    // outage takes these writes down with it, and an unguarded await here would surface the
+    // cleanup's socket timeout while hiding the cause. The stage is left mutated either way, so
+    // the values needed to undo it by hand are printed rather than merely logged as a failure.
+    const stranded: string[] = [];
+    for (const [name, value] of Object.entries(original)) {
+      try {
+        await writeSetting(name, value);
+      } catch (err) {
+        stranded.push(`${name}=${value ?? '(unset)'}`);
+        logger.warn(`Could not restore ${name}`, err);
+      }
+    }
+    // Released last: while any setting is still stranded the lease is the only marker that this
+    // stage is mid-sweep, and a run that starts against a half-restored stage is the corruption
+    // the lease exists to prevent.
+    if (stranded.length > 0) {
+      logger.error(
+        `SETTINGS LEFT MODIFIED ON THIS STAGE. Restore by hand: ${stranded.join(', ')} ` +
+          '("(unset)" means delete the row rather than writing a 0 - a 0 row and no row read the ' +
+          'same to the search path today, but not to a human reading the stage config later.) ' +
+          `Then clear the "${LEASE_SETTING}" row, which is deliberately left behind to block the ` +
+          'next run until you have.'
+      );
+      return;
+    }
+    try {
+      await writeSetting(LEASE_SETTING, null);
+    } catch (err) {
+      logger.warn(`Could not release the "${LEASE_SETTING}" row. Clear it by hand before the next run.`, err);
+      return;
+    }
+    logger.log('\nRestored the original settings values.');
+  };
+
+  const restore = (): Promise<void> => (inFlight ??= runRestore());
+
+  const onSignal = (signal: NodeJS.Signals): void => {
+    void (async () => {
+      logger.warn(`\nReceived ${signal}. Restoring the stage settings before exiting.`);
+      await restore();
+      // Re-raise with our handler gone so the process dies of the signal it was sent and the exit
+      // status stays honest (128+n), rather than reporting a clean exit from an aborted sweep.
+      process.removeListener('SIGINT', onSignal);
+      process.removeListener('SIGTERM', onSignal);
+      process.kill(process.pid, signal);
+    })();
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+
+  return {
+    restore: async () => {
+      process.removeListener('SIGINT', onSignal);
+      process.removeListener('SIGTERM', onSignal);
+      await restore();
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -416,8 +593,9 @@ async function runQuestion(question: ProbeQuestion, user: IUserDocument, capture
 
   if (reading.kind === 'keyword-fallback') {
     throw new Error(
-      `Question ${question.id} fell through to KEYWORD search (audit row carried no chunk scores). ` +
-        `The semantic arm did not run, so this configuration was never exercised. Check the ` +
+      `Question ${question.id} fell through to KEYWORD search (audit row carried no chunk scores) ` +
+        `WITHOUT the relevance-floor notice, so the semantic arm was never available rather than ` +
+        `emptied by the floor under test. This configuration was never exercised. Check the ` +
         `embedding credential and defaultEmbeddingModel on this stage.`
     );
   }
@@ -475,13 +653,7 @@ async function main(): Promise<void> {
   const rows: SweepRow[] = [];
   const detail: Record<string, QuestionResult[]> = {};
 
-  // Captured BEFORE the first write so the finally below restores whatever the stage had, including
-  // "unset" - writing a 0 back would leave a row where there was none and quietly change how a
-  // future reader interprets the stage's configuration.
-  const original = {
-    [TOKEN_BUDGET_SETTING]: await readSetting(TOKEN_BUDGET_SETTING),
-    [MIN_RELEVANCE_SETTING]: await readSetting(MIN_RELEVANCE_SETTING),
-  };
+  const { restore } = await acquireSettingsLease();
 
   try {
     for (const config of configs) {
@@ -500,29 +672,9 @@ async function main(): Promise<void> {
       rows.push({ ...config, aggregate: aggregate(results.map(r => r.outcome)) });
     }
   } finally {
-    // Restore every setting even if one throws, and never let a restore failure replace the error
-    // that actually ended the run - a mid-run DB outage takes the writes down with it, and an
-    // unguarded `await` here would surface the cleanup's socket timeout while hiding the cause.
-    // The stage is left mutated either way, so the values needed to undo it by hand are printed
-    // rather than merely logged as a failure.
-    const stranded: string[] = [];
-    for (const [name, value] of Object.entries(original)) {
-      try {
-        await writeSetting(name, value);
-      } catch (err) {
-        stranded.push(`${name}=${value ?? '(unset)'}`);
-        logger.warn(`Could not restore ${name}`, err);
-      }
-    }
-    if (stranded.length > 0) {
-      logger.error(
-        `SETTINGS LEFT MODIFIED ON THIS STAGE. Restore by hand: ${stranded.join(', ')} ` +
-          '("(unset)" means delete the row rather than writing a 0 - a 0 row and no row read the ' +
-          'same to the search path today, but not to a human reading the stage config later.)'
-      );
-    } else {
-      logger.log('\nRestored the original settings values.');
-    }
+    // Restores every setting and releases the lease, even if a question threw. Idempotent with the
+    // signal handlers the lease installed, so an interrupted run does not restore twice.
+    await restore();
   }
 
   const table = formatSweepTable(rows);

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -72,7 +72,8 @@ import { invalidateScopedSettingsCache, invalidateSettingsCache } from '@bike4mi
 import { Logger } from '@bike4mind/observability';
 import { b4mTools } from '@bike4mind/services/llm/tools';
 import type { ToolContext } from '@bike4mind/services/llm/tools';
-import type { IUserDocument, RecordLakeAccessEventInput } from '@bike4mind/common';
+import type { IUserDocument, RecordLakeAccessEventInput, SettingKey } from '@bike4mind/common';
+import { readServedDocuments } from './auditEvent';
 import { PROBE_QUESTIONS, type ProbeQuestion } from './corpus';
 import { aggregate, scoreQuestion, type QuestionOutcome } from './metrics';
 import {
@@ -88,8 +89,9 @@ import {
 const HELP_LAKE_SLUG = 'system-help';
 const HELP_TAG_PREFIX = 'help:';
 
-const TOKEN_BUDGET_SETTING = 'kbSearchResultTokenBudget';
-const MIN_RELEVANCE_SETTING = 'kbSearchMinRelevancePct';
+// Typed as SettingKey so a typo fails the build rather than writing a row nothing reads.
+const TOKEN_BUDGET_SETTING: SettingKey = 'kbSearchResultTokenBudget';
+const MIN_RELEVANCE_SETTING: SettingKey = 'kbSearchMinRelevancePct';
 
 const logger = new Logger();
 
@@ -183,7 +185,7 @@ function buildToolContext(user: IUserDocument, capture: Capture) {
  * `defaultEmbeddingModel` all send `search_knowledge_base` down its keyword fallback, which ignores
  * both knobs this probe exists to sweep. The run would complete and every row would look identical.
  */
-async function preflight(): Promise<{ lakeId: string; fileCount: number }> {
+async function preflight(user: IUserDocument): Promise<{ lakeId: string; fileCount: number }> {
   const lake = await dataLakeRepository.findBySlug(HELP_LAKE_SLUG);
   if (!lake) {
     throw new Error(
@@ -221,6 +223,31 @@ async function preflight(): Promise<{ lakeId: string; fileCount: number }> {
     logger.warn(
       `Only ${vectorized}/${fileIds.length} help files are vectorized. Recall is bounded by that, ` +
         `not by the settings under test - finish the ingest before trusting these numbers.`
+    );
+  }
+
+  // The harness identifies a served document by its `help:<slug>` tag, which the ingest writes
+  // alongside the lake meta-tag. If that prefix ever drifts, every served file resolves to
+  // UNTAGGED and recall collapses to zero across the board - which reads as a retrieval failure
+  // rather than a harness bug. Pin the assumption against the live corpus, loudly, up front.
+  const sample = await fabFileRepository.findById(fileIds[0]);
+  if (!sample?.tags?.some(t => t.name.startsWith(HELP_TAG_PREFIX))) {
+    throw new Error(
+      `Help lake files do not carry a "${HELP_TAG_PREFIX}" tag, so served documents cannot be ` +
+        `mapped back to help slugs. The ingest's FILE_TAG_PREFIX and this probe have drifted.`
+    );
+  }
+
+  // The unscoped search arm ranks the caller's OWN library alongside the lake, and a hit on a
+  // personal file is not attributable to any lake - so the tool records no audit event for it and
+  // the probe would read a real result as "served nothing". Ground truth cannot describe those
+  // files either. Enforce the precondition instead of documenting it.
+  const ownFiles = await fabFileRepository.findByUserId(user.id);
+  const ownNonLake = ownFiles.filter(f => !f.tags?.some(t => t.name.startsWith(HELP_TAG_PREFIX)));
+  if (ownNonLake.length > 0) {
+    throw new Error(
+      `Probe user ${user.id} owns ${ownNonLake.length} file(s) outside the help lake. They would ` +
+        `enter the ranking without being in the ground truth. Use a dedicated account with no files.`
     );
   }
 
@@ -299,28 +326,17 @@ async function runQuestion(question: ProbeQuestion, user: IUserDocument, capture
   const tool = b4mTools.search_knowledge_base.implementation(context, {});
   await tool.toolFn({ query: question.question });
 
-  const event = await waitForEvent(capture);
+  const reading = readServedDocuments(await waitForEvent(capture));
 
-  // No event at all is the correct reading of "served nothing": the tool only records once the
-  // semantic arm produced output, so a search that found nothing writes no row. That is exactly the
-  // outcome a relevance floor is supposed to produce on a negative question.
-  if (!event) {
-    const outcome = scoreQuestion([], new Set(question.supporting));
-    return { ...question, served: [], outcome };
-  }
-
-  // The keyword fallback records the SAME surface but carries no scores (see the two call sites in
-  // knowledgeBaseSearch/index.ts). Reaching it means neither knob under test applied, so the run
-  // must stop rather than report a keyword-search number as a budget-sweep result.
-  if (!event.scores || event.scores.length === 0) {
+  if (reading.kind === 'keyword-fallback') {
     throw new Error(
-      `Question ${question.id} fell through to KEYWORD search (audit row carried no scores). ` +
+      `Question ${question.id} fell through to KEYWORD search (audit row carried no chunk scores). ` +
         `The semantic arm did not run, so this configuration was never exercised. Check the ` +
         `embedding credential and defaultEmbeddingModel on this stage.`
     );
   }
 
-  const served = await resolveSlugs(event.fileIds ?? []);
+  const served = reading.kind === 'served' ? await resolveSlugs(reading.fileIds) : [];
   return { ...question, served, outcome: scoreQuestion(served, new Set(question.supporting)) };
 }
 
@@ -352,10 +368,10 @@ async function main(): Promise<void> {
 
   await connectDB(Resource.MONGODB_URI.value.replace('%STAGE%', Resource.App.stage));
   logger.log(`Connected (stage: ${Resource.App.stage})`);
-  const { lakeId, fileCount } = await preflight();
 
   const user = await userRepository.findById(argv.userId);
   if (!user) throw new Error(`No user ${argv.userId} on this stage.`);
+  const { lakeId, fileCount } = await preflight(user);
 
   if (argv['dry-run']) {
     logger.log(

--- a/packages/scripts/retrieval/sweep.test.ts
+++ b/packages/scripts/retrieval/sweep.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { BASELINE_CONFIG, formatConfig, formatSweepTable, parseConfigs } from './sweep';
+import { aggregate, scoreQuestion } from './metrics';
+
+describe('parseConfigs', () => {
+  it('parses a sweep of tokenBudget:minRelevancePct points', () => {
+    expect(parseConfigs('0:0,4000:0,4000:60')).toEqual([
+      { tokenBudget: 0, minRelevancePct: 0 },
+      { tokenBudget: 4000, minRelevancePct: 0 },
+      { tokenBudget: 4000, minRelevancePct: 60 },
+    ]);
+  });
+
+  it('tolerates whitespace and trailing separators', () => {
+    expect(parseConfigs(' 0:0 , 8000:50 ,')).toEqual([
+      { tokenBudget: 0, minRelevancePct: 0 },
+      { tokenBudget: 8000, minRelevancePct: 50 },
+    ]);
+  });
+
+  it('rejects a malformed point instead of silently dropping it', () => {
+    // A dropped row would leave a results table that looks complete and is missing what was asked for.
+    expect(() => parseConfigs('0:0,notanumber:0')).toThrow(/token budget/i);
+    expect(() => parseConfigs('4000')).toThrow(/relevance floor/i);
+    expect(() => parseConfigs('-1:0')).toThrow(/token budget/i);
+    expect(() => parseConfigs('4000:1.5')).toThrow(/relevance floor/i);
+  });
+
+  it('rejects a relevance floor outside 0-100, the unit the setting stores', () => {
+    expect(() => parseConfigs('0:101')).toThrow(/relevance floor/i);
+    expect(() => parseConfigs('0:-5')).toThrow(/relevance floor/i);
+  });
+
+  it('rejects an empty spec', () => {
+    expect(() => parseConfigs('')).toThrow(/no configurations/i);
+    expect(() => parseConfigs('  ,  ')).toThrow(/no configurations/i);
+  });
+
+  it('rejects a duplicated point, which would print two rows differing only by noise', () => {
+    expect(() => parseConfigs('4000:60,4000:60')).toThrow(/duplicate/i);
+  });
+
+  it('accepts the shipped baseline', () => {
+    expect(parseConfigs('0:0')).toEqual([BASELINE_CONFIG]);
+  });
+});
+
+describe('formatConfig', () => {
+  it('labels a point readably', () => {
+    expect(formatConfig({ tokenBudget: 4000, minRelevancePct: 60 })).toBe('budget=4000 floor=60%');
+  });
+});
+
+describe('formatSweepTable', () => {
+  const row = (tokenBudget: number, minRelevancePct: number) => ({
+    tokenBudget,
+    minRelevancePct,
+    aggregate: aggregate([
+      scoreQuestion(['a'], new Set(['a', 'b'])), // positive, recall 0.5
+      scoreQuestion(['x'], new Set()), // negative, served something
+    ]),
+  });
+
+  it('renders one row per configuration under a Markdown header', () => {
+    const table = formatSweepTable([row(0, 0), row(4000, 60)]);
+    const lines = table.split('\n');
+    expect(lines).toHaveLength(4); // header + separator + 2 rows
+    expect(lines[0]).toContain('false-positive rate');
+  });
+
+  it('prints a disabled knob as "off" rather than 0, which reads as a real budget', () => {
+    const lines = formatSweepTable([row(0, 0)]).split('\n');
+    expect(lines[2]).toContain('| off | off |');
+  });
+
+  it('shows configured values with their units', () => {
+    const lines = formatSweepTable([row(4000, 60)]).split('\n');
+    expect(lines[2]).toContain('| 4000 | 60% |');
+  });
+
+  it('reports the metrics that can independently change the decision', () => {
+    const lines = formatSweepTable([row(0, 0)]).split('\n');
+    expect(lines[2]).toContain('50.0%'); // recall of the positive
+    expect(lines[2]).toContain('100.0%'); // falsePositiveRate: the one negative served something
+  });
+
+  it('renders a header even with no rows, so an empty run is visibly empty', () => {
+    expect(formatSweepTable([]).split('\n')).toHaveLength(2);
+  });
+});

--- a/packages/scripts/retrieval/sweep.test.ts
+++ b/packages/scripts/retrieval/sweep.test.ts
@@ -21,9 +21,28 @@ describe('parseConfigs', () => {
   it('rejects a malformed point instead of silently dropping it', () => {
     // A dropped row would leave a results table that looks complete and is missing what was asked for.
     expect(() => parseConfigs('0:0,notanumber:0')).toThrow(/token budget/i);
-    expect(() => parseConfigs('4000')).toThrow(/relevance floor/i);
+    expect(() => parseConfigs('4000')).toThrow(/exactly/i);
     expect(() => parseConfigs('-1:0')).toThrow(/token budget/i);
     expect(() => parseConfigs('4000:1.5')).toThrow(/relevance floor/i);
+  });
+
+  it('requires exactly two components, since a missing one parses as a silent 0', () => {
+    // Number('') is 0 and Number.isInteger(0) is true, so without the arity and emptiness checks
+    // "4000:" would run a floor-0 row under the name of a floor someone asked for, and
+    // "4000:70:80" would drop its third segment. Both give a table that looks like the requested
+    // sweep and is not.
+    expect(() => parseConfigs('4000:')).toThrow(/relevance floor/i);
+    expect(() => parseConfigs(':70')).toThrow(/token budget/i);
+    expect(() => parseConfigs('4000:70:80')).toThrow(/exactly/i);
+  });
+
+  it('rejects a token budget above the ceiling the setting itself declares', () => {
+    // kbSearchResultTokenBudget caps at 20000, enforced only by the settings API's schema.parse -
+    // which this script bypasses by writing the model directly. A larger value is a row no admin
+    // could ever deploy, and is measurement-identical to 20000 anyway since the passage ceiling
+    // binds first above it.
+    expect(() => parseConfigs('50000:0')).toThrow(/ceiling/i);
+    expect(parseConfigs('20000:0')).toEqual([{ tokenBudget: 20_000, minRelevancePct: 0 }]);
   });
 
   it('rejects a relevance floor outside 0-100, the unit the setting stores', () => {
@@ -82,6 +101,25 @@ describe('formatSweepTable', () => {
     const lines = formatSweepTable([row(0, 0)]).split('\n');
     expect(lines[2]).toContain('50.0%'); // recall of the positive
     expect(lines[2]).toContain('100.0%'); // falsePositiveRate: the one negative served something
+  });
+
+  it('prints the precision denominator, which moves with the configuration', () => {
+    // Precision skips positives that served nothing, so its `n` shrinks as a floor bites. Without
+    // the count in the cell, a precision rising on a shrinking sample reads as an improvement.
+    const lines = formatSweepTable([row(0, 0)]).split('\n');
+    expect(lines[2]).toContain('(n=1)');
+  });
+
+  it('prints n/a rather than 0.0% when no positive served anything', () => {
+    const emptied = {
+      tokenBudget: 4000,
+      minRelevancePct: 90,
+      aggregate: aggregate([scoreQuestion([], new Set(['a']))]),
+    };
+    const lines = formatSweepTable([emptied]).split('\n');
+    // mean([]) is 0, and a bare 0.0% here would read as a measured collapse rather than an
+    // absence of anything to measure.
+    expect(lines[2]).toContain('n/a (n=0)');
   });
 
   it('renders a header even with no rows, so an empty run is visibly empty', () => {

--- a/packages/scripts/retrieval/sweep.ts
+++ b/packages/scripts/retrieval/sweep.ts
@@ -27,10 +27,22 @@ export const BASELINE_CONFIG: SweepConfig = { tokenBudget: 0, minRelevancePct: 0
 export const formatConfig = (c: SweepConfig): string => `budget=${c.tokenBudget} floor=${c.minRelevancePct}%`;
 
 /**
+ * The write-time ceiling `kbSearchResultTokenBudget` declares (`common/src/schemas/settings.ts`),
+ * enforced there only by the settings API's `schema.parse`. This script writes the model directly
+ * and bypasses that, so without this bound `--configs=50000:0` produces a table row for a value an
+ * admin could never save - and one that is measurement-identical to 20000 anyway, since the tool's
+ * passage ceiling binds first above it.
+ */
+const MAX_TOKEN_BUDGET = 20_000;
+
+/**
  * Parse `--configs=0:0,4000:0,4000:60` into sweep points ("tokenBudget:minRelevancePct").
  *
  * Throws rather than skipping a malformed entry: a silently dropped configuration would produce a
- * results table that looks complete and is missing the row someone asked for.
+ * results table that looks complete and is missing the row someone asked for. That is also why the
+ * component count is checked exactly - `Number('')` is 0 and `Number.isInteger(0)` is true, so
+ * "4000:" would otherwise parse as a floor of 0 and "4000:70:80" would drop its third segment,
+ * both landing a row that quietly is not the one that was asked for.
  */
 export function parseConfigs(spec: string): SweepConfig[] {
   const configs = spec
@@ -38,11 +50,26 @@ export function parseConfigs(spec: string): SweepConfig[] {
     .map(s => s.trim())
     .filter(Boolean)
     .map(part => {
-      const [budget, floor] = part.split(':');
+      const components = part.split(':');
+      if (components.length !== 2) {
+        throw new Error(
+          `Bad configuration "${part}": expected exactly "tokenBudget:minRelevancePct", got ${components.length} component(s)`
+        );
+      }
+      const [budget, floor] = components;
       const tokenBudget = Number(budget);
       const minRelevancePct = Number(floor);
-      if (!Number.isInteger(tokenBudget) || tokenBudget < 0) {
+      if (budget.trim() === '' || !Number.isInteger(tokenBudget) || tokenBudget < 0) {
         throw new Error(`Bad token budget in "${part}": expected a non-negative integer, got "${budget}"`);
+      }
+      if (tokenBudget > MAX_TOKEN_BUDGET) {
+        throw new Error(
+          `Token budget ${tokenBudget} in "${part}" exceeds the ${MAX_TOKEN_BUDGET} ceiling ` +
+            `kbSearchResultTokenBudget declares, so no admin could deploy the result.`
+        );
+      }
+      if (floor.trim() === '') {
+        throw new Error(`Bad relevance floor in "${part}": expected an integer percent 0-100, got ""`);
       }
       if (!Number.isInteger(minRelevancePct) || minRelevancePct < 0 || minRelevancePct > 100) {
         throw new Error(`Bad relevance floor in "${part}": expected an integer percent 0-100, got "${floor}"`);
@@ -67,6 +94,17 @@ export type SweepRow = SweepConfig & { aggregate: Aggregate };
 const pct = (n: number): string => `${(n * 100).toFixed(1)}%`;
 
 /**
+ * Precision carries its own denominator, because it is the one column whose denominator MOVES with
+ * the configuration: positives that served nothing are excluded from it (see `Aggregate.precision`
+ * for why), so one row's precision is only comparable to another's alongside the `n` it was
+ * averaged over - a rising precision on a shrinking `n` is a floor emptying questions, not a floor
+ * improving the result set. With no scored positive at all there is no precision to state: "n/a"
+ * rather than the 0.0% an empty mean prints, which would read as a collapse instead of an absence.
+ */
+const precisionCell = (a: Aggregate): string =>
+  a.precisionScored === 0 ? 'n/a (n=0)' : `${pct(a.precision)} (n=${a.precisionScored})`;
+
+/**
  * Render the sweep as a Markdown table for pasting into the ticket.
  *
  * Every column is here because it can independently change the decision: recall is the goal,
@@ -85,7 +123,7 @@ export function formatSweepTable(rows: readonly SweepRow[]): string {
       r.tokenBudget === 0 ? 'off' : String(r.tokenBudget),
       r.minRelevancePct === 0 ? 'off' : `${r.minRelevancePct}%`,
       pct(r.aggregate.recall),
-      pct(r.aggregate.precision),
+      precisionCell(r.aggregate),
       pct(r.aggregate.hitRate),
       r.aggregate.mrr.toFixed(3),
       r.aggregate.meanDocumentsServed.toFixed(1),

--- a/packages/scripts/retrieval/sweep.ts
+++ b/packages/scripts/retrieval/sweep.ts
@@ -1,0 +1,97 @@
+/**
+ * The configuration sweep for the `search_knowledge_base` recall probe (#1993).
+ *
+ * Pure: parsing and formatting only, so the shape of a sweep and the shape of its report are
+ * testable without a database, an embedding key, or a stage. The live driver is `recall-probe.ts`.
+ */
+
+import type { Aggregate } from './metrics';
+
+/**
+ * One point in the sweep. Both knobs are admin settings introduced by #1955 (PR #2009).
+ *
+ * `tokenBudget` is `kbSearchResultTokenBudget`: approximate tokens of served passage text one call
+ * may emit. `minRelevancePct` is `kbSearchMinRelevancePct`: a whole-number percent, converted to the
+ * 0..1 cosine fraction by `resolveSearchBudgets`. Zero disables each knob independently, and
+ * `{0, 0}` is today's shipped default - byte-identical to pre-#1955 retrieval, which is why every
+ * sweep must include it as its baseline row.
+ */
+export type SweepConfig = {
+  tokenBudget: number;
+  minRelevancePct: number;
+};
+
+/** Today's shipped defaults. Both knobs off; retrieval is byte-identical to pre-#1955. */
+export const BASELINE_CONFIG: SweepConfig = { tokenBudget: 0, minRelevancePct: 0 };
+
+export const formatConfig = (c: SweepConfig): string => `budget=${c.tokenBudget} floor=${c.minRelevancePct}%`;
+
+/**
+ * Parse `--configs=0:0,4000:0,4000:60` into sweep points ("tokenBudget:minRelevancePct").
+ *
+ * Throws rather than skipping a malformed entry: a silently dropped configuration would produce a
+ * results table that looks complete and is missing the row someone asked for.
+ */
+export function parseConfigs(spec: string): SweepConfig[] {
+  const configs = spec
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(part => {
+      const [budget, floor] = part.split(':');
+      const tokenBudget = Number(budget);
+      const minRelevancePct = Number(floor);
+      if (!Number.isInteger(tokenBudget) || tokenBudget < 0) {
+        throw new Error(`Bad token budget in "${part}": expected a non-negative integer, got "${budget}"`);
+      }
+      if (!Number.isInteger(minRelevancePct) || minRelevancePct < 0 || minRelevancePct > 100) {
+        throw new Error(`Bad relevance floor in "${part}": expected an integer percent 0-100, got "${floor}"`);
+      }
+      return { tokenBudget, minRelevancePct };
+    });
+  if (configs.length === 0) throw new Error('--configs listed no configurations');
+
+  const seen = new Set<string>();
+  for (const c of configs) {
+    const key = formatConfig(c);
+    // A repeated point would run the whole question set twice and print two rows that can only
+    // differ by noise, which reads as instability in the measurement rather than a duplicated input.
+    if (seen.has(key)) throw new Error(`Duplicate configuration in --configs: ${key}`);
+    seen.add(key);
+  }
+  return configs;
+}
+
+export type SweepRow = SweepConfig & { aggregate: Aggregate };
+
+const pct = (n: number): string => `${(n * 100).toFixed(1)}%`;
+
+/**
+ * Render the sweep as a Markdown table for pasting into the ticket.
+ *
+ * Every column is here because it can independently change the decision: recall is the goal,
+ * precision and falsePositiveRate are what a wider budget or a lower floor costs, and docs/q is the
+ * figure #1831 led with. Reporting recall alone is what "more passages is not automatically better"
+ * warns against.
+ */
+export function formatSweepTable(rows: readonly SweepRow[]): string {
+  const header = [
+    '| token budget | floor | recall | precision | hit rate | MRR | docs/q | false-positive rate |',
+    '|---:|---:|---:|---:|---:|---:|---:|---:|',
+  ];
+  const body = rows.map(r =>
+    [
+      '',
+      r.tokenBudget === 0 ? 'off' : String(r.tokenBudget),
+      r.minRelevancePct === 0 ? 'off' : `${r.minRelevancePct}%`,
+      pct(r.aggregate.recall),
+      pct(r.aggregate.precision),
+      pct(r.aggregate.hitRate),
+      r.aggregate.mrr.toFixed(3),
+      r.aggregate.meanDocumentsServed.toFixed(1),
+      pct(r.aggregate.falsePositiveRate),
+      '',
+    ].join(' | ')
+  );
+  return [...header, ...body].join('\n');
+}


### PR DESCRIPTION
## Description

Part of #1993. This is PR 1 of 2: the harness and the re-established baseline. PR 2 will carry the
config sweep and the resulting default change.

#1955 (PR #2009) shipped a token budget and a relevance floor for `search_knowledge_base`, both
defaulting to `0` (off), on the explicit understanding that the real values would be chosen from a
measurement. Nothing has measured them since, so retrieval today is still byte-identical to
pre-#1955 behavior. This PR builds the thing that can make that choice.

**The ticket's stated probe method measures the wrong path, and this PR does not follow it.** Both
#1831 and #1993 specify "forced retrieval, no authored prompt". Forced retrieval and
`search_knowledge_base` are separate code paths with separate budgets:

| | forced retrieval | `search_knowledge_base` |
|---|---|---|
| entry point | `KnowledgeRetrievalFeature` | `knowledgeBaseSearchTool` |
| routed through `semanticDataLakeSearch`? | **no** (`ChatCompletionFeatures.ts:1595`) | yes |
| size bound | `forcedRetrievalCharBudget` (12,000 chars) | **`kbSearchResultTokenBudget`** |
| relevance floor | `FORCED_RETRIEVAL_MIN_SIMILARITY` = 0.75, hardcoded | **`kbSearchMinRelevancePct`** |

`kbResultTokenBudget` / `kbMinRelevance` / `kbDefaultResults` are consumed in exactly one file,
`knowledgeBaseSearch/index.ts`. A forced-retrieval probe would have returned identical numbers at
every swept configuration and read as "these knobs do nothing". The probe drives the tool directly
instead, which also removes model tool-choice variance entirely (the variable forced retrieval was
chosen to control) while still exercising the shipped `resolvePassageCeiling`, adaptive topK
widening, floor and token-budget walk rather than a reimplementation that could drift from them.
I have updated #1993's description to record this.

## Measured baseline

Run on preview `pr2308` against the seeded 51-article help lake, both knobs off. Settings were
restored on the way out.

| token budget | floor | recall | precision | hit rate | MRR | docs/q | false-positive rate |
|---:|---:|---:|---:|---:|---:|---:|---:|
| off | off | **79.0%** | 47.7% | 96.0% | 0.698 | 3.1 | **100.0%** |

25 positives, 5 negatives. Verified by hand against the per-question log: summed recall 19.75/25 =
79.0%, hit rate 24/25 = 96%, false-positive rate 5/5.

The precision column now prints its own denominator (`47.7% (n=25)`), because positives that served
nothing are excluded from that mean - otherwise a floor would raise precision by emptying questions
rather than by improving what it serves. This row was measured before that change; the figure moves
only if some positive served nothing, and none of the swept rows exist yet to compare it against.

**The finding is the false-positive rate, not the recall.** With no relevance floor, retrieval
served documents on every one of the five negatives - it never once declined to answer:

| | question | served |
|---|---|---|
| `n03` | permanent account deletion | `context-telemetry`, `mementos`, `profile-settings` |
| `n05` | two-host podcast generation | `voice-v2`, `smart-tools`, `publish-and-share` |
| `n01` | Salesforce sync | `features/agents` |

`n03` is the near-miss the corpus was built around: the telemetry article's "Data Retention" and
"Your Rights" sections are served as though they answered a deletion request. Precision of 47.7%
says the same thing from the positive side - more than half of what is served is not supporting.
This is the direct evidence for `kbSearchMinRelevancePct`: at `0` there is no input for which the
system says "I do not have that."

The recall failures track the corpus design rules rather than being noise:

- `q22` (25%) - the deliberate breadth question over near-identical integration articles. Ranking
  crowded out three of the four sources and spent slots on `confluence-mcp-tools` and
  `common-issues`.
- `q06` (0%) - a genuine semantic miss: `lattice` and `image-processing-generation` instead of
  `smart-tools`.

**Two limits to carry into PR 2.**

1. `EnableDataLakeVectorSearch` is absent on this stage, so the run used the exhaustive cosine scan
   rather than Atlas ANN. Treat 79.0% as an **upper bound** on production ranking, not as the
   production number.
2. `kbSearchDefaultResults` (5) is already the binding constraint at 3.1 documents/question - the
   tool logged `returning 5/6 passages` on nearly every question. The token budget has less headroom
   to work with than the knob's range suggests, and the sweep should move both or say why it did not.

These numbers are **not comparable to #1831's 16%**: different corpus, different ground-truth
method, different code path.

## Changes

- `packages/scripts/retrieval/metrics.ts` - pure recall / precision / hit-rate / MRR over served
  documents, deliberately mirroring `b4m-core/memory/src/eval/metrics.ts` so the two evals share one
  vocabulary. Positives and negatives are aggregated separately: recall is vacuously 1 on a question
  nothing supports, so pooling them would report a recall no positive question earned.
- `packages/scripts/retrieval/corpus.ts` - 30 questions (25 positive, 5 negative) with hand-authored
  ground truth over the 51 public help articles.
- `packages/scripts/retrieval/sweep.ts` - sweep parsing and the Markdown results table.
- `packages/scripts/retrieval/auditEvent.ts` - the one decision the measurement rests on, kept pure
  and separate: reading a captured audit event as "what did retrieval actually serve".
- `packages/scripts/retrieval/pollEvent.ts` - the poll loop that waits out the tool's un-awaited
  audit write, with an injectable clock so its timeout is testable.
- `packages/scripts/retrieval/recall-probe.ts` - the live driver.
- Tests for all five pure modules (67 tests), including a CI gate that validates the ground truth
  against the real help corpus.

### Why the help lake, and why hand-authored ground truth

The probe needs a real corpus with real embeddings, and this repo is public, so a corpus built from a
customer lake could not be committed - which is exactly why #1831's measurement cannot be reproduced
today. The `system-help` lake is the one corpus that is simultaneously real, already vectorized with
the deployment's own embedding model, and publishable: 51 articles, close to the 47-document lake
#1831 measured.

#1831 derived its supporting set from an IDF-weighted token proxy and flagged its own 16% as
"directional, not precise". Because this corpus is in-repo, the supporting set can just be stated.
`corpus.test.ts` asserts every cited slug is a real public help article, so a docs rename cannot
silently turn a supporting document into an unreachable one and depress recall for a reason that has
nothing to do with retrieval.

### How it reads what was served

The tool already reports every read to the lake audit trail (`recordLakeAccessEvent`,
`knowledgeBaseSearch/index.ts:974`) with deduped file ids, chunk ids and per-chunk scores. That write
is deliberately un-awaited, so reading rows back out of Mongo would race the next question. The probe
supplies its own `db.lakeAccessEvents` recorder - the adapter seam `ToolContext` already exposes - and
captures the payload in memory. Same data, no race, no parsing of the model-facing string.

The keyword fallback records the same `surface` but carries no `scores`. A score-less audit row is a
hard error rather than a result: reaching the keyword arm means neither knob under test applied, and
reporting that as a budget-sweep row would be a confidently wrong number.

**With one exception, which is the whole point of the sweep.** A nonzero relevance floor that rejects
every candidate also empties the semantic arm and falls through to the keyword arm - by construction
on the five negative questions. Those two turns are indistinguishable in the audit trail, so the probe
reads `promptMeta.warnings`: the tool folds its relevance-floor notice in there and nowhere else. A
keyword fall-through carrying that notice is a legitimate served-nothing measurement; one without it
is the wiring failure above, and still stops the run.

**An absent audit event is ambiguous, and the probe does not guess.** It means two different things:
the tool writes no audit row when it served nothing, and the wait for that un-awaited write can
simply time out. The first is a real result - precisely the outcome a relevance floor exists to
produce - and the second is a harness malfunction. Scoring both as zero recall would make a stalled
write look exactly like the floor working, which is the single reading this ticket most needs to get
right.

So the probe also captures the tool's own status write, which every terminal path awaits before
returning:

| tool path | `retrieval.outcome` | `citables` | `warnings` |
|---|---|---|---|
| semantic arm success (`emitSemanticCitables`) | `ok` | present | - |
| keyword arm, hits | `ok` | present | - |
| keyword arm, no hits | `ok` | **absent** | - |
| keyword arm after the floor emptied the semantic one | `ok` | either | **floor notice** |
| failure paths | `failed` / `no_lakes` / `not_indexed` | absent | - |

That makes "served content" distinguishable from "ran and found nothing" without inferring either
from silence. An observation the harness could not make surfaces as an error, never as a zero.

### The preflight refuses to measure a stage that would lie

Every one of these degrades silently in production, which is correct for a chat turn and ruinous for
a measurement - each sends the search down a path where neither knob applies, and the run would
complete with every row looking identical:

- the lake is absent, inactive, or holds no files;
- `defaultEmbeddingModel` is unset, so the semantic arm cannot run at all;
- no file in the lake carries a `help:` tag, so served documents cannot be mapped back to slugs and
  recall would collapse to zero across the board - reading as a retrieval failure rather than a
  harness bug;
- **the probe user owns files of their own.** The unscoped arm ranks the caller's own library
  alongside the lake, a personal-file hit is not attributable to any lake so the tool records no
  audit event for it, and the probe would read a real result as "served nothing". This one was a
  documented precondition until self-review; it is now enforced.
- **the caller cannot reach the lake at all.** Caught the hard way: the first live run scored a
  clean 0% on all 30 questions against a correctly seeded, fully vectorized 51-file lake. The tool
  had logged `Found 0 of 0 results` - an empty candidate set, not an empty result set. The help lake
  is gateless, org-less and not public, and `findActiveByUserTagsAndEntitlements` admits that
  combination only via the owner bypass, so a probe running as any other account searches nothing,
  reports `outcome: 'ok'`, and produces a complete, plausible, entirely wrong table.

Every check above verified that the corpus exists; none verified that the caller could reach it. So
preflight now ends by driving **one real search** and refusing to run if it returns nothing. It is
empirical rather than a re-derivation of the access rules, which means it also catches an unusable
embedding credential, a tag drift, or an unvectorized corpus. It runs before the sweep applies
anything, so a floor already configured on the stage can trip it - a false stop costs one legible
error, while a false pass costs a wrong results table.

## Guide for Testers

This is a developer-facing measurement script with no UI. There is nothing to click.

### Automated checks (the real coverage)

1. Run `pnpm --filter @bike4mind/scripts test -- retrieval` (or `pnpm turbo:test`).
2. Expected: 5 test files, 67 tests, all passing.
3. Confirm `corpus.test.ts` passes specifically. It loads the REAL help corpus from
   `docs-site/docs/features` and asserts every ground-truth slug resolves to a public article, so a
   pass means the ground truth matches the docs currently on this branch.

### Verifying the probe's own guard rails (no stage needed)

4. Open `packages/scripts/retrieval/sweep.test.ts` and confirm the malformed-input cases assert a
   THROW rather than a skipped row. A silently dropped configuration would produce a results table
   that looks complete and is missing the row someone asked for.

### Running it live (optional, requires a stage)

5. Seed the help lake on the target stage:
   `pnpm --filter @bike4mind/scripts help:regenerate`, then
   `npx sst shell --stage <stage> -- tsx packages/scripts/help/ingest-help-datalake.ts --userId <id>`
6. Dry run first: append `--dry-run` to the probe command. Expected: it prints the preflight result
   (lake id, file count, vectorized count, embedding model) and the plan, and writes nothing.
7. Real run, as the account that CREATED the lake (see the canary note below - the help lake is
   private-by-default, so a different account resolves no access and every question scores 0%):
   `npx sst shell --stage <stage> -- tsx packages/scripts/retrieval/recall-probe.ts --userId <lake creator id> --configs=0:0`
8. Expected: a per-question log, then a Markdown table, then
   `packages/scripts/out/retrieval-recall-probe.json` (gitignored; override with `--out-dir`).
9. Confirm the settings were restored: the run prints `Restored the original settings values.` on the
   way out, including on failure.
10. Interrupt a run with Ctrl-C partway through and confirm it still prints that line before exiting,
    and that the two settings match what the stage had beforehand. The restore also runs from a
    SIGINT/SIGTERM handler, not only from the `finally`.
11. Start a second run while the first is in flight and confirm it REFUSES with a lease error rather
    than starting. A second run would otherwise capture the first run's mutated settings as its
    baseline and restore those on exit.

### Regression Checks

12. This PR adds a new directory under `packages/scripts` and one line to that package's
    `package.json` scripts block. It changes no application code. Confirm `git diff main --stat`
    touches only `packages/scripts/retrieval/**` and `packages/scripts/package.json`.
13. Confirm `pnpm turbo:typecheck` and `pnpm lint:check` are green.

### What NOT to test

- Do not look for UI changes; there are none.
- Do not expect retrieval behavior to change. This PR measures; it changes no default. Both knobs
  remain at `0`.
- Do not run the sweep (`--configs` with more than the `0:0` baseline) against a shared stage. The two
  settings are stage-wide while the run is in flight.
- The unverifiable-claim rate is NOT implemented here (see below); do not treat its absence as a bug.

## Additional Information

**Deliberately not in this PR: the unverifiable-claim rate.** #1993 asks for recall AND the
unverifiable-claim rate. This PR delivers recall only. The claim-rate arm needs an answer generated
from the served passages plus a judge pass over its claims, and it is the metric that can show a wider
budget making answers *worse* - so it is required before any default actually moves. It belongs in
PR 2 with the sweep, not bolted onto the harness. `recall-probe.ts` says this in its header so a
future reader does not assume the measurement is complete.

**#2122 item 1 now matters more, and is still not blocking.** The relevance-floor notice in
`knowledgeBaseSearch/index.ts` attributes an empty semantic result to the floor using only
`kbMinRelevance > 0 && search.results.length === 0`, and that second half is equally true when there
was nothing to filter in the first place. The probe reads that notice to tell a floor-emptied turn
from a wiring failure, so it inherits the mis-attribution.

It does not move any number. Both readings mean the semantic arm served nothing, so recall and the
false-positive rate score identically either way; what the mis-attribution costs is the ability to
say WHY a row is empty. The notice is also gated on a nonzero floor, so the `0:0` baseline row above
is unaffected entirely. Worth fixing before PR 2 leans on the distinction for interpretation, not
before this harness lands.

**#1831's 16% baseline cannot be carried forward** and this PR does not try to. Retrieval scoping
changed three times since it was measured - #2080, #2254 and #2273 - each narrowing what is eligible.
The baseline has to be re-established at today's defaults before any sweep means anything.

## Developer Notes

- **The `db.lakeAccessEvents` adapter is a usable capture seam for any retrieval measurement**, not
  just this one. Anything that wants to know what a tool actually served can substitute a recorder
  instead of racing the un-awaited audit write or parsing tool output.
- **`invalidateSettingsCache()` + `invalidateScopedSettingsCache()` make an in-process probe able to
  sweep settings without waiting a TTL.** An HTTP-driven probe would have to wait out the full ~5
  minute cache on every serving instance per configuration; an in-process one applies a config
  immediately. This is a large part of why the probe drives the tool in-process.
- **Metrics vocabulary is now shared with the memory eval.** `packages/scripts/retrieval/metrics.ts`
  mirrors `b4m-core/memory/src/eval/metrics.ts` deliberately, so recall/precision/MRR mean the same
  thing in both places.


