### PR TITLE
fix(client): stamp convergence origin on every chunk rescue re-enqueue

### DIFF
--- a/apps/client/server/cron/dataLakeBatchReconcile.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.test.ts
@@ -64,10 +64,11 @@ vi.mock('sst', () => ({
   Resource: { App: { stage: 'dev' }, fabFileChunkQueue: { url: 'http://sqs/fabFileChunkQueue' } },
 }));
 vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => h.sendToQueue(...a) }));
-vi.mock('@server/worker/chunkScan', () => ({
+// Only the filter is stubbed (so the call args are assertable); the payload builder stays real so
+// these tests pin the provenance the sweep actually sends.
+vi.mock('@server/worker/chunkScan', async importActual => ({
+  ...(await importActual<typeof import('@server/worker/chunkScan')>()),
   buildFabFileChunkScanFilter: (...a: unknown[]) => h.buildScanFilter(...(a as [Date, Date, unknown])),
-  CHUNK_SCAN_MIN_AGE_MS: 2 * 60_000,
-  CHUNK_CLAIM_STALE_MS: 30 * 60_000,
 }));
 vi.mock('@server/utils/cloudwatch', () => ({
   recordReconcilerForcedTerminal: (...a: unknown[]) => h.recordForced(...a),
@@ -192,19 +193,20 @@ describe('dataLakeBatchReconcile cron handler', () => {
       h.reconcile.mockResolvedValue([]);
     });
 
-    it('CLAIMS then re-enqueues only the ids it won, tagging each with its claim token', async () => {
+    it('re-enqueues what the filter selected, with both scan cutoffs and a convergence stamp', async () => {
       h.getSettingsValue.mockResolvedValue(true);
       h.fabFileFind.mockReturnValue({
         select: () => ({
           limit: () => ({
             lean: async () => [
-              { _id: 'ff1', userId: 'u1' }, // plain upload, no lake batch
-              { _id: 'ff2', userId: 'u2', batchId: 'batch-9' }, // data-lake file
+              { _id: 'ff1', userId: 'u1' },
+              { _id: 'ff2', userId: 'u2' },
             ],
           }),
         }),
       });
-      // The CAS claim wins both files, each with its stamp; the sweep enqueues only won ids.
+      // No producer-side claim and no batchId: the projection reads only _id and userId now, so a
+      // batch is invisible here - which is the point, both files are stamped the same way.
 
       const res = await handler();
 
@@ -217,22 +219,40 @@ describe('dataLakeBatchReconcile cron handler', () => {
       expect(staleClaimBefore).toBeInstanceOf(Date);
       expect(staleClaimBefore.getTime()).toBeLessThan(cutoff.getTime());
 
-      // Only won ids are enqueued (never the raw pre-read set), and each carries its claim token so
-      // the worker can reject a duplicate/superseded delivery.
       expect(h.sendToQueue).toHaveBeenCalledTimes(2);
-      // A plain lost-webhook upload (no batch) is user work - it must always run, so no origin (#1676).
+      // EVERY message is stamped convergence, with or without a batch: a scheduled sweep is
+      // background work, so it must stay haltable by the kill switch. An un-stamped re-enqueue
+      // reads as `user` and would re-chunk a file the switch had just parked as paused.
       expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', {
         fabFileId: 'ff1',
         userId: 'u1',
+        origin: 'convergence',
       });
-      // A data-lake file (has a batch) is convergence work, haltable by the kill switch; a global
-      // sweep carries no lakeId (platform switch only).
+      // A global sweep carries no lakeId, so only the platform-scope switch halts it.
       expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', {
         fabFileId: 'ff2',
         userId: 'u2',
         origin: 'convergence',
       });
       expect(JSON.parse(res.body).rescuedChunkFiles).toBe(2);
+    });
+
+    it('projects userId as well as _id - the lean() fixtures would otherwise mask a trimmed projection', async () => {
+      h.getSettingsValue.mockResolvedValue(true);
+      const selectSpy = vi.fn();
+      h.fabFileFind.mockReturnValue({
+        select: (projection: string) => {
+          selectSpy(projection);
+          return { limit: () => ({ lean: async () => [{ _id: 'ff1', userId: 'u1' }] }) };
+        },
+      });
+
+      await handler();
+
+      // Every fixture here supplies userId whatever is projected, so a trim back to '_id' alone
+      // stays green while production enqueues `userId: 'undefined'`. This is the only assertion
+      // that fails on that.
+      expect(selectSpy).toHaveBeenCalledWith('_id userId');
     });
 
     it('enqueues every id the filter selected - duplicates are the worker CAS to resolve', async () => {
@@ -256,6 +276,7 @@ describe('dataLakeBatchReconcile cron handler', () => {
       expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', {
         fabFileId: 'ff1',
         userId: 'u1',
+        origin: 'convergence',
       });
       expect(JSON.parse(res.body).rescuedChunkFiles).toBe(2);
     });
@@ -289,7 +310,11 @@ describe('dataLakeBatchReconcile cron handler', () => {
 
       // All four attempted - the ones behind a failure are not abandoned.
       expect(h.sendToQueue).toHaveBeenCalledTimes(4);
-      expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', { fabFileId: 'ff4', userId: 'u4' });
+      expect(h.sendToQueue).toHaveBeenCalledWith('http://sqs/fabFileChunkQueue', {
+        fabFileId: 'ff4',
+        userId: 'u4',
+        origin: 'convergence',
+      });
       // And the counts are honest: two really were rescued, two really were not.
       const body = JSON.parse(res.body);
       expect(body.rescuedChunkFiles).toBe(2);

--- a/apps/client/server/cron/dataLakeBatchReconcile.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.ts
@@ -30,8 +30,12 @@ import { Config } from '@server/utils/config';
 import { recordReconcilerForcedTerminal, recordStuckBatchGauge, recordReconcileRun } from '@server/utils/cloudwatch';
 import { enqueueTaxonomyAnalysisIfWanted } from '@server/queueHandlers/dataLakeBatchProgress';
 import { CONVERGENCE_PAUSE_SETTING_KEY } from '@server/queueHandlers/convergenceKillSwitch';
-import { buildFabFileChunkScanFilter, CHUNK_SCAN_MIN_AGE_MS, CHUNK_CLAIM_STALE_MS } from '@server/worker/chunkScan';
-import { CONVERGENCE_ORIGIN } from '@server/queueHandlers/convergenceProvenance';
+import {
+  buildChunkScanQueuePayload,
+  buildFabFileChunkScanFilter,
+  CHUNK_SCAN_MIN_AGE_MS,
+  CHUNK_CLAIM_STALE_MS,
+} from '@server/worker/chunkScan';
 import { sendToQueue } from '@server/utils/sqs';
 import { Resource } from 'sst';
 import { lakeConfigAuditDb } from '@server/dataLakes/lakeConfigAuditDb';
@@ -73,7 +77,7 @@ async function rescueUnchunkedFiles(): Promise<{ enqueued: number; failed: numbe
   const candidates = await FabFile.find(
     buildFabFileChunkScanFilter(cutoff, staleClaimBefore, { excludeConvergencePaused: convergencePaused })
   )
-    .select('_id userId batchId')
+    .select('_id userId')
     .limit(CHUNK_RESCUE_MAX_PER_RUN)
     .lean();
 
@@ -82,7 +86,6 @@ async function rescueUnchunkedFiles(): Promise<{ enqueued: number; failed: numbe
   // there and returns. The selection filter above already excludes in-flight files, so a merely-slow
   // file is not re-sent every pass.
   const userById = new Map(candidates.map(f => [String(f._id), String(f.userId)]));
-  const batchById = new Map(candidates.map(f => [String(f._id), f.batchId]));
 
   // Bounded-concurrency fan-out with a PER-FILE catch. A throttled or unroutable send used to reject
   // out of a sequential loop and abandon every candidate behind it, and because the caller turns a
@@ -97,11 +100,7 @@ async function rescueUnchunkedFiles(): Promise<{ enqueued: number; failed: numbe
   let failed = 0;
   const enqueueOne = async (id: string) => {
     try {
-      await sendToQueue(queueUrl, {
-        fabFileId: id,
-        userId: userById.get(id)!,
-        ...(batchById.get(id) ? { origin: CONVERGENCE_ORIGIN } : {}),
-      });
+      await sendToQueue(queueUrl, buildChunkScanQueuePayload({ fabFileId: id, userId: userById.get(id)! }));
       enqueued++;
     } catch (e) {
       failed++;

--- a/apps/client/server/worker/chunkRescueSweep.test.ts
+++ b/apps/client/server/worker/chunkRescueSweep.test.ts
@@ -18,11 +18,12 @@ vi.mock('@bike4mind/database', () => ({
 }));
 vi.mock('sst', () => ({ Resource: { fabFileChunkQueue: { url: 'http://elasticmq/fabFileChunkQueue' } } }));
 vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => h.sendToQueue(...a) }));
-vi.mock('./chunkScan', () => ({
+// Only the filter is stubbed; buildChunkScanQueuePayload stays real so the payload shape this
+// sweep sends is asserted against the shared producer, not a local copy of it. Spreading the actual
+// module also keeps the cutoff constants real, which the cutoff assertions below depend on.
+vi.mock('./chunkScan', async importActual => ({
+  ...(await importActual<typeof import('./chunkScan')>()),
   buildFabFileChunkScanFilter: (...a: unknown[]) => h.buildScanFilter(...(a as [Date, Date, unknown])),
-  CHUNK_SCAN_BATCH: 50,
-  CHUNK_SCAN_MIN_AGE_MS: 2 * 60_000,
-  CHUNK_CLAIM_STALE_MS: 30 * 60_000,
 }));
 
 import { runChunkRescueSweep } from './chunkRescueSweep';
@@ -34,14 +35,21 @@ const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 const runSweep = () => runChunkRescueSweep(logger as never);
 
 const limitSpy = vi.fn();
+const selectSpy = vi.fn();
 const withCandidates = (candidates: Candidate[]) => {
   h.fabFileFind.mockReturnValue({
-    select: () => ({
-      limit: (n: number) => {
-        limitSpy(n);
-        return { lean: async () => candidates };
-      },
-    }),
+    // The projection is spied, not ignored: the lean() fixtures below carry userId whatever is
+    // projected, so without this a trim back to '_id' would keep every test green and ship
+    // `userId: 'undefined'` to the queue.
+    select: (projection: string) => {
+      selectSpy(projection);
+      return {
+        limit: (n: number) => {
+          limitSpy(n);
+          return { lean: async () => candidates };
+        },
+      };
+    },
   });
 };
 
@@ -67,6 +75,14 @@ describe('runChunkRescueSweep (self-host chunk rescue)', () => {
     expect(h.sendToQueue).not.toHaveBeenCalled();
   });
 
+  it('projects userId as well as _id - the payload needs it and the fixtures would mask its absence', async () => {
+    withCandidates([{ _id: 'ff1', userId: 'u1' }]);
+
+    await runSweep();
+
+    expect(selectSpy).toHaveBeenCalledWith('_id userId');
+  });
+
   it('selects with both cutoffs and the per-pass cap', async () => {
     await runSweep();
 
@@ -80,7 +96,7 @@ describe('runChunkRescueSweep (self-host chunk rescue)', () => {
     expect(limitSpy).toHaveBeenCalledWith(50);
   });
 
-  it('stamps convergence provenance only on files that belong to a batch', async () => {
+  it('stamps convergence provenance on every message, batch or not', async () => {
     withCandidates([
       { _id: 'ff1', userId: 'u1', batchId: 'b1' },
       { _id: 'ff2', userId: 'u2' },
@@ -88,17 +104,19 @@ describe('runChunkRescueSweep (self-host chunk rescue)', () => {
 
     await expect(runSweep()).resolves.toEqual({ enqueued: 2, failed: 0 });
 
-    // Batch files are convergence work the kill switch may halt; a lone upload rescue is not, and
-    // stamping it would make the switch stop it too.
-    expect(h.sendToQueue).toHaveBeenCalledWith('http://elasticmq/fabFileChunkQueue', {
-      fabFileId: 'ff1',
-      userId: 'u1',
-      origin: 'convergence',
-    });
-    expect(h.sendToQueue).toHaveBeenCalledWith('http://elasticmq/fabFileChunkQueue', {
-      fabFileId: 'ff2',
-      userId: 'u2',
-    });
+    // A scheduled rescue is background work whatever its batchId. Stamping only batch files let an
+    // un-stamped re-enqueue default to `user` in isConvergenceHalted, so a file the chunk handler
+    // had just parked as paused got chunked and embedded on the next tick.
+    for (const [fabFileId, userId] of [
+      ['ff1', 'u1'],
+      ['ff2', 'u2'],
+    ]) {
+      expect(h.sendToQueue).toHaveBeenCalledWith('http://elasticmq/fabFileChunkQueue', {
+        fabFileId,
+        userId,
+        origin: 'convergence',
+      });
+    }
   });
 
   it('finishes the sweep when one enqueue fails, and reports the partial result (#2158)', async () => {
@@ -126,6 +144,7 @@ describe('runChunkRescueSweep (self-host chunk rescue)', () => {
     expect(h.sendToQueue).toHaveBeenCalledWith('http://elasticmq/fabFileChunkQueue', {
       fabFileId: 'ff4',
       userId: 'u4',
+      origin: 'convergence',
     });
     // Each failure names its file. The sweep's return value is discarded by the scheduled-task
     // wrapper, so without this line an operator cannot tell WHICH files were not enqueued.

--- a/apps/client/server/worker/chunkRescueSweep.ts
+++ b/apps/client/server/worker/chunkRescueSweep.ts
@@ -20,9 +20,9 @@ import { adminSettingsRepository, FabFile } from '@bike4mind/database';
 import type { Logger } from '@bike4mind/observability';
 import { Resource } from 'sst';
 import { sendToQueue } from '@server/utils/sqs';
-import { CONVERGENCE_ORIGIN } from '@server/queueHandlers/convergenceProvenance';
 import { CONVERGENCE_PAUSE_SETTING_KEY } from '@server/queueHandlers/convergenceKillSwitch';
 import {
+  buildChunkScanQueuePayload,
   buildFabFileChunkScanFilter,
   CHUNK_SCAN_BATCH,
   CHUNK_SCAN_MIN_AGE_MS,
@@ -59,7 +59,7 @@ export async function runChunkRescueSweep(runLogger: Logger): Promise<{ enqueued
   const candidates = await FabFile.find(
     buildFabFileChunkScanFilter(cutoff, staleClaimBefore, { excludeConvergencePaused })
   )
-    .select('_id userId batchId')
+    .select('_id userId')
     .limit(CHUNK_SCAN_BATCH)
     .lean();
 
@@ -68,7 +68,6 @@ export async function runChunkRescueSweep(runLogger: Logger): Promise<{ enqueued
   // there and returns. The selection filter above already excludes in-flight files, so a merely-slow
   // file is not re-sent every pass.
   const userById = new Map(candidates.map(f => [String(f._id), String(f.userId)]));
-  const batchById = new Map(candidates.map(f => [String(f._id), f.batchId]));
 
   // Bounded-concurrency fan-out with a PER-FILE catch. A throttled or unroutable send used to reject
   // out of a sequential loop and abandon every candidate behind it, and the count reported was the
@@ -81,11 +80,7 @@ export async function runChunkRescueSweep(runLogger: Logger): Promise<{ enqueued
   let failed = 0;
   const enqueueOne = async (id: string) => {
     try {
-      await sendToQueue(queueUrl, {
-        fabFileId: id,
-        userId: userById.get(id)!,
-        ...(batchById.get(id) ? { origin: CONVERGENCE_ORIGIN } : {}),
-      });
+      await sendToQueue(queueUrl, buildChunkScanQueuePayload({ fabFileId: id, userId: userById.get(id)! }));
       enqueued++;
     } catch (e) {
       failed++;

--- a/apps/client/server/worker/chunkScan.test.ts
+++ b/apps/client/server/worker/chunkScan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { buildFabFileChunkScanFilter } from './chunkScan';
-import { CHUNK_STALL_NOTICES } from '@bike4mind/common';
+import { z } from 'zod';
+import { buildChunkScanQueuePayload, buildFabFileChunkScanFilter } from './chunkScan';
+import { CHUNK_STALL_NOTICES, provenancePayloadShape, shouldHaltConvergence } from '@bike4mind/common';
 
 // Minimal evaluator for the subset of Mongo operators the scan filter uses, so we can assert
 // which documents the filter would (not) select without a live Mongo.
@@ -113,6 +114,25 @@ describe('buildFabFileChunkScanFilter', () => {
       notes: 'quarterly report, uploaded for the board deck',
     };
     expect(matches(doc, filter)).toBe(true);
+  });
+
+  it('KNOWN STRAND: does NOT re-select a paused MEDIA file - the halt write destroyed its only selection door', () => {
+    // Known one-way door, documented on buildChunkScanQueuePayload: a media file reaches this filter
+    // only through chunkRebuildRequestedAt, and the halt write nulls it in the same statement that
+    // records the stall reason. Asserted rather than left implicit so the strand is visible to
+    // whoever closes it - the switch-OFF block below covers the non-media file, which does come back.
+    const doc = {
+      status: 'complete',
+      chunkCount: 0,
+      isChunking: false,
+      createdAt: old,
+      deletedAt: null,
+      error: null,
+      mimeType: 'audio/mpeg',
+      chunkStallReason: 'rechunkPaused',
+      chunkRebuildRequestedAt: null,
+    };
+    expect(matches(doc, filter)).toBe(false);
   });
 
   it('skips a file whose chunking already failed (error persisted by the chunk handler)', () => {
@@ -292,5 +312,32 @@ describe('buildFabFileChunkScanFilter - stale-claim recovery arm', () => {
     // re-chunking.
     expect(matches({ ...base, isChunking: true, chunkClaimedAt: null }, filter)).toBe(true);
     expect(matches({ ...base, isChunking: true }, filter)).toBe(true);
+  });
+});
+
+describe('buildChunkScanQueuePayload', () => {
+  it('stamps convergence origin even when the file has no batch, so the kill switch can halt it', () => {
+    // A paused file carries no batchId, and an un-stamped message reads as `user` work
+    // (isConvergenceHalted fails soft) - which is how a paused file used to get re-chunked.
+    expect(buildChunkScanQueuePayload({ fabFileId: 'ff1', userId: 'u1' })).toEqual({
+      fabFileId: 'ff1',
+      userId: 'u1',
+      origin: 'convergence',
+    });
+  });
+
+  it('sends no lakeId: a global sweep is halted by the platform switch, not a per-lake pause', () => {
+    expect(buildChunkScanQueuePayload({ fabFileId: 'ff1', userId: 'u1' })).not.toHaveProperty('lakeId');
+  });
+
+  it('is halted by the shape the chunk handler actually parses, not just by carrying an origin key', () => {
+    // Binds the stamp to the vocabulary the switch actually decides on, rather than to the string
+    // 'convergence': a value outside WORK_ORIGINS parses to undefined, defaults to 'user' and stops
+    // being haltable. The consumer's own suite (fabFileChunk.test.ts) covers the handler's half of
+    // the contract; this covers the producer's.
+    const parsed = z
+      .object(provenancePayloadShape)
+      .parse(buildChunkScanQueuePayload({ fabFileId: 'ff1', userId: 'u1' }));
+    expect(shouldHaltConvergence(parsed.origin ?? 'user', true)).toBe(true);
   });
 });

--- a/apps/client/server/worker/chunkScan.ts
+++ b/apps/client/server/worker/chunkScan.ts
@@ -7,7 +7,7 @@
  * dataLakeBatchReconcile cron. Kept here so the selection filter is unit-testable without
  * importing either boot graph.
  */
-import { CHUNK_STALL_REASONS, LEGACY_CHUNK_STALL_NOTES } from '@bike4mind/common';
+import { CHUNK_STALL_REASONS, CONVERGENCE_ORIGIN, LEGACY_CHUNK_STALL_NOTES } from '@bike4mind/common';
 
 /** Only rescue files older than this, to avoid racing a webhook that is about to arrive. */
 export const CHUNK_SCAN_MIN_AGE_MS = 2 * 60_000;
@@ -122,10 +122,13 @@ export const buildFabFileChunkScanFilter = (
   //  - Switch OFF: excluding it would be a REGRESSION. This sweep is the only automatic exit a
   //    paused file has. The two other recovery paths are human-driven and lake-scoped, so neither
   //    reaches a file outside every lake - exactly what this sweep exists to catch. And the
-  //    re-enqueue really does rebuild it: the send below stamps `origin` only for a file with a
-  //    batchId, and `isConvergenceHalted` defaults a missing origin to 'user' and returns false, so
-  //    a batchId-less file is genuinely re-chunked rather than bounced. That is what makes
-  //    CHUNK_STALL_NOTICES.rechunkPaused's user-visible "rebuilt when convergence resumes" true.
+  //    re-enqueue really does rebuild it: `isConvergenceHalted` returns false whenever the switch is
+  //    off, whatever `origin` says, so a re-selected file is genuinely re-chunked rather than
+  //    bounced. That is what makes CHUNK_STALL_NOTICES.rechunkPaused's user-visible "rebuilt when
+  //    convergence resumes" true. Note this no longer turns on the file lacking a batchId:
+  //    buildChunkScanQueuePayload stamps `origin` unconditionally, so with the switch ON every sweep
+  //    message is haltable - which is why the exclusion above only has to spare the queue a
+  //    round-trip, not prevent a re-chunk.
   //
   // Via CHUNK_STALL_REASONS so this query and `isChunkStalled` cannot drift, plus the transitional
   // `notes` arm mirroring `isChunkStalledFile` - #2016's migration and this code do not deploy
@@ -169,4 +172,41 @@ export const buildFabFileChunkScanFilter = (
         }
       : { isChunking: { $ne: true } },
   ],
+});
+
+/**
+ * The chunk-queue payload for a file this scan selected. Shared by both sweep drivers (the
+ * self-host worker's fabFileChunkScan and the hosted dataLakeBatchReconcile cron) so the two
+ * can't drift on provenance.
+ *
+ * `origin` is stamped UNCONDITIONALLY, not just for files carrying a `batchId`. A scheduled rescue
+ * sweep is background work by definition, so it must be haltable by the convergence kill switch:
+ * with the switch on, the chunk handler parks a file with a stall reason but leaves it matching this
+ * scan's filter, and an un-stamped re-enqueue would be read as `user` work (isConvergenceHalted
+ * fails soft to `user`) and chunked anyway - spending exactly the budget the switch was set to stop.
+ * The tradeoff, which is the switch working as designed: while it is on, the sweep rescues nothing,
+ * including a genuinely stranded non-lake file. What brings such a file back is RE-SELECTION, not a
+ * resume path: the filter above excludes the stall reasons only while the switch is on, so the first
+ * sweep after it clears re-admits the file and rebuilds it (pinned in chunkScan.test.ts, because it
+ * is the only thing making this tradeoff acceptable). Belt and braces, deliberately - the exclusion
+ * decides SELECTION from a flag read once per pass, this stamp decides what the CONSUMER does with a
+ * message already in flight when the switch flips.
+ *
+ * One shape does NOT come back, and stamping unconditionally is what routes it there: a MEDIA file
+ * is admitted by the filter above only through `chunkRebuildRequestedAt`, and the halt write nulls
+ * that field, so once halted it leaves this filter for good and needs a manual reprocess. The
+ * mechanism predates this stamp, but a `batchId`-less media file never reached the halt branch
+ * before it did - so the one-way door is reachable here because of this function, and calling it
+ * pre-existing would be wrong. Closing it means readmitting a paused media file to the filter, which
+ * has to be reconciled with the switch-ON stall-reason exclusion above as well - the two would be
+ * pulling the same file in opposite directions. Tracked in #2224.
+ *
+ * No `lakeId`: a FabFile carries only `batchId`, so a pause set ONLY at Lake scope does not halt
+ * these messages - the platform-scope switch does. See resolvePauseFlag (convergenceKillSwitch.ts).
+ * Known and owned rather than introduced here: #2157 and #2251 both track that gap.
+ */
+export const buildChunkScanQueuePayload = ({ fabFileId, userId }: { fabFileId: string; userId: string }) => ({
+  fabFileId,
+  userId,
+  origin: CONVERGENCE_ORIGIN,
 });


### PR DESCRIPTION
# Pull Request

Closes #2169

## Description

With `PauseLakeConvergence` ON, a non-media lake file that the chunk handler had just parked as
paused was re-chunked and re-embedded on the next rescue sweep.

Both sweeps stamped `origin: CONVERGENCE_ORIGIN` only on a file that carried a `batchId`.
`isConvergenceHalted` defaults an un-stamped message to `user`, which is never haltable, so a
`batchId`-less re-enqueue was read as user work and chunked and embedded in full - spending exactly
the budget the switch was set to stop. Silently, too: a successful run clears the stall marker, so
the file then looks normal.

Worked case, self-host: an admin sets the switch, a wave parks 50 lake PDFs, and 60 seconds later
(`CHUNK_SCAN_INTERVAL_MS`) the scan re-enqueues all 50 as `user` work and they chunk and embed.
Hosted is the same leak through the daily `dataLakeBatchReconcile`, just slower.

**The producer is what was wrong, not the default.** A scheduled rescue sweep is background work by
definition, whatever its `batchId`. `isConvergenceHalted`'s fail-soft `?? 'user'` is deliberately
untouched - it is what stops a malformed message stranding a customer upload.

**This is belt and braces with #2126's selection exclusion, not a duplicate of it.** The exclusion
decides SELECTION, from a pause flag read once per pass; this stamp decides what the CONSUMER does
with a message already in flight when the switch flips - the window the exclusion cannot see,
because its flag was read before the flip.

## Changes

- **`chunkScan.ts`** gains `buildChunkScanQueuePayload({ fabFileId, userId })`, which stamps `origin`
  unconditionally. It lives beside `buildFabFileChunkScanFilter` so both sweeps share one producer
  and the payload is unit-testable without importing either boot graph.
- **`chunkRescueSweep.ts`** (self-host) and **`dataLakeBatchReconcile.ts`** (hosted cron) both build
  their payload through it. The two verbatim copies of the enqueue block are gone. `batchId` is no
  longer read, so it drops out of both `.select()` projections.
- **The filter's switch-OFF rationale is reworded.** It argued from "the send below stamps `origin`
  only for a file with a batchId, so a batchId-less file is genuinely re-chunked". That premise is
  gone. The conclusion survives - `isConvergenceHalted` returns false whenever the switch is off,
  whatever `origin` says - so the switch-OFF rebuild promise still holds, and the comment now says
  why rather than misleading the next reader.
- Tests: a payload-builder suite (including one binding the built payload to `provenancePayloadShape`
  + `shouldHaltConvergence`, so a key rename fails loudly instead of silently killing the switch), a
  projection spy on both drivers, and the batch-less candidate asserted stamped in both driver
  suites - where it previously asserted the opposite.

## Guide for Testers

This is a backend queue-provenance change with no UI. Fastest verification is the unit suite plus
three mutations.

1. Run: `pnpm --filter @bike4mind/client exec vitest run --project node server/worker/chunkScan.test.ts server/worker/chunkRescueSweep.test.ts server/cron/dataLakeBatchReconcile.test.ts`
   Expected: **3 files, 57 tests, all passing.**
2. Mutate `apps/client/server/worker/chunkScan.ts`: rename the payload's `origin` key to
   `workOrigin`. Re-run step 1. Expected: **7 failures** across all three files - the stamp is pinned
   to the key the handler actually parses, not just to the string `'convergence'`.
3. Mutate both drivers: replace the `buildChunkScanQueuePayload(...)` call with the old inline
   `{ fabFileId, userId }` object (i.e. reinstate the bug). Re-run step 1. Expected: **5 failures**.
4. Mutate both drivers: change `.select('_id userId')` to `.select('_id')`. Re-run step 1. Expected:
   **2 failures** - the projection is spied, because the `lean()` fixtures supply `userId` whatever
   is projected, so without the spy this trim would ship `userId: 'undefined'` to the queue and stay
   green.
5. Revert all mutations and re-run step 1 to confirm 57 green again.

### Regression Checks

- **A paused file still comes back when the switch is cleared.** This is the tradeoff the stamp
  makes, and it is deliberate: while the switch is ON the sweep now rescues nothing, including a
  genuinely stranded non-lake file. Recovery is by RE-SELECTION - #2126's exclusion is conditional on
  the switch, so the first sweep after it clears re-admits the file and rebuilds it. Pinned by the
  `while the kill switch is OFF` block in `chunkScan.test.ts`.
- **Customer uploads are unaffected.** They are stamped `user` (or unstamped, which defaults to
  `user`) and are never halted. `isConvergenceHalted`'s default is unchanged - assert this by
  checking `apps/client/server/queueHandlers/convergenceKillSwitch.ts` still reads
  `message.origin ?? 'user'`.
- **Full suite:** `pnpm --filter @bike4mind/client test` - 11526 passed, 81 skipped, 0 failed on
  this branch.

### What NOT to test

No UI, no API surface, no schema change, no migration. There is nothing to click. A live end-to-end
reproduction needs a deployed queue plus the `PauseLakeConvergence` admin setting and a wave in
flight, which is why the verification above is unit-level and mutation-checked.

## Additional Information

**This PR is deliberately scoped to the `origin` stamp alone.** An earlier attempt (#2180) also
carried a fix for a second, related defect: the chunk handler tells the owner of a never-chunked file
that "its passages were removed", which is false for every sweep-originated halt. That work was
written against the old `FabFile.notes` marker model, and #2147 has since moved the stall markers
into a dedicated `chunkStallReason` field. Porting it is a separate change against the new field
model, tracked separately - merging the old shape would write a third marker string into `notes`
that no reader on `main` recognises. The `origin` stamp is independent of all of that and is the
actual #2169 fix.

Two adjacent gaps left open, both disclosed in the `buildChunkScanQueuePayload` docblock rather than
silently carried:

- **Lake-scope-only pause is not halted.** Neither sweep sends `lakeId`, and `resolvePauseFlag` only
  consults a Lake-scope override when one is present, so a pause set ONLY at Lake scope still will
  not halt these messages; the platform switch does. `FabFile` carries `batchId` but no lake id, so
  supplying `lakeId` needs a batch lookup per candidate. #2157 and #2251 track this.
- **A paused MEDIA file is stranded.** A media file reaches the sweep filter only through
  `chunkRebuildRequestedAt`, and the halt write nulls it, so once halted it needs a manual reprocess.
  The mechanism predates this stamp, but a `batchId`-less media file never reached the halt branch
  before it did - so it is not fair to call it purely pre-existing. Asserted rather than left
  implicit, as the `KNOWN STRAND:` test in `chunkScan.test.ts`. Tracked as #2224.

Also adjacent and untouched: `/rechunk` resets before enqueueing and bypasses the kill switch
entirely (#2223), which is a wider hole than this one.

## Developer Notes

- `buildChunkScanQueuePayload` is the single producer of the chunk-rescue queue payload. Both sweep
  drivers go through it, so provenance cannot drift between the self-host worker and the hosted cron
  the way it did when the enqueue block was duplicated verbatim in both.
- Pattern worth reusing: the payload test parses the built object with the consumer's own
  `provenancePayloadShape` and runs it through `shouldHaltConvergence` with the handler's `?? 'user'`
  default, rather than asserting the literal `'convergence'`. That binds producer to consumer, so a
  key rename or an out-of-vocabulary value fails the producer's suite instead of silently disabling
  the kill switch.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have made corresponding changes to the documentation (if applicable)
