### PR TITLE
fix(scripts): fail closed on help access-level resolution

### DIFF
--- a/packages/scripts/help/__tests__/vectorize-help-content.test.ts
+++ b/packages/scripts/help/__tests__/vectorize-help-content.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadAccessLevelMap, resolveAccessLevel, buildChunks } from '../vectorize-help-content';
+
+/**
+ * accessLevel is the only gate keeping admin-only help docs out of non-admin
+ * users' Help AI chat responses (see apps/client/server/help/retrieval.ts).
+ * These tests guard against a fail-open regression: a broken help-index.json
+ * (or a slug missing from it) must never resolve to the less restrictive
+ * 'public' level.
+ */
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'help-vectorize-test-'));
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function writeIndex(content: string): string {
+  const indexPath = path.join(root, 'help-index.json');
+  fs.writeFileSync(indexPath, content);
+  return indexPath;
+}
+
+function writeArticle(relPath: string): string {
+  const contentRoot = path.join(root, 'content');
+  const filePath = path.join(contentRoot, relPath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '---\ntitle: Test Article\n---\n\n# Test Article\n\nSome body text.\n');
+  return contentRoot;
+}
+
+describe('loadAccessLevelMap', () => {
+  it('loads the slug -> accessLevel mapping from a valid index', () => {
+    const indexPath = writeIndex(
+      JSON.stringify({
+        entries: [
+          { slug: 'features/foo', accessLevel: 'public' },
+          { slug: 'admin/bar', accessLevel: 'admin' },
+        ],
+      })
+    );
+
+    const map = loadAccessLevelMap(indexPath);
+
+    expect(map.get('features/foo')).toBe('public');
+    expect(map.get('admin/bar')).toBe('admin');
+  });
+
+  it('throws instead of warning when help-index.json is missing', () => {
+    const missingPath = path.join(root, 'does-not-exist.json');
+
+    expect(() => loadAccessLevelMap(missingPath)).toThrow();
+  });
+
+  it('throws instead of warning when help-index.json is malformed', () => {
+    const indexPath = writeIndex('{ this is not valid JSON');
+
+    expect(() => loadAccessLevelMap(indexPath)).toThrow();
+  });
+});
+
+describe('resolveAccessLevel', () => {
+  it('returns the mapped access level for a known slug', () => {
+    const map = new Map([['features/foo', 'public' as const]]);
+
+    expect(resolveAccessLevel('features/foo', map)).toBe('public');
+  });
+
+  it('defaults an unmapped slug to admin, not public', () => {
+    const map = new Map([['features/foo', 'public' as const]]);
+
+    expect(resolveAccessLevel('features/unmapped', map)).toBe('admin');
+  });
+
+  it('defaults every slug to admin when the map is empty', () => {
+    expect(resolveAccessLevel('anything', new Map())).toBe('admin');
+  });
+});
+
+describe('buildChunks', () => {
+  it('fails closed: every chunk defaults to admin when the index has no matching entries', async () => {
+    const contentRoot = writeArticle('features/foo.md');
+    const indexPath = writeIndex(JSON.stringify({ entries: [] }));
+
+    const chunks = await buildChunks({ contentRoot, indexPath });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.every(chunk => chunk.accessLevel === 'admin')).toBe(true);
+  });
+
+  it('resolves accessLevel from the index when a slug is present', async () => {
+    const contentRoot = writeArticle('features/foo.md');
+    const indexPath = writeIndex(JSON.stringify({ entries: [{ slug: 'features/foo', accessLevel: 'public' }] }));
+
+    const chunks = await buildChunks({ contentRoot, indexPath });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.every(chunk => chunk.accessLevel === 'public')).toBe(true);
+  });
+
+  it('propagates the loadAccessLevelMap failure instead of vectorizing with an empty map', async () => {
+    const contentRoot = writeArticle('features/foo.md');
+    const missingPath = path.join(root, 'does-not-exist.json');
+
+    await expect(buildChunks({ contentRoot, indexPath: missingPath })).rejects.toThrow();
+  });
+});

--- a/packages/scripts/help/__tests__/vectorize-help-content.test.ts
+++ b/packages/scripts/help/__tests__/vectorize-help-content.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+
+// vectorize-help-content.ts imports these for its embedding step (unused by the
+// functions under test here), but they need a core-package build to resolve. The
+// Help Docs Guards CI job runs this suite standalone without one, so mock them out.
+vi.mock('@bike4mind/fab-pipeline', () => ({ EmbeddingFactory: vi.fn() }));
+vi.mock('@bike4mind/common', () => ({ OpenAIEmbeddingModel: { TEXT_EMBEDDING_3_SMALL: 'text-embedding-3-small' } }));
+
 import { loadAccessLevelMap, resolveAccessLevel, buildChunks } from '../vectorize-help-content';
 
 /**

--- a/packages/scripts/help/vectorize-help-content.ts
+++ b/packages/scripts/help/vectorize-help-content.ts
@@ -59,34 +59,50 @@ interface ChunkData {
 }
 
 /**
- * Load slug -> accessLevel mapping from help-index.json.
- * Falls back to 'public' if the index doesn't exist or a slug is missing.
+ * Load slug -> accessLevel mapping from help-index.json. Throws if the index
+ * can't be read or parsed: access-level labels gate admin-only content out of
+ * the Help AI chat for non-admin users, so a broken index must fail the build
+ * rather than silently produce chunks that resolveAccessLevel then defaults
+ * to the fail-closed 'admin' level (which would also hide public docs).
  */
-function loadAccessLevelMap(): Map<string, HelpAccessLevel> {
+export function loadAccessLevelMap(indexPath: string = HELP_INDEX_PATH): Map<string, HelpAccessLevel> {
+  const raw = fs.readFileSync(indexPath, 'utf-8');
+  const index = JSON.parse(raw) as HelpIndex;
   const map = new Map<string, HelpAccessLevel>();
-  try {
-    const raw = fs.readFileSync(HELP_INDEX_PATH, 'utf-8');
-    const index = JSON.parse(raw) as HelpIndex;
-    for (const entry of index.entries) {
-      map.set(entry.slug, entry.accessLevel);
-    }
-    console.log(`Loaded access levels for ${map.size} entries from help-index.json`);
-  } catch {
-    console.warn('Could not load help-index.json for access levels — defaulting all chunks to "public"');
+  for (const entry of index.entries) {
+    map.set(entry.slug, entry.accessLevel);
   }
+  console.log(`Loaded access levels for ${map.size} entries from help-index.json`);
   return map;
+}
+
+/**
+ * Resolve a slug's access level, defaulting to the more restrictive 'admin'
+ * when the slug isn't in the map. Fail-closed: an unresolvable slug must
+ * never fall back to 'public', or it bypasses the Help AI chat's admin gate.
+ */
+export function resolveAccessLevel(slug: string, accessLevelMap: Map<string, HelpAccessLevel>): HelpAccessLevel {
+  return accessLevelMap.get(slug) ?? 'admin';
+}
+
+export interface BuildChunksOptions {
+  /** Overridable roots for testing; default to the real repo locations. */
+  contentRoot?: string;
+  indexPath?: string;
 }
 
 /**
  * Process all help articles into chunks ready for embedding.
  * Reads directly from apps/client/public/help-content/ (already filtered and bundled).
  */
-async function buildChunks(): Promise<ChunkData[]> {
-  const accessLevelMap = loadAccessLevelMap();
+export async function buildChunks(opts: BuildChunksOptions = {}): Promise<ChunkData[]> {
+  const contentRoot = opts.contentRoot ?? HELP_CONTENT_ROOT;
+  const indexPath = opts.indexPath ?? HELP_INDEX_PATH;
+  const accessLevelMap = loadAccessLevelMap(indexPath);
   const chunks: ChunkData[] = [];
 
   const files = await glob('**/*.md', {
-    cwd: HELP_CONTENT_ROOT,
+    cwd: contentRoot,
     absolute: true,
   });
 
@@ -101,13 +117,13 @@ async function buildChunks(): Promise<ChunkData[]> {
       continue;
     }
 
-    const relativePath = path.relative(HELP_CONTENT_ROOT, filePath);
+    const relativePath = path.relative(contentRoot, filePath);
     let slug = relativePath.replace(/\.md$/, '');
     if (slug.endsWith('/index')) slug = slug.replace(/\/index$/, '');
     else if (slug === 'index') slug = '';
 
     const title = frontmatter.title as string;
-    const accessLevel = accessLevelMap.get(slug) ?? 'public';
+    const accessLevel = resolveAccessLevel(slug, accessLevelMap);
     const sections = chunkByHeadings(content, title);
 
     for (const section of sections) {
@@ -218,7 +234,10 @@ async function main(): Promise<void> {
   console.log(`  Output: ${OUTPUT_PATH}`);
 }
 
-main().catch(error => {
-  console.error('Failed to vectorize help content:', error);
-  process.exit(1);
-});
+// Only run when invoked directly (not when imported by tests)
+if (process.argv[1] && process.argv[1].endsWith('vectorize-help-content.ts')) {
+  main().catch(error => {
+    console.error('Failed to vectorize help content:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Description

`loadAccessLevelMap()` in `packages/scripts/help/vectorize-help-content.ts` silently swallowed a missing or corrupt `help-index.json`, returning an empty map with only a `console.warn`, while `help:vectorize` still exited 0. `buildChunks()` then defaulted any slug missing from that map to `'public'` - the least restrictive access level. Since `accessLevel` is the only runtime gate keeping admin-only help docs out of the Help AI chat for non-admin users (`apps/client/server/help/retrieval.ts`), running `help:vectorize` while `help-index.json` was missing or corrupt would silently label every admin-only help chunk as `public` and commit that into `help-embeddings.json`.

This closes the fail-open reported in the linked issue by making the failure loud (non-zero exit) and the default restrictive (`admin`) instead of permissive (`public`).

Closes #2280

## Changes

- `loadAccessLevelMap()` no longer catches read/parse errors - a missing or malformed `help-index.json` now propagates and fails `help:vectorize` (non-zero exit) instead of warning and continuing with an empty map.
- Extracted the access-level lookup into a `resolveAccessLevel()` helper; a slug absent from the index now defaults to `'admin'` (fail-closed) instead of `'public'`.
- `buildChunks()` and `loadAccessLevelMap()` now accept optional path overrides so they can be unit tested without depending on generated build artifacts (`apps/client/public/help-content/` is gitignored and only exists after a build step).
- Guarded the script's `main()` invocation to only run when the file is executed directly (matching the existing pattern in `bundle-help-content.ts`), so importing it in tests no longer triggers a live run.
- Added `packages/scripts/help/__tests__/vectorize-help-content.test.ts` covering both failure modes.

## Guide for Testers

This is a backend build-script change with no UI surface.

1. From the repo root, run `pnpm --filter @bike4mind/scripts exec vitest run help/__tests__/vectorize-help-content.test.ts` - all 9 tests should pass.
2. To see the old failure mode manually: temporarily rename `apps/client/app/generated/help-index.json` to something else, then run `OPENAI_API_KEY=sk-test pnpm --filter @bike4mind/scripts help:vectorize` from the repo root - the script should print an error and exit non-zero. It fails at the `loadAccessLevelMap` step before ever reaching the OpenAI call, so the API key does not need to be valid. Restore the renamed file afterward.
3. Run `pnpm turbo:typecheck && pnpm lint:check` - both should pass with no errors.

### What NOT to test

- No UI or user-facing behavior changed - this only affects the standalone `help:vectorize` build script's failure behavior and default access-level fallback.
- No need to run the full `help:regenerate` pipeline against a real OpenAI key to review this; the unit tests exercise the fixed logic without needing embeddings.

## Additional Information

Confirmed on `main` that the currently-committed `help-embeddings.json` is correctly labeled today (`{ admin: 249, public: 451 }` chunks) - this is a latent fail-open in the script, not a live data exposure. No CI workflow invokes `help:vectorize`; it's a manual step, which is exactly the path most likely to hit a stale or missing index.

## Security Testing (for security-labeled PRs only)

The underlying bug is a latent fail-open in a manually-run build script, not an exploitable runtime endpoint, so there is no live request to curl on staging. I don't have staging or preview-deploy access from this environment, so I have not completed the checklist below - flagging for a maintainer to verify before merge.

- [ ] Vulnerability reproduced on staging with a script/curl (output attached as PR comment)
- [ ] Fix verified on PR preview env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings