### PR TITLE
fix(client): answer notebook-export failures with the status the caller earned

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -43,7 +43,7 @@ fi
 
 # Check staged files for hardcoded deprecated model IDs
 echo "Running deprecated model usage check on staged files..."
-if ! git diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs' '*.json' | xargs -r npx tsx packages/scripts/src/checkDeprecatedModelUsage.ts --files; then
+if ! git diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs' '*.json' | xargs -r pnpm --filter @bike4mind/scripts exec tsx src/checkDeprecatedModelUsage.ts --files; then
   FINAL_EXIT_CODE=1
 fi
 

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
@@ -5,6 +5,12 @@ import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { NotebookExportRequestSchema } from '../../../types/api';
 
+// A UTC runner cannot tell the local-zone resolution from the UTC-anchoring bug it replaced: both
+// render "2026-01-15" as the same instant. The expected values below are literals for the same
+// reason - re-deriving them from `new Date(...).toISOString()` would just re-run the production
+// formula against this same zone and assert nothing.
+process.env.TZ = 'America/Los_Angeles';
+
 const { mockPost, mockToastError } = vi.hoisted(() => ({ mockPost: vi.fn(), mockToastError: vi.fn() }));
 
 vi.mock('@client/app/contexts/ApiContext', () => ({ api: { post: mockPost } }));
@@ -57,8 +63,8 @@ describe('NotebookExportModal', () => {
 
     await waitFor(() => expect(mockPost).toHaveBeenCalled());
     expect(mockPost.mock.calls[0][1]).toMatchObject({
-      fromDate: new Date('2026-01-15T00:00:00.000').toISOString(),
-      toDate: new Date('2026-01-20T23:59:59.999').toISOString(),
+      fromDate: '2026-01-15T08:00:00.000Z',
+      toDate: '2026-01-21T07:59:59.999Z',
     });
     expect(mockToastError).not.toHaveBeenCalled();
   });

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
@@ -49,7 +49,8 @@ describe('NotebookExportModal', () => {
     // The picker yields a bare "2026-01-15", which carries no offset - so whoever resolves it picks
     // the zone. Resolving it against UTC cost a user in UTC-8 the last 8 hours of the day they chose.
     renderModal();
-    const [from, to] = Array.from(document.querySelectorAll('input[type="date"]')) as HTMLInputElement[];
+    const from = screen.getByTestId('notebook-export-from-date-input');
+    const to = screen.getByTestId('notebook-export-to-date-input');
     fireEvent.change(from, { target: { value: '2026-01-15' } });
     fireEvent.change(to, { target: { value: '2026-01-20' } });
     clickExport();
@@ -66,7 +67,7 @@ describe('NotebookExportModal', () => {
     // The input is controlled: an onChange that skips setState leaves React restoring the old text,
     // so the box could never be emptied to type a fresh number.
     renderModal();
-    const box = screen.getByDisplayValue('10') as HTMLInputElement;
+    const box = screen.getByTestId('notebook-export-size-input') as HTMLInputElement;
     fireEvent.change(box, { target: { value: '' } });
     expect(box.value).toBe('');
 
@@ -76,15 +77,46 @@ describe('NotebookExportModal', () => {
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
+  it('does not submit a stale size after the box is backspaced empty', async () => {
+    // A real backspace on "10" fires "1" before it fires "": the first keystroke is a valid number
+    // and sets the option, the second cannot, so a guard that only skips the unparseable value
+    // leaves 1 MB behind while the box shows nothing. Clearing must restore the default, not the
+    // last digit that happened to parse.
+    renderModal();
+    const box = screen.getByTestId('notebook-export-size-input') as HTMLInputElement;
+    fireEvent.change(box, { target: { value: '1' } });
+    fireEvent.change(box, { target: { value: '' } });
+    expect(box.value).toBe('');
+
+    clickExport();
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    expect(mockPost.mock.calls[0][1]).toMatchObject({ maxFileSize: 10 * 1024 * 1024 });
+  });
+
   it('submits a retyped size', async () => {
     renderModal();
-    const box = screen.getByDisplayValue('10');
+    const box = screen.getByTestId('notebook-export-size-input');
     fireEvent.change(box, { target: { value: '' } });
     fireEvent.change(box, { target: { value: '25' } });
     clickExport();
 
     await waitFor(() => expect(mockPost).toHaveBeenCalled());
     expect(mockPost.mock.calls[0][1]).toMatchObject({ maxFileSize: 25 * 1024 * 1024 });
+  });
+
+  it('holds a number input to the bounds it advertises', async () => {
+    // A number input accepts more than its min/max attributes suggest: those are submit-time hints
+    // the browser does not enforce on typed text. "1e3" is the case worth pinning - it is valid
+    // input, and parseInt reads it as 1, the opposite end of the range from what it says.
+    renderModal();
+    const box = screen.getByTestId('notebook-export-size-input') as HTMLInputElement;
+    // The real sequence, captured from Chromium: a number input reports "" for the transient "1e",
+    // so typing this passes through the same intermediate the backspace case does.
+    for (const step of ['1', '', '1e3']) fireEvent.change(box, { target: { value: step } });
+    clickExport();
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    expect(mockPost.mock.calls[0][1]).toMatchObject({ maxFileSize: 100 * 1024 * 1024 });
   });
 
   it('names the offending field when the server rejects the body', async () => {

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
@@ -125,6 +125,21 @@ describe('NotebookExportModal', () => {
     expect(mockPost.mock.calls[0][1]).toMatchObject({ maxFileSize: 100 * 1024 * 1024 });
   });
 
+  it('snaps the box back to the size it will actually send', async () => {
+    // The clamp is silent, so a box left reading 500 while 100 goes out tells the user their large
+    // files will be embedded when they will be URL-referenced instead.
+    renderModal();
+    const box = screen.getByTestId('notebook-export-size-input') as HTMLInputElement;
+    fireEvent.change(box, { target: { value: '500' } });
+    expect(box.value).toBe('500');
+    fireEvent.blur(box);
+    expect(box.value).toBe('100');
+
+    clickExport();
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    expect(mockPost.mock.calls[0][1]).toMatchObject({ maxFileSize: 100 * 1024 * 1024 });
+  });
+
   it('names the offending field when the server rejects the body', async () => {
     mockPost.mockRejectedValue({
       response: {

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.test.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { NotebookExportRequestSchema } from '../../../types/api';
+
+const { mockPost, mockToastError } = vi.hoisted(() => ({ mockPost: vi.fn(), mockToastError: vi.fn() }));
+
+vi.mock('@client/app/contexts/ApiContext', () => ({ api: { post: mockPost } }));
+vi.mock('sonner', () => ({ toast: { error: mockToastError, success: vi.fn() } }));
+vi.mock('@client/app/components/help', () => ({ ContextHelpButton: () => null }));
+
+import NotebookExportModal from './NotebookExportModal';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+/**
+ * Judges the body the modal built against the route's real request schema, so a field the modal
+ * cannot express correctly fails here rather than only in production.
+ */
+const routeDouble = vi.fn(async (_url: string, body: unknown) => {
+  const parsed = NotebookExportRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error(`schema rejected: ${parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ')}`);
+  }
+  return { data: { success: true, data: { downloadUrl: 'x', fileSize: 1, notebookCount: 1 } } };
+});
+
+const renderModal = () =>
+  render(
+    <TestWrapper>
+      <NotebookExportModal open onClose={vi.fn()} />
+    </TestWrapper>
+  );
+
+const clickExport = () => fireEvent.click(screen.getByText('Export Notebooks', { selector: 'button' }));
+
+beforeEach(() => {
+  mockPost.mockReset().mockImplementation(routeDouble);
+  mockToastError.mockReset();
+});
+
+describe('NotebookExportModal', () => {
+  it("sends the picked day resolved in the viewer's own zone, not UTC", async () => {
+    // The picker yields a bare "2026-01-15", which carries no offset - so whoever resolves it picks
+    // the zone. Resolving it against UTC cost a user in UTC-8 the last 8 hours of the day they chose.
+    renderModal();
+    const [from, to] = Array.from(document.querySelectorAll('input[type="date"]')) as HTMLInputElement[];
+    fireEvent.change(from, { target: { value: '2026-01-15' } });
+    fireEvent.change(to, { target: { value: '2026-01-20' } });
+    clickExport();
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    expect(mockPost.mock.calls[0][1]).toMatchObject({
+      fromDate: new Date('2026-01-15T00:00:00.000').toISOString(),
+      toDate: new Date('2026-01-20T23:59:59.999').toISOString(),
+    });
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it('keeps the size box clearable, and does not submit the empty value', async () => {
+    // The input is controlled: an onChange that skips setState leaves React restoring the old text,
+    // so the box could never be emptied to type a fresh number.
+    renderModal();
+    const box = screen.getByDisplayValue('10') as HTMLInputElement;
+    fireEvent.change(box, { target: { value: '' } });
+    expect(box.value).toBe('');
+
+    clickExport();
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    expect(mockPost.mock.calls[0][1]).toMatchObject({ maxFileSize: 10 * 1024 * 1024 });
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it('submits a retyped size', async () => {
+    renderModal();
+    const box = screen.getByDisplayValue('10');
+    fireEvent.change(box, { target: { value: '' } });
+    fireEvent.change(box, { target: { value: '25' } });
+    clickExport();
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    expect(mockPost.mock.calls[0][1]).toMatchObject({ maxFileSize: 25 * 1024 * 1024 });
+  });
+
+  it('names the offending field when the server rejects the body', async () => {
+    mockPost.mockRejectedValue({
+      response: {
+        status: 400,
+        data: {
+          success: false,
+          message: 'Invalid request body',
+          errors: [{ field: 'notebookIds', message: 'must be a 24-character hex notebook id' }],
+        },
+      },
+    });
+    renderModal();
+    clickExport();
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockToastError.mock.calls[0][0]).toContain('must be a 24-character hex notebook id');
+  });
+
+  it('falls back to the server message when there are no per-field errors', async () => {
+    mockPost.mockRejectedValue({
+      response: { status: 404, data: { success: false, message: 'No notebooks found to export' } },
+      message: 'Request failed with status code 404',
+    });
+    renderModal();
+    clickExport();
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockToastError.mock.calls[0][0]).toBe('No notebooks found to export');
+  });
+});

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
@@ -83,7 +83,10 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
       }
     } catch (error: any) {
       console.error('Export error:', error);
-      toast.error(error.message || 'Failed to export notebooks');
+      // The server's message first: axios rejects with its own "Request failed with status code
+      // 404", so reading error.message throws away the only text that says what actually happened
+      // ("No notebooks found to export").
+      toast.error(error?.response?.data?.message || error.message || 'Failed to export notebooks');
     } finally {
       setIsExporting(false);
     }

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
@@ -321,6 +321,9 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                   setDrafts(d => ({ ...d, maxFileSizeMb: text }));
                   updateOption('maxFileSize', resolveSizeMb(text) * 1024 * 1024);
                 }}
+                // The box must not show a number the request does not carry: resolveSizeMb clamps,
+                // so a typed 500 would sit on screen while 100 went out.
+                onBlur={() => setDrafts(d => ({ ...d, maxFileSizeMb: String(resolveSizeMb(d.maxFileSizeMb)) }))}
                 endDecorator="MB"
                 slotProps={{
                   input: {

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
@@ -65,6 +65,20 @@ const localDayBoundary = (value: string, edge: 'start' | 'end'): string | undefi
   return Number.isNaN(at.getTime()) ? undefined : at.toISOString();
 };
 
+const SIZE_MB = { default: 10, min: 1, max: 100 } as const;
+
+/**
+ * Resolve the size box's text to the megabytes the request carries. A box that holds no usable
+ * number falls back to the default rather than keeping whatever last parsed: backspacing "10" yields
+ * "1" before "", so a guard that only skips the unparseable step submits 1MB while the box shows
+ * nothing. `Number` rather than `parseInt`, which reads "1e3" as 1 instead of 1000.
+ */
+const resolveSizeMb = (text: string): number => {
+  const mb = Number(text);
+  if (!text.trim() || !Number.isFinite(mb)) return SIZE_MB.default;
+  return Math.min(Math.max(Math.floor(mb), SIZE_MB.min), SIZE_MB.max);
+};
+
 const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose }) => {
   const [options, setOptions] = useState<ExportOptions>({
     includeKnowledge: true,
@@ -74,14 +88,18 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
     anonymize: false,
     includeMetadata: true,
     includeImages: true,
-    maxFileSize: 10 * 1024 * 1024, // 10MB
+    maxFileSize: SIZE_MB.default * 1024 * 1024,
     format: 'json',
   });
 
   // The date and size inputs display raw text while `options` holds the submitted value. Without
   // that split, a value the input can show but the request cannot carry (an empty size box, a
   // local calendar date) has nowhere to live, and the field becomes uneditable.
-  const [drafts, setDrafts] = useState({ fromDate: '', toDate: '', maxFileSizeMb: '10' });
+  const [drafts, setDrafts] = useState({
+    fromDate: '',
+    toDate: '',
+    maxFileSizeMb: String(SIZE_MB.default),
+  });
 
   const [isExporting, setIsExporting] = useState(false);
   const [exportResult, setExportResult] = useState<any>(null);
@@ -299,15 +317,16 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                 type="number"
                 value={drafts.maxFileSizeMb}
                 onChange={e => {
-                  setDrafts(d => ({ ...d, maxFileSizeMb: e.target.value }));
-                  const mb = parseInt(e.target.value, 10);
-                  if (mb > 0) updateOption('maxFileSize', mb * 1024 * 1024);
+                  const text = e.target.value;
+                  setDrafts(d => ({ ...d, maxFileSizeMb: text }));
+                  updateOption('maxFileSize', resolveSizeMb(text) * 1024 * 1024);
                 }}
                 endDecorator="MB"
                 slotProps={{
                   input: {
-                    min: 1,
-                    max: 100,
+                    min: SIZE_MB.min,
+                    max: SIZE_MB.max,
+                    'data-testid': 'notebook-export-size-input',
                   },
                 }}
               />
@@ -329,6 +348,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                       setDrafts(d => ({ ...d, fromDate: e.target.value }));
                       updateOption('fromDate', localDayBoundary(e.target.value, 'start'));
                     }}
+                    slotProps={{ input: { 'data-testid': 'notebook-export-from-date-input' } }}
                   />
                 </FormControl>
                 <FormControl sx={{ flex: 1 }}>
@@ -340,6 +360,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                       setDrafts(d => ({ ...d, toDate: e.target.value }));
                       updateOption('toDate', localDayBoundary(e.target.value, 'end'));
                     }}
+                    slotProps={{ input: { 'data-testid': 'notebook-export-to-date-input' } }}
                   />
                 </FormControl>
               </Stack>

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
@@ -52,6 +52,19 @@ interface ExportOptions {
   format: ExportFormat;
 }
 
+/**
+ * Resolve the calendar date an `<input type="date">` yields to an instant at the edge of that day
+ * in the viewer's own zone. A bare "2026-01-15" carries no offset, so whoever resolves it picks the
+ * zone; doing it here is the only place the user's actual zone is known. Omitting the `Z` is what
+ * makes Date parse the literal as local rather than UTC.
+ */
+const localDayBoundary = (value: string, edge: 'start' | 'end'): string | undefined => {
+  if (!value) return undefined;
+  const time = edge === 'start' ? '00:00:00.000' : '23:59:59.999';
+  const at = new Date(`${value}T${time}`);
+  return Number.isNaN(at.getTime()) ? undefined : at.toISOString();
+};
+
 const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose }) => {
   const [options, setOptions] = useState<ExportOptions>({
     includeKnowledge: true,
@@ -64,6 +77,11 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
     maxFileSize: 10 * 1024 * 1024, // 10MB
     format: 'json',
   });
+
+  // The date and size inputs display raw text while `options` holds the submitted value. Without
+  // that split, a value the input can show but the request cannot carry (an empty size box, a
+  // local calendar date) has nowhere to live, and the field becomes uneditable.
+  const [drafts, setDrafts] = useState({ fromDate: '', toDate: '', maxFileSizeMb: '10' });
 
   const [isExporting, setIsExporting] = useState(false);
   const [exportResult, setExportResult] = useState<any>(null);
@@ -83,10 +101,14 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
       }
     } catch (error: any) {
       console.error('Export error:', error);
-      // The server's message first: axios rejects with its own "Request failed with status code
-      // 404", so reading error.message throws away the only text that says what actually happened
-      // ("No notebooks found to export").
-      toast.error(error?.response?.data?.message || error.message || 'Failed to export notebooks');
+      // Most specific first. axios's own error.message is "Request failed with status code 404",
+      // and a ZodError's message is the generic "Invalid request body" - in both cases the useful
+      // text is further in. `error` is the shared errorHandler envelope, the rest this route's own.
+      const data = error?.response?.data;
+      const fieldErrors: string | undefined = data?.errors
+        ?.map((e: { field: string; message: string }) => `${e.field}: ${e.message}`)
+        .join(', ');
+      toast.error(fieldErrors || data?.error || data?.message || error.message || 'Failed to export notebooks');
     } finally {
       setIsExporting(false);
     }
@@ -275,8 +297,12 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
               <Input
                 className="notebook-export-modal-input"
                 type="number"
-                value={Math.round(options.maxFileSize / (1024 * 1024))}
-                onChange={e => updateOption('maxFileSize', parseInt(e.target.value) * 1024 * 1024)}
+                value={drafts.maxFileSizeMb}
+                onChange={e => {
+                  setDrafts(d => ({ ...d, maxFileSizeMb: e.target.value }));
+                  const mb = parseInt(e.target.value, 10);
+                  if (mb > 0) updateOption('maxFileSize', mb * 1024 * 1024);
+                }}
                 endDecorator="MB"
                 slotProps={{
                   input: {
@@ -298,16 +324,22 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                   <FormLabel>From Date</FormLabel>
                   <Input
                     type="date"
-                    value={options.fromDate || ''}
-                    onChange={e => updateOption('fromDate', e.target.value || undefined)}
+                    value={drafts.fromDate}
+                    onChange={e => {
+                      setDrafts(d => ({ ...d, fromDate: e.target.value }));
+                      updateOption('fromDate', localDayBoundary(e.target.value, 'start'));
+                    }}
                   />
                 </FormControl>
                 <FormControl sx={{ flex: 1 }}>
                   <FormLabel>To Date</FormLabel>
                   <Input
                     type="date"
-                    value={options.toDate || ''}
-                    onChange={e => updateOption('toDate', e.target.value || undefined)}
+                    value={drafts.toDate}
+                    onChange={e => {
+                      setDrafts(d => ({ ...d, toDate: e.target.value }));
+                      updateOption('toDate', localDayBoundary(e.target.value, 'end'));
+                    }}
                   />
                 </FormControl>
               </Stack>

--- a/apps/client/pages/api/notebooks/__tests__/export.test.ts
+++ b/apps/client/pages/api/notebooks/__tests__/export.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+// The route derives its HTTP status from NotebookExportError.statusCode, so the double has to be a
+// real class: an instanceof check is what selects the 4xx branch over the blanket 500.
+const { mockExport, NotebookExportError } = vi.hoisted(() => {
+  const STATUS_BY_CODE = new Map<string, number>([
+    ['NO_NOTEBOOKS', 404],
+    ['INVALID_NOTEBOOK_ID', 400],
+  ]);
+  class NotebookExportError extends Error {
+    public readonly statusCode: number;
+    constructor(
+      message: string,
+      public code: string,
+      public details?: unknown
+    ) {
+      super(message);
+      this.name = 'NotebookExportError';
+      this.statusCode = STATUS_BY_CODE.get(code) ?? 500;
+    }
+  }
+  return { mockExport: vi.fn(), NotebookExportError };
+});
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.POST = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+
+vi.mock('@bike4mind/services', () => ({
+  notebookExportService: {
+    NotebookExportService: class {
+      exportNotebooks = mockExport;
+    },
+    NotebookExportError,
+  },
+}));
+
+vi.mock('@bike4mind/observability', () => ({
+  Logger: class {
+    withMetadata() {
+      return this;
+    }
+  },
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  sessionRepository: {},
+  questRepository: {},
+  fabFileRepository: {},
+  artifactRepository: {},
+  agentRepository: {},
+  Tool: { find: vi.fn(), findById: vi.fn() },
+}));
+
+vi.mock('@server/utils/storage', () => ({ getFilesStorage: () => ({}) }));
+
+import handler from '../export';
+
+const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+const run = (body: Record<string, unknown> = {}, user: unknown = { id: 'user-1' }) => {
+  const { req, res } = createMocks({ method: 'POST', body });
+  if (user) (req as Record<string, unknown>).user = user;
+  (req as Record<string, unknown>).logger = logger;
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+};
+
+const HEX_ID = '67dbe18a7f9cf1fa5d9686aa';
+
+beforeEach(() => {
+  mockExport.mockReset().mockResolvedValue({
+    downloadUrl: 'https://example.invalid/export.zip',
+    fileSize: 1024,
+    notebookCount: 1,
+    messageCount: 2,
+    attachmentCount: 0,
+  });
+  logger.warn.mockReset();
+  logger.error.mockReset();
+});
+
+describe('POST /api/notebooks/export', () => {
+  it('rejects a malformed notebookId at the schema, before the service is reached', async () => {
+    const { res, promise } = run({ notebookIds: ['optimistic-session-abc'] });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockExport).not.toHaveBeenCalled();
+    expect(res._getJSONData().errors).toContainEqual(
+      expect.objectContaining({ field: 'notebookIds.0', message: 'must be a 24-character hex notebook id' })
+    );
+  });
+
+  it('answers 400 with the service code when the export is rejected as a caller fault', async () => {
+    mockExport.mockRejectedValue(new NotebookExportError('bad ids: nope', 'INVALID_NOTEBOOK_ID'));
+    const { res, promise } = run({ notebookIds: [HEX_ID] });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toMatchObject({ success: false, code: 'INVALID_NOTEBOOK_ID', message: 'bad ids: nope' });
+  });
+
+  it('answers 404 when the account has no notebooks to export', async () => {
+    mockExport.mockRejectedValue(new NotebookExportError('No notebooks found', 'NO_NOTEBOOKS'));
+    const { res, promise } = run();
+    await promise;
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toMatchObject({ code: 'NO_NOTEBOOKS' });
+  });
+
+  it('does not log a caller rejection again - the service already wrote that line', async () => {
+    mockExport.mockRejectedValue(new NotebookExportError('No notebooks found', 'NO_NOTEBOOKS'));
+    const { promise } = run();
+    await promise;
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps a genuine fault at 500 and loud, so a real outage still pages', async () => {
+    mockExport.mockRejectedValue(new NotebookExportError('upload died', 'EXPORT_FAILED'));
+    const { res, promise } = run();
+    await promise;
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData().message).toBe('Export failed. Please try again later.');
+    expect(logger.error).toHaveBeenCalledWith('Notebook export failed', expect.objectContaining({ userId: 'user-1' }));
+  });
+
+  it('keeps a non-NotebookExportError at 500 and loud', async () => {
+    mockExport.mockRejectedValue(new Error('mongo is on fire'));
+    const { res, promise } = run();
+    await promise;
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('returns the export payload on success', async () => {
+    const { res, promise } = run({ notebookIds: [HEX_ID] });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().data).toMatchObject({
+      downloadUrl: 'https://example.invalid/export.zip',
+      notebookCount: 1,
+    });
+    expect(mockExport).toHaveBeenCalledWith('user-1', expect.objectContaining({ notebookIds: [HEX_ID] }));
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const { res, promise } = run({}, null);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockExport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/notebooks/__tests__/export.test.ts
+++ b/apps/client/pages/api/notebooks/__tests__/export.test.ts
@@ -1,27 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
-// The route derives its HTTP status from NotebookExportError.statusCode, so the double has to be a
-// real class: an instanceof check is what selects the 4xx branch over the blanket 500.
-const { mockExport, NotebookExportError } = vi.hoisted(() => {
-  const STATUS_BY_CODE = new Map<string, number>([
-    ['NO_NOTEBOOKS', 404],
-    ['INVALID_NOTEBOOK_ID', 400],
-  ]);
-  class NotebookExportError extends Error {
-    public readonly statusCode: number;
-    constructor(
-      message: string,
-      public code: string,
-      public details?: unknown
-    ) {
-      super(message);
-      this.name = 'NotebookExportError';
-      this.statusCode = STATUS_BY_CODE.get(code) ?? 500;
-    }
-  }
-  return { mockExport: vi.fn(), NotebookExportError };
-});
+const { mockExport } = vi.hoisted(() => ({ mockExport: vi.fn() }));
 
 vi.mock('@server/middlewares/baseApi', () => ({
   baseApi: () => {
@@ -41,14 +21,22 @@ vi.mock('@server/middlewares/asyncHandler', () => ({
   asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
 }));
 
-vi.mock('@bike4mind/services', () => ({
+// Only the service class is doubled. NotebookExportError is the REAL one, so the status this route
+// answers is the status the error actually carries - a replica would let the two drift apart and
+// keep asserting the old behaviour with nothing failing. Imported from source because that module
+// is pure (one `import type`), while pulling the whole services barrel in costs seconds of module
+// load for one Error class. The route's `instanceof` resolves to this same object, since its
+// binding comes from this mock.
+vi.mock('@bike4mind/services', async () => ({
   notebookExportService: {
+    ...(await import('../../../../../../b4m-core/services/src/notebookExportService/types')),
     NotebookExportService: class {
       exportNotebooks = mockExport;
     },
-    NotebookExportError,
   },
 }));
+
+const { NotebookExportError } = await import('../../../../../../b4m-core/services/src/notebookExportService/types');
 
 vi.mock('@bike4mind/observability', () => ({
   Logger: class {

--- a/apps/client/pages/api/notebooks/__tests__/export.test.ts
+++ b/apps/client/pages/api/notebooks/__tests__/export.test.ts
@@ -104,6 +104,11 @@ describe('POST /api/notebooks/export', () => {
     expect(res._getJSONData().errors).toContainEqual(
       expect.objectContaining({ field: 'notebookIds.0', message: 'must be a 24-character hex notebook id' })
     );
+    // The service is never reached here, so this is the only line that records the fault at all.
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Notebook export rejected at the schema',
+      expect.objectContaining({ userId: 'user-1', fields: ['notebookIds.0'] })
+    );
   });
 
   it('answers 400 with the service code when the export is rejected as a caller fault', async () => {

--- a/apps/client/pages/api/notebooks/export.ts
+++ b/apps/client/pages/api/notebooks/export.ts
@@ -129,6 +129,8 @@ const handler = baseApi().post(
         return res.status(error.statusCode).json({ success: false, message: error.message, code: error.code });
       }
 
+      // The 4xx branch above logs exactly once; this one does not. It repeats the service's own
+      // error line for a genuine 500.
       req.logger.error('Notebook export failed', { userId, error });
 
       return res.status(500).json({

--- a/apps/client/pages/api/notebooks/export.ts
+++ b/apps/client/pages/api/notebooks/export.ts
@@ -129,8 +129,8 @@ const handler = baseApi().post(
         return res.status(error.statusCode).json({ success: false, message: error.message, code: error.code });
       }
 
-      // The 4xx branch above logs exactly once; this one does not. It repeats the service's own
-      // error line for a genuine 500.
+      // Deliberately a second error line: the service already logged this one at error, so a
+      // genuine 500 totals two. The 4xx branch above adds none, so a rejection stays at one.
       req.logger.error('Notebook export failed', { userId, error });
 
       return res.status(500).json({

--- a/apps/client/pages/api/notebooks/export.ts
+++ b/apps/client/pages/api/notebooks/export.ts
@@ -14,7 +14,7 @@ import { getFilesStorage } from '@server/utils/storage';
 import { z } from 'zod';
 import { NotebookExportRequestSchema } from '../../../types/api';
 
-const { NotebookExportService } = notebookExportService;
+const { NotebookExportService, NotebookExportError } = notebookExportService;
 type NotebookExportOptions = Parameters<typeof NotebookExportService.prototype.exportNotebooks>[1];
 
 const handler = baseApi().post(
@@ -115,6 +115,14 @@ const handler = baseApi().post(
         },
       });
     } catch (error) {
+      // Status comes off the error, which is where the service already put it. Answering 500 for
+      // everything is what paged LiveOps for a caller condition, since a 5xx-level log line is what
+      // trips the CloudWatch filter. Anything carrying 500 falls through and stays loud.
+      if (error instanceof NotebookExportError && error.statusCode < 500) {
+        req.logger.warn('Notebook export rejected', { userId, code: error.code, status: error.statusCode });
+        return res.status(error.statusCode).json({ success: false, message: error.message, code: error.code });
+      }
+
       req.logger.error('Notebook export failed', { userId, error });
 
       return res.status(500).json({

--- a/apps/client/pages/api/notebooks/export.ts
+++ b/apps/client/pages/api/notebooks/export.ts
@@ -117,9 +117,9 @@ const handler = baseApi().post(
     } catch (error) {
       // Status comes off the error, which is where the service already put it. Answering 500 for
       // everything is what paged LiveOps for a caller condition, since a 5xx-level log line is what
-      // trips the CloudWatch filter. Anything carrying 500 falls through and stays loud.
+      // trips the CloudWatch filter. Anything carrying 500 falls through and stays loud. No log
+      // line here: the service already wrote one at warn, through this same req.logger.
       if (error instanceof NotebookExportError && error.statusCode < 500) {
-        req.logger.warn('Notebook export rejected', { userId, code: error.code, status: error.statusCode });
         return res.status(error.statusCode).json({ success: false, message: error.message, code: error.code });
       }
 

--- a/apps/client/pages/api/notebooks/export.ts
+++ b/apps/client/pages/api/notebooks/export.ts
@@ -32,6 +32,12 @@ const handler = baseApi().post(
       validatedBody = NotebookExportRequestSchema.parse(req.body);
     } catch (error) {
       if (error instanceof z.ZodError) {
+        // The service is never reached on this path, so without this line the most common caller
+        // fault - a malformed notebook id - would 400 and leave no trace anywhere.
+        req.logger.warn('Notebook export rejected at the schema', {
+          userId,
+          fields: error.issues.map(err => err.path.join('.')),
+        });
         return res.status(400).json({
           success: false,
           message: 'Invalid request body',

--- a/apps/client/types/api.test.ts
+++ b/apps/client/types/api.test.ts
@@ -43,8 +43,9 @@ describe('NotebookExportRequestSchema - notebookIds', () => {
   });
 
   it('accepts the date-only value an <input type="date"> produces', () => {
-    // The export modal's Date Range sends "2026-01-15"; a datetime-only schema 400d every date a
-    // user could pick, and the toast named none of it.
+    // A datetime-only schema 400d every date a user could pick, and the toast named none of it.
+    // The modal now resolves the picked day in the viewer's zone before sending, so this form
+    // arrives from API callers.
     const parsed = NotebookExportRequestSchema.parse({ fromDate: '2026-01-15', toDate: '2026-01-20' });
     expect(parsed.fromDate).toBe('2026-01-15');
     expect(parsed.toDate).toBe('2026-01-20');

--- a/apps/client/types/api.test.ts
+++ b/apps/client/types/api.test.ts
@@ -41,6 +41,23 @@ describe('NotebookExportRequestSchema - notebookIds', () => {
     expect(NotebookExportRequestSchema.safeParse({ notebookIds: [] }).success).toBe(false);
   });
 
+  it('accepts the date-only value an <input type="date"> produces', () => {
+    // The export modal's Date Range sends "2026-01-15"; a datetime-only schema 400d every date a
+    // user could pick, and the toast named none of it.
+    const parsed = NotebookExportRequestSchema.parse({ fromDate: '2026-01-15', toDate: '2026-01-20' });
+    expect(parsed.fromDate).toBe('2026-01-15');
+    expect(parsed.toDate).toBe('2026-01-20');
+  });
+
+  it('still accepts a full ISO datetime, so existing API callers are unaffected', () => {
+    const parsed = NotebookExportRequestSchema.parse({ fromDate: '2026-01-15T08:30:00Z' });
+    expect(parsed.fromDate).toBe('2026-01-15T08:30:00Z');
+  });
+
+  it('still rejects a date that is neither form', () => {
+    expect(NotebookExportRequestSchema.safeParse({ fromDate: '15/01/2026' }).success).toBe(false);
+  });
+
   it('caps the batch at 50, matching the sibling curate schema', () => {
     const ids = Array.from({ length: 51 }, () => HEX);
     expect(NotebookExportRequestSchema.safeParse({ notebookIds: ids }).success).toBe(false);

--- a/apps/client/types/api.test.ts
+++ b/apps/client/types/api.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { NotebookExportRequestSchema } from './api';
+
+const HEX = '507f1f77bcf86cd799439011';
+
+describe('NotebookExportRequestSchema - notebookIds', () => {
+  it('accepts a request that names no notebooks', () => {
+    expect(NotebookExportRequestSchema.parse({}).notebookIds).toBeUndefined();
+  });
+
+  it('accepts a stringified ObjectId in either hex case', () => {
+    const parsed = NotebookExportRequestSchema.parse({ notebookIds: [HEX, HEX.toUpperCase()] });
+    expect(parsed.notebookIds).toEqual([HEX, HEX.toUpperCase()]);
+  });
+
+  it('rejects an id that cannot address a notebook, rather than letting Mongo throw', () => {
+    // SessionModel is ObjectId-keyed and the service puts these straight into `_id: { $in: ... }`,
+    // so an unguarded value fails the whole export with a 500 that names nothing actionable.
+    expect(() => NotebookExportRequestSchema.parse({ notebookIds: ['not-an-objectid'] })).toThrow();
+  });
+
+  it('rejects an optimistic client id, which is what a real caller would send too early', () => {
+    // createOptimisticSessionId() mints these, and a notebook carries one until the server id lands.
+    expect(() =>
+      NotebookExportRequestSchema.parse({ notebookIds: [`optimistic-session-${'a'.repeat(36)}`] })
+    ).toThrow();
+  });
+
+  it('rejects one bad id among good ones and names it, so a batch cannot half-succeed', () => {
+    const result = NotebookExportRequestSchema.safeParse({ notebookIds: [HEX, 'not-an-objectid'] });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path.join('.')).toBe('notebookIds.1');
+    }
+  });
+});

--- a/apps/client/types/api.test.ts
+++ b/apps/client/types/api.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from 'vitest';
 import { NotebookExportRequestSchema } from './api';
 
@@ -55,7 +56,11 @@ describe('NotebookExportRequestSchema - notebookIds', () => {
   });
 
   it('still rejects a date that is neither form', () => {
-    expect(NotebookExportRequestSchema.safeParse({ fromDate: '15/01/2026' }).success).toBe(false);
+    const bad = NotebookExportRequestSchema.safeParse({ fromDate: '15/01/2026' });
+    expect(bad.success).toBe(false);
+    // The message, not just the rejection: the route copies it into errors[] and the modal shows it,
+    // and a union reports zod's generic "Invalid input" unless it is labelled.
+    expect(bad.error?.issues[0].message).toBe('must be YYYY-MM-DD or a full ISO datetime');
   });
 
   it('caps the batch at 50, matching the sibling curate schema', () => {

--- a/apps/client/types/api.test.ts
+++ b/apps/client/types/api.test.ts
@@ -33,4 +33,17 @@ describe('NotebookExportRequestSchema - notebookIds', () => {
       expect(result.error.issues[0].path.join('.')).toBe('notebookIds.1');
     }
   });
+
+  it('rejects an empty array, which the service would otherwise read as "export everything"', () => {
+    // `getSessionsToExport` only adds the `_id` filter when the array is non-empty, so `[]` and an
+    // omitted field issue the same bare `{ userId }` query. Naming zero notebooks must not return
+    // all of them; omitting the field remains the way to ask for everything.
+    expect(NotebookExportRequestSchema.safeParse({ notebookIds: [] }).success).toBe(false);
+  });
+
+  it('caps the batch at 50, matching the sibling curate schema', () => {
+    const ids = Array.from({ length: 51 }, () => HEX);
+    expect(NotebookExportRequestSchema.safeParse({ notebookIds: ids }).success).toBe(false);
+    expect(NotebookExportRequestSchema.safeParse({ notebookIds: ids.slice(0, 50) }).success).toBe(true);
+  });
 });

--- a/apps/client/types/api.test.ts
+++ b/apps/client/types/api.test.ts
@@ -56,6 +56,13 @@ describe('NotebookExportRequestSchema - notebookIds', () => {
     expect(parsed.fromDate).toBe('2026-01-15T08:30:00Z');
   });
 
+  it('accepts an offset-bearing timestamp, which the message says is valid', () => {
+    // z.iso.datetime() defaults to offset: false, so this 400d under a message naming it as one of
+    // the two accepted forms.
+    const parsed = NotebookExportRequestSchema.parse({ fromDate: '2026-01-15T08:30:00+09:00' });
+    expect(parsed.fromDate).toBe('2026-01-15T08:30:00+09:00');
+  });
+
   it('still rejects a date that is neither form', () => {
     const bad = NotebookExportRequestSchema.safeParse({ fromDate: '15/01/2026' });
     expect(bad.success).toBe(false);

--- a/apps/client/types/api.ts
+++ b/apps/client/types/api.ts
@@ -122,7 +122,9 @@ export const NotebookExportRequestSchema = z.object({
     .positive()
     .optional()
     .prefault(10 * 1024 * 1024), // 10MB default
-  notebookIds: z.array(z.string()).optional(),
+  // These feed `_id: { $in: ... }` on ObjectId-keyed SessionModel, so one non-hex entry rejects the
+  // whole query with a CastError the route could only answer as a 500.
+  notebookIds: z.array(z.string().regex(/^[0-9a-fA-F]{24}$/, 'must be a 24-character hex notebook id')).optional(),
   fromDate: z.iso.datetime().optional(),
   toDate: z.iso.datetime().optional(),
 });

--- a/apps/client/types/api.ts
+++ b/apps/client/types/api.ts
@@ -132,8 +132,13 @@ export const NotebookExportRequestSchema = z.object({
     .min(1, 'name at least one notebook, or omit notebookIds to export all')
     .max(50, 'Maximum 50 notebooks per export request')
     .optional(),
-  fromDate: z.iso.datetime().optional(),
-  toDate: z.iso.datetime().optional(),
+  // A bare "2026-01-15" is accepted alongside a full timestamp, since that is what an
+  // `<input type="date">` produces and a datetime-only schema rejected every such value. The
+  // export modal no longer sends that form - it resolves the picked day in the viewer's own zone,
+  // the only place that zone is known - so this now serves API callers, whose bare date the
+  // service reads as a UTC day: the only defensible reading when no offset was supplied.
+  fromDate: z.union([z.iso.date(), z.iso.datetime()]).optional(),
+  toDate: z.union([z.iso.date(), z.iso.datetime()]).optional(),
 });
 
 export const NotebookCurateRequestSchema = z.object({

--- a/apps/client/types/api.ts
+++ b/apps/client/types/api.ts
@@ -123,8 +123,15 @@ export const NotebookExportRequestSchema = z.object({
     .optional()
     .prefault(10 * 1024 * 1024), // 10MB default
   // These feed `_id: { $in: ... }` on ObjectId-keyed SessionModel, so one non-hex entry rejects the
-  // whole query with a CastError the route could only answer as a 500.
-  notebookIds: z.array(z.string().regex(/^[0-9a-fA-F]{24}$/, 'must be a 24-character hex notebook id')).optional(),
+  // whole query with a CastError the route could only answer as a 500. Empty is rejected rather
+  // than treated as "all": getSessionsToExport only adds the `_id` filter when the array is
+  // non-empty, so `[]` and an omitted field produce the same bare `{ userId }` query - a caller
+  // who named zero notebooks would receive an archive of every one they own.
+  notebookIds: z
+    .array(z.string().regex(/^[0-9a-fA-F]{24}$/, 'must be a 24-character hex notebook id'))
+    .min(1, 'name at least one notebook, or omit notebookIds to export all')
+    .max(50, 'Maximum 50 notebooks per export request')
+    .optional(),
   fromDate: z.iso.datetime().optional(),
   toDate: z.iso.datetime().optional(),
 });

--- a/apps/client/types/api.ts
+++ b/apps/client/types/api.ts
@@ -109,6 +109,13 @@ export const ProjectInviteRequestSchema = z.object({
   available: z.number().positive().optional(),
 });
 
+// Labelled deliberately: a bare union reports only zod's generic "Invalid input", losing the
+// "Invalid ISO datetime" a lone datetime schema gave. The route copies issue.message into errors[]
+// and the modal renders it, so this string is what an API caller sending "15/01/2026" actually reads.
+const DATE_OR_DATETIME = z.union([z.iso.date(), z.iso.datetime()], {
+  error: 'must be YYYY-MM-DD or a full ISO datetime',
+});
+
 export const NotebookExportRequestSchema = z.object({
   includeKnowledge: z.boolean().optional().prefault(true),
   includeArtifacts: z.boolean().optional().prefault(true),
@@ -137,8 +144,8 @@ export const NotebookExportRequestSchema = z.object({
   // export modal no longer sends that form - it resolves the picked day in the viewer's own zone,
   // the only place that zone is known - so this now serves API callers, whose bare date the
   // service reads as a UTC day: the only defensible reading when no offset was supplied.
-  fromDate: z.union([z.iso.date(), z.iso.datetime()]).optional(),
-  toDate: z.union([z.iso.date(), z.iso.datetime()]).optional(),
+  fromDate: DATE_OR_DATETIME.optional(),
+  toDate: DATE_OR_DATETIME.optional(),
 });
 
 export const NotebookCurateRequestSchema = z.object({

--- a/apps/client/types/api.ts
+++ b/apps/client/types/api.ts
@@ -109,10 +109,12 @@ export const ProjectInviteRequestSchema = z.object({
   available: z.number().positive().optional(),
 });
 
+// `offset: true` because the default rejects "+09:00", which the docs table advertises and a
+// zone-aware caller is the most likely one to send.
 // Labelled deliberately: a bare union reports only zod's generic "Invalid input", losing the
 // "Invalid ISO datetime" a lone datetime schema gave. The route copies issue.message into errors[]
 // and the modal renders it, so this string is what an API caller sending "15/01/2026" actually reads.
-const DATE_OR_DATETIME = z.union([z.iso.date(), z.iso.datetime()], {
+const DATE_OR_DATETIME = z.union([z.iso.date(), z.iso.datetime({ offset: true })], {
   error: 'must be YYYY-MM-DD or a full ISO datetime',
 });
 

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -306,3 +306,79 @@ describe('notebook export', () => {
     expect(adapters.logger.warn).not.toHaveBeenCalled();
   });
 });
+
+describe('notebook export - notebookIds shape', () => {
+  it('rejects an id that cannot address a notebook instead of letting Mongo throw', async () => {
+    const { adapters } = makeAdapters();
+    const svc = new NotebookExportService(adapters);
+
+    await expect(
+      svc.exportNotebooks('user-1', { ...OPTIONS, notebookIds: ['not-an-objectid'] } as never)
+    ).rejects.toMatchObject({ code: 'INVALID_NOTEBOOK_ID' });
+
+    // Never dropped: the whole point is that the caller is told, not that fewer notebooks ship.
+    expect(adapters.sessionRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('names the offending id, so the 400 is actionable', async () => {
+    const svc = new NotebookExportService(makeAdapters().adapters);
+
+    await expect(
+      svc.exportNotebooks('user-1', { ...OPTIONS, notebookIds: [GOOD, 'legacy-uuid'] } as never)
+    ).rejects.toThrow(/legacy-uuid/);
+  });
+
+  it('accepts uppercase hex, which addresses the same row', async () => {
+    const { adapters } = makeAdapters();
+    await new NotebookExportService(adapters).exportNotebooks('user-1', {
+      ...OPTIONS,
+      notebookIds: [UPPER],
+    } as never);
+
+    expect(adapters.sessionRepository.find).toHaveBeenCalledWith(expect.objectContaining({ _id: { $in: [UPPER] } }));
+  });
+});
+
+describe('notebook export - log level', () => {
+  // The reason the status mapping exists at all: a 5xx-level line trips the CloudWatch filter and
+  // pages LiveOps. Answering 404 at the route is not enough if the service already logged `error`.
+  it('reports NO_NOTEBOOKS carrying a 404, and logs it at warn rather than error', async () => {
+    const { adapters } = makeAdapters({ sessionRepository: { find: vi.fn().mockResolvedValue([]) } });
+
+    await expect(new NotebookExportService(adapters).exportNotebooks('user-1', OPTIONS)).rejects.toMatchObject({
+      code: 'NO_NOTEBOOKS',
+      statusCode: 404,
+    });
+
+    expect(adapters.logger.error).not.toHaveBeenCalled();
+    expect(adapters.logger.warn).toHaveBeenCalledWith(
+      'Notebook export rejected',
+      expect.objectContaining({ code: 'NO_NOTEBOOKS' })
+    );
+  });
+
+  it('reports INVALID_NOTEBOOK_ID carrying a 400, and logs it at warn too', async () => {
+    const { adapters } = makeAdapters();
+
+    await expect(
+      new NotebookExportService(adapters).exportNotebooks('user-1', {
+        ...OPTIONS,
+        notebookIds: ['not-an-objectid'],
+      } as never)
+    ).rejects.toMatchObject({ code: 'INVALID_NOTEBOOK_ID', statusCode: 400 });
+
+    expect(adapters.logger.error).not.toHaveBeenCalled();
+  });
+
+  it('still logs an unexpected fault at error, so a real break stays loud', async () => {
+    const { adapters } = makeAdapters({
+      sessionRepository: { find: vi.fn().mockRejectedValue(new Error('mongo is on fire')) },
+    });
+
+    await expect(new NotebookExportService(adapters).exportNotebooks('user-1', OPTIONS)).rejects.toMatchObject({
+      code: 'EXPORT_FAILED',
+    });
+
+    expect(adapters.logger.error).toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -338,9 +338,10 @@ describe('notebook export - notebookIds shape', () => {
     expect(adapters.sessionRepository.find).toHaveBeenCalledWith(expect.objectContaining({ _id: { $in: [UPPER] } }));
   });
 
-  it('covers the whole of a date-only toDate, not just its midnight', async () => {
+  it('anchors a date-only fromDate to midnight and stretches a date-only toDate to end of day', async () => {
     // `new Date('2026-01-20')` is that day at 00:00Z, so an inclusive `$lte` on it returns nothing
-    // from the day the caller named - and a date input can only send this form.
+    // from the day the caller named. The modal resolves the picked day itself, so this form is what
+    // an API caller sends.
     const { adapters } = makeAdapters();
     await new NotebookExportService(adapters).exportNotebooks('user-1', {
       ...OPTIONS,

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -337,6 +337,38 @@ describe('notebook export - notebookIds shape', () => {
 
     expect(adapters.sessionRepository.find).toHaveBeenCalledWith(expect.objectContaining({ _id: { $in: [UPPER] } }));
   });
+
+  it('covers the whole of a date-only toDate, not just its midnight', async () => {
+    // `new Date('2026-01-20')` is that day at 00:00Z, so an inclusive `$lte` on it returns nothing
+    // from the day the caller named - and a date input can only send this form.
+    const { adapters } = makeAdapters();
+    await new NotebookExportService(adapters).exportNotebooks('user-1', {
+      ...OPTIONS,
+      fromDate: '2026-01-15',
+      toDate: '2026-01-20',
+    } as never);
+
+    expect(adapters.sessionRepository.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastUpdated: {
+          $gte: new Date('2026-01-15T00:00:00.000Z'),
+          $lte: new Date('2026-01-20T23:59:59.999Z'),
+        },
+      })
+    );
+  });
+
+  it('leaves a full ISO datetime toDate exactly where the caller put it', async () => {
+    const { adapters } = makeAdapters();
+    await new NotebookExportService(adapters).exportNotebooks('user-1', {
+      ...OPTIONS,
+      toDate: '2026-01-20T08:30:00.000Z',
+    } as never);
+
+    expect(adapters.sessionRepository.find).toHaveBeenCalledWith(
+      expect.objectContaining({ lastUpdated: { $lte: new Date('2026-01-20T08:30:00.000Z') } })
+    );
+  });
 });
 
 describe('notebook export - log level', () => {
@@ -370,7 +402,12 @@ describe('notebook export - log level', () => {
     expect(adapters.logger.error).not.toHaveBeenCalled();
     expect(adapters.logger.warn).toHaveBeenCalledWith(
       'Notebook export rejected',
-      expect.objectContaining({ code: 'INVALID_NOTEBOOK_ID', status: 400 })
+      expect.objectContaining({
+        code: 'INVALID_NOTEBOOK_ID',
+        status: 400,
+        // The ids are the only actionable part of this line; they exist nowhere else in any log.
+        reason: expect.stringContaining('not-an-objectid'),
+      })
     );
   });
 

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -368,6 +368,10 @@ describe('notebook export - log level', () => {
     ).rejects.toMatchObject({ code: 'INVALID_NOTEBOOK_ID', statusCode: 400 });
 
     expect(adapters.logger.error).not.toHaveBeenCalled();
+    expect(adapters.logger.warn).toHaveBeenCalledWith(
+      'Notebook export rejected',
+      expect.objectContaining({ code: 'INVALID_NOTEBOOK_ID', status: 400 })
+    );
   });
 
   it('still logs an unexpected fault at error, so a real break stays loud', async () => {

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -218,6 +218,9 @@ export class NotebookExportService {
         throw error;
       }
 
+      // Not de-duplicated, unlike the branch above: the route logs a genuine 500 again through the
+      // same logger. That feeds a fingerprint-deduplicating pipeline, so it costs one dropped queue
+      // message rather than a second page.
       this.adapters.logger.error('Notebook export failed', { userId, error });
 
       if (error instanceof NotebookExportError) {

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -201,9 +201,14 @@ export class NotebookExportService {
     } catch (error) {
       // Level chosen by code, not blanket `error`. A 5xx-level line is what trips the CloudWatch
       // filter, so logging a caller condition here would page LiveOps even though the route
-      // answers 4xx - which is the whole fault this change exists to remove.
+      // answers 4xx - which is the whole fault this change exists to remove. This is the only
+      // line a rejection logs: the route rethrows to the caller without logging it again.
       if (error instanceof NotebookExportError && error.statusCode < 500) {
-        this.adapters.logger.warn('Notebook export rejected', { userId, code: error.code });
+        this.adapters.logger.warn('Notebook export rejected', {
+          userId,
+          code: error.code,
+          status: error.statusCode,
+        });
         throw error;
       }
 
@@ -223,8 +228,8 @@ export class NotebookExportService {
     // Filter by specific notebook IDs
     if (options.notebookIds && options.notebookIds.length > 0) {
       // Rejected, never dropped: exporting fewer notebooks than were named, silently, is worse.
-      // Unreachable from the API - the request schema rejects first - so this guards the exported
-      // service, which the CLI also calls.
+      // Unreachable through the route, whose request schema rejects first; this guards any future
+      // caller of the exported service that has no schema in front of it.
       const unusable = options.notebookIds.filter(id => !isObjectIdOrHexString(id));
       if (unusable.length > 0) {
         throw new NotebookExportError(

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -11,7 +11,7 @@ import {
   NotebookExportError,
   CURRENT_EXPORT_VERSION,
 } from './types';
-import { isImageServeable } from '@bike4mind/common';
+import { dayjs, isImageServeable } from '@bike4mind/common';
 import type { ILogger } from '@bike4mind/observability';
 import type {
   IAgentDocument,
@@ -24,6 +24,9 @@ import type {
 
 import { isObjectIdOrHexString } from 'mongoose';
 import { usableSessionIds } from '../utils/objectIds';
+
+/** Matches a bare "2026-01-15", as opposed to a full ISO datetime. */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
 /** Mongo filter; stays loose because callers pass operator objects (`{ _id: { $in: [...] } }`). */
 type ExportQuery = Record<string, unknown>;
@@ -204,10 +207,13 @@ export class NotebookExportService {
       // answers 4xx - which is the whole fault this change exists to remove. This is the only
       // line a rejection logs: the route rethrows to the caller without logging it again.
       if (error instanceof NotebookExportError && error.statusCode < 500) {
+        // `reason` carries the offending ids: they live only in the message, and this is the sole
+        // line a rejection writes - the route answers the status without logging again.
         this.adapters.logger.warn('Notebook export rejected', {
           userId,
           code: error.code,
           status: error.statusCode,
+          reason: error.message,
         });
         throw error;
       }
@@ -241,14 +247,18 @@ export class NotebookExportService {
       query._id = { $in: options.notebookIds };
     }
 
-    // Date range filtering
+    // Date range filtering. A bare "2026-01-15" parses to that day's midnight, so an inclusive
+    // `$lte` on it would return nothing from the day the caller actually named - the `<input
+    // type="date">` in the export modal sends exactly that form.
     if (options.fromDate || options.toDate) {
       query.lastUpdated = {};
       if (options.fromDate) {
         query.lastUpdated.$gte = new Date(options.fromDate);
       }
       if (options.toDate) {
-        query.lastUpdated.$lte = new Date(options.toDate);
+        query.lastUpdated.$lte = DATE_ONLY.test(options.toDate)
+          ? dayjs.utc(options.toDate).endOf('day').toDate()
+          : new Date(options.toDate);
       }
     }
 

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -22,6 +22,7 @@ import type {
   IToolDocument,
 } from '@bike4mind/common';
 
+import { isObjectIdOrHexString } from 'mongoose';
 import { usableSessionIds } from '../utils/objectIds';
 
 /** Mongo filter; stays loose because callers pass operator objects (`{ _id: { $in: [...] } }`). */
@@ -198,6 +199,14 @@ export class NotebookExportService {
         downloadUrl,
       };
     } catch (error) {
+      // Level chosen by code, not blanket `error`. A 5xx-level line is what trips the CloudWatch
+      // filter, so logging a caller condition here would page LiveOps even though the route
+      // answers 4xx - which is the whole fault this change exists to remove.
+      if (error instanceof NotebookExportError && error.statusCode < 500) {
+        this.adapters.logger.warn('Notebook export rejected', { userId, code: error.code });
+        throw error;
+      }
+
       this.adapters.logger.error('Notebook export failed', { userId, error });
 
       if (error instanceof NotebookExportError) {
@@ -213,6 +222,17 @@ export class NotebookExportService {
 
     // Filter by specific notebook IDs
     if (options.notebookIds && options.notebookIds.length > 0) {
+      // Rejected, never dropped: exporting fewer notebooks than were named, silently, is worse.
+      // Unreachable from the API - the request schema rejects first - so this guards the exported
+      // service, which the CLI also calls.
+      const unusable = options.notebookIds.filter(id => !isObjectIdOrHexString(id));
+      if (unusable.length > 0) {
+        throw new NotebookExportError(
+          `notebookIds contains ids that cannot address a notebook: ${unusable.join(', ')}`,
+          'INVALID_NOTEBOOK_ID'
+        );
+      }
+
       query._id = { $in: options.notebookIds };
     }
 

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -251,8 +251,8 @@ export class NotebookExportService {
     }
 
     // Date range filtering. A bare "2026-01-15" parses to that day's midnight, so an inclusive
-    // `$lte` on it would return nothing from the day the caller actually named - the `<input
-    // type="date">` in the export modal sends exactly that form.
+    // `$lte` on it would return nothing from the day the caller actually named. Reached by API
+    // callers, not the modal - that resolves the picked day in the viewer's zone before sending.
     if (options.fromDate || options.toDate) {
       query.lastUpdated = {};
       if (options.fromDate) {

--- a/b4m-core/services/src/notebookExportService/types.ts
+++ b/b4m-core/services/src/notebookExportService/types.ts
@@ -181,9 +181,10 @@ export interface NotebookExportOptions {
   includeImages: boolean; // Embed images as base64
   maxFileSize: number; // Max size for embedded files (bytes)
 
-  // Date range filtering
-  fromDate?: string; // ISO timestamp
-  toDate?: string; // ISO timestamp
+  // Date range filtering. Either a full ISO timestamp or a bare "2026-01-15"; a bare date at
+  // `toDate` covers that whole day, so the two forms are ~24h apart at the top of the range.
+  fromDate?: string;
+  toDate?: string;
 }
 
 // Processing result types

--- a/b4m-core/services/src/notebookExportService/types.ts
+++ b/b4m-core/services/src/notebookExportService/types.ts
@@ -220,7 +220,19 @@ export const CURRENT_EXPORT_VERSION = '1.0.0';
 export const SUPPORTED_IMPORT_VERSIONS = ['1.0.0'];
 
 // Error types
+/**
+ * Status per failure code, following the same rule the HTTP error handler uses: below 500 is the
+ * caller's condition and logs at `warn`, 500 and above is ours and pages. Carried on the error so
+ * the service and the route both read it, rather than each keeping its own copy of the list.
+ */
+const STATUS_BY_CODE = new Map<string, number>([
+  ['NO_NOTEBOOKS', 404],
+  ['INVALID_NOTEBOOK_ID', 400],
+]);
+
 export class NotebookExportError extends Error {
+  public readonly statusCode: number;
+
   constructor(
     message: string,
     public code: string,
@@ -228,6 +240,7 @@ export class NotebookExportError extends Error {
   ) {
     super(message);
     this.name = 'NotebookExportError';
+    this.statusCode = STATUS_BY_CODE.get(code) ?? 500;
   }
 }
 

--- a/docs-site/docs/features/notebook-export-import.md
+++ b/docs-site/docs/features/notebook-export-import.md
@@ -244,6 +244,23 @@ POST /api/notebooks/export
 }
 ```
 
+**Field constraints:**
+
+| Field | Constraint |
+|---|---|
+| `notebookIds` | 24-character hex notebook ids, 1 to 50 entries. **Omit the field to export everything you own**; an empty array is rejected rather than treated as "all". |
+| `fromDate`, `toDate` | Either a full ISO timestamp or a bare `YYYY-MM-DD`. A bare date carries no offset, so it is read as a UTC day, and a bare `toDate` covers that whole day. |
+| `maxFileSize` | Bytes. Files above the limit are referenced by URL instead of embedded. |
+
+**Responses:**
+
+| Status | When |
+|---|---|
+| `200` | Export succeeded. |
+| `400` | The request body was rejected. `errors[]` names the offending field. |
+| `404` | The account owns no notebooks matching the request. |
+| `500` | A genuine server fault. Caller mistakes answer 4xx and never reach here. |
+
 ### Import Endpoint
 ```
 POST /api/notebooks/import

--- a/docs-site/docs/features/notebook-export-import.md
+++ b/docs-site/docs/features/notebook-export-import.md
@@ -230,7 +230,7 @@ POST /api/notebooks/export
 **Request Body:**
 ```json
 {
-  "notebookIds": ["id1", "id2"],
+  "notebookIds": ["507f1f77bcf86cd799439011", "67dbe18a7f9cf1fa5d9686aa"],
   "includeKnowledge": true,
   "includeArtifacts": true,
   "includeTools": true,


### PR DESCRIPTION
Closes #2168

## Description

Three ways this route answered **500** for something that was not a server fault. A 5xx logs at `error`, which is exactly what trips the LiveOps CloudWatch filter, so each of these paged someone for a caller condition.

`POST /api/notebooks/export` accepted any string in `notebookIds` and passed it straight into an `_id` query against ObjectId-keyed `SessionModel`. One entry that is not a 24-character hex id rejected the **whole** query with a `CastError`, which the service wrapped as `EXPORT_FAILED` and the route returned as a **500**.

A 500 is the wrong answer twice over. The body names nothing actionable, so a caller sees an opaque server fault and concludes the export API is broken. And `errorHandler` logs 5xx at `error` specifically because that is what trips the CloudWatch filter — so a caller-side bad id **pages LiveOps**.

The chain, traced end to end:

```
types/api.ts        notebookIds: z.array(z.string())          <- any string passes
  v
notebookExportService/index.ts:216
                    query._id = { $in: options.notebookIds }  <- SessionModel is ObjectId-keyed
  v                 CastError: whole $in rejected
index.ts:207        wrapped as NotebookExportError('EXPORT_FAILED')
  v
pages/api/notebooks/export.ts:120
                    blanket catch -> 500, logged at `error`
```

**Fixed at the schema, not in the service.** That is the trust boundary, the route already turns a `ZodError` into a 400 naming the offending field, and it is the only entry point — `NotebookExportService` has exactly one caller.

**Rejected rather than dropped.** Unlike a stored `knowledgeIds` entry the caller cannot repair, this id lives only in the request body, so the caller can fix it. Silently exporting fewer notebooks than were asked for is the worse failure, and it is the same silent-partial trap #2100 spent four commits removing.

### The empty account

The route caught every error the same way, so `NotebookExportError('NO_NOTEBOOKS')` — thrown when a user simply owns no notebooks — also came back as a 500 that paged. That needed no API key and no hand-built body; an empty account clicking Export was enough.

### Status alone was not enough

Mapping the route to 404 would have shipped a fix that still paged. The service's own catch logged **every** failure at `error` before rethrowing, and that line is what trips the CloudWatch filter — so the page fired regardless of what the route answered afterwards. Caught in review; the first version of this PR had exactly that hole, and its tests could not see it because they asserted on thrown codes and never on log level.

`NotebookExportError` now carries a `statusCode`, and both sides read it: the service logs `warn` below 500, the route answers with it. That mirrors the rule `errorHandler` already applies to `HTTPError` subclasses — down to the comment in that file naming the CloudWatch filter — but it is a parallel mechanism rather than that one, and an earlier draft of this description overstated it as following the existing convention. Routing this endpoint through `errorHandler` instead would swap the response envelope and pull in its blanket `CastError -> 404` remap, and `NotFoundError` carries no machine-readable `code` for a client to branch on, so the parallel is deliberate. A test pins that an unexpected fault still carries 500, still logs at `error`, and still 500s, so the guard cannot quietly widen.

An earlier revision of this PR built a bespoke code→status map in the route plus a hand-synced `CALLER_ERROR_CODES` list in the service. A cleanup pass flagged it as reimplementing `errorHandler`; putting the status on the error deleted both, and the fix commit came out smaller than the version that had the bug.

### Defense in depth, done without dropping

The service rejects a non-hex id too, for a future caller that bypasses the schema. It **throws** rather than dropping: silently exporting fewer notebooks than were named is the worse failure, and the same silent-partial trap #2100 spent four commits removing. The test asserts `sessionRepository.find` was never called — that absence is the proof it rejected rather than quietly proceeding.

## Changes

- `apps/client/types/api.ts` — `notebookIds` entries must be 24-character hex
- `apps/client/types/api.test.ts` — new; 10 cases, verified failing before the fix
- `apps/client/pages/api/notebooks/export.ts` — answer with the status the error carries (`NO_NOTEBOOKS` 404, `INVALID_NOTEBOOK_ID` 400); anything carrying 500 falls through and stays loud
- `b4m-core/services/src/notebookExportService/types.ts` — `NotebookExportError` carries its own `statusCode`, so status and log level are derived in one place rather than two
- `.../notebookExportService/index.ts` — log a caller condition at `warn`, so the 5xx-level line that pages is never written for one
- `NotebookExportModal.tsx` — read the server's message and its per-field `errors[]`; resolve a picked date in the viewer's own zone; keep the size box clearable
- `NotebookExportModal.test.tsx` — new; 5 cases covering the date, size and toast paths against the real request schema
- `b4m-core/services/src/notebookExportService/index.ts` — reject an unusable id at the query, never drop it, using mongoose's `isObjectIdOrHexString` rather than another local regex
- `.../index.test.ts` — 22 cases, each asserting code and status together; mutation-checked (forcing every status to 500 fails exactly the two status tests, and no others)

## Verified on the preview

A temporary instrumentation commit — four `[EXPORT-PROBE]` log lines and seven Playwright scenarios — was used to verify this on `pr2316` and has since been reverted, so what remains is the fix alone.

**7/7 scenarios passed**, two of them driving a real browser:

| | | |
|---|---|---|
| E1 | malformed id → 400 naming the field | HTTP |
| E2 | `optimistic-session-<uuid>` → 400 | HTTP |
| E3 | one bad id among good → 400, nothing exported | HTTP |
| E4 | valid id → 200 | HTTP |
| E5 | ordinary Export All still works | **browser** |
| E6 | empty account → 404 `NO_NOTEBOOKS` | HTTP |
| E7 | empty account clicks Export, sees "No notebooks found to export" | **browser** |

E7 is the one a real user can reach: no API key, no hand-built body, just an account with nothing in it pressing the button. It asserts both the 404 and the toast text, which is what the modal change exists for.

The probes corroborated *why* each passed. The decisive one was an absence: E1, E2 and E3 produced **no** `requested` and **no** `reached` line, so no unusable id ever got near Mongo — something a status code alone cannot show. The two `reached` lines that did appear carried only a valid ObjectId or `null`.

## Who could reach this

**Not the UI.** `NotebookExportModal` has no `notebookIds` field — it always exports everything the caller owns. Confirmed: the only other `notebookIds` in `apps/client/app` belongs to an unrelated search type.

**Any API key can.** The route is `baseApi()` with no `requiredScopes`, and a hand-built body is exactly where a stale or synthesized id comes from.

**The next feature will.** `generateFileName` already branches on `notebookIds.length === 1`, so per-notebook export was anticipated. `createOptimisticSessionId()` mints `optimistic-session-<uuid>` and a notebook carries one until the server id lands — the app already gates on `isOptimisticId` in `hooks/data/sessions.ts` and `hooks/data/fabFiles.ts`, the latter commented "so new callers can't re-introduce the 400".

## Relationship to #2100

Independent, and deliberately based on `main` rather than on that branch. The fix commit shares **no files** with #2100's 29. The one file both touch, `notebookExportService/index.ts`, overlaps only in this PR's throwaway commit, and in a different function: #2100 renames `usableObjectIds` in the per-session attachment reads, this touches `getSessionsToExport`. That is what the issue predicted, now verified in the diff.

## Guide for Testers

The malformed-id and empty-account paths cannot be reached by clicking. Steps 1-4 need an API client; step 5 is the browser regression check.

1. Get a bearer token for any account that owns at least one notebook.
2. `POST /api/notebooks/export` with body `{ "notebookIds": ["not-an-objectid"] }`.
   Expected: **400**, body `success: false`, and `errors` naming `notebookIds`. Before this change: 500 `"Export failed. Please try again later."`
3. `POST /api/notebooks/export` with body `{ "notebookIds": ["<a real 24-hex notebook id you own>"] }`.
   Expected: **200**, `data.notebookCount` is 1.
4. Sign in as an account that owns **no** notebooks and `POST /api/notebooks/export` with an empty body `{}`.
   Expected: **404**, message `No notebooks found to export`. Before this change: 500, and a LiveOps page.
5. In the browser, open Profile -> Settings -> **Export All**, then **Export Notebooks**.
   Expected: the export completes exactly as before. This is the regression check — the modal sends no `notebookIds`, so the field must stay optional.

### Regression Checks

- Export All from the modal still succeeds (step 5).
- A request with no `notebookIds` at all still exports everything.
- An uppercase-hex id is still accepted; Mongo resolves hex in either case.

### What NOT to test

Nothing in the export payload, file generation, or download URL changes. A successful export is byte-for-byte what it was; only the status and log level of *failures* differ.

## Additional Information

**Scope grew during review, on purpose.** This started as the malformed-id fix alone. Two adjacent faults were found while tracing it — the empty-account 500 and the unguarded service query — and both are the same defect class in the same route: a caller condition answered as a server fault. Fixing one and filing the others would have left the route still paging LiveOps for an empty account, which is the more reachable of the three.

**Still deferred:** `errorHandler`'s blanket `CastError -> 404` remap from #2067. Untouched here; it changes the status code and log level of every endpoint and needs its own blast-radius review.

**Found in review: `notebookIds: []` exported everything.** Raised on the first review pass and confirmed at the query boundary rather than from a response count, since `notebookCount: 2` on a two-notebook account is consistent with either explanation:

```
notebookIds omitted  -> {"userId":"user-1"}
notebookIds: []      -> {"userId":"user-1"}
notebookIds: [hex]   -> {"userId":"user-1","_id":{"$in":["507f..."]}}
```

`getSessionsToExport` adds the `_id` filter only when the array is non-empty, so an empty one issues the same bare query as omitting the field: a caller naming zero notebooks received an archive of every notebook they own. That is this PR's own argument inverted — not fewer notebooks than were asked for, but all of them when none were — and it is the reachable form of the multi-select case the description predicts. `.min(1)` closes it; omitting the field is still how a caller asks for everything, which is what the modal does. `.max(50)` mirrors `NotebookCurateRequestSchema`.

**Also from review:** the route's status mapping had no test, so `export.ts` now has one (8 cases, mutation-checked against the `statusCode < 500` guard); a caller rejection logged twice, once in the service and again in the route, so the route's duplicate is gone; and a comment — plus the first commit's message — claimed a CLI caller of `NotebookExportService` that does not exist. The route is its only caller repo-wide. The commit message was corrected in place, so the false claim does not reach `main` on squash.

**Found while answering that review: every date the modal could pick was rejected.** The Date Range inputs are `<input type="date">`, which emits `"2026-01-15"`; the schema wanted a full ISO timestamp. Driving the real modal:

```
fromDate on the wire -> "2026-01-15"
what the user sees   -> "Invalid request body"
server verdict       -> fromDate: Invalid ISO datetime
```

Entirely pre-existing — both the inputs and `z.iso.datetime()` predate this PR — but it is the same defect class, and I had claimed in review that this path was unreachable from the UI. That claim was wrong, checked only against the modal's untouched default state.

A bare date carries no offset, so whoever resolves it chooses the zone. The modal now resolves the picked day in the browser, where the viewer's zone is the one that applies. Resolving it against UTC instead would have swapped a visible 400 for a silent wrong answer:

```
toDate "2026-01-15" anchored to UTC -> $lte 2026-01-15T23:59:59.999Z
  seen from America/Los_Angeles        2026-01-15, 15:59   <- loses 8h of the chosen day
  seen from Pacific/Auckland           2026-01-16, 12:59   <- gains 13h nobody asked for
```

The schema still accepts a bare date for API callers, whose value the service reads as a UTC day. Two smaller faults on the same path: the size box could not be cleared (controlled off `maxFileSize`, so an `onChange` that skipped `setState` let React restore the old text), and the toast ignored the per-field `errors[]` the route already returns.

**Two logging gaps, both introduced by this PR and both measured before fixing.** The service's `warn` carried `{ userId, code, status }` while the offending ids sat in the message, and the route had stopped logging on the strength of that line — so `ids present in any log -> false`. Separately, a schema rejection returned 400 without reaching the service and wrote nothing at all (`logger.warn 0, logger.error 0, logger.info 0`), leaving the exact fault this route exists to answer invisible. Both now log once, at `warn`, with the ids.

## Checks

Services suite 22/22, schema 10/10, route 8/8, modal 5/5 — every fix mutation-checked by reverting it and confirming its own test fails. `apps/client` node suite passing. Services, client and e2e typechecks clean; lint clean outside an unrelated premium overlay package.



