### PR TITLE
feat(data-lake): report duplicate members on the lake health surface

### DIFF
--- a/apps/client/app/components/datalake/LakeHealthBadge.test.tsx
+++ b/apps/client/app/components/datalake/LakeHealthBadge.test.tsx
@@ -89,6 +89,7 @@ const health = (over?: Record<string, unknown>) => ({
   affectedMembers: [],
   affectedMemberCount: 0,
   scanTruncated: false,
+  duplicateMembers: { memberCount: 0, groupCount: 0, groups: [] },
   ...over,
 });
 

--- a/apps/client/app/components/datalake/LakeHealthBadge.tsx
+++ b/apps/client/app/components/datalake/LakeHealthBadge.tsx
@@ -95,7 +95,7 @@ function badgeLabel(level: BadgeLevel, health: LakeHealthApiResponse): string {
 const DRILLDOWN_ROWS = 8;
 
 function HealthTooltip({ health, failedFileCount = 0 }: { health: LakeHealthApiResponse; failedFileCount?: number }) {
-  const { predicates, coverage, affectedMembers, affectedMemberCount } = health;
+  const { predicates, coverage, affectedMembers, affectedMemberCount, duplicateMembers } = health;
   const measuredGap = coverage.membersWithChunks - coverage.measuredMembers;
   const anyMemberFails =
     predicates.chunkWithinPolicy.fail > 0 ||
@@ -125,6 +125,12 @@ function HealthTooltip({ health, failedFileCount = 0 }: { health: LakeHealthApiR
       {health.scanTruncated && (
         <Typography level="body-xs" sx={{ mt: 0.25, color: 'warning.400' }}>
           Large lake: figures cover the first {coverage.membersWithChunks} files.
+        </Typography>
+      )}
+      {duplicateMembers.memberCount > 0 && (
+        <Typography level="body-xs" sx={{ mt: 0.25, color: 'warning.400' }}>
+          {duplicateMembers.memberCount} file(s) share a name with a sibling ({duplicateMembers.groupCount} name
+          {duplicateMembers.groupCount === 1 ? '' : 's'}) - possibly duplicate upload generations.
         </Typography>
       )}
       <Divider sx={{ my: 0.5 }} />

--- a/apps/client/pages/api/data-lakes/[id]/health.ts
+++ b/apps/client/pages/api/data-lakes/[id]/health.ts
@@ -16,6 +16,8 @@ import { toAccessContext } from '@server/dataLakes/toAccessContext';
  *
  * Returns the four retrievability predicates and the reachable-content headline as RAW per-predicate
  * results; the UI derives the badge, so this contract stays stable when the presentation changes.
+ * Also returns `duplicateMembers` (#2239): members sharing an exact fileName with a sibling in this
+ * lake, report-only - no repair/removal action exists here yet.
  * Health is advisory and never blocks anything.
  *
  * Same read gate as GET /api/data-lakes/:id (owner/org/tag/public), with the not-found-style denial

--- a/b4m-core/common/src/constants/lakeHealth.test.ts
+++ b/b4m-core/common/src/constants/lakeHealth.test.ts
@@ -4,6 +4,7 @@ import {
   resolveLakeHealthPolicy,
   evaluateMemberHealth,
   summarizeLakeHealth,
+  findDuplicateMembers,
   type LakeHealthMemberInput,
 } from './lakeHealth';
 import { isMemberIndexingInFlight } from './lakeConvergence';
@@ -663,4 +664,68 @@ describe('lake health and convergence agree on what "still indexing" means', () 
       expect(evaluateMemberHealth(m, DEFAULT_POLICY).status.fullyVectorized === 'unknown').toBe(inFlight);
     });
   }
+});
+
+describe('findDuplicateMembers', () => {
+  it('reports no groups when every fileName is unique', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'one.txt', fileSize: 10 },
+      { fabFileId: 'b', fileName: 'two.txt', fileSize: 20 },
+    ]);
+    expect(result).toEqual({ memberCount: 0, groups: [] });
+  });
+
+  it('groups members sharing an exact fileName and counts every member in the group', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'report.pdf', fileSize: 100 },
+      { fabFileId: 'b', fileName: 'report.pdf', fileSize: 100 },
+      { fabFileId: 'c', fileName: 'unique.txt', fileSize: 5 },
+    ]);
+    expect(result.memberCount).toBe(2);
+    expect(result.groups).toEqual([
+      {
+        fileName: 'report.pdf',
+        members: [
+          { fabFileId: 'a', fileName: 'report.pdf', fileSize: 100 },
+          { fabFileId: 'b', fileName: 'report.pdf', fileSize: 100 },
+        ],
+        confirmedDiffering: false,
+      },
+    ]);
+  });
+
+  it('flags confirmedDiffering only when two measured sizes actually disagree', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'policy.md', fileSize: 100 },
+      { fabFileId: 'b', fileName: 'policy.md', fileSize: 250 },
+    ]);
+    expect(result.groups[0].confirmedDiffering).toBe(true);
+  });
+
+  it('does not treat an unmeasured (null) size as a confirmed difference', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'policy.md', fileSize: null },
+      { fabFileId: 'b', fileName: 'policy.md', fileSize: 100 },
+    ]);
+    expect(result.groups[0].confirmedDiffering).toBe(false);
+  });
+
+  it('ignores members with no fileName', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: undefined, fileSize: 1 },
+      { fabFileId: 'b', fileName: undefined, fileSize: 2 },
+    ]);
+    expect(result).toEqual({ memberCount: 0, groups: [] });
+  });
+
+  it('sorts groups largest first', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'pair.txt', fileSize: 1 },
+      { fabFileId: 'b', fileName: 'pair.txt', fileSize: 1 },
+      { fabFileId: 'c', fileName: 'triple.txt', fileSize: 1 },
+      { fabFileId: 'd', fileName: 'triple.txt', fileSize: 1 },
+      { fabFileId: 'e', fileName: 'triple.txt', fileSize: 1 },
+    ]);
+    expect(result.groups.map(g => g.fileName)).toEqual(['triple.txt', 'pair.txt']);
+  });
 });

--- a/b4m-core/common/src/constants/lakeHealth.test.ts
+++ b/b4m-core/common/src/constants/lakeHealth.test.ts
@@ -672,34 +672,60 @@ describe('findDuplicateMembers', () => {
       { fabFileId: 'a', fileName: 'one.txt', fileSize: 10 },
       { fabFileId: 'b', fileName: 'two.txt', fileSize: 20 },
     ]);
-    expect(result).toEqual({ memberCount: 0, groups: [] });
+    expect(result).toEqual({ memberCount: 0, groupCount: 0, groups: [] });
   });
 
-  it('groups members sharing an exact fileName and counts every member in the group', () => {
+  it('groups members sharing an exact fileName, counts every member, and drops the per-member fileName', () => {
     const result = findDuplicateMembers([
       { fabFileId: 'a', fileName: 'report.pdf', fileSize: 100 },
       { fabFileId: 'b', fileName: 'report.pdf', fileSize: 100 },
       { fabFileId: 'c', fileName: 'unique.txt', fileSize: 5 },
     ]);
     expect(result.memberCount).toBe(2);
+    expect(result.groupCount).toBe(1);
     expect(result.groups).toEqual([
       {
         fileName: 'report.pdf',
         members: [
-          { fabFileId: 'a', fileName: 'report.pdf', fileSize: 100 },
-          { fabFileId: 'b', fileName: 'report.pdf', fileSize: 100 },
+          { fabFileId: 'a', fileSize: 100 },
+          { fabFileId: 'b', fileSize: 100 },
         ],
-        confirmedDiffering: false,
+        memberCount: 2,
+        contentComparison: 'unprovable',
       },
     ]);
   });
 
-  it('flags confirmedDiffering only when two measured sizes actually disagree', () => {
+  it('reports "differing" when two measured sizes actually disagree', () => {
     const result = findDuplicateMembers([
       { fabFileId: 'a', fileName: 'policy.md', fileSize: 100 },
       { fabFileId: 'b', fileName: 'policy.md', fileSize: 250 },
     ]);
-    expect(result.groups[0].confirmedDiffering).toBe(true);
+    expect(result.groups[0].contentComparison).toBe('differing');
+  });
+
+  it('reports "differing" when hashes disagree even at equal size', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'policy.md', fileSize: 100, serverTextHash: 'hash-a' },
+      { fabFileId: 'b', fileName: 'policy.md', fileSize: 100, serverTextHash: 'hash-b' },
+    ]);
+    expect(result.groups[0].contentComparison).toBe('differing');
+  });
+
+  it('reports "identical" only when every member carries a matching hash', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'policy.md', fileSize: 100, serverTextHash: 'hash-a' },
+      { fabFileId: 'b', fileName: 'policy.md', fileSize: 100, serverTextHash: 'hash-a' },
+    ]);
+    expect(result.groups[0].contentComparison).toBe('identical');
+  });
+
+  it('does not report "identical" when only some members carry the matching hash', () => {
+    const result = findDuplicateMembers([
+      { fabFileId: 'a', fileName: 'policy.md', fileSize: 100, serverTextHash: 'hash-a' },
+      { fabFileId: 'b', fileName: 'policy.md', fileSize: 100, serverTextHash: null },
+    ]);
+    expect(result.groups[0].contentComparison).toBe('unprovable');
   });
 
   it('does not treat an unmeasured (null) size as a confirmed difference', () => {
@@ -707,7 +733,7 @@ describe('findDuplicateMembers', () => {
       { fabFileId: 'a', fileName: 'policy.md', fileSize: null },
       { fabFileId: 'b', fileName: 'policy.md', fileSize: 100 },
     ]);
-    expect(result.groups[0].confirmedDiffering).toBe(false);
+    expect(result.groups[0].contentComparison).toBe('unprovable');
   });
 
   it('ignores members with no fileName', () => {
@@ -715,7 +741,7 @@ describe('findDuplicateMembers', () => {
       { fabFileId: 'a', fileName: undefined, fileSize: 1 },
       { fabFileId: 'b', fileName: undefined, fileSize: 2 },
     ]);
-    expect(result).toEqual({ memberCount: 0, groups: [] });
+    expect(result).toEqual({ memberCount: 0, groupCount: 0, groups: [] });
   });
 
   it('sorts groups largest first', () => {

--- a/b4m-core/common/src/constants/lakeHealth.ts
+++ b/b4m-core/common/src/constants/lakeHealth.ts
@@ -94,6 +94,12 @@ export type LakeHealthMemberInput = {
   fileName?: string;
   /** Byte size (`FabFile.fileSize`); `null` until measured. Feeds `findDuplicateMembers` only. */
   fileSize?: number | null;
+  /**
+   * Server-verified SHA-256 over normalized extracted text (`FabFile.serverTextHash`), stamped at
+   * chunk time; `null` until measured. Feeds `findDuplicateMembers` only: unlike `fileSize`, a hash
+   * match is PROOF of identity, not just evidence, so it is the stronger of the two discriminators.
+   */
+  serverTextHash?: string | null;
   /** Chunks created for the file (`FabFile.chunkCount`). */
   chunkCount: number;
   /**
@@ -332,19 +338,32 @@ export type LakeHealthReport = {
  * signal is the P3 `fail` tally and the drill-down row, which is what `deriveLakeHealthBadge` reads
  * to drop the lake off `healthy` regardless of the percentage beside it.
  */
-export function summarizeLakeHealth(members: LakeHealthMemberInput[], policy: LakeHealthPolicy): LakeHealthReport {
-  // The CHUNK arm only, matching `findDataLakeHealthMembers`'s own `$match` and
-  // `partitionByIndexAvailability`: the vectorize arm of the switch leaves chunks in place, so it is
-  // already admitted by `chunkCount > 0` and needs no exception here.
-  //
-  // The pending-rebuild stamp (#1939) is admitted for the same reason as the marker and with the
-  // opposite grade: chunkless because a wave took its passages, but expected back, so it lands in
-  // `coverage` as an unmeasured member rather than in the ratio. Coverage below 1 is the honest
-  // report while a rebuild is running - and it is also what keeps a rebuild that was never enqueued
-  // visible instead of silently reducing the lake to the members it still has.
-  const withChunks = members.filter(
+/**
+ * The members `summarizeLakeHealth` grades: chunked, or chunkless via one of the two markers that
+ * mean "expected back", not "never had any". Exported so a sibling report over the same scan - e.g.
+ * `findDuplicateMembers` in `computeLakeHealth` - agrees by construction about which members are "in"
+ * the lake, rather than by a comment promising the two filters stay in sync.
+ *
+ * The CHUNK arm only, matching `findDataLakeHealthMembers`'s own `$match` and
+ * `partitionByIndexAvailability`: the vectorize arm of the switch leaves chunks in place, so it is
+ * already admitted by `chunkCount > 0` and needs no exception here.
+ *
+ * The pending-rebuild stamp (#1939) is admitted for the same reason as the marker and with the
+ * opposite grade: chunkless because a wave took its passages, but expected back, so it lands in
+ * `coverage` as an unmeasured member rather than in the ratio. Coverage below 1 is the honest
+ * report while a rebuild is running - and it is also what keeps a rebuild that was never enqueued
+ * visible instead of silently reducing the lake to the members it still has.
+ */
+export function selectLakeHealthMembers<
+  T extends Pick<LakeHealthMemberInput, 'chunkCount' | 'chunkStallReason' | 'chunkRebuildRequestedAt'>,
+>(members: T[]): T[] {
+  return members.filter(
     m => m.chunkCount > 0 || m.chunkStallReason === 'rechunkPaused' || isChunkRebuildPending(m.chunkRebuildRequestedAt)
   );
+}
+
+export function summarizeLakeHealth(members: LakeHealthMemberInput[], policy: LakeHealthPolicy): LakeHealthReport {
+  const withChunks = selectLakeHealthMembers(members);
   const results = withChunks.map(m => evaluateMemberHealth(m, policy));
 
   const predicates = {
@@ -384,10 +403,9 @@ export function summarizeLakeHealth(members: LakeHealthMemberInput[], policy: La
   };
 }
 
-/** One member of a duplicate-fileName group (#2239). */
+/** One member of a duplicate-fileName group (#2239). `fileName` lives on the group, not repeated here. */
 export type LakeHealthDuplicateMember = {
   fabFileId: string;
-  fileName: string;
   fileSize: number | null;
 };
 
@@ -402,20 +420,30 @@ export type LakeHealthDuplicateMember = {
  */
 export type LakeHealthDuplicateGroup = {
   fileName: string;
+  /** Members of this group, possibly truncated for payload size - see `memberCount` for the exact total. */
   members: LakeHealthDuplicateMember[];
+  /** Exact member count for this group, even when `members` above is truncated. */
+  memberCount: number;
   /**
-   * True when at least two members of this group carry different, both-measured `fileSize` values -
-   * PROOF the content differs, not just a repeat upload of identical bytes. Equal size is evidence of
-   * identity but never proof (a same-length substitution, e.g. a changed digit, preserves byte length
-   * exactly) - so `false` here must be read as "not confirmed to differ", never as "confirmed identical".
+   * What the group's `fileSize`/`serverTextHash` values can prove about content, computed over the
+   * FULL group before any truncation of `members`:
+   *  - `differing` - two both-measured `fileSize` values disagree, or two `serverTextHash` values do:
+   *    PROOF the content differs, reached either way a same-name pair can diverge.
+   *  - `identical` - every member carries a `serverTextHash` and they all match: PROOF of identity
+   *    (#2245 bucket A), the thing `fileSize` alone can never give.
+   *  - `unprovable` - neither proof applies: sizes are equal-or-unmeasured and hashes are missing on
+   *    at least one member, so equal size is evidence of identity but never proof (a same-length
+   *    substitution, e.g. a changed digit, preserves byte length exactly).
    */
-  confirmedDiffering: boolean;
+  contentComparison: 'differing' | 'identical' | 'unprovable';
 };
 
 export type LakeHealthDuplicatesReport = {
-  /** Total members that share a fileName with at least one sibling in this lake. */
+  /** Total members across every duplicate-name group in the lake - exact, even when `groups` is capped. */
   memberCount: number;
-  /** Duplicate-name groups, largest group first. */
+  /** Total duplicate-name groups in the lake - exact, even when `groups` is capped. */
+  groupCount: number;
+  /** Duplicate-name groups, largest group first, possibly capped for payload size - see `groupCount`. */
   groups: LakeHealthDuplicateGroup[];
 };
 
@@ -423,17 +451,23 @@ export type LakeHealthDuplicatesReport = {
  * Group a lake's members by exact fileName and report every group with more than one member
  * (#2239). Pure and report-only: it names what a bulk repair action would later act on, but takes
  * none - no gate and no executor exist yet for a cross-member delete/supersede (#2245's job).
+ *
+ * Deliberately UNCAPPED here - a caller reporting this over the network (`computeLakeHealth`) is
+ * responsible for capping `groups`/`members` for payload size, same as `affectedMembers`. Capping in
+ * THIS function would risk computing `contentComparison` over a truncated group, understating a
+ * confirmed difference; the caller's cap must be applied only after this returns.
  */
 export function findDuplicateMembers(
-  members: Array<Pick<LakeHealthMemberInput, 'fabFileId' | 'fileName' | 'fileSize'>>
+  members: Array<Pick<LakeHealthMemberInput, 'fabFileId' | 'fileName' | 'fileSize' | 'serverTextHash'>>
 ): LakeHealthDuplicatesReport {
-  const byName = new Map<string, LakeHealthDuplicateMember[]>();
+  type Row = { fabFileId: string; fileSize: number | null; serverTextHash: string | null };
+  const byName = new Map<string, Row[]>();
   for (const m of members) {
     if (!m.fileName) continue;
-    const entry: LakeHealthDuplicateMember = {
+    const entry: Row = {
       fabFileId: m.fabFileId,
-      fileName: m.fileName,
       fileSize: nonNegOrNull(m.fileSize),
+      serverTextHash: m.serverTextHash && m.serverTextHash.length > 0 ? m.serverTextHash : null,
     };
     const group = byName.get(m.fileName);
     if (group) group.push(entry);
@@ -445,13 +479,29 @@ export function findDuplicateMembers(
   for (const [fileName, groupMembers] of byName) {
     if (groupMembers.length < 2) continue;
     memberCount += groupMembers.length;
-    const distinctSizes = new Set(groupMembers.map(m => m.fileSize).filter((s): s is number => s !== null));
-    groups.push({ fileName, members: groupMembers, confirmedDiffering: distinctSizes.size > 1 });
+    groups.push({
+      fileName,
+      members: groupMembers.map(m => ({ fabFileId: m.fabFileId, fileSize: m.fileSize })),
+      memberCount: groupMembers.length,
+      contentComparison: compareGroupContent(groupMembers),
+    });
   }
   // Largest group first, so the drill-down leads with the lake's biggest accumulation.
-  groups.sort((a, b) => b.members.length - a.members.length);
+  groups.sort((a, b) => b.memberCount - a.memberCount);
 
-  return { memberCount, groups };
+  return { memberCount, groupCount: groups.length, groups };
+}
+
+function compareGroupContent(
+  members: Array<{ fileSize: number | null; serverTextHash: string | null }>
+): LakeHealthDuplicateGroup['contentComparison'] {
+  const sizes = members.map(m => m.fileSize).filter((s): s is number => s !== null);
+  const hashes = members.map(m => m.serverTextHash).filter((h): h is string => h !== null);
+  const distinctSizes = new Set(sizes);
+  const distinctHashes = new Set(hashes);
+  if (distinctSizes.size > 1 || distinctHashes.size > 1) return 'differing';
+  if (distinctHashes.size === 1 && hashes.length === members.length) return 'identical';
+  return 'unprovable';
 }
 
 /**
@@ -466,7 +516,11 @@ export type LakeHealthApiResponse = Omit<LakeHealthReport, 'affectedMembers'> & 
   affectedMemberCount: number;
   /** True when the lake exceeded the member scan bound, so every ratio here is partial. */
   scanTruncated: boolean;
-  /** Duplicate-fileName members (#2239). Report-only - see `findDuplicateMembers`. */
+  /**
+   * Duplicate-fileName members (#2239). Report-only - see `findDuplicateMembers`. `groups` (and each
+   * group's `members`) are capped for payload size by the caller; `memberCount`/`groupCount` on the
+   * report and `memberCount` on each group stay exact.
+   */
   duplicateMembers: LakeHealthDuplicatesReport;
 };
 

--- a/b4m-core/common/src/constants/lakeHealth.ts
+++ b/b4m-core/common/src/constants/lakeHealth.ts
@@ -92,6 +92,8 @@ export function resolveLakeHealthPolicy(opts: {
 export type LakeHealthMemberInput = {
   fabFileId: string;
   fileName?: string;
+  /** Byte size (`FabFile.fileSize`); `null` until measured. Feeds `findDuplicateMembers` only. */
+  fileSize?: number | null;
   /** Chunks created for the file (`FabFile.chunkCount`). */
   chunkCount: number;
   /**
@@ -382,6 +384,76 @@ export function summarizeLakeHealth(members: LakeHealthMemberInput[], policy: La
   };
 }
 
+/** One member of a duplicate-fileName group (#2239). */
+export type LakeHealthDuplicateMember = {
+  fabFileId: string;
+  fileName: string;
+  fileSize: number | null;
+};
+
+/**
+ * >= 2 live members sharing one exact `fileName` within a lake. This is a same-NAME check, not the
+ * identity-key derivation the admission checkpoint uses (#2238, itself blocked on #2235) - neither
+ * has landed, and this surface does not depend on either. A shared fileName is exactly the
+ * population that check would miss anyway: deliberate retention of a superseded document is normally
+ * expressed through naming (`policy-v2.md` beside `policy-v3.md`), which yields a different name and
+ * never groups here - so a same-name repeat is strong evidence of an accumulated upload generation,
+ * not a deliberate kept-both decision.
+ */
+export type LakeHealthDuplicateGroup = {
+  fileName: string;
+  members: LakeHealthDuplicateMember[];
+  /**
+   * True when at least two members of this group carry different, both-measured `fileSize` values -
+   * PROOF the content differs, not just a repeat upload of identical bytes. Equal size is evidence of
+   * identity but never proof (a same-length substitution, e.g. a changed digit, preserves byte length
+   * exactly) - so `false` here must be read as "not confirmed to differ", never as "confirmed identical".
+   */
+  confirmedDiffering: boolean;
+};
+
+export type LakeHealthDuplicatesReport = {
+  /** Total members that share a fileName with at least one sibling in this lake. */
+  memberCount: number;
+  /** Duplicate-name groups, largest group first. */
+  groups: LakeHealthDuplicateGroup[];
+};
+
+/**
+ * Group a lake's members by exact fileName and report every group with more than one member
+ * (#2239). Pure and report-only: it names what a bulk repair action would later act on, but takes
+ * none - no gate and no executor exist yet for a cross-member delete/supersede (#2245's job).
+ */
+export function findDuplicateMembers(
+  members: Array<Pick<LakeHealthMemberInput, 'fabFileId' | 'fileName' | 'fileSize'>>
+): LakeHealthDuplicatesReport {
+  const byName = new Map<string, LakeHealthDuplicateMember[]>();
+  for (const m of members) {
+    if (!m.fileName) continue;
+    const entry: LakeHealthDuplicateMember = {
+      fabFileId: m.fabFileId,
+      fileName: m.fileName,
+      fileSize: nonNegOrNull(m.fileSize),
+    };
+    const group = byName.get(m.fileName);
+    if (group) group.push(entry);
+    else byName.set(m.fileName, [entry]);
+  }
+
+  const groups: LakeHealthDuplicateGroup[] = [];
+  let memberCount = 0;
+  for (const [fileName, groupMembers] of byName) {
+    if (groupMembers.length < 2) continue;
+    memberCount += groupMembers.length;
+    const distinctSizes = new Set(groupMembers.map(m => m.fileSize).filter((s): s is number => s !== null));
+    groups.push({ fileName, members: groupMembers, confirmedDiffering: distinctSizes.size > 1 });
+  }
+  // Largest group first, so the drill-down leads with the lake's biggest accumulation.
+  groups.sort((a, b) => b.members.length - a.members.length);
+
+  return { memberCount, groups };
+}
+
 /**
  * The shape GET /api/data-lakes/:id/health returns - the report with its drill-down list capped and
  * an exact count beside it, plus a scan-bound flag. Defined here so the handler, the service and the
@@ -394,6 +466,8 @@ export type LakeHealthApiResponse = Omit<LakeHealthReport, 'affectedMembers'> & 
   affectedMemberCount: number;
   /** True when the lake exceeded the member scan bound, so every ratio here is partial. */
   scanTruncated: boolean;
+  /** Duplicate-fileName members (#2239). Report-only - see `findDuplicateMembers`. */
+  duplicateMembers: LakeHealthDuplicatesReport;
 };
 
 function emptyTally(): PredicateTally {

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -1049,6 +1049,10 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
       // confirmed to differ in content (a same-length substitution can still hide behind equal
       // size, so equality is evidence, not proof).
       fileSize: number | null;
+      // Server-verified content hash, for the same check: a same-fileName pair with matching hashes
+      // is confirmed IDENTICAL, and with differing hashes is confirmed to differ - proof `fileSize`
+      // alone cannot offer either direction of.
+      serverTextHash: string | null;
       chunkCount: number;
       // vectorizedChunkCount + error drive the in-flight vs settled decision in the pure evaluator;
       // omitting them here would silently disable that gate (rows arrive without them -> treated as

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -1045,6 +1045,10 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
     Array<{
       fabFileId: string;
       fileName?: string;
+      // Byte size, for the duplicate-members check: a same-fileName pair with differing size is
+      // confirmed to differ in content (a same-length substitution can still hide behind equal
+      // size, so equality is evidence, not proof).
+      fileSize: number | null;
       chunkCount: number;
       // vectorizedChunkCount + error drive the in-flight vs settled decision in the pure evaluator;
       // omitting them here would silently disable that gate (rows arrive without them -> treated as

--- a/b4m-core/services/src/dataLakeService/computeLakeHealth.test.ts
+++ b/b4m-core/services/src/dataLakeService/computeLakeHealth.test.ts
@@ -17,6 +17,7 @@ import { computeLakeHealth } from './computeLakeHealth';
 type Member = {
   fabFileId: string;
   fileName?: string;
+  fileSize?: number | null;
   chunkCount: number;
   vectorizedChunkCount: number | null;
   error: string | null;
@@ -184,5 +185,29 @@ describe('computeLakeHealth', () => {
     expect(health.coverage).toEqual({ measuredMembers: 1, membersWithChunks: 1 });
     expect(health.predicates.fullyVectorized.fail).toBe(1);
     expect(health.affectedMembers[0].failed).toContain('fullyVectorized');
+  });
+
+  it('reports duplicateMembers for two upload generations sharing a fileName (#2239)', async () => {
+    const older: Member = { ...healthyMember('gen1'), fileName: 'contract.pdf', fileSize: 1000 };
+    const newer: Member = { ...healthyMember('gen2'), fileName: 'contract.pdf', fileSize: 1200 };
+    const unique: Member = { ...healthyMember('solo'), fileName: 'solo.txt', fileSize: 5 };
+    const health = await computeLakeHealth(lake, makeAdapters([older, newer, unique]) as never);
+
+    expect(health.duplicateMembers.memberCount).toBe(2);
+    expect(health.duplicateMembers.groups).toEqual([
+      {
+        fileName: 'contract.pdf',
+        members: [
+          { fabFileId: 'gen1', fileName: 'contract.pdf', fileSize: 1000 },
+          { fabFileId: 'gen2', fileName: 'contract.pdf', fileSize: 1200 },
+        ],
+        confirmedDiffering: true,
+      },
+    ]);
+  });
+
+  it('reports an empty duplicateMembers report when no fileName repeats', async () => {
+    const health = await computeLakeHealth(lake, makeAdapters([healthyMember('a'), healthyMember('b')]) as never);
+    expect(health.duplicateMembers).toEqual({ memberCount: 0, groups: [] });
   });
 });

--- a/b4m-core/services/src/dataLakeService/computeLakeHealth.test.ts
+++ b/b4m-core/services/src/dataLakeService/computeLakeHealth.test.ts
@@ -12,12 +12,14 @@ vi.mock('../settings/resolveScopedSetting', async orig => ({
 
 import { computeLakeHealth } from './computeLakeHealth';
 
-// Mirrors IFabFileRepository.findDataLakeHealthMembers' row shape EXACTLY (incl. vectorizedChunkCount
-// + error) - if this drifts from the interface, the in-flight/errored gate silently no-ops in tests.
+// Mirrors IFabFileRepository.findDataLakeHealthMembers' row shape EXACTLY (incl. vectorizedChunkCount,
+// error, fileSize, serverTextHash) - if this drifts from the interface, the in-flight/errored gate or
+// the duplicate-report fields silently no-op in tests.
 type Member = {
   fabFileId: string;
   fileName?: string;
-  fileSize?: number | null;
+  fileSize: number | null;
+  serverTextHash: string | null;
   chunkCount: number;
   vectorizedChunkCount: number | null;
   error: string | null;
@@ -29,6 +31,8 @@ type Member = {
 
 const healthyMember = (id: string): Member => ({
   fabFileId: id,
+  fileSize: null,
+  serverTextHash: null,
   chunkCount: 3,
   vectorizedChunkCount: 3, // settled, fully vectorized
   error: null,
@@ -39,6 +43,8 @@ const healthyMember = (id: string): Member => ({
 });
 const brokenMember = (id: string): Member => ({
   fabFileId: id,
+  fileSize: null,
+  serverTextHash: null,
   chunkCount: 1,
   vectorizedChunkCount: 1, // oversized chunk reaches terminal -> settled, so P3 genuinely fails
   error: null,
@@ -126,6 +132,8 @@ describe('computeLakeHealth', () => {
   it('reports null reachableShare (not 0%) when the lake is entirely unmeasured', async () => {
     const unmeasured: Member = {
       fabFileId: 'legacy',
+      fileSize: null,
+      serverTextHash: null,
       chunkCount: 5,
       vectorizedChunkCount: 5, // legacy: fully vectorized long ago, just never char-backfilled
       error: null,
@@ -149,6 +157,8 @@ describe('computeLakeHealth', () => {
     // gate would silently no-op and this member would drag the share to ~0 - exactly what B2 guards.
     const indexing: Member = {
       fabFileId: 'indexing',
+      fileSize: null,
+      serverTextHash: null,
       chunkCount: 3,
       vectorizedChunkCount: 0,
       error: null,
@@ -171,6 +181,8 @@ describe('computeLakeHealth', () => {
     // reads unhealthy rather than the neutral "not measured".
     const failed: Member = {
       fabFileId: 'failed',
+      fileSize: null,
+      serverTextHash: null,
       chunkCount: 4,
       vectorizedChunkCount: 1, // stuck below chunkCount forever
       error: 'embedding provider rejected the request',
@@ -194,20 +206,49 @@ describe('computeLakeHealth', () => {
     const health = await computeLakeHealth(lake, makeAdapters([older, newer, unique]) as never);
 
     expect(health.duplicateMembers.memberCount).toBe(2);
+    expect(health.duplicateMembers.groupCount).toBe(1);
     expect(health.duplicateMembers.groups).toEqual([
       {
         fileName: 'contract.pdf',
         members: [
-          { fabFileId: 'gen1', fileName: 'contract.pdf', fileSize: 1000 },
-          { fabFileId: 'gen2', fileName: 'contract.pdf', fileSize: 1200 },
+          { fabFileId: 'gen1', fileSize: 1000 },
+          { fabFileId: 'gen2', fileSize: 1200 },
         ],
-        confirmedDiffering: true,
+        memberCount: 2,
+        contentComparison: 'differing',
       },
     ]);
   });
 
   it('reports an empty duplicateMembers report when no fileName repeats', async () => {
     const health = await computeLakeHealth(lake, makeAdapters([healthyMember('a'), healthyMember('b')]) as never);
-    expect(health.duplicateMembers).toEqual({ memberCount: 0, groups: [] });
+    expect(health.duplicateMembers).toEqual({ memberCount: 0, groupCount: 0, groups: [] });
+  });
+
+  it('excludes a member the raw scan admits but selectLakeHealthMembers would drop from duplicate grouping', async () => {
+    // A chunkless, unmarked row (never had passages) reaches the raw scan only if a caller's own
+    // $match is looser than the shared filter - exercised here directly against the pure function to
+    // prove findDuplicateMembers is called with the same filtered set summarizeLakeHealth grades, not
+    // the raw rows.
+    const chunkless: Member = { ...healthyMember('ghost'), fileName: 'contract.pdf', chunkCount: 0 };
+    const real: Member = { ...healthyMember('gen1'), fileName: 'contract.pdf' };
+    const health = await computeLakeHealth(lake, makeAdapters([chunkless, real]) as never);
+
+    expect(health.duplicateMembers.memberCount).toBe(0);
+  });
+
+  it("caps the duplicate-groups list and each group's member list, keeping exact counts", async () => {
+    const manyGroups = Array.from({ length: 60 }, (_, g) =>
+      Array.from({ length: 3 }, (_, i) => ({ ...healthyMember(`g${g}-m${i}`), fileName: `dup${g}.txt` }))
+    ).flat();
+    const bigGroup = Array.from({ length: 25 }, (_, i) => ({ ...healthyMember(`big-m${i}`), fileName: 'big.txt' }));
+    const health = await computeLakeHealth(lake, makeAdapters([...manyGroups, ...bigGroup]) as never);
+
+    expect(health.duplicateMembers.groupCount).toBe(61);
+    expect(health.duplicateMembers.groups).toHaveLength(50);
+    expect(health.duplicateMembers.memberCount).toBe(60 * 3 + 25);
+    const big = health.duplicateMembers.groups.find(g => g.fileName === 'big.txt');
+    expect(big?.memberCount).toBe(25);
+    expect(big?.members).toHaveLength(20);
   });
 });

--- a/b4m-core/services/src/dataLakeService/computeLakeHealth.ts
+++ b/b4m-core/services/src/dataLakeService/computeLakeHealth.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_PASSAGE_TOKEN_TARGET,
   findDuplicateMembers,
   resolveLakeHealthPolicy,
+  selectLakeHealthMembers,
   summarizeLakeHealth,
   type IAdminSettingsRepository,
   type IDataLakeDocument,
@@ -21,6 +22,16 @@ import { resolveScopedSetting, scopeForLake } from '../settings/resolveScopedSet
 const MEMBER_SCAN_LIMIT = 25_000;
 /** How many failing members the report carries for the drill-down. The count is always exact. */
 const AFFECTED_MEMBERS_RETURNED = 200;
+/**
+ * How many duplicate-fileName groups, and how many members per group, the report carries. Both the
+ * group count and each group's member count stay exact regardless. Bounded because neither dimension
+ * of `groups` is capped by MEMBER_SCAN_LIMIT: a connector-synced lake full of generic names (`scan.pdf`,
+ * `index.html`) can produce thousands of groups, and one giant group can hold every scanned member -
+ * uncapped, either shape can push the response into multiple megabytes on a lake this endpoint (an
+ * `isPublic` lake is reader-visible app-wide) can be asked to report on repeatedly.
+ */
+const DUPLICATE_GROUPS_RETURNED = 50;
+const DUPLICATE_MEMBERS_PER_GROUP = 20;
 
 export interface ComputeLakeHealthAdapters {
   db: {
@@ -46,6 +57,8 @@ export interface ComputeLakeHealthAdapters {
  * vectorized, chunk-consistent, vector-bearing, under the serve cap - while carrying two upload
  * generations of the same documents, which is measurably healthy and wrong. `findDuplicateMembers`
  * groups this same member scan by exact fileName; report-only, same as the rest of this module.
+ * `groups` and each group's `members` are capped here for payload size (`DUPLICATE_GROUPS_RETURNED`,
+ * `DUPLICATE_MEMBERS_PER_GROUP`); the counts stay exact regardless.
  */
 export async function computeLakeHealth(
   lake: Pick<
@@ -78,7 +91,7 @@ export async function computeLakeHealth(
       affectedMembers: [],
       affectedMemberCount: 0,
       scanTruncated: false,
-      duplicateMembers: { memberCount: 0, groups: [] },
+      duplicateMembers: { memberCount: 0, groupCount: 0, groups: [] },
     };
   }
 
@@ -93,12 +106,22 @@ export async function computeLakeHealth(
   }
 
   const report = summarizeLakeHealth(members, policy);
-  const duplicateMembers = findDuplicateMembers(members);
+  // Same admitted-members filter `summarizeLakeHealth` grades over, applied here explicitly rather
+  // than relied on implicitly: the raw scan and the health report agree on membership by
+  // construction, not because the DB `$match` happens to already filter it.
+  const duplicates = findDuplicateMembers(selectLakeHealthMembers(members));
   return {
     ...report,
     affectedMembers: report.affectedMembers.slice(0, AFFECTED_MEMBERS_RETURNED),
     affectedMemberCount: report.affectedMembers.length,
     scanTruncated,
-    duplicateMembers,
+    duplicateMembers: {
+      memberCount: duplicates.memberCount,
+      groupCount: duplicates.groupCount,
+      groups: duplicates.groups.slice(0, DUPLICATE_GROUPS_RETURNED).map(g => ({
+        ...g,
+        members: g.members.slice(0, DUPLICATE_MEMBERS_PER_GROUP),
+      })),
+    },
   };
 }

--- a/b4m-core/services/src/dataLakeService/computeLakeHealth.ts
+++ b/b4m-core/services/src/dataLakeService/computeLakeHealth.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PASSAGE_TOKEN_TARGET,
+  findDuplicateMembers,
   resolveLakeHealthPolicy,
   summarizeLakeHealth,
   type IAdminSettingsRepository,
@@ -40,6 +41,11 @@ export interface ComputeLakeHealthAdapters {
  * `inherited` platform/owner `DefaultChunkSize` (epic decision 5), resolved through the SAME
  * `deriveServeCharBudget` the serve path uses, so predicate P4 ("serve cap >= policy size") cannot
  * disagree with what retrieval actually does.
+ *
+ * Also reports duplicate members (#2239): a lake can pass all four predicates - every member
+ * vectorized, chunk-consistent, vector-bearing, under the serve cap - while carrying two upload
+ * generations of the same documents, which is measurably healthy and wrong. `findDuplicateMembers`
+ * groups this same member scan by exact fileName; report-only, same as the rest of this module.
  */
 export async function computeLakeHealth(
   lake: Pick<
@@ -67,7 +73,13 @@ export async function computeLakeHealth(
   // scanning on a null tag. Mirrors the same guard in GET /api/data-lakes/:id/articles.
   if (!lake.datalakeTag) {
     const empty = summarizeLakeHealth([], policy);
-    return { ...empty, affectedMembers: [], affectedMemberCount: 0, scanTruncated: false };
+    return {
+      ...empty,
+      affectedMembers: [],
+      affectedMemberCount: 0,
+      scanTruncated: false,
+      duplicateMembers: { memberCount: 0, groups: [] },
+    };
   }
 
   const rows = await db.fabFiles.findDataLakeHealthMembers(lakeMembershipScope(lake), MEMBER_SCAN_LIMIT);
@@ -81,10 +93,12 @@ export async function computeLakeHealth(
   }
 
   const report = summarizeLakeHealth(members, policy);
+  const duplicateMembers = findDuplicateMembers(members);
   return {
     ...report,
     affectedMembers: report.affectedMembers.slice(0, AFFECTED_MEMBERS_RETURNED),
     affectedMemberCount: report.affectedMembers.length,
     scanTruncated,
+    duplicateMembers,
   };
 }

--- a/packages/database/src/models/content/FabFileModel.lakeHealthRollups.test.ts
+++ b/packages/database/src/models/content/FabFileModel.lakeHealthRollups.test.ts
@@ -75,6 +75,7 @@ describe('lake-health rollup primitives (#1666)', () => {
       embeddedChunkCount: 3,
       embeddedCharCount: 9000,
       fileSize: 42,
+      serverTextHash: 'abc123',
       tags: [{ name: tag, strength: 1 }],
     });
     await makeFile('unmeasured.txt', {
@@ -104,9 +105,11 @@ describe('lake-health rollup primitives (#1666)', () => {
       maxChunkCharLength: 3000,
       embeddedChunkCount: 3,
       fileSize: 42,
+      serverTextHash: 'abc123',
     });
-    // No fileSize stamped: projected as null, not coerced to 0 (feeds findDuplicateMembers).
+    // No fileSize/serverTextHash stamped: projected as null, not coerced (feeds findDuplicateMembers).
     expect(byName['unmeasured.txt'].fileSize).toBeNull();
+    expect(byName['unmeasured.txt'].serverTextHash).toBeNull();
     // The terminal-failure marker is projected so the evaluator can grade a failed file (not hide it).
     expect(byName['failed.txt'].error).toBe('embedding provider rejected the request');
     // Unmeasured file: the #1666 CHAR rollups come back as null, NOT coerced to 0.

--- a/packages/database/src/models/content/FabFileModel.lakeHealthRollups.test.ts
+++ b/packages/database/src/models/content/FabFileModel.lakeHealthRollups.test.ts
@@ -74,6 +74,7 @@ describe('lake-health rollup primitives (#1666)', () => {
       maxChunkCharLength: 3000,
       embeddedChunkCount: 3,
       embeddedCharCount: 9000,
+      fileSize: 42,
       tags: [{ name: tag, strength: 1 }],
     });
     await makeFile('unmeasured.txt', {
@@ -102,7 +103,10 @@ describe('lake-health rollup primitives (#1666)', () => {
       chunkedCharCount: 9000,
       maxChunkCharLength: 3000,
       embeddedChunkCount: 3,
+      fileSize: 42,
     });
+    // No fileSize stamped: projected as null, not coerced to 0 (feeds findDuplicateMembers).
+    expect(byName['unmeasured.txt'].fileSize).toBeNull();
     // The terminal-failure marker is projected so the evaluator can grade a failed file (not hide it).
     expect(byName['failed.txt'].error).toBe('embedding provider rejected the request');
     // Unmeasured file: the #1666 CHAR rollups come back as null, NOT coerced to 0.

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -1363,9 +1363,11 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
    * membership + liveness filter as computeDataLakeStats, and only members that produced chunks
    * (`chunkCount > 0`): a chunkless image or a still-pending upload carries no retrievable content.
    *
-   * `fileSize` also feeds `findDuplicateMembers`: a same-fileName pair whose sizes differ is
-   * confirmed to differ in content, which is the only discriminator this row shape can offer without
-   * a second read (see that function's doc for why chunkCount cannot serve the same purpose).
+   * `fileSize` and `serverTextHash` both feed `findDuplicateMembers`: a same-fileName pair whose
+   * sizes disagree, or whose hashes disagree, is confirmed to differ in content; a pair whose hashes
+   * match is confirmed IDENTICAL, which size alone can never prove. Both come back for free in this
+   * same `$project` - no second read - and `chunkCount` cannot serve either purpose (see that
+   * function's doc).
    *
    * ONE exception, and it is the case this report exists for: a member the convergence kill switch
    * stopped mid-rewrite is chunkless because its passages were DELETED, not because it never had
@@ -1384,6 +1386,7 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
       fabFileId: string;
       fileName?: string;
       fileSize: number | null;
+      serverTextHash: string | null;
       chunkCount: number;
       vectorizedChunkCount: number | null;
       error: string | null;
@@ -1425,6 +1428,9 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
           fabFileId: { $toString: '$_id' },
           fileName: 1,
           fileSize: { $ifNull: ['$fileSize', null] },
+          // Server-verified SHA-256 over normalized extracted text, stamped at chunk time. Equal hash
+          // is PROOF of identity - the thing `fileSize` cannot give (see the doc comment above).
+          serverTextHash: { $ifNull: ['$serverTextHash', null] },
           chunkCount: { $ifNull: ['$chunkCount', 0] },
           // Preserve null (UNMEASURED) rather than coalescing to 0 - the evaluator must tell "not yet
           // measured" from "measured as zero". $ifNull with null keeps an ABSENT field as null too.

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -1363,6 +1363,10 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
    * membership + liveness filter as computeDataLakeStats, and only members that produced chunks
    * (`chunkCount > 0`): a chunkless image or a still-pending upload carries no retrievable content.
    *
+   * `fileSize` also feeds `findDuplicateMembers`: a same-fileName pair whose sizes differ is
+   * confirmed to differ in content, which is the only discriminator this row shape can offer without
+   * a second read (see that function's doc for why chunkCount cannot serve the same purpose).
+   *
    * ONE exception, and it is the case this report exists for: a member the convergence kill switch
    * stopped mid-rewrite is chunkless because its passages were DELETED, not because it never had
    * any. Excluding it made a lake report "Reachable 100%" over the members it still had while a
@@ -1379,6 +1383,7 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     Array<{
       fabFileId: string;
       fileName?: string;
+      fileSize: number | null;
       chunkCount: number;
       vectorizedChunkCount: number | null;
       error: string | null;
@@ -1419,6 +1424,7 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
           _id: 0,
           fabFileId: { $toString: '$_id' },
           fileName: 1,
+          fileSize: { $ifNull: ['$fileSize', null] },
           chunkCount: { $ifNull: ['$chunkCount', 0] },
           // Preserve null (UNMEASURED) rather than coalescing to 0 - the evaluator must tell "not yet
           // measured" from "measured as zero". $ifNull with null keeps an ABSENT field as null too.


### PR DESCRIPTION
## Summary
- `computeLakeHealth` now groups a lake's members by exact fileName and reports a `duplicateMembers` count + member list for any group with more than one member, plus a `contentComparison` (`differing`/`identical`/`unprovable`) per group derived from both `fileSize` and the server-verified `serverTextHash`.
- `GET /api/data-lakes/:id/health` surfaces the new `duplicateMembers` field alongside the existing predicates; the lake-health tooltip in the client now renders it too.
- `groups` and each group's `members` are capped for payload size (a public lake's uncapped inventory of file names could reach multi-megabyte responses); the report's `memberCount`/`groupCount` and each group's `memberCount` stay exact regardless.
- Report-only, as scoped: no repair/removal action is added here.

This is a same-fileName check, deliberately independent of the (still unlanded, still-open) admission-time identity-key work tracked in a separate issue - a shared fileName is exactly the population that check would miss, since a deliberately-retained historical copy is normally named differently.

Part of #2245 (the report-only surfacing this PR implements is superseded in part by that issue's repair plan). Leaving #2239 open - a re-scope comment on it after this PR opened narrowed what remains distinct to that issue to the membership-arm disclosure (meta-tag vs content-prefix counts), which this PR does not add.

## Test plan
- [x] `pnpm --filter @bike4mind/common test` (includes `findDuplicateMembers` unit tests, incl. the hash-based tri-state and payload-cap-adjacent cases)
- [x] `pnpm --filter @bike4mind/services test src/dataLakeService` (includes `computeLakeHealth` duplicate-report tests, incl. capping and the shared-filter fix)
- [x] `pnpm --filter @bike4mind/database test` (Mongo-backed `fileSize`/`serverTextHash` projection test)
- [x] `pnpm --filter @bike4mind/client exec vitest run --project jsdom` / `--project node` (typecheck clean, `LakeHealthBadge.test.tsx` / `health.test.ts` pass)
- [x] `pnpm turbo:typecheck && pnpm lint:check`
