### PR TITLE
feat(premium): let overlays declare which localStorage key prefixes logout clears

### DIFF
--- a/apps/client/__tests__/premiumGlueLinking.test.ts
+++ b/apps/client/__tests__/premiumGlueLinking.test.ts
@@ -74,6 +74,7 @@ beforeAll(() => {
           { generatedPath: 'server/premium-generated/fakeoverlay.ts', exportFrom: `${PKG_NAME}/handlers` },
         ],
         infra: true,
+        localStorageKeyPrefixes: ['fakeoverlay-'],
       },
     })
   );
@@ -120,8 +121,14 @@ describe('hydrated but UNLINKED overlay', () => {
     expect(existsSync(join(clientRoot, 'server/premium-generated/fakeoverlay.ts'))).toBe(false);
   });
 
-  it('still emits the PRESENT relative-import glue (infra + migrations need no link)', () => {
+  it('still emits the PRESENT no-import + relative-import glue (they need no link)', () => {
     runCodegen();
+
+    // Pure data lifted from package.json - it must never be demoted into the
+    // linked-only group, or the sweep silently stops covering unlinked overlays.
+    const lsKeys = readFileSync(join(clientRoot, 'app/premium-generated/premiumLocalStorageKeys.generated.ts'), 'utf8');
+    expect(lsKeys).toContain(`'fakeoverlay-'`);
+
     const infra = readFileSync(join(sandbox, 'infra/premium-generated/fakeoverlay-infra.generated.ts'), 'utf8');
     expect(infra).toContain(`from '../../packages/premium/fakeoverlay/src/infra'`);
 

--- a/apps/client/__tests__/premiumLocalStorageKeys.test.ts
+++ b/apps/client/__tests__/premiumLocalStorageKeys.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Guard for the localStorage-key-prefix contribution: overlays declare the prefixes
+ * they own and core sweeps them at identity change (see `PremiumLocalStorageKeyPrefixes`).
+ *
+ * The prefixes are interpolated raw into a generated string literal, so the validator
+ * is a build-time control, not a nicety - the rejection cases below are the control.
+ *
+ * Runs the real script inside a sandbox tree, since its paths derive from its own
+ * location: sandbox/apps/client/scripts/ next to sandbox/packages/premium/.
+ */
+
+const REAL_SCRIPT = join(__dirname, '../scripts/generate-premium-glue.mjs');
+const GENERATED = 'app/premium-generated/premiumLocalStorageKeys.generated.ts';
+
+let sandbox: string;
+let script: string;
+let clientRoot: string;
+
+function writeOverlay(dir: string, contributions: Record<string, unknown>) {
+  const overlayDir = join(sandbox, 'packages/premium', dir);
+  mkdirSync(overlayDir, { recursive: true });
+  writeFileSync(
+    join(overlayDir, 'package.json'),
+    JSON.stringify({ name: `@bike4mind/premium-${dir}`, b4mContributions: contributions })
+  );
+}
+
+function runCodegen() {
+  // CI is forced off: the script hard-fails a hydrated-but-unlinked tree when
+  // CI === 'true', and these overlays are deliberately never linked.
+  return spawnSync(process.execPath, [script], { encoding: 'utf8', env: { ...process.env, CI: '' } });
+}
+
+function generate() {
+  const result = runCodegen();
+  expect(result.status, result.stderr).toBe(0);
+  return readFileSync(join(clientRoot, GENERATED), 'utf8');
+}
+
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'b4m-lskeys-test-'));
+  clientRoot = join(sandbox, 'apps/client');
+  script = join(clientRoot, 'scripts/generate-premium-glue.mjs');
+
+  mkdirSync(join(clientRoot, 'scripts'), { recursive: true });
+  cpSync(REAL_SCRIPT, script);
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  rmSync(join(sandbox, 'packages/premium'), { recursive: true, force: true });
+});
+
+describe('premium localStorage key prefixes', () => {
+  it('emits the empty form when no overlay declares any', () => {
+    writeOverlay('silent', {});
+
+    const generated = generate();
+
+    expect(generated).toContain('premiumLocalStorageKeyPrefixes: PremiumLocalStorageKeyPrefixes = []');
+  });
+
+  it('emits the declared prefixes for an overlay that is NOT linked into node_modules', () => {
+    // The whole point of the contribution: it is data, not a module specifier, so it
+    // never needs the overlay resolvable. Nothing links the overlay in this sandbox.
+    writeOverlay('alpha', { localStorageKeyPrefixes: ['alpha-panel:', 'alpha.store'] });
+
+    const generated = generate();
+
+    expect(generated).toContain(`'alpha-panel:'`);
+    expect(generated).toContain(`'alpha.store'`);
+    // Data only - the package is never imported to read its own prefixes.
+    expect(generated).not.toContain('@bike4mind/premium-alpha');
+  });
+
+  it('merges prefixes across overlays and drops duplicates', () => {
+    writeOverlay('alpha', { localStorageKeyPrefixes: ['shared-', 'alpha-'] });
+    writeOverlay('beta', { localStorageKeyPrefixes: ['shared-', 'beta-'] });
+
+    const generated = generate();
+
+    expect(generated.match(/'shared-'/g)).toHaveLength(1);
+    expect(generated).toContain(`'alpha-'`);
+    expect(generated).toContain(`'beta-'`);
+  });
+
+  it('rejects an empty prefix rather than emitting a sweep that matches every key', () => {
+    writeOverlay('greedy', { localStorageKeyPrefixes: [''] });
+
+    const { status, stderr } = runCodegen();
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('invalid localStorageKeyPrefixes entry');
+  });
+
+  it('rejects a prefix that could break out of the generated string literal', () => {
+    writeOverlay('injector', { localStorageKeyPrefixes: [`x'; process.exit(0); //`] });
+
+    const { status, stderr } = runCodegen();
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('invalid localStorageKeyPrefixes entry');
+  });
+
+  it('rejects a non-array declaration', () => {
+    writeOverlay('malformed', { localStorageKeyPrefixes: 'alpha-' });
+
+    const { status, stderr } = runCodegen();
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('expected an array of key prefixes');
+  });
+});

--- a/apps/client/app/premiumContract.ts
+++ b/apps/client/app/premiumContract.ts
@@ -95,3 +95,26 @@ export interface PremiumNavDescriptor {
  * appears, so core never statically imports an absent package (the fork build stays green).
  */
 export type PremiumNotebookSidenav = ComponentType | null;
+
+/**
+ * localStorage key prefixes a premium overlay owns, contributed as literal data in
+ * `b4mContributions.localStorageKeyPrefixes` and swept by `clearClientCaches()` on
+ * every identity change.
+ *
+ * Core clears a fixed allowlist of its own keys; it cannot name an overlay's keys
+ * without naming the overlay's surface in the open-core repo. A prefix is the
+ * narrowest thing an overlay can declare that stays generic here and still lets
+ * core clear per-identity keys it has never heard of (`<prefix><userId>` and
+ * friends). Matching is `startsWith`, so declare the longest prefix that still
+ * covers every key you own.
+ *
+ * Unlike every other contribution, this one is DATA, not a module specifier: core
+ * reads it straight out of package.json and never imports overlay code for it. That
+ * is the whole point - the sweep has to work in a tab that never loaded the
+ * overlay's routes, which is exactly the tab a lazily-loaded contribution misses.
+ * It also means the glue needs no node_modules link (see the generator's grouping).
+ *
+ * Declaring a prefix here is a promise that core may delete those keys at any
+ * identity change. Never declare one that also matches a core key.
+ */
+export type PremiumLocalStorageKeyPrefixes = string[];

--- a/apps/client/app/utils/clearClientCaches.test.ts
+++ b/apps/client/app/utils/clearClientCaches.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// The generated glue is empty in the open-core tree, so the sweep has nothing to do
+// unless a contribution is stubbed in - mock it to stand in for an installed overlay.
+// The array identity is stable, so each test mutates it in place via setPrefixes().
+const { premiumLocalStorageKeyPrefixes } = vi.hoisted(() => ({
+  premiumLocalStorageKeyPrefixes: [] as string[],
+}));
+vi.mock('../premium-generated/premiumLocalStorageKeys.generated', () => ({
+  premiumLocalStorageKeyPrefixes,
+}));
+
+vi.mock('idb-keyval', () => ({ del: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./dexie', () => ({ dexie: { delete: vi.fn().mockResolvedValue(undefined) } }));
+vi.mock('./tagCache', () => ({ tagCacheManager: { clearAllCaches: vi.fn().mockResolvedValue(undefined) } }));
+
+import { clearClientCaches } from './clearClientCaches';
+
+function setPrefixes(prefixes: string[]) {
+  premiumLocalStorageKeyPrefixes.length = 0;
+  premiumLocalStorageKeyPrefixes.push(...prefixes);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  setPrefixes([]);
+});
+
+describe('clearClientCaches premium localStorage sweep', () => {
+  it('removes every key under a declared prefix, including per-identity variants', async () => {
+    setPrefixes(['overlay-panel:']);
+    localStorage.setItem('overlay-panel:', 'legacy-global');
+    localStorage.setItem('overlay-panel:user-a', 'a');
+    localStorage.setItem('overlay-panel:user-b', 'b');
+
+    await clearClientCaches();
+
+    expect(Object.keys(localStorage)).toEqual([]);
+  });
+
+  it('leaves keys no overlay declared alone', async () => {
+    setPrefixes(['overlay-panel:']);
+    localStorage.setItem('overlay-panel:user-a', 'a');
+    localStorage.setItem('unrelated-app-setting', 'keep me');
+    // Near-miss: the prefix must match at the START of the key, not anywhere in it.
+    localStorage.setItem('not-an-overlay-panel:user-a', 'keep me too');
+
+    await clearClientCaches();
+
+    expect(Object.keys(localStorage).sort()).toEqual(['not-an-overlay-panel:user-a', 'unrelated-app-setting']);
+  });
+
+  it('is a no-op for the open-core tree, where no overlay declares a prefix', async () => {
+    localStorage.setItem('some-other-key', 'value');
+
+    await clearClientCaches();
+
+    expect(localStorage.getItem('some-other-key')).toBe('value');
+  });
+
+  it('still clears the core allowlist alongside the sweep', async () => {
+    setPrefixes(['overlay-panel:']);
+    localStorage.setItem('user-context', 'stale');
+    localStorage.setItem('artifacts', 'stale');
+    localStorage.setItem('overlay-panel:user-a', 'stale');
+
+    await clearClientCaches();
+
+    expect(Object.keys(localStorage)).toEqual([]);
+  });
+});

--- a/apps/client/app/utils/clearClientCaches.ts
+++ b/apps/client/app/utils/clearClientCaches.ts
@@ -1,6 +1,7 @@
 import { del } from 'idb-keyval';
 import { dexie } from './dexie';
 import { tagCacheManager } from './tagCache';
+import { premiumLocalStorageKeyPrefixes } from '../premium-generated/premiumLocalStorageKeys.generated';
 
 /**
  * User-specific localStorage keys that must be removed on identity change.
@@ -21,6 +22,7 @@ export async function clearClientCaches(): Promise<void> {
   try {
     // Clear user-specific localStorage entries (Zustand stores + artifact cache)
     USER_SPECIFIC_LS_KEYS.forEach(key => localStorage.removeItem(key));
+    removePremiumLocalStorageKeys();
 
     await Promise.all([
       // React Query IndexedDB persistence (idb-keyval)
@@ -36,4 +38,24 @@ export async function clearClientCaches(): Promise<void> {
   } catch (error) {
     console.warn('Failed to clear client caches:', error);
   }
+}
+
+/**
+ * Removes every localStorage key a premium overlay has claimed via
+ * `b4mContributions.localStorageKeyPrefixes` (see `PremiumLocalStorageKeyPrefixes`).
+ *
+ * Prefix matching rather than an allowlist because core cannot know the whole key:
+ * an overlay's keys are typically user-scoped (`<prefix><userId>`), so the set is
+ * open-ended and only the overlay can name its shape. This runs here, in core's
+ * identity-change teardown, so it fires in EVERY tab that signs out - including one
+ * that never loaded the overlay's routes and therefore never ran a line of its code.
+ */
+function removePremiumLocalStorageKeys(): void {
+  if (premiumLocalStorageKeyPrefixes.length === 0) return;
+
+  // Snapshot the keys first: Object.keys returns a plain array, whereas iterating
+  // localStorage by index while removing entries re-indexes underneath and skips keys.
+  Object.keys(localStorage)
+    .filter(key => premiumLocalStorageKeyPrefixes.some(prefix => key.startsWith(prefix)))
+    .forEach(key => localStorage.removeItem(key));
 }

--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -11,6 +11,7 @@
  *   pages/api/<stub>.ts (per-package)                  - Next.js API stubs
  *   server/premium-generated/<stub>.ts (per-package)   - SST Lambda handler stubs
  *   server/premium-generated/premiumLlmTools.generated.ts - LLM tool contributions
+ *   app/premium-generated/premiumLocalStorageKeys.generated.ts - owned LS key prefixes
  *
  * Two distinct "empty" forms when no premium packages are present:
  *   SPA/nav   -> emit the file with an empty exported array
@@ -132,6 +133,23 @@ function assertModuleSpecifier(value, pkgName, field) {
   }
 }
 
+// A localStorage key prefix contributed as literal data (b4mContributions.
+// localStorageKeyPrefixes). Interpolated raw into a generated string literal, so the
+// charset is deliberately narrow - the punctuation real keys use as separators, and
+// nothing that could terminate the literal or inject code.
+const LS_KEY_PREFIX_RE = /^[a-z0-9][a-z0-9:_.-]*$/i;
+
+function assertLocalStorageKeyPrefix(value, pkgName) {
+  // An empty prefix matches every key, turning the sweep into localStorage.clear()
+  // and taking core's own keys with it. Reject loudly rather than at 3am.
+  if (typeof value !== 'string' || !LS_KEY_PREFIX_RE.test(value)) {
+    throw new Error(
+      `[codegen] invalid localStorageKeyPrefixes entry from package "${pkgName}": ` +
+        `${JSON.stringify(value)} is not a non-empty key prefix of [A-Za-z0-9:_.-]`
+    );
+  }
+}
+
 // --- Generate SPA routes ---
 
 function generateSpaRoutes(packages) {
@@ -245,6 +263,43 @@ export const premiumNotebookSidenav: PremiumNotebookSidenav = dynamic(
   { ssr: false }
 );
 `
+  );
+}
+
+// --- Generate localStorage key prefixes ---
+
+// Overlays own localStorage keys core cannot name without naming their surface, so
+// they declare the PREFIXES instead (b4mContributions.localStorageKeyPrefixes) and
+// clearClientCaches sweeps them on every identity change. Unlike the other
+// contributions this one is pure data lifted out of package.json: nothing here
+// imports overlay code, which is what lets the sweep run in a tab that never loaded
+// the overlay's routes - and why it needs no node_modules link.
+function generateLocalStorageKeyPrefixes(packages) {
+  const outPath = join(GENERATED_DIR, 'premiumLocalStorageKeys.generated.ts');
+  const typeImport = `import type { PremiumLocalStorageKeyPrefixes } from '../premiumContract';`;
+
+  const prefixes = [];
+  for (const pkg of packages) {
+    const declared = pkg.contributions.localStorageKeyPrefixes;
+    if (declared === undefined) continue;
+    if (!Array.isArray(declared)) {
+      throw new Error(
+        `[codegen] invalid localStorageKeyPrefixes from package "${pkg.name}": ` +
+          `expected an array of key prefixes, got ${JSON.stringify(declared)}`
+      );
+    }
+    for (const prefix of declared) {
+      assertLocalStorageKeyPrefix(prefix, pkg.name);
+      if (!prefixes.includes(prefix)) prefixes.push(prefix);
+    }
+  }
+
+  const entries = prefixes.map(prefix => `  '${prefix}'`).join(',\n');
+  const body = prefixes.length === 0 ? '[]' : `[\n${entries},\n]`;
+
+  writeFile(
+    outPath,
+    `${GENERATED_BANNER}\n${typeImport}\n\nexport const premiumLocalStorageKeyPrefixes: PremiumLocalStorageKeyPrefixes = ${body};\n`
   );
 }
 
@@ -699,5 +754,8 @@ generateLlmTools(linkedPackages);
 // Any NEW generator goes in whichever group matches how it imports the overlay.
 generateMigrations(packages);
 generateInfraGlue(packages);
+// No-import glue: pure data copied out of package.json, so it imports the overlay
+// not at all and is link-independent for an even simpler reason than the group above.
+generateLocalStorageKeyPrefixes(packages);
 
 console.log('[codegen] done.');


### PR DESCRIPTION
# Pull Request

## Description

Core clears a fixed allowlist of its own localStorage keys on every identity change (`USER_SPECIFIC_LS_KEYS` in `clearClientCaches.ts`). A premium overlay's keys are not on that list and cannot be: naming them in this repo would name the overlay's surface, which the open/closed boundary does not allow.

The result is a hole with no owner. An overlay can only clear its own keys from code that has actually loaded, and overlay code is reachable only from the overlay's own routes. In a tab that never visited one of those routes - the common case, since most sessions never touch a given overlay - signing out leaves the overlay's keys sitting on disk. They are readable by devtools or any same-origin script until that browser profile next happens to load the overlay. On a shared machine that is the whole of the exposure.

This adds the generic seam that closes it: an overlay declares the localStorage key **prefixes** it owns, and core sweeps them in the teardown it already runs.

A prefix rather than a key list because overlay keys are typically user-scoped (`<something><userId>`), so the full key set is open-ended and only the overlay can describe its shape. A prefix is also the narrowest thing that stays generic on this side of the boundary: this repo learns a string, not a feature.

The important property is that the contribution is **data, not a module specifier**. Every other `b4mContributions` entry points at a module core imports; this one is read straight out of `package.json` and copied into the generated file. Core never imports overlay code to find out what to clear - which is exactly why the sweep works in a tab that never loaded the overlay. It also makes the glue link-independent: no `node_modules` link required, unlike the bare-specifier contributions.

Inert in an open-core checkout: no overlay, no prefixes, generated empty array, `removePremiumLocalStorageKeys()` returns immediately.

## Changes

- `apps/client/app/premiumContract.ts` - documents the contribution and exports `PremiumLocalStorageKeyPrefixes`, the type both the present and empty generated forms are annotated with (same annotate-both-forms rule as the existing contributions).
- `apps/client/scripts/generate-premium-glue.mjs` - emits `app/premium-generated/premiumLocalStorageKeys.generated.ts` from `b4mContributions.localStorageKeyPrefixes`, merging and de-duplicating across overlays. Runs on the full package list, not the linked-only list, since it imports nothing.
- Validation, because the prefixes are interpolated raw into a generated string literal: each entry must be a non-empty `[A-Za-z0-9:_.-]` prefix starting with an alphanumeric. An empty prefix is rejected outright - it would match every key and quietly turn the sweep into `localStorage.clear()`, taking core's own keys with it. A non-array declaration is rejected too.
- `apps/client/app/utils/clearClientCaches.ts` - after the existing allowlist removal, snapshots `Object.keys(localStorage)` and removes every key matching a declared prefix.
- Tests: a new codegen suite (`__tests__/premiumLocalStorageKeys.test.ts`) covering the empty form, the unlinked-overlay case, cross-overlay merge/dedupe, and all three rejection paths; a new consumer suite (`app/utils/clearClientCaches.test.ts`); and one assertion added to `__tests__/premiumGlueLinking.test.ts` pinning the contribution into the no-link group, so a future refactor that demotes it into the linked-only group fails loudly instead of silently narrowing the sweep.

No behaviour change for anyone without an overlay installed, and no new dependency.

## Guide for Testers

This PR has no user-visible surface in a public checkout - there is no overlay to declare a prefix, so the sweep has nothing to do. Verify the mechanism instead.

**Automated (the real check)**

1. From the repo root, run `pnpm --filter @bike4mind/client run codegen`.
   Expected: it completes and the log includes a line ending in `premiumLocalStorageKeys.generated.ts`.
2. Run `cat apps/client/app/premium-generated/premiumLocalStorageKeys.generated.ts`.
   Expected: the empty form - `export const premiumLocalStorageKeyPrefixes: PremiumLocalStorageKeyPrefixes = [];`. This is the open-core state.
3. Run `pnpm --filter @bike4mind/client exec vitest run __tests__/premiumLocalStorageKeys.test.ts app/utils/clearClientCaches.test.ts __tests__/premiumGlueLinking.test.ts`.
   Expected: all suites pass. These build a throwaway overlay in a temp dir, so nothing in your checkout changes.

**Manual, if you want to watch it actually delete something**

4. Create `packages/premium/faketest/package.json` containing exactly:
   `{"name":"@bike4mind/premium-faketest","b4mContributions":{"localStorageKeyPrefixes":["faketest-"]}}`

   **Do not run `pnpm install` while this directory exists.** `pnpm-workspace.yaml` globs `packages/premium/*`, so an install would adopt it as a workspace package and rewrite `pnpm-lock.yaml` - the exact churn `scripts/check-no-overlay-lockfile.sh` exists to reject. `codegen` and `pnpm dev` are both safe; only `install` is not. If you do it by accident, `git checkout -- pnpm-lock.yaml` after step 10.
5. Run `pnpm --filter @bike4mind/client run codegen`, then `cat apps/client/app/premium-generated/premiumLocalStorageKeys.generated.ts`.
   Expected: the array now contains `'faketest-'`. A warning that the package is not resolvable from `apps/client` is expected and is the point - this contribution needs no link.
6. Start the app and sign in.
7. Open devtools -> Console and run:
   `localStorage.setItem('faketest-abc','x'); localStorage.setItem('keepme','y')`
8. Sign out via the profile menu.
9. On the login page, open devtools -> Console and run:
   `[localStorage.getItem('faketest-abc'), localStorage.getItem('keepme')]`
   Expected: `[null, 'y']`. The declared prefix was swept; the undeclared key survived.
10. Delete `packages/premium/faketest/` and re-run `pnpm --filter @bike4mind/client run codegen` to return to the empty form.

**Regression Checks**

11. Sign out normally with no overlay present and sign back in.
    Expected: sign-out completes and lands on `/login` with no console error; signing back in restores your notebooks and sessions as before.
12. As an admin, use Login-as-user on another account, then Return to admin.
    Expected: both transitions work, and neither shows the previous identity's cached data. (Both paths run the same `clearClientCaches()` teardown this PR extends.)
13. Let a session expire (or clear `access-token-storage` in devtools and trigger any request).
    Expected: you are redirected to `/login` with the session-expired message, as before.

**What NOT to test**

- Any premium feature's own behaviour. Nothing in this PR touches an overlay; it only defines the seam and the sweep.
- Cross-tab behaviour is unchanged by this PR. A background tab already redirects to `/login`, whose mount runs the same teardown - so it picks the sweep up for free, but that routing is pre-existing and not modified here.
- IndexedDB, Dexie, and the React Query cache. Untouched; the sweep is localStorage only.

## Additional Information

The sweep sits inside the existing `try` in `clearClientCaches()`, so a `localStorage` failure stays swallowed and never blocks sign-out - matching the function's existing contract that cache clearing must not block logout.

`Object.keys(localStorage)` is snapshotted before removal on purpose: iterating `localStorage` by index while removing entries re-indexes underneath the loop and skips keys.

## Developer Notes (Optional)

- **New extension point**: `b4mContributions.localStorageKeyPrefixes` - the first contribution that is pure declarative data rather than a module specifier. Any overlay that persists client state can adopt it with a package.json edit and no code.
- **New codegen group**: the generator now has three groups, not two - bare-specifier glue (needs a `node_modules` link), relative-import glue (does not), and no-import glue (imports nothing at all). The grouping comment in `main()` is the place a future generator picks its lane.
- **Architecture**: the reason this is data and not `localStorageKeysExport` pointing at an overlay module is the failure it is fixing. A module-specifier contribution is only as reachable as the code that imports it; the tab that most needs the sweep is precisely the one that never loaded the overlay.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI surface
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - the contract file is the documentation surface for contributions; updated there
