### PR TITLE
refactor(data-lakes)!: route count_knowledge_base through the registry membership scope

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/__tests__/registryScopeParity.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/registryScopeParity.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DATA_LAKES } from '@bike4mind/common';
+
+/**
+ * Link 2 of the count/browse parity chain (#2265): the single-lake browse must scope a REGISTRY
+ * lake through the shared `registryMembershipScope`, not a hand-rolled `dataLakeTags` +
+ * `dataLakeTagPrefixes` pair.
+ *
+ * Why the chain rather than one test comparing two numbers: the two surfaces live in different
+ * packages and neither can drive the other. So each link is asserted against the SHARED function,
+ * and the chain closes transitively:
+ *
+ *   count tool  -> passes `ResolvedLakeAccess.membership` verbatim
+ *                  (b4m-core/services/.../knowledgeBaseCount/index.test.ts)
+ *   resolver    -> attaches `registryMembershipScope(config)` to a registry lake
+ *                  (b4m-core/services/.../getDynamicDataLakeTags.test.ts)
+ *   browse      -> builds `registryMembershipScope(lake)`               <- THIS FILE
+ *
+ * Every link compares against the real function; none of them restates the predicate as a literal.
+ * A literal would be exactly the independently-written second copy whose drift produced the
+ * `0 vs 86` under-count on a built-in lake, so asserting one here would defeat the test.
+ *
+ * The assertion is on the SCOPE, and on the Mongo predicate derived from it - never on a count.
+ * `dataLakeMembershipParity.integration.test.ts` records why: its fixture has two liveness errors
+ * that cancel to equal totals over different sets, so a cardinality assertion passes against a
+ * broken predicate. The predicate determines the set; compare that.
+ */
+
+const { mockAssertLakeAccess, mockSearch, mockRecordLakeAccessEvent } = vi.hoisted(() => ({
+  mockAssertLakeAccess: vi.fn(),
+  mockSearch: vi.fn(),
+  mockRecordLakeAccessEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: Record<string, unknown> = {};
+    chain.use = () => chain;
+    chain.get = (fn: unknown) => fn;
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/featureFlag', () => ({ requireFeatureEnabled: () => () => undefined }));
+vi.mock('@server/dataLakes/toAccessContext', () => ({ toAccessContext: vi.fn().mockResolvedValue({}) }));
+vi.mock('@server/utils/storage', () => ({ getFilesStorage: () => ({ getSignedUrl: vi.fn() }) }));
+vi.mock('@bike4mind/database', () => ({
+  adminSettingsRepository: {
+    findBySettingNames: vi.fn().mockResolvedValue([]),
+    findAll: vi.fn().mockResolvedValue([]),
+  },
+  dataLakeAccessGrantRepository: {},
+  dataLakeRepository: {},
+  fabFileRepository: {},
+  projectRepository: {},
+  userRepository: {},
+  lakeAccessEventRepository: { record: vi.fn().mockResolvedValue(undefined) },
+}));
+
+// `isFallbackLake`, `lakeMembershipScope` and `registryMembershipScope` come from the REAL modules:
+// they are the shared code whose use is the thing under test, so stubbing them would make this
+// assert only that the route calls a mock. Only the access gate and the search primitive are faked.
+vi.mock('@bike4mind/services', async () => {
+  const assertLakeAccessModule =
+    await import('../../../../../../../b4m-core/services/src/dataLakeService/assertLakeAccess');
+  const scopeModule = await import('../../../../../../../b4m-core/services/src/dataLakeService/lakeMembershipScope');
+  return {
+    dataLakeService: {
+      assertLakeAccess: mockAssertLakeAccess,
+      isFallbackLake: assertLakeAccessModule.isFallbackLake,
+      lakeMembershipScope: scopeModule.lakeMembershipScope,
+      registryMembershipScope: scopeModule.registryMembershipScope,
+      recordLakeAccessEvent: mockRecordLakeAccessEvent,
+    },
+    fabFilesService: { search: mockSearch },
+  };
+});
+
+import handler from '@pages/api/data-lakes/[id]/articles';
+// Deep relative, not via the package barrels: `@bike4mind/database` is mocked above, and
+// `@bike4mind/services` is too - importing either by name here would resolve to the mock and the
+// comparison would be against a stub instead of the real predicate.
+import {
+  registryMembershipScope,
+  lakeMembershipScope,
+} from '../../../../../../../b4m-core/services/src/dataLakeService/lakeMembershipScope';
+import { buildDataLakeMembershipFilter } from '../../../../../../../packages/database/src/queries/dataLakeLifecycleScope';
+
+type RouteHandler = (req: unknown, res: unknown) => Promise<unknown>;
+const route = handler as unknown as RouteHandler;
+
+/** A real registry entry, so `isFallbackLake` decides by its own config-id rule rather than a flag. */
+const REGISTRY_LAKE = DATA_LAKES.find(dl => dl.id === 'opti-knowledge')!;
+
+const makeReq = (id: string) => ({
+  query: { id },
+  user: { id: 'viewer-1', groups: ['g1'] },
+  logger: { warn: vi.fn(), error: vi.fn() },
+});
+const makeRes = () => {
+  const json = vi.fn();
+  return { json, res: { json } as never };
+};
+
+/**
+ * The scope the route handed the search primitive on its single `lakeMemberships` arm.
+ * Argument 3 is fabFilesService.search's ownership-options bag (0 userId, 1 query, 2 adapters).
+ */
+const capturedScope = () => {
+  expect(mockSearch).toHaveBeenCalledTimes(1);
+  const options = mockSearch.mock.calls[0][3];
+  expect(options.lakeMemberships).toHaveLength(1);
+  return { options, scope: options.lakeMemberships[0] };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSearch.mockResolvedValue({ data: [], total: 0, hasMore: false });
+});
+
+describe('GET /api/data-lakes/:id/articles registry-lake scope (count/browse parity)', () => {
+  it('scopes a registry lake through registryMembershipScope, with no hand-rolled tag pair', async () => {
+    mockAssertLakeAccess.mockResolvedValue(REGISTRY_LAKE);
+
+    await route(makeReq(REGISTRY_LAKE.id), makeRes().res);
+
+    const { options, scope } = capturedScope();
+    expect(scope).toEqual(registryMembershipScope(REGISTRY_LAKE));
+    // The carve-out this replaced. Both surfaces used to pass these instead, and the count's copy
+    // is what drifted - so their absence here is half of what keeps the two in step.
+    expect(options).not.toHaveProperty('dataLakeTags');
+    expect(options).not.toHaveProperty('dataLakeTagPrefixes');
+    // Single-lake view: the broad owner/shared arms stay dropped, or the number stops being
+    // this lake's total.
+    expect(options.restrictToDataLake).toBe(true);
+  });
+
+  it('resolves the SAME predicate the count surface builds from the same lake', async () => {
+    mockAssertLakeAccess.mockResolvedValue(REGISTRY_LAKE);
+
+    await route(makeReq(REGISTRY_LAKE.id), makeRes().res);
+
+    // `count_knowledge_base` passes `ResolvedLakeAccess.membership` through untouched, and the
+    // resolver sets that to `registryMembershipScope(config)` - so this IS the count's scope.
+    // Comparing the derived Mongo predicate rather than the scope alone catches a drift that
+    // changes what matches while leaving the scope shape intact.
+    const countScope = registryMembershipScope(REGISTRY_LAKE);
+    const { scope: browseScope } = capturedScope();
+
+    expect(buildDataLakeMembershipFilter(browseScope)).toEqual(buildDataLakeMembershipFilter(countScope));
+    // Both arms present: an unanchored prefix arm beside the meta-tag is precisely what a registry
+    // lake needs and what narrowing it "for safety" would drop - the original under-count. Asserted
+    // by shape and by what the regex MATCHES, not against a literal pattern, so the anchoring and
+    // escaping stay `buildDataLakeMembershipFilter`'s business.
+    const predicate = buildDataLakeMembershipFilter(browseScope) as { $or: Record<string, never>[] };
+    expect(predicate.$or).toHaveLength(2);
+    expect(predicate.$or[0]).toEqual({ 'tags.name': REGISTRY_LAKE.datalakeTag });
+    const prefixArm = predicate.$or[1] as unknown as { 'tags.name': { $regex: RegExp } };
+    expect(prefixArm['tags.name'].$regex.test(`${REGISTRY_LAKE.fileTagPrefix}solvers`)).toBe(true);
+    // No ownership conjunct on that arm - a registry lake is a shared KB with many contributors.
+    expect(Object.keys(prefixArm)).toEqual(['tags.name']);
+  });
+
+  it('still scopes a DB lake through the creator-anchored scope, so the kinds are not collapsed', async () => {
+    const dbLake = {
+      id: '507f1f77bcf86cd799439011',
+      name: 'Acme Docs',
+      slug: 'acme',
+      datalakeTag: 'datalake:org1:acme',
+      fileTagPrefix: 'acme:',
+      createdByUserId: 'creator-1',
+    };
+    mockAssertLakeAccess.mockResolvedValue(dbLake);
+
+    await route(makeReq(dbLake.id), makeRes().res);
+
+    const { scope } = capturedScope();
+    expect(scope).toEqual(lakeMembershipScope(dbLake));
+    expect(scope.kind).toBe('owned');
+  });
+});

--- a/apps/client/pages/api/data-lakes/[id]/articles.ts
+++ b/apps/client/pages/api/data-lakes/[id]/articles.ts
@@ -66,8 +66,9 @@ const handler = baseApi()
     //
     // This was a hand-rolled `dataLakeTags`/`dataLakeTagPrefixes` pair on the registry arm,
     // justified as "nothing else needs to agree with this arm". Things did need to agree: the count
-    // surfaces resolved membership separately and under-counted every registry lake against this
-    // very list. Both now go through the same scope - keep it that way.
+    // surface (`count_knowledge_base`) carried a copy of that same pair and reports its number as
+    // the total this page shows. Both now go through the same scope, pinned by
+    // `registryScopeParity.test.ts` - keep it that way.
     const lakeMembership = dataLakeService.isFallbackLake(dataLake)
       ? dataLakeService.registryMembershipScope(dataLake)
       : dataLakeService.lakeMembershipScope(dataLake);

--- a/apps/client/pages/api/data-lakes/__tests__/semantic-search.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/semantic-search.test.ts
@@ -145,7 +145,12 @@ import handler from '@pages/api/data-lakes/semantic-search';
 import { emptyEmbeddingMismatchReport } from '../../../../../../b4m-core/services/src/dataLakeService/embeddingMismatch';
 import { emptyRetrievalUnavailableReport } from '../../../../../../b4m-core/services/src/dataLakeService/retrievalUnavailable';
 
-const ACME_MEMBERSHIP = { datalakeTag: 'datalake:acme-handbook', fileTagPrefix: 'acme:', creatorUserId: 'creator-1' };
+const ACME_MEMBERSHIP = {
+  kind: 'owned' as const,
+  datalakeTag: 'datalake:acme-handbook',
+  fileTagPrefix: 'acme:',
+  creatorUserId: 'creator-1',
+};
 
 const DYNAMIC_SCOPE = {
   dataLakeTags: ['datalake:acme-handbook'],
@@ -323,12 +328,23 @@ describe('POST /api/data-lakes/semantic-search lake scoping', () => {
     expect(searchParams()).not.toHaveProperty('scopedTagPrefixes');
   });
 
-  it('forwards an EMPTY lakeMemberships rather than omitting it, for a lake with no membership scope', async () => {
+  it('forwards an EMPTY lakeMemberships rather than omitting it, for a registry-only lake set', async () => {
     // The service defaults the field to [], so omission is invisible unless the empty case is
     // asserted for presence rather than truthiness.
+    //
+    // Reached through a REGISTRY lake rather than a membership-less one: every lake carries a scope
+    // now (#2265), and what empties this list is `lakeMembershipsFrom` dropping the unanchored
+    // `registry` kind - which is also the live path, since registry lakes match through the OPEN
+    // `dataLakeTagPrefixes` arm instead.
     mockResolveScope.mockResolvedValue({
       ...DYNAMIC_SCOPE,
-      lakes: [{ ...DYNAMIC_SCOPE.lakes[0], membership: undefined }],
+      lakes: [
+        {
+          ...DYNAMIC_SCOPE.lakes[0],
+          membership: { kind: 'registry' as const, datalakeTag: 'datalake:acme-handbook', fileTagPrefix: 'acme:' },
+          source: 'registry' as const,
+        },
+      ],
     });
 
     await handler(makeReq({ query: 'onboarding' }), makeRes());

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
@@ -12,9 +12,18 @@ const { mockGetDynamicDataLakeAccess, mockGetRequestEntitlements, mockGetUserEnt
 
 // The services barrel is mocked with a factory rather than vi.spyOn: under ESM a spy on a
 // re-exported binding does not reliably intercept the consumer's reference.
-vi.mock('@bike4mind/services', () => ({
-  dataLakeService: { getDynamicDataLakeAccess: mockGetDynamicDataLakeAccess },
-}));
+//
+// Only `getDynamicDataLakeAccess` is replaced; the rest of `dataLakeService` comes from the real
+// module. `withStaticRegistryBypass` calls `registryMembershipScope`, and a hand-written stand-in
+// for it here would be a second copy of the very predicate this file's assertions claim parity
+// with - the drift #2265 removed. Keep new helpers coming from importOriginal, not from a literal.
+vi.mock('@bike4mind/services', async importOriginal => {
+  const actual = (await importOriginal()) as typeof import('@bike4mind/services');
+  return {
+    ...actual,
+    dataLakeService: { ...actual.dataLakeService, getDynamicDataLakeAccess: mockGetDynamicDataLakeAccess },
+  };
+});
 vi.mock('@bike4mind/database', () => ({
   dataLakeRepository: { __marker: 'dataLakeRepository' },
   organizationRepository: { __marker: 'organizationRepository', findMembershipOrgIds: mockFindMembershipOrgIds },
@@ -133,12 +142,18 @@ describe('withStaticRegistryBypass', () => {
     const out = withStaticRegistryBypass(scopeOf(), REGISTRY);
 
     expect(out.lakes.map(l => l.datalakeTag)).toEqual(['datalake:opti-knowledge', 'datalake:house-kb']);
-    // Registry-sourced entries carry no membership scope - they have no creator to anchor one to.
-    // A fourth pinned property (#2243): since lakeMembershipsFrom (getDynamicDataLakeTags.ts) is
-    // exactly `lakes.flatMap(l => l.membership ? [l.membership] : [])`, "no lake here has a
-    // membership" IS "lakeMembershipsFrom(out.lakes) === []" - the injected lakes contribute no
-    // retrieval arm at all, unanchored or otherwise.
-    expect(out.lakes.every(l => l.source === 'registry' && !l.membership)).toBe(true);
+    // Each injected entry carries a REGISTRY membership scope, built off the registry config
+    // (property 1 above): the whole-lake count needs a scope for these lakes, or a privileged
+    // caller can search a registry lake and not count it.
+    expect(out.lakes.map(l => l.membership)).toEqual([
+      { kind: 'registry', datalakeTag: 'datalake:opti-knowledge', fileTagPrefix: 'opti:' },
+      { kind: 'registry', datalakeTag: 'datalake:house-kb', fileTagPrefix: 'house:' },
+    ]);
+    // The property #2243 actually needs, restated now that presence proves nothing: an unanchored
+    // arm must not reach a MULTI-lake retrieval query. `lakeMembershipsFrom` allow-lists `owned`,
+    // so the injected lakes still contribute no retrieval arm - which is what this asserts
+    // directly rather than via the absence of the field.
+    expect(out.lakes.every(l => l.source === 'registry' && l.membership.kind === 'registry')).toBe(true);
   });
 
   it('keeps a lake the scope already resolved, rather than replacing it with a registry entry', () => {
@@ -150,7 +165,12 @@ describe('withStaticRegistryBypass', () => {
       slug: 'opti-knowledge',
       datalakeTag: 'datalake:opti-knowledge',
       fileTagPrefix: 'opti:',
-      membership: { datalakeTag: 'datalake:opti-knowledge', fileTagPrefix: 'opti:', creatorUserId: 'owner1' },
+      membership: {
+        kind: 'owned' as const,
+        datalakeTag: 'datalake:opti-knowledge',
+        fileTagPrefix: 'opti:',
+        creatorUserId: 'owner1',
+      },
       source: 'dynamic' as const,
     };
 

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
@@ -59,7 +59,13 @@ export function withStaticRegistryBypass(
     // Per-lake entries follow the same widening, or a privileged caller could search a registry
     // lake but not count it. Registry-sourced by construction, like the prefixes above, and
     // keyed on the globally-unique meta-tag so a lake the scope already resolved keeps its own
-    // (possibly membership-carrying) entry.
+    // entry (and with it that lake's creator-anchored scope, rather than a weaker registry copy).
+    //
+    // The scope comes from `registryMembershipScope`, i.e. off the same compile-time registry
+    // config as the prefixes, which is property 1 above applied to this bucket: reading it off
+    // `scope` would let a DB row shadowing a registry id launder its user-controlled prefix into
+    // an unanchored arm. Multi-lake retrieval drops these anyway (`lakeMembershipsFrom`); what
+    // they buy is the whole-lake count, which is per-lake and access-gated.
     lakes: [
       ...scope.lakes,
       ...registry
@@ -70,6 +76,7 @@ export function withStaticRegistryBypass(
           slug: lake.slug,
           datalakeTag: lake.datalakeTag,
           fileTagPrefix: lake.fileTagPrefix,
+          membership: dataLakeService.registryMembershipScope(lake),
           source: 'registry' as const,
         })),
     ],

--- a/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.test.ts
+++ b/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.test.ts
@@ -6,6 +6,7 @@ import {
   type DataLakeAccessContext,
   type ResolvedLakeAccess,
 } from './getDynamicDataLakeTags';
+import { registryMembershipScope } from './lakeMembershipScope';
 
 const dbLake = (overrides: Partial<IDataLakeDocument> & Pick<IDataLakeDocument, 'id'>): IDataLakeDocument =>
   ({
@@ -326,6 +327,59 @@ describe('getDynamicDataLakeAccess — entitlement-aware lake resolution', () =>
 
 // #2243: the membership arms a retrieval query should carry - one per DYNAMIC lake, none for a
 // registry lake (no creator to anchor a prefix arm to).
+/**
+ * Link 1 of the count/browse parity chain (#2265). The count surface passes
+ * `ResolvedLakeAccess.membership` through verbatim (pinned in knowledgeBaseCount/index.test.ts) and
+ * the single-lake browse builds `registryMembershipScope(lake)` (pinned in
+ * apps/client/pages/api/data-lakes/[id]/__tests__/registryScopeParity.test.ts). What closes the
+ * chain is this: the scope the RESOLVER attaches to a registry lake is that same function's output,
+ * not a second construction that merely agrees.
+ *
+ * Asserted against `registryMembershipScope` rather than a literal on purpose - a literal here
+ * would be the third independent copy of the predicate, which is the drift this issue removed.
+ */
+describe('registry lakes carry the shared registry membership scope', () => {
+  const optiConfig = DATA_LAKES.find(dl => dl.id === 'opti-knowledge')!;
+
+  it('attaches registryMembershipScope, byte for byte, to a resolved registry lake', async () => {
+    const res = await getDynamicDataLakeAccess({
+      db: { organizations: { findMembershipOrgIds: vi.fn().mockResolvedValue([]) } },
+      user: { tags: ['Opti'] },
+    });
+
+    const opti = res.lakes.find(l => l.datalakeTag === optiConfig.datalakeTag)!;
+    expect(opti.source).toBe('registry');
+    expect(opti.membership).toEqual(registryMembershipScope(optiConfig));
+  });
+
+  it('gives it kind "registry", so the multi-lake fan-outs still drop its unanchored prefix arm', async () => {
+    const res = await getDynamicDataLakeAccess({
+      db: { organizations: { findMembershipOrgIds: vi.fn().mockResolvedValue([]) } },
+      user: { tags: ['Opti'] },
+    });
+
+    // The guard that replaced "membership is absent for registry lakes": presence proves nothing
+    // now, the discriminant is the whole check.
+    expect(res.lakes.every(l => l.membership.kind === 'registry')).toBe(true);
+    expect(lakeMembershipsFrom(res.lakes)).toEqual([]);
+  });
+
+  it('keeps a DB lake creator-anchored, so the two kinds are not collapsed', async () => {
+    const res = await getDynamicDataLakeAccess(
+      ctx([dbLake({ id: 'acme', createdByUserId: 'creator-1', isPublic: true })])
+    );
+
+    const acme = res.lakes.find(l => l.datalakeTag === 'datalake:acme')!;
+    expect(acme.membership).toEqual({
+      kind: 'owned',
+      datalakeTag: 'datalake:acme',
+      fileTagPrefix: 'acme:',
+      creatorUserId: 'creator-1',
+    });
+    expect(lakeMembershipsFrom(res.lakes)).toEqual([acme.membership]);
+  });
+});
+
 describe('lakeMembershipsFrom', () => {
   const dynamicLake = (id: string, creatorUserId: string): ResolvedLakeAccess => ({
     id,
@@ -333,15 +387,18 @@ describe('lakeMembershipsFrom', () => {
     slug: id,
     datalakeTag: `datalake:${id}`,
     fileTagPrefix: `${id}:`,
-    membership: { datalakeTag: `datalake:${id}`, fileTagPrefix: `${id}:`, creatorUserId },
+    membership: { kind: 'owned', datalakeTag: `datalake:${id}`, fileTagPrefix: `${id}:`, creatorUserId },
     source: 'dynamic',
   });
+  // A registry lake carries a scope too, an UNANCHORED one - so what this helper drops is decided
+  // by `kind`, not by the field being absent. Fixtures that omit it can no longer express the case.
   const registryLake = (id: string): ResolvedLakeAccess => ({
     id,
     name: id,
     slug: id,
     datalakeTag: `datalake:${id}`,
     fileTagPrefix: `${id}:`,
+    membership: { kind: 'registry', datalakeTag: `datalake:${id}`, fileTagPrefix: `${id}:` },
     source: 'registry',
   });
 

--- a/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
+++ b/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
@@ -10,7 +10,7 @@ import {
 } from '@bike4mind/common';
 import type { Logger } from '@bike4mind/observability';
 import { isDatalakeTagWellFormed } from './createDataLake';
-import { lakeMembershipScope } from './lakeMembershipScope';
+import { lakeMembershipScope, registryMembershipScope } from './lakeMembershipScope';
 
 /**
  * The minimal context the data-lake access resolver needs. The knowledge tools
@@ -62,10 +62,9 @@ export interface DataLakeAccessContext {
  * flattened unions: they answer "may this file be searched" but lose which lake a file belongs
  * to, the creator its prefix arm is anchored to, and the lake's product-facing name.
  *
- * `source` is load-bearing, not decoration. A registry lake's files carry only prefixed content
- * tags - no write path stamps its meta-tag - so a membership-scope count of one returns 0; it
- * has to be counted through the OPEN prefix arm instead. See lakeMembershipScope and the
- * articles route's `isFallback` branch, which this must stay in agreement with.
+ * `source` is load-bearing, not decoration: it is what tells a consumer whether this lake's
+ * `membership` is creator-anchored (`owned`) or unanchored (`registry`), and only the former may
+ * enter a cross-lake `$or` - see `lakeMembershipsFrom`.
  */
 export interface ResolvedLakeAccess {
   id: string;
@@ -74,31 +73,48 @@ export interface ResolvedLakeAccess {
   datalakeTag: string;
   fileTagPrefix: string;
   /**
-   * The whole-lake membership predicate, DB lakes only - the same scope the single-lake browse
-   * and every lifecycle write run on, so a count built from it equals the lake page's total.
-   * Absent for registry lakes: they have no creator to anchor the prefix arm to.
+   * The whole-lake membership predicate - the same scope the single-lake browse and every
+   * lifecycle write run on, so a count built from it equals the lake page's total.
+   *
+   * REQUIRED, for both lake kinds, and deliberately not optional. Every construction site must
+   * produce one (`lakeMembershipScope` for a DB lake, `registryMembershipScope` for a registry
+   * lake), because an absent value used to force each whole-lake consumer to hand-roll its own
+   * registry fallback - and the count surface's copy drifted from the browse's and under-counted
+   * every registry lake. A required field is what makes that class of drift unrepresentable.
    */
-  membership?: DataLakeMembershipScope;
+  membership: DataLakeMembershipScope;
   source: 'registry' | 'dynamic';
 }
 
 /**
- * The membership arms a retrieval query should carry for a resolved access set: one per lake that
- * HAS a membership scope. Registry lakes have none (no creator to anchor to) and keep using the
- * OPEN `dataLakeTagPrefixes` arm - dropping them here is what stops a registry lake being silently
- * demoted to meta-tag-only matching.
+ * The membership arms a MULTI-LAKE retrieval query may carry: one per lake whose scope is
+ * creator-anchored. Registry lakes have a scope too, but an unanchored one, so they are dropped
+ * here and keep matching through the OPEN `dataLakeTagPrefixes` arm instead.
  *
- * INVARIANT: every scope this returns is creator-anchored to a DYNAMIC lake. Two independent
- * guards hold it, because presence alone is no longer enough: `membership` is set ONLY on the
- * `source: 'dynamic'` branch below, AND the `kind` filter here drops a registry scope even if some
- * future construction site attaches one. #2216 gave `DataLakeMembershipScope` that discriminant
- * precisely so this could be checked - a registry scope's prefix arm carries no ownership conjunct
- * (see `buildDataLakeMembershipFilter`), so letting one reach a retrieval query would reopen the
- * cross-tenant promotion the SCOPED/OPEN split exists to forbid. Registry lakes keep using the
- * OPEN `dataLakeTagPrefixes` arm instead.
+ * INVARIANT: every scope this returns is creator-anchored. A registry scope's prefix arm carries
+ * no ownership conjunct (see `buildDataLakeMembershipFilter`), so beside other lakes' arms in one
+ * shared `$or` it stops being that lake's arm and becomes an unanchored prefix match any of the
+ * OR'd lakes can ride - the cross-tenant promotion the SCOPED/OPEN split exists to forbid.
+ *
+ * This `kind` filter is the ONLY guard on that. It used to be the second of two, backed by
+ * "`membership` is set only on the dynamic branch"; every lake now carries a scope, so presence
+ * proves nothing and the discriminant #2216 added is the whole check. It is an ALLOW-list on
+ * `owned` rather than `!== 'registry'` for that reason: a future third kind whose prefix arm is
+ * likewise unanchored would ride a deny-list in silently, with no type error. Stays in step with
+ * `dynamicMembershipScopesFor` (apps/client/server/dataLakes/index.ts), the same allow-list on the
+ * browse fan-out.
+ *
+ * Single-lake consumers do NOT filter: a query covering exactly one access-gated lake is where an
+ * unanchored prefix arm is safe, and narrowing a registry lake out there is what under-counted it.
+ * See `knowledgeBaseCount`'s `lakeScope` and the articles route.
+ *
+ * The optional read is not a live state - `membership` is required - it is the direction this
+ * degrades if some loosely-typed producer ever hands over a partial lake: contribute NO arm, i.e.
+ * match less. The count surface deliberately does the opposite and throws, because there a missing
+ * scope would silently report a wrong NUMBER; here it can only narrow a search.
  */
 export const lakeMembershipsFrom = (lakes: ResolvedLakeAccess[]): DataLakeMembershipScope[] =>
-  lakes.flatMap(l => (l.membership && l.membership.kind !== 'registry' ? [l.membership] : []));
+  lakes.flatMap(l => (l.membership?.kind === 'owned' ? [l.membership] : []));
 
 /** Above this many per-lake `$or` arms, subplanning cost may start to show in latency (R3). */
 const LARGE_MEMBERSHIP_ARM_COUNT = 50;
@@ -320,17 +336,18 @@ export async function getDynamicDataLakeAccess(context: DataLakeAccessContext): 
           slug: dl.slug,
           datalakeTag: dl.datalakeTag,
           fileTagPrefix: dl.fileTagPrefix,
-          // A creator-less row fails closed to meta-tag-only matching inside the filter builder,
-          // which is the safe direction (see buildDataLakeMembershipFilter).
-          ...(isDynamic
-            ? {
-                membership: lakeMembershipScope({
-                  datalakeTag: dl.datalakeTag,
-                  fileTagPrefix: dl.fileTagPrefix,
-                  createdByUserId: creatorUserId,
-                }),
-              }
-            : {}),
+          // Both kinds get a scope, so no whole-lake consumer has to hand-roll a registry
+          // fallback. A creator-less DB row fails closed to meta-tag-only matching inside the
+          // filter builder, which is the safe direction (see buildDataLakeMembershipFilter); a
+          // registry lake's arm is unanchored by design and is dropped from multi-lake retrieval
+          // queries by `lakeMembershipsFrom`, not by being left absent here.
+          membership: isDynamic
+            ? lakeMembershipScope({
+                datalakeTag: dl.datalakeTag,
+                fileTagPrefix: dl.fileTagPrefix,
+                createdByUserId: creatorUserId,
+              })
+            : registryMembershipScope(dl),
           source: isDynamic ? ('dynamic' as const) : ('registry' as const),
         };
       }),

--- a/b4m-core/services/src/dataLakeService/narrowLakeAccessToSession.test.ts
+++ b/b4m-core/services/src/dataLakeService/narrowLakeAccessToSession.test.ts
@@ -7,6 +7,10 @@ const lake = (id: string, source: 'registry' | 'dynamic') => ({
   slug: id,
   datalakeTag: `datalake:${id}`,
   fileTagPrefix: `${id}:`,
+  membership:
+    source === 'dynamic'
+      ? { kind: 'owned' as const, datalakeTag: `datalake:${id}`, fileTagPrefix: `${id}:`, creatorUserId: `${id}-owner` }
+      : { kind: 'registry' as const, datalakeTag: `datalake:${id}`, fileTagPrefix: `${id}:` },
   source,
 });
 

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -687,7 +687,12 @@ describe('ChatCompletionProcess', () => {
   // see Approach property 1. Pin both directions.
   describe('countLakeReachableAttachments (#2243 lake-membership arm)', () => {
     const LAKE = { id: 'lake1', name: 'Acme', slug: 'acme', datalakeTag: 'datalake:acme', fileTagPrefix: 'acme:' };
-    const MEMBERSHIP = { datalakeTag: LAKE.datalakeTag, fileTagPrefix: LAKE.fileTagPrefix, creatorUserId: 'creator-1' };
+    const MEMBERSHIP = {
+      kind: 'owned' as const,
+      datalakeTag: LAKE.datalakeTag,
+      fileTagPrefix: LAKE.fileTagPrefix,
+      creatorUserId: 'creator-1',
+    };
 
     it('forwards lakeMemberships (derived from access.lakes), not scopedTagPrefixes', async () => {
       (service as any).accessibleDataLakeAccessMemo = {

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseCount/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseCount/index.test.ts
@@ -17,17 +17,26 @@ const dynamicLake = {
   slug: 'research',
   datalakeTag: 'datalake:org1:research',
   fileTagPrefix: 'acme:',
-  membership: { datalakeTag: 'datalake:org1:research', fileTagPrefix: 'acme:', creatorUserId: 'owner1' },
+  membership: {
+    kind: 'owned' as const,
+    datalakeTag: 'datalake:org1:research',
+    fileTagPrefix: 'acme:',
+    creatorUserId: 'owner1',
+  },
   source: 'dynamic' as const,
 };
 
-/** A static-registry lake: no creator, so it can only be counted through the OPEN prefix arm. */
+/**
+ * A static-registry lake: no creator, so its prefix arm is unanchored - which is why its scope is
+ * `kind: 'registry'` and not `owned`. It still HAS a scope; being counted through one is the point.
+ */
 const registryLake = {
   id: 'lake2',
   name: 'Shared KB',
   slug: 'shared',
   datalakeTag: 'datalake:shared',
   fileTagPrefix: 'opti:',
+  membership: { kind: 'registry' as const, datalakeTag: 'datalake:shared', fileTagPrefix: 'opti:' },
   source: 'registry' as const,
 };
 
@@ -80,8 +89,12 @@ describe('count_knowledge_base', () => {
     expect(searchCalls(ctx)[0][5]).not.toHaveProperty('dataLakeTags');
   });
 
-  it('counts a registry lake through the OPEN prefix arm instead', async () => {
-    // A registry lake's files carry no meta-tag, so a membership-scope count would return 0.
+  it('counts a registry lake through its registry membership scope, not a hand-rolled tag pair', async () => {
+    // The regression this pins: this arm used to assemble `dataLakeTags` + `dataLakeTagPrefixes`
+    // by hand because `membership` was absent for registry lakes. It happened to emit the same
+    // OR-set as `buildDataLakeMembershipFilter`'s registry arm, so nothing caught the divergence
+    // when one of them moved. Asserting the SCOPE (not the resulting count) is what makes the
+    // parity structural - see registryScopeParity.test.ts for the count-vs-browse half.
     getDynamicDataLakeAccessMock.mockResolvedValue({
       dataLakeTags: [],
       dataLakeTagPrefixes: [registryLake.fileTagPrefix],
@@ -91,11 +104,12 @@ describe('count_knowledge_base', () => {
     const ctx = makeContext();
     await run(ctx);
     expect(searchCalls(ctx)[0][5]).toMatchObject({
-      dataLakeTags: [registryLake.datalakeTag],
-      dataLakeTagPrefixes: [registryLake.fileTagPrefix],
+      lakeMemberships: [registryLake.membership],
       restrictToDataLake: true,
+      includeShared: true,
     });
-    expect(searchCalls(ctx)[0][5]).not.toHaveProperty('lakeMemberships');
+    expect(searchCalls(ctx)[0][5]).not.toHaveProperty('dataLakeTags');
+    expect(searchCalls(ctx)[0][5]).not.toHaveProperty('dataLakeTagPrefixes');
   });
 
   it('totals several libraries and names each', async () => {
@@ -224,12 +238,20 @@ describe('count_knowledge_base narrows lake access to the session lake', () => {
       dataLakeTagPrefixes: ['mine:', 'unrel:'],
       scopedTagPrefixes: [],
       lakes: [
-        { id: 'l1', name: 'mine', datalakeTag: 'datalake:mine', fileTagPrefix: 'mine:', source: 'registry' },
+        {
+          id: 'l1',
+          name: 'mine',
+          datalakeTag: 'datalake:mine',
+          fileTagPrefix: 'mine:',
+          membership: { kind: 'registry', datalakeTag: 'datalake:mine', fileTagPrefix: 'mine:' },
+          source: 'registry',
+        },
         {
           id: 'l2',
           name: 'Unrelated-Product-KB',
           datalakeTag: 'datalake:unrelated',
           fileTagPrefix: 'unrel:',
+          membership: { kind: 'registry', datalakeTag: 'datalake:unrelated', fileTagPrefix: 'unrel:' },
           source: 'registry',
         },
       ],

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseCount/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseCount/index.ts
@@ -87,7 +87,21 @@ async function countScope(context: ToolContext, scope: CountScope): Promise<Coun
   return { count, exact: false };
 }
 
-/** The scope arm a lake is counted through - see ResolvedLakeAccess.source for why they differ. */
+/**
+ * The scope a single lake is counted through: that lake's own membership predicate and nothing
+ * else, for both lake kinds.
+ *
+ * ONE query per lake, which is what makes a `registry` scope's unanchored prefix arm safe here -
+ * the precondition the `lakeMemberships` docblock states is "access gated upstream, query covers
+ * ONE lake", and access is gated by `resolveSessionLakeAccess`. Do not batch these into a shared
+ * cross-lake `$or`; that is the case `lakeMembershipsFrom` exists to filter.
+ *
+ * This used to fork on `lake.membership` being absent and hand-roll a `dataLakeTags` +
+ * `dataLakeTagPrefixes` pair for registry lakes. It emitted the same OR-set as the real predicate
+ * by coincidence, and the number here is reported to the user as "the same totals the library shows
+ * on its page" - a parity claim two independently-written predicates cannot hold. Keep it routed
+ * through the shared scope.
+ */
 function lakeScope(lake: ResolvedLakeAccess, context: ToolContext): CountScope {
   return {
     options: {
@@ -96,9 +110,7 @@ function lakeScope(lake: ResolvedLakeAccess, context: ToolContext): CountScope {
       restrictToDataLake: true,
       includeShared: true,
       userGroups: context.user.groups ?? [],
-      ...(lake.membership
-        ? { lakeMemberships: [lake.membership] }
-        : { dataLakeTags: [lake.datalakeTag], dataLakeTagPrefixes: [lake.fileTagPrefix] }),
+      lakeMemberships: [lake.membership],
     },
   };
 }

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.test.ts
@@ -177,16 +177,27 @@ describe('retrieve_knowledge_content — by-id (Path A) retrieval exclusion', ()
 // caller who passes the lake gate (not only the lake's creator). Without this membership arm,
 // retrieve_knowledge_content would deny exactly the file search just returned.
 describe('retrieve_knowledge_content - by-id (Path A) dynamic-lake membership arm (#2243)', () => {
-  const LAKE_SCOPE = { datalakeTag: 'datalake:org1:acme', fileTagPrefix: 'acme:', creatorUserId: 'creator-1' };
-  const lakesWith = (scope: typeof LAKE_SCOPE | undefined) => [
+  const LAKE_SCOPE = {
+    kind: 'owned' as const,
+    datalakeTag: 'datalake:org1:acme',
+    fileTagPrefix: 'acme:',
+    creatorUserId: 'creator-1',
+  };
+  /** The same lake under a registry scope: same tags, but an UNANCHORED prefix arm. */
+  const REGISTRY_SCOPE = {
+    kind: 'registry' as const,
+    datalakeTag: LAKE_SCOPE.datalakeTag,
+    fileTagPrefix: LAKE_SCOPE.fileTagPrefix,
+  };
+  const lakesWith = (scope: typeof LAKE_SCOPE | typeof REGISTRY_SCOPE) => [
     {
       id: 'lake1',
       name: 'Acme Docs',
       slug: 'acme',
       datalakeTag: LAKE_SCOPE.datalakeTag,
       fileTagPrefix: LAKE_SCOPE.fileTagPrefix,
-      source: 'dynamic' as const,
-      ...(scope ? { membership: scope } : {}),
+      membership: scope,
+      source: scope.kind === 'owned' ? ('dynamic' as const) : ('registry' as const),
     },
   ];
 
@@ -226,12 +237,15 @@ describe('retrieve_knowledge_content - by-id (Path A) dynamic-lake membership ar
     expect(out).toContain(`No document found with ID "${FILE_ID}"`);
   });
 
-  it('a registry lake (no membership scope) grants no membership access on its own', async () => {
+  it('a registry lake grants no membership access on its own, scope present or not', async () => {
+    // This case used to be expressed as a lake with NO membership scope. Registry lakes carry one
+    // now (#2265), so the guard being tested is no longer "the field is absent" but "its `kind` is
+    // not creator-anchored, so `lakeMembershipsFrom` drops it". Same denial, live reason.
     getDynamicDataLakeAccessMock.mockResolvedValueOnce({
       dataLakeTags: [LAKE_SCOPE.datalakeTag],
       dataLakeTagPrefixes: [],
       scopedTagPrefixes: [],
-      lakes: lakesWith(undefined),
+      lakes: lakesWith(REGISTRY_SCOPE),
     });
     const ctx = makeContext();
     (ctx.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -1207,12 +1221,20 @@ describe('retrieve_knowledge_content narrows lake access to the session lake', (
     dataLakeTagPrefixes: ['mine:', 'unrel:'],
     scopedTagPrefixes: [],
     lakes: [
-      { id: 'l1', name: 'mine', datalakeTag: 'datalake:mine', fileTagPrefix: 'mine:', source: 'registry' },
+      {
+        id: 'l1',
+        name: 'mine',
+        datalakeTag: 'datalake:mine',
+        fileTagPrefix: 'mine:',
+        membership: { kind: 'registry', datalakeTag: 'datalake:mine', fileTagPrefix: 'mine:' },
+        source: 'registry',
+      },
       {
         id: 'l2',
         name: 'Unrelated-Product-KB',
         datalakeTag: 'datalake:unrelated',
         fileTagPrefix: 'unrel:',
+        membership: { kind: 'registry', datalakeTag: 'datalake:unrelated', fileTagPrefix: 'unrel:' },
         source: 'registry',
       },
     ],

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
@@ -2940,8 +2940,20 @@ describe('search_knowledge_base narrows lake access to the session lake', () => 
     dataLakeTagPrefixes: ['mine:', 'other:'],
     scopedTagPrefixes: [],
     lakes: [
-      { id: 'l1', datalakeTag: 'datalake:mine', fileTagPrefix: 'mine:', source: 'registry' },
-      { id: 'l2', datalakeTag: 'datalake:other', fileTagPrefix: 'other:', source: 'registry' },
+      {
+        id: 'l1',
+        datalakeTag: 'datalake:mine',
+        fileTagPrefix: 'mine:',
+        membership: { kind: 'registry', datalakeTag: 'datalake:mine', fileTagPrefix: 'mine:' },
+        source: 'registry',
+      },
+      {
+        id: 'l2',
+        datalakeTag: 'datalake:other',
+        fileTagPrefix: 'other:',
+        membership: { kind: 'registry', datalakeTag: 'datalake:other', fileTagPrefix: 'other:' },
+        source: 'registry',
+      },
     ],
   };
 

--- a/packages/database/src/queries/fabFileSearchQuery.ts
+++ b/packages/database/src/queries/fabFileSearchQuery.ts
@@ -179,13 +179,17 @@ export function buildOwnershipConditions(
      *
      * A `registry` scope's prefix arm carries NO ownership conjunct (see
      * `buildDataLakeMembershipFilter`), so it is safe ONLY where access is gated upstream and the
-     * query covers ONE lake - today that is the single-lake browse (`data-lakes/[id]/articles.ts`,
-     * gated by `assertLakeAccess`). Never put one in a multi-lake retrieval query: an unanchored
-     * prefix arm beside other lakes' arms is the cross-tenant promotion the SCOPED/OPEN split
-     * forbids. `lakeMembershipsFrom` filters `registry` out for that reason, but it is NOT the only
-     * door - `knowledgeBaseCount` reads `ResolvedLakeAccess.membership` directly. What actually
-     * holds the invariant is that `membership` is only ever attached to dynamic lakes; the filter
-     * is the second guard, not the first.
+     * query covers ONE lake: today the single-lake browse (`data-lakes/[id]/articles.ts`, gated by
+     * `assertLakeAccess`) and `knowledgeBaseCount`'s per-lake count (one query per lake, gated by
+     * `resolveSessionLakeAccess`). Never put one in a MULTI-lake query: an unanchored prefix arm
+     * beside other lakes' arms is the cross-tenant promotion the SCOPED/OPEN split forbids.
+     *
+     * Every `ResolvedLakeAccess` now carries a scope, registry lakes included, so presence is no
+     * longer a proxy for "creator-anchored" and the `kind` discriminant is the only thing that
+     * decides. The two multi-lake fan-outs allow-list it: `lakeMembershipsFrom`
+     * (getDynamicDataLakeTags.ts) and `dynamicMembershipScopesFor` (server/dataLakes/index.ts).
+     * Any NEW multi-lake call site must go through one of them rather than mapping
+     * `lakes.map(l => l.membership)` itself.
      */
     lakeMemberships?: DataLakeMembershipScope[];
     /**


### PR DESCRIPTION
# Pull Request

## Description

`count_knowledge_base` still carried the hand-rolled registry carve-out that #2216 deleted from the single-lake browse:

```ts
...(lake.membership
  ? { lakeMemberships: [lake.membership] }
  : { dataLakeTags: [lake.datalakeTag], dataLakeTagPrefixes: [lake.fileTagPrefix] }),
```

The fallback arm existed only because `getDynamicDataLakeTags` never populated a registry lake's `membership` - a shape the discriminated union has been able to express since #2216.

**No numeric divergence today** - both paths emit the same OR-set, so this is drift risk rather than a live bug. What makes it worth closing is the claim attached to it: the tool's closing instruction tells the model these are *"the same totals the library shows on its page in the product"*. That parity was maintained by two independently-written predicates that merely happened to agree, and #2216 exists because exactly that arrangement drifted and produced `0 vs 86` on a built-in lake.

## Changes

- **`getDynamicDataLakeTags.ts`** - the registry arm now attaches `registryMembershipScope(dl)`. `ResolvedLakeAccess.membership` becomes **required**, so no whole-lake consumer can be forced to hand-roll a fallback again.
- **`resolveRetrievalLakeScope.ts`** - `withStaticRegistryBypass` is the *second* production site that builds registry `ResolvedLakeAccess` entries (the count fallback was absorbing both), so it attaches the scope too, sourced from the registry config like its prefixes.
- **`knowledgeBaseCount/index.ts`** - fallback branch deleted; `lakeScope` always passes `lakeMemberships: [lake.membership]`.
- **`lakeMembershipsFrom`** - now an **allow-list on `owned`** rather than `!== 'registry'`. This is the load-bearing change in the safety argument, see below.
- **Docblocks** - four asserted the old arrangement as the primary invariant and are flipped together: `getDynamicDataLakeTags.ts` (the `ResolvedLakeAccess` header, the `membership` field, and `lakeMembershipsFrom`) plus `fabFileSearchQuery.ts`'s `lakeMemberships` contract. The articles-route comment claiming "both now go through the same scope" was false for the count surface and now points at the test that pins it.

### The safety argument changed, so it is written down

Previously two guards kept an unanchored registry prefix arm out of a shared cross-lake `$or`: `membership` was set only on the dynamic branch, **and** the `kind` filter dropped a registry scope. This PR removes the first one - every lake carries a scope now, so presence proves nothing and the discriminant is the whole check. What holds it:

- both multi-lake fan-outs drop a non-`owned` scope: `lakeMembershipsFrom` and `dynamicMembershipScopesFor` (`server/dataLakes/index.ts:203`, added by #2273);
- `knowledgeBaseCount` is one-query-per-lake (`index.ts:159`) behind `resolveSessionLakeAccess`, which is exactly the "access gated upstream, query covers ONE lake" precondition `fabFileSearchQuery`'s docblock states for a registry scope.

The allow-list upgrade is deliberate: with the second guard gone, the remaining one should be the strong form, so a future third unanchored `kind` cannot ride a deny-list in with no type error.

### Parity is pinned as a chain of real links

The two surfaces live in different packages and neither can drive the other, so each link is asserted against the **shared function** and the chain closes transitively. No link restates the predicate as a literal - a literal would be the third independent copy, which is the drift this PR removes.

| link | asserted in |
| --- | --- |
| count tool passes `membership` verbatim | `knowledgeBaseCount/index.test.ts` |
| resolver attaches `registryMembershipScope(config)` | `getDynamicDataLakeTags.test.ts` |
| single-lake browse builds `registryMembershipScope(lake)` | `pages/api/data-lakes/[id]/__tests__/registryScopeParity.test.ts` (new) |

Per `dataLakeMembershipParity.integration.test.ts`'s lesson, the assertions compare **scopes and the Mongo predicates derived from them, never counts** - that fixture has two liveness errors that cancel to equal totals over different sets, so a cardinality assertion passes against a broken predicate.

Both new links were **mutation-verified**: re-introducing the hand-rolled pair in the route fails 2 of 3 parity tests, and hand-rolling the scope in the resolver fails the byte-for-byte test.

## Guide for Testers

Backend-only refactor with no UI surface. The observable behavior is a chat tool's reported number.

**Setup**

1. Open `app.staging.bike4mind.com` and log in.
2. In the sidebar, go to **Data Lakes** and pick a **built-in / registry** lake (one you cannot edit or delete - e.g. a platform knowledge base). Open it.
3. Note the total the lake's article list reports at the top of its page. Record that number.

**The parity check (the point of this PR)**

4. Start a new chat session scoped to that same lake.
5. Type exactly: `How many documents are in the knowledge base?`
6. Expect a reply within ~20 seconds naming the lake and a document count.
7. **The count in step 6 must equal the number recorded in step 3.** A mismatch is the regression this PR guards.

**Regression Checks**

8. Repeat steps 3-7 for a **user-created (DB) data lake** you own that has files. The two numbers must still match - this path was already going through the membership scope and must not have moved.
9. In that DB lake, confirm the article list still shows only that lake's files (no files from your other lakes bleeding in).
10. In a chat session scoped to one lake, ask `What lakes can you see?` - it must name only the session's lake, not every lake your account can reach.
11. Ask a content question against the registry lake (`Summarize what this library covers`) and confirm `search_knowledge_base` still returns passages - retrieval must be unchanged.
12. As an **admin/developer** account, run steps 4-7 against a registry lake. This exercises `withStaticRegistryBypass`, the second construction site fixed here: the count must be a real number, not an error or `0`.

**What NOT to test**

- No UI, styling, routing, or component changes - nothing visual moved.
- No schema, index, or migration changes; no new env vars or feature flags.
- The liveness divergence between `computeDataLakeStats` (drops `status: 'pending'`) and the browse query (drops session summaries) is a **known, separate remainder** pinned in `dataLakeMembershipParity.integration.test.ts` and documented in #2216. A small stats-vs-browse gap on a lake with pending files is out of scope here.

## Additional Information

**Breaking-change labelling.** `ResolvedLakeAccess.membership` goes optional to required on a type exported from `@bike4mind/services`, which is source-breaking for anything *constructing* one (consumers *reading* it only get simpler). I grepped all five premium overlays (`optihashi`, `pi`, `libreoncology`, `overwatch`, `tavern`) and none reference `ResolvedLakeAccess`, `lakeMembershipsFrom`, or the scope builders at all - so there is no known out-of-repo producer. Titled `refactor(data-lakes)!:` anyway so the auto-generated changeset carries the right signal rather than shipping a required-field tightening as a patch.

**Verification.** `pnpm typecheck:fast`, `pnpm lint:check`, full `@bike4mind/services` suite (5793 passed), full `@bike4mind/database` suite (2191 passed), and the `@bike4mind/client` node project over `server/**` + `pages/api/data-lakes/**` + `pages/api/files/**` (5018 passed). Note `b4m-core/services/tsconfig.json` excludes `**/*.test.ts`, so the required-field tightening surfaced in test fixtures at runtime rather than at compile time - the fixture updates in this diff are that fallout.

## Developer Notes

- **`registryMembershipScope` is now the single door for a registry lake's whole-lake predicate.** All four whole-lake surfaces route through it: single-lake browse (`[id]/articles.ts`), stats (`[id].ts:60`), multi-lake browse (`server/dataLakes/index.ts:179`), and now the count tool via the resolver. Nothing hand-rolls the pair any more.
- **`ResolvedLakeAccess.membership` being required is the design point, not an incidental tightening.** The absent value was what forced each consumer to invent its own registry fallback; a required field makes that class of drift unrepresentable rather than merely discouraged.
- **`lakeMembershipsFrom` reads `membership?.kind` even though the field is required.** Deliberate and commented: an absent value is not a live state, and the optional read is the *direction* it degrades if a loosely-typed producer ever appears - contribute no arm, i.e. match less. The count surface intentionally does the opposite and throws (caught by the tool, reported as "count unavailable"), because there a missing scope would silently report a wrong *number* rather than narrow a search.
- **Pattern: parity as a chain of real links.** When two surfaces that must agree live in packages that cannot drive each other, assert each one against the shared function instead of writing one test that restates the predicate. The restatement is the very duplication the parity is supposed to prevent.
- **`vi.mock` factories should use `importOriginal` for pure shared helpers.** `resolveRetrievalLakeScope.test.ts` now does; a hand-written stand-in for `registryMembershipScope` would have been a second copy of the predicate inside the test asserting parity with it.

Closes #2265
