### PR TITLE
fix(navigation): drop a hardcoded catalogue count from a navigate_view description

### DIFF
--- a/b4m-core/common/src/navigation/viewRegistry.test.ts
+++ b/b4m-core/common/src/navigation/viewRegistry.test.ts
@@ -21,6 +21,20 @@ describe('FEATURE_PATH_PREFIXES', () => {
   });
 });
 
+describe('VIEW_REGISTRY descriptions', () => {
+  // Every description is spliced verbatim into the navigate_view system prompt by
+  // getViewSummaryForLLM, so a stale one misinforms the model with nothing to catch it.
+  // Counts of things this repo cannot count are the drift-prone case: the catalogues they
+  // quantify live in packages this one does not import, so no build error ever fires.
+  // opti.root carried such a count until it had gone badly stale. Describe, do not tally.
+  const INVENTORY_COUNT = /\b\d+\b[^.]*\b(famil|pattern|solver|card)/i;
+
+  it('quantify no catalogue this package cannot count', () => {
+    const offenders = VIEW_REGISTRY.filter(v => INVENTORY_COUNT.test(v.description)).map(v => v.id);
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe('getCurrentPathFromContext', () => {
   it('returns null for undefined or empty input', () => {
     expect(getCurrentPathFromContext(undefined)).toBeNull();

--- a/b4m-core/common/src/navigation/viewRegistry.ts
+++ b/b4m-core/common/src/navigation/viewRegistry.ts
@@ -43,7 +43,7 @@ export const VIEW_REGISTRY: NavigableView[] = [
     id: 'opti.root',
     section: 'opti',
     label: 'OptiHashi Home',
-    description: 'The OptiHashi Optimizer landing page showing all 8 pattern family cards',
+    description: 'The OptiHashi Optimizer landing page showing the pattern family cards',
     navigationType: 'route',
     target: '/opti',
     keywords: ['optimization', 'canvasser', 'home', 'patterns', 'families'],


### PR DESCRIPTION
# Pull Request

## Description

`getViewSummaryForLLM` splices every `VIEW_REGISTRY` description verbatim into the
`navigate_view` system prompt. The `opti.root` entry described the page as *"The OptiHashi
Optimizer landing page showing all 8 pattern family cards"* - and that count had gone stale.
The model was being handed a wrong fact on every turn that builds navigation context.

The reason it stayed wrong is the interesting part: **this package cannot import the catalogue
it was counting.** The registry that would settle the number lives in a package `common` does
not depend on, so the literal was unverifiable from inside this repo. No build error, no test,
and nothing a reviewer walking the UI would notice - the string is only ever read by the model.

So the fix is to stop asserting the quantity rather than to correct it. Descriptions here exist
to help the model decide *when* to suggest a view; the tally does no work for that, and every
sibling entry in the registry already describes without counting.

## Changes

- `viewRegistry.ts`: `opti.root`'s description drops the count. It now reads "The OptiHashi
  Optimizer landing page showing the pattern family cards".
- `viewRegistry.test.ts`: a guard for the class, not the instance. Any registry description that
  quantifies a family/pattern/solver/card catalogue fails the suite, and the failure names the
  offending view id. This sits alongside the existing "is derived from the registry, not
  hardcoded" test, which is the same idea applied to `FEATURE_PATH_PREFIXES`.

## Guide for Testers

This changes text that only the LLM reads. There is no visual change anywhere in the app, and
no behavioural change to navigation itself.

1. Go to `app.staging.bike4mind.com` and sign in.
2. Open a new chat from the main chat page (`/`).
3. Type `how do I configure solvers?` and send it.
   Expected: the assistant answers AND renders a clickable navigation button. The button still
   works and lands on the right view.
4. Type `take me to the optimizer home` and send it.
   Expected: a navigation button for OptiHashi Home appears and navigates to `/opti`.
5. Ask the assistant `how many pattern families are there?` from the main chat page.
   Expected: it does not answer "8" on the strength of the navigation context. (Before this PR
   that number was reachable from the system prompt and was wrong.)

### Regression Checks

6. Ask a question that maps to an admin view, e.g. `where do I manage users?` (as an admin).
   Expected: `navigate_view` still fires with an admin suggestion; admin-only views are still
   filtered out for non-admin users.
7. Ask something unrelated to any view, e.g. `write me a haiku about the sea`.
   Expected: no navigation button is forced onto the answer.
8. Confirm navigation still works from a feature page, not just `/`.
   Expected: unchanged behaviour - the current-path detection is untouched by this PR.

### What NOT to test

- Any `/opti` UI. Nothing rendered there reads this string; the surfaces that show the family
  cards derive their own copy and are not touched here.
- The count itself. This PR does not change how many of anything exist - it stops this file
  from claiming a number it has no way to check.

## Additional Information

Found while tracing the consumers of the view-context system message, not from a bug report -
nothing user-visible was broken, which is precisely why it survived. The same class of stale
literal is worth watching for anywhere a string in one package describes a catalogue owned by
another.

## Developer Notes (Optional)

- The new test is a **class guard**: it asserts a property over the whole registry rather than
  pinning one entry's copy, so it keeps working as entries are added and fails on the next
  instance instead of this one. Worth copying wherever a hand-written string describes a
  collection the surrounding package cannot enumerate.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
