### PR TITLE
feat(admin): add an API-key scope-enforcement preflight

### DIFF
--- a/apps/client/app/components/admin/AdminPage.tsx
+++ b/apps/client/app/components/admin/AdminPage.tsx
@@ -95,6 +95,7 @@ const ContextInspectorTab = dynamic(() => import('./ContextInspectorTab'), { ssr
 const RetrievalRateTab = dynamic(() => import('./RetrievalRateTab'), { ssr: false });
 const RateLimitsTab = dynamic(() => import('./RateLimits'), { ssr: false });
 const DlqReplayTab = dynamic(() => import('./DlqReplayTab'), { ssr: false });
+const ApiKeyScopePreflightTab = dynamic(() => import('./ApiKeyScopePreflightTab'), { ssr: false });
 const IntegrationHealthTab = dynamic(() => import('./IntegrationHealth'), { ssr: false });
 const SreAgentTab = dynamic(() => import('./SreAgentTab'), { ssr: false });
 const SecopsTriageTab = dynamic(() => import('./SecopsTriageTab'), { ssr: false });
@@ -586,6 +587,9 @@ const AdminPage = ({ enableUserMigration }: AdminPageProps) => {
               </TabPanel>
               <TabPanel value={AdminTab.RateLimits}>{activeTab === AdminTab.RateLimits && <RateLimitsTab />}</TabPanel>
               <TabPanel value={AdminTab.DlqReplay}>{activeTab === AdminTab.DlqReplay && <DlqReplayTab />}</TabPanel>
+              <TabPanel value={AdminTab.ApiKeyScopePreflight}>
+                {activeTab === AdminTab.ApiKeyScopePreflight && <ApiKeyScopePreflightTab />}
+              </TabPanel>
               <TabPanel value={AdminTab.IntegrationHealth}>
                 {activeTab === AdminTab.IntegrationHealth && <IntegrationHealthTab />}
               </TabPanel>

--- a/apps/client/app/components/admin/ApiKeyScopePreflightTab.test.tsx
+++ b/apps/client/app/components/admin/ApiKeyScopePreflightTab.test.tsx
@@ -31,7 +31,6 @@ const row = (over: Partial<IApiKeyScopePreflightRow> = {}): IApiKeyScopePrefligh
   userId: 'u1',
   requests: 9,
   lastUsed: new Date('2026-08-01'),
-  endpoints: ['/api/x/a'],
   heldScopes: [],
   outcome: 'deny',
   ...over,
@@ -44,6 +43,7 @@ const result = (over: Partial<IApiKeyScopePreflight> = {}): IApiKeyScopePrefligh
   stagedScopes: [],
   rows: [],
   truncated: false,
+  coverage: { fullWindow: true, unloggedPrefixes: [] },
   ...over,
 });
 
@@ -74,9 +74,10 @@ describe('ApiKeyScopePreflightTab', () => {
     expect(screen.getByTestId('scope-preflight-run-btn')).toBeDisabled();
   });
 
-  it('reads an empty result as safe-to-enforce, not as missing data', () => {
+  it('reads a fully-covered empty result as safe-to-enforce, not as missing data', () => {
     // The distinction the tool exists for: nobody calls these routes, so the
-    // staging sequence can be skipped entirely.
+    // staging sequence can be skipped entirely. Only licensed when the run saw
+    // the whole logged history over a prefix that is actually logged.
     mockUseApiKeyScopePreflight.mockReturnValue(state({ data: result({ rows: [] }) }));
     renderTab();
 
@@ -84,6 +85,50 @@ describe('ApiKeyScopePreflightTab', () => {
     expect(empty.textContent).toMatch(/No API key has called these routes/);
     expect(empty.textContent).toMatch(/enforced in one step/);
     expect(screen.queryByTestId('scope-preflight-results')).toBeNull();
+  });
+
+  it('withholds the enforce-in-one-step advice on a short-window empty result', () => {
+    // A key that fires monthly leaves no trace in 7 days. Repeating the
+    // full-window wording here would license the exact one-shot rollout this
+    // tool was built to prevent.
+    mockUseApiKeyScopePreflight.mockReturnValue(
+      state({ data: result({ rows: [], windowDays: 7, coverage: { fullWindow: false, unloggedPrefixes: [] } }) })
+    );
+    renderTab();
+
+    expect(screen.queryByTestId('scope-preflight-empty')).toBeNull();
+    const inconclusive = screen.getByTestId('scope-preflight-empty-inconclusive');
+    expect(inconclusive.textContent).toMatch(/re-run at 90 days/);
+    expect(inconclusive.textContent).toMatch(/Do not skip the staging sequence/);
+    expect(inconclusive.textContent).not.toMatch(/enforced in one step/);
+  });
+
+  it('names the unlogged surfaces a prefix sweeps up, and will not call the result clean', () => {
+    // ApiKeyUsageLog is written only by baseApi, so traffic to verifyApiKey
+    // routes is invisible here - an unqualified "nobody calls these" would be a
+    // false statement of fact, not a coverage caveat.
+    mockUseApiKeyScopePreflight.mockReturnValue(
+      state({
+        data: result({ rows: [], coverage: { fullWindow: true, unloggedPrefixes: ['/api/ai/v1', '/api/embed'] } }),
+      })
+    );
+    renderTab();
+
+    expect(screen.getByTestId('scope-preflight-unlogged').textContent).toMatch(/\/api\/ai\/v1/);
+    expect(screen.queryByTestId('scope-preflight-empty')).toBeNull();
+    expect(screen.getByTestId('scope-preflight-empty-inconclusive').textContent).toMatch(/Unlogged routes/);
+  });
+
+  it('shows the unlogged-surface warning alongside real rows too', () => {
+    // The caveat is about what the scan could not see, so it applies whether or
+    // not the visible part of the prefix turned up keys.
+    mockUseApiKeyScopePreflight.mockReturnValue(
+      state({ data: result({ rows: [row()], coverage: { fullWindow: true, unloggedPrefixes: ['/api/embed'] } }) })
+    );
+    renderTab();
+
+    expect(screen.getByTestId('scope-preflight-unlogged')).toBeTruthy();
+    expect(screen.getByTestId('scope-preflight-results')).toBeTruthy();
   });
 
   it('renders a row per key with its outcome, and counts the breakage', () => {
@@ -114,7 +159,11 @@ describe('ApiKeyScopePreflightTab', () => {
     mockUseApiKeyScopePreflight.mockReturnValue(state({ data: result({ truncated: true, rows: [row()] }) }));
     renderTab();
 
-    expect(screen.getByTestId('scope-preflight-truncated').textContent).toMatch(/partial/);
+    const banner = screen.getByTestId('scope-preflight-truncated').textContent!;
+    expect(banner).toMatch(/partial/);
+    // Narrowing the window clears the cap by shrinking coverage, dropping the
+    // low-traffic keys for good rather than paging past them.
+    expect(banner).toMatch(/Do not\s+narrow the window/);
   });
 
   it('surfaces a failed preflight instead of showing an empty result', () => {

--- a/apps/client/app/components/admin/ApiKeyScopePreflightTab.test.tsx
+++ b/apps/client/app/components/admin/ApiKeyScopePreflightTab.test.tsx
@@ -51,8 +51,30 @@ const state = (over: Record<string, unknown> = {}) => ({
   data: undefined,
   isFetching: false,
   error: null,
+  refetch: vi.fn(),
   ...over,
 });
+
+/**
+ * `isAxiosError` keys off the flag alone, so this is the real shape as far as the
+ * component's extraction is concerned. A plain `Error` would pass either way -
+ * its `.message` *is* the right text - which is why the axios path needs its own
+ * fixture to be pinned at all.
+ */
+const axiosError = (serverMessage: string) => ({
+  isAxiosError: true,
+  message: 'Request failed with status code 400',
+  response: { data: { error: serverMessage } },
+});
+
+/** Fill the form enough to enable Run: a rooted prefix plus one scope. */
+const fillForm = async (prefix = '/api/x') => {
+  const input = screen.getByTestId('scope-preflight-prefix-input').querySelector('input')!;
+  await userEvent.clear(input);
+  await userEvent.type(input, prefix);
+  await userEvent.click(screen.getByTestId('scope-preflight-scopes-select').querySelector('button')!);
+  await userEvent.click(screen.getByRole('option', { name: 'admin:*' }));
+};
 
 describe('ApiKeyScopePreflightTab', () => {
   beforeEach(() => {
@@ -72,6 +94,42 @@ describe('ApiKeyScopePreflightTab', () => {
     await userEvent.clear(input);
     await userEvent.type(input, '/api/x'); // rooted, but still no scope selected
     expect(screen.getByTestId('scope-preflight-run-btn')).toBeDisabled();
+
+    // The other half of the rule: with both inputs supplied it must actually run.
+    // Without this, hardcoding `disabled` or dropping the scope check leaves the
+    // three assertions above green.
+    await userEvent.click(screen.getByTestId('scope-preflight-scopes-select').querySelector('button')!);
+    await userEvent.click(screen.getByRole('option', { name: 'admin:*' }));
+    expect(screen.getByTestId('scope-preflight-run-btn')).not.toBeDisabled();
+  });
+
+  it('re-runs when Run is pressed on unchanged inputs', async () => {
+    // Identical params hash to the same react-query key, so the mounted observer
+    // serves cache and fires nothing - no request and no spinner, which makes a
+    // stale verdict indistinguishable from a fresh one.
+    const refetch = vi.fn();
+    mockUseApiKeyScopePreflight.mockReturnValue(state({ data: result({ rows: [] }), refetch }));
+    renderTab();
+
+    await fillForm();
+    await userEvent.click(screen.getByTestId('scope-preflight-run-btn'));
+    expect(refetch).not.toHaveBeenCalled(); // first run: the query key is new
+
+    await userEvent.click(screen.getByTestId('scope-preflight-run-btn'));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('names the run the results belong to', async () => {
+    // The form stays editable while results stay on screen. Without an echo, a
+    // green verdict for one prefix reads as answering whatever is in the box now.
+    mockUseApiKeyScopePreflight.mockReturnValue(
+      state({ data: result({ endpointPrefix: '/api/widgets', requiredScopes: ['ai:chat'], rows: [row()] }) })
+    );
+    renderTab();
+
+    const echo = screen.getByTestId('scope-preflight-run-echo').textContent!;
+    expect(echo).toContain('/api/widgets');
+    expect(echo).toContain('ai:chat');
   });
 
   it('reads a fully-covered empty result as safe-to-enforce, not as missing data', () => {
@@ -174,5 +232,20 @@ describe('ApiKeyScopePreflightTab', () => {
     expect(screen.getByTestId('scope-preflight-error').textContent).toContain('scan exploded');
     expect(screen.queryByTestId('scope-preflight-empty')).toBeNull();
     expect(screen.queryByTestId('scope-preflight-results')).toBeNull();
+  });
+
+  it("shows the handler's refusal, not axios's generic status string", () => {
+    // The refusals are the remedy: an unlogged prefix explains why the answer
+    // would have been false, and an unknown scope explains a caught typo.
+    // `errorHandler` puts that text at `response.data.error`; `error.message` is
+    // only "Request failed with status code 400", which reads as a broken tool.
+    mockUseApiKeyScopePreflight.mockReturnValue(
+      state({ error: axiosError('/api/ai/v1 is served by verifyApiKey, not baseApi') })
+    );
+    renderTab();
+
+    const alert = screen.getByTestId('scope-preflight-error').textContent!;
+    expect(alert).toContain('served by verifyApiKey');
+    expect(alert).not.toContain('Request failed with status code');
   });
 });

--- a/apps/client/app/components/admin/ApiKeyScopePreflightTab.test.tsx
+++ b/apps/client/app/components/admin/ApiKeyScopePreflightTab.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { IApiKeyScopePreflight, IApiKeyScopePreflightRow } from '@bike4mind/common';
+
+// The hook is mocked rather than the axios client: the component only fetches
+// once a scope is chosen from a Joy multi-select, and driving that in jsdom
+// tests the Select, not this component's rendering. Mocking here lets the render
+// paths be asserted directly - which is the behaviour worth pinning.
+const { mockUseApiKeyScopePreflight } = vi.hoisted(() => ({ mockUseApiKeyScopePreflight: vi.fn() }));
+vi.mock('@client/app/hooks/data/apiKeyScopePreflight', () => ({
+  useApiKeyScopePreflight: mockUseApiKeyScopePreflight,
+}));
+
+import ApiKeyScopePreflightTab from './ApiKeyScopePreflightTab';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const renderTab = () =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <ApiKeyScopePreflightTab />
+    </CssVarsProvider>
+  );
+
+const row = (over: Partial<IApiKeyScopePreflightRow> = {}): IApiKeyScopePreflightRow => ({
+  keyId: 'k1',
+  userId: 'u1',
+  requests: 9,
+  lastUsed: new Date('2026-08-01'),
+  endpoints: ['/api/x/a'],
+  heldScopes: [],
+  outcome: 'deny',
+  ...over,
+});
+
+const result = (over: Partial<IApiKeyScopePreflight> = {}): IApiKeyScopePreflight => ({
+  endpointPrefix: '/api/x',
+  requiredScopes: ['admin:*'],
+  windowDays: 90,
+  stagedScopes: [],
+  rows: [],
+  truncated: false,
+  ...over,
+});
+
+const state = (over: Record<string, unknown> = {}) => ({
+  data: undefined,
+  isFetching: false,
+  error: null,
+  ...over,
+});
+
+describe('ApiKeyScopePreflightTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseApiKeyScopePreflight.mockReturnValue(state());
+  });
+
+  it('keeps Run disabled until a rooted prefix and a scope are both supplied', async () => {
+    // The scan is unindexed, so a half-filled form must not be runnable.
+    renderTab();
+    expect(screen.getByTestId('scope-preflight-run-btn')).toBeDisabled();
+
+    const input = screen.getByTestId('scope-preflight-prefix-input').querySelector('input')!;
+    await userEvent.type(input, 'api/x'); // no leading slash
+    expect(screen.getByTestId('scope-preflight-run-btn')).toBeDisabled();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '/api/x'); // rooted, but still no scope selected
+    expect(screen.getByTestId('scope-preflight-run-btn')).toBeDisabled();
+  });
+
+  it('reads an empty result as safe-to-enforce, not as missing data', () => {
+    // The distinction the tool exists for: nobody calls these routes, so the
+    // staging sequence can be skipped entirely.
+    mockUseApiKeyScopePreflight.mockReturnValue(state({ data: result({ rows: [] }) }));
+    renderTab();
+
+    const empty = screen.getByTestId('scope-preflight-empty');
+    expect(empty.textContent).toMatch(/No API key has called these routes/);
+    expect(empty.textContent).toMatch(/enforced in one step/);
+    expect(screen.queryByTestId('scope-preflight-results')).toBeNull();
+  });
+
+  it('renders a row per key with its outcome, and counts the breakage', () => {
+    mockUseApiKeyScopePreflight.mockReturnValue(
+      state({
+        data: result({
+          rows: [
+            row({ keyId: 'breaks', outcome: 'deny' }),
+            row({ keyId: 'staged', outcome: 'stagedAllow' }),
+            row({ keyId: 'fine', outcome: 'allow', heldScopes: ['admin:*'] }),
+          ],
+        }),
+      })
+    );
+    renderTab();
+
+    const table = screen.getByTestId('scope-preflight-results');
+    expect(table.querySelectorAll('tbody tr')).toHaveLength(3);
+    expect(table.textContent).toContain('breaks');
+    expect(table.textContent).toContain('would 403');
+    expect(table.textContent).toContain('staged only');
+    expect(table.textContent).toContain('passes');
+    expect(screen.getByTestId('scope-preflight-deny-count').textContent).toContain('1');
+  });
+
+  it('warns that a truncated list is not the whole population', () => {
+    // Silently showing a capped list would read as a complete re-mint list.
+    mockUseApiKeyScopePreflight.mockReturnValue(state({ data: result({ truncated: true, rows: [row()] }) }));
+    renderTab();
+
+    expect(screen.getByTestId('scope-preflight-truncated').textContent).toMatch(/partial/);
+  });
+
+  it('surfaces a failed preflight instead of showing an empty result', () => {
+    // A failed scan must never look like "nobody breaks".
+    mockUseApiKeyScopePreflight.mockReturnValue(state({ error: new Error('scan exploded') }));
+    renderTab();
+
+    expect(screen.getByTestId('scope-preflight-error').textContent).toContain('scan exploded');
+    expect(screen.queryByTestId('scope-preflight-empty')).toBeNull();
+    expect(screen.queryByTestId('scope-preflight-results')).toBeNull();
+  });
+});

--- a/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
+++ b/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
@@ -1,0 +1,221 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  FormLabel,
+  Input,
+  Option,
+  Select,
+  Sheet,
+  Stack,
+  Table,
+  Typography,
+} from '@mui/joy';
+import SearchIcon from '@mui/icons-material/Search';
+import WarningIcon from '@mui/icons-material/Warning';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import { ApiKeyScope } from '@bike4mind/common';
+import type { IApiKeyScopePreflightRow } from '@bike4mind/common';
+import { useApiKeyScopePreflight, type ScopePreflightParams } from '@client/app/hooks/data/apiKeyScopePreflight';
+
+const WINDOW_OPTIONS = [7, 30, 90];
+
+const OutcomeChip: React.FC<{ outcome: IApiKeyScopePreflightRow['outcome'] }> = ({ outcome }) => {
+  const config = {
+    deny: { color: 'danger' as const, icon: <ErrorIcon fontSize="small" />, label: 'would 403' },
+    stagedAllow: { color: 'warning' as const, icon: <WarningIcon fontSize="small" />, label: 'staged only' },
+    allow: { color: 'success' as const, icon: <CheckCircleIcon fontSize="small" />, label: 'passes' },
+  }[outcome];
+  return (
+    <Chip size="sm" color={config.color} startDecorator={config.icon} variant="soft">
+      {config.label}
+    </Chip>
+  );
+};
+
+/**
+ * Scope-enforcement preflight: before declaring `requiredScopes` on routes that
+ * currently have none, find every key already calling them that would be
+ * rejected. See the route handler for why this beats reading the staged-allow
+ * log line.
+ */
+export const ApiKeyScopePreflightTab: React.FC = () => {
+  const [endpointPrefix, setEndpointPrefix] = useState('');
+  const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
+  const [days, setDays] = useState(90);
+  const [submitted, setSubmitted] = useState<ScopePreflightParams | null>(null);
+
+  const { data, isFetching, error } = useApiKeyScopePreflight(submitted);
+
+  const scopeOptions = useMemo(() => Object.values(ApiKeyScope), []);
+  const canRun = endpointPrefix.trim().startsWith('/') && selectedScopes.length > 0;
+
+  const counts = useMemo(() => {
+    const rows = data?.rows ?? [];
+    return {
+      deny: rows.filter(r => r.outcome === 'deny').length,
+      stagedAllow: rows.filter(r => r.outcome === 'stagedAllow').length,
+      allow: rows.filter(r => r.outcome === 'allow').length,
+    };
+  }, [data]);
+
+  return (
+    <Stack spacing={2} data-testid="admin-scope-preflight-tab">
+      <Box>
+        <Typography level="h4">API key scope preflight</Typography>
+        <Typography level="body-sm" textColor="text.secondary">
+          Before declaring <code>requiredScopes</code> on routes that currently have none, check which live keys would
+          start getting 403s. A key holds only the scopes it was minted with, so they must be re-minted before the gate
+          enforces. Reads {data?.windowDays ?? 90} days of API-key usage history.
+        </Typography>
+      </Box>
+
+      <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }}>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'flex-end' }}>
+          <FormControl sx={{ flex: 2 }}>
+            <FormLabel>Endpoint prefix</FormLabel>
+            <Input
+              placeholder="/api/some/prefix"
+              value={endpointPrefix}
+              onChange={e => setEndpointPrefix(e.target.value)}
+              data-testid="scope-preflight-prefix-input"
+            />
+          </FormControl>
+
+          <FormControl sx={{ flex: 2 }}>
+            <FormLabel>Scopes the routes would require (any one passes)</FormLabel>
+            <Select
+              multiple
+              value={selectedScopes}
+              onChange={(_, value) => setSelectedScopes(value as string[])}
+              data-testid="scope-preflight-scopes-select"
+            >
+              {scopeOptions.map(scope => (
+                <Option key={scope} value={scope}>
+                  {scope}
+                </Option>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl sx={{ flex: 1 }}>
+            <FormLabel>Window</FormLabel>
+            <Select value={days} onChange={(_, value) => setDays((value as number) ?? 90)}>
+              {WINDOW_OPTIONS.map(option => (
+                <Option key={option} value={option}>
+                  {option} days
+                </Option>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            startDecorator={<SearchIcon />}
+            disabled={!canRun || isFetching}
+            onClick={() => setSubmitted({ endpointPrefix: endpointPrefix.trim(), scopes: selectedScopes, days })}
+            data-testid="scope-preflight-run-btn"
+          >
+            Run
+          </Button>
+        </Stack>
+      </Sheet>
+
+      {error ? (
+        <Alert color="danger" data-testid="scope-preflight-error">
+          {error instanceof Error ? error.message : 'Preflight failed'}
+        </Alert>
+      ) : null}
+
+      {isFetching ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size="sm" />
+          <Typography level="body-sm">Scanning usage history...</Typography>
+        </Stack>
+      ) : null}
+
+      {data && !isFetching ? (
+        <Stack spacing={2}>
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            <Chip color="danger" variant="soft" data-testid="scope-preflight-deny-count">
+              {counts.deny} would 403
+            </Chip>
+            <Chip color="warning" variant="soft">
+              {counts.stagedAllow} surviving on staging
+            </Chip>
+            <Chip color="success" variant="soft">
+              {counts.allow} already fine
+            </Chip>
+          </Stack>
+
+          {data.stagedScopes.length > 0 ? (
+            <Alert color="warning">
+              Staged on this stage: {data.stagedScopes.join(', ')}. Rows marked &quot;staged only&quot; pass today and
+              will 403 when the staging entry is removed.
+            </Alert>
+          ) : null}
+
+          {data.truncated ? (
+            <Alert color="warning" data-testid="scope-preflight-truncated">
+              Result cap reached - this list is partial. Narrow the prefix or the window before treating it as complete.
+            </Alert>
+          ) : null}
+
+          {data.rows.length === 0 ? (
+            <Alert color="success" data-testid="scope-preflight-empty">
+              No API key has called these routes in the last {data.windowDays} days. There is no grandfathered
+              population to re-mint, so the gate can be declared and enforced in one step.
+            </Alert>
+          ) : (
+            <Table size="sm" stickyHeader data-testid="scope-preflight-results">
+              <thead>
+                <tr>
+                  <th>Outcome</th>
+                  <th>Key</th>
+                  <th>User</th>
+                  <th>Held scopes</th>
+                  <th>Requests</th>
+                  <th>Last used</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.rows.map(row => (
+                  <tr key={row.keyId}>
+                    <td>
+                      <OutcomeChip outcome={row.outcome} />
+                    </td>
+                    <td>
+                      <Typography level="body-xs" fontFamily="monospace">
+                        {row.keyId}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography level="body-xs" fontFamily="monospace">
+                        {row.userId}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography level="body-xs">
+                        {row.heldScopes.length > 0 ? row.heldScopes.join(', ') : 'none'}
+                      </Typography>
+                    </td>
+                    <td>{row.requests}</td>
+                    <td>
+                      <Typography level="body-xs">{new Date(row.lastUsed).toLocaleDateString()}</Typography>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          )}
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+};
+
+export default ApiKeyScopePreflightTab;

--- a/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
+++ b/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
@@ -20,6 +20,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import WarningIcon from '@mui/icons-material/Warning';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
+import { isAxiosError } from 'axios';
 import { ApiKeyScope } from '@bike4mind/common';
 import type { IApiKeyScopePreflightRow } from '@bike4mind/common';
 import { useApiKeyScopePreflight, type ScopePreflightParams } from '@client/app/hooks/data/apiKeyScopePreflight';
@@ -28,6 +29,28 @@ const WINDOW_OPTIONS = [7, 30, 90];
 
 /** ApiKeyUsageLog's TTL. Only a run at this window has seen the whole logged history. */
 const FULL_WINDOW_DAYS = 90;
+
+/**
+ * The handler's refusals are the remedy, not the symptom: an unlogged prefix and
+ * an unknown scope both explain themselves in the thrown message, which
+ * `errorHandler` puts at `response.data.error`. Axios's own `.message` is the
+ * generic "Request failed with status code 400", which turns an explained refusal
+ * into what looks like a broken tool.
+ */
+const preflightErrorMessage = (error: unknown): string => {
+  if (isAxiosError(error)) {
+    return error.response?.data?.error || error.response?.data?.message || error.message;
+  }
+  return error instanceof Error ? error.message : 'Preflight failed';
+};
+
+/** Whether Run would re-ask the question already on screen, rather than a new one. */
+const isSameRun = (a: ScopePreflightParams | null, b: ScopePreflightParams): boolean =>
+  a !== null &&
+  a.endpointPrefix === b.endpointPrefix &&
+  a.days === b.days &&
+  a.scopes.length === b.scopes.length &&
+  a.scopes.every((scope, i) => scope === b.scopes[i]);
 
 const OutcomeChip: React.FC<{ outcome: IApiKeyScopePreflightRow['outcome'] }> = ({ outcome }) => {
   const config = {
@@ -54,7 +77,7 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
   const [days, setDays] = useState(90);
   const [submitted, setSubmitted] = useState<ScopePreflightParams | null>(null);
 
-  const { data, isFetching, error } = useApiKeyScopePreflight(submitted);
+  const { data, isFetching, error, refetch } = useApiKeyScopePreflight(submitted);
 
   const scopeOptions = useMemo(() => Object.values(ApiKeyScope), []);
   const canRun = endpointPrefix.trim().startsWith('/') && selectedScopes.length > 0;
@@ -125,7 +148,18 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
           <Button
             startDecorator={<SearchIcon />}
             disabled={!canRun || isFetching}
-            onClick={() => setSubmitted({ endpointPrefix: endpointPrefix.trim(), scopes: selectedScopes, days })}
+            onClick={() => {
+              const next = { endpointPrefix: endpointPrefix.trim(), scopes: selectedScopes, days };
+              // Identical params hash to the same react-query key, so the mounted
+              // observer serves cache and fires nothing - no request, and no
+              // `isFetching` either, so a stale answer is indistinguishable from a
+              // fresh one. Run must always mean run.
+              if (isSameRun(submitted, next)) {
+                void refetch();
+                return;
+              }
+              setSubmitted(next);
+            }}
             data-testid="scope-preflight-run-btn"
           >
             Run
@@ -135,7 +169,7 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
 
       {error ? (
         <Alert color="danger" data-testid="scope-preflight-error">
-          {error instanceof Error ? error.message : 'Preflight failed'}
+          {preflightErrorMessage(error)}
         </Alert>
       ) : null}
 
@@ -148,6 +182,17 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
 
       {data && !isFetching ? (
         <Stack spacing={2}>
+          {/*
+            The form stays editable while these results stay on screen, so without
+            an echo of the run that produced them a verdict can be read as
+            answering a prefix nobody ran. The server echoes both fields back for
+            exactly this.
+          */}
+          <Typography level="body-sm" textColor="text.secondary" data-testid="scope-preflight-run-echo">
+            Showing <code>{data.endpointPrefix}</code> against <code>{data.requiredScopes.join(', ')}</code> over{' '}
+            {data.windowDays} days.
+          </Typography>
+
           <Stack direction="row" spacing={1} flexWrap="wrap">
             <Chip color="danger" variant="soft" data-testid="scope-preflight-deny-count">
               {counts.deny} would 403
@@ -187,7 +232,9 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
             data.coverage.fullWindow && data.coverage.unloggedPrefixes.length === 0 ? (
               <Alert color="success" data-testid="scope-preflight-empty">
                 No API key has called these routes in the last {data.windowDays} days, the full logged history. There is
-                no grandfathered population to re-mint, so the gate can be declared and enforced in one step.
+                no grandfathered population to re-mint, so the gate can be declared and enforced in one step. This
+                counts pre-enforcement traffic only: a request rejected by a scope gate is never logged, so if these
+                routes already require a scope, the keys being turned away today do not appear here.
               </Alert>
             ) : (
               // An empty list is only actionable when the run saw everything there

--- a/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
+++ b/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
@@ -113,8 +113,13 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
               data-testid="scope-preflight-prefix-input"
             />
             <FormHelperText>
-              Matched as a plain string prefix, not by path segment, so <code>/api/chat</code> also matches{' '}
-              <code>/api/chatbots</code>.
+              {/* Joy's FormHelperText and Alert roots are both flex with no wrap, so text interleaved
+                  with an inline element lays out as side-by-side columns instead of one sentence. A
+                  single wrapping child keeps it prose. Same trap as PartnerSignupRulesTab's helper. */}
+              <span>
+                Matched as a plain string prefix, not by path segment, so <code>/api/chat</code> also matches{' '}
+                <code>/api/chatbots</code>.
+              </span>
             </FormHelperText>
           </FormControl>
 
@@ -221,10 +226,14 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
 
           {data.coverage.unloggedPrefixes.length > 0 ? (
             <Alert color="warning" data-testid="scope-preflight-unlogged">
-              {data.coverage.unloggedPrefixes.join(', ')} falls under this prefix and writes no usage log. Those routes
-              authenticate through <code>verifyApiKey</code> rather than the <code>baseApi</code> gate, and only that
-              gate records API-key traffic, so calls to them are invisible here however busy they are. Read this result
-              as covering the rest of the prefix only.
+              {/* Wrapped for the same reason as the prefix helper above: this is the message that says
+                  why a zero here would be false, so it is the one that most has to stay readable. */}
+              <span>
+                {data.coverage.unloggedPrefixes.join(', ')} falls under this prefix and writes no usage log. Those
+                routes authenticate through <code>verifyApiKey</code> rather than the <code>baseApi</code> gate, and
+                only that gate records API-key traffic, so calls to them are invisible here however busy they are. Read
+                this result as covering the rest of the prefix only.
+              </span>
             </Alert>
           ) : null}
 

--- a/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
+++ b/apps/client/app/components/admin/ApiKeyScopePreflightTab.tsx
@@ -6,6 +6,7 @@ import {
   Chip,
   CircularProgress,
   FormControl,
+  FormHelperText,
   FormLabel,
   Input,
   Option,
@@ -24,6 +25,9 @@ import type { IApiKeyScopePreflightRow } from '@bike4mind/common';
 import { useApiKeyScopePreflight, type ScopePreflightParams } from '@client/app/hooks/data/apiKeyScopePreflight';
 
 const WINDOW_OPTIONS = [7, 30, 90];
+
+/** ApiKeyUsageLog's TTL. Only a run at this window has seen the whole logged history. */
+const FULL_WINDOW_DAYS = 90;
 
 const OutcomeChip: React.FC<{ outcome: IApiKeyScopePreflightRow['outcome'] }> = ({ outcome }) => {
   const config = {
@@ -85,6 +89,10 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
               onChange={e => setEndpointPrefix(e.target.value)}
               data-testid="scope-preflight-prefix-input"
             />
+            <FormHelperText>
+              Matched as a plain string prefix, not by path segment, so <code>/api/chat</code> also matches{' '}
+              <code>/api/chatbots</code>.
+            </FormHelperText>
           </FormControl>
 
           <FormControl sx={{ flex: 2 }}>
@@ -161,15 +169,43 @@ export const ApiKeyScopePreflightTab: React.FC = () => {
 
           {data.truncated ? (
             <Alert color="warning" data-testid="scope-preflight-truncated">
-              Result cap reached - this list is partial. Narrow the prefix or the window before treating it as complete.
+              Result cap reached - this list is partial. Narrow the prefix before treating it as complete. Do not narrow
+              the window: that drops the low-traffic keys for good rather than paging past them.
+            </Alert>
+          ) : null}
+
+          {data.coverage.unloggedPrefixes.length > 0 ? (
+            <Alert color="warning" data-testid="scope-preflight-unlogged">
+              {data.coverage.unloggedPrefixes.join(', ')} falls under this prefix and writes no usage log. Those routes
+              authenticate through <code>verifyApiKey</code> rather than the <code>baseApi</code> gate, and only that
+              gate records API-key traffic, so calls to them are invisible here however busy they are. Read this result
+              as covering the rest of the prefix only.
             </Alert>
           ) : null}
 
           {data.rows.length === 0 ? (
-            <Alert color="success" data-testid="scope-preflight-empty">
-              No API key has called these routes in the last {data.windowDays} days. There is no grandfathered
-              population to re-mint, so the gate can be declared and enforced in one step.
-            </Alert>
+            data.coverage.fullWindow && data.coverage.unloggedPrefixes.length === 0 ? (
+              <Alert color="success" data-testid="scope-preflight-empty">
+                No API key has called these routes in the last {data.windowDays} days, the full logged history. There is
+                no grandfathered population to re-mint, so the gate can be declared and enforced in one step.
+              </Alert>
+            ) : (
+              // An empty list is only actionable when the run saw everything there
+              // was to see. Short of that it is an absence of evidence, and the
+              // "enforce in one step" advice above would license the exact
+              // one-shot rollout this tool exists to prevent.
+              <Alert color="warning" data-testid="scope-preflight-empty-inconclusive">
+                No API key called these routes in the last {data.windowDays} days, but this run did not cover enough to
+                enforce on.{' '}
+                {!data.coverage.fullWindow
+                  ? `A key that fires monthly or quarterly leaves no trace in a ${data.windowDays}-day window - re-run at ${FULL_WINDOW_DAYS} days before deciding. `
+                  : null}
+                {data.coverage.unloggedPrefixes.length > 0
+                  ? 'Unlogged routes under this prefix are not counted. '
+                  : null}
+                Do not skip the staging sequence on this result.
+              </Alert>
+            )
           ) : (
             <Table size="sm" stickyHeader data-testid="scope-preflight-results">
               <thead>

--- a/apps/client/app/components/admin/adminSidebarConfig.tsx
+++ b/apps/client/app/components/admin/adminSidebarConfig.tsx
@@ -97,6 +97,7 @@ export enum AdminTab {
   ModelLifecycle = 58,
   PrReport = 59,
   RetrievalRate = 60,
+  ApiKeyScopePreflight = 61,
 }
 
 /**
@@ -189,6 +190,12 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       { Icon: BugReportIcon, tab: AdminTab.SreAgent, label: 'SRE Agent', testid: 'admin-sre-agent-btn' },
       { Icon: QueueIcon, tab: AdminTab.DlqReplay, label: 'DLQ Management', testid: 'admin-dlq-replay-btn' },
       { Icon: SpeedIcon, tab: AdminTab.RateLimits, label: 'Rate Limits', testid: 'admin-rate-limits-btn' },
+      {
+        Icon: SecurityIcon,
+        tab: AdminTab.ApiKeyScopePreflight,
+        label: 'API Key Scope Preflight',
+        testid: 'admin-scope-preflight-btn',
+      },
       { Icon: MonitorHeartIcon, tab: AdminTab.SystemHealth, label: 'System Health' },
       { Icon: QueryStatsIcon, tab: AdminTab.EventMetrics, label: 'Event Metrics' },
     ],

--- a/apps/client/app/hooks/data/apiKeyScopePreflight.ts
+++ b/apps/client/app/hooks/data/apiKeyScopePreflight.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import type { IApiKeyScopePreflight } from '@bike4mind/common';
+import { api } from '@client/app/contexts/ApiContext';
+
+export type ScopePreflightParams = {
+  endpointPrefix: string;
+  scopes: string[];
+  days: number;
+};
+
+/**
+ * Which live API keys would start getting 403s if `scopes` were declared as
+ * `requiredScopes` on the routes under `endpointPrefix`.
+ *
+ * Disabled until the operator supplies both inputs - this runs an unindexed scan
+ * of the usage log, so it must never fire on a keystroke or an empty form.
+ * `enabled` is the whole guard; there is no debounce on the input by design,
+ * the operator presses Run.
+ */
+export const useApiKeyScopePreflight = (params: ScopePreflightParams | null) => {
+  return useQuery({
+    queryKey: ['admin', 'api-keys', 'scope-preflight', params],
+    enabled: params !== null && params.endpointPrefix.length > 0 && params.scopes.length > 0,
+    // The scan is expensive and the underlying data moves slowly (a 90-day
+    // window), so do not re-run it on window focus.
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const response = await api.get<IApiKeyScopePreflight>('/api/admin/api-keys/scope-preflight', {
+        params: {
+          endpointPrefix: params!.endpointPrefix,
+          scopes: params!.scopes.join(','),
+          days: params!.days,
+        },
+      });
+      return response.data;
+    },
+  });
+};

--- a/apps/client/pages/api/admin/api-keys/__tests__/scope-preflight.test.ts
+++ b/apps/client/pages/api/admin/api-keys/__tests__/scope-preflight.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * Scope-preflight route contract. The load-bearing behaviour is the verdict per
+ * key, and this suite deliberately does NOT mock apiKeyScopeGate: the whole
+ * point of the route is that it asks the same `decideScopeGate` the runtime gate
+ * asks, so a test that stubbed it would prove nothing about the thing that
+ * matters (a preflight that drifts from enforcement reports a confidently wrong
+ * re-mint list).
+ *
+ * The baseApi mock records the config it was called with. A mock that discards
+ * it - the common shape elsewhere in this repo - would let the admin-scope
+ * declaration silently disappear while this file still passed.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+  config: undefined as undefined | Record<string, unknown>,
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    post: () => chain,
+    put: () => chain,
+    delete: () => chain,
+    patch: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return {
+    baseApi: (config?: Record<string, unknown>) => {
+      mockRefs.config = config;
+      return chain;
+    },
+  };
+});
+vi.mock('@server/middlewares/asyncHandler', () => ({ asyncHandler: (fn: any) => fn }));
+
+const findKeyTrafficByEndpointPrefix = vi.hoisted(() => vi.fn());
+const find = vi.hoisted(() => vi.fn());
+vi.mock('@bike4mind/database/auth', () => ({
+  apiKeyUsageLogRepository: { findKeyTrafficByEndpointPrefix },
+  userApiKeyRepository: { find },
+}));
+
+import '../scope-preflight';
+
+const invoke = async (query: Record<string, unknown>, user: unknown = { isAdmin: true }) => {
+  const { req, res } = createMocks({ method: 'GET' });
+  Object.assign(req, { query, user });
+  await mockRefs.getHandler!(req, res);
+  return res;
+};
+
+describe('GET /api/admin/api-keys/scope-preflight', () => {
+  const ORIGINAL_STAGING = process.env.API_KEY_SCOPE_STAGING;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.API_KEY_SCOPE_STAGING;
+    findKeyTrafficByEndpointPrefix.mockResolvedValue([]);
+    find.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_STAGING === undefined) delete process.env.API_KEY_SCOPE_STAGING;
+    else process.env.API_KEY_SCOPE_STAGING = ORIGINAL_STAGING;
+  });
+
+  it('declares the admin scope on the route itself', () => {
+    expect(mockRefs.config?.requiredScopes).toEqual(['admin:*']);
+  });
+
+  it('refuses a non-admin before touching the usage log', async () => {
+    await expect(invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }, { isAdmin: false })).rejects.toThrow(
+      /Admin access required/
+    );
+    expect(findKeyTrafficByEndpointPrefix).not.toHaveBeenCalled();
+  });
+
+  it('rejects a prefix that is missing or not rooted at /', async () => {
+    await expect(invoke({ scopes: 'admin:*' })).rejects.toThrow(/endpointPrefix/);
+    await expect(invoke({ endpointPrefix: 'api/x', scopes: 'admin:*' })).rejects.toThrow(/endpointPrefix/);
+  });
+
+  it('rejects an unknown scope rather than dropping it', async () => {
+    // Dropping it would narrow the required set and under-report who breaks,
+    // producing a false "nobody is affected".
+    await expect(invoke({ endpointPrefix: '/api/x', scopes: 'notascope:read' })).rejects.toThrow(/Unknown scope/);
+    await expect(invoke({ endpointPrefix: '/api/x', scopes: '' })).rejects.toThrow(/scopes is required/);
+  });
+
+  it('clamps the window to the usage log TTL', async () => {
+    await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*', days: '365' });
+    expect(findKeyTrafficByEndpointPrefix).toHaveBeenCalledWith(expect.objectContaining({ days: 90 }));
+  });
+
+  it('classifies each key by the real gate and puts the breakage first', async () => {
+    findKeyTrafficByEndpointPrefix.mockResolvedValue([
+      { keyId: 'passes', userId: 'u1', requests: 5, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: 'breaks', userId: 'u2', requests: 99, lastUsed: new Date(), endpoints: ['/api/x/b'] },
+    ]);
+    find.mockResolvedValue([
+      { id: 'passes', scopes: ['notebooks:read', 'admin:*'] },
+      { id: 'breaks', scopes: ['notebooks:read'] },
+    ]);
+
+    const res = await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' });
+    const body = res._getJSONData();
+
+    // Sorted worst-first despite `passes` coming first out of the aggregation.
+    expect(body.rows.map((r: any) => r.keyId)).toEqual(['breaks', 'passes']);
+    expect(body.rows[0].outcome).toBe('deny');
+    expect(body.rows[1].outcome).toBe('allow');
+    expect(body.rows[0].heldScopes).toEqual(['notebooks:read']);
+  });
+
+  it('reports a key that no longer exists as holding nothing', async () => {
+    findKeyTrafficByEndpointPrefix.mockResolvedValue([
+      { keyId: 'deleted', userId: 'u1', requests: 3, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+    ]);
+    find.mockResolvedValue([]);
+
+    const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].outcome).toBe('deny');
+    expect(body.rows[0].heldScopes).toEqual([]);
+  });
+
+  it('marks a key as surviving only on staging when the scope is staged', async () => {
+    process.env.API_KEY_SCOPE_STAGING = 'optihashi:read';
+    findKeyTrafficByEndpointPrefix.mockResolvedValue([
+      { keyId: 'grandfathered', userId: 'u1', requests: 7, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+    ]);
+    find.mockResolvedValue([{ id: 'grandfathered', scopes: [] }]);
+
+    const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'optihashi:read' }))._getJSONData();
+    expect(body.rows[0].outcome).toBe('stagedAllow');
+    expect(body.stagedScopes).toEqual(['optihashi:read']);
+  });
+
+  it('says so when no key has called the routes', async () => {
+    const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
+    expect(body.rows).toEqual([]);
+    expect(body.truncated).toBe(false);
+  });
+});

--- a/apps/client/pages/api/admin/api-keys/__tests__/scope-preflight.test.ts
+++ b/apps/client/pages/api/admin/api-keys/__tests__/scope-preflight.test.ts
@@ -108,8 +108,8 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
 
   it('classifies each key by the real gate and puts the breakage first', async () => {
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: PASSES, userId: 'u1', requests: 5, lastUsed: new Date(), endpoints: ['/api/x/a'] },
-      { keyId: BREAKS, userId: 'u2', requests: 99, lastUsed: new Date(), endpoints: ['/api/x/b'] },
+      { keyId: PASSES, userId: 'u1', requests: 5, lastUsed: new Date() },
+      { keyId: BREAKS, userId: 'u2', requests: 99, lastUsed: new Date() },
     ]);
     find.mockResolvedValue([
       { id: PASSES, scopes: ['notebooks:read', 'admin:*'] },
@@ -128,7 +128,7 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
 
   it('reports a key that no longer exists as holding nothing', async () => {
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: DELETED, userId: 'u1', requests: 3, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: DELETED, userId: 'u1', requests: 3, lastUsed: new Date() },
     ]);
     find.mockResolvedValue([]);
 
@@ -141,7 +141,7 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
   it('marks a key as surviving only on staging when the scope is staged', async () => {
     process.env.API_KEY_SCOPE_STAGING = 'optihashi:read';
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: GRANDFATHERED, userId: 'u1', requests: 7, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: GRANDFATHERED, userId: 'u1', requests: 7, lastUsed: new Date() },
     ]);
     find.mockResolvedValue([{ id: GRANDFATHERED, scopes: [] }]);
 
@@ -154,15 +154,15 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
     // An unfiltered $in would raise a Mongoose CastError, which errorHandler
     // turns into a 404 - indistinguishable from "no data" to the operator.
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: 'not-an-objectid', userId: 'u1', requests: 2, lastUsed: new Date(), endpoints: ['/api/x/a'] },
-      { keyId: '507f1f77bcf86cd799439011', userId: 'u2', requests: 1, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: 'not-an-objectid', userId: 'u1', requests: 2, lastUsed: new Date() },
+      { keyId: '507f1f77bcf86cd799439011', userId: 'u2', requests: 1, lastUsed: new Date() },
     ]);
     find.mockResolvedValue([{ id: '507f1f77bcf86cd799439011', scopes: ['admin:*'] }]);
 
     const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
 
-    // Only the castable id reaches the query...
-    expect(find).toHaveBeenCalledWith({ _id: { $in: ['507f1f77bcf86cd799439011'] } });
+    // Only the castable id reaches the query, projected to the one field read.
+    expect(find).toHaveBeenCalledWith({ _id: { $in: ['507f1f77bcf86cd799439011'] } }, { scopes: 1 });
     // ...and the malformed row is still reported rather than dropped.
     expect(body.rows).toHaveLength(2);
     expect(body.rows.find((r: any) => r.keyId === 'not-an-objectid').outcome).toBe('deny');
@@ -170,7 +170,7 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
 
   it('does not query at all when no keyId is castable', async () => {
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: 'junk', userId: 'u1', requests: 1, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: 'junk', userId: 'u1', requests: 1, lastUsed: new Date() },
     ]);
 
     const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
@@ -182,5 +182,72 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
     const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
     expect(body.rows).toEqual([]);
     expect(body.truncated).toBe(false);
+  });
+
+  describe('coverage', () => {
+    it('reports a default-window run over a logged prefix as fully covered', async () => {
+      const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
+      expect(body.coverage).toEqual({ fullWindow: true, unloggedPrefixes: [] });
+    });
+
+    it('clears fullWindow below the TTL, so an empty result cannot read as conclusive', async () => {
+      // A key that fires monthly leaves no trace in a 7-day window; an empty
+      // result there is an absence of evidence, not a clean bill of health.
+      const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*', days: '7' }))._getJSONData();
+      expect(body.windowDays).toBe(7);
+      expect(body.coverage.fullWindow).toBe(false);
+    });
+
+    it('refuses a prefix whose traffic is never logged rather than answering zero', async () => {
+      // ApiKeyUsageLog is written only by baseApi's apiKeyAuth hook. These routes
+      // authenticate through verifyApiKey and log nothing, so a "no keys" answer
+      // here would be a false statement of fact - and verifyApiKey has no staging
+      // path, so acting on it breaks live keys with no grace period.
+      for (const prefix of ['/api/ai/v1', '/api/ai/v1/tools', '/api/embed/chat']) {
+        await expect(invoke({ endpointPrefix: prefix, scopes: 'admin:*' })).rejects.toThrow(/verifyApiKey/);
+      }
+      expect(findKeyTrafficByEndpointPrefix).not.toHaveBeenCalled();
+    });
+
+    it('names the unlogged surfaces a broader prefix sweeps up, and still runs', async () => {
+      const body = (await invoke({ endpointPrefix: '/api/', scopes: 'admin:*' }))._getJSONData();
+      expect(body.coverage.unloggedPrefixes).toEqual(['/api/ai/v1', '/api/embed']);
+      expect(findKeyTrafficByEndpointPrefix).toHaveBeenCalled();
+    });
+
+    it('does not flag a sibling prefix that merely shares a stem', async () => {
+      const body = (await invoke({ endpointPrefix: '/api/notebooks', scopes: 'admin:*' }))._getJSONData();
+      expect(body.coverage.unloggedPrefixes).toEqual([]);
+    });
+  });
+
+  describe('truncation', () => {
+    const traffic = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        keyId: `k${i}`,
+        userId: 'u1',
+        requests: 1,
+        lastUsed: new Date(),
+      }));
+
+    it('does not report a complete list as partial at exactly the cap', async () => {
+      // The route asks for MAX_ROWS + 1, so a full page with no overflow row is
+      // known to be the whole population - `length === MAX_ROWS` alone could not
+      // tell the two apart and would send the operator narrowing for no reason.
+      findKeyTrafficByEndpointPrefix.mockResolvedValue(traffic(500));
+
+      const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
+      expect(findKeyTrafficByEndpointPrefix).toHaveBeenCalledWith(expect.objectContaining({ limit: 501 }));
+      expect(body.rows).toHaveLength(500);
+      expect(body.truncated).toBe(false);
+    });
+
+    it('flags truncation and drops the overflow row when there is more', async () => {
+      findKeyTrafficByEndpointPrefix.mockResolvedValue(traffic(501));
+
+      const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
+      expect(body.rows).toHaveLength(500);
+      expect(body.truncated).toBe(true);
+    });
   });
 });

--- a/apps/client/pages/api/admin/api-keys/__tests__/scope-preflight.test.ts
+++ b/apps/client/pages/api/admin/api-keys/__tests__/scope-preflight.test.ts
@@ -49,6 +49,13 @@ vi.mock('@bike4mind/database/auth', () => ({
 
 import '../scope-preflight';
 
+// Real ObjectId strings: the route filters uncastable ids out of the $in, so
+// placeholder names like 'passes' would be dropped and every row would read deny.
+const PASSES = '507f1f77bcf86cd799439011';
+const BREAKS = '507f1f77bcf86cd799439012';
+const DELETED = '507f1f77bcf86cd799439013';
+const GRANDFATHERED = '507f1f77bcf86cd799439014';
+
 const invoke = async (query: Record<string, unknown>, user: unknown = { isAdmin: true }) => {
   const { req, res } = createMocks({ method: 'GET' });
   Object.assign(req, { query, user });
@@ -101,19 +108,19 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
 
   it('classifies each key by the real gate and puts the breakage first', async () => {
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: 'passes', userId: 'u1', requests: 5, lastUsed: new Date(), endpoints: ['/api/x/a'] },
-      { keyId: 'breaks', userId: 'u2', requests: 99, lastUsed: new Date(), endpoints: ['/api/x/b'] },
+      { keyId: PASSES, userId: 'u1', requests: 5, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: BREAKS, userId: 'u2', requests: 99, lastUsed: new Date(), endpoints: ['/api/x/b'] },
     ]);
     find.mockResolvedValue([
-      { id: 'passes', scopes: ['notebooks:read', 'admin:*'] },
-      { id: 'breaks', scopes: ['notebooks:read'] },
+      { id: PASSES, scopes: ['notebooks:read', 'admin:*'] },
+      { id: BREAKS, scopes: ['notebooks:read'] },
     ]);
 
     const res = await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' });
     const body = res._getJSONData();
 
     // Sorted worst-first despite `passes` coming first out of the aggregation.
-    expect(body.rows.map((r: any) => r.keyId)).toEqual(['breaks', 'passes']);
+    expect(body.rows.map((r: any) => r.keyId)).toEqual([BREAKS, PASSES]);
     expect(body.rows[0].outcome).toBe('deny');
     expect(body.rows[1].outcome).toBe('allow');
     expect(body.rows[0].heldScopes).toEqual(['notebooks:read']);
@@ -121,7 +128,7 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
 
   it('reports a key that no longer exists as holding nothing', async () => {
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: 'deleted', userId: 'u1', requests: 3, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: DELETED, userId: 'u1', requests: 3, lastUsed: new Date(), endpoints: ['/api/x/a'] },
     ]);
     find.mockResolvedValue([]);
 
@@ -134,13 +141,41 @@ describe('GET /api/admin/api-keys/scope-preflight', () => {
   it('marks a key as surviving only on staging when the scope is staged', async () => {
     process.env.API_KEY_SCOPE_STAGING = 'optihashi:read';
     findKeyTrafficByEndpointPrefix.mockResolvedValue([
-      { keyId: 'grandfathered', userId: 'u1', requests: 7, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: GRANDFATHERED, userId: 'u1', requests: 7, lastUsed: new Date(), endpoints: ['/api/x/a'] },
     ]);
-    find.mockResolvedValue([{ id: 'grandfathered', scopes: [] }]);
+    find.mockResolvedValue([{ id: GRANDFATHERED, scopes: [] }]);
 
     const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'optihashi:read' }))._getJSONData();
     expect(body.rows[0].outcome).toBe('stagedAllow');
     expect(body.stagedScopes).toEqual(['optihashi:read']);
+  });
+
+  it('survives a log row whose keyId is not a valid ObjectId', async () => {
+    // An unfiltered $in would raise a Mongoose CastError, which errorHandler
+    // turns into a 404 - indistinguishable from "no data" to the operator.
+    findKeyTrafficByEndpointPrefix.mockResolvedValue([
+      { keyId: 'not-an-objectid', userId: 'u1', requests: 2, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+      { keyId: '507f1f77bcf86cd799439011', userId: 'u2', requests: 1, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+    ]);
+    find.mockResolvedValue([{ id: '507f1f77bcf86cd799439011', scopes: ['admin:*'] }]);
+
+    const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
+
+    // Only the castable id reaches the query...
+    expect(find).toHaveBeenCalledWith({ _id: { $in: ['507f1f77bcf86cd799439011'] } });
+    // ...and the malformed row is still reported rather than dropped.
+    expect(body.rows).toHaveLength(2);
+    expect(body.rows.find((r: any) => r.keyId === 'not-an-objectid').outcome).toBe('deny');
+  });
+
+  it('does not query at all when no keyId is castable', async () => {
+    findKeyTrafficByEndpointPrefix.mockResolvedValue([
+      { keyId: 'junk', userId: 'u1', requests: 1, lastUsed: new Date(), endpoints: ['/api/x/a'] },
+    ]);
+
+    const body = (await invoke({ endpointPrefix: '/api/x', scopes: 'admin:*' }))._getJSONData();
+    expect(find).not.toHaveBeenCalled();
+    expect(body.rows[0].outcome).toBe('deny');
   });
 
   it('says so when no key has called the routes', async () => {

--- a/apps/client/pages/api/admin/api-keys/scope-preflight.ts
+++ b/apps/client/pages/api/admin/api-keys/scope-preflight.ts
@@ -89,6 +89,15 @@ function unloggedSurfacesUnder(prefix: string): string[] {
  * `coverage.fullWindow`. An empty row list is safe to act on only when `coverage`
  * is clean on both counts.
  *
+ * One blind spot `coverage` does not model, because it opens only after a gate is
+ * already live: the scope 403 throws before `apiKeyAuth` registers its
+ * `res.finish` usage-log hook, so a *denied* request writes no row. Traffic here
+ * is therefore pre-enforcement traffic. On a prefix that already requires a scope,
+ * the keys it is rejecting today contribute nothing, and once their last passing
+ * request ages out of the TTL an empty result says only "nobody is getting through",
+ * not "nobody is calling". Nothing new breaks from acting on that - those keys are
+ * already failing - but it is not the same statement as a true zero.
+ *
  * Read-only by design: it produces the list, a human rotates the keys.
  */
 const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(

--- a/apps/client/pages/api/admin/api-keys/scope-preflight.ts
+++ b/apps/client/pages/api/admin/api-keys/scope-preflight.ts
@@ -1,6 +1,7 @@
 import { ApiKeyScope, IApiKeyScopePreflight, IApiKeyScopePreflightRow } from '@bike4mind/common';
 import { apiKeyUsageLogRepository, userApiKeyRepository } from '@bike4mind/database/auth';
 import { BadRequestError } from '@bike4mind/utils';
+import mongoose from 'mongoose';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { decideScopeGate, parseStagedScopes, SCOPE_STAGING_ENV_VAR } from '@server/middlewares/apiKeyScopeGate';
@@ -39,8 +40,10 @@ function readSingle(value: string | string[] | undefined): string | undefined {
  * circulation. The documented fallback (docs/architecture/api-key-scope-rollout.md)
  * is to stage the scope and read the re-mint backlog off a log line - but that is
  * discovery by traffic, and a key that fires monthly never appears in a two-week
- * staging window. This reads the 90 days of history in ApiKeyUsageLog instead, so
- * the list is complete for anything that has actually called the routes.
+ * staging window. This reads the history in ApiKeyUsageLog instead - up to the
+ * collection's 90-day TTL - so the list covers anything that has actually called
+ * the routes in that window, capped at MAX_ROWS with `truncated` set when the cap
+ * is hit.
  *
  * The verdict per key comes from `decideScopeGate` - the same function the
  * runtime gate uses - so this cannot drift from enforcement. That also means the
@@ -91,7 +94,14 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
       limit: MAX_ROWS,
     });
 
-    const keyDocs = traffic.length ? await userApiKeyRepository.find({ _id: { $in: traffic.map(t => t.keyId) } }) : [];
+    // keyId comes from 90 days of historical log rows, so one unparseable value
+    // must not sink the whole report: an unfiltered $in raises a Mongoose
+    // CastError, which errorHandler rewrites to 404 "Resource not found" - and an
+    // operator reads that as "no data", the worst way for this tool in particular
+    // to fail. Ids dropped here resolve to no scopes below and are still reported
+    // as would-403, which is the safe direction.
+    const lookupIds = traffic.map(t => t.keyId).filter(id => mongoose.Types.ObjectId.isValid(id));
+    const keyDocs = lookupIds.length ? await userApiKeyRepository.find({ _id: { $in: lookupIds } }) : [];
     const scopesByKeyId = new Map<string, ApiKeyScope[]>(keyDocs.map(doc => [String(doc.id), doc.scopes ?? []]));
 
     const { staged } = parseStagedScopes(process.env[SCOPE_STAGING_ENV_VAR]);

--- a/apps/client/pages/api/admin/api-keys/scope-preflight.ts
+++ b/apps/client/pages/api/admin/api-keys/scope-preflight.ts
@@ -1,0 +1,129 @@
+import { ApiKeyScope, IApiKeyScopePreflight, IApiKeyScopePreflightRow } from '@bike4mind/common';
+import { apiKeyUsageLogRepository, userApiKeyRepository } from '@bike4mind/database/auth';
+import { BadRequestError } from '@bike4mind/utils';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { baseApi } from '@server/middlewares/baseApi';
+import { decideScopeGate, parseStagedScopes, SCOPE_STAGING_ENV_VAR } from '@server/middlewares/apiKeyScopeGate';
+import { ForbiddenError } from '@server/utils/errors';
+
+/** ApiKeyUsageLog's TTL is 90 days, so a longer window would silently return less. */
+const MAX_WINDOW_DAYS = 90;
+const DEFAULT_WINDOW_DAYS = 90;
+const MAX_ROWS = 500;
+
+const ALL_SCOPES: ReadonlySet<string> = new Set<string>(Object.values(ApiKeyScope));
+
+/** Outcome ordering: the operator wants the keys that break at the top. */
+const OUTCOME_RANK: Record<IApiKeyScopePreflightRow['outcome'], number> = {
+  deny: 0,
+  stagedAllow: 1,
+  allow: 2,
+};
+
+function readSingle(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * GET /api/admin/api-keys/scope-preflight
+ *   ?endpointPrefix=/api/some/prefix
+ *   &scopes=a:read,a:write
+ *   &days=90
+ *
+ * Admin-only. Answers the question a scope rollout actually needs: *which live
+ * API keys would start getting 403s* if `scopes` were declared as
+ * `requiredScopes` on the routes under `endpointPrefix`.
+ *
+ * This exists because a key holds only the scopes it was minted with, so
+ * declaring a gate on routes that never had one rejects every caller already in
+ * circulation. The documented fallback (docs/architecture/api-key-scope-rollout.md)
+ * is to stage the scope and read the re-mint backlog off a log line - but that is
+ * discovery by traffic, and a key that fires monthly never appears in a two-week
+ * staging window. This reads the 90 days of history in ApiKeyUsageLog instead, so
+ * the list is complete for anything that has actually called the routes.
+ *
+ * The verdict per key comes from `decideScopeGate` - the same function the
+ * runtime gate uses - so this cannot drift from enforcement. That also means the
+ * `stagedAllow` rows reflect API_KEY_SCOPE_STAGING *as set on the stage serving
+ * this request*, which is the stage whose rollout you are planning.
+ *
+ * Read-only by design: it produces the list, a human rotates the keys.
+ */
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
+  asyncHandler(async (req, res) => {
+    if (!req.user?.isAdmin) {
+      throw new ForbiddenError('Unauthorized. Admin access required.');
+    }
+
+    const query = req.query as Record<string, string | string[] | undefined>;
+
+    const endpointPrefix = readSingle(query.endpointPrefix)?.trim();
+    if (!endpointPrefix || !endpointPrefix.startsWith('/')) {
+      throw new BadRequestError('endpointPrefix is required and must start with "/"');
+    }
+
+    const rawScopes = readSingle(query.scopes) ?? '';
+    const requestedScopes = rawScopes
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+    if (requestedScopes.length === 0) {
+      throw new BadRequestError('scopes is required (comma-separated)');
+    }
+    // Fail loudly on a typo. Silently dropping an unknown scope would narrow the
+    // required set and under-report who breaks - the one error this tool must not make.
+    const unknown = requestedScopes.filter(s => !ALL_SCOPES.has(s));
+    if (unknown.length > 0) {
+      throw new BadRequestError(`Unknown scope(s): ${unknown.join(', ')}`);
+    }
+    const requiredScopes = requestedScopes as ApiKeyScope[];
+
+    const rawDays = readSingle(query.days);
+    const parsedDays = rawDays === undefined ? DEFAULT_WINDOW_DAYS : Number(rawDays);
+    if (!Number.isFinite(parsedDays) || parsedDays < 1) {
+      throw new BadRequestError('days must be a positive number');
+    }
+    const windowDays = Math.min(Math.floor(parsedDays), MAX_WINDOW_DAYS);
+
+    const traffic = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+      endpointPrefix,
+      days: windowDays,
+      limit: MAX_ROWS,
+    });
+
+    const keyDocs = traffic.length ? await userApiKeyRepository.find({ _id: { $in: traffic.map(t => t.keyId) } }) : [];
+    const scopesByKeyId = new Map<string, ApiKeyScope[]>(keyDocs.map(doc => [String(doc.id), doc.scopes ?? []]));
+
+    const { staged } = parseStagedScopes(process.env[SCOPE_STAGING_ENV_VAR]);
+
+    const rows: IApiKeyScopePreflightRow[] = traffic
+      .map(entry => {
+        // A key absent from UserApiKey was deleted after its last logged call.
+        // Treat it as holding nothing: it cannot be re-minted, and reporting it
+        // as `allow` would hide a row the operator should still see.
+        const heldScopes = scopesByKeyId.get(entry.keyId) ?? [];
+        const { outcome } = decideScopeGate(requiredScopes, heldScopes, staged);
+        return { ...entry, heldScopes, outcome };
+      })
+      .sort((a, b) => OUTCOME_RANK[a.outcome] - OUTCOME_RANK[b.outcome] || b.requests - a.requests);
+
+    const payload: IApiKeyScopePreflight = {
+      endpointPrefix,
+      requiredScopes,
+      windowDays,
+      stagedScopes: [...staged],
+      rows,
+      truncated: traffic.length === MAX_ROWS,
+    };
+
+    return res.status(200).json(payload);
+  })
+);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/pages/api/admin/api-keys/scope-preflight.ts
+++ b/apps/client/pages/api/admin/api-keys/scope-preflight.ts
@@ -12,6 +12,23 @@ const MAX_WINDOW_DAYS = 90;
 const DEFAULT_WINDOW_DAYS = 90;
 const MAX_ROWS = 500;
 
+/**
+ * HTTP surfaces whose API-key traffic is NEVER in ApiKeyUsageLog.
+ *
+ * The collection has exactly one writer: `baseApi` -> `apiKeyAuth`'s `res.finish`
+ * hook (apps/client/server/middlewares/apiKeyAuth.ts). Everything authenticated
+ * through `verifyApiKey` (apps/client/server/cli/auth.ts) - public contract routes
+ * via `resolveContractAuth`, and the embed surfaces - logs nothing. A preflight
+ * over those paths returns zero rows however busy they are, which would make this
+ * tool assert the one thing it must never assert: a false "nobody calls these".
+ *
+ * Must stay in sync with the routes wired through `resolveContractAuth` and
+ * `verifyEmbedKeyById`. A path added there and not here reads as a real empty
+ * result. The runbook's "Staging applies to the `baseApi` gate only" paragraph
+ * (docs/architecture/api-key-scope-rollout.md) describes the same boundary.
+ */
+const UNLOGGED_ENDPOINT_PREFIXES = ['/api/ai/v1', '/api/embed'] as const;
+
 const ALL_SCOPES: ReadonlySet<string> = new Set<string>(Object.values(ApiKeyScope));
 
 /** Outcome ordering: the operator wants the keys that break at the top. */
@@ -23,6 +40,21 @@ const OUTCOME_RANK: Record<IApiKeyScopePreflightRow['outcome'], number> = {
 
 function readSingle(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+/** The unlogged surface `prefix` sits entirely within, if any. Zero rows there proves nothing. */
+function enclosingUnloggedSurface(prefix: string): string | undefined {
+  return UNLOGGED_ENDPOINT_PREFIXES.find(unlogged => prefix === unlogged || prefix.startsWith(`${unlogged}/`));
+}
+
+/**
+ * Unlogged surfaces swept up by a broader `prefix` (`/api/` contains both). The
+ * result is real but partial: those routes contribute no rows. The inverse case -
+ * a prefix sitting inside a surface - is rejected outright above, so it cannot
+ * reach here.
+ */
+function unloggedSurfacesUnder(prefix: string): string[] {
+  return UNLOGGED_ENDPOINT_PREFIXES.filter(unlogged => unlogged.startsWith(prefix));
 }
 
 /**
@@ -50,6 +82,13 @@ function readSingle(value: string | string[] | undefined): string | undefined {
  * `stagedAllow` rows reflect API_KEY_SCOPE_STAGING *as set on the stage serving
  * this request*, which is the stage whose rollout you are planning.
  *
+ * The one thing it must never do is report a confident zero. `ApiKeyUsageLog` is
+ * written only by `baseApi`, so a prefix served by `verifyApiKey` is rejected
+ * outright, a broader prefix that merely contains one reports the invisible
+ * surfaces in `coverage.unloggedPrefixes`, and a sub-TTL window clears
+ * `coverage.fullWindow`. An empty row list is safe to act on only when `coverage`
+ * is clean on both counts.
+ *
  * Read-only by design: it produces the list, a human rotates the keys.
  */
 const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
@@ -63,6 +102,19 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
     const endpointPrefix = readSingle(query.endpointPrefix)?.trim();
     if (!endpointPrefix || !endpointPrefix.startsWith('/')) {
       throw new BadRequestError('endpointPrefix is required and must start with "/"');
+    }
+    // Refuse rather than answer "zero keys" for a prefix that structurally cannot
+    // produce a row. Returning an empty result here would be a false statement of
+    // fact, and acting on it breaks live keys with no grace period, because the
+    // gate on these routes is enforced by `verifyApiKey`, which has no staging path.
+    const enclosingUnlogged = enclosingUnloggedSurface(endpointPrefix);
+    if (enclosingUnlogged) {
+      throw new BadRequestError(
+        `${endpointPrefix} is served by verifyApiKey, not baseApi, so no API-key traffic to it is ` +
+          `logged and this preflight can only ever return zero keys. Routes under ${enclosingUnlogged} ` +
+          `need no preflight: every scope they gate is bound to a credential minted with it, so there ` +
+          `is no grandfathered population. See docs/architecture/api-key-scope-rollout.md.`
+      );
     }
 
     const rawScopes = readSingle(query.scopes) ?? '';
@@ -88,11 +140,16 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
     }
     const windowDays = Math.min(Math.floor(parsedDays), MAX_WINDOW_DAYS);
 
-    const traffic = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+    // Fetch one past the cap so `truncated` is exact: `length === MAX_ROWS` alone
+    // cannot tell "exactly MAX_ROWS keys" from "MAX_ROWS of more", and reporting a
+    // complete list as partial sends the operator narrowing a prefix for no reason.
+    const fetched = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
       endpointPrefix,
       days: windowDays,
-      limit: MAX_ROWS,
+      limit: MAX_ROWS + 1,
     });
+    const truncated = fetched.length > MAX_ROWS;
+    const traffic = truncated ? fetched.slice(0, MAX_ROWS) : fetched;
 
     // keyId comes from 90 days of historical log rows, so one unparseable value
     // must not sink the whole report: an unfiltered $in raises a Mongoose
@@ -101,7 +158,11 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
     // to fail. Ids dropped here resolve to no scopes below and are still reported
     // as would-403, which is the safe direction.
     const lookupIds = traffic.map(t => t.keyId).filter(id => mongoose.Types.ObjectId.isValid(id));
-    const keyDocs = lookupIds.length ? await userApiKeyRepository.find({ _id: { $in: lookupIds } }) : [];
+    // Project to `scopes`: this handler reads one field, and an unprojected find
+    // hydrates the whole UserApiKey document - `keyHash` included, since that
+    // schema's `toObject` has no strip transform (only `toJSON` deletes it).
+    // Nothing leaks, but a credential hash has no business in this request.
+    const keyDocs = lookupIds.length ? await userApiKeyRepository.find({ _id: { $in: lookupIds } }, { scopes: 1 }) : [];
     const scopesByKeyId = new Map<string, ApiKeyScope[]>(keyDocs.map(doc => [String(doc.id), doc.scopes ?? []]));
 
     const { staged } = parseStagedScopes(process.env[SCOPE_STAGING_ENV_VAR]);
@@ -123,7 +184,11 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
       windowDays,
       stagedScopes: [...staged],
       rows,
-      truncated: traffic.length === MAX_ROWS,
+      truncated,
+      coverage: {
+        fullWindow: windowDays === MAX_WINDOW_DAYS,
+        unloggedPrefixes: unloggedSurfacesUnder(endpointPrefix),
+      },
     };
 
     return res.status(200).json(payload);

--- a/b4m-core/common/src/types/analytics.ts
+++ b/b4m-core/common/src/types/analytics.ts
@@ -72,6 +72,53 @@ export interface IPlatformEndpointUsage {
 }
 
 /**
+ * One API key's observed traffic against a set of routes, from ApiKeyUsageLog.
+ * The join key is `keyId`, which is the UserApiKey document id (set by
+ * userApiKeyService/validate.ts).
+ */
+export interface IApiKeyEndpointTraffic {
+  keyId: string;
+  userId: string;
+  requests: number;
+  lastUsed: Date;
+  /** Distinct endpoints this key hit under the prefix, capped for display. */
+  endpoints: string[];
+}
+
+/**
+ * What the scope gate WOULD decide for one key if a set of `requiredScopes`
+ * were declared on the routes it has been calling.
+ *
+ * `outcome` mirrors ScopeGateDecision (apps/client/server/middlewares/apiKeyScopeGate.ts)
+ * and is produced by calling that module's `decideScopeGate` - never by
+ * reimplementing its rules here. A preflight that drifts from the runtime gate
+ * reports a confidently wrong re-mint list, which is worse than no preflight.
+ */
+export interface IApiKeyScopePreflightRow extends IApiKeyEndpointTraffic {
+  /** Scopes the key was actually minted with. */
+  heldScopes: string[];
+  /** 'deny' = 403s on enforcement. 'stagedAllow' = only surviving via staging. */
+  outcome: 'allow' | 'stagedAllow' | 'deny';
+}
+
+/**
+ * Result of a scope-enforcement preflight: who breaks if these scopes are
+ * declared on these routes.
+ */
+export interface IApiKeyScopePreflight {
+  endpointPrefix: string;
+  requiredScopes: string[];
+  /** Days of history examined. ApiKeyUsageLog's TTL caps real coverage at 90. */
+  windowDays: number;
+  /** Scopes currently staged, so a stagedAllow row is explicable. */
+  stagedScopes: string[];
+  /** Every key seen on these routes in the window, worst outcome first. */
+  rows: IApiKeyScopePreflightRow[];
+  /** True when the row cap was hit, so the caller knows the list is partial. */
+  truncated: boolean;
+}
+
+/**
  * Resolves source for the /api/ai/v1/completions endpoint. This endpoint is
  * called only by CLI and 3rd-party API users (never by web chat - that uses a
  * different pipeline). We distinguish CLI from raw API by the `b4m-cli/`

--- a/b4m-core/common/src/types/analytics.ts
+++ b/b4m-core/common/src/types/analytics.ts
@@ -81,8 +81,6 @@ export interface IApiKeyEndpointTraffic {
   userId: string;
   requests: number;
   lastUsed: Date;
-  /** Distinct endpoints this key hit under the prefix, capped for display. */
-  endpoints: string[];
 }
 
 /**
@@ -102,6 +100,23 @@ export interface IApiKeyScopePreflightRow extends IApiKeyEndpointTraffic {
 }
 
 /**
+ * What a preflight run did and did not actually look at. An empty row list only
+ * licenses enforcing in one step when BOTH hold: the window covered the full
+ * logged history, and no part of the prefix is served by a router that does not
+ * write ApiKeyUsageLog. Either one alone turns "nobody breaks" into a guess.
+ */
+export interface IApiKeyScopePreflightCoverage {
+  /** True only when the window covered ApiKeyUsageLog's full 90-day TTL. */
+  fullWindow: boolean;
+  /**
+   * Unlogged surfaces overlapping the prefix. API-key traffic to these is
+   * authenticated by `verifyApiKey`, which writes no usage log, so it is
+   * invisible to this tool no matter how busy the routes are.
+   */
+  unloggedPrefixes: string[];
+}
+
+/**
  * Result of a scope-enforcement preflight: who breaks if these scopes are
  * declared on these routes.
  */
@@ -116,6 +131,8 @@ export interface IApiKeyScopePreflight {
   rows: IApiKeyScopePreflightRow[];
   /** True when the row cap was hit, so the caller knows the list is partial. */
   truncated: boolean;
+  /** What this run could and could not see. Read before acting on zero rows. */
+  coverage: IApiKeyScopePreflightCoverage;
 }
 
 /**

--- a/docs/architecture/api-key-scope-rollout.md
+++ b/docs/architecture/api-key-scope-rollout.md
@@ -59,8 +59,23 @@ target stage - the same as any other lever there.
 
 While a scope is listed, a route requiring it lets through a key that lacks it and
 logs `API key scope check missed but staged - allowing` with the key id, the held
-scopes, and the endpoint. That log line *is* the re-mint backlog: every hit is a
-production key that will start failing the day the entry is removed.
+scopes, and the endpoint. Every hit is a production key that will start failing the
+day the entry is removed.
+
+That log is a *confirmation* of the backlog, not the way to discover it. Discovery by
+traffic is incomplete on its own: a key that fires monthly never appears in a
+two-week staging window, so a quiet log cannot distinguish "everyone re-minted" from
+"the quarterly job has not run yet". Size the population up front with the
+**scope preflight** (Admin -> Reliability / Incident Ops -> API Key Scope Preflight,
+backed by `GET /api/admin/api-keys/scope-preflight`). Given an endpoint prefix and the
+scopes you intend to require, it reads the 90 days of history in `ApiKeyUsageLog` and
+lists every key that has actually called those routes, marking each as would-403,
+surviving-only-on-staging, or already fine. It reaches its verdict by calling
+`decideScopeGate` - the same function the runtime gate calls - so it cannot drift from
+enforcement.
+
+If the preflight returns nothing, there is no grandfathered population and the whole
+staging sequence below can be skipped: declare the gate and enforce in one step.
 
 Two things it deliberately will not do:
 
@@ -91,15 +106,20 @@ brand-new scope is a brand-new endpoint with no keys in circulation.
 ## The rollout
 
 1. Land the enum value and the catalog registration.
-2. Set `API_KEY_SCOPE_STAGING` to the new scope(s) on the target stage.
-3. Land `requiredScopes` on the routes. Nothing breaks - misses are logged, not rejected.
-4. Watch `API key scope check missed but staged - allowing`. Each distinct `keyId` is a
-   key to re-mint with the new scope. Rotate them with their owners.
-5. When the line stops appearing, remove the entry from `API_KEY_SCOPE_STAGING`.
-   The gate is now live.
+2. Run the **scope preflight** against the routes you are about to gate. If it returns
+   no keys, skip to step 6 and enforce in one step - there is nobody to grandfather,
+   and staging a gate with no population to protect just means it never enforces.
+   Otherwise the result is your re-mint list.
+3. Set `API_KEY_SCOPE_STAGING` to the new scope(s) on the target stage.
+4. Land `requiredScopes` on the routes. Nothing breaks - misses are logged, not rejected.
+5. Re-mint the keys from step 2 with their owners. Watch
+   `API key scope check missed but staged - allowing` as a cross-check that the list was
+   complete - a `keyId` there that step 2 did not name means the preflight window was too
+   short, so widen it rather than trusting the log alone.
+6. Remove the entry from `API_KEY_SCOPE_STAGING`. The gate is now live.
 
-Do not skip step 5 quietly. A scope left in the list forever is a gate that has never
-once enforced.
+Do not skip the last step quietly. A scope left in the list forever is a gate that has
+never once enforced.
 
 ## Troubleshooting
 

--- a/docs/architecture/api-key-scope-rollout.md
+++ b/docs/architecture/api-key-scope-rollout.md
@@ -145,7 +145,10 @@ to a question it cannot see.
    `API key scope check missed but staged - allowing` as a cross-check that the list was
    complete - a `keyId` there that step 2 did not name means the preflight window was too
    short, so widen it rather than trusting the log alone.
-6. Remove the entry from `API_KEY_SCOPE_STAGING`. The gate is now live.
+6. When that line stops appearing, remove the entry from `API_KEY_SCOPE_STAGING`. The
+   gate is now live. Wait for the log to go quiet, not for step 5's re-mints to be
+   dispatched - this is the step that starts rejecting, and a key whose owner has not
+   yet rotated is still calling until the traffic says otherwise.
 
 Do not skip the last step quietly. A scope left in the list forever is a gate that has
 never once enforced.

--- a/docs/architecture/api-key-scope-rollout.md
+++ b/docs/architecture/api-key-scope-rollout.md
@@ -72,12 +72,27 @@ scopes you intend to require, it reads the history in `ApiKeyUsageLog` - up to t
 collection's 90-day TTL - and lists the keys that have actually called those routes,
 marking each as would-403, surviving-only-on-staging, or already fine. It caps the
 result and says so when the cap is hit, so treat a truncated list as partial and
-narrow the prefix. It reaches its verdict by calling
+narrow the prefix - not the window, which drops the low-traffic keys for good rather
+than paging past them. It reaches its verdict by calling
 `decideScopeGate` - the same function the runtime gate calls - so it cannot drift from
-enforcement.
+enforcement. The prefix matches as a plain string, not by path segment, so `/api/chat`
+also reports keys that only ever called `/api/chatbots`; that over-reports rather than
+under-reports, which is the safe direction.
 
-If the preflight returns nothing, there is no grandfathered population and the whole
-staging sequence below can be skipped: declare the gate and enforce in one step.
+An empty result means "there is nobody to grandfather" only when the run actually saw
+everything. Two preconditions, both surfaced in the tool's own output:
+
+- **The window covered the full 90 days.** The 7- and 30-day options exist for a quick
+  look, and a key that fires monthly or quarterly leaves no trace in them. An empty
+  short-window run is an absence of evidence, and the tool labels it as one.
+- **The prefix is under the `baseApi` gate.** `ApiKeyUsageLog` has exactly one writer -
+  `apiKeyAuth`, on `baseApi`'s response hook. Routes served by `verifyApiKey` log
+  nothing, so a preflight over them can only ever return zero keys. The tool rejects a
+  prefix that sits entirely inside one of those surfaces, and names them when a broader
+  prefix merely contains one.
+
+When both hold and the result is empty, there is no grandfathered population and the
+whole staging sequence below can be skipped: declare the gate and enforce in one step.
 
 Two things it deliberately will not do:
 
@@ -105,13 +120,25 @@ credential minted with that exact scope, or to an endpoint that shipped with its
 from the start, so nothing there was ever grandfathered. A contract route declaring a
 brand-new scope is a brand-new endpoint with no keys in circulation.
 
+The preflight inherits that same boundary, because its evidence comes from the
+`baseApi` gate's logging: `ApiKeyUsageLog` is written by `apiKeyAuth` and by nothing
+else, so `verifyApiKey`-served paths produce no rows at all. This matters more for the
+preflight than for staging - a missing staging path is a documented non-need, whereas a
+silent zero would read as a positive finding. It does not stay silent: the tool refuses
+a prefix under `/api/ai/v1` or `/api/embed` outright, rather than answering "no keys"
+to a question it cannot see.
+
 ## The rollout
 
 1. Land the enum value and the catalog registration.
-2. Run the **scope preflight** against the routes you are about to gate. If it returns
-   no keys, skip to step 6 and enforce in one step - there is nobody to grandfather,
-   and staging a gate with no population to protect just means it never enforces.
-   Otherwise the result is your re-mint list.
+2. Run the **scope preflight** against the routes you are about to gate, at the full
+   90-day window. If it returns no keys *and* the run met both preconditions above -
+   full 90-day window, and a prefix under the `baseApi` gate - skip to step 6 and
+   enforce in one step: there is nobody to grandfather, and staging a gate with no
+   population to protect just means it never enforces. An empty result that misses
+   either precondition proves nothing; do not take the skip, because step 5's
+   cross-check is the safety net you would be giving up along with it. Otherwise the
+   result is your re-mint list.
 3. Set `API_KEY_SCOPE_STAGING` to the new scope(s) on the target stage.
 4. Land `requiredScopes` on the routes. Nothing breaks - misses are logged, not rejected.
 5. Re-mint the keys from step 2 with their owners. Watch

--- a/docs/architecture/api-key-scope-rollout.md
+++ b/docs/architecture/api-key-scope-rollout.md
@@ -68,9 +68,11 @@ two-week staging window, so a quiet log cannot distinguish "everyone re-minted" 
 "the quarterly job has not run yet". Size the population up front with the
 **scope preflight** (Admin -> Reliability / Incident Ops -> API Key Scope Preflight,
 backed by `GET /api/admin/api-keys/scope-preflight`). Given an endpoint prefix and the
-scopes you intend to require, it reads the 90 days of history in `ApiKeyUsageLog` and
-lists every key that has actually called those routes, marking each as would-403,
-surviving-only-on-staging, or already fine. It reaches its verdict by calling
+scopes you intend to require, it reads the history in `ApiKeyUsageLog` - up to that
+collection's 90-day TTL - and lists the keys that have actually called those routes,
+marking each as would-403, surviving-only-on-staging, or already fine. It caps the
+result and says so when the cap is hit, so treat a truncated list as partial and
+narrow the prefix. It reaches its verdict by calling
 `decideScopeGate` - the same function the runtime gate calls - so it cannot drift from
 enforcement.
 

--- a/packages/database/src/__test__/apiKeyUsageLog.test.ts
+++ b/packages/database/src/__test__/apiKeyUsageLog.test.ts
@@ -136,3 +136,91 @@ describe('ApiKeyUsageLogRepository.platformEndpointUsage', () => {
     expect(threeHours.byEndpoint).toHaveLength(1);
   });
 });
+
+describe('ApiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await connectTestDB();
+  }, 30000);
+
+  afterAll(async () => {
+    await disconnectTestDB(mongoServer);
+  }, 30000);
+
+  beforeEach(async () => {
+    await ApiKeyUsageLog.deleteMany({});
+  });
+
+  const log = (overrides: Partial<Record<string, unknown>> = {}) =>
+    apiKeyUsageLogRepository.create({
+      userId: 'user-1',
+      keyId: 'keyA',
+      ipAddress: '203.0.113.1',
+      endpoint: '/api/thing/one',
+      method: 'GET',
+      responseTime: 10,
+      statusCode: 200,
+      timestamp: new Date(),
+      ...overrides,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test seed: partial log doc
+    } as any);
+
+  it('groups matching traffic per key, busiest first, with last use and distinct endpoints', async () => {
+    await log({ keyId: 'busy', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
+    await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: new Date('2026-01-03') });
+    await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: new Date('2026-01-02') });
+    await log({ keyId: 'quiet', userId: 'user-2', endpoint: '/api/thing/one' });
+
+    const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+      endpointPrefix: '/api/thing',
+      days: 36500,
+    });
+
+    expect(rows.map(r => r.keyId)).toEqual(['busy', 'quiet']);
+    expect(rows[0]).toMatchObject({ keyId: 'busy', userId: 'user-1', requests: 3 });
+    expect(rows[0].endpoints.sort()).toEqual(['/api/thing/one', '/api/thing/two']);
+    expect(new Date(rows[0].lastUsed).toISOString()).toBe(new Date('2026-01-03').toISOString());
+    expect(rows[1]).toMatchObject({ keyId: 'quiet', userId: 'user-2', requests: 1 });
+  });
+
+  it('matches on prefix only, and anchors it to the start of the endpoint', async () => {
+    await log({ keyId: 'inside', endpoint: '/api/thing/one' });
+    await log({ keyId: 'elsewhere', endpoint: '/api/other/one' });
+    // Anchoring matters: an unanchored match would pull this in and overstate the blast radius.
+    await log({ keyId: 'suffix', endpoint: '/nested/api/thing/one' });
+
+    const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+      endpointPrefix: '/api/thing',
+      days: 36500,
+    });
+
+    expect(rows.map(r => r.keyId)).toEqual(['inside']);
+  });
+
+  it('treats regex metacharacters in the prefix as literals', async () => {
+    // Unescaped, `/api/a+b` would match '/api/aab' and miss the real route,
+    // under-reporting affected keys - a false "nobody breaks".
+    await log({ keyId: 'literal', endpoint: '/api/a+b/one' });
+    await log({ keyId: 'regexy', endpoint: '/api/aab/one' });
+
+    const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+      endpointPrefix: '/api/a+b',
+      days: 36500,
+    });
+
+    expect(rows.map(r => r.keyId)).toEqual(['literal']);
+  });
+
+  it('excludes traffic older than the window', async () => {
+    await log({ keyId: 'recent', timestamp: new Date() });
+    await log({ keyId: 'ancient', timestamp: new Date(Date.now() - 120 * 24 * 60 * 60 * 1000) });
+
+    const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+      endpointPrefix: '/api/thing',
+      days: 90,
+    });
+
+    expect(rows.map(r => r.keyId)).toEqual(['recent']);
+  });
+});

--- a/packages/database/src/__test__/apiKeyUsageLog.test.ts
+++ b/packages/database/src/__test__/apiKeyUsageLog.test.ts
@@ -166,22 +166,55 @@ describe('ApiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test seed: partial log doc
     } as any);
 
-  it('groups matching traffic per key, busiest first, with last use and distinct endpoints', async () => {
+  it('groups matching traffic per key with its request count and last use', async () => {
     await log({ keyId: 'busy', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
     await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: new Date('2026-01-03') });
     await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: new Date('2026-01-02') });
-    await log({ keyId: 'quiet', userId: 'user-2', endpoint: '/api/thing/one' });
+    await log({ keyId: 'quiet', userId: 'user-2', endpoint: '/api/thing/one', timestamp: new Date('2026-01-02') });
 
     const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
       endpointPrefix: '/api/thing',
       days: 36500,
     });
 
-    expect(rows.map(r => r.keyId)).toEqual(['busy', 'quiet']);
-    expect(rows[0]).toMatchObject({ keyId: 'busy', userId: 'user-1', requests: 3 });
-    expect(rows[0].endpoints.sort()).toEqual(['/api/thing/one', '/api/thing/two']);
-    expect(new Date(rows[0].lastUsed).toISOString()).toBe(new Date('2026-01-03').toISOString());
-    expect(rows[1]).toMatchObject({ keyId: 'quiet', userId: 'user-2', requests: 1 });
+    expect(rows).toHaveLength(2);
+    expect(rows.find(r => r.keyId === 'busy')).toMatchObject({ userId: 'user-1', requests: 3 });
+    expect(new Date(rows.find(r => r.keyId === 'busy')!.lastUsed).toISOString()).toBe(
+      new Date('2026-01-03').toISOString()
+    );
+    expect(rows.find(r => r.keyId === 'quiet')).toMatchObject({ userId: 'user-2', requests: 1 });
+  });
+
+  it('truncates by recency, not by request count, so a quiet key outranks an older busy one', async () => {
+    // The keys this tool exists to catch are the monthly and quarterly callers.
+    // Ordering by `requests` before the limit would discard exactly those first,
+    // and narrowing the window to clear the cap would drop them for good.
+    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
+    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
+    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
+    await log({ keyId: 'quiet-but-recent', endpoint: '/api/thing/one', timestamp: new Date('2026-06-01') });
+
+    const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+      endpointPrefix: '/api/thing',
+      days: 36500,
+      limit: 1,
+    });
+
+    expect(rows.map(r => r.keyId)).toEqual(['quiet-but-recent']);
+  });
+
+  it('does not return an endpoints array', async () => {
+    // `endpoint` is `req.originalUrl`, so a distinct-set accumulator is effectively
+    // per-request cardinality and could blow the 16MB group-document limit on a
+    // broad prefix. Nothing renders it, so it is not collected.
+    await log({ keyId: 'busy', endpoint: '/api/thing/one' });
+
+    const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
+      endpointPrefix: '/api/thing',
+      days: 36500,
+    });
+
+    expect(rows[0]).not.toHaveProperty('endpoints');
   });
 
   it('matches on prefix only, and anchors it to the start of the endpoint', async () => {

--- a/packages/database/src/__test__/apiKeyUsageLog.test.ts
+++ b/packages/database/src/__test__/apiKeyUsageLog.test.ts
@@ -152,6 +152,15 @@ describe('ApiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix', () => {
     await ApiKeyUsageLog.deleteMany({});
   });
 
+  /**
+   * Seed timestamps must stay inside the collection's 90-day TTL. `ApiKeyUsageLog`
+   * declares `expireAfterSeconds` and `createMongoServer` cannot disable autoIndex,
+   * so a real mongod builds that index and its background monitor is entitled to
+   * sweep an older fixture between the write and the aggregate. Widening the query
+   * with `days` does not help - the TTL is a separate mechanism.
+   */
+  const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
   const log = (overrides: Partial<Record<string, unknown>> = {}) =>
     apiKeyUsageLogRepository.create({
       userId: 'user-1',
@@ -167,21 +176,20 @@ describe('ApiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix', () => {
     } as any);
 
   it('groups matching traffic per key with its request count and last use', async () => {
-    await log({ keyId: 'busy', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
-    await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: new Date('2026-01-03') });
-    await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: new Date('2026-01-02') });
-    await log({ keyId: 'quiet', userId: 'user-2', endpoint: '/api/thing/one', timestamp: new Date('2026-01-02') });
+    const newestBusy = daysAgo(8);
+    await log({ keyId: 'busy', endpoint: '/api/thing/one', timestamp: daysAgo(10) });
+    await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: newestBusy });
+    await log({ keyId: 'busy', endpoint: '/api/thing/two', timestamp: daysAgo(9) });
+    await log({ keyId: 'quiet', userId: 'user-2', endpoint: '/api/thing/one', timestamp: daysAgo(9) });
 
     const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
       endpointPrefix: '/api/thing',
-      days: 36500,
+      days: 90,
     });
 
     expect(rows).toHaveLength(2);
     expect(rows.find(r => r.keyId === 'busy')).toMatchObject({ userId: 'user-1', requests: 3 });
-    expect(new Date(rows.find(r => r.keyId === 'busy')!.lastUsed).toISOString()).toBe(
-      new Date('2026-01-03').toISOString()
-    );
+    expect(new Date(rows.find(r => r.keyId === 'busy')!.lastUsed).toISOString()).toBe(newestBusy.toISOString());
     expect(rows.find(r => r.keyId === 'quiet')).toMatchObject({ userId: 'user-2', requests: 1 });
   });
 
@@ -189,14 +197,14 @@ describe('ApiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix', () => {
     // The keys this tool exists to catch are the monthly and quarterly callers.
     // Ordering by `requests` before the limit would discard exactly those first,
     // and narrowing the window to clear the cap would drop them for good.
-    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
-    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
-    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: new Date('2026-01-01') });
-    await log({ keyId: 'quiet-but-recent', endpoint: '/api/thing/one', timestamp: new Date('2026-06-01') });
+    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: daysAgo(80) });
+    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: daysAgo(80) });
+    await log({ keyId: 'busy-but-stale', endpoint: '/api/thing/one', timestamp: daysAgo(80) });
+    await log({ keyId: 'quiet-but-recent', endpoint: '/api/thing/one', timestamp: daysAgo(1) });
 
     const rows = await apiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix({
       endpointPrefix: '/api/thing',
-      days: 36500,
+      days: 90,
       limit: 1,
     });
 

--- a/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
+++ b/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
@@ -251,7 +251,7 @@ export class ApiKeyUsageLogRepository extends BaseRepository<IApiKeyUsageLogDocu
 
   /**
    * Every API key that has called a route under `endpointPrefix` within the
-   * window, with its request count, last use, and the distinct endpoints it hit.
+   * window, with its request count and last use.
    *
    * This is the evidence half of a scope-enforcement preflight: before declaring
    * `requiredScopes` on routes that are currently scope-less, you need the list
@@ -271,15 +271,19 @@ export class ApiKeyUsageLogRepository extends BaseRepository<IApiKeyUsageLogDocu
     days?: number;
     /** Max keys returned; the caller should surface truncation to the operator. */
     limit?: number;
-    /** Distinct endpoints kept per key, for display. */
-    endpointsPerKey?: number;
   }): Promise<IApiKeyEndpointTraffic[]> {
-    const { endpointPrefix, days = 90, limit = 500, endpointsPerKey = 10 } = params;
+    const { endpointPrefix, days = 90, limit = 500 } = params;
     const from = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
     // The prefix is operator-supplied and goes into a $regex, so escape it.
     // Without this, a prefix like `/api/a+b` silently matches the wrong routes
     // and the preflight under-reports - a false "nobody breaks".
+    //
+    // This is a plain string prefix, not a path-segment one: `/api/chat` also
+    // matches `/api/chatbots`. Over-reporting is the safe direction here (the
+    // operator re-mints a key that would not have broken), and segment-awareness
+    // would break the query-string match this relies on, since `endpoint` is
+    // `req.originalUrl` - `/api/chat?x=1` has to match too.
     const escaped = endpointPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
     return this.model.aggregate<IApiKeyEndpointTraffic>([
@@ -290,7 +294,6 @@ export class ApiKeyUsageLogRepository extends BaseRepository<IApiKeyUsageLogDocu
           userId: { $first: '$userId' },
           requests: { $sum: 1 },
           lastUsed: { $max: '$timestamp' },
-          endpoints: { $addToSet: '$endpoint' },
         },
       },
       {
@@ -300,10 +303,13 @@ export class ApiKeyUsageLogRepository extends BaseRepository<IApiKeyUsageLogDocu
           userId: 1,
           requests: 1,
           lastUsed: 1,
-          endpoints: { $slice: ['$endpoints', endpointsPerKey] },
         },
       },
-      { $sort: { requests: -1 } },
+      // Order by recency, NOT by request count: truncation has to discard the
+      // least relevant rows, and sorting by `requests` would drop the quietest
+      // keys first - the monthly and quarterly callers whose invisibility is the
+      // whole reason this tool exists. The handler re-sorts by outcome anyway.
+      { $sort: { lastUsed: -1 } },
       { $limit: limit },
     ]);
   }

--- a/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
+++ b/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
@@ -1,4 +1,10 @@
-import { IEndpointUsageBucket, IEndpointUsageDay, IMongoDocument, IPlatformEndpointUsage } from '@bike4mind/common';
+import {
+  IApiKeyEndpointTraffic,
+  IEndpointUsageBucket,
+  IEndpointUsageDay,
+  IMongoDocument,
+  IPlatformEndpointUsage,
+} from '@bike4mind/common';
 import mongoose, { Model } from 'mongoose';
 import BaseRepository from '@bike4mind/db-core';
 
@@ -241,6 +247,65 @@ export class ApiKeyUsageLogRepository extends BaseRepository<IApiKeyUsageLogDocu
       byEndpoint: result?.byEndpoint ?? [],
       overTime: result?.overTime ?? [],
     };
+  }
+
+  /**
+   * Every API key that has called a route under `endpointPrefix` within the
+   * window, with its request count, last use, and the distinct endpoints it hit.
+   *
+   * This is the evidence half of a scope-enforcement preflight: before declaring
+   * `requiredScopes` on routes that are currently scope-less, you need the list
+   * of keys already calling them, because a key holds only what it was minted
+   * with and will 403 the moment the gate enforces. Deciding which of these keys
+   * would actually break is the caller's job - it must ask `decideScopeGate`
+   * rather than compare scope arrays itself.
+   *
+   * Note there is NO index on `endpoint` (see the schema's index block), so this
+   * is a collection scan bounded by the timestamp match. That is tolerable
+   * because the collection carries a 90-day TTL and this runs a handful of times
+   * per scope rollout, not on a request path. Add a compound index if that
+   * changes.
+   */
+  async findKeyTrafficByEndpointPrefix(params: {
+    endpointPrefix: string;
+    days?: number;
+    /** Max keys returned; the caller should surface truncation to the operator. */
+    limit?: number;
+    /** Distinct endpoints kept per key, for display. */
+    endpointsPerKey?: number;
+  }): Promise<IApiKeyEndpointTraffic[]> {
+    const { endpointPrefix, days = 90, limit = 500, endpointsPerKey = 10 } = params;
+    const from = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    // The prefix is operator-supplied and goes into a $regex, so escape it.
+    // Without this, a prefix like `/api/a+b` silently matches the wrong routes
+    // and the preflight under-reports - a false "nobody breaks".
+    const escaped = endpointPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    return this.model.aggregate<IApiKeyEndpointTraffic>([
+      { $match: { timestamp: { $gte: from }, endpoint: { $regex: `^${escaped}` } } },
+      {
+        $group: {
+          _id: '$keyId',
+          userId: { $first: '$userId' },
+          requests: { $sum: 1 },
+          lastUsed: { $max: '$timestamp' },
+          endpoints: { $addToSet: '$endpoint' },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          keyId: '$_id',
+          userId: 1,
+          requests: 1,
+          lastUsed: 1,
+          endpoints: { $slice: ['$endpoints', endpointsPerKey] },
+        },
+      },
+      { $sort: { requests: -1 } },
+      { $limit: limit },
+    ]);
   }
 }
 


### PR DESCRIPTION
## Description

Declaring `requiredScopes` on routes that currently have none 403s **every API key already in circulation**, because a key holds only the scopes it was minted with. Finding those keys before you break them is the hard part of a scope rollout, and today there is no way to do it.

The runbook's answer is the staged-allow log line, and it says so plainly: *"That log line **is** the re-mint backlog."* That is discovery by traffic, and it has a hole - a key that fires monthly never appears in a two-week staging window, so a quiet log cannot distinguish "everyone re-minted" from "the quarterly job has not run yet". Remove the staging entry on that evidence and you break the key you were trying to protect, just later.

This adds an admin tool that answers the question directly from history instead. Give it an endpoint prefix and the scopes you intend to require; it reads the 90 days in `ApiKeyUsageLog` and lists every key that has actually called those routes, marked **would 403 / staged only / already fine**.

It is generic on purpose - the endpoint prefix is a parameter, so the next scope rollout reuses it rather than re-deriving a one-off Mongo query. Read-only: it produces the list, a human rotates the keys.

Context: this unblocks the ops half of #2046, but does not close it.

## Changes

- **`GET /api/admin/api-keys/scope-preflight`** - admin-only. Takes `endpointPrefix`, `scopes` (comma-separated), `days`. Returns each key's held scopes, request count, last use, and the gate's verdict, plus a `coverage` block stating what the run could not see.
- **`ApiKeyUsageLogRepository.findKeyTrafficByEndpointPrefix`** - groups usage by `keyId` under a prefix, within a window.
- **`ApiKeyScopePreflightTab`** - new admin tab under Reliability / Incident Ops, plus sidebar entry and panel wiring.
- **`useApiKeyScopePreflight`** - React Query hook, disabled until both inputs are supplied.
- **Coverage guardrails** - `ApiKeyUsageLog` has exactly one writer (`baseApi` -> `apiKeyAuth`), so routes served by `verifyApiKey` log nothing. The route rejects a prefix under `/api/ai/v1` or `/api/embed` outright rather than answering "no keys" to a question it cannot see, and reports those surfaces in `coverage.unloggedPrefixes` when a broader prefix merely contains them. The UI withholds its enforce-in-one-step advice unless the window covered the full 90-day TTL *and* nothing under the prefix is unlogged.
- **The results panel names its own run** - it echoes the `endpointPrefix`, `requiredScopes` and `windowDays` the payload came back with, and **Run** re-fetches when the submitted params are unchanged. The form stays editable while results stay on screen, so without both, a green "enforce in one step" verdict for one prefix can be read as answering whatever is in the box now.
- **Handler refusals reach the operator** - the error alert reads `response.data.error` before falling back, so the unlogged-prefix explanation and `Unknown scope(s): ...` show up instead of axios's `Request failed with status code 400`.
- **Shared types** in `analytics.ts`.
- **Runbook update** - `docs/architecture/api-key-scope-rollout.md` previously told operators the staged log line was the backlog. That is now false, so the staging section and the rollout sequence are rewritten with the preflight as step 2, including the branch where an empty result means staging can be skipped entirely - and the two preconditions that branch depends on (a full 90-day window, and a prefix under the `baseApi` gate). Step 6, the one step that starts rejecting live keys, keeps the stop condition `main` had: remove the staging entry when the staged-allow line goes quiet, not when the re-mints are dispatched.

Four decisions worth a reviewer's attention:

1. **The verdict comes from `decideScopeGate`** - the same function `apiKeyAuth` calls at runtime - not from a reimplementation. A preflight that drifts from the gate reports a confidently wrong re-mint list, which is worse than no preflight. The route test deliberately leaves it unmocked for that reason.
2. **The endpoint prefix is escaped before it reaches `$regex`.** Unescaped, an operator typing `/api/a+b` matches `/api/aab`, finds nothing, and the tool reports "nobody breaks" - the worst output it could produce. Pinned by a test.
3. **`UNLOGGED_ENDPOINT_PREFIXES` is hand-maintained.** It names the HTTP surfaces served by `verifyApiKey` rather than `baseApi`, and it is what stops the tool reporting a confident zero for routes it structurally cannot see. A new contract route landing under a different prefix would drift, and the failure mode is exactly the one this guardrail exists to prevent. It carries a must-stay-in-sync comment pointing at `resolveContractAuth`; deriving it from the contract registry is the real fix, and I would rather do that as a follow-up than widen this PR. Flag it if you would rather it land here.
4. **The tool sees pre-enforcement traffic only, and `coverage` does not model that.** The scope 403 throws before `apiKeyAuth` registers its `res.finish` usage-log hook, so a *denied* request writes no row. On a prefix that already requires a scope, the keys being turned away today contribute nothing, and once their last passing request ages out of the 90-day TTL an empty result means "nobody is getting through", not "nobody is calling". Nothing new breaks from acting on it - those keys already fail - but it is a third precondition that `coverage.fullWindow` and `coverage.unloggedPrefixes` do not capture, so it is documented in the docblock and the success copy rather than modelled. Raised by review; say so if you would rather it were a real `coverage` field.

I originally flagged the route's own `requiredScopes: [ApiKeyScope.ADMIN]` declaration as a deviation from neighbouring admin routes. Review checked it and it is not - it is the established pattern across 13 admin routes, each with the same "gates the API-key path only" comment, and the in-handler `isAdmin` check is load-bearing alongside it rather than redundant. Recorded here so the next reader does not re-open it.

## Guide for Testers

Requires an **admin** account. Works on any deployed environment; steps below use staging.

1. Go to `app.staging.bike4mind.com` and log in as an admin.
2. Open **Sidebar -> Admin**.
3. In the admin sidebar, expand **Reliability / Incident Ops**.
4. Click **API Key Scope Preflight**.
   - *Expected:* a page titled "API key scope preflight" with an "Endpoint prefix" text box, a "Scopes the routes would require" multi-select, a "Window" dropdown showing `90 days`, and a disabled **Run** button.
5. Type `/api/chat` in **Endpoint prefix**.
   - *Expected:* Run is still disabled - no scope is selected yet.
6. Open the **Scopes** multi-select and choose `ai:chat`.
   - *Expected:* **Run** becomes enabled.
7. Click **Run**.
   - *Expected:* a brief "Scanning usage history..." spinner, then either a results table or a green box reading "No API key has called these routes in the last 90 days, the full logged history."
8. Confirm a line above the results reads `Showing /api/chat against ai:chat over 90 days.` - the run the result belongs to, echoed from the server rather than from the form.
   - Now change **Endpoint prefix** to `/api/sessions` **without** pressing Run. *Expected:* the echo still says `/api/chat`, because that is still the question the result on screen answers.
   - Press **Run** twice in a row without changing anything. *Expected:* the spinner appears both times. A second press that does nothing at all is the bug this line exists to catch.
9. **Produce a real results table.** Steps 5-8 will always come back empty against `/api/chat`, so do not stop there: that route *already* declares `scopes: [ai:chat, ai:generate]` in `chat.contract.ts`, and a scope-denied request throws before `apiKeyAuth` registers its usage-log hook, so its rejected traffic was never logged in the first place. Reaching a table needs a route with **no** `requiredScopes`:
   - In **Profile -> API Keys**, mint two keys: one **Read-only** (does not hold `ai:chat`) and one **Full access** (does).
   - Call `GET /api/files` once with each (`X-API-Key: b4m_live_...`). That route is a plain `baseApi()` with no scope gate, so both calls succeed and both are logged.
   - Run the preflight with prefix `/api/files`, scope `ai:chat`, window `90 days`.
   - *Expected:* two rows - the Read-only key **would 403**, the Full-access key **passes**, and the **would 403** row sorts above it.
   - *Expected:* each row carries an outcome chip (**would 403**, **staged only**, or **passes**), a key id, a user id, held scopes (the Read-only row's list must **not** contain `ai:chat`), a request count of 1, and today's date.
   - Revoke both keys when you are done with them.
10. Confirm the three summary chips above the table ("N would 403", "N surviving on staging", "N already fine") sum to the number of table rows.
11. Change **Window** to `7 days` and click **Run** again.
    - *Expected:* the result refreshes; the row count is the same or lower than the 90-day run, never higher.
    - *Expected if the 7-day run comes back empty:* a **yellow** box, not a green one, telling you to re-run at 90 days before deciding and not to skip the staging sequence. A key that fires monthly leaves no trace in a 7-day window, so a short empty run must not read as "safe to enforce".
12. Clear **Endpoint prefix** and type `api/chat` (no leading slash).
    - *Expected:* **Run** is disabled. The route also rejects it server-side, so a crafted request returns 400.
13. Set the prefix to `/api/` and select **every** scope in the multi-select, then Run.
    - *Expected:* a broad result, plus a yellow banner naming `/api/ai/v1, /api/embed` as routes that write no usage log and are therefore invisible to this scan.
    - If the "Result cap reached - this list is partial" banner also appears, that is correct behaviour at 500 rows, not a bug. Confirm it tells you to narrow the **prefix** and explicitly *not* the window.
14. Set the prefix to `/api/ai/v1/tools`, pick any scope, and Run.
    - *Expected:* a red error, not a result. Those routes authenticate through `verifyApiKey`, which writes no usage log, so the scan could only ever answer "no keys" - the tool refuses rather than saying something false.
    - *Read the error text.* It must be the handler's explanation, naming `verifyApiKey` and pointing at the runbook. `Request failed with status code 400` is a bug: the explanation is the entire point of refusing rather than returning zero. Same check with a bad scope - `?scopes=nope:nope` should say `Unknown scope(s): nope:nope`, not a generic status string.

### Negative / authorization check

15. Log in as a **non-admin** user and request `/api/admin/api-keys/scope-preflight?endpointPrefix=/api/chat&scopes=ai:chat` directly.
    - *Expected:* `403` with `"Insufficient API key permissions"` or `"Unauthorized. Admin access required."` Never a result set.

### Regression Checks

16. In the admin sidebar, confirm **Rate Limits**, **DLQ Management**, and **Retrieval Rate** still open their own pages. This PR added an enum value adjacent to those, and a mis-numbered tab shows up as one entry opening another's content.
17. Confirm the admin sidebar's expand/collapse state still persists across a page reload.
18. Exercise any normal API-key-authenticated request (e.g. the CLI, or a `b4m_live_` call to `/api/chat`) and confirm it still succeeds. This PR does not change `apiKeyAuth`, but it imports from it.

### What NOT to test

- **Nothing about enforcement changes in this PR.** No route's `requiredScopes` is added, removed, or altered; no key gains or loses access. The tool only *reports* what would happen.
- **Do not expect the preflight to re-mint, rotate, or revoke anything.** It is read-only by design.
- **Do not read a yellow "did not cover enough" box as a bug.** That is the tool declining to license enforcement on a run that did not see the whole picture. Only the green box means safe-to-enforce.
- **Do not treat a result older than 90 days as missing data** - `ApiKeyUsageLog` has a 90-day TTL, so that history does not exist.
- No changes to the New-Key modal, scope catalog, or the `API_KEY_SCOPE_STAGING` mechanism itself.

## Additional Information

**Performance.** There is no index on `ApiKeyUsageLog.endpoint`, so this is a collection scan bounded by the timestamp match. That is acceptable for an admin tool run a handful of times per rollout rather than on a request path, and the collection is capped by its 90-day TTL. If it proves slow against real prod volume, the fix is a `{ endpoint: 1, timestamp: -1 }` compound index - deliberately not added here, since a background index build on a high-write collection is a bigger operation than the tool warrants today.

**No endpoints column.** The aggregation deliberately does not collect the distinct endpoints per key. `endpoint` is `req.originalUrl`, so the distinct set is effectively per-request cardinality (query strings and path params included) and could blow the 16MB group-document limit on a broad prefix - for a field nothing renders. If a per-endpoint breakdown is ever wanted, it needs a capped accumulator rather than an unbounded `$addToSet`.

**Truncation order.** The row cap truncates by `lastUsed`, not by request count. Ordering by traffic would discard the quietest keys first, and the monthly and quarterly callers are precisely the population this tool exists to find.

**Staging awareness.** Because the verdict comes from `decideScopeGate`, `stagedAllow` rows reflect `API_KEY_SCOPE_STAGING` *as set on the stage serving the request* - which is the stage whose rollout you are planning. The UI calls that out when the list is non-empty.

**Verification.** Route tests 18/18, aggregation tests against real Mongo 12/12, scope-preflight UI 11/11, sidebar wiring 14/14, client typecheck and `lint:check` pass.

**Test-fixture timestamps are relative on purpose.** `ApiKeyUsageLog` carries a 90-day TTL and `createMongoServer` cannot disable `autoIndex`, so a real mongod builds that index and its background monitor may sweep a fixture dated months in the past between the seed and the aggregate. Widening the *query* with `days` does not help - the TTL is a separate mechanism. Anything seeded here stays inside the window.

## Developer Notes (Optional)

- **`findKeyTrafficByEndpointPrefix` is a reusable seam.** Any future "who is calling these routes with a key" question - deprecation notices, per-integration usage, abuse triage - can build on it rather than writing another aggregation.
- **Pattern: ask the runtime decision function, do not mirror it.** The preflight's correctness rests entirely on sharing `decideScopeGate` with `apiKeyAuth`. Worth copying anywhere a tool predicts what a gate will do.
- **Pattern: a `baseApi` mock that records its config.** Most route tests in this repo mock `baseApi` in a form that discards the options argument, which means a route's `requiredScopes` declaration can silently disappear without any test noticing. The test here captures it and asserts on it. `apps/client/pages/api/hearth/__tests__/hearthRoutes.test.ts` does the same and warns about the failure mode.
- **Trap: a test that mocks a plain `Error` cannot catch bad axios-error extraction.** `errorHandler` puts the thrown message at `response.data.error`, and axios's `.message` is only `Request failed with status code 400` - but a `new Error('...')` fixture has the right text on `.message`, so the wrong extraction passes. This suite now uses an `isAxiosError`-shaped fixture for that case. Worth copying wherever a component renders a server-thrown message.
- **The scope catalog now understates its own reach** in a couple of places (`apiKeyScopes.ts` lists illustrative endpoints, not complete ones). Not touched here; worth a follow-up so the mint modal copy matches what a scope actually opens.
- **Deferred from review, if anyone wants them as follow-ups:** a `$facet` distinct-key count so `truncated` reads "500 of 640" rather than just "partial"; splitting `IApiKeyEndpointTraffic.lastUsed` into its repository (`Date`) and wire (ISO string) shapes; surfacing `parseStagedScopes`'s `rejected` so a typo'd staging entry explains itself; and narrowing the "cannot drift from enforcement" claim to say *the `requiredScopes` gate* specifically, since a route can also assert scopes in-handler (`hearth/channels.ts`).



