### PR TITLE
chore: fold engine/client maintainers into core-team, gate infra + CI on new devops team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,91 +1,36 @@
 # CODEOWNERS - Bike4Mind open core
 #
-# Real path-to-team mapping for the public snapshot's first commit. These teams are
-# created in the org-foundation track (lumina5#9809 A3); this file is the source of
-# truth for which teams MUST exist. Until they exist, GitHub shows a cosmetic
-# "unknown owner" annotation - it does NOT block merges until the `main` ruleset
-# turns on "Require review from Code Owners" (see lumina5#9772). Enable that ruleset
-# only after the teams below are created and staffed.
+# RULE: last matching pattern wins - order matters. Leading "/" anchors to repo
+# root; trailing "/" matches the directory and everything under it.
 #
 # Teams:
-#   @bike4mind/core-team           steward (Bike4Mind, Inc.); final say. Default
-#                                  owner + all closed/commercial/infra/governance.
-#   @bike4mind/engine-maintainers  open engine: b4m-core/* + shared packages/*.
-#                                  May include trusted external maintainers.
-#   @bike4mind/client-maintainers  the apps/client app (SPA + Next API routes).
-#                                  To launch with fewer teams, fold this into
-#                                  engine-maintainers (see the apps/client line).
-#   @bike4mind/triage              issue/PR routing ONLY; owns no code paths here
-#                                  (its home is .github/ISSUE_TEMPLATE/config.yml).
+#   @bike4mind/core-team  steward (Bike4Mind, Inc.); final say. Owns everything
+#                         by default - the open engine (b4m-core/*, packages/*),
+#                         the client app, the closed/commercial surfaces
+#                         (billing, entitlements, Stripe, credits, premium
+#                         overlays), legal content, CI and governance files.
+#                         The former engine-maintainers and client-maintainers
+#                         teams are folded into this one.
+#   @bike4mind/devops     infrastructure: everything under /infra/.
+#   @bike4mind/triage     issue/PR routing ONLY; owns no code paths here
+#                         (its home is .github/ISSUE_TEMPLATE/config.yml).
 #
-# RULE: last matching pattern wins - order matters. Layout: default first, then
-# broad open surfaces, then closed overrides that live inside them, then infra/CI,
-# then governance files last. Leading "/" anchors to repo root; trailing "/"
-# matches the directory and everything under it.
+# NOTE: the `main` ruleset has "Require review from Code Owners" ON, so these
+# lines are load-bearing - a PR touching /infra/ needs a @bike4mind/devops
+# approval, and everything else needs @bike4mind/core-team.
 #
 # NOTE: export-ignore'd paths (docs-site/**, .claude/**, CLAUDE.md, .cursor/**,
-# internal .github workflows/scripts, infra/waf/*.json, root ops shell scripts) are
-# NOT in the public tree, so they need no entry - they can never match a public PR.
+# internal .github workflows/scripts, infra/waf/*.json, root ops shell scripts)
+# are NOT in the public tree, so they need no entry - they can never match a
+# public PR.
 
 
 # --- 1) Default owner for everything not matched below ---
 *                                           @bike4mind/core-team
 
 
-# --- 2) Open engine: the community-maintainable core ---
-# b4m-core workspace packages (@bike4mind/*: agents, common, services, llm-adapters,
-# mcp, resource, slack, utils, and siblings).
-/b4m-core/                                  @bike4mind/engine-maintainers
-# Shared open libraries: cli, database, scripts, eslint-config, typescript-config.
-/packages/                                  @bike4mind/engine-maintainers
-
-
-# --- 3) Frontend app: one pane of glass ---
-/apps/client/                               @bike4mind/client-maintainers
-# Fold-down option: to launch with fewer teams, set the owner above to
-# @bike4mind/engine-maintainers and drop the client-maintainers team.
-
-
-# --- 4) Closed / commercial overrides INSIDE the open surfaces (must come after 2/3) ---
-# Billing, entitlements, and Stripe gate the commercial model -> core-team only.
-/apps/client/lib/entitlements/              @bike4mind/core-team
-/apps/client/server/entitlements/           @bike4mind/core-team
-/apps/client/server/integrations/stripe/    @bike4mind/core-team
-/apps/client/pages/api/stripe/              @bike4mind/core-team
-/apps/client/pages/api/subscriptions/       @bike4mind/core-team
-/apps/client/pages/api/entitlements/        @bike4mind/core-team
-/packages/database/src/models/billing/      @bike4mind/core-team
-# Credits are a paid-usage unit; the subscription/user-subscription libs are the
-# same commercial primitives as the api/subscriptions + entitlements entries above.
-/apps/client/pages/api/credits/             @bike4mind/core-team
-/apps/client/lib/credits/                   @bike4mind/core-team
-/apps/client/lib/subscriptions/             @bike4mind/core-team
-/apps/client/lib/userSubscriptions/         @bike4mind/core-team
-# Premium overlays are private / hydrated-at-deploy; the in-client tavern seam is
-# the cc-bridge / b4m-tavern integration point. core-team wherever present.
-/apps/client/server/tavern/                 @bike4mind/core-team
-/packages/premium/                          @bike4mind/core-team
-
-
-# --- 5) Legal / policy content: carries the launch claims ---
-/apps/client/content/legal/                 @bike4mind/core-team
-
-
-# --- 6) Infra, deploy, CI, supply-chain: live trust surface -> core-team ---
-/infra/                                     @bike4mind/core-team
-/sst.config.ts                              @bike4mind/core-team
-/.github/                                   @bike4mind/core-team
-/pnpm-workspace.yaml                        @bike4mind/core-team
-/turbo.json                                 @bike4mind/core-team
-
-
-# --- 7) Governance / licensing files: steward decisions (LAST, so nothing overrides) ---
-/LICENSE                                    @bike4mind/core-team
-/NOTICE                                     @bike4mind/core-team
-/CONTRIBUTING.md                            @bike4mind/core-team
-/CODE_OF_CONDUCT.md                         @bike4mind/core-team
-/SECURITY.md                                @bike4mind/core-team
-/CLA.md                                     @bike4mind/core-team
-/README.md                                  @bike4mind/core-team
-/SELF_HOST.md                               @bike4mind/core-team
-/.github/CODEOWNERS                         @bike4mind/core-team
+# --- 2) Infrastructure (LAST, so it overrides the default) ---
+# Use "/infra/" and not "infra/*": a trailing "/*" matches only files directly
+# inside the directory, which would silently skip infra/__tests__/ and any
+# future subdirectory.
+/infra/                                     @bike4mind/devops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,33 +4,40 @@
 # root; trailing "/" matches the directory and everything under it.
 #
 # Teams:
-#   @bike4mind/core-team  steward (Bike4Mind, Inc.); final say. Owns everything
-#                         by default - the open engine (b4m-core/*, packages/*),
-#                         the client app, the closed/commercial surfaces
-#                         (billing, entitlements, Stripe, credits, premium
-#                         overlays), legal content, CI and governance files.
-#                         The former engine-maintainers and client-maintainers
-#                         teams are folded into this one.
-#   @bike4mind/devops     infrastructure: everything under /infra/.
+#   @bike4mind/core-team  steward (Bike4Mind, Inc.); final say. Owns everything:
+#                         the open engine (b4m-core/*, packages/*), the client
+#                         app, the closed/commercial surfaces (billing,
+#                         entitlements, Stripe, credits, premium overlays),
+#                         legal content, CI and governance files. The former
+#                         engine-maintainers and client-maintainers teams are
+#                         folded into this one.
 #   @bike4mind/triage     issue/PR routing ONLY; owns no code paths here
 #                         (its home is .github/ISSUE_TEMPLATE/config.yml).
 #
-# NOTE: the `main` ruleset has "Require review from Code Owners" ON, so these
-# lines are load-bearing - a PR touching /infra/ needs a @bike4mind/devops
-# approval, and everything else needs @bike4mind/core-team.
+# WHY @bike4mind/devops IS NOT IN THIS FILE
 #
-# NOTE: export-ignore'd paths (docs-site/**, .claude/**, CLAUDE.md, .cursor/**,
-# internal .github workflows/scripts, infra/waf/*.json, root ops shell scripts)
-# are NOT in the public tree, so they need no entry - they can never match a
-# public PR.
+# devops review of infra / CI / scanner config is meant to be an ADDITIONAL
+# requirement layered on top of core-team, and CODEOWNERS cannot express that.
+# Owners listed against a pattern are ALTERNATIVES: any one of them satisfies
+# "Require review from Code Owners". So `/infra/ @core-team @devops` would let
+# either team approve alone, and `/infra/ @devops` would REPLACE the core-team
+# requirement instead of adding to it. Neither is what we want.
+#
+# The devops requirement therefore lives in the `main-protection` ruleset as a
+# path-scoped `required_reviewers` entry, covering:
+#
+#   infra/**                       sst.config.ts
+#   .github/workflows/**           .github/actions/**
+#   .github/dependabot.yml         .gitleaks.toml{,.simple} / .gitleaksignore
+#   .semgrep.yml
+#
+# Both gates then apply independently: core-team from this file, devops from
+# the ruleset. Editing this file does not relax the devops requirement, and
+# editing the ruleset does not relax core-team's.
+#
+# NOTE: `main` has "Require review from Code Owners" ON, so the pattern below
+# is load-bearing, not documentation.
 
 
-# --- 1) Default owner for everything not matched below ---
+# --- Default owner: everything ---
 *                                           @bike4mind/core-team
-
-
-# --- 2) Infrastructure (LAST, so it overrides the default) ---
-# Use "/infra/" and not "infra/*": a trailing "/*" matches only files directly
-# inside the directory, which would silently skip infra/__tests__/ and any
-# future subdirectory.
-/infra/                                     @bike4mind/devops


### PR DESCRIPTION
## What

`.github/CODEOWNERS` collapses to a single pattern, and the infra/CI review requirement moves to where it can actually be expressed.

1. **Folded `@bike4mind/engine-maintainers` and `@bike4mind/client-maintainers` into `@bike4mind/core-team`.** Those two teams had byte-identical membership (16 each) and core-team was a subset, so the three-way split bought nothing but review-routing ambiguity. core-team is now the union: 17 members. Every override line in the old file already pointed at core-team, so once the open-engine and client lines collapse into the `*` default, the entire commercial/legal/infra/governance block becomes a no-op and is deleted.
2. **Added a `@bike4mind/devops` team (2 members) as a required reviewer on infra, CI, and scanner config** . via the `main-protection` ruleset, not this file. Reasoning below.
3. **Dropped a stale comment.** The old header claimed export-ignored paths "are NOT in the public tree, so they need no entry . they can never match a public PR." That is not true of this repo: `docs-site/` (89 files) and `CLAUDE.md` are both physically present here, because `export-ignore` only affects `git archive`, not the working tree. Only `.claude/` is genuinely absent. The claim is moot now that a single catch-all owns everything, so rather than carry a wrong statement forward the note is gone.

Net: 9 sections and ~30 patterns down to one.

## Why devops is enforced in the ruleset instead of CODEOWNERS

The intent is that infra changes need devops **in addition to** core-team. CODEOWNERS cannot express that. Owners listed against a pattern are alternatives . any single one of them satisfies "Require review from Code Owners". So:

- `/infra/ @core-team @devops` would let either team approve alone, which is weaker than today, not stronger.
- `/infra/ @devops` would *replace* the core-team requirement rather than add to it, and would put every infra PR behind a 2-person team.

`main-protection`'s `pull_request` rule takes a path-scoped `required_reviewers` entry, which is a genuine AND. devops is pinned there with `minimum_approvals: 1` over `infra/**`, `sst.config.ts`, `.github/workflows/**`, `.github/actions/**`, `.github/dependabot.yml`, `.gitleaks.toml`, `.gitleaks.toml.simple`, `.gitleaksignore`, and `.semgrep.yml`. Both gates now apply independently: core-team from CODEOWNERS, devops from the ruleset. Editing either one does not relax the other.

That ruleset change is already applied. It was built by reading the live ruleset, injecting only the `required_reviewers` key, and writing the whole object back . a partial PATCH replaces the entire `rules` array and would have silently dropped the 4 required status checks. Verified after the fact by diffing against the pre-change snapshot: `required_reviewers` is the only field that moved, and all 6 rules plus all 4 status checks are intact.

`.github/actions/` is in scope because it holds `sst-remove-idempotent` and `reconcile-orphaned-alb.sh`, which are deploy machinery rather than CI glue. The scanner configs are in scope because editing them can silently disable a gate without failing anything.

## Path-pattern care

Both `foo/**` and `foo/*` are listed for each directory. A trailing `/*` matches only files directly inside a directory and does not recurse . `infra/` already has an `__tests__/` subdirectory, and `.github/actions/` is entirely subdirectories, so a `/*`-only pattern would have quietly skipped exactly the files most worth gating. Listing both forms is robust regardless of which glob semantics the ruleset matcher applies.

## Blast radius

`main` has `require_code_owner_review: true`, so CODEOWNERS here is live. Checked before touching anything:

- Both retired teams granted `write` on only two repos, `bike4mind` and `b4m-devtools`. core-team already has `write` on both and now contains all 16 people, so nobody loses repo access.
- Neither retired team appears as a bypass actor in any of the four repo rulesets or the org ruleset.
- Neither is a parent or child of another team, and no other CODEOWNERS in the org references them.
- The `required_reviewers` API shape was validated on a throwaway ruleset created with `enforcement: disabled` and deleted immediately, so the live protection was never in a half-configured state.

Two consequences worth stating plainly rather than burying:

- The 7 people who were in engine/client but not core-team are now code owners on the commercial and governance paths . billing, entitlements, Stripe, credits, `packages/premium/`, legal content, LICENSE/CLA. That is the intended result of a single-team fold, but it is a widening of authority, not a rename.
- devops currently has 2 members. Every PR touching infra, a workflow, a composite action, or a scanner config now needs one of them. Repo admins retain ruleset bypass, so this cannot hard-deadlock, but it is a real new dependency in the merge path.

After this merges, `engine-maintainers` and `client-maintainers` get deleted from the org. Deleting them first would leave GitHub rendering "unknown owner" annotations against patterns that are still referenced on `main`.
