### PR TITLE
chore: preview harness

### DIFF
--- a/apps/client/.preview-cachebust
+++ b/apps/client/.preview-cachebust
@@ -3,4 +3,4 @@ Cache key for preview container image builds.
 The image tag is derived from git tree objects, so a container rebuild only
 happens when one of the hashed paths changes. Bumping this file forces one.
 
-nonce: 20260903T095057Z
+nonce: 20260903T193655Z

--- a/apps/client/.preview-cachebust
+++ b/apps/client/.preview-cachebust
@@ -3,4 +3,4 @@ Cache key for preview container image builds.
 The image tag is derived from git tree objects, so a container rebuild only
 happens when one of the hashed paths changes. Bumping this file forces one.
 
-nonce: 20260903T064401Z
+nonce: 20260903T095057Z

--- a/apps/client/.preview-cachebust
+++ b/apps/client/.preview-cachebust
@@ -1,0 +1,6 @@
+Cache key for preview container image builds.
+
+The image tag is derived from git tree objects, so a container rebuild only
+happens when one of the hashed paths changes. Bumping this file forces one.
+
+nonce: 20260903T064401Z

--- a/apps/client/.preview-cachebust
+++ b/apps/client/.preview-cachebust
@@ -3,4 +3,4 @@ Cache key for preview container image builds.
 The image tag is derived from git tree objects, so a container rebuild only
 happens when one of the hashed paths changes. Bumping this file forces one.
 
-nonce: 20260903T193655Z
+nonce: 20260903T095057Z


### PR DESCRIPTION
Throwaway draft PR. Exists only to give the deployer a stack name for a preview environment. Empty tree (identical to main) - do not review, do not merge. Will be closed and its branch deleted when the preview is torn down.