### PR TITLE
refactor(session): remove the unreachable transparentTop prop from SessionContainer

### DIFF
--- a/apps/client/app/components/Session/SessionContainer.tsx
+++ b/apps/client/app/components/Session/SessionContainer.tsx
@@ -67,9 +67,6 @@ interface SessionLayoutProps {
   dockedChatTitle?: React.ReactNode;
   /** Called when the server auto-creates a session (e.g. first prompt with no session). Lets parent pages like /opti sync their local session state. */
   onSessionCreated?: (sessionId: string) => void;
-  /** When true, the top toolbar bar renders transparent (no solid background) so a surface's
-   *  own backdrop shows through - used by the chat-first Data Lake surface. (#836) */
-  transparentTop?: boolean;
 }
 
 /**
@@ -192,7 +189,6 @@ const SessionContainer: FC<SessionLayoutProps> = ({
   floatingChatHeaderActions,
   dockedChatTitle,
   onSessionCreated,
-  transparentTop,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { changeSession, currentSessionId: contextSessionId, setCurrentSessionId, setCurrentSession } = useSessions();
@@ -527,11 +523,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
                     // a rule under it just cuts the pane in two.
                     borderBottom: isKnowledgeViewerOpen ? '1px solid' : 'none',
                     borderColor: 'divider',
-                    background: transparentTop
-                      ? 'transparent'
-                      : isKnowledgeViewerOpen
-                        ? theme.palette.background.level1
-                        : theme.palette.background.body,
+                    background: isKnowledgeViewerOpen ? theme.palette.background.level1 : theme.palette.background.body,
                     zIndex: 1,
                     padding: '8px 8px 16px',
                     display: {

--- a/apps/client/app/utils/themes/components/chatbox.ts
+++ b/apps/client/app/utils/themes/components/chatbox.ts
@@ -1,14 +1,12 @@
-import { brand, gray, grayAlpha, unique } from '../colors';
+import { brand, gray, grayAlpha } from '../colors';
 
 export const chatboxTheme = {
   dark: {
-    topbarBg: unique.solidDisabledColor,
     replyBg: brand[700],
     messageInputDivider: grayAlpha[200][20],
     messageInputColor: gray[200],
   },
   light: {
-    topbarBg: gray[100],
     replyBg: gray[75],
     messageInputDivider: gray[150],
     messageInputColor: brand[600],

--- a/apps/client/app/utils/themes/index.ts
+++ b/apps/client/app/utils/themes/index.ts
@@ -55,7 +55,6 @@ declare module '@mui/joy/styles' {
      * Chatbox or the Prompt area related colors
      */
     chatbox: {
-      topbarBg: string;
       replyBg: string;
       messageInputDivider: string;
       messageInputColor: string;


### PR DESCRIPTION
## Description

Follow-up tidy from #2281 (approved with this deferred). `SessionContainer`'s `transparentTop` prop had no caller anywhere in the app, so the `transparentTop ? 'transparent' : ...` branch that picked the chat top bar's background never executed and the bar always took the else branch. #2281 already removed the matching `SessionTop` half of this prop; this removes the surviving `SessionContainer` half.

While removing it, the `chatbox.topbarBg` theme token turned out to be dead: a repo-wide grep shows it had no remaining reader once this ternary is gone, so the token (and the now-unused `unique` import it needed) are removed with it.

Purely dead-code removal - no user-visible change, since the branch never ran today.

## Changes

- `apps/client/app/components/Session/SessionContainer.tsx`: drop the `transparentTop` prop declaration + its JSDoc, its destructure, and the ternary (the background now reads `isKnowledgeViewerOpen ? level1 : body` directly).
- `apps/client/app/utils/themes/components/chatbox.ts`: remove the dead `topbarBg` token from the `dark` and `light` chatbox themes, and drop the now-unused `unique` import.
- `apps/client/app/utils/themes/index.ts`: remove `topbarBg` from the `chatbox` theme-module type.

## Guide for Testers

No behavior change to verify - the removed branch was unreachable. Confirmation is static:
1. `grep -rn "transparentTop" apps/client/` returns nothing.
2. `grep -rn "topbarBg" apps/client/` returns nothing.
3. Open a chat session (and toggle the Knowledge viewer): the chat top bar background still resolves to `background.level1` when the viewer is open and `background.body` otherwise - identical to before.

## Additional Information

Author self-verification: client typecheck is clean for the three changed files after a local core-dist rebuild (the only residual local tsc errors are the pre-existing `packages/premium/bob` overlay-not-linked noise and a missing `@asteasolutions/zod-to-openapi` dep in a local install - both environmental, unrelated to this diff). Lint clean on the changed files. No tests exist for these files and none are warranted for a pure dead-code deletion. Relying on CI for the authoritative typecheck/test run.

## Developer Notes (Optional)

N/A

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings