### PR TITLE
fix(infra): link the prod API key to DataSyncer only instead of the shared secrets map

### DIFF
--- a/infra/dataSyncer.ts
+++ b/infra/dataSyncer.ts
@@ -9,7 +9,7 @@
  */
 
 import { DEFAULT_LAMBDA_ENVIRONMENT } from './constants';
-import { secrets } from './secrets';
+import { b4mProdApiKey, secrets } from './secrets';
 import { lambdaVpc } from './vpc';
 
 /**
@@ -32,7 +32,7 @@ export const dataSyncer = new sst.aws.Function('DataSyncer', {
   timeout: '5 minutes', // Generous timeout for fetching and writing mappings
   memory: '512 MB',
   vpc: lambdaVpc,
-  link: [secrets.MONGODB_URI, secrets.B4M_PROD_API_KEY],
+  link: [secrets.MONGODB_URI, b4mProdApiKey],
   logging: {
     retention: '3 days',
   },

--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -45,7 +45,6 @@ export const secrets = {
   NPM_TOKEN: new sst.Secret('NPM_TOKEN', 'not-configured'),
   SLACK_SIGNING_SECRET: new sst.Secret('SLACK_SIGNING_SECRET', 'not-configured'),
   SLACK_APP_ID: new sst.Secret('SLACK_APP_ID', 'not-configured'),
-  B4M_PROD_API_KEY: new sst.Secret('B4M_PROD_API_KEY', 'not-configured'),
   SLACK_CLIENT_ID: new sst.Secret('SLACK_CLIENT_ID', 'not-configured'),
   SLACK_CLIENT_SECRET: new sst.Secret('SLACK_CLIENT_SECRET', 'not-configured'),
   SLACK_OAUTH_REDIRECT_URI: new sst.Secret('SLACK_OAUTH_REDIRECT_URI', 'not-configured'),
@@ -169,3 +168,9 @@ export const secrets = {
 };
 
 export const allSecrets = Object.values(secrets);
+
+// Deliberately outside `secrets`, and therefore outside both `allSecrets` and the
+// `Object.values(secrets)` spread in web.ts - either one links a secret into every
+// Lambda and service on every stage. DataSyncer is the only consumer and links this
+// export directly (infra/dataSyncer.ts); keep it that way when adding a consumer.
+export const b4mProdApiKey = new sst.Secret('B4M_PROD_API_KEY', 'not-configured');


### PR DESCRIPTION
## Description

`B4M_PROD_API_KEY` was declared inside the shared `secrets` map in `infra/secrets.ts`. Everything in that map is linked into every Lambda and every Fargate service on every stage, by two independent paths: the `allSecrets` spread used throughout `infra/`, and the `...Object.values(secrets)` spread in `infra/web.ts`. DataSyncer is the only thing that reads the key, so the declaration now lives outside the map as its own export and DataSyncer links it directly.

The secret itself is untouched: same name, same default, same `sst secret set B4M_PROD_API_KEY` workflow, and it stays declared in `infra/secrets.ts` so `sst secret list` and the rotation registry still see it. No stage needs reconfiguring.

## Changes

- `infra/secrets.ts`: `B4M_PROD_API_KEY` moves out of the `secrets` map into a standalone `b4mProdApiKey` export, with a comment recording why it has to stay out of the map.
- `infra/dataSyncer.ts`: links `b4mProdApiKey` instead of `secrets.B4M_PROD_API_KEY`.

## Scope

This is criterion 1 of bike4mind/b4m-internal#86 only. The issue stays open for criteria 2 through 8.

Criterion 2 (`STAGING_MONGODB_URI` in the DataSyncer environment, same file) is deliberately not in here even though the issue pairs the two. Removing that variable breaks preview configuration seeding, and the replacement is a design decision - a staging-side export or push instead of a preview-side pull - that has not been made yet. It needs its own PR.

## Consumer audit

I checked for a second consumer before narrowing the link, since a second one would change the shape of the fix. There is none:

- `Resource.B4M_PROD_API_KEY` appears in application code only in `apps/client/server/jobs/dataSyncerHandler.ts`, which is DataSyncer's own handler.
- `apps/client/lib/secretRotation/constants.ts` names the key, but only as rotation metadata - nothing under `apps/client/lib/secretRotation/` reads a `Resource` value at all.
- No dynamic access reaches it either. The one dynamic `Resource[name]` reader in the repo is a migration script that only looks up encryption keys.
- The only whole-map spreads are `allSecrets` in `infra/secrets.ts` and `Object.values(secrets)` in `infra/web.ts`. Nothing else passes the `secrets` object as a whole - the premium `contributeInfra` entry points in `sst.config.ts` take `allSecrets` plus individually named secrets, so they lose this key along with everything else on `allSecrets`.
- `b4m-core/resource/src/manifest.ts` marks the key manifest-optional, so a function that no longer has it linked resolves `undefined` rather than throwing in the getter. Self-host reads it from the environment through the shim and is unaffected.

## Guide for Testers

Infrastructure only - no UI, no route, no schema, no admin setting. The proof is a deployed stage's resolved link set, so it has to run after a deploy.

One wrinkle worth knowing before running anything: SST delivers linked values differently per component type. A Fargate service gets them as plain `SST_RESOURCE_<name>` container environment variables, so `describe-task-definition` is a direct read. A Lambda gets them inside an encrypted `resource.enc` in its bundle with only `SST_KEY` in the environment, so `get-function-configuration` shows the name neither before nor after this change - the Lambda check has to read the bundle's own key list instead. Both commands below print names only, never values.

1. Fargate, any stage. Confirm the name is gone from the subscriber-fanout task definition:

```bash
aws ecs describe-task-definition --task-definition <stage-subscriber-fanout-td> --query 'taskDefinition.containerDefinitions[].environment[].name' --output text | tr '\t' '\n' | grep -c SST_RESOURCE_B4M_PROD_API_KEY
```

Expected `0`.

2. Lambda. Pick any function other than DataSyncer on a non-production stage and list the link names its bundle carries:

```bash
FN=<preview-stage function name>
aws lambda get-function --function-name "$FN" --query Code.Location --output text | xargs curl -s -o /tmp/fn.zip
unzip -oq /tmp/fn.zip resource.enc -d /tmp/fnres
SST_KEY_FILE=/tmp/fnres/resource.enc SST_KEY="$(aws lambda get-function-configuration --function-name "$FN" --query Environment.Variables.SST_KEY --output text)" node --input-type=module -e 'import {Resource} from "sst"; console.log(Object.keys(Resource).sort().join("\n"))'
```

Expected: no `B4M_PROD_API_KEY` line in the output. Run it from the repo root so the `sst` import resolves. Repeat on a queue consumer and a cron function from the same stage.

3. Same command against that stage's `DataSyncer` function. Expected: `B4M_PROD_API_KEY` present. This is the half that proves the link was narrowed rather than dropped.

4. Functional check. Deploy a non-production stage with `SYNC_RAPID_REPLY_MAPPINGS=true` and confirm DataSyncer completes its rapid-reply sync. A wrong link fails loudly with `B4M_PROD_API_KEY secret is not configured` rather than degrading quietly.

### Regression Checks

Nothing else should move. Every other secret keeps its position in the map, so every other function's and service's link set is otherwise identical.

### What NOT to test

No application behaviour changes here. There is no UI surface, no API response shape and no user-visible path in this PR.

## Additional Information

Verified locally before pushing:

- `pnpm run typecheck:infra` - clean. A fresh worktree needs `pnpm install`, `pnpm --filter @bike4mind/infra build` and `pnpm sst install` first, otherwise the script silently skips.
- `pnpm exec eslint infra/secrets.ts infra/dataSyncer.ts` - clean.
- `grep -rn "B4M_PROD_API_KEY\|b4mProdApiKey" infra/` returns only the declaration, the DataSyncer link and the DataSyncer docblock.

Rotation is an open call and this PR does not take it. Nothing here re-mints the key. The reasoning is on `bike4mind/b4m-internal#86` so the decision is recorded where it belongs.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] AdminSettings - not applicable
- [ ] UI/UX - not applicable, no UI surface
- [ ] Documentation - not applicable
- [ ] Telemetry fields - not applicable

