### PR TITLE
fix(waf): redact credential headers in the log and allowlist what the admin API serves

### DIFF
--- a/apps/client/server/security/__tests__/wafHeaderRedaction.test.ts
+++ b/apps/client/server/security/__tests__/wafHeaderRedaction.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import { WAF_MASKED_HEADER_VALUE, isWafDiagnosticHeader, maskWafRequestHeaders } from '../wafHeaderRedaction';
+
+const valueOf = (headers: Array<{ name: string; value: string }>, name: string) =>
+  headers.find(h => h.name.toLowerCase() === name.toLowerCase())?.value;
+
+describe('maskWafRequestHeaders', () => {
+  it('serves diagnostic header values unchanged', () => {
+    const masked = maskWafRequestHeaders([
+      { name: 'host', value: 'app.example.com' },
+      { name: 'user-agent', value: 'curl/8.4.0' },
+      { name: 'x-forwarded-for', value: '203.0.113.7' },
+    ]);
+
+    expect(valueOf(masked, 'host')).toBe('app.example.com');
+    expect(valueOf(masked, 'user-agent')).toBe('curl/8.4.0');
+    expect(valueOf(masked, 'x-forwarded-for')).toBe('203.0.113.7');
+  });
+
+  it('masks the value of every credential header the app authenticates with', () => {
+    const credentialHeaders = [
+      'authorization',
+      'proxy-authorization',
+      'cookie',
+      'x-api-key',
+      'x-security-ingest-token',
+      'x-e2e-cleanup-secret',
+      'x-internal-ws-secret',
+      'x-rate-limit-ingest-token',
+      'x-webhook-token',
+      'stripe-signature',
+      'x-hub-signature',
+      'x-hub-signature-256',
+      'x-slack-signature',
+    ];
+
+    const masked = maskWafRequestHeaders(credentialHeaders.map(name => ({ name, value: 'the-secret-value' })));
+
+    expect(masked.map(h => h.value)).toEqual(credentialHeaders.map(() => WAF_MASKED_HEADER_VALUE));
+    expect(JSON.stringify(masked)).not.toContain('the-secret-value');
+  });
+
+  it('masks an unrecognized header rather than passing it through', () => {
+    const masked = maskWafRequestHeaders([{ name: 'x-some-header-added-next-quarter', value: 'sk-live-abc' }]);
+
+    expect(masked).toEqual([{ name: 'x-some-header-added-next-quarter', value: WAF_MASKED_HEADER_VALUE }]);
+  });
+
+  it('matches the allowlist case-insensitively, because WAF logs the casing the client sent', () => {
+    const masked = maskWafRequestHeaders([
+      { name: 'Host', value: 'app.example.com' },
+      { name: 'X-Api-Key', value: 'the-secret-value' },
+    ]);
+
+    expect(valueOf(masked, 'Host')).toBe('app.example.com');
+    expect(valueOf(masked, 'X-Api-Key')).toBe(WAF_MASKED_HEADER_VALUE);
+  });
+
+  it('keeps header names so an admin can still see what the request carried', () => {
+    const masked = maskWafRequestHeaders([{ name: 'x-api-key', value: 'the-secret-value' }]);
+
+    expect(masked[0].name).toBe('x-api-key');
+  });
+
+  it('handles an empty header list', () => {
+    expect(maskWafRequestHeaders([])).toEqual([]);
+  });
+});
+
+describe('isWafDiagnosticHeader', () => {
+  it('rejects a header whose name merely contains a diagnostic name', () => {
+    expect(isWafDiagnosticHeader('host')).toBe(true);
+    expect(isWafDiagnosticHeader('x-host-token')).toBe(false);
+  });
+});

--- a/apps/client/server/security/__tests__/wafLogsInsights.test.ts
+++ b/apps/client/server/security/__tests__/wafLogsInsights.test.ts
@@ -11,7 +11,8 @@ import {
   StopQueryCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 import { WAFV2Client, GetLoggingConfigurationCommand } from '@aws-sdk/client-wafv2';
-import { getWafLogsInsightsOverview } from '../wafLogsInsights';
+import { getWafBlockedRequests, getWafLogsInsightsOverview } from '../wafLogsInsights';
+import { WAF_MASKED_HEADER_VALUE } from '../wafHeaderRedaction';
 import { wafQueryCache } from '../wafQueryCache';
 import type { WafCustomRange } from '../wafSharedHelpers';
 
@@ -328,6 +329,75 @@ describe('wafLogsInsights', () => {
       // WAF calls should use us-east-1 for CloudFront-scope WebACLs
       const wafCalls = wafMock.calls();
       expect(wafCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getWafBlockedRequests', () => {
+    const blockedLogRecord = (headers: Array<{ name: string; value: string }>) =>
+      JSON.stringify({
+        action: 'BLOCK',
+        terminatingRuleId: 'ai-route-rate-limit',
+        httpRequest: {
+          clientIp: '203.0.113.7',
+          country: 'US',
+          uri: '/api/chat',
+          args: '',
+          httpVersion: 'HTTP/2.0',
+          httpMethod: 'POST',
+          requestId: 'req-abc123',
+          headers,
+        },
+      });
+
+    function mockBlockedRequest(headers: Array<{ name: string; value: string }>) {
+      cloudWatchLogsMock.on(GetQueryResultsCommand).resolves({
+        status: 'Complete',
+        results: [
+          [
+            { field: '@timestamp', value: '2026-09-03 01:02:03.000' },
+            { field: '@message', value: blockedLogRecord(headers) },
+          ],
+        ],
+      });
+    }
+
+    it('masks credential header values that a pre-redaction log record still holds', async () => {
+      mockBlockedRequest([
+        { name: 'X-Api-Key', value: 'b4m_live_the_secret_value' },
+        { name: 'X-Security-Ingest-Token', value: 'ingest-the_secret_value' },
+        { name: 'X-E2E-Cleanup-Secret', value: 'cleanup-the_secret_value' },
+        { name: 'Authorization', value: 'Bearer the_secret_value' },
+        { name: 'Cookie', value: 'session=the_secret_value' },
+      ]);
+
+      const result = await getWafBlockedRequests({ stage: 'dev', range: '24h' });
+
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0].headers.map(h => h.value)).toEqual([
+        WAF_MASKED_HEADER_VALUE,
+        WAF_MASKED_HEADER_VALUE,
+        WAF_MASKED_HEADER_VALUE,
+        WAF_MASKED_HEADER_VALUE,
+        WAF_MASKED_HEADER_VALUE,
+      ]);
+      expect(JSON.stringify(result)).not.toContain('the_secret_value');
+    });
+
+    it('still serves the diagnostic headers needed to triage the block', async () => {
+      mockBlockedRequest([
+        { name: 'Host', value: 'app.example.com' },
+        { name: 'User-Agent', value: 'python-requests/2.32.0' },
+        { name: 'X-Api-Key', value: 'b4m_live_the_secret_value' },
+      ]);
+
+      const result = await getWafBlockedRequests({ stage: 'dev', range: '24h' });
+
+      const headers = result.requests[0].headers;
+      expect(headers.find(h => h.name === 'Host')?.value).toBe('app.example.com');
+      expect(headers.find(h => h.name === 'User-Agent')?.value).toBe('python-requests/2.32.0');
+      expect(headers.find(h => h.name === 'X-Api-Key')?.value).toBe(WAF_MASKED_HEADER_VALUE);
+      expect(result.requests[0].clientIp).toBe('203.0.113.7');
+      expect(result.requests[0].terminatingRuleId).toBe('ai-route-rate-limit');
     });
   });
 

--- a/apps/client/server/security/wafHeaderRedaction.ts
+++ b/apps/client/server/security/wafHeaderRedaction.ts
@@ -1,0 +1,76 @@
+/**
+ * Header exposure policy for the admin blocked-requests view.
+ *
+ * WAF-side redaction (infra/wafRedaction.ts) is the write-time gate, and it only covers the headers
+ * that were known when the WebACL was last deployed. This is the read-time gate: only the headers
+ * listed here keep their value on the way to the browser, so a header introduced after that deploy,
+ * or one already sitting in a log record written before redaction was configured, is withheld by
+ * default rather than passed through.
+ *
+ * Membership test: does an admin triaging a blocked request need this to tell a bot from a customer,
+ * or to correlate the block with an application log line? Anything that carries a secret, or that
+ * might, does not belong here.
+ */
+const WAF_DIAGNOSTIC_HEADERS: readonly string[] = [
+  'host',
+  'user-agent',
+  'referer',
+  'origin',
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'content-type',
+  'content-length',
+  'cache-control',
+  'connection',
+  'via',
+  'upgrade-insecure-requests',
+  // Client hints and fetch metadata: the signals that separate a real browser from a scripted client.
+  'sec-ch-ua',
+  'sec-ch-ua-mobile',
+  'sec-ch-ua-platform',
+  'sec-fetch-dest',
+  'sec-fetch-mode',
+  'sec-fetch-site',
+  'sec-fetch-user',
+  // Forwarding chain and trace identifiers, for correlating a block with the application logs.
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+  'x-real-ip',
+  'x-amzn-trace-id',
+  'x-request-id',
+  'x-b4m-client',
+  // Webhook delivery metadata. Identifies which integration got blocked; neither value is a secret,
+  // unlike the signature headers that accompany them.
+  'x-github-event',
+  'x-github-delivery',
+];
+
+const diagnosticHeaderSet = new Set(WAF_DIAGNOSTIC_HEADERS);
+
+/**
+ * Placeholder for a header this API withheld. Deliberately not WAF's own "REDACTED", so the
+ * dashboard distinguishes a value the log never held from one the log holds but we do not serve.
+ */
+export const WAF_MASKED_HEADER_VALUE = 'MASKED';
+
+export function isWafDiagnosticHeader(name: string): boolean {
+  return diagnosticHeaderSet.has(name.toLowerCase());
+}
+
+/**
+ * Replace the value of every non-diagnostic header with a mask, keeping the name. Names survive so
+ * an admin can still see which headers a blocked request carried.
+ *
+ * WAF logs header names in the casing the client sent, so matching is case-insensitive.
+ */
+export function maskWafRequestHeaders(
+  headers: ReadonlyArray<{ name: string; value: string }>
+): Array<{ name: string; value: string }> {
+  return headers.map(header =>
+    isWafDiagnosticHeader(header.name)
+      ? { name: header.name, value: header.value }
+      : { name: header.name, value: WAF_MASKED_HEADER_VALUE }
+  );
+}

--- a/apps/client/server/security/wafLogsInsights.ts
+++ b/apps/client/server/security/wafLogsInsights.ts
@@ -14,6 +14,7 @@ import {
   resolveTimeWindow,
   type WafRangeInput,
 } from './wafSharedHelpers';
+import { maskWafRequestHeaders } from './wafHeaderRedaction';
 import { WAF_CACHE_TTL, wafQueryCache } from './wafQueryCache';
 
 export interface WafLogsTopItem {
@@ -185,6 +186,10 @@ export interface WafBlockedRequest {
   terminatingRuleId: string;
   clientIp: string;
   country: string;
+  /**
+   * Request headers as served to the client: diagnostic headers carry their value, everything else
+   * is masked. See wafHeaderRedaction.ts for why the API does not serve the log record verbatim.
+   */
   headers: Array<{ name: string; value: string }>;
   uri: string;
   args: string;
@@ -288,7 +293,7 @@ async function fetchWafBlockedRequests(params: {
         terminatingRuleId: typeof parsed.terminatingRuleId === 'string' ? parsed.terminatingRuleId : '',
         clientIp: typeof httpRequest.clientIp === 'string' ? httpRequest.clientIp : '',
         country: typeof httpRequest.country === 'string' ? httpRequest.country : '',
-        headers,
+        headers: maskWafRequestHeaders(headers),
         uri: typeof httpRequest.uri === 'string' ? httpRequest.uri : '',
         args: typeof httpRequest.args === 'string' ? httpRequest.args : '',
         httpVersion: typeof httpRequest.httpVersion === 'string' ? httpRequest.httpVersion : '',

--- a/infra/__tests__/wafRedaction.test.ts
+++ b/infra/__tests__/wafRedaction.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import { WAF_REDACTED_HEADERS } from '../wafRedaction';
+import { isWafDiagnosticHeader } from '../../apps/client/server/security/wafHeaderRedaction';
+
+describe('WAF_REDACTED_HEADERS', () => {
+  it('covers every credential-bearing header the app authenticates with', () => {
+    // Kept in step with the inbound auth headers read under apps/client/pages/api and
+    // apps/client/server. A new one belongs here before it reaches a route.
+    for (const header of [
+      'authorization',
+      'cookie',
+      'x-api-key',
+      'x-security-ingest-token',
+      'x-e2e-cleanup-secret',
+      'x-internal-ws-secret',
+      'x-rate-limit-ingest-token',
+      'x-webhook-token',
+      'stripe-signature',
+      'x-hub-signature',
+      'x-hub-signature-256',
+      'x-slack-signature',
+    ]) {
+      expect(WAF_REDACTED_HEADERS).toContain(header);
+    }
+  });
+
+  it('names headers in the lowercase form WAF matches on', () => {
+    for (const header of WAF_REDACTED_HEADERS) {
+      expect(header).toBe(header.toLowerCase());
+    }
+  });
+
+  it('holds no duplicates, which WAF rejects as a duplicate redacted field', () => {
+    expect(new Set(WAF_REDACTED_HEADERS).size).toBe(WAF_REDACTED_HEADERS.length);
+  });
+
+  it('stays within the 100 redacted fields AWS allows per logging configuration', () => {
+    expect(WAF_REDACTED_HEADERS.length).toBeLessThanOrEqual(100);
+  });
+
+  it('shares no header with the admin dashboard diagnostic allowlist', () => {
+    // The two lists are complements: a header worth redacting at write time must never be one the
+    // admin blocked-requests API serves verbatim at read time.
+    const overlap = WAF_REDACTED_HEADERS.filter(isWafDiagnosticHeader);
+    expect(overlap).toEqual([]);
+  });
+});

--- a/infra/waf.ts
+++ b/infra/waf.ts
@@ -9,6 +9,7 @@
  */
 
 import { buildDevWafRuleJson, getDevWafMeta } from './wafPolicy';
+import { WAF_REDACTED_HEADERS } from './wafRedaction';
 import { secrets } from './secrets';
 import { DEFAULT_LAMBDA_ENVIRONMENT } from './constants';
 
@@ -124,7 +125,7 @@ export const wafWebAcl = isWafEnabled
  * This resource:
  * 1. Enables real-time logging for all traffic evaluated by the WebACL
  * 2. Sends logs to the CloudWatch log group automatically
- * 3. Redacts sensitive headers (authorization, cookie) to protect PII and credentials
+ * 3. Redacts every credential-bearing header listed in infra/wafRedaction.ts
  *
  * The log format is AWS WAF's standard JSON structure containing all fields
  * required by the 4 Security Dashboard graphs:
@@ -163,9 +164,10 @@ export const wafLoggingConfig =
           resourceArn: wafWebAcl.arn,
           // CloudWatch log group destination (AWS requires :* suffix)
           logDestinationConfigs: [wafLogGroup.arn.apply(arn => `${arn}:*`)],
-          // Redact sensitive headers to prevent logging PII/credentials
-          // Values are replaced with 'REDACTED' in logs while keeping field names visible
-          redactedFields: [{ singleHeader: { name: 'authorization' } }, { singleHeader: { name: 'cookie' } }],
+          // Values are replaced with 'REDACTED' in logs while keeping field names visible.
+          // Redaction applies from the moment this configuration is updated; log records already
+          // written keep whatever they captured until the group's retention window expires.
+          redactedFields: WAF_REDACTED_HEADERS.map(name => ({ singleHeader: { name } })),
         },
         {
           // MUST be us-east-1 for CloudFront-scope WAF

--- a/infra/wafRedaction.ts
+++ b/infra/wafRedaction.ts
@@ -1,0 +1,29 @@
+/**
+ * Credential-bearing request headers whose values must never be written to the WAF log.
+ *
+ * Consumed by the WebACL logging configuration in infra/waf.ts as `redactedFields`: AWS substitutes
+ * "REDACTED" for each value at write time while keeping the header name visible in the log record.
+ * Names must be lowercase, which is the form WAF matches on.
+ *
+ * The list is derived from the headers this app actually authenticates with, so adding a new auth
+ * header to an API route means adding it here as well. Until that happens
+ * apps/client/server/security/wafHeaderRedaction.ts is the second gate: it withholds any header
+ * value it does not recognize, so an unlisted header is not exposed through the admin dashboard.
+ */
+export const WAF_REDACTED_HEADERS: readonly string[] = [
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'x-api-key',
+  'x-security-ingest-token',
+  'x-e2e-cleanup-secret',
+  'x-internal-ws-secret',
+  'x-rate-limit-ingest-token',
+  'x-webhook-token',
+  // Request signatures. Not replayable the way a bearer token is, but each is derived from a shared
+  // secret and gets the same handling.
+  'stripe-signature',
+  'x-hub-signature',
+  'x-hub-signature-256',
+  'x-slack-signature',
+];


### PR DESCRIPTION
# Pull Request

## Description

Two gates so a credential-bearing request header does not end up in a WAF log record or in the admin security dashboard's response.

The write-time gate is the WebACL logging configuration. `redactedFields` previously listed two headers inline; it now maps the full list of headers this app authenticates with, so WAF substitutes `REDACTED` for each value as the record is written.

The read-time gate is `getWafBlockedRequests`, which previously served the log record's header array verbatim. It now serves only an explicit diagnostic allowlist with real values; every other header keeps its name and gets its value replaced with `MASKED`. An allowlist rather than a blocklist, so an auth header introduced next quarter is withheld by default instead of served by default. The two lists are complements, and a test asserts they stay disjoint.

Closes the log-redaction criterion of the WAF hardening work tracked in the private tracker. The remaining criteria there are untouched by this PR.

Coverage is per-stage, not global. Every WAF resource here, the logging configuration included, is gated on `ENABLE_WAF` (`infra/waf.ts:17`), which is supplied per stage as a GitHub Variable; `infra/waf.ts:16` records the intent as production and dev. So both gates exist only on a stage where that variable is `true`. A stage without it has no WAF log group to redact and no blocked-requests rows to mask, which means this PR closes nothing there and any exposure on such a stage has to be tracked on its own.

## Changes

- `infra/wafRedaction.ts` (new): `WAF_REDACTED_HEADERS`, derived from the inbound auth headers actually read under `apps/client/pages/api` and `apps/client/server`. `authorization`, `proxy-authorization`, `cookie`, `x-api-key`, `x-security-ingest-token`, `x-e2e-cleanup-secret`, `x-internal-ws-secret`, `x-rate-limit-ingest-token`, `x-webhook-token`, plus the four request-signature headers (`stripe-signature`, `x-hub-signature`, `x-hub-signature-256`, `x-slack-signature`). A signature is not replayable the way a bearer token is, but each is derived from a shared secret, so it gets the same handling. Names are lowercase because that is the form WAF matches a `singleHeader` field on.
- `infra/waf.ts`: `redactedFields` maps that list instead of holding two entries inline.
- `apps/client/server/security/wafHeaderRedaction.ts` (new): the diagnostic allowlist plus `maskWafRequestHeaders`. Allowlist members are what an admin needs to tell a bot from a customer or to correlate a block with an application log line: `host`, `user-agent`, `referer`, `origin`, the `accept-*` set, `content-type`/`content-length`, the `sec-ch-ua-*` and `sec-fetch-*` client hints, the forwarding chain (`x-forwarded-*`, `x-real-ip`), the trace identifiers (`x-amzn-trace-id`, `x-request-id`), `x-b4m-client`, and the two non-secret webhook delivery identifiers (`x-github-event`, `x-github-delivery`). Matching is case-insensitive here, because WAF logs header names in whatever casing the client sent.
- `apps/client/server/security/wafLogsInsights.ts`: the blocked-request mapper masks headers. Applied in the parse step rather than in the route handler, so the five-minute `wafQueryCache` entry never holds an unmasked value either.
- Tests: `infra/__tests__/wafRedaction.test.ts` (new), `apps/client/server/security/__tests__/wafHeaderRedaction.test.ts` (new), and two cases added to `apps/client/server/security/__tests__/wafLogsInsights.test.ts`.

No UI surface changes. `WafBlockedRequestsTable.tsx` renders timestamp, action, rule, IP, country, method, URI, args, version and request ID; it never rendered headers, which were only ever carried in the JSON payload.

## Guide for Testers

This is an infrastructure and backend change with no visible UI. Verifying it needs a stage with `ENABLE_WAF=true` and an admin account. A change under `infra/` also has to have a real preview deploy behind it before the infra gate reports green, which needs a maintainer to trigger a preview.

1. On a stage with the WAF enabled, send a request that the WebACL blocks, carrying every header named in `infra/wafRedaction.ts` with a distinctive dummy value (for example `dummy-value-for-redaction-check`). The admin API only surfaces rows where `action = BLOCK`, so a request that is allowed through will not appear in step 3.
2. Read the log record: `aws logs filter-log-events --region us-east-1 --log-group-name aws-waf-logs-bike4mind-<stage> --start-time <epoch-ms>`. Expected: the record's `httpRequest.headers` lists each of those header names with `"value": "REDACTED"`, and the dummy value appears nowhere in the record.
3. Call `GET /api/admin/security-dashboard/waf-blocked-requests?range=1h` while signed in as an admin. Expected: each of those header names comes back with `"value": "MASKED"`, the diagnostic headers come back with their real values, and the dummy value appears nowhere in the response body.
4. Allow for the five-minute `wafQueryCache` TTL between steps 1 and 3. A response cached before step 1 will not include the new row; wait it out rather than concluding the query is broken.
5. Open Admin then Security Dashboard then the blocked-requests table. Expected: unchanged. Same columns, same rows, no new empty column and no rendering error.

Regression checks: the rest of the security dashboard reads the same log group through the same helpers. Confirm the traffic overview, the logs-insights section and the blocked-requests table all still populate, and that the WAF continues to block what it blocked before. Rule evaluation is untouched by this PR; redaction is a log-write concern only and does not change what WAF inspects or how it decides.

What NOT to test: no client-side behavior changed, no schema or model changed, no admin setting was added, and no route was added or removed. The blocked-requests payload is the only response shape affected, and only in the value of non-allowlisted header entries.

## Additional Information

Unit coverage, both green locally:

- `pnpm exec vitest run --dir infra` asserts every credential header is present, all names are lowercase, there are no duplicates, the list stays within the 100 redacted fields AWS allows per logging configuration, and the write-side list is disjoint from the read-side allowlist. The disjointness assertion is the one that earns its keep over time.
- `pnpm --filter @bike4mind/client exec vitest run --project node server/security/__tests__` covers `maskWafRequestHeaders` directly and covers `getWafBlockedRequests` against a mocked Logs Insights result whose record carries unmasked header values. The served response has `MASKED` for each and `JSON.stringify(result)` contains none of them. Both `getWafBlockedRequests` cases fail against the previous behavior, which is how I know they test something.

Two things I am flagging rather than acting on.

Existing log records. Redaction takes effect when the logging configuration is updated, so it governs records written after this lands. This PR does not delete or alter any existing log data. How pre-existing records should be handled is a real decision with an argument either way, and it is written up in the private tracker rather than here. Flagging it so the call is explicit rather than implied by this merging.

Adjacent, not fixed here. One related item is out of reach of header redaction by its nature and needs its own criterion. It is described in the private tracker. Raising it there rather than quietly widening this PR.

Related WAF work. I checked the other open WAF work on this same WebACL for overlap before opening this. It all sits in the rule definitions, meaning the `infra/waf/*.json` policy files and the rule ordering in `wafPolicy.ts`, and none of it touches the logging configuration or `redactedFields`. The one open PR in this repo against those files, #2342, changes only `infra/waf/bike4mind-api-protection-dev.json` and `infra/waf/bike4mind-api-protection-prod.json`, so there is no file overlap with this branch and no rebase conflict in either direction. This branch adds two modules and rewrites one property of `WafLoggingConfiguration`; the rule work can land before or after it in any order.

Scope. The log-redaction criterion only. The other criteria on that private issue are deliberately untouched here, so it stays open for them and should not be closed on this merging.

## Developer Notes

- `infra/wafRedaction.ts` is a plain constants module with no imports, on purpose: `infra/waf.ts` evaluates SST and Pulumi globals at import time and cannot be pulled into a test, so the list had to live somewhere importable for the guard test to exist at all. Any future infra value worth asserting on can follow the same shape.
- `maskWafRequestHeaders` masks by allowlist and keeps header names. Any other surface that comes to serve raw WAF log records should reuse it rather than grow a second policy.
- `MASKED` is deliberately not WAF's own `REDACTED`, so a reader can tell a value the log never held from a value the log holds and the API declines to serve.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no admin setting added
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI change
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry field changed


