### PR TITLE
fix(ci): pass workflow inputs through env and prefix snapshot dist-tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
       - name: Check deploy contract matches infra
         run: python3 scripts/check-deploy-contract.py
 
+      - name: Check workflows pass values through env, not run-body interpolation
+        run: python3 scripts/check-no-run-interpolation.py
+
 
 
 
@@ -629,10 +632,15 @@ jobs:
       # client ones, where it carries `--shard=i/3` - deliberately with no `--` separator
       # before it, see the matrix entries above for why that is load-bearing.
       - name: Run Tests (${{ matrix.shard.name }})
-        run: pnpm --recursive --workspace-concurrency=4 ${{ matrix.shard.filter }} ${{ matrix.shard.script || 'test' }} ${{ matrix.shard.args }}
         env:
           CI: true
           VITEST_MAX_WORKERS: ${{ matrix.shard.workers }}
+          SHARD_FILTER: ${{ matrix.shard.filter }}
+          SHARD_SCRIPT: ${{ matrix.shard.script || 'test' }}
+          SHARD_ARGS: ${{ matrix.shard.args }}
+        run: |
+          # shellcheck disable=SC2086 # each carries several args; word splitting is the point
+          pnpm --recursive --workspace-concurrency=4 $SHARD_FILTER $SHARD_SCRIPT $SHARD_ARGS
 
       # Tests that live outside every pnpm workspace, which the sharded run above cannot reach:
       # infra/ has no package.json, and scripts/codemods is not in pnpm-workspace.yaml, so
@@ -675,9 +683,11 @@ jobs:
       # so an early failure (before the mark step) reports nothing instead of nonsense.
       - name: Report shard duration
         if: always() && env.SHARD_START_SECONDS != ''
+        env:
+          SHARD_NAME: ${{ matrix.shard.name }}
         run: |
           elapsed=$(( $(date +%s) - SHARD_START_SECONDS ))
-          summary=$(printf '%s: %dm%02ds' '${{ matrix.shard.name }}' "$(( elapsed / 60 ))" "$(( elapsed % 60 ))")
+          summary=$(printf '%s: %dm%02ds' "$SHARD_NAME" "$(( elapsed / 60 ))" "$(( elapsed % 60 ))")
           echo "- Run Tests (${summary})" >> "$GITHUB_STEP_SUMMARY"
           if [ "$elapsed" -gt "$SHARD_SOFT_BUDGET_SECONDS" ]; then
             echo "::warning title=Slow test shard::${summary} - over its ${SHARD_SOFT_BUDGET_SECONDS}s soft budget. Not a failure: split or speed up the shard before it reaches the job timeout."
@@ -700,8 +710,10 @@ jobs:
       contents: read
     steps:
       - name: Verify all test shards passed
+        env:
+          SHARDS_RESULT: ${{ needs.test-shards.result }}
         run: |
-          result='${{ needs.test-shards.result }}'
+          result="$SHARDS_RESULT"
           echo "test-shards result: $result"
           test "$result" = "success"
 

--- a/.github/workflows/code-semgrep.yml
+++ b/.github/workflows/code-semgrep.yml
@@ -32,6 +32,18 @@ jobs:
       SEMGREP_JSON_REPORT_PATH: ${{ github.workspace }}/semgrep-report.json
 
     steps:
+      # `stage` selects the ingest host that receives the report, so it is
+      # constrained to the shapes this workflow documents before any step can
+      # send anything. Job-level env above is evaluated before the first step
+      # runs, so this gate works by failing the job ahead of the ingest step,
+      # not by preventing the URL from being built.
+      - name: Validate stage input
+        run: |
+          if [ -n "$CODE_STAGE" ] && ! printf '%s' "$CODE_STAGE" | grep -qxE '(dev|staging|production|pr[0-9]+)'; then
+            echo "::error::stage must be dev, staging, production or prNNN"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/e2e-ai-latency.yml
+++ b/.github/workflows/e2e-ai-latency.yml
@@ -226,6 +226,11 @@ jobs:
         env:
           DISCOVERED_GPT: ${{ needs.discover-models.outputs.latest_gpt }}
           DISCOVERED_CLAUDE: ${{ needs.discover-models.outputs.latest_claude }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_FULL_MATRIX: ${{ inputs.run_full_matrix }}
+          RUN_ALL_SPECS: ${{ inputs.run_all_specs }}
+          AI_MODEL: ${{ inputs.ai_model }}
+          SPEC_FILE: ${{ inputs.spec_file }}
         run: |
           ALL_SPECS='["ai-latency-short-answers","ai-latency-long-answers","ai-latency-tool-prompts","ai-latency-intermediate-tools"]'
 
@@ -240,16 +245,16 @@ jobs:
             echo "ai_models=$(jq -cn --arg c "$DISCOVERED_CLAUDE" --arg g "$DISCOVERED_GPT" '[$c, $g]')" >> $GITHUB_OUTPUT
           }
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.run_full_matrix }}" = "true" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$RUN_FULL_MATRIX" = "true" ]; then
             build_full_matrix
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.run_all_specs }}" = "true" ]; then
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$RUN_ALL_SPECS" = "true" ]; then
             # All specs on the single selected model.
             echo "spec_files=$ALL_SPECS" >> $GITHUB_OUTPUT
-            echo "ai_models=[\"${{ inputs.ai_model }}\"]" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "ai_models=$(jq -cn --arg m "$AI_MODEL" '[$m]')" >> $GITHUB_OUTPUT
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             # Single cell: selected spec × selected model.
-            echo "spec_files=[\"${{ inputs.spec_file }}\"]" >> $GITHUB_OUTPUT
-            echo "ai_models=[\"${{ inputs.ai_model }}\"]" >> $GITHUB_OUTPUT
+            echo "spec_files=$(jq -cn --arg s "$SPEC_FILE" '[$s]')" >> $GITHUB_OUTPUT
+            echo "ai_models=$(jq -cn --arg m "$AI_MODEL" '[$m]')" >> $GITHUB_OUTPUT
           else
             # Scheduled run: full matrix.
             build_full_matrix
@@ -284,20 +289,26 @@ jobs:
     steps:
       - name: Sanitize names for artifact labels
         id: sanitize
+        env:
+          AI_MODEL: ${{ matrix.ai_model }}
         run: |
-          MODEL_SAFE="${{ matrix.ai_model }}"
+          MODEL_SAFE="$AI_MODEL"
           MODEL_SAFE="${MODEL_SAFE// /-}"
           MODEL_SAFE="${MODEL_SAFE//./-}"
           echo "model_safe=$MODEL_SAFE" >> $GITHUB_OUTPUT
 
       - name: Compute per-cell E2E test ID
         id: testid
+        env:
+          E2E_TEST_ID_INPUT: ${{ inputs.e2e_test_id }}
+          MODEL_SAFE: ${{ steps.sanitize.outputs.model_safe }}
+          SPEC_FILE: ${{ matrix.spec_file }}
         run: |
           # Derive a unique-per-cell ID so concurrent matrix cells isolate their test data.
           # Without this, the cleanup endpoint (no testId) deletes ALL e2e users globally,
           # causing the first-finishing cell to wipe data for the rest.
-          USER_PREFIX="${{ inputs.e2e_test_id }}"
-          CELL_ID="${{ steps.sanitize.outputs.model_safe }}-${{ matrix.spec_file }}"
+          USER_PREFIX="$E2E_TEST_ID_INPUT"
+          CELL_ID="${MODEL_SAFE}-${SPEC_FILE}"
           if [ -n "$USER_PREFIX" ]; then
             TEST_ID="${USER_PREFIX}-${CELL_ID}"
           else
@@ -315,6 +326,8 @@ jobs:
           STAGE_INPUT: ${{ inputs.stage }}
           PREVIEW_SERVER_DOMAIN: ${{ vars.PREVIEW_SERVER_DOMAIN }}
           STAGING_SERVER_DOMAIN: ${{ vars.STAGING_SERVER_DOMAIN }}
+          SPEC_FILE: ${{ matrix.spec_file }}
+          AI_MODEL: ${{ matrix.ai_model }}
         run: |
           if [ -n "$PR_NUMBER" ]; then
             if ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
@@ -331,8 +344,8 @@ jobs:
           echo "api_url=$API_URL" >> $GITHUB_OUTPUT
           echo "Stage: $STAGE"
           echo "API URL: $API_URL"
-          echo "Spec: ${{ matrix.spec_file }}"
-          echo "AI Model: ${{ matrix.ai_model }}"
+          echo "Spec: $SPEC_FILE"
+          echo "AI Model: $AI_MODEL"
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -413,6 +426,7 @@ jobs:
           STAGE: ${{ steps.config.outputs.stage }}
           E2E_TEST_ID: ${{ steps.testid.outputs.test_id }}
           AI_MODEL: ${{ matrix.ai_model }}
+          SPEC_FILE: ${{ matrix.spec_file }}
           AI_LATENCY_RUN: 'true'
           PW_WORKERS: '3'
           CI: 'true'
@@ -425,38 +439,40 @@ jobs:
                 echo "::error::E2E_CLEANUP_SECRET repo secret is required for preview runs"
                 exit 1
               fi
-              pnpm --filter client exec playwright test e2e/${{ matrix.spec_file }}.spec.ts \
+              pnpm --filter client exec playwright test "e2e/${SPEC_FILE}.spec.ts" \
                 2>&1 | tee apps/client/playwright-output.txt
               ;;
             *)
               # dev (same account): resolve the secret from SST.
               pnpm sst shell --stage "$STAGE" -- \
-                pnpm --filter client exec playwright test e2e/${{ matrix.spec_file }}.spec.ts \
+                pnpm --filter client exec playwright test "e2e/${SPEC_FILE}.spec.ts" \
                 2>&1 | tee apps/client/playwright-output.txt
               ;;
           esac
 
       - name: Persist test results
         if: always()
+        env:
+          SPEC_FILE: ${{ matrix.spec_file }}
         run: |
           mkdir -p apps/client/playwright-report
           # Prefer the deterministic path from `apps/client/playwright.config.ts`.
           if [ -f apps/client/playwright-report/pw-results.json ]; then
-            cp apps/client/playwright-report/pw-results.json apps/client/playwright-report/${{ matrix.spec_file }}-pw-results.json
+            cp apps/client/playwright-report/pw-results.json "apps/client/playwright-report/${SPEC_FILE}-pw-results.json"
           elif [ -f apps/client/pw-results.json ]; then
             # Backwards-compat fallback.
-            cp apps/client/pw-results.json apps/client/playwright-report/${{ matrix.spec_file }}-pw-results.json
+            cp apps/client/pw-results.json "apps/client/playwright-report/${SPEC_FILE}-pw-results.json"
           else
             # Last-resort: Playwright may have written relative to a different CWD or config resolution.
             FOUND="$(find . -type f -name 'pw-results.json' 2>/dev/null | head -1 || true)"
             if [ -n "$FOUND" ]; then
-              cp "$FOUND" apps/client/playwright-report/${{ matrix.spec_file }}-pw-results.json
+              cp "$FOUND" "apps/client/playwright-report/${SPEC_FILE}-pw-results.json"
             fi
           fi
 
           echo "=== pw-results debug ==="
-          echo "Spec file: ${{ matrix.spec_file }}"
-          echo "Copied summary exists? $(test -f apps/client/playwright-report/${{ matrix.spec_file }}-pw-results.json && echo yes || echo no)"
+          echo "Spec file: $SPEC_FILE"
+          echo "Copied summary exists? $(test -f "apps/client/playwright-report/${SPEC_FILE}-pw-results.json" && echo yes || echo no)"
           echo "Found pw-results.json candidates:"
           find . -type f -name 'pw-results.json' 2>/dev/null | head -20 || true
 
@@ -482,12 +498,16 @@ jobs:
     steps:
       - name: Resolve environment URL
         id: config
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PREVIEW_SERVER_DOMAIN: ${{ vars.PREVIEW_SERVER_DOMAIN }}
+          STAGING_SERVER_DOMAIN: ${{ vars.STAGING_SERVER_DOMAIN }}
         run: |
-          if [ -n "${{ inputs.pr_number }}" ]; then
-            API_URL="https://app.pr${{ inputs.pr_number }}.${{ vars.PREVIEW_SERVER_DOMAIN }}"
-            ENV_LABEL="preview-${{ inputs.pr_number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            API_URL="https://app.pr${PR_NUMBER}.${PREVIEW_SERVER_DOMAIN}"
+            ENV_LABEL="preview-${PR_NUMBER}"
           else
-            API_URL="https://app.${{ vars.STAGING_SERVER_DOMAIN }}"
+            API_URL="https://app.${STAGING_SERVER_DOMAIN}"
             ENV_LABEL="Staging"
           fi
           echo "api_url=$API_URL" >> $GITHUB_OUTPUT
@@ -495,8 +515,10 @@ jobs:
 
       - name: Set trigger label
         id: trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "label=Run via Dispatch" >> $GITHUB_OUTPUT
           else
             echo "label=Run via Schedule" >> $GITHUB_OUTPUT
@@ -521,6 +543,11 @@ jobs:
         env:
           AI_MODELS_JSON: ${{ needs.setup-matrix.outputs.ai_models }}
           SPEC_FILES_JSON: ${{ needs.setup-matrix.outputs.spec_files }}
+          TRIGGER_LABEL: ${{ steps.trigger.outputs.label }}
+          BRANCH: ${{ github.ref_name }}
+          NOTIFY_API_URL: ${{ steps.config.outputs.api_url }}
+          ENV_LABEL: ${{ steps.config.outputs.env_label }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts
         run: |
           mapfile -t ALL_PW_RESULTS < <(find downloaded-results -type f -name '*-pw-results.json' 2>/dev/null | sort)
           mapfile -t ALL_LATENCY_JSONS < <(find downloaded-results -type f -name '*-results.json' ! -name '*-pw-results.json' 2>/dev/null | sort)
@@ -677,13 +704,13 @@ jobs:
 
           jq -n \
             --arg overall_status "$OVERALL_STATUS" \
-            --arg trigger_label "${{ steps.trigger.outputs.label }}" \
-            --arg branch "${{ github.ref_name }}" \
-            --arg api_url "${{ steps.config.outputs.api_url }}" \
-            --arg env_label "${{ steps.config.outputs.env_label }}" \
+            --arg trigger_label "$TRIGGER_LABEL" \
+            --arg branch "$BRANCH" \
+            --arg api_url "$NOTIFY_API_URL" \
+            --arg env_label "$ENV_LABEL" \
             --arg latency_summary "$LATENCY_SUMMARY" \
             --arg normal_prompts "$NORMAL_PROMPTS_TEXT" \
-            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts" \
+            --arg run_url "$RUN_URL" \
             '{
               "text": ("AI Latency — " + $overall_status),
               "blocks": [

--- a/.github/workflows/e2e-on-label.yml
+++ b/.github/workflows/e2e-on-label.yml
@@ -28,9 +28,12 @@ jobs:
     steps:
       - name: Resolve configuration
         id: config
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          PREVIEW_SERVER_DOMAIN: ${{ vars.PREVIEW_SERVER_DOMAIN }}
         run: |
-          STAGE="pr${{ github.event.number }}"
-          API_URL="https://app.pr${{ github.event.number }}.${{ vars.PREVIEW_SERVER_DOMAIN }}"
+          STAGE="pr${PR_NUMBER}"
+          API_URL="https://app.${STAGE}.${PREVIEW_SERVER_DOMAIN}"
           echo "stage=$STAGE" >> $GITHUB_OUTPUT
           echo "api_url=$API_URL" >> $GITHUB_OUTPUT
           echo "Stage: $STAGE"

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -253,10 +253,12 @@ jobs:
           PW_WORKERS: '3'
           CI: 'true'
           PLAYWRIGHT_ARGS: ${{ inputs.playwright_args }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SST_STAGE: ${{ steps.config.outputs.stage }}
         run: |
           set -o pipefail
           [ -n "$PLAYWRIGHT_ARGS" ] && echo "Running: playwright test $PLAYWRIGHT_ARGS" || echo "Running full suite"
-          if [ -n "${{ inputs.pr_number }}" ]; then
+          if [ -n "$PR_NUMBER" ]; then
             # Preview (cross-account): E2E_CLEANUP_SECRET is injected from the repo secret above.
             if [ -z "${E2E_CLEANUP_SECRET:-}" ]; then
               echo "::error::E2E_CLEANUP_SECRET repo secret is required for preview runs"
@@ -265,7 +267,7 @@ jobs:
             pnpm --filter client exec playwright test $PLAYWRIGHT_ARGS 2>&1 | tee apps/client/playwright-output.txt
           else
             # dev/staging (same account): resolve the secret from SST.
-            pnpm sst shell --stage ${{ steps.config.outputs.stage }} -- pnpm --filter client exec playwright test $PLAYWRIGHT_ARGS 2>&1 | tee apps/client/playwright-output.txt
+            pnpm sst shell --stage "$SST_STAGE" -- pnpm --filter client exec playwright test $PLAYWRIGHT_ARGS 2>&1 | tee apps/client/playwright-output.txt
           fi
 
       - name: Upload Playwright report

--- a/.github/workflows/generate-whats-new-modal-reusable.yml
+++ b/.github/workflows/generate-whats-new-modal-reusable.yml
@@ -273,16 +273,20 @@ jobs:
 
       - name: Validate GitHub Secrets
         if: steps.prs-initial.outputs.count > 0
+        env:
+          WHATS_NEW_AWS_ACCESS_KEY_ID: ${{ secrets.WHATS_NEW_AWS_ACCESS_KEY_ID }}
+          WHATS_NEW_AWS_SECRET_ACCESS_KEY: ${{ secrets.WHATS_NEW_AWS_SECRET_ACCESS_KEY }}
+          WHATS_NEW_QUEUE_URL: ${{ secrets.WHATS_NEW_QUEUE_URL }}
         run: |
-          if [ -z "${{ secrets.WHATS_NEW_AWS_ACCESS_KEY_ID }}" ]; then
+          if [ -z "$WHATS_NEW_AWS_ACCESS_KEY_ID" ]; then
             echo "::error::WHATS_NEW_AWS_ACCESS_KEY_ID secret is not configured"
             exit 1
           fi
-          if [ -z "${{ secrets.WHATS_NEW_AWS_SECRET_ACCESS_KEY }}" ]; then
+          if [ -z "$WHATS_NEW_AWS_SECRET_ACCESS_KEY" ]; then
             echo "::error::WHATS_NEW_AWS_SECRET_ACCESS_KEY secret is not configured"
             exit 1
           fi
-          if [ -z "${{ secrets.WHATS_NEW_QUEUE_URL }}" ]; then
+          if [ -z "$WHATS_NEW_QUEUE_URL" ]; then
             echo "::error::WHATS_NEW_QUEUE_URL secret is not configured"
             exit 1
           fi
@@ -295,6 +299,9 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.WHATS_NEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WHATS_NEW_AWS_SECRET_ACCESS_KEY }}
           WHATS_NEW_QUEUE_URL: ${{ secrets.WHATS_NEW_QUEUE_URL }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          REPOSITORY_URL: ${{ github.repositoryUrl }}
+          CHANGELOG_EXCERPT: ${{ steps.changelog-excerpt.outputs.excerpt }}
         run: |
           # Read collected data
           commits=$(cat commits.json)
@@ -309,15 +316,15 @@ jobs:
 
           echo "Generated Date: $GENERATED_DATE"
           echo "Correlation ID: $CORRELATION_ID"
-          echo "Environment: ${{ inputs.environment }}"
+          echo "Environment: $ENVIRONMENT"
 
           # Build JSON payload (PR-based, no releases)
           jq -n \
             --arg correlationId "$CORRELATION_ID" \
             --arg generatedDate "$GENERATED_DATE" \
-            --arg environment "${{ inputs.environment }}" \
-            --arg repo "${{ github.repositoryUrl }}" \
-            --arg changelogExcerpt "${{ steps.changelog-excerpt.outputs.excerpt }}" \
+            --arg environment "$ENVIRONMENT" \
+            --arg repo "$REPOSITORY_URL" \
+            --arg changelogExcerpt "$CHANGELOG_EXCERPT" \
             --argjson commits "$commits" \
             --argjson prs "$prs" \
             --argjson changelogData "$changelog" \
@@ -351,17 +358,23 @@ jobs:
 
       - name: Report success
         if: success() && steps.prs-initial.outputs.count > 0
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          PR_COUNT: ${{ steps.prs-initial.outputs.count }}
+          COMMIT_COUNT: ${{ steps.commits.outputs.count }}
         run: |
           echo "::notice::What's New modal generation queued successfully!"
           echo "::notice::Date: $(date -u +%Y-%m-%d)"
-          echo "::notice::Environment: ${{ inputs.environment }}"
-          echo "::notice::PRs: ${{ steps.prs-initial.outputs.count }}, Commits: ${{ steps.commits.outputs.count }}"
+          echo "::notice::Environment: $ENVIRONMENT"
+          echo "::notice::PRs: $PR_COUNT, Commits: $COMMIT_COUNT"
 
       - name: Report dry run
         if: success() && steps.prs-initial.outputs.count > 0 && inputs.dry_run == true
+        env:
+          PR_COUNT: ${{ steps.prs-initial.outputs.count }}
         run: |
           echo "::notice::DRY RUN MODE - No message sent to SQS"
-          echo "::notice::Would have processed ${{ steps.prs-initial.outputs.count }} PRs"
+          echo "::notice::Would have processed $PR_COUNT PRs"
 
       - name: Report failure
         if: failure()

--- a/.github/workflows/nightly-seed-staleness.yml
+++ b/.github/workflows/nightly-seed-staleness.yml
@@ -20,8 +20,11 @@ jobs:
     steps:
       - name: Check repository
         id: check
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CANONICAL_REPO: ${{ vars.CANONICAL_REPO || 'MillionOnMars/lumina5' }}
         run: |
-          if [ "${{ github.repository }}" = "${{ vars.CANONICAL_REPO || 'MillionOnMars/lumina5' }}" ]; then
+          if [ "$REPOSITORY" = "$CANONICAL_REPO" ]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
@@ -52,7 +55,9 @@ jobs:
           cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Authenticate with private NPM package
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/nightly-tsc-baseline.yml
+++ b/.github/workflows/nightly-tsc-baseline.yml
@@ -21,8 +21,11 @@ jobs:
     steps:
       - name: Check repository
         id: check
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CANONICAL_REPO: ${{ vars.CANONICAL_REPO || 'MillionOnMars/lumina5' }}
         run: |
-          if [ "${{ github.repository }}" = "${{ vars.CANONICAL_REPO || 'MillionOnMars/lumina5' }}" ]; then
+          if [ "$REPOSITORY" = "$CANONICAL_REPO" ]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
@@ -55,7 +58,9 @@ jobs:
           cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Authenticate with private NPM package
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/packages-audit.yml
+++ b/.github/workflows/packages-audit.yml
@@ -32,6 +32,18 @@ jobs:
       PACKAGES_JSON_REPORT_PATH: ${{ github.workspace }}/packages-audit-report.json
 
     steps:
+      # `stage` selects the ingest host that receives the report, so it is
+      # constrained to the shapes this workflow documents before any step can
+      # send anything. Job-level env above is evaluated before the first step
+      # runs, so this gate works by failing the job ahead of the ingest step,
+      # not by preventing the URL from being built.
+      - name: Validate stage input
+        run: |
+          if [ -n "$PACKAGES_STAGE" ] && ! printf '%s' "$PACKAGES_STAGE" | grep -qxE '(dev|staging|production|pr[0-9]+)'; then
+            echo "::error::stage must be dev, staging, production or prNNN"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -79,26 +79,32 @@ jobs:
 
       - name: Determine configuration
         id: config
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          AWS_PROD_ROLE_ARN: ${{ secrets.AWS_PROD_ROLE_ARN }}
+          AWS_DEV_ROLE_ARN: ${{ secrets.AWS_DEV_ROLE_ARN }}
+          APP_NAME: ${{ vars.SEED_APP_NAME || 'bike4mind' }}
         run: |
           # Determine stage based on event and branch
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
             # For workflow_run events, the branch is from the triggering workflow
             # Since we filter by prod branch, this should always be production
             echo "stage=production" | tee -a "$GITHUB_OUTPUT"
-            echo "aws_role_arn=${{ secrets.AWS_PROD_ROLE_ARN }}" | tee -a "$GITHUB_OUTPUT"
-          elif [ "${{ github.ref }}" = "refs/heads/prod" ]; then
+            echo "aws_role_arn=$AWS_PROD_ROLE_ARN" | tee -a "$GITHUB_OUTPUT"
+          elif [ "$REF" = "refs/heads/prod" ]; then
             echo "stage=production" | tee -a "$GITHUB_OUTPUT"
-            echo "aws_role_arn=${{ secrets.AWS_PROD_ROLE_ARN }}" | tee -a "$GITHUB_OUTPUT"
-          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "aws_role_arn=$AWS_PROD_ROLE_ARN" | tee -a "$GITHUB_OUTPUT"
+          elif [ "$REF" = "refs/heads/main" ]; then
             echo "stage=dev" | tee -a "$GITHUB_OUTPUT"
-            echo "aws_role_arn=${{ secrets.AWS_DEV_ROLE_ARN }}" | tee -a "$GITHUB_OUTPUT"
+            echo "aws_role_arn=$AWS_DEV_ROLE_ARN" | tee -a "$GITHUB_OUTPUT"
           else
             # For manual workflow_dispatch on other branches, use dev
             echo "stage=dev" | tee -a "$GITHUB_OUTPUT"
-            echo "aws_role_arn=${{ secrets.AWS_DEV_ROLE_ARN }}" | tee -a "$GITHUB_OUTPUT"
+            echo "aws_role_arn=$AWS_DEV_ROLE_ARN" | tee -a "$GITHUB_OUTPUT"
           fi
 
-          echo "app_name=${{ vars.SEED_APP_NAME || 'bike4mind' }}" | tee -a "$GITHUB_OUTPUT"
+          echo "app_name=$APP_NAME" | tee -a "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -159,18 +165,22 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           # For workflow_run (auto), explicitly use 'prod'. For manual dispatch, use input (defaults to 'HEAD')
           TARGET_BRANCH: ${{ github.event_name == 'workflow_run' && 'prod' || github.event.inputs.target_branch || 'HEAD' }}
+          SST_STAGE: ${{ steps.config.outputs.stage }}
         run: |
-          pnpm sst shell --stage ${{ steps.config.outputs.stage }} --print-logs -- pnpm --filter @bike4mind/scripts create-prod-release --target-branch "$TARGET_BRANCH"
+          pnpm sst shell --stage "$SST_STAGE" --print-logs -- pnpm --filter @bike4mind/scripts create-prod-release --target-branch "$TARGET_BRANCH"
 
       - name: Summary
         if: success()
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SST_STAGE: ${{ steps.config.outputs.stage }}
         run: |
           echo "✅ Production release created successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
             echo "**Triggered by**: Deploy workflow completion" >> $GITHUB_STEP_SUMMARY
             echo "**Branch**: prod" >> $GITHUB_STEP_SUMMARY
           else
             echo "**Triggered by**: Manual workflow dispatch" >> $GITHUB_STEP_SUMMARY
-            echo "**Stage**: ${{ steps.config.outputs.stage }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Stage**: $SST_STAGE" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/prowler-only.yml
+++ b/.github/workflows/prowler-only.yml
@@ -36,6 +36,11 @@ jobs:
         env:
           INPUT_ENVIRONMENT: ${{ inputs.environment }}
           INPUT_STAGE: ${{ inputs.stage }}
+          ROLE_ARN_PRODUCTION: ${{ vars.PROWLER_AUDIT_ROLE_ARN_PRODUCTION }}
+          ROLE_ARN_STAGING: ${{ vars.PROWLER_AUDIT_ROLE_ARN_STAGING }}
+          TARGET_PROD: ${{ vars.OWASP_ZAP_TARGET_PROD }}
+          TARGET_STAGING: ${{ vars.OWASP_ZAP_TARGET }}
+          PREVIEW_SERVER_DOMAIN: ${{ vars.PREVIEW_SERVER_DOMAIN }}
         run: |
           if [[ -n "$INPUT_STAGE" && ! "$INPUT_STAGE" =~ ^[a-z0-9]+$ ]]; then
             echo "::error::Invalid stage input '${INPUT_STAGE}': must be lowercase alphanumeric (e.g. pr1234)"
@@ -43,16 +48,16 @@ jobs:
           fi
 
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "role_arn=${{ vars.PROWLER_AUDIT_ROLE_ARN_PRODUCTION }}" >> $GITHUB_OUTPUT
-            DEFAULT_INGEST_URL="${{ vars.OWASP_ZAP_TARGET_PROD }}"
+            echo "role_arn=$ROLE_ARN_PRODUCTION" >> $GITHUB_OUTPUT
+            DEFAULT_INGEST_URL="$TARGET_PROD"
           else
-            echo "role_arn=${{ vars.PROWLER_AUDIT_ROLE_ARN_STAGING }}" >> $GITHUB_OUTPUT
-            DEFAULT_INGEST_URL="${{ vars.OWASP_ZAP_TARGET }}"
+            echo "role_arn=$ROLE_ARN_STAGING" >> $GITHUB_OUTPUT
+            DEFAULT_INGEST_URL="$TARGET_STAGING"
           fi
 
           # If a PR stage is provided (e.g. "pr1234"), route ingest to that PR's preview host
           if [[ "$INPUT_STAGE" == pr* ]]; then
-            PREVIEW_DOMAIN="${{ vars.PREVIEW_SERVER_DOMAIN }}"
+            PREVIEW_DOMAIN="$PREVIEW_SERVER_DOMAIN"
             echo "ingest_url=https://app.${INPUT_STAGE}.${PREVIEW_DOMAIN}" >> $GITHUB_OUTPUT
             echo "ingest_stage=${INPUT_STAGE}" >> $GITHUB_OUTPUT
           else
@@ -97,9 +102,11 @@ jobs:
           run_install: false
 
       - name: Configure npm authentication
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+          pnpm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -32,6 +32,18 @@ jobs:
       SECRETS_JSON_REPORT_PATH: ${{ github.workspace }}/secrets-scan-report.json
 
     steps:
+      # `stage` selects the ingest host that receives the report, so it is
+      # constrained to the shapes this workflow documents before any step can
+      # send anything. Job-level env above is evaluated before the first step
+      # runs, so this gate works by failing the job ahead of the ingest step,
+      # not by preventing the URL from being built.
+      - name: Validate stage input
+        run: |
+          if [ -n "$SECRETS_STAGE" ] && ! printf '%s' "$SECRETS_STAGE" | grep -qxE '(dev|staging|production|pr[0-9]+)'; then
+            echo "::error::stage must be dev, staging, production or prNNN"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/selfhost-image.yml
+++ b/.github/workflows/selfhost-image.yml
@@ -105,9 +105,11 @@ jobs:
 
       - name: Export digest
         if: github.event_name != 'pull_request'
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest='${{ steps.build.outputs.digest }}'
+          digest="$BUILD_DIGEST"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
@@ -164,7 +166,9 @@ jobs:
           # shellcheck disable=SC2046 # word splitting is the point: many -t and digest args
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+            $(for digest in *; do printf '%s@sha256:%s ' "$IMAGE" "$digest"; done)
 
       - name: Inspect published image
-        run: docker buildx imagetools inspect '${{ env.IMAGE }}:${{ steps.meta.outputs.version }}'
+        env:
+          META_VERSION: ${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect "$IMAGE:$META_VERSION"

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -66,8 +66,10 @@ jobs:
     steps:
       - name: Determine notification emoji and text
         id: message
+        env:
+          STATUS: ${{ inputs.status }}
         run: |
-          case "${{ inputs.status }}" in
+          case "$STATUS" in
             success)
               echo "emoji=✅" >> $GITHUB_OUTPUT
               echo "status_text=Succeeded" >> $GITHUB_OUTPUT
@@ -82,7 +84,7 @@ jobs:
               ;;
             *)
               echo "emoji=ℹ️" >> $GITHUB_OUTPUT
-              echo "status_text=${{ inputs.status }}" >> $GITHUB_OUTPUT
+              echo "status_text=$(printf '%s' "$STATUS" | head -n1)" >> $GITHUB_OUTPUT
               ;;
           esac
 
@@ -96,15 +98,13 @@ jobs:
       - name: Prepare commit message for JSON
         id: prepare
         if: inputs.commit_message != ''
+        env:
+          COMMIT_MESSAGE: ${{ inputs.commit_message }}
         run: |
-          COMMIT_MSG=$(cat << 'COMMIT_MSG_EOF'
-          ${{ inputs.commit_message }}
-          COMMIT_MSG_EOF
-          )
           # First line only, truncated to 200 Unicode code points (not bytes, so emoji
           # are preserved intact), then JSON-escaped with outer quotes stripped so we
           # can splice into the payload's mrkdwn string.
-          ESCAPED_MSG=$(printf '%s' "$COMMIT_MSG" | python3 -c '
+          ESCAPED_MSG=$(printf '%s' "$COMMIT_MESSAGE" | python3 -c '
           import json, sys
           lines = sys.stdin.read().strip().splitlines()
           text = lines[0] if lines else ""

--- a/.github/workflows/snapshot-publish.yaml
+++ b/.github/workflows/snapshot-publish.yaml
@@ -98,7 +98,7 @@ jobs:
             echo "has-changes=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Sanitize branch name for npm tag
+      - name: Derive npm dist-tag from branch name
         if: steps.changes.outputs.has-changes == 'true'
         id: branch
         env:
@@ -106,9 +106,18 @@ jobs:
         run: |
           # Pass the branch name via env to prevent shell injection (backticks/$() in branch names)
           # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
-          SANITIZED=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g' | cut -c1-50)
-          echo "tag=$SANITIZED" >> $GITHUB_OUTPUT
-          echo "Sanitized branch name: $SANITIZED"
+          #
+          # Budget: 41 chars of branch + the 9-char "snapshot-" prefix keeps the
+          # final tag within the 50 chars this step has always bounded it to.
+          SANITIZED=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g' | cut -c1-41 | sed 's/-$//')
+          # Every snapshot tag carries a fixed prefix, so no branch name can ever
+          # resolve to a consumer-facing dist-tag (latest/next/beta/canary). The
+          # prefix is applied AFTER sanitization: sanitizing afterwards could
+          # rewrite the prefix itself. A branch that sanitizes away to nothing
+          # still needs a valid tag, hence the fallback.
+          TAG="snapshot-${SANITIZED:-branch}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Branch $BRANCH -> dist-tag $TAG"
 
       - name: Generate changeset for changed packages
         if: steps.changes.outputs.has-changes == 'true'
@@ -192,14 +201,17 @@ jobs:
           # entries with commit/PR/contributor info. Without this token the step
           # fails with: "Please create a GitHub personal access token..."
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm changeset version --snapshot ${{ steps.branch.outputs.tag }}
+          SNAPSHOT_TAG: ${{ steps.branch.outputs.tag }}
+        run: pnpm changeset version --snapshot "$SNAPSHOT_TAG"
 
       - name: Publish snapshot
         if: steps.changes.outputs.has-changes == 'true' && steps.generate.outputs.has-publishable-packages != 'false'
         id: publish
+        env:
+          SNAPSHOT_TAG: ${{ steps.branch.outputs.tag }}
         run: |
           set -o pipefail
-          TAG="${{ steps.branch.outputs.tag }}"
+          TAG="$SNAPSHOT_TAG"
 
           # `changeset publish` publishes the changed packages in quick succession. The npm
           # registry intermittently returns "E409 Conflict - Failed to save packument" for a

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,8 +25,11 @@ jobs:
     steps:
       - name: Check repository
         id: check
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CANONICAL_REPO: ${{ vars.CANONICAL_REPO || 'MillionOnMars/lumina5' }}
         run: |
-          if [ "${{ github.repository }}" = "${{ vars.CANONICAL_REPO || 'MillionOnMars/lumina5' }}" ]; then
+          if [ "$REPOSITORY" = "$CANONICAL_REPO" ]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
@@ -61,7 +64,9 @@ jobs:
           cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Authenticate with private NPM package
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile --filter "./b4m-core/*" --filter "@bike4mind/cli"

--- a/.github/workflows/website-owasp-zap.yml
+++ b/.github/workflows/website-owasp-zap.yml
@@ -45,12 +45,70 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Both dispatch inputs are load-bearing: `stage` selects which ingest host
+      # receives the summarized report, and `target` is fetched with the WAF
+      # bypass token attached. Constrain them before anything reads them, and
+      # publish the resolved target so later steps consume the checked value
+      # rather than re-deriving it.
+      - name: Validate scan inputs
+        id: inputs
+        env:
+          PREVIEW_DOMAIN: ${{ vars.PREVIEW_SERVER_DOMAIN }}
+          PROD_TARGET_URL: ${{ vars.OWASP_ZAP_TARGET_PROD }}
+        run: |
+          if [ -n "$ZAP_STAGE" ] && ! printf '%s' "$ZAP_STAGE" | grep -qxE '(dev|production|pr[0-9]+)'; then
+            echo "::error::stage must be dev, production or prNNN"
+            exit 1
+          fi
+
+          TARGET="${ZAP_TARGET_URL:-$DEFAULT_ZAP_TARGET_URL}"
+          if [ -z "$TARGET" ]; then
+            echo "::error::no scan target: pass the target input or set the OWASP_ZAP_TARGET variable"
+            exit 1
+          fi
+
+          # https only, then strip scheme/path/port to get the bare host. A
+          # userinfo trick (https://allowed@evil.test/) leaves the "@" in HOST,
+          # which matches nothing in the allowlist below and so is rejected.
+          case "$TARGET" in
+            https://*) ;;
+            *) echo "::error::target must be an https:// URL"; exit 1 ;;
+          esac
+          HOST="${TARGET#https://}"; HOST="${HOST%%/*}"; HOST="${HOST%%:*}"
+          if ! printf '%s' "$HOST" | grep -qxE '[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?'; then
+            echo "::error::target host is not a plain hostname"
+            exit 1
+          fi
+
+          # Allowlist: the two configured scan targets, plus any preview host
+          # under the preview domain. Empty variables must never widen this, so
+          # each arm is guarded on its source being set.
+          ALLOWED=false
+          for CONFIGURED in "$DEFAULT_ZAP_TARGET_URL" "$PROD_TARGET_URL"; do
+            [ -n "$CONFIGURED" ] || continue
+            CONFIGURED_HOST="${CONFIGURED#https://}"; CONFIGURED_HOST="${CONFIGURED_HOST#http://}"
+            CONFIGURED_HOST="${CONFIGURED_HOST%%/*}"; CONFIGURED_HOST="${CONFIGURED_HOST%%:*}"
+            [ -n "$CONFIGURED_HOST" ] && [ "$HOST" = "$CONFIGURED_HOST" ] && ALLOWED=true
+          done
+          if [ -n "$PREVIEW_DOMAIN" ]; then
+            case "$HOST" in
+              *".$PREVIEW_DOMAIN") ALLOWED=true ;;
+            esac
+          fi
+          if [ "$ALLOWED" != "true" ]; then
+            echo "::error::target host $HOST is not an allowlisted scan target"
+            exit 1
+          fi
+
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "Validated target: $TARGET"
+
       - name: Verify target is reachable (2xx/3xx only)
         id: pre-check
         env:
           ZAP_BYPASS_TOKEN: ${{ secrets.ZAP_WAF_BYPASS_TOKEN }}
+          TARGET: ${{ steps.inputs.outputs.target }}
         run: |
-          TARGET="${{ env.ZAP_TARGET_URL || env.DEFAULT_ZAP_TARGET_URL }}"
           echo "Target URL: $TARGET"
           REACHABLE=false
           for attempt in 1 2 3; do
@@ -86,7 +144,7 @@ jobs:
         env:
           ZAP_BYPASS_TOKEN: ${{ secrets.ZAP_WAF_BYPASS_TOKEN }}
         with:
-          target: ${{ env.ZAP_TARGET_URL || env.DEFAULT_ZAP_TARGET_URL }}
+          target: ${{ steps.inputs.outputs.target }}
           cmd_options: '-a -T 180'
           artifact_name: 'zap-scan'
           allow_issue_writing: false
@@ -94,10 +152,13 @@ jobs:
 
       - name: Debug - Check ZAP scan results
         if: always()
+        env:
+          ZAP_OUTCOME: ${{ steps.zap-scan.outcome }}
+          ZAP_CONCLUSION: ${{ steps.zap-scan.conclusion }}
         run: |
           echo "=== ZAP Scan Step Outcome ==="
-          echo "Outcome: ${{ steps.zap-scan.outcome }}"
-          echo "Conclusion: ${{ steps.zap-scan.conclusion }}"
+          echo "Outcome: $ZAP_OUTCOME"
+          echo "Conclusion: $ZAP_CONCLUSION"
           echo ""
           echo "=== Current Directory Contents ==="
           ls -lah

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -87,6 +87,12 @@ if ! bash scripts/check-no-smart-punctuation.sh; then
   FINAL_EXIT_CODE=1
 fi
 
+# Check that no workflow interpolates ${{ }} inside a run: body
+echo "Running workflow run-interpolation check..."
+if ! python3 scripts/check-no-run-interpolation.py; then
+  FINAL_EXIT_CODE=1
+fi
+
 # Run gitleaks to check for secrets
 echo "Running gitleaks check..."
 if ! sh "$(dirname -- "$0")/gitleaks-pre-commit.sh"; then

--- a/scripts/check-no-run-interpolation.py
+++ b/scripts/check-no-run-interpolation.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fails if a workflow interpolates ${{ ... }} inside a step's `run:` body.
+
+GitHub substitutes ${{ }} into the script text before bash parses it, so any
+value carrying shell metacharacters changes what the script does. Passing the
+value through `env:` and reading it as "$VAR" hands it to bash as data instead.
+
+The rule is deliberately shaped as "no interpolation at all" rather than "no
+interpolation of untrusted values": which expressions are attacker-influenceable
+changes as triggers and inputs change, so a per-expression judgement rots while
+a blanket rule does not.
+
+Stdlib only, so it cannot degrade into a silent skip on a runner without PyYAML.
+Scanning is indentation-based, which is why it reports the `run:` line rather
+than the offending line within the script.
+
+Run in CI on every PR (ci.yml) and locally via husky pre-commit.
+
+To add a legitimate exception, add the workflow filename to EXEMPT with a
+comment saying why and when it goes away.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS = Path(".github/workflows")
+
+# pr-bot-review.yml is being reworked separately to remove the review agent's
+# general shell; its run-body interpolations go away with that change. Delete
+# this entry once that lands - it is not a standing exemption.
+EXEMPT = {"pr-bot-review.yml"}
+
+RUN_KEY = re.compile(r"^(\s*)(?:-\s+)?run:\s*(\S.*)?$")
+STEPS_KEY = re.compile(r"^(\s*)steps:\s*$")
+BLOCK_SCALAR = re.compile(r"^[|>][+-]?\d*$")
+EXPR = re.compile(r"\$\{\{\s*(.*?)\s*\}\}", re.DOTALL)
+
+
+def run_bodies(lines):
+    """Yield (line_number, body_text) for every `run:` value in a workflow.
+
+    Only `run:` keys inside a `steps:` block count. A job may itself be named
+    `run`, which sits at job-key indentation and is not a script.
+    """
+    i = 0
+    steps_indent = None
+    while i < len(lines):
+        line = lines[i]
+        stripped_indent = len(line) - len(line.lstrip())
+        steps_match = STEPS_KEY.match(line)
+        if steps_match:
+            steps_indent = len(steps_match.group(1))
+            i += 1
+            continue
+        if line.strip() and steps_indent is not None and stripped_indent <= steps_indent:
+            steps_indent = None
+        match = RUN_KEY.match(line)
+        if not match or steps_indent is None:
+            i += 1
+            continue
+        indent = len(match.group(1))
+        if indent <= steps_indent:
+            i += 1
+            continue
+        first = match.group(2) or ""
+        start = i
+        collected = [] if BLOCK_SCALAR.match(first.strip()) else [first]
+        # Both a block scalar and a wrapped inline scalar continue on the
+        # following lines that are indented deeper than the `run:` key itself.
+        i += 1
+        while i < len(lines):
+            line = lines[i]
+            if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+                break
+            collected.append(line)
+            i += 1
+        yield start + 1, "\n".join(collected)
+
+
+def main() -> int:
+    violations = []
+    for path in sorted(list(WORKFLOWS.glob("*.yml")) + list(WORKFLOWS.glob("*.yaml"))):
+        if path.name in EXEMPT:
+            continue
+        lines = path.read_text().split("\n")
+        for line_number, body in run_bodies(lines):
+            if "${{" not in body:
+                continue
+            for expr in sorted(set(EXPR.findall(body))):
+                violations.append((path, line_number, expr))
+
+    if not violations:
+        print("OK: no ${{ }} interpolation inside any run: body")
+        return 0
+
+    print("ERROR: workflow steps interpolate ${{ }} directly into a run: body.\n")
+    print("GitHub substitutes these before bash parses the script. Move each value")
+    print("to the step's env: block and read it as \"$VAR\" instead:\n")
+    print("      - name: Example")
+    print("        env:")
+    print("          MY_VALUE: ${{ inputs.something }}")
+    print("        run: echo \"$MY_VALUE\"\n")
+    for path, line_number, expr in violations:
+        print(f"  {path}:{line_number}  ->  ${{{{ {expr} }}}}")
+    print(f"\n{len(violations)} violation(s)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Covers criteria 2 and 3 of bike4mind/b4m-internal#77. That issue stays open: criterion 1 (the OIDC trust policy in `scripts/setup-github-actions.sh`) and criterion 4 (the PR-review agent's shell allowlist and process environment) are deliberately not touched here and are being handled separately.

## What changed

**Workflow values reach bash through `env:`, not through the script text.** Every step that interpolated `${{ ... }}` inside a `run:` body now declares the value in the step's `env:` block and reads it as `"$VAR"`. GitHub substitutes `${{ }}` into the script text before bash parses it, so the value became part of the program; through `env:` it arrives as data. This touched 15 workflows: `slack-notify.yml`, `website-owasp-zap.yml`, `snapshot-publish.yaml`, `ci.yml`, `e2e-ai-latency.yml`, `e2e-on-label.yml`, `e2e-run.yml`, `generate-whats-new-modal-reusable.yml`, `nightly-seed-staleness.yml`, `nightly-tsc-baseline.yml`, `prod-release.yml`, `prowler-only.yml`, `selfhost-image.yml`, `test.yaml`, and the three scan workflows below.

**Dispatch inputs are validated before anything reads them.** `website-owasp-zap.yml` gained a first step that checks `stage` against `dev|production|prNNN` and `target` against an allowlist built from the two configured scan-target variables plus any host under the preview domain, https only. It publishes the checked target as a step output so the reachability step and the ZAP action both consume the validated value instead of re-deriving it. `secrets-scan.yml`, `code-semgrep.yml` and `packages-audit.yml` already passed `stage` through job-level `env:`, so what they were missing was the format check; each now validates `stage` as its first step.

**Snapshot publishes always carry a fixed `snapshot-` dist-tag prefix**, applied after sanitization, so branch-derived tags can no longer land on a consumer-facing channel. This is the allowlist-shaped fix rather than a blocklist of reserved names: a blocklist has to be kept in step with whatever npm treats as meaningful, while a mandatory prefix cannot be escaped by any branch name. The sanitized portion is truncated to 41 characters so the final tag stays inside the 50 the step has always bounded it to, and a branch that sanitizes away to nothing falls back to `snapshot-branch` rather than a bare `snapshot-`.

**A guard keeps it from coming back.** `scripts/check-no-run-interpolation.py` fails if any workflow interpolates `${{ }}` inside a `run:` body, wired into `ci.yml` and the husky pre-commit hook. The rule is blanket rather than per-expression on purpose: which values are influenceable changes as triggers and inputs change, so a per-expression judgement rots, and a uniform rule is checkable. It is stdlib-only so it cannot degrade into a silent skip on a runner without PyYAML.

## How to prove it

Reviewers with access: the exact inputs for the first two checks are on bike4mind/b4m-internal#77 rather than here.

**Workflow values as data.** A commit message carrying shell metacharacters across multiple lines now reaches `slack-notify.yml` as data. The notification renders its first line verbatim and nothing executes.

**ZAP dispatch inputs.** Dispatch `website-owasp-zap.yml` with a malformed `stage` or a `target` that is not on the allowlist. Each fails in `Validate scan inputs`, which runs before the reachability check, so nothing downstream is contacted. `stage=dev`, `stage=production`, `stage=prNNN` and a target on a configured or preview host still pass.

**The dist-tag.** Push a branch named `latest` that touches `packages/cli/`. The publish resolves to `snapshot-latest`, so `npm dist-tag ls @bike4mind/cli` still shows `latest` at the last reviewed release. The same holds for `next`, `beta` and `canary`. Exercising the derivation directly: `latest` gives `snapshot-latest`, a branch of only punctuation gives `snapshot-branch`, and an 80-character branch gives a 50-character tag.

**The guard.** `python3 scripts/check-no-run-interpolation.py` passes on this branch and exits 1 with the file, line and offending expression when an interpolation is reintroduced.

## Verification run

`actionlint` over `.github/workflows/` reports no new findings against `origin/main`: 10 pre-existing SC2086 notes shift line and column because the surrounding scripts changed, and each still resolves to the same unquoted `$GITHUB_OUTPUT` / `$GITHUB_STEP_SUMMARY` redirect or the intentional `$PLAYWRIGHT_ARGS` word splitting it flagged before. All workflows still parse. The guard's line-based scanner was cross-checked against a PyYAML-based walk over the `origin/main` tree and agreed on all 70 interpolations found there, with no false positives and none missed.

The pre-push hook was skipped: it runs `turbo typecheck:fast` and the infra typecheck, and this branch changes no TypeScript (15 `.yml`, 2 `.yaml`, one new `.py`, one shell hook).

## Two things worth a second opinion

**`stage` accepts `staging` in the three scan workflows but not in the ZAP scan.** The ZAP scan uses the pattern named in the fix criteria, `dev|production|prNNN`, which matches its own input description. The secrets, semgrep and packages scans document `staging` in their input descriptions, so rejecting it would have been a silent functional regression, and they accept `dev|staging|production|prNNN`. The consequence for ZAP is that a dispatch passing `staging` or `main`, which the workflow's inline comment contemplates, now fails validation. Behaviourally those values were already indistinguishable from `dev` or from leaving the field empty, so nothing is lost beyond having to pass a listed value, but the divergence between the two regexes is deliberate rather than an oversight and can be unified either way.

**`ci.yml` keeps word splitting on the test-shard arguments.** `SHARD_FILTER`, `SHARD_SCRIPT` and `SHARD_ARGS` are read unquoted with a `shellcheck disable=SC2086`, because each carries several arguments and the splitting is what makes the shard matrix work. Those values are literals in the workflow file rather than inputs, so this is a readability trade-off and not a gap, but it is the one place the "consume it as `"$VAR"`" rule is not followed literally.

## Not in scope

`pr-bot-review.yml` is untouched and is the guard's only exemption, since its `run:` bodies are reworked by criterion 4. Whoever picks up criterion 4 should delete the `EXEMPT` entry in `scripts/check-no-run-interpolation.py` when that lands; the comment there says so, and bike4mind/b4m-internal#77 carries the detail.

A note on the criterion 4 file list: the two files named there, `daily-pr-review.yml` and `latest-pr-refresh.yml`, do not exist in this repository. They live in the polaris repo, so there was no overlap to avoid here and nothing was left behind on their account. Corrected on the issue.
