### PR TITLE
fix(sre): bind tracking mutations to their repo, deny-by-default approval, escape issue bodies

### DIFF
--- a/apps/client/__tests__/api/sre/workflow-callback.test.ts
+++ b/apps/client/__tests__/api/sre/workflow-callback.test.ts
@@ -127,6 +127,9 @@ describe('workflow-callback handler', () => {
     });
     mockDecryptSecret.mockReturnValue('valid-token');
     mockResolveFullConfig.mockReturnValue({ slack: { approverIds: '' } });
+    // The handler confirms the tracking doc belongs to the authenticated repo
+    // before doing anything, so every case needs an owned doc by default.
+    mockFindFullById.mockResolvedValue({ id: 'track-1', repoSlug: 'MillionOnMars/lumina5', status: 'fixing' });
   });
 
   describe('auth', () => {
@@ -164,6 +167,71 @@ describe('workflow-callback handler', () => {
     });
   });
 
+  describe('tracking document ownership', () => {
+    it('rejects a trackingId belonging to another repo without touching state', async () => {
+      mockFindFullById.mockResolvedValue({ id: 'track-1', repoSlug: 'other-owner/other-repo', status: 'fixing' });
+
+      const { req, res } = createMockReqRes({
+        fingerprint: 'fp-123',
+        trackingId: 'track-1',
+        repoSlug: 'MillionOnMars/lumina5',
+        status: 'success',
+        prNumber: 10,
+        prUrl: 'https://github.com/org/repo/pull/10',
+      });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+      expect(mockAtomicTransition).not.toHaveBeenCalled();
+      expect(mockClaimCiRetry).not.toHaveBeenCalled();
+      expect(mockUpsertFromFix).not.toHaveBeenCalled();
+      expect(mockSendToQueue).not.toHaveBeenCalled();
+      expect(mockPostSreFixSuccessMessage).not.toHaveBeenCalled();
+      expect(mockAddIssueComment).not.toHaveBeenCalled();
+    });
+
+    it('rejects a recoverable CI callback for another repo without escalating', async () => {
+      mockFindFullById.mockResolvedValue({ id: 'track-1', repoSlug: 'other-owner/other-repo', status: 'fixing' });
+      mockResolveFullConfig.mockReturnValue({ slack: { approverIds: '' }, maxCiRetries: 2 });
+
+      const { req, res } = createMockReqRes({
+        fingerprint: 'fp-123',
+        trackingId: 'track-1',
+        repoSlug: 'MillionOnMars/lumina5',
+        status: 'failure',
+        recoverable: true,
+        failureReason: 'typecheck failed',
+      });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(mockClaimCiRetry).not.toHaveBeenCalled();
+      expect(mockAtomicTransition).not.toHaveBeenCalled();
+      expect(mockPostSreFixFailureMessage).not.toHaveBeenCalled();
+      expect(mockAddIssueComment).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown trackingId', async () => {
+      mockFindFullById.mockResolvedValue(null);
+
+      const { req, res } = createMockReqRes({
+        fingerprint: 'fp-123',
+        trackingId: 'nope',
+        status: 'success',
+        prNumber: 10,
+        prUrl: 'https://github.com/org/repo/pull/10',
+      });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(mockAtomicTransition).not.toHaveBeenCalled();
+    });
+  });
+
   describe('success callback', () => {
     it('should transition fixing → fixed and return ok', async () => {
       const transitionedDoc = {
@@ -189,7 +257,7 @@ describe('workflow-callback handler', () => {
 
       await handler(req, res);
 
-      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'fixing', 'fixed', {
+      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'MillionOnMars/lumina5', 'fixing', 'fixed', {
         fixPrNumber: 42,
         workflowRunUrl: 'https://github.com/MillionOnMars/lumina5/actions/runs/1',
       });
@@ -279,7 +347,7 @@ describe('workflow-callback handler', () => {
 
       await handler(req, res);
 
-      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'fixing', 'failed', {
+      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'MillionOnMars/lumina5', 'fixing', 'failed', {
         workflowRunUrl: undefined,
         errorMessage: 'Build failed',
       });
@@ -340,7 +408,7 @@ describe('workflow-callback handler', () => {
     it('does not dispatch when the CI retry cap is exhausted', async () => {
       mockResolveFullConfig.mockReturnValue({ slack: {}, defaultBranch: 'main', maxCiRetries: 3 });
       mockClaimCiRetry.mockResolvedValue(null); // claim failed
-      mockFindFullById.mockResolvedValue({ status: 'fixing', errorMessage: 'boom' }); // still fixing -> cap exhausted
+      mockFindFullById.mockResolvedValue({ repoSlug: 'MillionOnMars/lumina5', status: 'fixing', errorMessage: 'boom' }); // still fixing -> cap exhausted
 
       const { req, res } = createMockReqRes({
         fingerprint: 'fp-123',
@@ -366,6 +434,7 @@ describe('workflow-callback handler', () => {
       // claimCiRetry returns null (cap reached) and the doc is still 'fixing' -> cap-exhausted path.
       mockClaimCiRetry.mockResolvedValue(null);
       mockFindFullById.mockResolvedValue({
+        repoSlug: 'MillionOnMars/lumina5',
         status: 'fixing',
         errorMessage: 'tests failing',
         githubIssueNumber: 777,
@@ -386,6 +455,7 @@ describe('workflow-callback handler', () => {
 
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-1',
+        'MillionOnMars/lumina5',
         'fixing',
         'failed',
         expect.objectContaining({ errorMessage: expect.stringContaining('CI retry cap reached') })
@@ -410,6 +480,7 @@ describe('workflow-callback handler', () => {
       // and a githubIssueNumber. The escalation comment should land on the PR, not the issue.
       mockClaimCiRetry.mockResolvedValue(null);
       mockFindFullById.mockResolvedValue({
+        repoSlug: 'MillionOnMars/lumina5',
         status: 'fixing',
         errorMessage: 'tests failing',
         githubIssueNumber: 777,
@@ -438,7 +509,11 @@ describe('workflow-callback handler', () => {
 
     it('skips the GH comment when there is no source issue (CloudWatch-only)', async () => {
       mockClaimCiRetry.mockResolvedValue(null);
-      mockFindFullById.mockResolvedValue({ status: 'fixing', errorMessage: 'tests failing' }); // no githubIssueNumber
+      mockFindFullById.mockResolvedValue({
+        repoSlug: 'MillionOnMars/lumina5',
+        status: 'fixing',
+        errorMessage: 'tests failing',
+      }); // no githubIssueNumber
       mockAtomicTransition.mockResolvedValue({ id: 'track-1' });
 
       const { req, res } = createMockReqRes({
@@ -570,7 +645,7 @@ describe('workflow-callback handler', () => {
 
       await handler(req, res);
 
-      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'fixing', 'already_fixed', {
+      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'MillionOnMars/lumina5', 'fixing', 'already_fixed', {
         workflowRunUrl: 'https://github.com/MillionOnMars/lumina5/actions/runs/1',
       });
       expect(res.status).toHaveBeenCalledWith(200);
@@ -740,7 +815,7 @@ describe('workflow-callback handler', () => {
 
       await handler(req, res);
 
-      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'fixing', 'failed', {
+      expect(mockAtomicTransition).toHaveBeenCalledWith('track-1', 'MillionOnMars/lumina5', 'fixing', 'failed', {
         workflowRunUrl: undefined,
         errorMessage: 'Workflow failed',
       });

--- a/apps/client/__tests__/integrations/slack/sreSlackApproval.test.ts
+++ b/apps/client/__tests__/integrations/slack/sreSlackApproval.test.ts
@@ -14,6 +14,7 @@ import {
 const mockGetSettingsValue = vi.fn();
 const mockFindFullById = vi.fn();
 const mockFindByIdWithToken = vi.fn();
+const mockAtomicTransition = vi.fn();
 const mockPostMessage = vi.fn().mockResolvedValue({ ok: true });
 
 vi.mock('@slack/web-api', () => ({
@@ -32,7 +33,7 @@ vi.mock('@bike4mind/database', () => ({
   sreErrorTrackingRepository: {
     findById: vi.fn(),
     findFullById: (...args: unknown[]) => mockFindFullById(...args),
-    atomicTransition: vi.fn(),
+    atomicTransition: (...args: unknown[]) => mockAtomicTransition(...args),
   },
   slackDevWorkspaceRepository: {
     findByIdWithToken: (...args: unknown[]) => mockFindByIdWithToken(...args),
@@ -317,15 +318,46 @@ describe('handleSreApprovalAction — authorization', () => {
   beforeEach(() => {
     mockFindFullById.mockResolvedValue({ repoSlug: 'MillionOnMars/lumina5' });
     mockGetSettingsValue.mockResolvedValue({ repos: [] });
+    mockAtomicTransition.mockReset();
+    mockAtomicTransition.mockResolvedValue(null);
   });
 
-  it('empty approverIds → anyone can approve', async () => {
-    mockResolveFullConfig.mockReturnValue({ slack: { approverIds: '' } });
+  it('unset approverIds → nobody can approve', async () => {
+    mockResolveFullConfig.mockReturnValue({ slack: {} });
 
     const result = await handleSreApprovalAction('sre_approve_fix', trackingId, { id: 'U_RANDOM' });
 
-    // Auth passed - response may be undefined text (downstream error) but NOT the unauthorized message
-    expect(String(result.response.text ?? '')).not.toContain(':no_entry:');
+    expect(result.response.text).toContain(':no_entry:');
+    expect(result.deferred).toBeUndefined();
+    expect(mockAtomicTransition).not.toHaveBeenCalled();
+  });
+
+  it('empty approverIds → nobody can approve', async () => {
+    mockResolveFullConfig.mockReturnValue({ slack: { approverIds: '   ' } });
+
+    const result = await handleSreApprovalAction('sre_approve_fix', trackingId, { id: 'U_RANDOM' });
+
+    expect(result.response.text).toContain(':no_entry:');
+    expect(result.deferred).toBeUndefined();
+    expect(mockAtomicTransition).not.toHaveBeenCalled();
+  });
+
+  it('unconfigured repo → nobody can approve', async () => {
+    mockResolveFullConfig.mockReturnValue(null);
+
+    const result = await handleSreApprovalAction('sre_approve_fix', trackingId, { id: 'U_RANDOM' });
+
+    expect(result.response.text).toContain(':no_entry:');
+    expect(mockAtomicTransition).not.toHaveBeenCalled();
+  });
+
+  it('unset approverIds → nobody can reject either', async () => {
+    mockResolveFullConfig.mockReturnValue({ slack: {} });
+
+    const result = await handleSreApprovalAction('sre_reject_fix', trackingId, { id: 'U_RANDOM' });
+
+    expect(result.response.text).toContain(':no_entry:');
+    expect(mockAtomicTransition).not.toHaveBeenCalled();
   });
 
   it('configured approverIds → authorized user proceeds', async () => {
@@ -334,6 +366,14 @@ describe('handleSreApprovalAction — authorization', () => {
     const result = await handleSreApprovalAction('sre_approve_fix', trackingId, { id: 'U01' });
 
     expect(String(result.response.text ?? '')).not.toContain(':no_entry:');
+    await result.deferred;
+    expect(mockAtomicTransition).toHaveBeenCalledWith(
+      trackingId,
+      'MillionOnMars/lumina5',
+      'awaiting_approval',
+      'fixing',
+      expect.objectContaining({ dispatchedAt: expect.any(Date) })
+    );
   });
 
   it('configured approverIds → unauthorized user rejected', async () => {
@@ -342,6 +382,7 @@ describe('handleSreApprovalAction — authorization', () => {
     const result = await handleSreApprovalAction('sre_approve_fix', trackingId, { id: 'U99' });
 
     expect(result.response.text).toContain(':no_entry:');
+    expect(mockAtomicTransition).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/pages/api/sre/workflow-callback.ts
+++ b/apps/client/pages/api/sre/workflow-callback.ts
@@ -129,6 +129,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(404).json({ error: 'Repo not configured' });
     }
 
+    // The callback token authenticates a repo, not a document. trackingId is
+    // caller-supplied, so confirm the doc belongs to the authenticated repo before
+    // any state transition, pattern write or notification. The repo-bound filters in
+    // atomicTransition/claimCiRetry below are the backstop; this check exists because
+    // a bare null return from those is indistinguishable from an idempotent duplicate,
+    // and the claimCiRetry null branch would otherwise still write state and notify.
+    // 404 rather than 403: do not confirm the existence of another repo's document.
+    const owned = await sreErrorTrackingRepository.findFullById(body.trackingId);
+    if (!owned || owned.repoSlug !== callbackRepoSlug) {
+      logger.warn('[SRE-CALLBACK] Tracking document does not belong to the authenticated repo', {
+        trackingId: body.trackingId,
+        authenticatedRepoSlug: callbackRepoSlug,
+      });
+      return res.status(404).json({ error: 'Not found' });
+    }
+
     logger.info('[SRE-CALLBACK] Processing workflow callback', {
       trackingId: body.trackingId,
       status: body.status,
@@ -148,10 +164,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Idempotent: atomicTransition only succeeds if status is still 'fixing'.
       // Duplicate callbacks (GitHub retry) get null and return 200 to stop retry chain.
-      const transitioned = await sreErrorTrackingRepository.atomicTransition(body.trackingId, 'fixing', 'fixed', {
-        fixPrNumber: body.prNumber,
-        workflowRunUrl: body.workflowRunUrl,
-      });
+      const transitioned = await sreErrorTrackingRepository.atomicTransition(
+        body.trackingId,
+        callbackRepoSlug,
+        'fixing',
+        'fixed',
+        {
+          fixPrNumber: body.prNumber,
+          workflowRunUrl: body.workflowRunUrl,
+        }
+      );
       if (!transitioned) {
         logger.info('[SRE-CALLBACK] Already processed (idempotent skip)', { trackingId: body.trackingId });
         return res.status(200).json({ ok: true, duplicate: true });
@@ -163,7 +185,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       try {
         if (transitioned.diagnosisResult && transitioned.diagnosisResult.confidence >= 70) {
           const errorType = transitioned.errorMessage?.split(':')[0]?.trim() || 'Unknown';
-          await sreErrorPatternRepository.upsertFromFix(body.fingerprint, transitioned.repoSlug, {
+          await sreErrorPatternRepository.upsertFromFix(body.fingerprint, callbackRepoSlug, {
             name: `${errorType} in ${transitioned.diagnosisResult.affectedFiles[0]?.filePath || 'unknown'}`,
             errorMessage: transitioned.errorMessage || '',
             diagnosis: transitioned.diagnosisResult,
@@ -202,6 +224,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     } else if (body.status === 'already_fixed') {
       const transitioned = await sreErrorTrackingRepository.atomicTransition(
         body.trackingId,
+        callbackRepoSlug,
         'fixing',
         'already_fixed',
         {
@@ -262,7 +285,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     } else {
       // Recoverable CI failures (typecheck/apply-fix) - route to revision queue for re-diagnosis
       if (body.recoverable) {
-        const claimed = await sreErrorTrackingRepository.claimCiRetry(body.trackingId, repoConfig.maxCiRetries);
+        const claimed = await sreErrorTrackingRepository.claimCiRetry(
+          body.trackingId,
+          callbackRepoSlug,
+          repoConfig.maxCiRetries
+        );
 
         if (!claimed) {
           // Distinguish cap exhaustion from true duplicate:
@@ -275,7 +302,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               trackingId: body.trackingId,
               maxCiRetries: repoConfig.maxCiRetries,
             });
-            await sreErrorTrackingRepository.atomicTransition(body.trackingId, 'fixing', 'failed', {
+            await sreErrorTrackingRepository.atomicTransition(body.trackingId, callbackRepoSlug, 'fixing', 'failed', {
               workflowRunUrl: body.workflowRunUrl,
               errorMessage: `CI retry cap reached (${repoConfig.maxCiRetries} retries)`,
             });
@@ -345,10 +372,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             trackingId: body.trackingId,
           });
           // Transition back to failed since we cannot retry without a diagnosis
-          await sreErrorTrackingRepository.atomicTransition(body.trackingId, 'revision_requested', 'failed', {
-            workflowRunUrl: body.workflowRunUrl,
-            errorMessage: body.failureReason || 'Workflow failed (no diagnosis to retry)',
-          });
+          await sreErrorTrackingRepository.atomicTransition(
+            body.trackingId,
+            callbackRepoSlug,
+            'revision_requested',
+            'failed',
+            {
+              workflowRunUrl: body.workflowRunUrl,
+              errorMessage: body.failureReason || 'Workflow failed (no diagnosis to retry)',
+            }
+          );
           return res.status(200).json({ ok: true });
         } else {
           const revisionRequest: SreRevisionRequest = {
@@ -390,10 +423,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
       }
 
-      const transitioned = await sreErrorTrackingRepository.atomicTransition(body.trackingId, 'fixing', 'failed', {
-        workflowRunUrl: body.workflowRunUrl,
-        errorMessage: body.failureReason || 'Workflow failed',
-      });
+      const transitioned = await sreErrorTrackingRepository.atomicTransition(
+        body.trackingId,
+        callbackRepoSlug,
+        'fixing',
+        'failed',
+        {
+          workflowRunUrl: body.workflowRunUrl,
+          errorMessage: body.failureReason || 'Workflow failed',
+        }
+      );
       if (!transitioned) {
         logger.info('[SRE-CALLBACK] Already processed (idempotent skip)', { trackingId: body.trackingId });
         return res.status(200).json({ ok: true, duplicate: true });

--- a/apps/client/server/cron/sreStaleDispatch.test.ts
+++ b/apps/client/server/cron/sreStaleDispatch.test.ts
@@ -79,15 +79,17 @@ describe('sreStaleDispatch cron', () => {
   });
 
   it('should blame GitHub Actions when the dispatch reached GitHub', async () => {
-    mockFindStaleDispatches.mockResolvedValue([{ id: 'doc-1', errorFingerprint: 'fp-1', githubRunDispatched: true }]);
+    mockFindStaleDispatches.mockResolvedValue([
+      { id: 'doc-1', repoSlug: 'acme/widgets', errorFingerprint: 'fp-1', githubRunDispatched: true },
+    ]);
 
     const result = await handler();
 
     expect(mockFindStaleDispatches).toHaveBeenCalledWith(20);
-    expect(mockAtomicTransition).toHaveBeenCalledWith('doc-1', 'fixing', 'failed', {
+    expect(mockAtomicTransition).toHaveBeenCalledWith('doc-1', 'acme/widgets', 'fixing', 'failed', {
       errorMessage: expect.stringContaining('timed out after 20 minutes'),
     });
-    const { errorMessage } = mockAtomicTransition.mock.calls[0][3];
+    const { errorMessage } = mockAtomicTransition.mock.calls[0][4];
     expect(errorMessage).toContain('dispatched to GitHub Actions but no callback received');
     expect(errorMessage).not.toContain('sreFix handler never dispatched');
     expect(result.transitioned).toBe(1);
@@ -97,11 +99,11 @@ describe('sreStaleDispatch cron', () => {
   // githubRunDispatched absent, and the old message blamed GitHub Actions for a
   // dispatch that never happened.
   it('should blame the sreFix handler when githubRunDispatched is absent', async () => {
-    mockFindStaleDispatches.mockResolvedValue([{ id: 'doc-1', errorFingerprint: 'fp-1' }]);
+    mockFindStaleDispatches.mockResolvedValue([{ id: 'doc-1', repoSlug: 'acme/widgets', errorFingerprint: 'fp-1' }]);
 
     const result = await handler();
 
-    const { errorMessage } = mockAtomicTransition.mock.calls[0][3];
+    const { errorMessage } = mockAtomicTransition.mock.calls[0][4];
     expect(errorMessage).toContain('timed out after 20 minutes');
     expect(errorMessage).toContain('sreFix handler never dispatched to GitHub');
     expect(errorMessage).not.toContain('no callback received');
@@ -111,25 +113,27 @@ describe('sreStaleDispatch cron', () => {
   // A revision cycle resets githubRunDispatched to false, so explicit false must
   // read the same as absent rather than falling through to the dispatched branch.
   it('should treat githubRunDispatched: false as never dispatched', async () => {
-    mockFindStaleDispatches.mockResolvedValue([{ id: 'doc-1', errorFingerprint: 'fp-1', githubRunDispatched: false }]);
+    mockFindStaleDispatches.mockResolvedValue([
+      { id: 'doc-1', repoSlug: 'acme/widgets', errorFingerprint: 'fp-1', githubRunDispatched: false },
+    ]);
 
     await handler();
 
-    const { errorMessage } = mockAtomicTransition.mock.calls[0][3];
+    const { errorMessage } = mockAtomicTransition.mock.calls[0][4];
     expect(errorMessage).toContain('sreFix handler never dispatched to GitHub');
     expect(errorMessage).not.toContain('no callback received');
   });
 
   it('should timeout stale analyzing docs after 10 min', async () => {
     mockFindStaleByStatus.mockImplementation((status: string) => {
-      if (status === 'analyzing') return Promise.resolve([{ id: 'doc-2' }]);
+      if (status === 'analyzing') return Promise.resolve([{ id: 'doc-2', repoSlug: 'acme/widgets' }]);
       return Promise.resolve([]);
     });
 
     const result = await handler();
 
     expect(mockFindStaleByStatus).toHaveBeenCalledWith('analyzing', 10);
-    expect(mockAtomicTransition).toHaveBeenCalledWith('doc-2', 'analyzing', 'failed', {
+    expect(mockAtomicTransition).toHaveBeenCalledWith('doc-2', 'acme/widgets', 'analyzing', 'failed', {
       errorMessage: expect.stringContaining('Analysis timed out'),
     });
     expect(result.transitioned).toBe(1);
@@ -141,6 +145,7 @@ describe('sreStaleDispatch cron', () => {
         return Promise.resolve([
           {
             id: 'doc-3',
+            repoSlug: 'acme/widgets',
             updatedAt: new Date(Date.now() - 13 * 60 * 60 * 1000), // 13h ago — exceeds 12h timeout
           },
         ]);
@@ -150,9 +155,15 @@ describe('sreStaleDispatch cron', () => {
     const result = await handler();
 
     expect(mockFindStaleByStatus).toHaveBeenCalledWith('awaiting_approval', 720);
-    expect(mockAtomicTransition).toHaveBeenCalledWith('doc-3', 'awaiting_approval', 'approval_expired', {
-      errorMessage: expect.stringContaining('Approval timed out after 12h'),
-    });
+    expect(mockAtomicTransition).toHaveBeenCalledWith(
+      'doc-3',
+      'acme/widgets',
+      'awaiting_approval',
+      'approval_expired',
+      {
+        errorMessage: expect.stringContaining('Approval timed out after 12h'),
+      }
+    );
     expect(result.transitioned).toBe(1);
   });
 

--- a/apps/client/server/cron/sreStaleDispatch.ts
+++ b/apps/client/server/cron/sreStaleDispatch.ts
@@ -52,7 +52,7 @@ export async function handler() {
 
       // Use atomicTransition (CAS) instead of updateStatus to prevent race with
       // Surgeon callback that may have already transitioned fixing -> fixed.
-      const result = await sreErrorTrackingRepository.atomicTransition(doc.id, 'fixing', 'failed', {
+      const result = await sreErrorTrackingRepository.atomicTransition(doc.id, doc.repoSlug, 'fixing', 'failed', {
         errorMessage,
       });
       if (!result) continue; // Callback already transitioned it — skip
@@ -71,7 +71,7 @@ export async function handler() {
   const staleAnalyzing = await sreErrorTrackingRepository.findStaleByStatus('analyzing', ANALYZING_TIMEOUT_MINUTES);
   for (const doc of staleAnalyzing) {
     try {
-      const result = await sreErrorTrackingRepository.atomicTransition(doc.id, 'analyzing', 'failed', {
+      const result = await sreErrorTrackingRepository.atomicTransition(doc.id, doc.repoSlug, 'analyzing', 'failed', {
         errorMessage: 'Analysis timed out — Lambda may have crashed',
       });
       if (result) {
@@ -90,9 +90,15 @@ export async function handler() {
   );
   for (const doc of staleRevisions) {
     try {
-      const result = await sreErrorTrackingRepository.atomicTransition(doc.id, 'revision_requested', 'failed', {
-        errorMessage: 'Revision timed out — Lambda may have crashed',
-      });
+      const result = await sreErrorTrackingRepository.atomicTransition(
+        doc.id,
+        doc.repoSlug,
+        'revision_requested',
+        'failed',
+        {
+          errorMessage: 'Revision timed out - Lambda may have crashed',
+        }
+      );
       if (result) {
         transitioned++;
         logger.warn('[SRE-STALE-DISPATCH] Revision timed out', { trackingId: doc.id });
@@ -133,6 +139,7 @@ export async function handler() {
 
       const result = await sreErrorTrackingRepository.atomicTransition(
         doc.id,
+        docRepoSlug,
         'awaiting_approval',
         'approval_expired',
         {

--- a/apps/client/server/integrations/github/sreRevisionDispatch.test.ts
+++ b/apps/client/server/integrations/github/sreRevisionDispatch.test.ts
@@ -117,7 +117,7 @@ describe('dispatchReviewToSreRevision', () => {
 
     expect(result.dispatched).toBe(true);
     expect(mockFindByPrNumber).toHaveBeenCalledWith(42, 'owner/repo');
-    expect(mockClaimRevision).toHaveBeenCalledWith('track-1', 2);
+    expect(mockClaimRevision).toHaveBeenCalledWith('track-1', 'owner/repo', 2);
     expect(mockSendToQueue).toHaveBeenCalledWith(
       'https://sqs.us-east-2.amazonaws.com/123/sreJobQueue',
       expect.objectContaining({

--- a/apps/client/server/integrations/github/sreRevisionDispatch.ts
+++ b/apps/client/server/integrations/github/sreRevisionDispatch.ts
@@ -105,8 +105,10 @@ export async function dispatchReviewToSreRevision(
   const rawConfig = await adminSettingsRepository.getSettingsValue('sreAgentConfig');
   const config = SreAgentConfigSchema.parse(rawConfig ?? {});
 
-  const repoSlug = review.repository?.full_name;
-  const repoConfig = resolveFullConfig(config, repoSlug ?? '');
+  // '' never resolves to a configured repo, so a non-null repoConfig proves the
+  // webhook named a repo we know - which is what the claim below is bound to.
+  const repoSlug = review.repository?.full_name ?? '';
+  const repoConfig = resolveFullConfig(config, repoSlug);
 
   if (!repoConfig) {
     logger?.info('[SRE-REVISION] Repo not configured, skipping revision');
@@ -144,7 +146,7 @@ export async function dispatchReviewToSreRevision(
   }
 
   // 7. Atomic claim: fixed -> revision_requested (handles dupes, cap, merged-PR guard)
-  const claimed = await sreErrorTrackingRepository.claimRevision(tracking.id, repoConfig.maxRevisions);
+  const claimed = await sreErrorTrackingRepository.claimRevision(tracking.id, repoSlug, repoConfig.maxRevisions);
 
   if (!claimed) {
     // Check if we hit the revision cap - if so, escalate to human

--- a/apps/client/server/integrations/slack/sreSlackApproval.ts
+++ b/apps/client/server/integrations/slack/sreSlackApproval.ts
@@ -646,34 +646,31 @@ export async function postSreTimeoutSummaryMessage(
 }
 
 /**
- * Get allowed approver IDs from the SRE config (admin settings).
- * Resolves per-repo slack config using the tracking doc's repoSlug.
- * Returns empty array if not configured (anyone can approve).
+ * Resolve the tracking doc's repo and that repo's allowed approver IDs from the
+ * SRE config (admin settings). `approverIds` is empty when the repo is
+ * unconfigured or no approvers are set; callers must treat that as "nobody may
+ * approve", never as "anyone may". `repoSlug` is the repo the subsequent state
+ * transition is bound to, so it is resolved here rather than read back off the
+ * document the transition returns.
  */
-async function getAllowedApproverIds(trackingId?: string): Promise<string[]> {
+async function resolveApprovalContext(trackingId: string): Promise<{ repoSlug: string; approverIds: string[] }> {
   const rawConfig = await adminSettingsRepository.getSettingsValue('sreAgentConfig');
   const sreConfig = SreAgentConfigSchema.parse(rawConfig ?? {});
 
-  // Resolve per-repo slack config if we have a tracking doc with repoSlug
-  let repoSlug = SRE_DEFAULT_REPO_SLUG;
-  if (trackingId) {
-    const tracking = await sreErrorTrackingRepository.findFullById(trackingId);
-    if (tracking?.repoSlug) {
-      repoSlug = tracking.repoSlug;
-    }
-  }
+  const tracking = await sreErrorTrackingRepository.findFullById(trackingId);
+  const repoSlug = tracking?.repoSlug ?? SRE_DEFAULT_REPO_SLUG;
+
   const repoConfig = resolveFullConfig(sreConfig, repoSlug);
-  if (!repoConfig) return [];
+  if (!repoConfig) return { repoSlug, approverIds: [] };
 
   const configApprovers = repoConfig.slack?.approverIds || '';
-  if (configApprovers.trim()) {
-    return configApprovers
+  return {
+    repoSlug,
+    approverIds: configApprovers
       .split(',')
       .map((s: string) => s.trim())
-      .filter(Boolean);
-  }
-
-  return [];
+      .filter(Boolean),
+  };
 }
 
 /**
@@ -702,6 +699,7 @@ async function sendSlackResponse(responseUrl: string, message: Record<string, un
 async function processApprovalAsync(
   actionId: string,
   trackingId: string,
+  repoSlug: string,
   user: { id: string; name?: string },
   responseUrl?: string
 ): Promise<void> {
@@ -717,15 +715,18 @@ async function processApprovalAsync(
 
       // Atomic state transition: only proceed if still awaiting_approval.
       // Include dispatchedAt atomically to prevent gap if Lambda crashes between transition and updateStatus.
-      const tracking = await sreErrorTrackingRepository.atomicTransition(trackingId, 'awaiting_approval', 'fixing', {
-        dispatchedAt: new Date(),
-      });
+      const tracking = await sreErrorTrackingRepository.atomicTransition(
+        trackingId,
+        repoSlug,
+        'awaiting_approval',
+        'fixing',
+        { dispatchedAt: new Date() }
+      );
       if (!tracking) {
         await respond({ text: ':warning: This fix request has already been processed.' });
         return;
       }
 
-      const repoSlug = tracking.repoSlug ?? SRE_DEFAULT_REPO_SLUG;
       const repoConfig = resolveFullConfig(sreConfig, repoSlug);
 
       if (!repoConfig) {
@@ -769,7 +770,12 @@ async function processApprovalAsync(
       await respond({ text: `:white_check_mark: Fix approved by <@${user.id}>. Dispatched to Surgeon.` });
     } else {
       // sre_reject_fix - atomic transition from awaiting_approval
-      const tracking = await sreErrorTrackingRepository.atomicTransition(trackingId, 'awaiting_approval', 'wont_fix');
+      const tracking = await sreErrorTrackingRepository.atomicTransition(
+        trackingId,
+        repoSlug,
+        'awaiting_approval',
+        'wont_fix'
+      );
       if (!tracking) {
         await respond({ text: ':warning: This fix request has already been processed.' });
         return;
@@ -795,7 +801,8 @@ async function processApprovalAsync(
  * Returns an immediate response (within Slack's 3-second deadline) and processes
  * the actual approval asynchronously via response_url.
  *
- * Authorization: checks approver against config approverIds.
+ * Authorization: checks approver against config approverIds, denying by default
+ * when that list is empty or unset.
  * Atomic: uses findOneAndUpdate to transition status, preventing double-approve.
  */
 export async function handleSreApprovalAction(
@@ -808,12 +815,28 @@ export async function handleSreApprovalAction(
     return { response: { text: 'Missing tracking ID.', response_type: 'ephemeral' } };
   }
 
-  // Authorization check (fast - can run synchronously before the 3s deadline)
-  const allowedApprovers = await getAllowedApproverIds(trackingId);
-  if (allowedApprovers.length > 0 && !allowedApprovers.includes(user.id)) {
+  // Authorization check (fast - can run synchronously before the 3s deadline).
+  // An empty allowlist denies everyone: an unconfigured repo must not fall back
+  // to letting any workspace member drive the fix pipeline.
+  const { repoSlug, approverIds } = await resolveApprovalContext(trackingId);
+  if (approverIds.length === 0) {
+    logger.warn('[SRE-SLACK-APPROVAL] Approval denied - no approvers configured', {
+      userId: user.id,
+      userName: user.name,
+      trackingId,
+    });
+    return {
+      response: {
+        response_type: 'ephemeral',
+        text: ':no_entry: No SRE approvers are configured for this repo. Set approver Slack IDs in the SRE agent admin settings.',
+      },
+    };
+  }
+  if (!approverIds.includes(user.id)) {
     logger.warn('[SRE-SLACK-APPROVAL] Unauthorized approval attempt', {
       userId: user.id,
       userName: user.name,
+      trackingId,
     });
     return {
       response: {
@@ -836,7 +859,7 @@ export async function handleSreApprovalAction(
 
   // Return response + deferred work. Caller awaits deferred after res.json()
   // to prevent Lambda freeze from killing it mid-flight.
-  const deferred = processApprovalAsync(actionId, trackingId, user, responseUrl).catch(err => {
+  const deferred = processApprovalAsync(actionId, trackingId, repoSlug, user, responseUrl).catch(err => {
     logger.error('[SRE-SLACK-APPROVAL] Async processing failed', { error: err, trackingId });
     if (responseUrl) {
       sendSlackResponse(responseUrl, {

--- a/apps/client/server/integrations/sre/escalation.ts
+++ b/apps/client/server/integrations/sre/escalation.ts
@@ -16,7 +16,7 @@
  *     is not re-used on future occurrences.
  *
  * Exactly-once semantics: callers invoke this helper ONLY after a successful
- * `atomicTransition(id, 'analyzing', 'recurrence_detected', ...)` CAS, which
+ * `atomicTransition(id, repoSlug, 'analyzing', 'recurrence_detected', ...)` CAS, which
  * guarantees a single execution per tracking doc even under SQS redelivery.
  */
 

--- a/apps/client/server/queueHandlers/sreAnalysis.ts
+++ b/apps/client/server/queueHandlers/sreAnalysis.ts
@@ -309,6 +309,7 @@ export async function runSreAnalysis(payload: SreEventPayload, logger: Logger): 
       // Atomic CAS ensures exactly-once side-effect emission even under SQS redelivery.
       const transitioned = await sreErrorTrackingRepository.atomicTransition(
         tracking.id,
+        repoSlug,
         'analyzing',
         'recurrence_detected',
         {
@@ -388,6 +389,7 @@ export async function runSreAnalysis(payload: SreEventPayload, logger: Logger): 
     const priorPrNumbers = priorFixHistory.map(h => h.prNumber);
     const transitioned = await sreErrorTrackingRepository.atomicTransition(
       tracking.id,
+      repoSlug,
       'analyzing',
       'recurrence_detected',
       {

--- a/apps/client/server/queueHandlers/sreRevision.test.ts
+++ b/apps/client/server/queueHandlers/sreRevision.test.ts
@@ -200,6 +200,7 @@ describe('sreRevision handler', () => {
 
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'wont_fix',
         expect.objectContaining({
@@ -208,6 +209,7 @@ describe('sreRevision handler', () => {
       );
       expect(mockAtomicTransition).not.toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'fixing',
         expect.anything()
@@ -234,6 +236,7 @@ describe('sreRevision handler', () => {
 
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'wont_fix',
         expect.any(Object)
@@ -367,6 +370,7 @@ describe('sreRevision handler', () => {
       // CAS attempted; no follow-up side effects since we lost the race
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'wont_fix',
         expect.any(Object)
@@ -399,6 +403,7 @@ describe('sreRevision handler', () => {
       // Still transitioned to wont_fix
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'wont_fix',
         expect.any(Object)
@@ -420,6 +425,7 @@ describe('sreRevision handler', () => {
 
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'fixing',
         expect.any(Object)
@@ -476,6 +482,7 @@ describe('sreRevision handler', () => {
 
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'failed',
         expect.any(Object)
@@ -524,6 +531,7 @@ describe('sreRevision handler', () => {
 
       expect(mockAtomicTransition).toHaveBeenCalledWith(
         'track-123',
+        'MillionOnMars/lumina5',
         'revision_requested',
         'failed',
         expect.objectContaining({ errorMessage: expect.stringContaining('Escalated to human') })

--- a/apps/client/server/queueHandlers/sreRevision.ts
+++ b/apps/client/server/queueHandlers/sreRevision.ts
@@ -126,9 +126,15 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
 
   if (!repoConfig) {
     logger.warn('Repo not configured, skipping revision', { repoSlug });
-    await sreErrorTrackingRepository.atomicTransition(revisionRequest.trackingId, 'revision_requested', 'failed', {
-      errorMessage: 'Repo not configured',
-    });
+    await sreErrorTrackingRepository.atomicTransition(
+      revisionRequest.trackingId,
+      repoSlug,
+      'revision_requested',
+      'failed',
+      {
+        errorMessage: 'Repo not configured',
+      }
+    );
     // Intentionally no Slack notification here: repoConfig is null, so slackConfig is unavailable.
     // Operators can detect this via CloudWatch logs (logger.warn above) or the failed doc in the admin UI.
     await clearRevisionDedup(repoSlug, revisionRequest.prNumber);
@@ -137,9 +143,15 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
 
   if (!repoConfig.enabled) {
     logger.info('SRE agent disabled, skipping revision');
-    await sreErrorTrackingRepository.atomicTransition(revisionRequest.trackingId, 'revision_requested', 'failed', {
-      errorMessage: 'SRE agent disabled during revision',
-    });
+    await sreErrorTrackingRepository.atomicTransition(
+      revisionRequest.trackingId,
+      repoSlug,
+      'revision_requested',
+      'failed',
+      {
+        errorMessage: 'SRE agent disabled during revision',
+      }
+    );
     try {
       await postSreAnalysisFailureMessage(
         revisionRequest.trackingId,
@@ -166,9 +178,15 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
       repoFailures,
       threshold: repoConfig.circuitBreaker.failureThreshold,
     });
-    await sreErrorTrackingRepository.atomicTransition(revisionRequest.trackingId, 'revision_requested', 'failed', {
-      errorMessage: revCbFailureReason,
-    });
+    await sreErrorTrackingRepository.atomicTransition(
+      revisionRequest.trackingId,
+      repoSlug,
+      'revision_requested',
+      'failed',
+      {
+        errorMessage: revCbFailureReason,
+      }
+    );
     try {
       await postSreAnalysisFailureMessage(
         revisionRequest.trackingId,
@@ -195,6 +213,7 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
     });
     await sreErrorTrackingRepository.atomicTransition(
       revisionRequest.trackingId,
+      repoSlug,
       'revision_requested',
       'rate_limited',
       {
@@ -244,9 +263,15 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
   }
   if (!githubService) {
     logger.error('GitHub service unavailable');
-    await sreErrorTrackingRepository.atomicTransition(revisionRequest.trackingId, 'revision_requested', 'failed', {
-      errorMessage: 'GitHub service unavailable during revision',
-    });
+    await sreErrorTrackingRepository.atomicTransition(
+      revisionRequest.trackingId,
+      repoSlug,
+      'revision_requested',
+      'failed',
+      {
+        errorMessage: 'GitHub service unavailable during revision',
+      }
+    );
     try {
       await postSreAnalysisFailureMessage(
         revisionRequest.trackingId,
@@ -337,9 +362,15 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
       : (result.failureReason ?? 'Diagnostician revision failed');
 
     logger.warn('Revision diagnosis failed', { reason });
-    await sreErrorTrackingRepository.atomicTransition(revisionRequest.trackingId, 'revision_requested', 'failed', {
-      errorMessage: reason,
-    });
+    await sreErrorTrackingRepository.atomicTransition(
+      revisionRequest.trackingId,
+      repoSlug,
+      'revision_requested',
+      'failed',
+      {
+        errorMessage: reason,
+      }
+    );
 
     try {
       await postSreFixFailureMessage(
@@ -380,10 +411,16 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
       fingerprint: revisionRequest.fingerprint,
       rootCause: result.diagnosis.rootCause?.slice(0, 200),
     });
-    await sreErrorTrackingRepository.atomicTransition(revisionRequest.trackingId, 'revision_requested', 'failed', {
-      diagnosisResult: result.diagnosis,
-      errorMessage: 'Escalated to human — fix would require editing a test or conflicts with test intent',
-    });
+    await sreErrorTrackingRepository.atomicTransition(
+      revisionRequest.trackingId,
+      repoSlug,
+      'revision_requested',
+      'failed',
+      {
+        diagnosisResult: result.diagnosis,
+        errorMessage: 'Escalated to human - fix would require editing a test or conflicts with test intent',
+      }
+    );
     try {
       await postSreFixFailureMessage(
         revisionRequest.trackingId,
@@ -422,6 +459,7 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
     });
     const wontFixTransitioned = await sreErrorTrackingRepository.atomicTransition(
       revisionRequest.trackingId,
+      repoSlug,
       'revision_requested',
       'wont_fix',
       {
@@ -481,6 +519,7 @@ export async function runSreRevision(revisionRequest: SreRevisionRequest, logger
   // Transition to fixing and dispatch to sreFixQueue
   const transitioned = await sreErrorTrackingRepository.atomicTransition(
     revisionRequest.trackingId,
+    repoSlug,
     'revision_requested',
     'fixing',
     {

--- a/apps/client/server/utils/telemetryAnalysis.test.ts
+++ b/apps/client/server/utils/telemetryAnalysis.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import type { ContextTelemetry, AnomaliesTelemetry } from '@bike4mind/common';
+import { formatIssueBody, type LLMAnalysis } from './telemetryAnalysis';
+
+function createTestTelemetry(overrides: { anomalies?: Partial<AnomaliesTelemetry> } = {}): ContextTelemetry {
+  const defaultAnomalies: AnomaliesTelemetry = {
+    contextOverflow: false,
+    highUtilization: false,
+    criticalUtilization: false,
+    highTruncation: false,
+    criticalTruncation: false,
+    toolFailureSpike: false,
+    toolTimeout: false,
+    subagentTimeout: false,
+    slowFirstToken: false,
+    slowTotalResponse: false,
+    anomalyScore: 30,
+    severity: 'medium',
+    dedupKey: 'test-key',
+    primaryAnomaly: 'slow_response',
+  };
+
+  return {
+    schemaVersion: '1.0',
+    timestamp: new Date().toISOString(),
+    captureOverheadMs: 10,
+    anonymousSessionId: { hash: 'test-hash', dateKey: '2025-01-01' },
+    operation: { name: 'chat_completion' },
+    model: {
+      modelId: 'claude-3-5-sonnet-20241022',
+      provider: 'anthropic',
+      fallbackUsed: false,
+      usedThinking: false,
+      usedTools: false,
+    },
+    contextWindow: {
+      inputTokens: 1000,
+      outputTokens: 500,
+      contextWindowLimit: 200000,
+      utilizationPercentage: 0.5,
+      reservedOutputTokens: 8000,
+      overflowDetected: false,
+      tokensBySource: {
+        systemPrompts: 100,
+        conversationHistory: 400,
+        mementos: 100,
+        fabFiles: 100,
+        urlContent: 100,
+        toolSchemas: 100,
+        userPrompt: 100,
+      },
+    },
+    costs: {
+      inputCostUsd: 0.01,
+      outputCostUsd: 0.02,
+      totalCostUsd: 0.03,
+      creditsUsed: 1,
+    },
+    performance: {
+      totalResponseTimeMs: 5000,
+    },
+    anomalies: { ...defaultAnomalies, ...overrides.anomalies },
+    tools: [],
+    subagents: [],
+  };
+}
+
+describe('formatIssueBody', () => {
+  it('escapes LLM analysis text written into the issue body', () => {
+    const telemetry = createTestTelemetry();
+    const analysis: LLMAnalysis = {
+      summary: 'see [x](https://example.invalid) and @org/team <img>',
+      rootCause: 'caused by `unstable_fn` and *retries*',
+      findings: ['finding with <img src=x> and @someone'],
+      recommendations: ['recommend [click](https://example.invalid)'],
+      correlations: ['correlated with @another/team'],
+      estimatedImpact: 'impact is *severe* with `code`',
+    };
+
+    const body = formatIssueBody(telemetry, { analysis });
+    const zwsp = '\u200B';
+
+    // Escaped forms are present.
+    expect(body).toContain('\\[x\\](https://example.invalid)');
+    expect(body).toContain('&lt;img&gt;');
+    expect(body).toContain(`@${zwsp}org/team`);
+    expect(body).toContain('\\`unstable\\_fn\\`');
+    expect(body).toContain('\\*retries\\*');
+    expect(body).toContain('&lt;img src=x&gt;');
+    expect(body).toContain(`@${zwsp}someone`);
+    expect(body).toContain('\\[click\\](https://example.invalid)');
+    expect(body).toContain(`@${zwsp}another/team`);
+    expect(body).toContain('\\*severe\\*');
+    expect(body).toContain('\\`code\\`');
+
+    // Raw, unescaped active markdown must not survive.
+    expect(body).not.toContain('[x](');
+    expect(body).not.toContain('<img>');
+    expect(body).not.toContain('<img src=x>');
+    expect(body).not.toContain('[click](');
+    expect(body).not.toContain('@org/team');
+    expect(body).not.toContain('@someone');
+    expect(body).not.toContain('@another/team');
+  });
+});

--- a/apps/client/server/utils/telemetryAnalysis.ts
+++ b/apps/client/server/utils/telemetryAnalysis.ts
@@ -718,44 +718,49 @@ export function formatIssueBody(telemetry: ContextTelemetry, options: IssueBodyO
   sections.push(`**Timestamp:** ${telemetry.timestamp}`);
   sections.push('');
 
-  // AI Analysis Section (if available)
+  // AI Analysis Section (if available). LLM-generated text rendered as GitHub
+  // markdown, so every field is escaped before interpolation.
   if (analysis) {
+    const safeSummary = escapeMarkdown(analysis.summary);
+    const safeRootCause = analysis.rootCause ? escapeMarkdown(analysis.rootCause) : undefined;
+    const safeEstimatedImpact = escapeMarkdown(analysis.estimatedImpact);
+
     sections.push(`## AI Analysis`);
     if (analysisSource) {
       sections.push(`> _Analysis source: ${analysisSource}_`);
     }
     sections.push('');
     sections.push(`### Summary`);
-    sections.push(analysis.summary);
+    sections.push(safeSummary);
     sections.push('');
 
-    if (analysis.rootCause) {
+    if (safeRootCause) {
       sections.push(`### Root Cause`);
-      sections.push(analysis.rootCause);
+      sections.push(safeRootCause);
       sections.push('');
     }
 
     sections.push(`### Findings`);
     for (const finding of analysis.findings) {
-      sections.push(`- ${finding}`);
+      sections.push(`- ${escapeMarkdown(finding)}`);
     }
     sections.push('');
 
     sections.push(`### Recommendations`);
     for (const rec of analysis.recommendations) {
-      sections.push(`- ${rec}`);
+      sections.push(`- ${escapeMarkdown(rec)}`);
     }
     sections.push('');
 
     if (analysis.correlations && analysis.correlations.length > 0) {
       sections.push(`### Correlations`);
       for (const corr of analysis.correlations) {
-        sections.push(`- ${corr}`);
+        sections.push(`- ${escapeMarkdown(corr)}`);
       }
       sections.push('');
     }
 
-    sections.push(`**Estimated Impact:** ${analysis.estimatedImpact}`);
+    sections.push(`**Estimated Impact:** ${safeEstimatedImpact}`);
     sections.push('');
     sections.push('---');
     sections.push('');

--- a/packages/database/src/models/infra/ops/SreErrorPatternModel.ts
+++ b/packages/database/src/models/infra/ops/SreErrorPatternModel.ts
@@ -178,6 +178,10 @@ class SreErrorPatternRepository extends BaseRepository<ISreErrorPattern> {
   /**
    * Create or update a pattern from a successful fix.
    * Uses upsert - if the fingerprint already exists, updates the diagnosis.
+   *
+   * Because it upserts, repoSlug decides which repo's pattern library is written,
+   * not just which one is searched. Callers driven by an authenticated request must
+   * pass the repo that authenticated it, never one read off a caller-named document.
    */
   async upsertFromFix(
     fingerprint: string,

--- a/packages/database/src/models/infra/ops/SreErrorTrackingModel.test.ts
+++ b/packages/database/src/models/infra/ops/SreErrorTrackingModel.test.ts
@@ -15,14 +15,15 @@ describe('SreErrorTrackingRepository', () => {
       (sreErrorTrackingRepository as any).model.findOneAndUpdate = mockFindOneAndUpdate;
     });
 
-    it('queries with correct filter (status in [fixed, failed], has PR, revisionCount < max, not merged)', async () => {
+    it('queries with correct filter (repoSlug, status in [fixed, failed], has PR, revisionCount < max, not merged)', async () => {
       mockFindOneAndUpdate.mockResolvedValue(null);
 
-      await sreErrorTrackingRepository.claimRevision('doc-1', 2);
+      await sreErrorTrackingRepository.claimRevision('doc-1', 'acme/widgets', 2);
 
       expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
         {
           _id: 'doc-1',
+          repoSlug: 'acme/widgets',
           status: { $in: ['fixed', 'failed', 'wont_fix'] },
           fixPrNumber: { $exists: true },
           revisionCount: { $lt: 2 },
@@ -50,7 +51,7 @@ describe('SreErrorTrackingRepository', () => {
       };
       mockFindOneAndUpdate.mockResolvedValue(doc);
 
-      const result = await sreErrorTrackingRepository.claimRevision('doc-1', 2);
+      const result = await sreErrorTrackingRepository.claimRevision('doc-1', 'acme/widgets', 2);
 
       expect(result).toEqual({
         id: 'doc-1',
@@ -62,7 +63,7 @@ describe('SreErrorTrackingRepository', () => {
     it('returns null when claim fails (status not fixed)', async () => {
       mockFindOneAndUpdate.mockResolvedValue(null);
 
-      const result = await sreErrorTrackingRepository.claimRevision('doc-1', 2);
+      const result = await sreErrorTrackingRepository.claimRevision('doc-1', 'acme/widgets', 2);
 
       expect(result).toBeNull();
     });
@@ -70,7 +71,7 @@ describe('SreErrorTrackingRepository', () => {
     it('returns null when revision cap is reached', async () => {
       mockFindOneAndUpdate.mockResolvedValue(null);
 
-      const result = await sreErrorTrackingRepository.claimRevision('doc-1', 2);
+      const result = await sreErrorTrackingRepository.claimRevision('doc-1', 'acme/widgets', 2);
 
       // The $lt filter in the query prevents matching when revisionCount >= 2
       expect(result).toBeNull();
@@ -79,7 +80,7 @@ describe('SreErrorTrackingRepository', () => {
     it('resets githubRunDispatched in the update', async () => {
       mockFindOneAndUpdate.mockResolvedValue(null);
 
-      await sreErrorTrackingRepository.claimRevision('doc-1', 3);
+      await sreErrorTrackingRepository.claimRevision('doc-1', 'acme/widgets', 3);
 
       const updateArg = mockFindOneAndUpdate.mock.calls[0][1];
       expect(updateArg.$set.githubRunDispatched).toBe(false);
@@ -88,7 +89,7 @@ describe('SreErrorTrackingRepository', () => {
     it('increments revisionCount atomically', async () => {
       mockFindOneAndUpdate.mockResolvedValue(null);
 
-      await sreErrorTrackingRepository.claimRevision('doc-1', 3);
+      await sreErrorTrackingRepository.claimRevision('doc-1', 'acme/widgets', 3);
 
       const updateArg = mockFindOneAndUpdate.mock.calls[0][1];
       expect(updateArg.$inc.revisionCount).toBe(1);
@@ -97,7 +98,7 @@ describe('SreErrorTrackingRepository', () => {
     it('respects different maxRevisions values', async () => {
       mockFindOneAndUpdate.mockResolvedValue(null);
 
-      await sreErrorTrackingRepository.claimRevision('doc-1', 5);
+      await sreErrorTrackingRepository.claimRevision('doc-1', 'acme/widgets', 5);
 
       const filterArg = mockFindOneAndUpdate.mock.calls[0][0];
       expect(filterArg.revisionCount.$lt).toBe(5);

--- a/packages/database/src/models/infra/ops/SreErrorTrackingModel.ts
+++ b/packages/database/src/models/infra/ops/SreErrorTrackingModel.ts
@@ -489,17 +489,24 @@ class SreErrorTrackingRepository extends BaseRepository<ISreErrorTracking> {
   }
 
   /**
-   * Atomic state transition: only updates if current status matches expectedStatus.
-   * Returns the updated document, or null if the transition was not possible.
+   * Atomic state transition: only updates if current status matches expectedStatus
+   * AND the doc belongs to repoSlug. Returns the updated document, or null if the
+   * transition was not possible.
+   *
+   * repoSlug is required rather than optional so every caller has to name the repo
+   * it believes it is acting on: an id alone is caller-supplied and does not prove
+   * which repo the doc belongs to. Callers driven by an authenticated request must
+   * pass the repo that authenticated it, not one read off the doc.
    */
   async atomicTransition(
     id: string,
+    repoSlug: string,
     expectedStatus: ISreErrorTracking['status'],
     newStatus: ISreErrorTracking['status'],
     updates?: Partial<ISreErrorTracking>
   ): Promise<ISreErrorTracking | null> {
     const result = await this.model.findOneAndUpdate(
-      { _id: id, status: expectedStatus },
+      { _id: id, ...repoSlugFilter(repoSlug), status: expectedStatus },
       { $set: { status: newStatus, ...updates } },
       { returnDocument: 'after' }
     );
@@ -539,12 +546,14 @@ class SreErrorTrackingRepository extends BaseRepository<ISreErrorTracking> {
    *   - no PR was created (fixPrNumber missing)
    *   - revisionCount >= maxRevisions (cap reached)
    *   - PR already merged (fixMergedAt exists)
+   *   - the doc does not belong to repoSlug (see atomicTransition on why it is required)
    * Also resets githubRunDispatched for the new dispatch cycle.
    */
-  async claimRevision(id: string, maxRevisions: number): Promise<ISreErrorTracking | null> {
+  async claimRevision(id: string, repoSlug: string, maxRevisions: number): Promise<ISreErrorTracking | null> {
     const result = await this.model.findOneAndUpdate(
       {
         _id: id,
+        ...repoSlugFilter(repoSlug),
         status: { $in: ['fixed', 'failed', 'wont_fix'] },
         fixPrNumber: { $exists: true },
         revisionCount: { $lt: maxRevisions },
@@ -562,12 +571,14 @@ class SreErrorTrackingRepository extends BaseRepository<ISreErrorTracking> {
   /**
    * Atomic CI retry claim: transitions 'fixing' -> 'revision_requested' when below maxCiRetries.
    * Uses $expr/$ifNull to handle docs where ciRetryCount is absent (treated as 0).
-   * Returns null for duplicate callbacks AND when the retry cap is already reached.
+   * Returns null for duplicate callbacks, when the retry cap is already reached, AND
+   * when the doc does not belong to repoSlug (see atomicTransition on why it is required).
    */
-  async claimCiRetry(id: string, maxCiRetries: number): Promise<ISreErrorTracking | null> {
+  async claimCiRetry(id: string, repoSlug: string, maxCiRetries: number): Promise<ISreErrorTracking | null> {
     const result = await this.model.findOneAndUpdate(
       {
         _id: id,
+        ...repoSlugFilter(repoSlug),
         status: 'fixing',
         $expr: { $lt: [{ $ifNull: ['$ciRetryCount', 0] }, maxCiRetries] },
       },

--- a/packages/database/src/models/infra/ops/__tests__/SreErrorTrackingModel.test.ts
+++ b/packages/database/src/models/infra/ops/__tests__/SreErrorTrackingModel.test.ts
@@ -372,6 +372,7 @@ describe('SreErrorTrackingModel — recurrence queries', () => {
     function makeTrackingDoc(overrides: Record<string, unknown> = {}) {
       return SreErrorTrackingModel.create({
         errorFingerprint: 'fp-revision',
+        repoSlug: 'acme/widgets',
         source: 'GITHUB_ISSUE',
         sourceRef: 'https://github.com/owner/repo/issues/1',
         status: 'fixed',
@@ -390,7 +391,7 @@ describe('SreErrorTrackingModel — recurrence queries', () => {
 
     it('claims from wont_fix status and increments revisionCount', async () => {
       const doc = await makeTrackingDoc({ status: 'wont_fix' });
-      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 3);
+      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 'acme/widgets', 3);
       expect(result).not.toBeNull();
       expect(result?.status).toBe('revision_requested');
       expect(result?.revisionCount).toBe(1);
@@ -398,7 +399,7 @@ describe('SreErrorTrackingModel — recurrence queries', () => {
 
     it('claims from fixed status (normal flow)', async () => {
       const doc = await makeTrackingDoc({ status: 'fixed' });
-      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 3);
+      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 'acme/widgets', 3);
       expect(result).not.toBeNull();
       expect(result?.status).toBe('revision_requested');
       expect(result?.revisionCount).toBe(1);
@@ -406,22 +407,75 @@ describe('SreErrorTrackingModel — recurrence queries', () => {
 
     it('returns null when wont_fix doc has reached revisionCount cap', async () => {
       const doc = await makeTrackingDoc({ status: 'wont_fix', revisionCount: 3 });
-      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 3);
+      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 'acme/widgets', 3);
       expect(result).toBeNull();
     });
 
     it('returns null when fixMergedAt is set (PR already merged)', async () => {
       const doc = await makeTrackingDoc({ status: 'fixed', fixMergedAt: new Date() });
-      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 3);
+      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 'acme/widgets', 3);
       expect(result).toBeNull();
     });
 
     it('returns null for non-claimable statuses', async () => {
       for (const status of ['analyzing', 'fixing', 'revision_requested', 'dismissed'] as const) {
         const doc = await makeTrackingDoc({ status, errorFingerprint: `fp-${status}` });
-        const result = await sreErrorTrackingRepository.claimRevision(doc.id, 3);
+        const result = await sreErrorTrackingRepository.claimRevision(doc.id, 'acme/widgets', 3);
         expect(result, `should not claim from ${status}`).toBeNull();
       }
+    });
+
+    it('returns null when the document belongs to a different repo', async () => {
+      const doc = await makeTrackingDoc({ status: 'fixed' });
+      const result = await sreErrorTrackingRepository.claimRevision(doc.id, 'other/repo', 3);
+      expect(result).toBeNull();
+      const untouched = await SreErrorTrackingModel.findById(doc.id);
+      expect(untouched?.status).toBe('fixed');
+      expect(untouched?.revisionCount).toBe(0);
+    });
+  });
+
+  describe('repo binding on tracking mutations', () => {
+    function makeDoc(overrides: Record<string, unknown> = {}) {
+      return SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-repo-binding',
+        repoSlug: 'acme/widgets',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/acme/widgets/issues/1',
+        status: 'fixing',
+        ciRetryCount: 0,
+        ...overrides,
+      });
+    }
+
+    it('atomicTransition leaves the document alone when repoSlug does not match', async () => {
+      const doc = await makeDoc();
+      const result = await sreErrorTrackingRepository.atomicTransition(doc.id, 'other/repo', 'fixing', 'fixed');
+      expect(result).toBeNull();
+      const untouched = await SreErrorTrackingModel.findById(doc.id);
+      expect(untouched?.status).toBe('fixing');
+    });
+
+    it('atomicTransition applies when repoSlug matches', async () => {
+      const doc = await makeDoc({ errorFingerprint: 'fp-repo-binding-ok' });
+      const result = await sreErrorTrackingRepository.atomicTransition(doc.id, 'acme/widgets', 'fixing', 'fixed');
+      expect(result?.status).toBe('fixed');
+    });
+
+    it('claimCiRetry leaves the document alone when repoSlug does not match', async () => {
+      const doc = await makeDoc({ errorFingerprint: 'fp-repo-binding-ci' });
+      const result = await sreErrorTrackingRepository.claimCiRetry(doc.id, 'other/repo', 3);
+      expect(result).toBeNull();
+      const untouched = await SreErrorTrackingModel.findById(doc.id);
+      expect(untouched?.status).toBe('fixing');
+      expect(untouched?.ciRetryCount).toBe(0);
+    });
+
+    it('claimCiRetry applies when repoSlug matches', async () => {
+      const doc = await makeDoc({ errorFingerprint: 'fp-repo-binding-ci-ok' });
+      const result = await sreErrorTrackingRepository.claimCiRetry(doc.id, 'acme/widgets', 3);
+      expect(result?.status).toBe('revision_requested');
+      expect(result?.ciRetryCount).toBe(1);
     });
   });
 


### PR DESCRIPTION
## What

Three self-contained changes in the SRE autofix path.

**Tracking mutations carry the repo they act on.** `atomicTransition`, `claimRevision` and `claimCiRetry` on `sreErrorTrackingRepository` now take a required `repoSlug` and fold it into the `findOneAndUpdate` filter, so a caller-supplied document id no longer selects the document on its own. The parameter is required rather than optional on purpose: an optional one would silently preserve the old behaviour at any call site nobody remembered to update, whereas a required one turns every omission into a type error. Every call site now names the repo it believes it is acting on, and the queue handlers and cron pass the repo already in scope. `/api/sre/workflow-callback` additionally resolves the tracking document before doing anything and returns 404 unless its `repoSlug` matches the repo whose callback token authenticated the request; the callback's pattern-library write passes that same authenticated slug rather than one read back off the document. That endpoint check is not redundant with the repo-bound filters: a null return from a repo-bound `findOneAndUpdate` is indistinguishable from an idempotent duplicate callback, and the `claimCiRetry` null branch goes on to write state and post to Slack and GitHub.

**Slack fix approval denies by default.** `handleSreApprovalAction` read an empty or unset `approverIds` as "no allowlist configured, so no restriction", which made the gate depend on someone having remembered to populate it. It now refuses when the resolved list is empty, with its own message pointing at the admin setting so an operator can tell an unconfigured repo apart from a genuine authorization failure. Both the approve and the reject action are behind the same check. `getAllowedApproverIds` became `resolveApprovalContext` and returns the repo alongside the approver list, because the transition that follows needs the repo before it runs rather than after; that also drops a duplicate document read.

**LLM analysis text is escaped into GitHub issue bodies.** `formatIssueBody` in `telemetryAnalysis.ts` interpolated `summary`, `rootCause`, `findings`, `recommendations`, `correlations` and `estimatedImpact` raw. They now go through the existing `escapeMarkdown` helper, the same way `wontFixComment.ts` already handles its LLM-generated fields. No new escaping logic was written. One accepted cosmetic consequence: `generateRuleBasedAnalysis` already escapes tool and agent names into a couple of its own findings, so those substrings are escaped twice and a tool whose name contains markdown characters renders with visible backslashes. Moving that escaping to the sink would have pulled three unrelated call sites into this change, and the sink is the correct layer, so the source-side escaping stays as is.

## How to prove each one

**Repo binding.** `pnpm --filter @bike4mind/database test src/models/infra/ops/__tests__/SreErrorTrackingModel.test.ts` exercises all three methods against a real Mongo: a mutation naming a different repo returns null and leaves status and counters untouched, and the matching repo still succeeds. At the endpoint, the `tracking document ownership` block in `apps/client/__tests__/api/sre/workflow-callback.test.ts` asserts that a callback whose trackingId belongs to another repo gets 404 with no transition, no `claimCiRetry`, no pattern-library write, no queue message, no Slack post and no GitHub comment - including on the recoverable-CI path, which previously still transitioned and commented.

**Approval.** `apps/client/__tests__/integrations/slack/sreSlackApproval.test.ts` covers both directions. Unset, whitespace-only and unconfigured-repo all refuse and never reach `atomicTransition`, for both the approve and the reject action; a configured approver still proceeds and transitions with the bound repo, asserted on the actual call arguments rather than just the absence of a denial.

**Escaping.** `apps/client/server/utils/telemetryAnalysis.test.ts` drives an analysis whose six fields carry markdown control characters and org/team handles, then asserts the rendered body contains only the escaped forms and none of the raw ones.

## Verification run

- `pnpm lint:check` clean.
- `scripts/check-no-smart-punctuation.sh` and `scripts/check-no-control-bytes.sh` clean against `origin/main`.
- `pnpm --filter @bike4mind/client typecheck` and `pnpm --filter @bike4mind/database typecheck` clean.
- Full client suite across all three CI shards: 11726 passed, 81 skipped, 0 failed.
- `pnpm --filter @bike4mind/database test`: 2249 passed, 1 skipped, 0 failed.

## Scope

Covers criteria 1, 6 and 7 of bike4mind/b4m-internal#75. That issue stays open on purpose: criteria 2, 3, 4 and 5 are the larger trust-model work (prompt framing for externally-authored text, an approval step that does not key off model confidence, author-association checks, and webhook tenancy) and none of it is touched here.

Nothing in this change needed a decision I could not make from the code, so there is nothing held back for a reviewer to rule on beyond the deliberate scope split above.
