### PR TITLE
fix(data-lake): bound disambiguateSlug's suffixed slug to MAX_DATA_LAKE_SLUG_LENGTH

### DIFF
--- a/b4m-core/services/src/dataLakeService/createDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/createDataLake.ts
@@ -6,6 +6,13 @@ import type { z } from 'zod';
 
 type CreateDataLakeParams = z.infer<typeof CreateDataLakeRequestInput>;
 
+// Mirrors the slug.max(60) bound on CreateDataLakeRequestInput (and
+// MAX_DATA_LAKE_SLUG_LENGTH in apps/client/app/hooks/data/dataLakeSlug.ts) - the input schema
+// only bounds the caller's base slug, so disambiguateSlug's own suffixing must re-enforce this
+// or a collision can persist a slug the rest of the system (e.g. entitlements/registry.ts)
+// treats as invalid.
+const MAX_SLUG_LENGTH = 60;
+
 interface CreateDataLakeAdapters {
   db: {
     dataLakes: Pick<IDataLakeRepository, 'create' | 'find'>;
@@ -42,7 +49,15 @@ async function disambiguateSlug(
   const scope = organizationId ? { organizationId } : { organizationId: { $in: [null, ''] } };
   const reservedTags = new Set(DATA_LAKES.map(lake => lake.datalakeTag));
   for (let attempt = 0; attempt < 50; attempt++) {
-    const slug = attempt === 0 ? baseSlug : `${baseSlug}-${attempt}`;
+    let slug = baseSlug;
+    if (attempt > 0) {
+      // Truncate the base (not the suffix) so the persisted slug never exceeds
+      // MAX_SLUG_LENGTH, and trim a hyphen the truncation may have exposed - slugRegex
+      // requires the slug to end alphanumeric, which the "-N" suffix already guarantees.
+      const suffix = `-${attempt}`;
+      const truncatedBase = baseSlug.slice(0, MAX_SLUG_LENGTH - suffix.length).replace(/-+$/, '');
+      slug = `${truncatedBase}${suffix}`;
+    }
     if (reservedTags.has(buildDatalakeTag(slug, organizationId))) continue;
     const existing = await db.dataLakes.find({ ...scope, slug });
     if (existing.length === 0) return slug;

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -986,6 +986,24 @@ describe('createDataLake', () => {
 
     expect(create).toHaveBeenCalledWith(expect.objectContaining({ slug: registrySlug }));
   });
+
+  it('truncates the base rather than growing past 60 chars when disambiguating a max-length slug', async () => {
+    // A max-length (60-char) base slug that collides must still get a suffixed slug that
+    // fits the same 60-char bound every other surface (e.g. entitlements/registry.ts) judges
+    // slugs by - appending "-1" onto it unbounded would persist an over-long slug.
+    const baseSlug = 'a'.repeat(60);
+    const create = vi.fn().mockImplementation(async (d: IDataLakeDocument) => d);
+    // Call order: the tag-prefix availability check (no candidates), then the slug probes -
+    // base slug taken, truncated+suffixed slug free.
+    const find = vi.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([lake()]).mockResolvedValueOnce([]);
+    const db = { dataLakes: { create, find } };
+
+    await createDataLake('owner', { name: 'X', slug: baseSlug, fileTagPrefix: 'xy:' }, { db });
+
+    const written = create.mock.calls[0][0] as IDataLakeDocument;
+    expect(written.slug.length).toBeLessThanOrEqual(60);
+    expect(written.slug).toBe(`${'a'.repeat(58)}-1`);
+  });
 });
 
 describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {


### PR DESCRIPTION
## Summary
- Collision disambiguation in `disambiguateSlug` appended `-1`, `-2`, ... to an already-validated slug without re-checking the 60-char bound, so a lake could persist a slug longer than `MAX_DATA_LAKE_SLUG_LENGTH` when the base slug was already at (or near) the max and collided.
- Now truncates the base slug (not the suffix) before appending the disambiguation suffix, so the persisted slug always stays within the same 60-char bound every other surface (e.g. the entitlement key gate in `apps/client/lib/entitlements/registry.ts`) judges slugs by.

Fixes #2032.

## Test plan
- [x] Added a unit test covering a 60-char base slug that collides, asserting the persisted slug is truncated+suffixed and never exceeds 60 chars.
- [x] `pnpm --filter @bike4mind/services test` passes (3944 passed).
- [x] `pnpm --filter @bike4mind/services typecheck` passes.
- [x] Pre-push typecheck/lint hooks passed.