### PR TITLE
fix(api): gate POST /api/ai/llm on the ai:chat scope it advertises

### DIFF
--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -660,6 +660,8 @@ Direct access to AI capabilities outside the chat flow.
 POST /api/ai/llm
 \`\`\`
 
+**Required API-key scope:** \`ai:chat\`.
+
 **Request Body:**
 
 | Field | Type | Required | Description |

--- a/apps/client/pages/api/ai/__tests__/llm.integration.test.ts
+++ b/apps/client/pages/api/ai/__tests__/llm.integration.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment node
+/**
+ * Integration test for POST /api/ai/llm scope enforcement.
+ *
+ * Drives the real next-connect chain `baseApi` assembles (see
+ * generate-image.integration.test.ts for the rationale) to prove the
+ * `baseApi({ requiredScopes: [AI_CHAT] })` wiring reaches `apiKeyAuth`: a key lacking
+ * `ai:chat` is rejected 403 before the handler runs, so no billed chat completion is
+ * dispatched. A key holding it, and JWT/browser callers, pass through.
+ *
+ * The route's mint catalogue entry (`apiKeyScopes.ts`, AI_CHAT) advertises this gate to
+ * anyone creating a key, so losing `requiredScopes` again would put that prose back ahead
+ * of the code - this suite is what fails if it goes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { createMocks } from 'node-mocks-http';
+
+const {
+  mockValidate,
+  mockUserFindById,
+  mockUserUpdate,
+  mockApiKeyRateLimit,
+  mockTryIncrement,
+  mockGetOrCreateSession,
+  mockInvoke,
+  mockWillInjectAuthoredPrompt,
+  mockLoadIdentityPrompts,
+} = vi.hoisted(() => ({
+  mockValidate: vi.fn(),
+  mockUserFindById: vi.fn(),
+  mockUserUpdate: vi.fn(),
+  mockApiKeyRateLimit: vi.fn(),
+  mockTryIncrement: vi.fn(),
+  mockGetOrCreateSession: vi.fn(),
+  mockInvoke: vi.fn(),
+  mockWillInjectAuthoredPrompt: vi.fn(),
+  mockLoadIdentityPrompts: vi.fn(),
+}));
+
+const RATE_LIMIT_HEADERS = {
+  'X-RateLimit-Limit-Minute': '60',
+  'X-RateLimit-Remaining-Minute': '59',
+  'X-RateLimit-Reset-Minute': '0',
+  'X-RateLimit-Limit-Day': '1000',
+  'X-RateLimit-Remaining-Day': '999',
+  'X-RateLimit-Reset-Day': '0',
+};
+
+vi.mock('@server/utils/apiKeyRateLimitCheck', async orig => ({
+  // Keep the real (pure) extractApiKeyFromHeaders - apiKeyAuth imports it; only
+  // checkApiKeyRateLimit is stubbed.
+  ...(await orig<Record<string, unknown>>()),
+  checkApiKeyRateLimit: (...a: unknown[]) => mockApiKeyRateLimit(...a),
+}));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('@bike4mind/services', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  class MockChatCompletionInvoke {
+    prefetchedSession = undefined;
+    prefetchedOrganization = undefined;
+    invoke = (...a: unknown[]) => mockInvoke(...a);
+  }
+  return {
+    ...actual,
+    userApiKeyService: {
+      ...(actual.userApiKeyService as object),
+      validateUserApiKey: (...a: unknown[]) => mockValidate(...a),
+    },
+    ChatCompletionInvoke: MockChatCompletionInvoke,
+  };
+});
+
+vi.mock('@bike4mind/utils', async orig => ({
+  ...(await orig<Record<string, unknown>>()),
+  SQSService: class {},
+}));
+
+// connectDB must not hit Mongo; User.findById backs apiKeyAuth's user lookup, and
+// cacheRepository backs the route's own in-memory rateLimit middleware.
+vi.mock('@bike4mind/database', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  const RealUser = actual.User as Record<string, unknown>;
+  return {
+    ...actual,
+    connectDB: vi.fn().mockResolvedValue(undefined),
+    User: Object.assign(Object.create(RealUser), { findById: (...a: unknown[]) => mockUserFindById(...a) }),
+    userRepository: {
+      ...(actual.userRepository as object),
+      update: (...a: unknown[]) => mockUserUpdate(...a),
+    },
+    cacheRepository: {
+      ...(actual.cacheRepository as object),
+      tryIncrementWithinLimitFixedWindow: (...a: unknown[]) => mockTryIncrement(...a),
+    },
+  };
+});
+
+vi.mock('@server/managers/sessionManager', () => ({
+  getOrCreateSession: (...a: unknown[]) => mockGetOrCreateSession(...a),
+}));
+
+vi.mock('@server/utils/chatCompletionDefaults', () => ({
+  getDefaultChatCompletionOptions: () => ({}),
+  getSharedTokenizer: () => ({}),
+}));
+
+vi.mock('@server/utils/sessionSystemPromptResolver', () => ({
+  sessionWillInjectAuthoredPrompt: (...a: unknown[]) => mockWillInjectAuthoredPrompt(...a),
+}));
+
+vi.mock('@server/utils/systemPrompts/loader', () => ({
+  loadBaseIdentitySystemPromptMessages: (...a: unknown[]) => mockLoadIdentityPrompts(...a),
+}));
+
+// Never reached: the real invokeLambda callback is owned by the mocked
+// ChatCompletionInvoke. Stubbed so the module's transitive AWS edges stay out of the test.
+vi.mock('@server/utils/dispatchQuest', () => ({ dispatchQuest: vi.fn().mockResolvedValue(undefined) }));
+
+const JWT_USER = { id: 'jwt-user', _id: 'jwt-user', isBanned: false, disputePending: false };
+vi.mock('@server/auth/auth', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  return {
+    ...actual,
+    // any: node-mocks-http req/res aren't structurally the Express types this seam is typed for.
+    auth: (req: any, _res: any, next: any) => {
+      if (!req.user) req.user = JWT_USER;
+      next();
+    },
+  };
+});
+
+import handler from '../llm';
+import { ApiKeyScope } from '@bike4mind/common';
+
+const VALID_KEY = 'sk-test-valid-key';
+
+function fire({ apiKey = VALID_KEY as string | null }: { apiKey?: string | null } = {}) {
+  const { req, res } = createMocks(
+    {
+      method: 'POST',
+      url: '/api/ai/llm',
+      body: { sessionId: 'sess-1', message: 'Hello there' },
+      headers: { ...(apiKey ? { 'x-api-key': apiKey } : {}) },
+    },
+    { eventEmitter: EventEmitter }
+  );
+  // any: node-mocks-http mocks aren't structurally the Express Request/Response types.
+  return { req: req as any, res: res as any };
+}
+
+function validateWithScopes(scopes: ApiKeyScope[] | string[]) {
+  mockValidate.mockResolvedValue({
+    isValid: true,
+    keyId: 'k1',
+    userId: 'user-1',
+    scopes,
+    rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
+  });
+}
+
+describe('POST /api/ai/llm (integration - ai:chat scope enforcement)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindById.mockResolvedValue({ id: 'user-1', _id: 'user-1', isBanned: false, disputePending: false });
+    mockApiKeyRateLimit.mockResolvedValue({ allowed: true, retryAfter: undefined, headers: RATE_LIMIT_HEADERS });
+    mockTryIncrement.mockResolvedValue({ success: true, expiresAt: new Date(Date.now() + 60_000) });
+    mockUserUpdate.mockResolvedValue(undefined);
+    mockWillInjectAuthoredPrompt.mockResolvedValue(false);
+    mockLoadIdentityPrompts.mockResolvedValue([]);
+    mockGetOrCreateSession.mockResolvedValue({
+      sessionId: 'sess-1',
+      asyncPromises: [],
+      session: { id: 'sess-1', name: 'Test Session' },
+    });
+    mockInvoke.mockResolvedValue({ id: 'quest-1', status: 'pending' });
+  });
+
+  it('rejects a key lacking ai:chat (403) before dispatching any billed completion', async () => {
+    validateWithScopes([ApiKeyScope.READ_NOTEBOOKS]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error).toMatch(/insufficient/i);
+    expect(mockInvoke).not.toHaveBeenCalled();
+    // The 403 lands before the handler body, so no session is created as a side effect.
+    expect(mockGetOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects an ai:generate-only key (403) - this route is narrower than /api/chat', async () => {
+    // Pins the deliberate narrowing: the contract surfaces accept [AI_CHAT, AI_GENERATE] to
+    // preserve legacy completions behavior, this route accepts AI_CHAT alone (see llm.ts).
+    // Widening it later should be a conscious edit, not a silent one.
+    validateWithScopes([ApiKeyScope.AI_GENERATE]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('accepts a key with ai:chat (200) and dispatches the quest', async () => {
+    validateWithScopes([ApiKeyScope.AI_CHAT]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({ quest: { id: 'quest-1' } });
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves JWT/browser callers unaffected (200, no api key)', async () => {
+    const { req, res } = fire({ apiKey: null });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/ai/llm.ts
+++ b/apps/client/pages/api/ai/llm.ts
@@ -1,5 +1,5 @@
 import { userRepository } from '@bike4mind/database';
-import { LLMApiRequestBody, redactSessionForClient } from '@bike4mind/common';
+import { ApiKeyScope, LLMApiRequestBody, redactSessionForClient } from '@bike4mind/common';
 import { ChatCompletionInvoke } from '@bike4mind/services';
 import { SQSService } from '@bike4mind/utils';
 import { getOrCreateSession } from '@server/managers/sessionManager';
@@ -11,7 +11,16 @@ import { dispatchQuest } from '@server/utils/dispatchQuest';
 import { loadBaseIdentitySystemPromptMessages } from '@server/utils/systemPrompts/loader';
 import { Request } from 'express';
 
-const handler = baseApi()
+// Gate API-key callers on `ai:chat`: this route commissions a billed chat completion
+// (ChatCompletionInvoke -> dispatchQuest), so a key minted without chat access must not be able
+// to spend here. `apiKeyScopes.ts` already advertises exactly this mapping in the New-Key modal,
+// so the gate was promised to users before it existed. An `ai:chat`-only key still drives the
+// whole flow - GET /api/quests/{id} accepts AI_CHAT too. Narrower than the [AI_CHAT, AI_GENERATE]
+// pair on the contract surfaces (chat.contract.ts, cli/auth.ts DEFAULT_COMPLETION_SCOPES), which
+// accept AI_GENERATE only to preserve legacy completions behavior; that rationale does not
+// extend here, since this route is in no contract. Scope checks apply only to API-key requests;
+// browser/JWT sessions fall through untouched (see apiKeyAuth).
+const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT] })
   .use(
     rateLimit({
       // More permissive rate limiting in development


### PR DESCRIPTION
# Pull Request

Closes #2328

## Description

`POST /api/ai/llm` was a bare `baseApi()`. `requiredScopes` is opt-in and defaults open (`apiKeyAuth.ts:81` guards the whole gate behind `if (requiredScopes)`), so any valid `b4m_live_` key authorized here regardless of what it was minted with.

The mint catalogue has been asserting the opposite the whole time. `apps/client/app/constants/apiKeyScopes.ts:57-61` lists `POST /api/ai/llm` as `ai:chat`'s endpoint, and the New-Key modal renders that list verbatim (`UserApiKeysTab.tsx:1147`, `Endpoints: {item.endpoints.join(', ')}`). A user who read that and deliberately withheld `ai:chat` reasonably believed they had closed this route. They had not.

This matters more than a missing gate usually would because the route spends: it constructs `ChatCompletionInvoke` and dispatches via `dispatchQuest` (`llm.ts:62-73`). The gap was not "a read is more open than intended" - a delegated credential minted *without* chat access could commission billed LLM work against its owner's budget.

A second thing this closes, which was not in the original report: `cc-bridge/redeem.ts:97-99` mints bridge keys with `[CC_BRIDGE]` alone, and its comment states that granting `AI_CHAT` "would let a leaked bridge key bill completions on the user's account". That protection was only ever real on gated routes. With no gate here, a bridge key could POST this route and bill anyway. `decideScopeGate` has no bridge bypass (`CC_BRIDGE` at `apiKeyScopeGate.ts:33` is the *unstageable* list, not an exemption), so the declaration now denies it.

## Changes

- **`apps/client/pages/api/ai/llm.ts`** - declares `requiredScopes: [ApiKeyScope.AI_CHAT]`, matching the catalogue and the sibling `/api/ai/generate-image.ts:18`.
- **`apps/client/pages/api/ai/__tests__/llm.integration.test.ts`** (new) - drives the real `baseApi` chain, mirroring `generate-image.integration.test.ts`.
- **`apps/client/app/components/admin/content/apiReferenceContent.ts`** - adds the `Required API-key scope: ai:chat` line to the LLM Completion section, the one `/api/ai/*` entry that lacked it.

### Why `[AI_CHAT]` alone, not the `[AI_CHAT, AI_GENERATE]` pair

The contract surfaces (`chat.contract.ts:25`, `agentExecutions.contract.ts`, `completions.contract.ts`) accept both. That pair is not a general convention - `cli/auth.ts:124-129` says `DEFAULT_COMPLETION_SCOPES` exists "to preserve the legacy completions behavior". That rationale is specific to endpoints published in the OpenAPI contract; `/api/ai/llm` appears nowhere in `openapi.json`. The nearest siblings each declare their single catalogue scope (`generate-image.ts` -> `[AI_GENERATE]`, `refineText.ts` -> `[AI_GENERATE]`).

Widening to the pair would have traded one prose/code mismatch for another: the catalogue maps `ai:generate` to `generate-image` only, so an `ai:generate` key opening this route would have been undocumented in turn.

## Guide for Testers

Backend authorization change. Everything below is API-level except steps 9-11.

Use `app.staging.bike4mind.com` for the BEFORE (vulnerable) behavior, and the `pr<N>.preview.bike4mind.com` URL for the AFTER - a maintainer triggers the preview and a bot posts the URL on this PR.

**Setup - mint two keys**

1. Open `https://app.staging.bike4mind.com` and log in.
2. Navigate: **Settings -> API Keys**.
3. Click **Create New Key**. Name it `test-no-chat`. Select **only** the `Read Notebooks` scope. Leave `AI Chat` unchecked. Click create.
   - Expected: the key is shown once, starting `b4m_live_`. Copy it. Call this `$KEY_NO_CHAT`.
4. Click **Create New Key** again. Name it `test-with-chat`. Select **only** the `AI Chat` scope.
   - Expected: key shown once. Copy it. Call this `$KEY_WITH_CHAT`.
5. While the New-Key modal is open, confirm the `AI Chat` row reads `Endpoints: POST /api/ai/llm`.
   - Expected: it does. This is the prose the fix makes true.

**Reproduce on staging (BEFORE - vulnerable)**

6. Run this against staging with the under-scoped key:

```bash
curl -i -X POST https://app.staging.bike4mind.com/api/ai/llm \
  -H "x-api-key: $KEY_NO_CHAT" \
  -H "content-type: application/json" \
  -d '{"message": "Say hello in five words.", "params": {"model": "gpt-4o-mini"}}'
```

   - Expected on staging (the bug): **`HTTP/2 200`** with a JSON body containing `quest` and `session`. A key holding only `notebooks:read` just commissioned a billed completion.

**Verify on the PR preview (AFTER - fixed)**

7. Re-run the exact command from step 6 against `https://app.pr<N>.preview.bike4mind.com/api/ai/llm` with `$KEY_NO_CHAT`.
   - Expected: **`HTTP/2 403`** with body `{"error":"Insufficient API key permissions"}`. No quest is created.
8. Run the same command against the preview with `$KEY_WITH_CHAT`.
   - Expected: **`HTTP/2 200`** with a JSON body containing `quest` (an object with an `id`) and `session`. Poll it:

```bash
curl -s -H "x-api-key: $KEY_WITH_CHAT" \
  https://app.pr<N>.preview.bike4mind.com/api/quests/<quest id from step 8>
```

   - Expected: `200`, and `status` reaches `done` within ~30 seconds with a reply. This proves an `ai:chat`-only key drives the whole chat -> poll flow with a single key.

**Documentation surface**

9. On the preview, navigate: **Sidebar -> Admin -> API Reference**.
10. Scroll to **AI Services -> LLM Completion**.
    - Expected: the line **`Required API-key scope: ai:chat`** now appears between the `POST /api/ai/llm` code block and the `Request Body` table, matching the format used by `Image Generation` directly below it.

### Regression Checks

11. On the preview, open any notebook in the browser and send the message `Hello, how are you?` in the chat input.
    - Expected: a reply streams back within ~15 seconds, no errors. This is the JWT/session path, which the scope gate never runs for - it only applies to requests authenticated by an API key.
12. On the preview, with `$KEY_WITH_CHAT`, confirm image generation is unaffected by the narrowing:

```bash
curl -i -X POST https://app.pr<N>.preview.bike4mind.com/api/ai/generate-image \
  -H "x-api-key: $KEY_WITH_CHAT" \
  -H "content-type: application/json" \
  -d '{"prompt": "a red bicycle", "model": "gpt-image-1"}'
```

   - Expected: **`403`** - unchanged behavior. `generate-image` has always required `ai:generate`, and an `ai:chat` key never opened it. This step confirms the fix did not widen anything.
13. Send a chat message via the already-gated contract route, to confirm it is untouched:

```bash
curl -i -X POST https://app.pr<N>.preview.bike4mind.com/api/chat \
  -H "x-api-key: $KEY_WITH_CHAT" \
  -H "content-type: application/json" \
  -d '{"message": "Say hello.", "wait": true}'
```

   - Expected: **`200`** with a reply. `/api/chat` accepts `[AI_CHAT, AI_GENERATE]` and is not modified by this PR.

### What NOT to test

- **No UI behavior changed.** The only front-end diff is one line of static Markdown in the Admin API Reference tab (step 10). There is nothing to click, no new control, no loading/empty/error state.
- **Don't test the CLI.** `packages/cli` reaches chat through `client.sendChat()` -> `POST /api/chat` and `client.getQuest()` -> `GET /api/quests/{id}` (`b4mApiClient.ts:168-179`). Neither is touched.
- **Don't test the cc-bridge, embed keys, or the voice proxy.** The bridge runs WebSocket `cc_agent_*` actions; embed keys go through `verifyApiKey`; `voice/v2/llm-proxy` authenticates with `verifyVoiceSessionToken`, not API keys.
- **Don't re-test other scope gates.** No other route's `requiredScopes` changed.

## Additional Information

### Sequencing - please read before merging

`requiredScopes` enforces the moment it deploys, and a key holds only the scopes it was minted with. Per `docs/architecture/api-key-scope-rollout.md`, if any key in circulation has been calling `/api/ai/llm` without `ai:chat`, this 403s it the same minute.

**I could not size that population.** The scope preflight the issue points at (Admin -> Reliability / Incident Ops -> API Key Scope Preflight) is on the still-open #2327, not on `main`, and I cannot query production. Treat this as unknown, not as clear.

Two ways to resolve it, either is fine:

- Land #2327, run the preflight against `/api/ai/llm` with `ai:chat`, and act on the result: no keys -> merge and enforce in one step; some keys -> stage first.
- Or set `API_KEY_SCOPE_STAGING=ai:chat` on the target stage before this deploys, watch `API key scope check missed but staged - allowing` for the re-mint backlog, then remove the entry. This is a deploy-time env lever (`infra/web.ts`), so there is no code change in this PR for it.

What makes the population plausibly small, though not verified: the only documented API-key callers of this route are the copy-paste samples in `UserApiKeysTab.tsx:615,671`, and the endpoint table directly beneath them (`:1046`) has always told those users `ai:chat`.

### Scope left deliberately open

Sibling #2329 covers auditing the rest of the catalogue's `endpoints` lists, which are hand-written prose with nothing pinning them to the routes' actual `requiredScopes`. This PR fixes the one route #2328 names and does not touch that class.

I did check the immediate neighbourhood: of every route reaching `ChatCompletionInvoke`/`dispatchQuest`, `chat.ts` is already gated, `chat-completion-status.ts` is a health probe that only mentions `dispatchQuest` in a docblock, and `voice/v2/llm-proxy` uses its own session token. No other API-key-reachable spend route is left ungated.

## Developer Notes

- **The integration test is load-bearing, and I verified that.** I reverted the `requiredScopes` declaration and re-ran: the two 403 cases fail, the two pass-through cases correctly still pass. A future accidental removal of the gate breaks the build rather than silently re-opening the route.
- **The `ai:generate`-only 403 case pins a decision, not just behavior.** It exists so that widening this route to the contract-surfaces pair has to be a conscious edit with a failing test in front of it.
- `generate-image.integration.test.ts` is the reusable shape for "prove a `baseApi({ requiredScopes })` declaration actually reaches `apiKeyAuth`". It is now used twice; a third route gating a billable action should copy it rather than assert on `handler._config`, which several admin-route tests do and which cannot distinguish a declared gate from an enforced one.

## Security Testing (for security-labeled PRs only)

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

**These three are deliberately unchecked - not done yet.** The reasoning above is a code trace, not a live repro. Steps 6-8 of the tester guide are exactly the script to run; step 6 on staging is the BEFORE, steps 7-8 on the preview are the AFTER. I will run both and attach the output as a PR comment, then tick these. Do not read the code trace as verification.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI change beyond one static doc line
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - N/A, no telemetry fields
