### PR TITLE
fix(agents): derive the optimizer agent's premium tool list instead of restating it

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.optiProfile.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.optiProfile.test.ts
@@ -1,23 +1,53 @@
 import { describe, it, expect } from 'vitest';
-import { buildOptiOrchestrationProfile, OPTI_AGENT_TOOLS, OPTI_AGENT_LOOP_PROMPT } from './agentExecutor.optiProfile';
+import {
+  buildOptiOrchestrationProfile,
+  resolveOptiAgentTools,
+  OPTI_CORE_AGENT_TOOLS,
+  OPTI_AGENT_LOOP_PROMPT,
+} from './agentExecutor.optiProfile';
 import { pickEffectiveEnabledTools, pickEffectiveMaxIterations } from './agentExecutor.orchestrationProfile';
 
+// Stands in for `Object.keys(premiumLlmTools)`. Deliberately NOT the real generated map: that map
+// is gitignored and empty in a checkout with no overlay hydrated, so asserting against it would
+// pass vacuously in CI and drag an overlay's whole tool module into a unit test locally.
+const PREMIUM_TOOLS = ['premium_alpha', 'premium_beta'];
+
+const build = (overrides: Partial<Parameters<typeof buildOptiOrchestrationProfile>[0]> = {}) =>
+  buildOptiOrchestrationProfile({ premiumToolNames: PREMIUM_TOOLS, ...overrides });
+
+describe('resolveOptiAgentTools', () => {
+  it('offers every premium tool the caller passes, plus the core generics', () => {
+    expect(resolveOptiAgentTools(PREMIUM_TOOLS)).toEqual(['premium_alpha', 'premium_beta', ...OPTI_CORE_AGENT_TOOLS]);
+  });
+
+  // The drift guard this file exists for: the premium half must come from the caller, never from a
+  // list written here. A hardcoded tool name would survive every other case in this file, so pin
+  // the empty-map result exactly - re-adding one turns this red.
+  it('bakes in no premium tool names of its own', () => {
+    expect(resolveOptiAgentTools([])).toEqual([...OPTI_CORE_AGENT_TOOLS]);
+  });
+
+  it('offers a premium name colliding with a generic once, not twice', () => {
+    expect(resolveOptiAgentTools(['premium_alpha', 'web_search'])).toEqual([
+      'premium_alpha',
+      'web_search',
+      'retrieve_knowledge_content',
+      'current_datetime',
+    ]);
+  });
+});
+
 describe('buildOptiOrchestrationProfile', () => {
-  it('offers the optimizer tools plus safe generics, and nothing else', () => {
-    const profile = buildOptiOrchestrationProfile();
-    expect(profile.allowedTools).toEqual(OPTI_AGENT_TOOLS);
-    expect(profile.allowedTools).toContain('optihashi_decompose');
-    expect(profile.allowedTools).toContain('optihashi_formulate');
-    expect(profile.allowedTools).toContain('optihashi_edit_problem');
-    expect(profile.allowedTools).toContain('optihashi_schedule');
-    expect(profile.allowedTools).toContain('optihashi_solve');
+  it('offers the derived optimizer tools plus safe generics, and nothing else', () => {
+    const profile = build();
+    expect(profile.allowedTools).toEqual(resolveOptiAgentTools(PREMIUM_TOOLS));
     // No general-purpose escape hatches that would pull the loop off-task.
     expect(profile.allowedTools).not.toContain('image_generation');
     expect(profile.allowedTools).not.toContain('coordinate_task');
   });
 
   it('offers retrieve_knowledge_content so attached files are readable, without open-ended lake search', () => {
-    const profile = buildOptiOrchestrationProfile();
+    const profile = build();
     // The agent path injects attached files as metadata only and points the agent at
     // `retrieve_knowledge_content`; dropping it makes every attachment on this surface
     // unreadable even though the file ingested fine.
@@ -27,27 +57,32 @@ describe('buildOptiOrchestrationProfile', () => {
     expect(profile.allowedTools).not.toContain('search_knowledge_base');
   });
 
+  // A host with no overlay hydrated generates an empty premium map. Offering only the generics is
+  // the honest outcome; the previous hardcoded list named five tools that resolved to nothing.
+  it('degrades to the core generics when no premium tools are registered', () => {
+    expect(build({ premiumToolNames: [] }).allowedTools).toEqual([...OPTI_CORE_AGENT_TOOLS]);
+  });
+
   it('denies image generation and multi-agent delegation', () => {
-    const profile = buildOptiOrchestrationProfile();
+    const profile = build();
     expect(profile.deniedTools).toEqual(
       expect.arrayContaining(['image_generation', 'edit_image', 'delegate_to_agent', 'coordinate_task'])
     );
   });
 
   it('is a synthetic profile with a stable id and the loop prompt as its persona', () => {
-    const profile = buildOptiOrchestrationProfile();
+    const profile = build();
     expect(profile.isSynthetic).toBe(true);
     expect(profile.id).toBe('synthetic:opti-orchestration');
     expect(profile.systemPrompt).toBe(OPTI_AGENT_LOOP_PROMPT);
   });
 
   it('accepts a system-prompt override (e.g. an admin-tuned prompt)', () => {
-    const profile = buildOptiOrchestrationProfile('CUSTOM PROMPT');
-    expect(profile.systemPrompt).toBe('CUSTOM PROMPT');
+    expect(build({ systemPrompt: 'CUSTOM PROMPT' }).systemPrompt).toBe('CUSTOM PROMPT');
   });
 
   it('raises the iteration ceiling so a multi-step ladder does not truncate mid-walk', () => {
-    const profile = buildOptiOrchestrationProfile();
+    const profile = build();
     expect(profile.defaultThoroughness).toBe('very_thorough');
     // A decompose + per-step formulate/solve/read walk needs headroom.
     expect(pickEffectiveMaxIterations(undefined, profile)).toBeGreaterThanOrEqual(30);
@@ -56,8 +91,8 @@ describe('buildOptiOrchestrationProfile', () => {
 
 describe('opti profile x pickEffectiveEnabledTools', () => {
   it('resolves the optimizer tools when the payload pins none', () => {
-    const profile = buildOptiOrchestrationProfile();
-    expect(pickEffectiveEnabledTools(undefined, profile)).toEqual(OPTI_AGENT_TOOLS);
+    const profile = build();
+    expect(pickEffectiveEnabledTools(undefined, profile)).toEqual(resolveOptiAgentTools(PREMIUM_TOOLS));
   });
 
   // The exclusivity is what fixes the production failure this guards: a classifier-routed
@@ -65,13 +100,16 @@ describe('opti profile x pickEffectiveEnabledTools', () => {
   // walk's toolset with it left the agent unable to decompose the scenario it was asked
   // to break down. Pinned as a flag assertion too, so deleting the flag from the profile
   // turns a test red rather than only changing behaviour.
+  //
+  // It is also why deriving the list matters: with the payload ignored, this profile is the ONLY
+  // thing that decides, so a name missing from it has no caller-side escape hatch.
   it('declares its toolset exclusive, so a payload selection cannot narrow the walk', () => {
-    const profile = buildOptiOrchestrationProfile();
+    const profile = build();
     expect(profile.toolsetIsExclusive).toBe(true);
-    expect(pickEffectiveEnabledTools(['optihashi_formulate'], profile)).toEqual(OPTI_AGENT_TOOLS);
+    expect(pickEffectiveEnabledTools(['premium_alpha'], profile)).toEqual(resolveOptiAgentTools(PREMIUM_TOOLS));
   });
 
-  // NOT a subtraction test: OPTI_AGENT_TOOLS never contained image_generation, and the
+  // NOT a subtraction test: the optimizer toolset never contained image_generation, and the
   // exclusive toolset ignores the payload, so the denylist has nothing visible to remove
   // here (a previous version of this case passed with OPTI_DENIED_TOOLS emptied). The
   // denylist's real job on this profile is downstream - agentExecutor subtracts it from
@@ -79,7 +117,7 @@ describe('opti profile x pickEffectiveEnabledTools', () => {
   // honestly pin is the config itself, which the 'denies image generation and multi-agent
   // delegation' case above already does.
   it('yields the full optimizer toolset even when the payload names a denied tool', () => {
-    const profile = buildOptiOrchestrationProfile();
-    expect(pickEffectiveEnabledTools(['image_generation'], profile)).toEqual(OPTI_AGENT_TOOLS);
+    const profile = build();
+    expect(pickEffectiveEnabledTools(['image_generation'], profile)).toEqual(resolveOptiAgentTools(PREMIUM_TOOLS));
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
@@ -16,10 +16,9 @@
 import type { ResolvedOrchestrationProfile } from './agentExecutor.orchestrationProfile';
 
 /**
- * Tools offered to the optimizer agent. The five `optihashi_*` tools resolve from the premium
- * tool map already merged into `externalTools`; the rest are core generics (verified registered
- * in `b4m-core/services/src/llm/tools/index.ts`). Kept deliberately small so the loop stays on
- * the model->formulate->solve->advance task.
+ * Core generics offered to the optimizer agent alongside the premium optimizer tools (verified
+ * registered in `b4m-core/services/src/llm/tools/index.ts`). Kept deliberately small so the loop
+ * stays on the model->formulate->solve->advance task.
  *
  * `retrieve_knowledge_content` is load-bearing rather than a convenience: the agent path injects
  * attached files as METADATA ONLY and points the agent at this tool to read them
@@ -29,16 +28,32 @@ import type { ResolvedOrchestrationProfile } from './agentExecutor.orchestration
  * the loop on task, whereas open-ended lake search invites it off task, and that search is
  * still available on the chat path.
  */
-export const OPTI_AGENT_TOOLS: string[] = [
-  'optihashi_decompose',
-  'optihashi_formulate',
-  'optihashi_edit_problem',
-  'optihashi_schedule',
-  'optihashi_solve',
+export const OPTI_CORE_AGENT_TOOLS: readonly string[] = [
   'retrieve_knowledge_content',
   'web_search',
   'current_datetime',
 ];
+
+/**
+ * The optimizer agent's toolbelt: every premium tool the host has registered, plus the core
+ * generics above (deduped, so an overlay name colliding with a generic is offered once).
+ *
+ * The premium names are DERIVED from the caller's tool map rather than restated here. That map is
+ * generated from whichever overlay packages are hydrated at install/dev-server time
+ * (`apps/client/scripts/generate-premium-glue.mjs` -> `premiumLlmTools.generated.ts`, gitignored),
+ * so a list written out here drifts silently: a newly registered tool is resolvable on the chat
+ * path but invisible to this profile until someone edits the list by hand, and nothing fails loudly
+ * when that happens - the agent simply never sees the tool and answers in prose instead.
+ *
+ * Assumption, true of every premium tool registered today: a premium tool belongs on the optimizer
+ * surface. `ToolDefinition` carries no surface tag, so if a non-optimizer overlay ever contributes
+ * one, the fix is to tag the definition rather than to reintroduce a name list here.
+ *
+ * `OPTI_DENIED_TOOLS` is still subtracted downstream, so a derived name remains deniable.
+ */
+export function resolveOptiAgentTools(premiumToolNames: readonly string[]): string[] {
+  return [...new Set([...premiumToolNames, ...OPTI_CORE_AGENT_TOOLS])];
+}
 
 /**
  * Explicitly denied even if a payload override tries to re-add them: image generation has a
@@ -115,16 +130,27 @@ Discipline:
   the tool call does the real work.`;
 
 /**
- * Build the opti orchestration profile. `systemPrompt` defaults to the built-in loop prompt but
- * accepts an override (e.g. an admin-tuned prompt) resolved by the caller.
+ * Build the opti orchestration profile.
+ *
+ * `premiumToolNames` is required rather than defaulted: this file stays a pure builder (no Mongo,
+ * AWS or overlay engine imports), so it cannot read the generated premium map itself and the caller
+ * passes `Object.keys(premiumLlmTools)`. Requiring it turns a caller that forgets into a compile
+ * error rather than an agent silently missing its optimizer tools.
+ *
+ * `systemPrompt` defaults to the built-in loop prompt but accepts an override (e.g. an admin-tuned
+ * prompt) resolved by the caller.
  */
-export function buildOptiOrchestrationProfile(
-  systemPrompt: string = OPTI_AGENT_LOOP_PROMPT
-): ResolvedOrchestrationProfile {
+export function buildOptiOrchestrationProfile({
+  premiumToolNames,
+  systemPrompt = OPTI_AGENT_LOOP_PROMPT,
+}: {
+  premiumToolNames: readonly string[];
+  systemPrompt?: string;
+}): ResolvedOrchestrationProfile {
   return {
     id: 'synthetic:opti-orchestration',
     name: 'Optimizer',
-    allowedTools: OPTI_AGENT_TOOLS,
+    allowedTools: resolveOptiAgentTools(premiumToolNames),
     deniedTools: OPTI_DENIED_TOOLS,
     maxIterations: { ...OPTI_MAX_ITERATIONS },
     defaultThoroughness: 'very_thorough',

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -1040,7 +1040,18 @@ async function processExecution(
     // formulate/schedule to advance the ladder. An explicit `@agent` mention still wins
     // on the initial send (it sets `startPayload.agentId` -> the persisted-agent path).
     if (!startPayload?.agentId && session.surface === OPTI_SURFACE) {
-      orchestrationProfile = buildOptiOrchestrationProfile();
+      // Premium tool names come from the generated map (the same one merged into `externalTools`
+      // below), so a tool an overlay registers is offerable here without editing a list by hand.
+      const premiumToolNames = Object.keys(premiumLlmTools);
+      // An empty map means codegen ran with no overlay hydrated. The loop then has no optimizer
+      // tools at all and answers in prose, which reads as a model failure rather than a build one -
+      // so say it once, here, where the cause is known.
+      if (premiumToolNames.length === 0) {
+        logger.warn('[opti] optimizer surface resolved no premium tools; the agent has only core generics', {
+          executionId,
+        });
+      }
+      orchestrationProfile = buildOptiOrchestrationProfile({ premiumToolNames });
     } else if (isNewExecution) {
       // `getSettingsValue<K>` is generic-narrowed to `SettingValue<K>` -
       // `OrchestrationDefaults` here - so no cast is needed.


### PR DESCRIPTION
## Description

The optimizer agent profile (`agentExecutor.optiProfile.ts`) carried a hardcoded list of tool
names that had to mirror the premium tool map. That map is not a checked-in file: it is generated
from whichever overlay packages are hydrated, at install and dev-server start
(`apps/client/scripts/generate-premium-glue.mjs` -> `server/premium-generated/premiumLlmTools.generated.ts`,
gitignored).

So the two drifted silently. A tool an overlay registers is resolvable and offerable on the chat
path, but stays invisible to the optimizer agent profile until someone remembers to edit the list
by hand -- and nothing fails loudly when that happens. The agent simply never sees the tool and
answers in prose, or reaches for a neighbouring tool instead.

There is no caller-side workaround, either. `buildOptiOrchestrationProfile` sets
`toolsetIsExclusive: true`, and `pickEffectiveEnabledTools`
(`agentExecutor.orchestrationProfile.ts:166-175`) reads that as "ignore the payload outright", so a
dispatch that pins a tool explicitly is discarded on this surface. That exclusivity is deliberate
and worth keeping -- it exists because a narrowed payload stranded the loop mid-walk in production
-- but it means the profile's list is the only additive decision there is.

This derives the premium half instead of restating it, which removes the drift class rather than
patching one instance of it.

Closes #2347

## Changes

- `OPTI_AGENT_TOOLS` (8 hardcoded names) is replaced by two pieces:
  - `OPTI_CORE_AGENT_TOOLS` -- the three core generics this file legitimately owns
    (`retrieve_knowledge_content`, `web_search`, `current_datetime`), with the existing rationale
    for each kept intact.
  - `resolveOptiAgentTools(premiumToolNames)` -- unions the caller's premium names with those
    generics, deduped so a premium name colliding with a generic is offered once.
- `buildOptiOrchestrationProfile` now takes an options object, and `premiumToolNames` is
  **required** rather than defaulted. That is the guard: a caller who forgets gets a compile error
  instead of an agent that silently has no optimizer tools. The file stays a pure builder with no
  Mongo/AWS/overlay imports, so it remains unit-testable -- which is why it takes the names rather
  than reading the generated map itself.
- The single call site (`agentExecutor.ts:1043`) passes `Object.keys(premiumLlmTools)` -- the same
  map merged into `externalTools` further down. Verified that the three guard wrappers applied to
  it (`guardDecomposeOnce`, `guardPlanCompletion`, `injectBriefContext`) each spread `...tools` and
  add no keys, so the key set the profile sees is the key set the run resolves.
- Added a `logger.warn` when the derived premium list is empty. That state means codegen ran with
  no overlay hydrated; previously the profile offered five names that resolved to nothing, which
  presents as a model failure rather than a build one.
- Test suite reworked against a synthetic premium list, plus three new cases: derivation,
  dedupe-on-collision, and the empty-map degradation.

`OPTI_DENIED_TOOLS` is untouched and still subtracted downstream, so a derived name remains
deniable.

## Guide for Testers

This is a backend refactor with no UI surface of its own. What it changes is *which tools the
optimizer agent is offered*, so the test is that the agent-mode walk still runs end to end.

The change is in `apps/client/server/**`, which the preview image hash does cover, so a normal
preview deploy picks it up -- no cachebust needed.

1. Open `https://app.pr2360.preview.bike4mind.com` and log in.
2. Navigate to the optimizer surface: `https://app.pr2360.preview.bike4mind.com/opti`.
   **Expected:** the optimizer console loads with no error banner.
3. Turn **Agent mode ON** in the chat composer (the toggle beside the send control).
   **Expected:** the composer shows agent mode active.
4. In the message input, type exactly:
   `I run a small bakery. Plan tomorrow's baking schedule across two ovens, then decide how many
   staff to roster for the morning shift.`
   and send it.
   **Expected, within about 90 seconds:** the run streams a multi-step walk -- a short narration
   sentence, then a plan being broken into steps, then per-step model-building and solving. Each
   tool call appears as its own step in the execution timeline. The run ends with a written summary
   naming a result for each step, not with a question back to you.
5. Confirm the run actually called tools rather than only describing them: expand the execution
   timeline.
   **Expected:** at least three distinct optimizer tool steps, each with an observation attached.
   **Fail condition for this PR:** the agent answers in prose with zero tool steps.
6. Attach a small text file to a new message on the same surface (paperclip -> upload a `.txt`
   containing two or three lines of plain text), then send `Read the attached file and summarise it.`
   **Expected:** the agent reads the file contents back. **Fail condition:** any reply along the
   lines of "I can't access the attached file".

### Regression Checks

7. **Chat path unaffected.** Turn agent mode **OFF** on `/opti` and send
   `Schedule three jobs across two machines.`
   **Expected:** the ordinary chat-path behaviour, unchanged from `main` -- a reply that models and
   solves the problem.
8. **Explicit agent mention still wins.** On a normal (non-optimizer) session, send a message
   pinning an agent with `@` as you normally would.
   **Expected:** that agent's own tool configuration applies, not the optimizer profile's. This PR
   does not touch that branch.
9. **Denials still hold.** With agent mode ON on `/opti`, send
   `Draw me a picture of the schedule.`
   **Expected:** no image is generated. Image generation is denied on this surface and stays denied.
10. **Iteration ceiling unchanged.** The step-4 walk should not truncate mid-plan; if it stops
    early with steps still unsolved, that is a regression worth reporting.

### What NOT to test

- **There is no UI change.** No component, route, style, or copy was touched. Nothing to screenshot.
- **No API or contract change.** No endpoint, request schema, or response shape moved.
- **Do not try to observe the new `logger.warn`.** It only fires on a host where codegen ran with
  no overlay package hydrated. Every deployed environment has one, so it should never appear in
  preview or staging logs -- and if it does, that is a build/provisioning finding, not a test result.
- **Do not test tool availability by reading the code's tool list.** The list is now derived at
  runtime, so the only honest check is the behavioural one in steps 4-6.

## Additional Information

Two things I found while doing this and deliberately did not fix here:

1. **The loop prompt is a second derived surface.** `OPTI_AGENT_LOOP_PROMPT` enumerates tool names
   in prose and its `Loop:` steps prescribe which to call. A newly derived tool is therefore
   *offerable* after this change, but the prompt does not mention it, so the model is unlikely to
   reach for it unprompted. The builder already accepts a `systemPrompt` override (an admin-tuned
   prompt) and that is the right seam for it; hardcoding prompt prose per tool would recreate
   exactly the coupling this PR removes.
2. **No unit test covers the surface-selection branch** in `agentExecutor.ts` -- it needs the full
   handler dependency graph -- so the new warn and the call-site wiring are not test-covered. The
   required parameter is what guards the wiring; a caller that omits it cannot compile.

Also noticed, out of scope and worth its own issue: `app/utils/toolMapping.ts:238-253` and
`app/utils/toolRecommender.ts:24-26` carry display metadata for only three of the five optimizer
tools -- two have none. Presentational and pre-existing.

One probe that came back clean and is worth recording: `applySessionToolPolicy` runs after the
profile and is **subtractive only** -- it deliberately does not union `session.enabledTools` -- so
it cannot widen or re-add a name. The profile really is the only additive decision on this surface,
which is what makes deriving it the whole fix rather than half of one.

## Developer Notes (Optional)

- **New extension point:** `resolveOptiAgentTools(premiumToolNames)` is the seam for "what may the
  optimizer agent use". Anything that needs to compose that list (a different surface profile, a
  narrower demo profile) composes it here rather than restating names.
- **Pattern:** requiring the derived input as a parameter, rather than importing the generated map
  into the profile module, keeps the module free of the overlay dependency graph *and* turns a
  forgotten wiring into a compile error. Same shape as `agentExecutor.firstIterationQuery.ts` and
  `agentExecutor.sessionToolPolicy.ts` -- pure functions with the server-only inputs passed in.
- **Assumption now written down in the code:** a premium tool belongs on the optimizer surface.
  `ToolDefinition` (`b4m-core/services/src/llm/tools/base/types.ts:288`) is `{ name, implementation }`
  and carries no surface tag, so if a non-optimizer overlay ever contributes a tool, the fix is to
  tag the definition -- not to reintroduce a name list in the profile. The comment says so, so the
  next person hits the decision rather than the symptom.
