### PR TITLE
fix(scripts): throw instead of guessing a help access level

### DIFF
--- a/packages/scripts/help/__tests__/vectorize-help-content.test.ts
+++ b/packages/scripts/help/__tests__/vectorize-help-content.test.ts
@@ -9,14 +9,14 @@ import * as path from 'path';
 vi.mock('@bike4mind/fab-pipeline', () => ({ EmbeddingFactory: vi.fn() }));
 vi.mock('@bike4mind/common', () => ({ OpenAIEmbeddingModel: { TEXT_EMBEDDING_3_SMALL: 'text-embedding-3-small' } }));
 
-import { loadAccessLevelMap, resolveAccessLevel, buildChunks } from '../vectorize-help-content';
+import { loadAccessLevelMap, resolveAccessLevel, relativePathToSlug, buildChunks } from '../vectorize-help-content';
 
 /**
  * accessLevel is the only gate keeping admin-only help docs out of non-admin
  * users' Help AI chat responses (see apps/client/server/help/retrieval.ts).
- * These tests guard against a fail-open regression: a broken help-index.json
- * (or a slug missing from it) must never resolve to the less restrictive
- * 'public' level.
+ * These tests guard both directions of the same failure: an accessLevel must
+ * never be inferred from a broken help-index.json or a slug missing from it -
+ * guessing 'public' leaks admin docs, guessing 'admin' hides the public ones.
  */
 
 let root: string;
@@ -24,7 +24,6 @@ let root: string;
 beforeEach(() => {
   root = fs.mkdtempSync(path.join(os.tmpdir(), 'help-vectorize-test-'));
   vi.spyOn(console, 'log').mockImplementation(() => {});
-  vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -38,11 +37,11 @@ function writeIndex(content: string): string {
   return indexPath;
 }
 
-function writeArticle(relPath: string): string {
+function writeArticle(relPath: string, title = 'Test Article'): string {
   const contentRoot = path.join(root, 'content');
   const filePath = path.join(contentRoot, relPath);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, '---\ntitle: Test Article\n---\n\n# Test Article\n\nSome body text.\n');
+  fs.writeFileSync(filePath, `---\ntitle: ${title}\n---\n\n# ${title}\n\nSome body text.\n`);
   return contentRoot;
 }
 
@@ -74,6 +73,18 @@ describe('loadAccessLevelMap', () => {
 
     expect(() => loadAccessLevelMap(indexPath)).toThrow();
   });
+
+  it('throws when entries is absent, rather than iterating undefined', () => {
+    const indexPath = writeIndex(JSON.stringify({ version: 'abc123' }));
+
+    expect(() => loadAccessLevelMap(indexPath)).toThrow(/unexpected artifact shape/);
+  });
+
+  it('throws when entries is empty, which would leave every slug unresolvable', () => {
+    const indexPath = writeIndex(JSON.stringify({ entries: [] }));
+
+    expect(() => loadAccessLevelMap(indexPath)).toThrow(/unexpected artifact shape/);
+  });
 });
 
 describe('resolveAccessLevel', () => {
@@ -83,36 +94,71 @@ describe('resolveAccessLevel', () => {
     expect(resolveAccessLevel('features/foo', map)).toBe('public');
   });
 
-  it('defaults an unmapped slug to admin, not public', () => {
+  it('throws on an unmapped slug rather than inferring a level in either direction', () => {
     const map = new Map([['features/foo', 'public' as const]]);
 
-    expect(resolveAccessLevel('features/unmapped', map)).toBe('admin');
+    expect(() => resolveAccessLevel('features/unmapped', map)).toThrow(/features\/unmapped/);
+  });
+});
+
+describe('relativePathToSlug', () => {
+  it('strips the .md extension', () => {
+    expect(relativePathToSlug('features/notebooks.md')).toBe('features/notebooks');
   });
 
-  it('defaults every slug to admin when the map is empty', () => {
-    expect(resolveAccessLevel('anything', new Map())).toBe('admin');
+  it('collapses a directory index to the directory itself', () => {
+    expect(relativePathToSlug('features/notebooks/index.md')).toBe('features/notebooks');
+    expect(relativePathToSlug('index.md')).toBe('');
+  });
+
+  it('normalizes Windows separators, which would otherwise miss every index entry', () => {
+    expect(relativePathToSlug('features\\notebooks.md')).toBe('features/notebooks');
+  });
+
+  it('agrees with filePathToSlug on a Windows directory index', () => {
+    // filePathToSlug (loadHelpArticles.ts) also strips `/index` before normalizing
+    // separators, so on Windows both leave the trailing `index` in place. What
+    // matters is that the index builder and this consumer agree; the shared quirk
+    // is worth fixing in one place once the three slug copies are collapsed.
+    expect(relativePathToSlug('features\\notebooks\\index.md')).toBe('features/notebooks/index');
   });
 });
 
 describe('buildChunks', () => {
-  it('fails closed: every chunk defaults to admin when the index has no matching entries', async () => {
-    const contentRoot = writeArticle('features/foo.md');
-    const indexPath = writeIndex(JSON.stringify({ entries: [] }));
+  it('resolves accessLevel from the index for both public and admin articles', async () => {
+    writeArticle('features/foo.md', 'Public Article');
+    const contentRoot = writeArticle('admin/bar.md', 'Admin Article');
+    const indexPath = writeIndex(
+      JSON.stringify({
+        entries: [
+          { slug: 'features/foo', accessLevel: 'public' },
+          { slug: 'admin/bar', accessLevel: 'admin' },
+        ],
+      })
+    );
 
     const chunks = await buildChunks({ contentRoot, indexPath });
 
     expect(chunks.length).toBeGreaterThan(0);
-    expect(chunks.every(chunk => chunk.accessLevel === 'admin')).toBe(true);
+    expect(chunks.filter(chunk => chunk.slug === 'features/foo').every(chunk => chunk.accessLevel === 'public')).toBe(
+      true
+    );
+    expect(chunks.filter(chunk => chunk.slug === 'admin/bar').every(chunk => chunk.accessLevel === 'admin')).toBe(true);
   });
 
-  it('resolves accessLevel from the index when a slug is present', async () => {
-    const contentRoot = writeArticle('features/foo.md');
+  it('throws when a bundled article has no index entry, naming the offending slug', async () => {
+    const contentRoot = writeArticle('admin/unindexed.md');
     const indexPath = writeIndex(JSON.stringify({ entries: [{ slug: 'features/foo', accessLevel: 'public' }] }));
 
-    const chunks = await buildChunks({ contentRoot, indexPath });
+    await expect(buildChunks({ contentRoot, indexPath })).rejects.toThrow(/admin\/unindexed/);
+  });
 
-    expect(chunks.length).toBeGreaterThan(0);
-    expect(chunks.every(chunk => chunk.accessLevel === 'public')).toBe(true);
+  it('names every unresolvable slug in one error, not just the first', async () => {
+    writeArticle('admin/one.md');
+    const contentRoot = writeArticle('admin/two.md');
+    const indexPath = writeIndex(JSON.stringify({ entries: [{ slug: 'features/foo', accessLevel: 'public' }] }));
+
+    await expect(buildChunks({ contentRoot, indexPath })).rejects.toThrow(/admin\/one.*admin\/two/s);
   });
 
   it('propagates the loadAccessLevelMap failure instead of vectorizing with an empty map', async () => {

--- a/packages/scripts/help/vectorize-help-content.ts
+++ b/packages/scripts/help/vectorize-help-content.ts
@@ -58,16 +58,24 @@ interface ChunkData {
   accessLevel: HelpAccessLevel;
 }
 
+/** Remedy quoted in every failure below; see also .husky/check-help-content.sh. */
+const REGENERATE_HINT = 'regenerate the help artifacts with `pnpm --filter @bike4mind/scripts help:regenerate`';
+
 /**
  * Load slug -> accessLevel mapping from help-index.json. Throws if the index
- * can't be read or parsed: access-level labels gate admin-only content out of
- * the Help AI chat for non-admin users, so a broken index must fail the build
- * rather than silently produce chunks that resolveAccessLevel then defaults
- * to the fail-closed 'admin' level (which would also hide public docs).
+ * can't be read, parsed, or is not a non-empty entries[]: access-level labels
+ * gate admin-only content out of the Help AI chat for non-admin users, so a
+ * broken index must fail the build rather than silently produce chunks whose
+ * labels were never derived from it. An empty entries[] parses fine but would
+ * leave every slug unresolvable, so it is rejected here rather than surfacing
+ * as one "no entry for slug" complaint per bundled article.
  */
 export function loadAccessLevelMap(indexPath: string = HELP_INDEX_PATH): Map<string, HelpAccessLevel> {
   const raw = fs.readFileSync(indexPath, 'utf-8');
   const index = JSON.parse(raw) as HelpIndex;
+  if (!Array.isArray(index.entries) || index.entries.length === 0) {
+    throw new Error(`unexpected artifact shape in ${indexPath}: expected a non-empty entries[] - ${REGENERATE_HINT}`);
+  }
   const map = new Map<string, HelpAccessLevel>();
   for (const entry of index.entries) {
     map.set(entry.slug, entry.accessLevel);
@@ -77,12 +85,32 @@ export function loadAccessLevelMap(indexPath: string = HELP_INDEX_PATH): Map<str
 }
 
 /**
- * Resolve a slug's access level, defaulting to the more restrictive 'admin'
- * when the slug isn't in the map. Fail-closed: an unresolvable slug must
- * never fall back to 'public', or it bypasses the Help AI chat's admin gate.
+ * Resolve a slug's access level, throwing when the slug is absent from the index.
+ * No level is ever inferred from a miss: defaulting to 'public' bypasses the Help
+ * AI chat's admin gate, and defaulting to 'admin' silently hides the public docs.
+ * A miss is an invariant violation, not a normal condition - bundle-help-content.ts
+ * copies exactly the index's entries and sweeps everything else, so the bundled
+ * corpus and the index agree unless help:vectorize ran without a preceding bundle.
  */
 export function resolveAccessLevel(slug: string, accessLevelMap: Map<string, HelpAccessLevel>): HelpAccessLevel {
-  return accessLevelMap.get(slug) ?? 'admin';
+  const accessLevel = accessLevelMap.get(slug);
+  if (!accessLevel) {
+    throw new Error(`no help-index.json entry for bundled help article "${slug}" - ${REGENERATE_HINT}`);
+  }
+  return accessLevel;
+}
+
+/**
+ * Derive a slug from a content-root-relative markdown path. Must stay in sync with
+ * filePathToSlug in loadHelpArticles.ts, which builds the index this slug is looked
+ * up in - including normalizing separators last, so both agree on Windows, where a
+ * relative path arrives as `features\\notebooks` and would otherwise never match.
+ */
+export function relativePathToSlug(relativePath: string): string {
+  let slug = relativePath.replace(/\.md$/, '');
+  if (slug.endsWith('/index')) slug = slug.replace(/\/index$/, '');
+  else if (slug === 'index') slug = '';
+  return slug.replace(/\\/g, '/');
 }
 
 export interface BuildChunksOptions {
@@ -99,7 +127,6 @@ export async function buildChunks(opts: BuildChunksOptions = {}): Promise<ChunkD
   const contentRoot = opts.contentRoot ?? HELP_CONTENT_ROOT;
   const indexPath = opts.indexPath ?? HELP_INDEX_PATH;
   const accessLevelMap = loadAccessLevelMap(indexPath);
-  const chunks: ChunkData[] = [];
 
   const files = await glob('**/*.md', {
     cwd: contentRoot,
@@ -108,6 +135,7 @@ export async function buildChunks(opts: BuildChunksOptions = {}): Promise<ChunkD
 
   console.log(`Found ${files.length} markdown files in help-content`);
 
+  const articles: { slug: string; title: string; content: string }[] = [];
   for (const filePath of files) {
     const fileContent = fs.readFileSync(filePath, 'utf-8');
     const { data: frontmatter, content } = matter(fileContent);
@@ -117,16 +145,31 @@ export async function buildChunks(opts: BuildChunksOptions = {}): Promise<ChunkD
       continue;
     }
 
-    const relativePath = path.relative(contentRoot, filePath);
-    let slug = relativePath.replace(/\.md$/, '');
-    if (slug.endsWith('/index')) slug = slug.replace(/\/index$/, '');
-    else if (slug === 'index') slug = '';
+    articles.push({
+      slug: relativePathToSlug(path.relative(contentRoot, filePath)),
+      title: frontmatter.title as string,
+      content,
+    });
+  }
 
-    const title = frontmatter.title as string;
+  // Report every unresolvable slug at once: a stale bundle typically misses many,
+  // and throwing on the first would make it a one-slug-at-a-time fix. Sorted
+  // because glob order is not stable and the list is read by a human.
+  const unindexed = articles
+    .filter(article => !accessLevelMap.has(article.slug))
+    .map(article => article.slug)
+    .sort();
+  if (unindexed.length > 0) {
+    throw new Error(
+      `${unindexed.length} bundled help article(s) have no help-index.json entry: ${unindexed.join(', ')} - ${REGENERATE_HINT}`
+    );
+  }
+
+  const chunks: ChunkData[] = [];
+  for (const { slug, title, content } of articles) {
     const accessLevel = resolveAccessLevel(slug, accessLevelMap);
-    const sections = chunkByHeadings(content, title);
 
-    for (const section of sections) {
+    for (const section of chunkByHeadings(content, title)) {
       // Prepend article title for embedding context
       const embeddingContent = `# ${title}\n\n${section.content}`;
       chunks.push({
@@ -234,8 +277,9 @@ async function main(): Promise<void> {
   console.log(`  Output: ${OUTPUT_PATH}`);
 }
 
-// Only run when invoked directly (not when imported by tests)
-if (process.argv[1] && process.argv[1].endsWith('vectorize-help-content.ts')) {
+// Only run when invoked directly (not when imported by tests). Compared by resolved
+// path rather than filename suffix so a mismatch cannot silently no-op the script.
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
   main().catch(error => {
     console.error('Failed to vectorize help content:', error);
     process.exit(1);


### PR DESCRIPTION
## Description

Follow-up hardening on #2311, which fixed the original fail-open in `packages/scripts/help/vectorize-help-content.ts` by dropping the swallowed `catch` and flipping the unresolved-slug default from `'public'` to `'admin'`.

That was a strict improvement, but `?? 'admin'` is still a silent default that borrows a real value's meaning. When every slug misses the map, all 703 chunks become `admin`, the script exits 0, and the Help AI chat serves *nothing* to non-admin users. Nothing gates either direction: the husky drift check (`.husky/check-help-content.sh`) compares slug sets only and never looks at `accessLevel`, and no CI job runs `help:vectorize` at all. So the fail-open became a fail-blackout, equally silent.

A slug missing from `help-index.json` is an invariant violation, not a normal condition. `bundle-help-content.ts:112` copies exactly `helpIndex.entries.map(e => e.filePath)` and its `cleanupDirectory` sweep at `:213-238` deletes every bundled file not in that set, so the bundled corpus and the index agree by construction. The only way a miss happens on a healthy tree is running `help:vectorize` without a preceding `help:bundle-content` - which means the pipeline ran out of order and *should* fail loudly. `help:regenerate` sequences all three steps correctly.

This PR therefore stops inferring an access level in either direction, and makes the remaining silent paths loud.

There is also a second, independent trigger that needed no filesystem failure at all: vectorize hand-rolled its own slug transform and was the only one of the three copies missing the Windows separator normalization that `filePathToSlug` (`loadHelpArticles.ts:117`) documents. On Windows `path.relative` yields `features\notebooks`, which never matches the index's `features/notebooks`, so *every* slug missed the map on the happy path - pre-#2311 that silently relabelled the whole corpus `public`.

## Changes

- `resolveAccessLevel()` now throws on a miss instead of defaulting. `buildChunks()` collects *every* unresolvable slug and throws once with the sorted list plus the remedy command, so a stale bundle is not a one-slug-at-a-time fix. The list is sorted because glob order is not stable and a human reads it.
- `loadAccessLevelMap()` validates the parsed index: `entries` must be an array and must be non-empty. Previously `{}` threw a bare `TypeError` (fail-closed by accident, with an unhelpful message) and a valid `{"entries": []}` yielded a size-0 map that made every chunk `admin` at exit 0. The message mirrors the existing `unexpected artifact shape` phrasing in `.husky/check-help-content.sh`.
- Extracted the slug derivation into `relativePathToSlug()` and added the `\` to `/` normalization so it matches `filePathToSlug` in `loadHelpArticles.ts` (the builder of the very index it is looked up in), including keeping the normalization last so both agree on Windows.
- The entrypoint guard now compares resolved paths (`path.resolve(process.argv[1]) === __filename`) rather than matching a filename suffix, so a mismatch cannot silently no-op the script. Verified under `tsx` that the resolved paths are equal.
- Rewrote `packages/scripts/help/__tests__/vectorize-help-content.test.ts` for the new contract (15 tests, up from 9), and dropped a `console.warn` spy that guarded a warning no longer on the fixed path.

## Guide for Testers

This is a backend build-script change with no UI surface. No runtime code path, no schema, no migration.

1. From the repo root, run `pnpm --filter @bike4mind/scripts exec vitest run help/__tests__/vectorize-help-content.test.ts`. Expected: `15 passed`.
2. Run the whole package suite with the worker pool capped, as CLAUDE.md advises for the Mongo-backed tests: `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/scripts test`. Expected: `Test Files 53 passed (53)`, `Tests 558 passed (558)`. Without the cap, roughly 20 `migrate/migrations/*.integration.test.ts` tests fail on the documented port-collision race; that is pre-existing and unrelated to this change.
3. To see the new loud failure by hand, temporarily corrupt the index: `node -e "require('fs').writeFileSync('apps/client/app/generated/help-index.json','{\"entries\":[]}')"`, then run `OPENAI_API_KEY=sk-test pnpm --filter @bike4mind/scripts help:vectorize`. Expected: it prints `unexpected artifact shape in .../help-index.json: expected a non-empty entries[]` and exits non-zero, before ever reaching the OpenAI call, so the key does not need to be valid. Restore with `git checkout apps/client/app/generated/help-index.json`.
4. Run `pnpm turbo:typecheck && pnpm lint:check`. Expected: both pass.

### Regression Checks

1. Confirm the committed embeddings artifact is untouched by this PR: `git diff origin/main --stat` should list only the two files under `packages/scripts/help/`.
2. Confirm the artifact is still internally consistent on `main` (this PR does not regenerate it): 703 chunks, `{ admin: 251, public: 452 }`, zero chunk slugs absent from `help-index.json`, zero `accessLevel` disagreements against it.

### What NOT to test

- No UI or user-facing behavior changed. Only the standalone `help:vectorize` build script's failure behavior changed.
- No need to run the full `help:regenerate` against a real OpenAI key. The unit tests exercise the fixed logic without embeddings, and regenerating would rewrite `help-embeddings.json`, which this PR deliberately leaves alone.

## Additional Information

**Test baselines.** Against `origin/main` (which already contains #2311), 9 of the 15 tests fail and 6 pass. The 6 that pass are the ones #2311 already covered. Honest caveat on the failures: 3 of the 9 (`relativePathToSlug` stripping `.md`, collapsing a directory index) fail only because the exported helper does not exist on `main` - they are new characterization coverage of an extracted function, not proof of a fixed defect. The other 6 are genuine behavior changes: `entries` absent throws, `entries: []` throws, an unmapped slug throws, a bundled article with no index entry throws naming the slug, every unresolvable slug is named in one error, and the Windows separator case. Confirmed directly that `main`'s inline logic maps `features\notebooks.md` to `features\notebooks` while the new helper maps it to `features/notebooks`.

**The artifact is not regenerated here.** `help-embeddings.json` is correct today and regenerating it needs a live `OPENAI_API_KEY`, so it is deliberately out of this diff.

**Complementary work, not duplicated here.** #2331 proposes asserting `chunk.accessLevel === entry.accessLevel` in the drift gate. That is the artifact-level complement to this code-level fix and the only thing that catches a bad artifact regardless of how it was produced. It depends on #2293 landing first.

**Adjacent same-class defect, deliberately out of scope.** `loadHelpArticles.ts:182` is `CATEGORY_ACCESS_LEVELS[topCategory] ?? 'public'` - the identical fail-open shape one layer up, in the index builder. It is unreachable today because the glob at `:139` restricts `topCategory` to `features|admin`, both mapped. But it arms itself the moment someone adds a category to `INCLUDED_CATEGORIES` without adding it to `CATEGORY_ACCESS_LEVELS`, and #2331's parity assertion could not catch it because both artifacts would derive from the same wrong source. Left out per smallest-change; worth its own issue.

## Developer Notes (Optional)

- `relativePathToSlug()` is now an exported seam, which makes the slug transform unit-testable for the first time. This is the third copy of that transform in the repo (`filePathToSlug` in `loadHelpArticles.ts`, `normalizeSlug` in `validate-help-content.ts`, and this one); collapsing all three onto one shared helper is now a mechanical follow-up. Note that all copies share a quirk on Windows directory indexes - they strip `/index` before normalizing separators, so `features\notebooks\index.md` keeps its trailing `index`. Because every copy agrees, it causes no mismatch today, and a test pins that agreement.
- The general pattern worth reusing: when a default value borrows a real value's meaning (`'public'`, `'admin'`), neither choice is safe. Throwing keeps "unknown" distinguishable from both.

## Security Testing (for security-labeled PRs only)

The underlying bug is a latent fail-open in a manually-run build script, not an exploitable runtime endpoint, so there is no live request to curl on staging. I do not have staging or preview-deploy access from this environment, so the checklist below is unticked - flagging for a maintainer to verify before merge.

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
