### PR TITLE
fix(client): return the chat to its dock when the launcher is reopened

### DIFF
--- a/apps/client/app/components/Session/DockedChatPanel.test.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.test.tsx
@@ -33,4 +33,33 @@ describe('DockedChatPanel', () => {
     expect(state.floatingChatMinimized).toBe(true);
     expect(state.layout).toBe('floatingChat');
   });
+
+  // Hiding is a round trip, not a move: the pill has to know where to put the panel back,
+  // and 'floatingChat' on its own is a layout the chat was never in.
+  it.each(['dockRight', 'dockBottom'] as const)('remembers %s as the dock to come back to', dock => {
+    setSessionLayout({ layout: dock });
+    render(
+      <Wrapper>
+        <DockedChatPanel>chat</DockedChatPanel>
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('docked-chat-close'));
+
+    expect(useSessionLayout.getState().hiddenFromLayout).toBe(dock);
+  });
+
+  it('forgets the dock once the user picks a layout themselves', () => {
+    render(
+      <Wrapper>
+        <DockedChatPanel>chat</DockedChatPanel>
+      </Wrapper>
+    );
+    fireEvent.click(screen.getByTestId('docked-chat-close'));
+
+    // What the layout menu does - a deliberate choice, which ends the hide episode.
+    setSessionLayout({ layout: 'floatingChat' });
+
+    expect(useSessionLayout.getState().hiddenFromLayout).toBeUndefined();
+  });
 });

--- a/apps/client/app/components/Session/DockedChatPanel.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.tsx
@@ -22,8 +22,11 @@ const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActio
     setSessionLayout({
       layout: 'floatingChat',
       floatingChatMinimized: true,
+      // Remembered so expanding the pill returns the chat to this dock. Only this panel's
+      // two layouts reach here, and dockRight is the one the split row renders on the left.
+      hiddenFromLayout: layout === 'dockBottom' ? 'dockBottom' : 'dockRight',
     });
-  }, []);
+  }, [layout]);
 
   return (
     <Box

--- a/apps/client/app/components/Session/DockedChatPanel.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.tsx
@@ -22,9 +22,9 @@ const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActio
     setSessionLayout({
       layout: 'floatingChat',
       floatingChatMinimized: true,
-      // Remembered so expanding the pill returns the chat to this dock. Only this panel's
-      // two layouts reach here, and dockRight is the one the split row renders on the left.
-      hiddenFromLayout: layout === 'dockBottom' ? 'dockBottom' : 'dockRight',
+      // Remembered so expanding the pill returns the chat to this dock. Narrowed rather than
+      // defaulted so a dock layout added later cannot silently collapse to dockRight.
+      hiddenFromLayout: layout === 'dockBottom' || layout === 'dockRight' ? layout : 'dockRight',
     });
   }, [layout]);
 

--- a/apps/client/app/components/Session/FloatingChatWindow.test.tsx
+++ b/apps/client/app/components/Session/FloatingChatWindow.test.tsx
@@ -34,8 +34,8 @@ describe('FloatingChatWindow', () => {
 
   // The other half of DockedChatPanel's "Hide chat": the pill is a waypoint back to the
   // dock, so expanding it must not strand the chat in a floating window.
-  it('expands back into the dock that hid the chat here', () => {
-    setSessionLayout({ layout: 'floatingChat', floatingChatMinimized: true, hiddenFromLayout: 'dockRight' });
+  it.each(['dockRight', 'dockBottom'] as const)('expands back into the %s that hid the chat here', dock => {
+    setSessionLayout({ layout: 'floatingChat', floatingChatMinimized: true, hiddenFromLayout: dock });
     render(
       <Wrapper>
         <FloatingChatWindow>chat</FloatingChatWindow>
@@ -45,13 +45,13 @@ describe('FloatingChatWindow', () => {
     fireEvent.click(screen.getByTestId('floating-chat-minimized'));
 
     const state = useSessionLayout.getState();
-    expect(state.layout).toBe('dockRight');
+    expect(state.layout).toBe(dock);
     expect(state.floatingChatMinimized).toBe(false);
     expect(state.hiddenFromLayout).toBeUndefined();
   });
 
   it('stays floating when the pill was minimized rather than hidden from a dock', () => {
-    setSessionLayout({ layout: 'floatingChat', floatingChatMinimized: true });
+    setSessionLayout({ layout: 'floatingChat', floatingChatMinimized: true, hiddenFromLayout: undefined });
     render(
       <Wrapper>
         <FloatingChatWindow>chat</FloatingChatWindow>

--- a/apps/client/app/components/Session/FloatingChatWindow.test.tsx
+++ b/apps/client/app/components/Session/FloatingChatWindow.test.tsx
@@ -31,4 +31,37 @@ describe('FloatingChatWindow', () => {
 
     expect(useSessionLayout.getState().layout).toBe('hide');
   });
+
+  // The other half of DockedChatPanel's "Hide chat": the pill is a waypoint back to the
+  // dock, so expanding it must not strand the chat in a floating window.
+  it('expands back into the dock that hid the chat here', () => {
+    setSessionLayout({ layout: 'floatingChat', floatingChatMinimized: true, hiddenFromLayout: 'dockRight' });
+    render(
+      <Wrapper>
+        <FloatingChatWindow>chat</FloatingChatWindow>
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('floating-chat-minimized'));
+
+    const state = useSessionLayout.getState();
+    expect(state.layout).toBe('dockRight');
+    expect(state.floatingChatMinimized).toBe(false);
+    expect(state.hiddenFromLayout).toBeUndefined();
+  });
+
+  it('stays floating when the pill was minimized rather than hidden from a dock', () => {
+    setSessionLayout({ layout: 'floatingChat', floatingChatMinimized: true });
+    render(
+      <Wrapper>
+        <FloatingChatWindow>chat</FloatingChatWindow>
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('floating-chat-minimized'));
+
+    const state = useSessionLayout.getState();
+    expect(state.layout).toBe('floatingChat');
+    expect(state.floatingChatMinimized).toBe(false);
+  });
 });

--- a/apps/client/app/components/Session/FloatingChatWindow.tsx
+++ b/apps/client/app/components/Session/FloatingChatWindow.tsx
@@ -91,6 +91,7 @@ const FloatingChatWindow: React.FC<FloatingChatWindowProps> = ({ children, heade
   const position = useSessionLayout(s => s.floatingChatPosition);
   const size = useSessionLayout(s => s.floatingChatSize);
   const isMinimized = useSessionLayout(s => s.floatingChatMinimized);
+  const hiddenFromLayout = useSessionLayout(s => s.hiddenFromLayout);
 
   // Prevent wheel events from bubbling out of the floating window to parent
   // JS scroll handlers (e.g. a docked landing page). Re-attaches after minimize/
@@ -278,6 +279,13 @@ const FloatingChatWindow: React.FC<FloatingChatWindowProps> = ({ children, heade
   );
 
   const handleMinimize = useCallback(() => {
+    // Expanding a pill that "Hide chat" put here: back to the dock it came from, not into a
+    // floating window the chat was never in. Ahead of the narrow-viewport branch below,
+    // which sizes a floating window this path is not going to open.
+    if (isMinimized && hiddenFromLayout) {
+      setSessionLayout({ layout: hiddenFromLayout, floatingChatMinimized: false });
+      return;
+    }
     if (isMinimized && typeof window !== 'undefined' && window.innerWidth < 900) {
       // Expanding on a small screen: use full viewport so the chat is usable
       const fullWidth = Math.floor(window.innerWidth * MAX_WIDTH_RATIO);
@@ -297,7 +305,7 @@ const FloatingChatWindow: React.FC<FloatingChatWindowProps> = ({ children, heade
     } else {
       setSessionLayout({ floatingChatMinimized: !isMinimized });
     }
-  }, [isMinimized]);
+  }, [isMinimized, hiddenFromLayout]);
 
   // Handle close - dismiss the panel entirely. Re-docking is a separate action
   // (the dock-right/dock-bottom controls in ChatPanelControls), not this button's job.

--- a/apps/client/app/hooks/__tests__/useSessionLayout.test.ts
+++ b/apps/client/app/hooks/__tests__/useSessionLayout.test.ts
@@ -38,6 +38,7 @@ describe('useSessionLayout - LRU Cache Functions', () => {
       recentArtifacts: [],
       maxRecentArtifacts: 10,
       selectedArtifactVersions: {},
+      hiddenFromLayout: undefined,
     });
   });
 
@@ -260,6 +261,24 @@ describe('useSessionLayout - LRU Cache Functions', () => {
 
       // Should still hide (explicit hide request)
       expect(useSessionLayout.getState().layout).toBe('hide');
+    });
+
+    // The store owns the rule, not the two chat components: any layout write ends the hide
+    // episode, so the dock a hidden chat remembers cannot outlive the user moving it.
+    it('clears hiddenFromLayout on a layout write that does not set it', () => {
+      useSessionLayout.setState({ hiddenFromLayout: 'dockBottom' });
+
+      setSessionLayout({ layout: 'vertical' });
+
+      expect(useSessionLayout.getState().hiddenFromLayout).toBeUndefined();
+    });
+
+    it('leaves hiddenFromLayout alone when the write carries no layout', () => {
+      useSessionLayout.setState({ hiddenFromLayout: 'dockBottom' });
+
+      setSessionLayout({ floatingChatMinimized: true });
+
+      expect(useSessionLayout.getState().hiddenFromLayout).toBe('dockBottom');
     });
   });
 

--- a/apps/client/app/hooks/useSessionLayout.ts
+++ b/apps/client/app/hooks/useSessionLayout.ts
@@ -94,6 +94,12 @@ interface SessionLayoutControlState {
   // Docked chat panel sizing (percentage)
   dockChatWidth: number; // Width % for dockRight mode (default 40)
   dockChatHeight: number; // Height % for dockBottom mode (default 40)
+  // Which dock "Hide chat" sent the panel to the launcher pill from, so expanding the pill
+  // puts it back there instead of leaving it floating where it never was. Written only by
+  // the hide action; every other layout write clears it (see setSessionLayout), because
+  // choosing a layout deliberately ends the hide episode. Not persisted - a reload starts
+  // over, the same reason floatingChatMinimized is left out below.
+  hiddenFromLayout?: 'dockRight' | 'dockBottom';
   // Optimistic first-message: holds the user's prompt while the new session is being
   // confirmed by the server. Cleared on session.created. Not persisted.
   pendingFirstMessage: string | null;
@@ -186,7 +192,13 @@ export const setSessionLayout = (
   const currentState = useSessionLayout.getState();
 
   // If it's a function, call it with current state
-  const newState = typeof newStateOrUpdater === 'function' ? newStateOrUpdater(currentState) : newStateOrUpdater;
+  let newState = typeof newStateOrUpdater === 'function' ? newStateOrUpdater(currentState) : newStateOrUpdater;
+
+  // Any layout write that does not itself set the hide marker ends the hide episode, so a
+  // remembered dock can never outlive the user moving the chat somewhere else.
+  if (newState.layout !== undefined && !('hiddenFromLayout' in newState)) {
+    newState = { ...newState, hiddenFromLayout: undefined };
+  }
 
   // If artifactData is provided, add to recentArtifacts
   if (newState.artifactData) {


### PR DESCRIPTION
## Description

Hiding the docked chat and reopening it from the launcher pill left the chat in a floating window instead of putting it back in its dock.

`DockedChatPanel`'s "Hide chat" wrote `layout: 'floatingChat'`, and that overwrote the only record that the panel had been docked at all. By the time the user clicked the pill there was nothing left saying where it came from, so `handleMinimize` just cleared `floatingChatMinimized` and the chat opened as a floating window it had never been in. Hiding behaved as a move rather than a round trip.

Reproducible from any docked chat, in either dock direction.

## Changes

- `useSessionLayout`: new `hiddenFromLayout?: 'dockRight' | 'dockBottom'` recording the dock a hide is leaving. Not persisted, for the same reason `floatingChatMinimized` is not.
- `setSessionLayout` now clears that marker on any layout write that does not set it itself. This is the invariant that keeps the feature honest: a deliberate dock, float or close ends the hide episode, so a remembered dock can never outlive the user moving the chat somewhere else, and a future caller that changes `layout` gets the right behaviour without knowing this field exists.
- `DockedChatPanel`: "Hide chat" records the dock it is leaving.
- `FloatingChatWindow`: expanding the pill restores that dock. The branch runs ahead of the existing narrow-viewport branch, which sizes and positions a floating window this path is not going to open.

## Guide for Testers

1. Open any session on `localhost:3000` (or staging) with the chat docked. If it is floating, use the layout dropdown in the chat header and pick **Dock left**.
2. Confirm the chat pane is docked beside the main content.
3. Click the **X** ("Hide chat") in the chat header. Expected: the chat pane disappears and a blue **AI Chat** pill appears in the bottom-right corner. No floating window opens.
4. Click the **AI Chat** pill. Expected: the chat returns **to the dock it was in**, in the same position and at the same width. No floating window at any point.
5. Repeat steps 1-4 with **Dock bottom** selected in step 1. Expected: the chat returns to the bottom dock.

### Regression Checks

6. In the chat header layout dropdown pick **Float**. Expected: a draggable floating chat window opens.
7. Click the **minimize** control in the floating window's header. Expected: it collapses to the same **AI Chat** pill.
8. Click the pill. Expected: it reopens as a **floating window** - not docked. This is the case the fix must not break: a chat the user floated deliberately carries no marker and must stay floating.
9. With the floating window open, click its **X** (close). Expected: the chat is dismissed entirely, no pill remains.
10. Dock the chat, hide it to the pill, then pick a layout from a different surface or reload the page. Expected: nothing is stuck - the marker is not persisted, so a reload starts from the stored layout as before.

### What NOT to test

Chat content, message sending, and session switching are untouched - this PR only moves the panel around.

## Additional Information

Found while working with a docked chat beside a full-width content pane, where the round trip is the normal way to reclaim screen space, so the broken return was hit constantly.

## Developer Notes

- The clear-on-layout-write rule lives in `setSessionLayout` rather than at each call site. There are only three layout writers today, but the invariant ("this marker belongs to one hide episode") is a property of the store, not of the components, and centralising it means a fourth writer cannot silently strand a stale dock.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
