### PR TITLE
fix(data-lakes): stop telling a never-chunked file that its passages were removed

### DIFF
--- a/apps/client/server/queueHandlers/fabFileChunk.test.ts
+++ b/apps/client/server/queueHandlers/fabFileChunk.test.ts
@@ -62,6 +62,7 @@ const h = vi.hoisted(() => {
     resolveScopedSetting: vi.fn(async () => ({ value: 512, source: 'platform' })),
     sendToQueue: vi.fn(),
     fabFileUpdate: vi.fn(async () => null),
+    markConvergencePaused: vi.fn(async () => undefined),
   };
 });
 
@@ -78,6 +79,7 @@ vi.mock('@bike4mind/database', () => ({
     shareable: { findAccessibleById: h.findAccessibleById },
     markFailedIfNotAlready: h.markFailedIfNotAlready,
     update: h.fabFileUpdate,
+    markConvergencePaused: h.markConvergencePaused,
   },
   // Deps for the convergence kill switch (#1676), built eagerly on every message. Never exercised
   // by these user-origin payloads (origin absent -> user work short-circuits before any read), but
@@ -802,27 +804,26 @@ describe('fabFileChunk handler - convergence kill switch', () => {
   // Without this the file sits at chunkCount:0 with no error - a shape indistinguishable from an
   // image or a pending upload, which is how QA's stranded document fell out of health's denominator,
   // out of the convergence plan and past the retrieval withhold all at once.
-  // The marker and the clear of the pending-rebuild stamp go in ONE `$set` (#1939), so the file can
-  // never be both "rebuilding, returns on its own" and "halted, needs an administrator" - and so the
-  // rebuild door's stale-pending arm does not offer a second repair for a file its paused arm
-  // already selects.
-  it('upgrades the pending-rebuild stamp to the paused marker in a single write', async () => {
+  //
+  // Delegated to `markConvergencePaused` rather than written inline, because WHICH chunk-arm reason
+  // is right depends on `chunkRebuildRequestedAt`, which the same write clears - so the choice, the
+  // clear and the redelivery guard all have to happen in one statement. That is only observable
+  // against a real server; see FabFileModel.markConvergencePaused.test.ts. All this pins is that the
+  // handler routes through it, and passes the file it was handed.
+  it('marks the file paused through the repository method that decides the reason', async () => {
     await dispatch(makeEvent(convergencePayload), {} as never, mockLogger);
 
-    expect(h.fabFileUpdate).toHaveBeenCalledWith({
-      id: 'ff1',
-      chunkStallReason: 'rechunkPaused',
-      chunkRebuildRequestedAt: null,
-    });
+    expect(h.markConvergencePaused).toHaveBeenCalledWith('ff1');
+    expect(h.fabFileUpdate).not.toHaveBeenCalled();
   });
 
   // A transient failure must not cost the marker, so the write is retried in-process before the
   // delivery is failed. This pins that the retry is what handles the realistic case.
   it('retries the marker write and acks once it succeeds', async () => {
-    h.fabFileUpdate.mockRejectedValueOnce(new Error('pool timeout')).mockResolvedValueOnce(undefined);
+    h.markConvergencePaused.mockRejectedValueOnce(new Error('pool timeout')).mockResolvedValueOnce(undefined);
 
     await expect(dispatch(makeEvent(convergencePayload), {} as never, mockLogger)).resolves.toBeUndefined();
-    expect(h.fabFileUpdate).toHaveBeenCalledTimes(2);
+    expect(h.markConvergencePaused).toHaveBeenCalledTimes(2);
     expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
@@ -834,7 +835,7 @@ describe('fabFileChunk handler - convergence kill switch', () => {
   // worse. A redelivery is also idempotent here: this branch has done nothing destructive, and if the
   // switch has since gone off the redelivery rebuilds the file for real.
   it('fails the delivery when the marker write keeps failing, so SQS retries instead of stranding it', async () => {
-    h.fabFileUpdate.mockRejectedValue(new Error('mongo down'));
+    h.markConvergencePaused.mockRejectedValue(new Error('mongo down'));
 
     await expect(dispatch(makeEvent(convergencePayload), {} as never, mockLogger)).rejects.toThrow('mongo down');
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('could not mark ff1'));
@@ -849,7 +850,7 @@ describe('fabFileChunk handler - convergence kill switch', () => {
 
     await dispatch(makeEvent({ fabFileId: 'ff1', userId: 'u1' }), {} as never, mockLogger);
 
-    expect(h.fabFileUpdate).not.toHaveBeenCalledWith(expect.objectContaining({ chunkStallReason: 'rechunkPaused' }));
+    expect(h.markConvergencePaused).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/server/queueHandlers/fabFileChunk.ts
+++ b/apps/client/server/queueHandlers/fabFileChunk.ts
@@ -117,13 +117,17 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
   // background work already on the queue. Gated before any DB read, so a user upload (origin absent)
   // short-circuits with zero I/O.
   //
-  // Dropping the message is NOT the whole job. By the time this runs, the producer has already reset
-  // the wave's chunk state, so the file sits at chunkCount 0 with no error. The reset stamps
-  // `chunkRebuildRequestedAt` (#1939), so that state is not invisible - but it reads as "rebuilding,
-  // returns on its own", which is now false: nothing will rebuild this file until an administrator
-  // lifts the switch. So upgrade the stamp to `chunkStallReason: 'rechunkPaused'`, the marker every
+  // Dropping the message is NOT the whole job. The file sits at chunkCount 0 with no error, which
+  // reads as an image or a pending upload, so it needs a chunk-arm stall reason - the marker every
   // reader keys on to say "halted, needs intervention". Mirrors what the vectorize handler already
   // does for its half of the same switch.
+  //
+  // WHICH reason depends on how the file got here, and `markConvergencePaused` decides inside the
+  // write (it must: the discriminator is a field the same write clears). A wave's producer resets the
+  // chunk state before its messages are handled, stamping `chunkRebuildRequestedAt` (#1939) - that
+  // state is not invisible, but it reads as "rebuilding, returns on its own", which is now false, so
+  // it is upgraded to `rechunkPaused`. The rescue sweep instead selects on chunkCount 0 and enqueues
+  // without resetting, so its files arrive with nothing removed and get `unchunkedPaused`.
   if (
     await isConvergenceHalted(
       { origin, lakeId },
@@ -165,11 +169,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     // already selects.
     for (let attempt = 1; attempt <= MARK_PAUSED_MAX_ATTEMPTS; attempt++) {
       try {
-        await fabFileRepository.update({
-          id: fabFileId,
-          chunkStallReason: 'rechunkPaused',
-          chunkRebuildRequestedAt: null,
-        });
+        await fabFileRepository.markConvergencePaused(fabFileId);
         break;
       } catch (err) {
         if (attempt === MARK_PAUSED_MAX_ATTEMPTS) {

--- a/apps/client/server/worker/chunkScan.e2e.test.ts
+++ b/apps/client/server/worker/chunkScan.e2e.test.ts
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
 import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../../packages/database/src/__test__/createMongoServer';
-import { CHUNK_STALL_NOTICES } from '@bike4mind/common';
+import { CHUNK_STALL_NOTICES, CHUNK_STALL_REASONS, LEGACY_CHUNK_STALL_NOTES } from '@bike4mind/common';
 import { buildDataLakeMembershipFilter } from '@bike4mind/database';
 import { buildFabFileChunkScanFilter } from './chunkScan';
 
@@ -267,8 +267,8 @@ describe('buildFabFileChunkScanFilter - scoped pause against real Mongo (#2157)'
     const viaNor = buildFabFileChunkScanFilter(CUTOFF, undefined, { convergencePause: PLATFORM_ON });
     const viaNin = {
       ...buildFabFileChunkScanFilter(CUTOFF, undefined, { convergencePause: PLATFORM_OFF }),
-      chunkStallReason: { $nin: ['vectorizePaused', 'rechunkPaused'] },
-      notes: { $nin: Object.values(CHUNK_STALL_NOTICES) },
+      chunkStallReason: { $nin: [...CHUNK_STALL_REASONS] },
+      notes: { $nin: [...LEGACY_CHUNK_STALL_NOTES] },
     };
 
     expect(await selectedNames(viaNor)).toEqual(['reason-missing', 'reason-null']);

--- a/apps/client/server/worker/chunkScan.test.ts
+++ b/apps/client/server/worker/chunkScan.test.ts
@@ -231,6 +231,7 @@ describe('buildFabFileChunkScanFilter - convergence-paused exclusion (#2120/#215
 
     it.each([
       ['the chunk-handler reason', 'rechunkPaused'],
+      ['the never-chunked reason', 'unchunkedPaused'],
       ['the vectorize reason', 'vectorizePaused'],
     ])('skips a stalled file - %s', (_label, reason) => {
       // A stalled file matches every OTHER clause (the reset zeroed chunkCount, the pause writes no
@@ -277,6 +278,7 @@ describe('buildFabFileChunkScanFilter - convergence-paused exclusion (#2120/#215
 
     it.each([
       ['the chunk-handler reason', 'rechunkPaused'],
+      ['the never-chunked reason', 'unchunkedPaused'],
       ['the vectorize reason', 'vectorizePaused'],
     ])('SELECTS a stalled file so it is rebuilt - %s', (_label, reason) => {
       // The regression this conditionality prevents. This sweep is the only AUTOMATIC exit a stalled

--- a/b4m-core/common/src/constants/chunking.test.ts
+++ b/b4m-core/common/src/constants/chunking.test.ts
@@ -5,15 +5,51 @@ import { describe, expect, it } from 'vitest';
 import {
   CHUNK_STALL_NOTICES,
   CHUNK_STALL_REASONS,
+  CHUNKLESS_STALL_REASONS,
+  LEGACY_CHUNK_STALL_NOTES,
   NO_EXTRACTABLE_TEXT_NOTICE,
   describePipelineStall,
   isChunkStalled,
+  isChunklessStall,
 } from './chunking';
+
+// The reasons the #2016 migration backfilled from prose in `notes`, and therefore the only ones whose
+// wording it is allowed to match. Any reason added after that migration ran was never stored in
+// `notes` by anything, so no row carries its prose and its wording is free to change.
+const MIGRATED_STALL_REASONS = ['vectorizePaused', 'rechunkPaused'] as const;
 
 describe('isChunkStalled', () => {
   it('accepts every stall reason and nothing else', () => {
     for (const reason of CHUNK_STALL_REASONS) expect(isChunkStalled(reason)).toBe(true);
     for (const other of [null, undefined, '', 'paused', 'vectorized']) expect(isChunkStalled(other)).toBe(false);
+  });
+});
+
+describe('isChunklessStall', () => {
+  it('accepts both chunk-arm reasons and rejects the vectorize arm, which keeps its passages', () => {
+    for (const reason of ['rechunkPaused', 'unchunkedPaused'] as const) {
+      expect(isChunklessStall(reason)).toBe(true);
+    }
+    // The distinction the subset exists for: folding the arms together would grade a file that still
+    // HAS its chunks as chunkless, in a Mongo `$in` that fails silently by selecting the wrong set.
+    expect(isChunklessStall('vectorizePaused')).toBe(false);
+    for (const other of [null, undefined, '', 'paused']) expect(isChunklessStall(other)).toBe(false);
+  });
+
+  it('is a subset of the full set, so every member is also a stall', () => {
+    for (const reason of CHUNKLESS_STALL_REASONS) expect(isChunkStalled(reason)).toBe(true);
+    expect(CHUNKLESS_STALL_REASONS.length).toBeLessThan(CHUNK_STALL_REASONS.length);
+  });
+});
+
+describe('LEGACY_CHUNK_STALL_NOTES', () => {
+  // Pinned to the migrated prose rather than every notice. A reason that postdates the migration has
+  // no rows carrying its text, so admitting it here would only ever match an owner who happened to
+  // type that sentence into `notes` - and read them as stalled.
+  it('carries only the prose the migration actually backfilled', () => {
+    expect([...LEGACY_CHUNK_STALL_NOTES].sort()).toEqual(
+      MIGRATED_STALL_REASONS.map(reason => CHUNK_STALL_NOTICES[reason]).sort()
+    );
   });
 });
 
@@ -45,14 +81,17 @@ describe('describePipelineStall', () => {
 // land here first and be a deliberate act. Reading the migration source is the only thing that
 // notices; a fixture would carry its own copy and drift green.
 describe('the backfill migration still matches the current prose', () => {
-  it('inlines both stall notices and the zero-chunk notice verbatim', () => {
+  it('inlines the two migrated stall notices and the zero-chunk notice verbatim', () => {
     const dir = join(dirname(fileURLToPath(import.meta.url)), '../../../../packages/scripts/migrate/migrations');
     const name = readdirSync(dir).find(f => f.endsWith('_split-chunk-stall-markers-off-notes.ts'));
     expect(name).toBeDefined();
 
     // Joined across the source's own line-wrapping concatenations, so a reflow is not a failure.
     const source = readFileSync(join(dir, name as string), 'utf8').replace(/' \+\s*\n\s*'/g, '');
-    for (const reason of CHUNK_STALL_REASONS) {
+    // MIGRATED_STALL_REASONS, not CHUNK_STALL_REASONS: the migration hardcodes exactly the two
+    // literals it derived and must NOT gain a third, since no row ever carried a later reason's prose
+    // in `notes`.
+    for (const reason of MIGRATED_STALL_REASONS) {
       // The source escapes the em dash, so compare against the same escaped form.
       expect(source).toContain(CHUNK_STALL_NOTICES[reason].replace(/\u2014/g, '\\u2014'));
     }

--- a/b4m-core/common/src/constants/chunking.ts
+++ b/b4m-core/common/src/constants/chunking.ts
@@ -129,10 +129,15 @@ export function deriveServeCharBudget(chunkTokenTarget?: number | null): ServeCh
  *  - `rechunkPaused`: the OTHER half of the same switch dropped a re-chunk before it ran
  *    (#1676/#1681). The damage is worse - the producer resets a wave's chunk state BEFORE the
  *    messages are handled, so a file halted here has NO chunks at all.
+ *  - `unchunkedPaused`: the same chunk half, on a file that never had passages to lose. The rescue
+ *    sweep selects on `chunkCount: 0` and enqueues without resetting anything, so a file it routes
+ *    into the halt branch arrives already empty. The halted STATE is identical to `rechunkPaused`
+ *    and every reader keys on both (CHUNKLESS_STALL_REASONS) - the split exists so the owner is not
+ *    told that passages were removed which never existed.
  *
- * Neither auto-resumes; both need a reprocess or a lifted switch.
+ * None auto-resumes; each needs a reprocess or a lifted switch.
  *
- * Without a marker either state is misread by every surface at once, which is the failure the field
+ * Without a marker the state is misread by every surface at once, which is the failure the field
  * exists to prevent: `chunkCount: 0` with `error: null` reads as an image or a pending upload, so
  * health drops it from the denominator, convergence grades it `conformant` (its stale stamp still
  * matches), and search does not withhold it because it is not "in flight". The file's passages are
@@ -151,13 +156,13 @@ export function deriveServeCharBudget(chunkTokenTarget?: number | null): ServeCh
  * read it to tell a permanently-stalled file from one still in flight. b4m-core cannot import from
  * apps/client, so a copy there would have to drift silently.
  */
-export const CHUNK_STALL_REASONS = ['vectorizePaused', 'rechunkPaused'] as const;
+export const CHUNK_STALL_REASONS = ['vectorizePaused', 'rechunkPaused', 'unchunkedPaused'] as const;
 export type ChunkStallReason = (typeof CHUNK_STALL_REASONS)[number];
 
 /**
- * Whether a file is stalled by the convergence kill switch, by either arm. THE predicate every
- * reader uses, so adding a third stall reason reaches health, convergence and retrieval without
- * three separate comparisons drifting apart. Also the in-memory mirror of a Mongo
+ * Whether a file is stalled by the convergence kill switch, by any arm. THE predicate every
+ * reader uses, so adding a stall reason reaches health, convergence and retrieval without separate
+ * comparisons drifting apart. Also the in-memory mirror of a Mongo
  * `chunkStallReason: { $in: [...CHUNK_STALL_REASONS] }`.
  */
 export function isChunkStalled(reason?: string | null): boolean {
@@ -165,15 +170,53 @@ export function isChunkStalled(reason?: string | null): boolean {
 }
 
 /**
- * Owner-facing prose for a stall reason, and the ONLY place it is worded. These are the exact
- * strings the markers used while they lived in `notes`, which is also what the #2016 migration
- * matches on to derive the field for existing rows - do not reword either without updating it.
+ * Which reasons leave the file with NO passages, as opposed to passages with no vectors. A `Record`
+ * over every reason rather than a hand-written subset array: a new stall reason then cannot compile
+ * until it is classified, where a member missing from a literal array would just make a health count
+ * silently wrong.
+ */
+const STALL_LEAVES_NO_PASSAGES: Record<ChunkStallReason, boolean> = {
+  vectorizePaused: false,
+  rechunkPaused: true,
+  unchunkedPaused: true,
+};
+
+/**
+ * The CHUNK arm's reasons, as distinct from the vectorize arm's, and the datastore mirror for a
+ * Mongo `chunkStallReason: { $in: [...] }`.
+ *
+ * Pick between this and CHUNK_STALL_REASONS/`isChunkStalled` by the question you are asking. The
+ * full set: "is this file stalled by the switch at all?" This subset: "is this file WITHOUT PASSAGES
+ * because the switch stopped the work that would have built them?" A vectorize-paused file answers
+ * yes to the first and no to the second - it still has its chunks - so folding the arms together
+ * would grade it as chunkless. Choosing wrong in a Mongo `$in` fails SILENTLY, it just selects the
+ * wrong set, which is why this is a shared constant rather than an inline array.
+ */
+export const CHUNKLESS_STALL_REASONS: readonly ChunkStallReason[] = CHUNK_STALL_REASONS.filter(
+  reason => STALL_LEAVES_NO_PASSAGES[reason]
+);
+
+/** In-memory mirror of CHUNKLESS_STALL_REASONS, for a reader holding a file rather than a query. */
+export function isChunklessStall(reason?: string | null): boolean {
+  return CHUNKLESS_STALL_REASONS.includes(reason as ChunkStallReason);
+}
+
+/**
+ * Owner-facing prose for a stall reason, and the ONLY place it is worded.
+ *
+ * `vectorizePaused` and `rechunkPaused` are the exact strings those markers used while they lived in
+ * `notes`, which is also what the #2016 migration matches on to derive the field for existing rows -
+ * do not reword either without updating it. `unchunkedPaused` postdates that migration and was never
+ * written to `notes`, so its wording is free to change: nothing matches on it.
  */
 export const CHUNK_STALL_NOTICES: Record<ChunkStallReason, string> = {
   vectorizePaused: 'Indexing paused by the data-lake convergence kill switch - reprocess to complete.',
   rechunkPaused:
     'Re-chunking paused by the data-lake convergence kill switch - its passages were removed and are ' +
     'rebuilt when convergence resumes.',
+  unchunkedPaused:
+    'Chunking paused by the data-lake convergence kill switch - this file has no passages yet and they ' +
+    'are built when convergence resumes.',
 };
 
 /**
@@ -226,8 +269,15 @@ export function isConvergencePausedNote(notes?: string | null): boolean {
  *
  * Mirrored in Mongo by `buildFabFileSearchQuery`'s `vectorizedOnly` exemption. Delete the legacy arm
  * from both together, one release after the migration has landed everywhere.
+ *
+ * Pinned to the two reasons the migration backfilled rather than every notice: `unchunkedPaused`
+ * postdates it, so no row carries its prose, and including it would read an owner who happens to type
+ * that sentence into `notes` as stalled.
  */
-export const LEGACY_CHUNK_STALL_NOTES: readonly string[] = Object.values(CHUNK_STALL_NOTICES);
+export const LEGACY_CHUNK_STALL_NOTES: readonly string[] = [
+  CHUNK_STALL_NOTICES.vectorizePaused,
+  CHUNK_STALL_NOTICES.rechunkPaused,
+];
 
 export function isChunkStalledFile(file: { chunkStallReason?: string | null; notes?: string | null }): boolean {
   return isChunkStalled(file.chunkStallReason) || LEGACY_CHUNK_STALL_NOTES.includes(file.notes ?? '');

--- a/b4m-core/common/src/constants/lakeHealth.ts
+++ b/b4m-core/common/src/constants/lakeHealth.ts
@@ -22,6 +22,7 @@ import {
   deriveServeCharBudget,
   isChunkRebuildPending,
   isChunkStalled,
+  isChunklessStall,
 } from './chunking';
 
 /** The four predicate keys, ordered as stated in #1666. Members name the ones they fail. */
@@ -212,7 +213,11 @@ export function evaluateMemberHealth(member: LakeHealthMemberInput, policy: Lake
   // outlives a rebuild the RESCUE SWEEP performs (that path enqueues without a reset), so keying on
   // the reason alone would fail a repaired file forever.
   // Same guard, same reason, as `decideMemberConvergence`'s own arm.
-  const passagesRemoved = member.chunkCount === 0 && member.chunkStallReason === 'rechunkPaused';
+  //
+  // `isChunklessStall`, not the bare `rechunkPaused`: `unchunkedPaused` is the same halted state on a
+  // file that arrived empty rather than one a wave emptied, and it grades identically here. NOT the
+  // full CHUNK_STALL_REASONS - a vectorize-paused file still has its passages.
+  const passagesRemoved = member.chunkCount === 0 && isChunklessStall(member.chunkStallReason);
   // A rebuild that was REQUESTED and has not committed (#1939). Deliberately NOT folded into
   // `passagesRemoved`: the passages are equally gone, but this one is expected back, so forcing P3
   // to `fail` here would make every ordinary "Rebuild passages" wave and every per-file reprocess
@@ -339,12 +344,13 @@ export type LakeHealthReport = {
  * to drop the lake off `healthy` regardless of the percentage beside it.
  */
 /**
- * The members `summarizeLakeHealth` grades: chunked, or chunkless via one of the two markers that
- * mean "expected back", not "never had any". Exported so a sibling report over the same scan - e.g.
+ * The members `summarizeLakeHealth` grades: chunked, or chunkless via a marker that says so. A
+ * chunkless member with no marker at all is the one thing left out - nothing distinguishes it from an
+ * image or a pending upload. Exported so a sibling report over the same scan - e.g.
  * `findDuplicateMembers` in `computeLakeHealth` - agrees by construction about which members are "in"
  * the lake, rather than by a comment promising the two filters stay in sync.
  *
- * The CHUNK arm only, matching `findDataLakeHealthMembers`'s own `$match` and
+ * The CHUNK arm only (`isChunklessStall`), matching `findDataLakeHealthMembers`'s own `$match` and
  * `partitionByIndexAvailability`: the vectorize arm of the switch leaves chunks in place, so it is
  * already admitted by `chunkCount > 0` and needs no exception here.
  *
@@ -358,7 +364,7 @@ export function selectLakeHealthMembers<
   T extends Pick<LakeHealthMemberInput, 'chunkCount' | 'chunkStallReason' | 'chunkRebuildRequestedAt'>,
 >(members: T[]): T[] {
   return members.filter(
-    m => m.chunkCount > 0 || m.chunkStallReason === 'rechunkPaused' || isChunkRebuildPending(m.chunkRebuildRequestedAt)
+    m => m.chunkCount > 0 || isChunklessStall(m.chunkStallReason) || isChunkRebuildPending(m.chunkRebuildRequestedAt)
   );
 }
 

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -1234,6 +1234,16 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    */
   resetChunkStateByIds(ids: string[]): Promise<string[]>;
   /**
+   * Mark a file as halted by the convergence kill switch's CHUNK arm, choosing between the two
+   * chunkless reasons by whether a producer actually removed its passages, and clearing the
+   * pending-rebuild stamp in the SAME write so the file is never both paused and pending.
+   *
+   * A dedicated method rather than an `update` from the caller because the reason to write depends on
+   * a field the same statement clears - see the implementation for why that has to be one statement
+   * and why it has to be idempotent.
+   */
+  markConvergencePaused(id: string): Promise<void>;
+  /**
    * Count the lake's files whose re-chunk failed (error set, no chunks) - invisible to both the
    * under-chunked detection and the rescue sweep, so surfaced separately so a manager can tell
    * "rebuild done" from "some files gave up".

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -105,6 +105,7 @@ export const createMockFabFileRepository = (): IFabFileRepository => ({
   findChunkedFilesByScope: vi.fn(),
   findConvergencePausedFilesByScope: vi.fn(),
   resetChunkStateByIds: vi.fn(),
+  markConvergencePaused: vi.fn(),
   countFailedFilesByScope: vi.fn(),
   countDataLakeFilesByMembership: vi.fn(),
   countDistinctDataLakeFilesByMembership: vi.fn(),

--- a/b4m-core/services/src/dataLakeService/retrievalUnavailable.test.ts
+++ b/b4m-core/services/src/dataLakeService/retrievalUnavailable.test.ts
@@ -8,7 +8,7 @@ import {
   partitionByIndexAvailability,
 } from './retrievalUnavailable';
 import { emptyEmbeddingMismatchReport } from './embeddingMismatch';
-import { CHUNK_STALL_NOTICES } from '@bike4mind/common';
+import { CHUNK_STALL_NOTICES, CHUNK_STALL_REASONS } from '@bike4mind/common';
 
 /** A settled, fully-embedded file - every case below perturbs one field. */
 const settled = { id: 'f1', fileName: 'a.pdf', chunkCount: 8, vectorizedChunkCount: 8, error: null, notes: null };
@@ -67,7 +67,7 @@ describe('partitionByIndexAvailability (#1681 constraint 1)', () => {
   // vector count is what distinguishes repaired from stranded. commitFabFileChunks also clears the
   // marker now; this asserts the reader holds even if that clear is ever lost.
   it('serves a REPAIRED file that still carries the marker - it has vectors again', () => {
-    for (const chunkStallReason of ['vectorizePaused', 'rechunkPaused'] as const) {
+    for (const chunkStallReason of CHUNK_STALL_REASONS) {
       const repaired = { ...settled, chunkCount: 8, vectorizedChunkCount: 8, chunkStallReason };
       expect(partitionByIndexAvailability([repaired]).withheld).toEqual([]);
     }

--- a/b4m-core/services/src/fabFileService/chunk.test.ts
+++ b/b4m-core/services/src/fabFileService/chunk.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { chunkFabfile, commitFabFileChunks, prepareFabFileChunks } from './chunk';
-import { ChunkClaimLostError } from '@bike4mind/common';
+import { CHUNK_STALL_REASONS, ChunkClaimLostError } from '@bike4mind/common';
 import { computeServerTextHash } from '../dataLakeService/admissionContract';
 import type { IUserDocument } from '@bike4mind/common';
 
@@ -313,7 +313,7 @@ describe('chunkFabfile', () => {
   // enqueues without a reset, so before this a fully re-chunked and re-vectorized file kept its
   // kill-switch marker - and every reader keying on it went on treating the file as broken.
   it('clears a convergence kill-switch marker when a rebuild succeeds', async () => {
-    for (const chunkStallReason of ['vectorizePaused', 'rechunkPaused'] as const) {
+    for (const chunkStallReason of CHUNK_STALL_REASONS) {
       mockAdapter.db.fabFiles.update.mockClear();
       mockAdapter.db.fabFiles.shareable.findAccessibleById.mockResolvedValue({ ...mockFabFile, chunkStallReason });
 

--- a/packages/database/src/models/content/FabFileModel.markConvergencePaused.test.ts
+++ b/packages/database/src/models/content/FabFileModel.markConvergencePaused.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { KnowledgeType } from '@bike4mind/common';
+import { FabFile, fabFileRepository } from './FabFileModel';
+import { setupMongoTest } from '../../__test__/utils';
+
+// Which reason the halt branch writes is decided INSIDE the update, by a field that same update
+// clears, so a mocked test can only assert that the method was called. These run the real pipeline
+// against a real server: the discrimination, the clear, and the idempotence on redelivery.
+describe('markConvergencePaused', () => {
+  setupMongoTest();
+
+  const makeFile = (fields: Record<string, unknown>) =>
+    FabFile.create({
+      userId: 'u-paused',
+      fileName: 'report.pdf',
+      mimeType: 'application/pdf',
+      type: KnowledgeType.FILE,
+      filePath: 'report.pdf',
+      status: 'complete',
+      chunkCount: 0,
+      ...fields,
+    });
+
+  const reasonOf = async (id: string) => (await FabFile.findById(id).lean())?.chunkStallReason;
+
+  it('a file a producer reset is told its passages were removed', async () => {
+    const file = await makeFile({ chunkRebuildRequestedAt: new Date('2026-01-01T00:00:00.000Z') });
+
+    await fabFileRepository.markConvergencePaused(String(file._id));
+
+    expect(await reasonOf(String(file._id))).toBe('rechunkPaused');
+  });
+
+  it('a file the sweep selected is NOT told its passages were removed - it never had any', async () => {
+    // The reported bug: the sweep selects on chunkCount 0 and never resets, so `rechunkPaused`'s
+    // "its passages were removed" was false, and it is user-visible - `describePipelineStall` renders
+    // it to the owner, `knowledge_base_search` reports it to the model, and lake health files the
+    // member under `passagesRemoved`.
+    const file = await makeFile({ chunkRebuildRequestedAt: null });
+
+    await fabFileRepository.markConvergencePaused(String(file._id));
+
+    expect(await reasonOf(String(file._id))).toBe('unchunkedPaused');
+  });
+
+  it('clears the pending-rebuild stamp in the same write, so a file is never both paused and pending', async () => {
+    const file = await makeFile({ chunkRebuildRequestedAt: new Date('2026-01-01T00:00:00.000Z') });
+
+    await fabFileRepository.markConvergencePaused(String(file._id));
+
+    expect((await FabFile.findById(file._id).lean())?.chunkRebuildRequestedAt).toBeNull();
+  });
+
+  it('is idempotent: a redelivery does not downgrade the accurate reason to the never-chunked one', async () => {
+    // The first call nulls the stamp, so a naive re-run would read the file as never-chunked and
+    // overwrite a true statement with a false one. SQS redelivers on a 60-minute visibility timeout,
+    // so this is an ordinary occurrence, not a corner case.
+    const file = await makeFile({ chunkRebuildRequestedAt: new Date('2026-01-01T00:00:00.000Z') });
+
+    await fabFileRepository.markConvergencePaused(String(file._id));
+    await fabFileRepository.markConvergencePaused(String(file._id));
+
+    expect(await reasonOf(String(file._id))).toBe('rechunkPaused');
+  });
+
+  it("does not preserve the vectorize arm's reason - only chunk-arm reasons count as already-paused", async () => {
+    // `vectorizePaused` means "has chunks, no vectors", so the fixture has chunks. The assertion is
+    // only that the reason is REPLACED rather than kept by the idempotence guard: no producer routes
+    // a chunk-bearing file into the halt branch today, so which chunk-arm reason would be right for
+    // that state is not a question this pins.
+    const file = await makeFile({
+      chunkStallReason: 'vectorizePaused',
+      chunkCount: 4,
+      chunkRebuildRequestedAt: null,
+    });
+
+    await fabFileRepository.markConvergencePaused(String(file._id));
+
+    expect(await reasonOf(String(file._id))).not.toBe('vectorizePaused');
+  });
+
+  it('still bumps updatedAt, as the object-form write it replaced did', async () => {
+    // A pipeline-form update is not obviously timestamped - mongoose handles the two forms in
+    // different code paths. It does: applyTimestampsToUpdate pushes its own `$set` stage onto the
+    // pipeline (mongoose 8.x). Pinned because a silent stop would reorder the owner's file list,
+    // which sorts on updatedAt.
+    const file = await makeFile({ chunkRebuildRequestedAt: null });
+    const before = (await FabFile.findById(file._id).lean())?.updatedAt;
+
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await fabFileRepository.markConvergencePaused(String(file._id));
+
+    const after = (await FabFile.findById(file._id).lean())?.updatedAt;
+    expect(after!.getTime()).toBeGreaterThan(before!.getTime());
+  });
+});

--- a/packages/database/src/models/content/FabFileModel.markConvergencePaused.test.ts
+++ b/packages/database/src/models/content/FabFileModel.markConvergencePaused.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import mongoose from 'mongoose';
 import { KnowledgeType } from '@bike4mind/common';
 import { FabFile, fabFileRepository } from './FabFileModel';
 import { setupMongoTest } from '../../__test__/utils';
@@ -77,6 +78,30 @@ describe('markConvergencePaused', () => {
     await fabFileRepository.markConvergencePaused(String(file._id));
 
     expect(await reasonOf(String(file._id))).not.toBe('vectorizePaused');
+  });
+
+  it('handles a legacy row whose chunkStallReason field is absent, not null', async () => {
+    // The #2016 backfill only set the field on rows carrying the legacy prose, so a row predating it
+    // has no `chunkStallReason` key at all - and the sweep's `$nin` filter matches an absent field,
+    // so these do reach the halt branch. `FabFile.create` cannot produce the state (the schema
+    // defaults it to null), hence the raw insert. Both pipeline operators resolve a missing path as
+    // falsy rather than erroring, which is what keeps the write off the DLQ; pinned because it is a
+    // MongoDB semantic, not something the code says.
+    const fabFiles = mongoose.connection.db!.collection('fabfiles');
+    const { insertedId } = await fabFiles.insertOne({
+      userId: 'u-paused',
+      fileName: 'legacy.pdf',
+      mimeType: 'application/pdf',
+      filePath: 'legacy.pdf',
+      status: 'complete',
+      chunkCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await fabFileRepository.markConvergencePaused(String(insertedId));
+
+    expect(await reasonOf(String(insertedId))).toBe('unchunkedPaused');
   });
 
   it('still bumps updatedAt, as the object-form write it replaced did', async () => {

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -1,5 +1,6 @@
 import {
   CHUNK_STALL_REASONS,
+  CHUNKLESS_STALL_REASONS,
   type ChunkStallReason,
   DATALAKE_TAG_PREFIX,
   DataLakeMembershipScope,
@@ -1405,10 +1406,12 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
    * function's doc).
    *
    * ONE exception, and it is the case this report exists for: a member the convergence kill switch
-   * stopped mid-rewrite is chunkless because its passages were DELETED, not because it never had
-   * any. Excluding it made a lake report "Reachable 100%" over the members it still had while a
-   * document sat entirely unsearchable and absent from the drill-down - the green-counters-but-
-   * broken reading the four rules exist to catch. Admitted by its marker so it grades its real zero.
+   * stopped is chunkless because the switch halted the work that would have given it passages -
+   * whether a wave had already DELETED them (`rechunkPaused`) or it arrived empty and none were ever
+   * built (`unchunkedPaused`). Excluding it made a lake report "Reachable 100%" over the members it
+   * still had while a document sat entirely unsearchable and absent from the drill-down - the green-
+   * counters-but-broken reading the four rules exist to catch. Admitted by CHUNKLESS_STALL_REASONS
+   * (the chunk arm only - a vectorize-paused file keeps its chunks) so it grades its real zero.
    *
    * `limit` bounds how many rows reach app memory. It fetches one extra to detect overflow, so the
    * caller can report coverage as partial and log it, rather than silently truncating a percentage.
@@ -1448,7 +1451,7 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
           // never enqueued. It grades as in-flight, not as a failure; see evaluateMemberHealth.
           $or: [
             { chunkCount: { $gt: 0 } },
-            { chunkStallReason: 'rechunkPaused' },
+            { chunkStallReason: { $in: [...CHUNKLESS_STALL_REASONS] } },
             { chunkRebuildRequestedAt: { $ne: null } },
           ],
         }),
@@ -1523,16 +1526,17 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
           deletedAt: null,
           archivedAt: null,
           status: { $ne: 'pending' },
-          // `chunkCount > 0` OR the halted-rewrite marker. A member the kill switch stopped mid-wave
-          // has no chunks BECAUSE ITS OWN WERE DELETED, and excluding it is what let it disappear
-          // from this plan at the same time as from health and from search - repairable by exactly
-          // the rewrite this plan produces, but only if it is allowed to reach the grader.
+          // `chunkCount > 0` OR a chunk-arm halt marker. A member the kill switch stopped has no
+          // chunks because the switch halted the work that would have built them - its own were
+          // deleted, or none ever existed - and excluding it is what let it disappear from this plan
+          // at the same time as from health and from search - repairable by exactly the rewrite this
+          // plan produces, but only if it is allowed to reach the grader.
           // Same third arm as findDataLakeHealthMembers, same reason (#1939): a member between its
           // reset and its rebuild is chunkless and unmarked, and dropping it here is what let a
           // never-enqueued rebuild disappear from the plan that would have re-driven it.
           $or: [
             { chunkCount: { $gt: 0 } },
-            { chunkStallReason: 'rechunkPaused' },
+            { chunkStallReason: { $in: [...CHUNKLESS_STALL_REASONS] } },
             { chunkRebuildRequestedAt: { $ne: null } },
           ],
           // A file a chunk worker is mid-run on is excluded, not refused later: its rollups describe
@@ -1769,6 +1773,39 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
       )
       .lean();
     return docs.map(d => ({ id: d._id.toString(), userId: String(d.userId) }));
+  }
+
+  async markConvergencePaused(id: string): Promise<void> {
+    // One pipeline update rather than read-then-write, because the reason to write DEPENDS on a field
+    // the same statement clears. A separate read could be overtaken by a concurrent
+    // `resetChunkStateByIds`, and the file would then be labelled as having lost passages a wave was
+    // in the middle of removing, or vice versa.
+    //
+    // `chunkRebuildRequestedAt` is the discriminator: `resetChunkStateByIds` stamps it in the write
+    // that deletes the passages, so non-null means a producer really did remove them and null means
+    // the file reached the handler already empty (the rescue sweep selects on `chunkCount: 0` and
+    // never resets). Getting this wrong is user-visible - `describePipelineStall` shows the reason's
+    // prose to the file's owner, `knowledge_base_search` reports it to the model, and lake health
+    // files it under "passages removed".
+    //
+    // Idempotent by the outer `$cond`: a redelivery after a successful mark finds the stamp already
+    // nulled and would otherwise downgrade the accurate "passages removed" reason to the
+    // never-chunked one. fabFileChunkQueue's visibility timeout is 60 minutes with `dlq: {retry: 3}`,
+    // so a second delivery is an ordinary occurrence. An existing chunk-arm reason is kept as-is.
+    await this.fabFileModel.updateOne({ _id: id }, [
+      {
+        $set: {
+          chunkStallReason: {
+            $cond: [
+              { $in: ['$chunkStallReason', [...CHUNKLESS_STALL_REASONS]] },
+              '$chunkStallReason',
+              { $cond: [{ $ifNull: ['$chunkRebuildRequestedAt', false] }, 'rechunkPaused', 'unchunkedPaused'] },
+            ],
+          },
+          chunkRebuildRequestedAt: null,
+        },
+      },
+    ]);
   }
 
   async resetChunkStateByIds(ids: string[]): Promise<string[]> {


### PR DESCRIPTION
Closes #2310

## Description

`chunkStallReason: 'rechunkPaused'` means "the data-lake convergence kill switch stopped a re-chunk, so this file's passages were removed". Its owner-facing notice says exactly that: *"Re-chunking paused by the data-lake convergence kill switch - its passages were removed and are rebuilt when convergence resumes."*

The chunk queue handler's kill-switch halt branch wrote that literal unconditionally. But two different producers route a file into that branch, and only one of them removes anything:

- A **"Rebuild passages" wave** or a per-file reprocess calls `resetChunkStateByIds`, which deletes the chunk rollups and stamps `chunkRebuildRequestedAt` in the same `$set`. Passages really were removed - `rechunkPaused` is accurate.
- The **rescue sweeps** (`chunkRescueSweep`, the daily `dataLakeBatchReconcile`) select on `chunkCount: 0` and never reset anything - they only `sendToQueue`. The file reaches the handler already empty, having never chunked at all. `rechunkPaused` is a false statement about it.

So a file left empty by a lost ingest webhook, swept while the kill switch was on, was told its passages had been removed. That is not only wording: `rechunkPaused` is the value four readers key on to mean "chunkless because a producer deleted its passages" - the lake-health denominator, `passagesRemoved`/`fullyVectorized: 'fail'`, `selectLakeHealthMembers`, and the convergence plan's `$match`. Retrieval also withheld the file and reported the result set `partial` under the paused-because-removed bucket.

`chunkRebuildRequestedAt` is an exact discriminator for the two states, and it is already the right one: non-null means a producer removed the passages, null means the file arrived empty.

Two constraints follow from the fact that the halt write *clears* that stamp:

1. **The choice has to happen in one statement.** A separate read can be overtaken by a concurrent `resetChunkStateByIds` and label the file backwards. A Mongo pipeline-form update decides inside the write.
2. **It has to be idempotent.** `fabFileChunkQueue` has a 60-minute visibility timeout and `dlq: { retry: 3 }`, so a redelivery after a successful mark finds the stamp already nulled and would otherwise downgrade an accurate "passages removed" marker to the never-chunked one.

Only reachable with the convergence kill switch ON. No data loss either way - the file was visible and repairable; it was described wrongly.

## Changes

- **`b4m-core/common/src/constants/chunking.ts`** - adds `unchunkedPaused` to `CHUNK_STALL_REASONS` with its own `CHUNK_STALL_NOTICES` entry, which makes no claim about removal. The mongoose schema enum is derived from the array, so no schema edit was needed.
- **`CHUNKLESS_STALL_REASONS` / `isChunklessStall`** - the chunk-arm subset, for readers that mean "chunkless because the switch stopped the work that would have built the passages". Deliberately excludes `vectorizePaused`: a vectorize-paused file still HAS its passages, so folding the arms together would grade it as chunkless, and in a Mongo `$in` that fails silently by selecting the wrong set. Derived from a `Record` over every reason, so a future stall reason cannot compile until it is classified.
- **`fabFileRepository.markConvergencePaused`** (`packages/database`) - one pipeline update. Inner `$cond` is the discrimination on `chunkRebuildRequestedAt`; outer `$cond` is the redelivery guard; `chunkRebuildRequestedAt: null` goes in the same `$set` so a file is never both paused and pending.
- **The four grading sites** move from the bare `rechunkPaused` literal to the subset: `evaluateMemberHealth`'s `passagesRemoved`, `selectLakeHealthMembers`, `findDataLakeHealthMembers`'s `$match`, `findLakeConvergenceMembers`'s `$match`. **Behaviour-preserving for every existing row** - a never-chunked halted file carries `rechunkPaused` today and is already admitted and graded, so the subset keeps it exactly where it was. The docblocks that described those arms as removal-only are reworded.
- **`LEGACY_CHUNK_STALL_NOTES`** is pinned to the two reasons the `#2016` backfill migration actually derived, rather than `Object.values(CHUNK_STALL_NOTICES)`. No row carries the new prose - it postdates the migration - so admitting it to the legacy `notes` matcher would only ever catch an owner who happened to type that sentence themselves.
- **The migration's source-text assertion** in `chunking.test.ts` is narrowed the same way. The migration hardcodes exactly the two literals it backfilled and must NOT gain a third, so looping the full reason set would have failed the moment a reason was added.

Sites that needed **no** change because they already read the full set: `isChunkStalled`/`isChunkStalledFile`, `lakeConvergence.ts`, `buildFabFileSearchQuery`, the "Rebuild passages" door's paused arm, and the rescue sweep's own `stalledFile()` - which is why the sweep stops re-selecting a newly-marked file for free.

**No data migration.** The new reason is only ever written to `chunkStallReason`, never to `notes`.

## Tests

`packages/database/src/models/content/FabFileModel.markConvergencePaused.test.ts` - 7 cases against a real `mongod`, because which reason gets written is decided *inside* the update by a field that same update clears, so a mocked test can only assert that the method was called:

1. a file a producer reset is told its passages were removed
2. **a file the sweep selected is NOT told its passages were removed** - the reported bug; this is the case that fails before the fix (`expected 'rechunkPaused' to be 'unchunkedPaused'`)
3. the pending-rebuild stamp is cleared in the same write
4. idempotent - a redelivery does not downgrade the accurate reason
5. the vectorize arm's reason is not preserved by the idempotence guard
6. a legacy row whose `chunkStallReason` key is ABSENT rather than null still lands the never-chunked reason. The `#2016` backfill only set the field on rows carrying the legacy prose, and the sweep's `$nin` filter matches an absent field, so these reach the halt branch - but `FabFile.create` cannot build the state, because the schema defaults the field to null. Both pipeline operators resolve a missing path as falsy rather than erroring, which is what keeps the write off the DLQ; pinned because that is a MongoDB semantic the code does not state
7. `updatedAt` is still bumped - a pipeline-form update is not obviously timestamped, and mongoose handles the two forms in different code paths, so this is verified against a real server rather than reasoned about

Also: `isChunklessStall` accepts both chunk-arm reasons and rejects `vectorizePaused`; `LEGACY_CHUNK_STALL_NOTES` carries only the migrated prose; the handler test asserts it routes through the new method; `chunkScan.test.ts`'s two reason tables gain the new reason on both sides of the switch (excluded while ON, re-selected while OFF); and two service tests that enumerated "every stall reason" as a hardcoded pair now read the constant, which is what pins that a successful repair clears the new reason too.

## Guide for Testers

This is backend-only and reachable only with a platform-level kill switch on, so it is not a click-through flow. Verification is by unit/integration test.

### Automated

1. Run `pnpm --filter @bike4mind/database test src/models/content/FabFileModel.markConvergencePaused.test.ts`. Expected: 7 passed.
2. Run `pnpm --filter @bike4mind/common test src/constants/chunking.test.ts`. Expected: all passed.
3. Run `pnpm --filter @bike4mind/client exec vitest run server/queueHandlers/fabFileChunk.test.ts server/worker/chunkScan.test.ts`. Expected: all passed.

To see the bug itself, revert `markConvergencePaused`'s body to `{ $set: { chunkStallReason: 'rechunkPaused', chunkRebuildRequestedAt: null } }` and re-run step 1: case 2 fails.

### Manual, if a staging environment with the switch is available

1. Turn the convergence kill switch ON (`PauseLakeConvergence`, platform-level).
2. Leave a non-media FabFile in the shape a lost ingest webhook leaves behind: `status: 'complete'`, `chunkCount: 0`, `error: null`, `noExtractableTextAt: null`, `chunkStallReason: null`, `chunkRebuildRequestedAt: null`, `createdAt` older than 2 minutes.
3. Let a rescue sweep run (`chunkRescueSweep`, or the daily `dataLakeBatchReconcile`).
4. Open the file in the Data Lake viewer. **Expected:** the pipeline notice reads "Chunking paused by the data-lake convergence kill switch - this file has no passages yet and they are built when convergence resumes." **Before this fix** it claimed the passages "were removed".
5. Separately, run a "Rebuild passages" wave on a chunked file with the switch ON. **Expected:** that file still shows the "its passages were removed" notice - it is the accurate one there.

### Regression Checks

1. A lake's health headline and `Reachable %` are unchanged for a lake containing a halted chunkless member - the member stays in the denominator and still grades its real zero.
2. The "Rebuild passages" door still offers a repair for a halted file, and does not offer two.
3. `knowledge_base_search` still withholds a halted chunkless file and reports the result set as partial.

### What NOT to test

No UI was added or moved, no route or contract changed, and no admin setting was added. There is nothing to check on responsiveness, toasters, or navigation.

## Additional Information

`packages/database` and `b4m-core/common` are both published, so the enum widening reaches downstream consumers. The change is additive - no exported symbol removed, no existing value reworded - which is the shape that stays safe across a staggered deploy.

Two things noted and deliberately left out of scope:

- **The migration's `down()`** maps only the two original reasons back into `notes`. A row carrying the new reason gets nothing restored, so a rollback past `#2016` would render it unstalled and therefore invisible to the pre-migration readers. Mapping the new reason to the `rechunkPaused` prose in `down()` would trade that invisibility for the mislabelling this PR fixes - which is the trade the codebase already makes elsewhere ("mislabelled-but-visible beats invisible") - but it is a separate decision and not needed for this fix. Worth a follow-up.
- **Media files.** A media file admitted to the sweep only via `chunkRebuildRequestedAt` leaves the filter for good once the halt write nulls that field (tracked separately as #2224). Unchanged here; noted so nobody reads this PR as addressing it.

## Developer Notes

- **`CHUNKLESS_STALL_REASONS` is a new extension point with a type-level guard.** It is derived by filtering `CHUNK_STALL_REASONS` through a `Record<ChunkStallReason, boolean>` classification map, so adding a fourth stall reason is a compile error until someone decides whether it leaves the file with passages. The alternative - a hand-written subset array - would have let an omission through as a silently wrong health count, which is the failure mode this whole area of the codebase is built to avoid.
- **Pipeline-form `updateOne` as the pattern for "the value to write depends on a field this write changes."** `markConvergencePaused` is a small, readable example: inner `$cond` for the decision, outer `$cond` for at-least-once-delivery idempotence. Any other marker write that has to consult and clear the same field can copy its shape.

