### PR TITLE
fix(data-lakes): make renewSyncClaim's no-chain arm a real compare-and-set

### DIFF
--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -875,17 +875,70 @@ describe('driveLakeIngest consumer', () => {
       );
     });
 
-    it('does not heal the connection when the claim was taken away mid-slice', async () => {
-      // Someone else owns the connection now (a stale-claim reclaim). Healing it to 'connected' here
-      // would release a claim this run no longer holds, letting a second walk run alongside theirs.
+    it('tolerates a release that loses its CAS when the claim was taken away mid-slice', async () => {
+      // Someone else owns the connection now (a stale-claim reclaim). The release still RUNS - it is a
+      // compare-and-set on this run's token, so it misses the new owner's document and heals nothing,
+      // which is what keeps a second walk from starting alongside theirs. What is pinned here is that
+      // the handler tolerates the null: a lost release is an expected outcome, not a failure.
       h.walkFolder.mockResolvedValue(walkOf('d1', 'd2'));
       h.fetchDriveFileContent.mockResolvedValue(okBytes());
       h.renewSyncClaim.mockResolvedValue(null);
+      h.releaseSyncClaim.mockResolvedValue(null);
 
       await run({ connectionId: 'conn1' }, contextAllowingFiles(1));
 
       expect(h.sendToQueue).not.toHaveBeenCalled();
-      expect(h.releaseSyncClaim).not.toHaveBeenCalled();
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
+    });
+
+    it('releases when a renew is rejected while this run STILL holds the claim', async () => {
+      // A renew can be rejected without the claim having moved: a continuation whose adopt WON but
+      // whose batch is no longer adoptable (settled meanwhile) plans a FRESH batch, so it renews a
+      // batch id the connection's pointer does not match and misses both $or arms while its token is
+      // still live. Returning without releasing would park a connection this run genuinely owns at
+      // 'syncing' until the chained-stale window reclaims it an hour later - no poll can pick it up
+      // in the meantime (findDueForPoll filters on 'connected') and disconnect 409s while syncing.
+      h.adoptSyncClaim.mockResolvedValue('token-adopt');
+      h.walkFolder.mockResolvedValue(walkOf('d1', 'd2'));
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      // Terminal, so adoptedBatch is null and the run plans a fresh batch under a live adopted claim.
+      h.batchFindById.mockResolvedValue({
+        id: 'batch1',
+        dataLakeId: 'lake1',
+        status: 'completed',
+        totalFiles: 2,
+        skippedFiles: 0,
+        files: [],
+        vectorizedFiles: 0,
+        failedFiles: 0,
+      });
+      h.renewSyncClaim.mockResolvedValue(null);
+
+      await run(
+        { connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'tok0' },
+        contextAllowingFiles(1)
+      );
+
+      expect(h.sendToQueue).not.toHaveBeenCalled();
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-adopt', null);
+    });
+
+    it('releases with the ROTATED token when the continuation enqueue fails after a successful renew', async () => {
+      // The renew rotated the stored token, so the pre-rotation one this run arrived with is no longer
+      // the claim. If the enqueue then throws, the catch must release on the ROTATED value or the CAS
+      // misses its own connection: nothing is released, no continuation was enqueued, and the
+      // connection sits at 'syncing' with every recovery route closed until the 60-minute chained-stale
+      // window - a transient SQS blip turned into a wedge that needs a human.
+      h.walkFolder.mockResolvedValue(walkOf('d1', 'd2'));
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      // Once, not a standing rejection: vi.clearAllMocks() clears calls but not implementations, so a
+      // standing one would leak into every later test in this file.
+      h.sendToQueue.mockRejectedValueOnce(new Error('sqs throttled'));
+
+      await expect(run({ connectionId: 'conn1' }, contextAllowingFiles(1))).rejects.toThrow('sqs throttled');
+
+      expect(h.renewSyncClaim).toHaveBeenCalledWith('conn1', expect.any(String), 'token-claim');
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-renew', 'sqs throttled');
     });
 
     it('falls back to a fresh claim when a continuation finds its chain claim already gone', async () => {
@@ -1048,10 +1101,12 @@ describe('driveLakeIngest consumer', () => {
     });
 
     it.each([
-      ['the connection', () => h.connFindById.mockResolvedValue(null)],
-      ['the target data lake', () => h.lakeFindById.mockResolvedValue(null)],
-      ['the connecting user', () => h.userFindById.mockResolvedValue(null)],
-    ])('settles an adopted batch even when %s cannot be resolved', async (_label, breakLookup) => {
+      // The connection exit runs BEFORE the claim is taken, so it has nothing to release; the other two
+      // sit after it and must hand the claim back or the connection stays 'syncing' with no owner.
+      ['the connection', () => h.connFindById.mockResolvedValue(null), false],
+      ['the target data lake', () => h.lakeFindById.mockResolvedValue(null), true],
+      ['the connecting user', () => h.userFindById.mockResolvedValue(null), true],
+    ])('settles an adopted batch even when %s cannot be resolved', async (_label, breakLookup, releases) => {
       // These exits sit ABOVE where adoptedBatch is normally resolved, so a continuation reaching one
       // of them (a connection deleted mid-chain, a purged lake, a deleted connecting user) must still
       // settle the batch it was adopting via resumeBatchId directly - otherwise it strands in
@@ -1071,6 +1126,10 @@ describe('driveLakeIngest consumer', () => {
       await run({ connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'tok0' });
 
       expect(h.finalizeBatchIfComplete).toHaveBeenCalled();
+      // Asserted explicitly because settleChainedBatch runs FIRST on both exits: without this, deleting
+      // either release leaves the suite green.
+      if (releases) expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-adopt', null);
+      else expect(h.releaseSyncClaim).not.toHaveBeenCalled();
     });
 
     it('forwards the chain identity when a continuation loses the claim race and must defer', async () => {

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -11,7 +11,6 @@ const h = vi.hoisted(() => ({
   connFindById: vi.fn(),
   claimForSync: vi.fn(),
   releaseSyncClaim: vi.fn(),
-  updateHealth: vi.fn(),
   lakeFindById: vi.fn(),
   lakeFind: vi.fn(),
   userFindById: vi.fn(),
@@ -86,7 +85,6 @@ vi.mock('@bike4mind/database', () => ({
     adoptSyncClaim: h.adoptSyncClaim,
     renewSyncClaim: h.renewSyncClaim,
     releaseSyncClaim: h.releaseSyncClaim,
-    updateHealth: h.updateHealth,
   },
 }));
 vi.mock('@bike4mind/services', () => ({
@@ -178,8 +176,8 @@ describe('driveLakeIngest consumer', () => {
     h.markUploaded.mockResolvedValue(undefined);
     h.setTotalFilesIfActive.mockResolvedValue(null);
     h.recordSkippedDriveFile.mockResolvedValue(true);
-    h.releaseSyncClaim.mockResolvedValue(null);
-    h.updateHealth.mockResolvedValue(null);
+    // A successful release returns the healed doc; null means the claim was taken away first.
+    h.releaseSyncClaim.mockResolvedValue({ id: 'conn1', status: 'connected' });
     h.lakeFindById.mockResolvedValue({
       id: 'lake1',
       datalakeTag: 'lake-tag',
@@ -337,7 +335,7 @@ describe('driveLakeIngest consumer', () => {
     // The dominant poll outcome, so it must stay cheap: nothing is retired, so the retire gate's
     // candidate-lake lookup is never resolved at all.
     expect(h.loadPrefixArmCandidateLakes).not.toHaveBeenCalled();
-    expect(h.updateHealth).toHaveBeenCalledWith('conn1', expect.objectContaining({ status: 'connected' }));
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
   });
 
   it('re-ingests an EDITED file: recreates it fresh, THEN unpicks and fully deletes the stale copy', async () => {
@@ -661,9 +659,10 @@ describe('driveLakeIngest consumer', () => {
     expect(h.recomputeLakeStats).not.toHaveBeenCalled();
     expect(h.batchCreate).not.toHaveBeenCalled();
     expect(h.createFabFile).not.toHaveBeenCalled();
-    expect(h.updateHealth).toHaveBeenCalledWith(
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith(
       'conn1',
-      expect.objectContaining({ status: 'connected', lastError: expect.stringContaining('limit for one sync') })
+      'token-claim',
+      expect.stringContaining('limit for one sync')
     );
   });
 
@@ -681,7 +680,7 @@ describe('driveLakeIngest consumer', () => {
     expect(h.removeFileFromLake).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'ff-d2', expect.anything());
     expect(h.recomputeLakeStats).toHaveBeenCalledTimes(1);
     expect(h.batchCreate).not.toHaveBeenCalled();
-    expect(h.updateHealth).toHaveBeenCalledWith('conn1', expect.objectContaining({ status: 'connected' }));
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
   });
 
   it('refuses to prune the whole lake when the folder walk comes back empty (transient-glitch guard)', async () => {
@@ -697,7 +696,7 @@ describe('driveLakeIngest consumer', () => {
 
     expect(h.removeFileFromLake).not.toHaveBeenCalled();
     expect(h.batchCreate).not.toHaveBeenCalled();
-    expect(h.updateHealth).toHaveBeenCalledWith('conn1', expect.objectContaining({ status: 'connected' }));
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
   });
 
   it('refuses a folder over the candidate cap before creating any batch or FabFile', async () => {
@@ -715,9 +714,10 @@ describe('driveLakeIngest consumer', () => {
 
     expect(h.batchCreate).not.toHaveBeenCalled();
     expect(h.createFabFile).not.toHaveBeenCalled();
-    expect(h.updateHealth).toHaveBeenCalledWith(
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith(
       'conn1',
-      expect.objectContaining({ status: 'connected', lastError: expect.stringContaining('limit for one sync') })
+      'token-claim',
+      expect.stringContaining('limit for one sync')
     );
   });
 
@@ -738,7 +738,6 @@ describe('driveLakeIngest consumer', () => {
       // The claim is HANDED to the next slice, never released: a poll slipping in between slices would
       // start a competing walk that duplicates the tail, which is the same failure by another route.
       expect(h.renewSyncClaim).toHaveBeenCalledWith('conn1', 'batch1', 'token-claim');
-      expect(h.updateHealth).not.toHaveBeenCalled();
       expect(h.releaseSyncClaim).not.toHaveBeenCalled();
       expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', {
         connectionId: 'conn1',
@@ -804,7 +803,9 @@ describe('driveLakeIngest consumer', () => {
       // is needed and the finalize gate is nudged - the batch cannot strand in `processing`.
       expect(h.setTotalFilesIfActive).not.toHaveBeenCalled();
       expect(h.finalizeBatchIfComplete).toHaveBeenCalled();
-      expect(h.updateHealth).toHaveBeenCalledWith('conn1', expect.objectContaining({ status: 'connected' }));
+      // This slice ADOPTED the chain, so the token it releases with is the one adoptSyncClaim rotated
+      // onto it - not the one a fresh claimForSync would have minted.
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-adopt', null);
     });
 
     it('re-plans the shared batch down to what the chain actually produced', async () => {
@@ -867,9 +868,10 @@ describe('driveLakeIngest consumer', () => {
       expect(h.sendToQueue).not.toHaveBeenCalled();
       // Settled rather than stranded, the claim released, and the operator told why it stopped short.
       expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 1);
-      expect(h.updateHealth).toHaveBeenCalledWith(
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith(
         'conn1',
-        expect.objectContaining({ status: 'connected', lastError: expect.stringContaining('continuation runs') })
+        'token-claim',
+        expect.stringContaining('continuation runs')
       );
     });
 
@@ -883,7 +885,6 @@ describe('driveLakeIngest consumer', () => {
       await run({ connectionId: 'conn1' }, contextAllowingFiles(1));
 
       expect(h.sendToQueue).not.toHaveBeenCalled();
-      expect(h.updateHealth).not.toHaveBeenCalled();
       expect(h.releaseSyncClaim).not.toHaveBeenCalled();
     });
 
@@ -1043,10 +1044,7 @@ describe('driveLakeIngest consumer', () => {
       await run({ connectionId: 'conn1' });
 
       expect(h.createFabFile).not.toHaveBeenCalled();
-      expect(h.updateHealth).toHaveBeenCalledWith(
-        'conn1',
-        expect.objectContaining({ status: 'connected', lastError: expect.stringContaining('files') })
-      );
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', expect.stringContaining('files'));
     });
 
     it.each([
@@ -1115,7 +1113,7 @@ describe('driveLakeIngest consumer', () => {
     await expect(run()).rejects.toThrow('s3 blip');
     // The release heals status back to 'connected' and stamps lastPolledAt, so the failure has to ride
     // along as lastError or a deterministically-broken connection reads healthy and freshly-polled.
-    expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 's3 blip');
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', 's3 blip');
   });
 
   it('de-dups a multi-parented file so it is ingested once, not twice', async () => {
@@ -1156,7 +1154,7 @@ describe('driveLakeIngest consumer', () => {
     // d1's stale copy was already retired; d2's was not (it threw first) - no orphaned duplicate for d1.
     expect(h.deleteFabFile).toHaveBeenCalledWith('user1', { id: 'ff-old1' }, expect.anything());
     expect(h.deleteFabFile).not.toHaveBeenCalledWith('user1', { id: 'ff-old2' }, expect.anything());
-    expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 's3 blip');
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', 's3 blip');
     // The `finally` still deducts what d1's committed delete gave back: the SQS retry re-walks and
     // never sees that copy again, so an un-flushed deduction would bill those bytes forever.
     expect(h.changeStorageSize).toHaveBeenCalledWith(expect.objectContaining({ id: 'user1' }), -100);
@@ -1401,9 +1399,10 @@ describe('driveLakeIngest consumer', () => {
     expect(h.batchCreate).not.toHaveBeenCalled();
     expect(h.createFabFile).not.toHaveBeenCalled();
     expect(h.fetchDriveFileContent).not.toHaveBeenCalled();
-    expect(h.updateHealth).toHaveBeenCalledWith(
+    expect(h.releaseSyncClaim).toHaveBeenCalledWith(
       'conn1',
-      expect.objectContaining({ status: 'connected', lastError: expect.stringContaining('requires passages of 1000') })
+      'token-claim',
+      expect.stringContaining('requires passages of 1000')
     );
   });
 

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -168,9 +168,10 @@ describe('driveLakeIngest consumer', () => {
       organizationId: 'org1',
       driveFolderId: 'FOLDER',
     });
-    h.claimForSync.mockResolvedValue(true);
-    // adoptSyncClaim/renewSyncClaim now return the freshly-rotated token (or null on failure) rather
-    // than a bare boolean - see OrgGoogleDriveConnection.ingestClaimToken.
+    // claimForSync/adoptSyncClaim/renewSyncClaim all return the freshly-minted or -rotated claim
+    // token (or null on failure) rather than a bare boolean - see
+    // OrgGoogleDriveConnection.ingestClaimToken.
+    h.claimForSync.mockResolvedValue('token-claim');
     h.adoptSyncClaim.mockResolvedValue('token-adopt');
     h.renewSyncClaim.mockResolvedValue('token-renew');
     h.findDriveFileIdsByBatchId.mockResolvedValue([]);
@@ -229,7 +230,7 @@ describe('driveLakeIngest consumer', () => {
   });
 
   it('is a cheap no-op when the claim is lost and there is nothing in flight to defer behind', async () => {
-    h.claimForSync.mockResolvedValue(false);
+    h.claimForSync.mockResolvedValue(null);
     // Default connection has no 'syncing' status, so this is a duplicate/errored case, not a genuine
     // second sync - drop it (do not re-enqueue) and do not release a claim it does not own.
     await run();
@@ -240,7 +241,7 @@ describe('driveLakeIngest consumer', () => {
   });
 
   it('defers a genuine second sync (re-enqueue with delay) when a real run is in flight', async () => {
-    h.claimForSync.mockResolvedValue(false);
+    h.claimForSync.mockResolvedValue(null);
     h.connFindById.mockResolvedValue({
       id: 'conn1',
       status: 'syncing', // another run genuinely holds the claim
@@ -261,7 +262,7 @@ describe('driveLakeIngest consumer', () => {
   });
 
   it('stops deferring once the redrive bound is hit (cannot spin)', async () => {
-    h.claimForSync.mockResolvedValue(false);
+    h.claimForSync.mockResolvedValue(null);
     h.connFindById.mockResolvedValue({
       id: 'conn1',
       status: 'syncing',
@@ -736,7 +737,7 @@ describe('driveLakeIngest consumer', () => {
       expect(h.upload).toHaveBeenCalledTimes(1);
       // The claim is HANDED to the next slice, never released: a poll slipping in between slices would
       // start a competing walk that duplicates the tail, which is the same failure by another route.
-      expect(h.renewSyncClaim).toHaveBeenCalledWith('conn1', 'batch1', undefined);
+      expect(h.renewSyncClaim).toHaveBeenCalledWith('conn1', 'batch1', 'token-claim');
       expect(h.updateHealth).not.toHaveBeenCalled();
       expect(h.releaseSyncClaim).not.toHaveBeenCalled();
       expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', {
@@ -913,6 +914,39 @@ describe('driveLakeIngest consumer', () => {
       expect(h.createFabFile.mock.calls[0][0]).toMatchObject({ driveFileId: 'd2' });
     });
 
+    it('renews against the token its FRESH claim minted, not the one its lost adopt presented', async () => {
+      // A continuation whose adopt lost and that fell back to claimForSync now holds a DIFFERENT claim
+      // than the payload names. renewSyncClaim compare-and-sets on the token the connection actually
+      // stores, so presenting the payload's consumed one would fail every renew and collapse the chain
+      // to a single slice - it has to carry the freshly-minted token forward instead.
+      h.adoptSyncClaim.mockResolvedValue(null);
+      h.walkFolder.mockResolvedValue(walkOf('d1', 'd2', 'd3'));
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      h.batchFindById.mockResolvedValue({
+        id: 'batch1',
+        dataLakeId: 'lake1',
+        status: 'processing',
+        totalFiles: 3,
+        skippedFiles: 0,
+        files: [],
+        vectorizedFiles: 0,
+        failedFiles: 0,
+      });
+
+      await run(
+        { connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'tok0' },
+        contextAllowingFiles(1)
+      );
+
+      expect(h.renewSyncClaim).toHaveBeenCalledWith('conn1', 'batch1', 'token-claim');
+      expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', {
+        connectionId: 'conn1',
+        resumeBatchId: 'batch1',
+        slice: 2,
+        claimToken: 'token-renew',
+      });
+    });
+
     it('does not re-fetch a driveFileId the chain has already permanently skipped', async () => {
       // skip() mints no FabFile, so a permanently-unsupported file is invisible to
       // findDriveFileIdsByBatchId - without subtracting skippedDriveFileIds too, a chain would
@@ -1046,7 +1080,7 @@ describe('driveLakeIngest consumer', () => {
       // first-slice sync on its deferred retry - that would carry no resumeBatchId, subtract
       // nothing, and re-ingest the still-`pending` tail as duplicate ADDs.
       h.adoptSyncClaim.mockResolvedValue(null);
-      h.claimForSync.mockResolvedValue(false);
+      h.claimForSync.mockResolvedValue(null);
       h.connFindById.mockResolvedValue({
         id: 'conn1',
         status: 'syncing',

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -243,18 +243,17 @@ export function hasDriveFileChanged(
  */
 export const dispatch = dispatchWithLogger(async (event, context, logger) => {
   let connectionId: string | undefined;
-  let claimed = false;
+  // The CAS token this run HOLDS for the connection's sync claim, or undefined while it holds none.
+  // Every acquisition path mints one and every renew rotates it, so holding a token IS holding the
+  // claim - which is what the catch below reads to decide whether releasing is ours to do. Distinct
+  // from `payload.claimToken`, which a continuation only PRESENTS to adopt with; that becomes ours
+  // only once adoptSyncClaim consumes it and hands back a rotated one.
+  let ingestClaimToken: string | undefined;
   try {
     const payload = Payload.parse(JSON.parse(event.Records[0].body));
     connectionId = payload.connectionId;
     const { redriveCount, resumeBatchId, slice } = payload;
     logger.updateMetadata({ handler: 'driveLakeIngest', connectionId });
-
-    // The CAS token this run currently holds for the chain, if any - reassigned to the freshly
-    // rotated value on a successful adopt, and again on every renewSyncClaim before a continuation
-    // is enqueued. See OrgGoogleDriveConnection.ingestClaimToken for why the batch id alone can't
-    // serve as this token.
-    let ingestClaimToken = payload.claimToken;
 
     // `?? ` alone is not enough: a non-finite reading is not nullish and every comparison against it
     // is false, which would disable the deadline guard silently rather than fall back to the budget.
@@ -314,20 +313,15 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     // same already-consumed token) loses rather than racing this run. Falling back to a fresh claim
     // covers the one case where the chain's claim is genuinely gone: the previous slice threw,
     // released, and SQS redelivered its message.
-    claimed = false;
-    if (resumeBatchId && ingestClaimToken) {
-      const adopted = await orgGoogleDriveConnectionRepository.adoptSyncClaim(
-        connectionId,
-        resumeBatchId,
-        ingestClaimToken
-      );
-      if (adopted) {
-        claimed = true;
-        ingestClaimToken = adopted;
-      }
+    if (resumeBatchId && payload.claimToken) {
+      ingestClaimToken =
+        (await orgGoogleDriveConnectionRepository.adoptSyncClaim(connectionId, resumeBatchId, payload.claimToken)) ??
+        undefined;
     }
-    if (!claimed) claimed = await orgGoogleDriveConnectionRepository.claimForSync(connectionId);
-    if (!claimed) {
+    if (!ingestClaimToken) {
+      ingestClaimToken = (await orgGoogleDriveConnectionRepository.claimForSync(connectionId)) ?? undefined;
+    }
+    if (!ingestClaimToken) {
       // Someone else holds the claim. If a real ingest is in flight ('syncing'), DEFER this run by
       // re-enqueuing with a delay so a genuine second sync (new files added mid-run) isn't dropped -
       // bounded so it can't spin. If instead the connection is in an error state (claimForSync won't
@@ -1040,7 +1034,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
           slice,
           deferred,
         });
-        claimed = false;
+        ingestClaimToken = undefined;
         await settleChainedBatch(batch.id);
         return;
       } else if (deferred > 0) {
@@ -1100,7 +1094,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     // onto `lastError`: the release heals the status back to 'connected' and stamps lastPolledAt, so
     // without this a deterministically-broken connection reads healthy and freshly-polled with no
     // operator-visible sign that every sync is dying.
-    if (claimed && connectionId) {
+    if (ingestClaimToken && connectionId) {
       await orgGoogleDriveConnectionRepository
         .releaseSyncClaim(connectionId, err instanceof Error ? err.message : String(err))
         .catch(e =>

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -295,6 +295,27 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       await finalizeBatchIfComplete(settled ?? current, logger);
     };
 
+    /**
+     * End this run's claim: heal the connection back to 'connected' (or record why the sync stopped)
+     * and stamp lastPolledAt. Compare-and-set on the token this run holds, so a run that already lost
+     * the claim - to a stale-claim reclaim, or to a disconnect/reconnect landing mid-run - leaves the
+     * new owner alone instead of flipping a live ingest back to 'connected' for a poll to walk over.
+     * Losing it is an expected outcome, not a failure: the new owner releases when it finishes.
+     */
+    const releaseClaim = async (lastError: string | null) => {
+      if (!ingestClaimToken) return;
+      const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(
+        payload.connectionId,
+        ingestClaimToken,
+        lastError
+      );
+      if (!released) {
+        logger.warn('[driveLakeIngest] claim was taken away before release; leaving the new owner alone', {
+          connectionId,
+        });
+      }
+    };
+
     const connection = await orgGoogleDriveConnectionRepository.findById(connectionId);
     if (!connection) {
       logger.warn('[driveLakeIngest] connection not found; dropping', { connectionId });
@@ -362,20 +383,14 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       // Same reasoning as the connection-not-found exit above: a continuation reaching here still
       // owns an adopted batch that needs settling.
       if (resumeBatchId) await settleChainedBatch(resumeBatchId);
-      await orgGoogleDriveConnectionRepository.updateHealth(connectionId, {
-        status: 'connected',
-        lastPolledAt: new Date(),
-      });
+      await releaseClaim(null);
       return;
     }
     const user = await User.findById(connection.connectedBy);
     if (!user) {
       logger.warn('[driveLakeIngest] connecting user not found; dropping', { connectionId });
       if (resumeBatchId) await settleChainedBatch(resumeBatchId);
-      await orgGoogleDriveConnectionRepository.updateHealth(connectionId, {
-        status: 'connected',
-        lastPolledAt: new Date(),
-      });
+      await releaseClaim(null);
       return;
     }
     const ability = defineAbilitiesFor(user as unknown as IUserDocument);
@@ -733,11 +748,9 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       // A folder that grew past the cap mid-chain still owes its adopted batch a settlement - the
       // same exit this cap refusal shares with the zero-candidate and admission-refusal returns below.
       if (adoptedBatch) await settleChainedBatch(adoptedBatch.id);
-      await orgGoogleDriveConnectionRepository.updateHealth(connectionId, {
-        status: 'connected',
-        lastPolledAt: new Date(),
-        lastError: `Folder has ${walkAndDiffSize} files (folder listing or connection's stored set), over the ${MAX_INGEST_CANDIDATES}-file limit for one sync. Split it into subfolders and connect them separately.`,
-      });
+      await releaseClaim(
+        `Folder has ${walkAndDiffSize} files (folder listing or connection's stored set), over the ${MAX_INGEST_CANDIDATES}-file limit for one sync. Split it into subfolders and connect them separately.`
+      );
       return;
     }
 
@@ -786,10 +799,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         // A chain whose last slice happened to consume the remainder exactly lands here, with its
         // batch still open on the previous slice's plan. Settle it rather than leaving it processing.
         if (adoptedBatch) await settleChainedBatch(adoptedBatch.id);
-        await orgGoogleDriveConnectionRepository.updateHealth(connectionId, {
-          status: 'connected',
-          lastPolledAt: new Date(),
-        });
+        await releaseClaim(null);
         return;
       }
 
@@ -824,11 +834,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         // A lever flipped mid-chain refuses the remainder; the slices already ingested still have to
         // settle their shared batch rather than leave it processing.
         if (adoptedBatch) await settleChainedBatch(adoptedBatch.id);
-        await orgGoogleDriveConnectionRepository.updateHealth(connectionId, {
-          status: 'connected',
-          lastPolledAt: new Date(),
-          lastError: admissionError.message,
-        });
+        await releaseClaim(admissionError.message);
         return;
       }
 
@@ -1057,14 +1063,11 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       if (adoptedBatch || deferred > 0) await settleChainedBatch(batch.id);
       else await finalizeBatchIfComplete(await dataLakeBatchRepository.findById(batch.id), logger);
 
-      // Releases the syncing claim (syncing -> connected).
-      await orgGoogleDriveConnectionRepository.updateHealth(connectionId, {
-        status: 'connected',
-        lastPolledAt: new Date(),
-        ...(deferred > 0 && {
-          lastError: `Sync stopped after ${MAX_INGEST_SLICES} continuation runs with ${deferred} files left. The next scheduled poll continues from here; split very large folders into subfolders to converge faster.`,
-        }),
-      });
+      await releaseClaim(
+        deferred > 0
+          ? `Sync stopped after ${MAX_INGEST_SLICES} continuation runs with ${deferred} files left. The next scheduled poll continues from here; split very large folders into subfolders to converge faster.`
+          : null
+      );
     } finally {
       await flushReclaimedStorage();
 
@@ -1090,16 +1093,25 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     }
   } catch (err) {
     // Release the syncing claim so a retry can re-run - guarded so it can't clobber a
-    // credential_error that getValidConnectionDriveAccessToken set underneath us. Carry the failure
-    // onto `lastError`: the release heals the status back to 'connected' and stamps lastPolledAt, so
-    // without this a deterministically-broken connection reads healthy and freshly-polled with no
-    // operator-visible sign that every sync is dying.
+    // credential_error that getValidConnectionDriveAccessToken set underneath us, nor a claim this
+    // run already lost. Carry the failure onto `lastError`: the release heals the status back to
+    // 'connected' and stamps lastPolledAt, so without this a deterministically-broken connection
+    // reads healthy and freshly-polled with no operator-visible sign that every sync is dying.
     if (ingestClaimToken && connectionId) {
-      await orgGoogleDriveConnectionRepository
-        .releaseSyncClaim(connectionId, err instanceof Error ? err.message : String(err))
-        .catch(e =>
-          logger.error(`[driveLakeIngest] failed to release sync claim: ${e instanceof Error ? e.message : String(e)}`)
-        );
+      const released = await orgGoogleDriveConnectionRepository
+        .releaseSyncClaim(connectionId, ingestClaimToken, err instanceof Error ? err.message : String(err))
+        .catch(e => {
+          logger.error(`[driveLakeIngest] failed to release sync claim: ${e instanceof Error ? e.message : String(e)}`);
+          return undefined;
+        });
+      // null (rather than undefined) is the CAS losing: the claim moved on while this run was failing,
+      // so both the release and the lastError belong to a run that no longer owns the connection.
+      // Worth a line either way - it separates "released" from "someone took it" in the logs.
+      if (released === null) {
+        logger.warn('[driveLakeIngest] claim was taken away before the failure release; left the new owner alone', {
+          connectionId,
+        });
+      }
     }
     if (err instanceof ZodError || err instanceof SyntaxError) {
       logger.warn(`Skipping drive-lake-ingest message: ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -1016,12 +1016,20 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
           ingestClaimToken
         );
         if (renewedToken) {
+          // The renew rotated the stored token, so the one this run was holding is no longer the claim.
+          // Adopt the rotated value BEFORE the enqueue can throw: the catch releases on whatever this
+          // holds, and releasing on a superseded token is a silent no-op that would strand the
+          // connection at 'syncing' with no continuation ever enqueued.
+          ingestClaimToken = renewedToken;
           await sendToQueue(Resource.driveLakeIngestQueue.url, {
             connectionId,
             resumeBatchId: batch.id,
             slice: slice + 1,
             claimToken: renewedToken,
           });
+          // Handed off: the continuation owns the claim from here, so a later throw (the `finally`
+          // below) must NOT release it out from under that slice.
+          ingestClaimToken = undefined;
           logger.info('[driveLakeIngest] out of time; enqueued continuation slice', {
             connectionId,
             batchId: batch.id,
@@ -1031,17 +1039,21 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
           // Deliberately NOT releasing the claim, and NOT finalizing: the chain owns both until it ends.
           return;
         }
-        // The claim went while this slice ran (a stale-claim reclaim, a disconnect). Someone else owns
-        // the connection now: settle the batch, but touch NOTHING on the connection - healing it to
-        // 'connected' here would release a claim this run no longer holds.
+        // Either the claim went while this slice ran (a stale-claim reclaim, a disconnect), or this run
+        // still holds it but renewed a batch id the connection's pointer does not match - an adopt that
+        // won the claim and then could not adopt its batch plans a fresh one (see the warn above the
+        // batch resolution). Settle the batch and release: the release is a compare-and-set, so the
+        // genuine loser no-ops and logs, while the still-holding case heals the connection now instead
+        // of leaving it at 'syncing' until the chained-stale window reclaims it an hour later.
         logger.warn('[driveLakeIngest] lost the sync claim mid-slice; ending the chain', {
           connectionId,
           batchId: batch.id,
           slice,
           deferred,
         });
-        ingestClaimToken = undefined;
         await settleChainedBatch(batch.id);
+        await releaseClaim(null);
+        ingestClaimToken = undefined;
         return;
       } else if (deferred > 0) {
         // Chain ceiling. Coverage is not lost - the files this chain uploaded stop being candidates

--- a/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
+++ b/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
@@ -96,10 +96,12 @@ export interface IOrgGoogleDriveConnection {
   activeIngestBatchId?: string;
 
   /**
-   * One-time-use companion to `activeIngestBatchId`: the CAS value each slice's adoptSyncClaim call
-   * must present, rotated to a fresh value on every successful adopt/renew. `activeIngestBatchId`
-   * cannot itself serve as that CAS value - it stays fixed for the whole chain (it also names the
-   * batch document to resume) - so two deliveries of one continuation message would otherwise both
+   * The CAS value identifying whoever currently holds the 'syncing' claim: minted by claimForSync,
+   * rotated to a fresh value on every successful adopt/renew, and cleared on every release. Each slice
+   * must present the value it was issued to adoptSyncClaim or renewSyncClaim, and consuming it is what
+   * makes those a real compare-and-set. `activeIngestBatchId` cannot serve as that value - it is absent
+   * until a chain's first renew names a batch, and fixed for the whole chain afterwards (it also names
+   * the batch document to resume) - so two deliveries of one continuation message would otherwise both
    * match it and both win. Only meaningful while status === 'syncing'.
    */
   ingestClaimToken?: string;
@@ -251,9 +253,12 @@ export interface IOrgGoogleDriveConnectionRepository extends IBaseRepository<IOr
    * `syncClaimedAt`) iff the connection is idle ('connected') OR its existing 'syncing' claim is
    * STALE (older than the Lambda timeout) - so a process that died mid-sync can't wedge it forever,
    * and a claim never lands OVER a credential_error/needs_reconnect state (which a later release
-   * would erase). Returns whether THIS caller won the claim; exactly one concurrent run proceeds.
+   * would erase). Exactly one concurrent run proceeds.
+   *
+   * Returns the freshly-minted `ingestClaimToken` identifying this claim, or null if the claim was
+   * lost. The winner must carry that token into its own renewSyncClaim, which compare-and-sets on it.
    */
-  claimForSync(id: string): Promise<boolean>;
+  claimForSync(id: string): Promise<string | null>;
 
   /**
    * Continuation-only claim take-over: refreshes `syncClaimedAt` iff the connection is still 'syncing'
@@ -272,11 +277,13 @@ export interface IOrgGoogleDriveConnectionRepository extends IBaseRepository<IOr
    * Hold the claim across a slice boundary: re-stamps `syncClaimedAt` (so the stale-claim window never
    * elapses mid-chain), records the batch the next slice must present to adopt it, and mints a fresh
    * `ingestClaimToken` for that same slice to present. Guarded on 'syncing', and a real compare-and-set
-   * on `expectedToken` (the token THIS run currently holds for the chain, or omitted on a first slice
-   * that never held one) so a caller that already lost the claim to a reclaim/adopt cannot re-point it
-   * back at a chain nobody else is running. Returns the minted token on success, or null.
+   * on `expectedToken` - the token THIS run holds, minted by its own claimForSync or rotated onto it by
+   * adoptSyncClaim - so a caller that already lost the claim to a reclaim/adopt/disconnect cannot
+   * re-point the connection back at a chain nobody else is running. Required for that reason: it is the
+   * only field that distinguishes the holder, since the batch id is absent on a first slice and fixed
+   * for the whole of a later one. Returns the minted token on success, or null.
    */
-  renewSyncClaim(id: string, activeIngestBatchId: string, expectedToken?: string | null): Promise<string | null>;
+  renewSyncClaim(id: string, activeIngestBatchId: string, expectedToken: string): Promise<string | null>;
 
   /**
    * Release a 'syncing' claim on a failure path, guarded so it only moves 'syncing' -> 'connected'

--- a/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
+++ b/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
@@ -286,11 +286,19 @@ export interface IOrgGoogleDriveConnectionRepository extends IBaseRepository<IOr
   renewSyncClaim(id: string, activeIngestBatchId: string, expectedToken: string): Promise<string | null>;
 
   /**
-   * Release a 'syncing' claim on a failure path, guarded so it only moves 'syncing' -> 'connected'
-   * and can never clobber a terminal status (e.g. credential_error) set underneath it. The success
-   * path releases via `updateHealth({ status: 'connected' })` instead.
+   * The one way an ingest run ends its own claim - both the failure and the success exit. Moves
+   * 'syncing' -> 'connected' and stamps `lastPolledAt`, guarded so it can never clobber a terminal
+   * status (e.g. credential_error) set underneath it, and compare-and-set on `expectedToken` so a run
+   * that already lost the claim cannot release the NEW owner's - which would flip a live ingest back
+   * to 'connected' and let a poll start a competing walk. Losing that race returns null and is not an
+   * error; the new owner releases when it finishes. `lastError` is required and nullable because both
+   * exits share this method: a string records the failure, null heals.
    */
-  releaseSyncClaim(id: string, lastError?: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
+  releaseSyncClaim(
+    id: string,
+    expectedToken: string,
+    lastError: string | null
+  ): Promise<IOrgGoogleDriveConnectionDocument | null>;
 
   /**
    * Delete a connection (org-scoped), releasing its GLOBAL Drive-folder claim so the folder can be

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
@@ -269,16 +269,16 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
   it('claimForSync wins once and blocks a concurrent second claim until released', async () => {
     const created = await OrgGoogleDriveConnection.create(base);
 
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(true);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).not.toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('syncing');
 
     // A second run for the same connection cannot claim while the first holds it.
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(false);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBeNull();
 
     // Once released, a later run can claim again.
     await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id);
     expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('connected');
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(true);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).not.toBeNull();
   });
 
   it('releaseSyncClaim stamps lastPolledAt so a hard-failing connection is not re-enqueued every tick', async () => {
@@ -341,10 +341,10 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
 
   it('reclaims a STALE syncing claim so a dead ingest process cannot wedge it forever', async () => {
     const created = await OrgGoogleDriveConnection.create(base);
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(true);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).not.toBeNull();
 
     // A fresh claim is not reclaimable...
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(false);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBeNull();
 
     // ...but once the claim ages past the stale bound (simulating a process that died without
     // releasing), the next run can reclaim it instead of the connection being stuck 'syncing'.
@@ -352,7 +352,7 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
       { _id: created.id },
       { $set: { syncClaimedAt: new Date(Date.now() - 60 * 60 * 1000) } } // 1h ago >> 20min bound
     );
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(true);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).not.toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('syncing');
   });
 
@@ -360,9 +360,9 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     // The chain invariant for a folder too large for one run: the connection must stay 'syncing' the
     // whole way, or the re-sync poll slips in between slices and starts a competing walk.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
 
-    const token1 = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1');
+    const token1 = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', claimToken!);
     expect(token1).not.toBeNull();
     const held = await OrgGoogleDriveConnection.findById(created.id);
     expect(held?.status).toBe('syncing');
@@ -380,7 +380,7 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     expect(token2).not.toBeNull();
     expect(token2).not.toBe(token1);
     // A plain claim still loses to the live chain, exactly as it does to any other in-flight run.
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(false);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBeNull();
   });
 
   it('consumes the token on adopt, so a redelivered duplicate of the same continuation message loses', async () => {
@@ -388,8 +388,8 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     // batch id alone; the token has to be the thing that is actually CONSUMED (rotated) so only the
     // first of the two can win - otherwise both would proceed to ingest the same tail.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
-    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1');
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', claimToken!);
 
     const first = await orgGoogleDriveConnectionRepository.adoptSyncClaim(created.id, 'batch-1', token!);
     expect(first).not.toBeNull();
@@ -398,23 +398,26 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     expect(secondDelivery).toBeNull();
   });
 
-  it('drops the chain id and token whenever the claim is taken or released', async () => {
+  it('drops the chain id and invalidates its token whenever the claim is taken or released', async () => {
     // Otherwise a continuation message left over from a dead chain could adopt a claim nobody holds.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
-    await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1');
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const chainToken = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', claimToken!);
 
     await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id);
     const releasedDoc = await OrgGoogleDriveConnection.findById(created.id);
     expect(releasedDoc?.activeIngestBatchId).toBeUndefined();
     expect(releasedDoc?.ingestClaimToken).toBeUndefined();
     expect(await orgGoogleDriveConnectionRepository.adoptSyncClaim(created.id, 'batch-1', 'anything')).toBeNull();
+    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-2', chainToken!)).toBeNull(); // no-op: not syncing
 
-    await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-2'); // no-op: not syncing
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    // A fresh claim clears the dead chain's batch pointer but MINTS a token rather than clearing it -
+    // a null token would leave the no-chain-yet renew arm with nothing to compare against.
+    const freshToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
     const freshDoc = await OrgGoogleDriveConnection.findById(created.id);
     expect(freshDoc?.activeIngestBatchId).toBeUndefined();
-    expect(freshDoc?.ingestClaimToken).toBeUndefined();
+    expect(freshDoc?.ingestClaimToken).toBe(freshToken);
+    expect(freshToken).not.toBe(chainToken);
   });
 
   it('holds a CHAINED claim past the unchained stale bound, but still reclaims an abandoned chain', async () => {
@@ -423,14 +426,14 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     // connection to a fresh poll that has no resumeBatchId, and it would re-ingest the still-`pending`
     // tail as new ADDs - the duplicate spiral chaining exists to prevent.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
-    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1');
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', claimToken!);
 
     await OrgGoogleDriveConnection.updateOne(
       { _id: created.id },
       { $set: { syncClaimedAt: new Date(Date.now() - 30 * 60 * 1000) } } // past 20min, inside 60min
     );
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(false);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBeNull();
     expect(await orgGoogleDriveConnectionRepository.adoptSyncClaim(created.id, 'batch-1', token!)).not.toBeNull();
 
     // Finite, though: a chain that really is dead must not wedge the connection forever.
@@ -438,7 +441,7 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
       { _id: created.id },
       { $set: { syncClaimedAt: new Date(Date.now() - 90 * 60 * 1000) } }
     );
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(true);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).not.toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.activeIngestBatchId).toBeUndefined();
   });
 
@@ -446,14 +449,14 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     // A slow slice renewing after its claim was reclaimed and re-chained must lose, not stamp its own
     // dead batch over the live one.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
-    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live');
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live', claimToken!);
 
     // Wrong batch id refuses outright, whatever token accompanies it.
-    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-dead', token)).toBeNull();
+    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-dead', token!)).toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.activeIngestBatchId).toBe('batch-live');
     // Only the matching batch id AND its current token succeeds.
-    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live', token)).not.toBeNull();
+    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live', token!)).not.toBeNull();
   });
 
   it('renewSyncClaim requires the current token once a chain has one, not the batch id alone', async () => {
@@ -461,28 +464,64 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     // cannot tell "my own live chain" apart from "a chain I used to hold and lost" - both have the
     // same activeIngestBatchId once a new owner renews or adopts over it.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
-    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live');
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const token = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live', claimToken!);
 
-    // Right batch id, no token presented: refused.
-    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live')).toBeNull();
+    // Right batch id, but the claim token this chain has already rotated away from: refused.
+    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live', claimToken!)).toBeNull();
     // Right batch id, wrong token: refused.
     expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-live', 'wrong-token')).toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.ingestClaimToken).toBe(token);
   });
 
-  it('a slice that already lost its claim to a reclaim cannot renew back over the new owner', async () => {
+  it("a slice that already lost its claim to the chain's next slice cannot renew back over it", async () => {
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
-    const staleToken = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1');
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const staleToken = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', claimToken!);
 
     // Someone else takes over the same chain - the chain's own next slice adopting, in practice.
     const newToken = await orgGoogleDriveConnectionRepository.adoptSyncClaim(created.id, 'batch-1', staleToken!);
     expect(newToken).not.toBeNull();
 
     // The original slice, unaware it already lost the claim, tries to renew with the token it holds.
-    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', staleToken)).toBeNull();
+    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', staleToken!)).toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.ingestClaimToken).toBe(newToken);
+  });
+
+  it('a slice that lost its claim to a FRESH reclaim cannot renew over the new owner', async () => {
+    // Every path that takes a claim away - claimForSync, releaseSyncClaim, updateHealth leaving
+    // 'syncing' - leaves the batch pointer NULL, which is the state a first slice legitimately renews
+    // through. So the no-chain-yet arm has only the claim token to tell the new owner apart from the
+    // slice that just lost it. Regression: that arm used to match null unconditionally, letting the
+    // stale slice re-point the connection at its own dead batch and put two runners on one folder.
+    const created = await OrgGoogleDriveConnection.create(base);
+    const staleClaim = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    expect(staleClaim).not.toBeNull();
+
+    // Disconnect -> reconnect landing inside the live run: the disconnect drops the claim, and the
+    // reconnect heals the status because it is no longer 'syncing'.
+    await orgGoogleDriveConnectionRepository.updateHealth(created.id, { status: 'credential_error' });
+    await orgGoogleDriveConnectionRepository.updateCredential(
+      created.id,
+      base.organizationId,
+      'enc-new',
+      base.connectedBy
+    );
+
+    // The re-sync now owns the connection.
+    const newOwnerClaim = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    expect(newOwnerClaim).not.toBeNull();
+
+    // The original slice, still walking, renews with the token it was issued - and loses.
+    expect(await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-stale', staleClaim!)).toBeNull();
+    const doc = await OrgGoogleDriveConnection.findById(created.id);
+    expect(doc?.activeIngestBatchId).toBeUndefined();
+    expect(doc?.ingestClaimToken).toBe(newOwnerClaim);
+
+    // Still a compare-and-set, not a blanket refusal: the new owner's own first renew succeeds.
+    expect(
+      await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-fresh', newOwnerClaim!)
+    ).not.toBeNull();
   });
 
   it('adoptSyncClaim refuses a connection that is not syncing at all', async () => {
@@ -497,7 +536,7 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
 
     // Claiming a broken connection would let a later release flip it to 'connected' and erase the
     // real error. The claim must refuse, leaving the error state intact.
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBe(false);
+    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('credential_error');
   });
 });

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
@@ -269,14 +269,15 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
   it('claimForSync wins once and blocks a concurrent second claim until released', async () => {
     const created = await OrgGoogleDriveConnection.create(base);
 
-    expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).not.toBeNull();
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    expect(claimToken).not.toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('syncing');
 
     // A second run for the same connection cannot claim while the first holds it.
     expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).toBeNull();
 
     // Once released, a later run can claim again.
-    await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id);
+    await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, claimToken!, null);
     expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('connected');
     expect(await orgGoogleDriveConnectionRepository.claimForSync(created.id)).not.toBeNull();
   });
@@ -286,10 +287,10 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     // this release. Without stamping lastPolledAt it would stay due and be re-enqueued every hourly
     // tick, re-walking then failing each time. Stamping keeps the 6h cadence on the failure path.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
 
     const before = Date.now();
-    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id);
+    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, claimToken!, null);
     expect(released?.status).toBe('connected');
     expect(released?.lastPolledAt?.getTime()).toBeGreaterThanOrEqual(before);
 
@@ -305,36 +306,41 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     // deterministically-failing connection reads healthy and recently-polled with nothing anywhere to
     // tell an operator its syncs keep dying.
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
 
-    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, 'Drive folder unreadable');
+    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(
+      created.id,
+      claimToken!,
+      'Drive folder unreadable'
+    );
     expect(released?.status).toBe('connected');
     expect(released?.lastError).toContain('Drive folder unreadable');
   });
 
-  it('releaseSyncClaim leaves a stored lastError alone when the caller supplies none', async () => {
-    // Only ever WRITTEN when supplied - a caller with nothing to say must not silently clear a real
-    // error, unlike updateHealth, whose contract is to set the field to exactly what it is given.
+  it('releaseSyncClaim heals a stored lastError on a null (successful) release', async () => {
+    // The success exit comes through here too, so a null lastError has to CLEAR the field - otherwise
+    // a connection that failed once would keep reading broken through every later healthy sync.
     const created = await OrgGoogleDriveConnection.create(base);
     await orgGoogleDriveConnectionRepository.updateHealth(created.id, {
       status: 'connected',
       lastError: 'earlier failure',
     });
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
 
-    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id);
-    expect(released?.lastError).toContain('earlier failure');
+    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, claimToken!, null);
+    expect(released?.status).toBe('connected');
+    expect(released?.lastError).toBeNull();
   });
 
   it('releaseSyncClaim is guarded: it never clobbers a terminal status set under the claim', async () => {
     const created = await OrgGoogleDriveConnection.create(base);
-    await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
 
     // Simulate a credential failure marking the connection while a run held 'syncing'.
     await orgGoogleDriveConnectionRepository.updateHealth(created.id, { status: 'credential_error' });
 
     // The failure-path release must be a no-op now - status is not 'syncing' anymore.
-    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id);
+    const released = await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, claimToken!, null);
     expect(released).toBeNull();
     expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('credential_error');
   });
@@ -404,7 +410,7 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     const claimToken = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
     const chainToken = await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-1', claimToken!);
 
-    await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id);
+    await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, chainToken!, null);
     const releasedDoc = await OrgGoogleDriveConnection.findById(created.id);
     expect(releasedDoc?.activeIngestBatchId).toBeUndefined();
     expect(releasedDoc?.ingestClaimToken).toBeUndefined();
@@ -522,6 +528,35 @@ describe('OrgGoogleDriveConnectionModel - sync claim (per-connection serializati
     expect(
       await orgGoogleDriveConnectionRepository.renewSyncClaim(created.id, 'batch-fresh', newOwnerClaim!)
     ).not.toBeNull();
+  });
+
+  it('a run that lost its claim cannot RELEASE the new owner on its way out', async () => {
+    // The release-side half of the same hole renewSyncClaim had: releasing is guarded on 'syncing',
+    // but the new owner is also 'syncing', so without the token the loser would flip a live ingest
+    // back to 'connected' and clear its chain - freeing the re-sync poll to walk the same folder.
+    const created = await OrgGoogleDriveConnection.create(base);
+    const staleClaim = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+
+    // The claim ages out and a fresh run reclaims it.
+    await OrgGoogleDriveConnection.updateOne(
+      { _id: created.id },
+      { $set: { syncClaimedAt: new Date(Date.now() - 60 * 60 * 1000) } }
+    );
+    const newOwnerClaim = await orgGoogleDriveConnectionRepository.claimForSync(created.id);
+    expect(newOwnerClaim).not.toBeNull();
+
+    // The loser's error path fires. It must not touch the new owner.
+    expect(
+      await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, staleClaim!, 'some failure')
+    ).toBeNull();
+    const held = await OrgGoogleDriveConnection.findById(created.id);
+    expect(held?.status).toBe('syncing');
+    expect(held?.ingestClaimToken).toBe(newOwnerClaim);
+    expect(held?.lastError).toBeUndefined();
+
+    // The actual owner still releases normally.
+    expect(await orgGoogleDriveConnectionRepository.releaseSyncClaim(created.id, newOwnerClaim!, null)).not.toBeNull();
+    expect((await OrgGoogleDriveConnection.findById(created.id))?.status).toBe('connected');
   });
 
   it('adoptSyncClaim refuses a connection that is not syncing at all', async () => {

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
@@ -379,12 +379,19 @@ class OrgGoogleDriveConnectionRepository
    * (which is renewing precisely to name its batch for the first time), and on a later slice it is
    * fixed for the whole chain, so it cannot tell "my own live chain" apart from "a chain I used to hold
    * and lost to a reclaim/disconnect/reconnect" - both read back the same id once a new owner renews or
-   * adopts. Hence the $or is only over the batch pointer, and describes the two states a legitimate
-   * token-holder can be in:
+   * adopts. Hence the $or is only over the batch pointer, and covers the two states a token-holder
+   * renewing its OWN batch can be in:
    *   - null - a first slice straight off its own claimForSync, about to point the connection at the
    *     batch it just planned (also the state a continuation lands in when its adopt lost and it fell
    *     back to a fresh claim);
    *   - the same id - a later slice re-renewing the chain it is already running.
+   *
+   * It is deliberately NOT an enumeration of every state a token-holder can reach. A continuation whose
+   * adopt WON the claim but could not adopt its batch (settled meanwhile, or belonging to another lake)
+   * plans a fresh batch while the connection still points at the old id, and renews with a third tuple
+   * that matches neither arm. That caller is a genuine holder and is still rejected - correctly, since
+   * silently re-pointing a live chain's batch is the thing this guard exists to stop. It is the
+   * CALLER's job to treat a null return as "stop and release", not as "I lost the claim".
    *
    * Always mints a fresh `ingestClaimToken` on success and returns it - the caller carries it into the
    * next slice's continuation payload for adoptSyncClaim to present.

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
@@ -274,8 +274,10 @@ class OrgGoogleDriveConnectionRepository
     // Clear the error on a healthy update; redact + truncate otherwise (lastError is client-visible
     // and its predictable caller is a raw provider err.message - see redactLastError).
     set.lastError = update.lastError ? redactLastError(update.lastError) : null;
-    // Every caller here moves the connection OUT of 'syncing' (the success release, a credential
-    // failure, a disconnect), so any ingest-chain id/token goes with it - see releaseSyncClaim.
+    // Every caller here moves the connection out of 'syncing' into an ERROR state (a credential
+    // failure, a disconnect) and must be able to force it, so this is deliberately not claim-guarded.
+    // An ingest run ending its OWN claim goes through releaseSyncClaim instead, which is. Either way
+    // the chain id/token goes with the claim, or a stale continuation could adopt one nobody holds.
     const unset = update.status === 'syncing' ? undefined : { activeIngestBatchId: '', ingestClaimToken: '' };
     return this.model.findByIdAndUpdate(id, { $set: set, ...(unset && { $unset: unset }) }, { new: true });
   }
@@ -371,7 +373,7 @@ class OrgGoogleDriveConnectionRepository
    * Every path that takes the claim away either rotates that token to a value this caller cannot know
    * (claimForSync, adoptSyncClaim, a rival renew) or clears it outright (releaseSyncClaim, updateHealth
    * leaving 'syncing'), so a caller that already lost the claim presents a token nobody stores any more
-   * and matches nothing.
+   * and matches nothing. releaseSyncClaim compare-and-sets on the same token, for the same reason.
    *
    * The batch id cannot carry that guard on its own, in either direction: it is ABSENT on a first slice
    * (which is renewing precisely to name its batch for the first time), and on a later slice it is
@@ -403,9 +405,21 @@ class OrgGoogleDriveConnectionRepository
   }
 
   /**
-   * Guarded release for the failure path: 'syncing' -> 'connected' only. The `status: 'syncing'`
-   * conjunct means it no-ops if a terminal status (e.g. credential_error) was set underneath, so a
-   * failed run never overwrites a real error state.
+   * The ONE way an ingest run ends its own claim - both the failure exit and the success exit come
+   * through here. 'syncing' -> 'connected', guarded on the status AND on `expectedToken`.
+   *
+   * The status conjunct means it no-ops if a terminal status (e.g. credential_error) was set
+   * underneath, so a run never overwrites a real error state. The token conjunct means a run that has
+   * already LOST its claim - to a stale-claim reclaim, or to a disconnect/reconnect healing the status
+   * out from under it - cannot release the NEW owner's claim on its way out, which would flip a live
+   * ingest back to 'connected' and let the re-sync poll start a competing walk over the same folder.
+   * Losing that race is a no-op returning null, and is not an error: the new owner releases when it
+   * is done. This is the release-side half of the compare-and-set renewSyncClaim does for the chain.
+   *
+   * `lastError` is REQUIRED and nullable rather than optional precisely because both exits share this
+   * method: a string records the failure, null heals (matching updateHealth's contract for a healthy
+   * update). There is deliberately no "leave whatever is stored" arm - every caller knows which of the
+   * two it is, and an omitted argument would silently pick one of them.
    *
    * Stamps `lastPolledAt` too: a connection that fails DETERMINISTICALLY (a subtree the credential
    * cannot list, a Mongo timeout) would otherwise heal back to 'connected' with lastPolledAt
@@ -413,23 +427,29 @@ class OrgGoogleDriveConnectionRepository
    * before failing again. Stamping keeps the 6h poll cadence on the failure path, matching every
    * non-throwing exit (findDueForPoll's status filter can't help once the release flips it back).
    *
-   * `lastError` is the operator-visible half of that: without it, such a connection reads `connected`
-   * with a fresh poll time and no signal anywhere that its syncs keep dying. Redacted like
-   * updateHealth's, since the caller's message is a raw provider/driver `err.message`. Only WRITTEN
-   * when supplied - an omitted one leaves whatever is stored, so a caller with nothing to say cannot
-   * silently clear a real error.
+   * A recorded `lastError` is the operator-visible half of that: without it, such a connection reads
+   * `connected` with a fresh poll time and no signal anywhere that its syncs keep dying. Redacted
+   * like updateHealth's, since the caller's message is a raw provider/driver `err.message`.
    */
   async releaseSyncClaim(
     id: string,
-    lastError?: string
+    expectedToken: string,
+    lastError: string | null
   ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
-    const set: Record<string, unknown> = { status: 'connected', lastPolledAt: new Date() };
-    if (lastError) set.lastError = redactLastError(lastError);
     // The chain (if any) is over once the claim goes; leaving the id/token would let an in-flight
     // continuation message adopt a claim nobody holds.
     return this.model.findOneAndUpdate(
-      { _id: id, status: 'syncing' },
-      { $set: set, $unset: { activeIngestBatchId: '', ingestClaimToken: '' } },
+      { _id: id, status: 'syncing', ingestClaimToken: expectedToken },
+      {
+        $set: {
+          status: 'connected',
+          lastPolledAt: new Date(),
+          // Empty-string-to-null matches updateHealth: a caller whose err.message is blank has nothing
+          // to report, and storing '' would read as a present error on the client.
+          lastError: lastError ? redactLastError(lastError) : null,
+        },
+        $unset: { activeIngestBatchId: '', ingestClaimToken: '' },
+      },
       { new: true }
     );
   }

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
@@ -293,7 +293,7 @@ class OrgGoogleDriveConnectionRepository
    * Guarded ingest lock: atomically flip status to 'syncing' (stamping `syncClaimedAt`) only when the
    * connection is idle ('connected') OR its existing 'syncing' claim is STALE. A single atomic
    * compare-and-set - a losing concurrent caller matches nothing and gets `null`, so exactly one run
-   * proceeds. Returns whether THIS caller claimed it.
+   * proceeds.
    *
    * Deliberately NOT `$ne: 'syncing'`: that also claimed OVER a `credential_error`/`needs_reconnect`
    * connection, and a later release would erase the real error state (leaving it reading healthy with
@@ -305,10 +305,14 @@ class OrgGoogleDriveConnectionRepository
    * The staleness arm is SPLIT by whether the claim carries a chain token, because the two measure
    * different durations and stealing a live chain is far more damaging than stealing an idle claim -
    * see CHAINED_SYNC_CLAIM_STALE_MS.
+   *
+   * Returns the freshly-minted `ingestClaimToken` this claim is identified by (null if the claim was
+   * lost). The caller must carry it into its own renewSyncClaim, which compare-and-sets on it.
    */
-  async claimForSync(id: string): Promise<boolean> {
+  async claimForSync(id: string): Promise<string | null> {
     const staleBefore = new Date(Date.now() - SYNC_CLAIM_STALE_MS);
     const chainedStaleBefore = new Date(Date.now() - CHAINED_SYNC_CLAIM_STALE_MS);
+    const claimToken = randomUUID();
     const claimed = await this.model.findOneAndUpdate(
       {
         _id: id,
@@ -323,15 +327,17 @@ class OrgGoogleDriveConnectionRepository
           },
         ],
       },
-      // A fresh claim starts no chain, so any continuation id/token left by a dead one is cleared
-      // here - otherwise a stale message could still present it to adoptSyncClaim and join a chain
-      // that is no longer running.
+      // A fresh claim starts no chain, so the batch pointer left by a dead one is cleared - otherwise
+      // a stale message could still present it to adoptSyncClaim and join a chain that is no longer
+      // running. The token is REPLACED rather than cleared, for the same reason: it is what makes
+      // renewSyncClaim a compare-and-set even before this claim has named a batch, so leaving it null
+      // would let the dead chain's last slice renew straight back over this one.
       {
-        $set: { status: 'syncing', syncClaimedAt: new Date() },
-        $unset: { activeIngestBatchId: '', ingestClaimToken: '' },
+        $set: { status: 'syncing', syncClaimedAt: new Date(), ingestClaimToken: claimToken },
+        $unset: { activeIngestBatchId: '' },
       }
     );
-    return claimed !== null;
+    return claimed !== null ? claimToken : null;
   }
 
   /**
@@ -360,36 +366,36 @@ class OrgGoogleDriveConnectionRepository
 
   /**
    * Hold the claim across a slice boundary; guarded on 'syncing' so it cannot resurrect a released one.
-   * The later-slice arm (activeIngestBatchId AND expectedToken must both still match) is a real
-   * compare-and-set for that case, for the same reason adoptSyncClaim's is: `expectedToken` closes the
-   * gap the batch id alone leaves, since the batch id never changes across a whole chain and so cannot
-   * tell "my own live chain" apart from "a chain I used to hold and lost to a reclaim/disconnect/
-   * reconnect" (both have the same activeIngestBatchId once a new owner renews or adopts).
+   * `expectedToken` is the one-time token this run currently holds - minted by its own claimForSync, or
+   * rotated onto it by adoptSyncClaim - and it is REQUIRED, because it is the whole compare-and-set.
+   * Every path that takes the claim away either rotates that token to a value this caller cannot know
+   * (claimForSync, adoptSyncClaim, a rival renew) or clears it outright (releaseSyncClaim, updateHealth
+   * leaving 'syncing'), so a caller that already lost the claim presents a token nobody stores any more
+   * and matches nothing.
    *
-   * The no-chain-yet arm is NOT a compare-and-set against the caller's own `activeIngestBatchId`: it
-   * matches any doc currently sitting at null/null regardless of which batch id the caller passed in,
-   * so a stale first-slice caller (e.g. an abandoned attempt whose crash-retry already produced a fresh,
-   * unrelated claim on the same connection) can still win it and redirect the connection to ITS batch
-   * id. Known gap, tracked separately rather than closed here - not blocking because the un-chained
-   * `updateHealth` path already has an equivalent window on main.
+   * The batch id cannot carry that guard on its own, in either direction: it is ABSENT on a first slice
+   * (which is renewing precisely to name its batch for the first time), and on a later slice it is
+   * fixed for the whole chain, so it cannot tell "my own live chain" apart from "a chain I used to hold
+   * and lost to a reclaim/disconnect/reconnect" - both read back the same id once a new owner renews or
+   * adopts. Hence the $or is only over the batch pointer, and describes the two states a legitimate
+   * token-holder can be in:
+   *   - null - a first slice straight off its own claimForSync, about to point the connection at the
+   *     batch it just planned (also the state a continuation lands in when its adopt lost and it fell
+   *     back to a fresh claim);
+   *   - the same id - a later slice re-renewing the chain it is already running.
    *
    * Always mints a fresh `ingestClaimToken` on success and returns it - the caller carries it into the
    * next slice's continuation payload for adoptSyncClaim to present.
    */
-  async renewSyncClaim(id: string, activeIngestBatchId: string, expectedToken?: string | null): Promise<string | null> {
+  async renewSyncClaim(id: string, activeIngestBatchId: string, expectedToken: string): Promise<string | null> {
     const rotatedToken = randomUUID();
     const renewed = await this.model.findOneAndUpdate(
       {
         _id: id,
         status: 'syncing',
-        $or: [
-          // No chain yet: the first slice, right after its own fresh claimForSync (which unsets both
-          // fields). Not gated on expectedToken - a first slice never held one to present.
-          { activeIngestBatchId: { $in: [null] }, ingestClaimToken: { $in: [null] } },
-          // A later slice renewing its own still-held chain: both the id AND the token must still match
-          // what this run was issued, or the claim moved on without us.
-          ...(expectedToken ? [{ activeIngestBatchId, ingestClaimToken: expectedToken }] : []),
-        ],
+        ingestClaimToken: expectedToken,
+        // $in: [null] matches a missing field too - a claim that has not named a batch yet.
+        $or: [{ activeIngestBatchId: { $in: [null] } }, { activeIngestBatchId }],
       },
       { $set: { syncClaimedAt: new Date(), activeIngestBatchId, ingestClaimToken: rotatedToken } }
     );


### PR DESCRIPTION
## Description

A Drive ingest run could stomp a claim it no longer held, at **both** ends of the run. #2325 reported the first; the second is the same bug on the release side, and is folded in here.

**Renewing (the reported bug).** `renewSyncClaim`'s no-chain arm matched **any** connection sitting at a null `activeIngestBatchId`, regardless of the token the caller presented. A slice that had already lost its sync claim could renew straight back over the new owner, re-point the connection at its own dead chain, and enqueue a continuation off a stale plan. Two runners then walked the same folder.

The arm could not do better before, because every path that takes a claim away - `claimForSync`, `releaseSyncClaim`, `updateHealth` leaving `'syncing'` - leaves the batch pointer **null**. That is also the state a legitimate first slice renews through, since a first slice renews precisely in order to name its batch for the first time. The batch id cannot tell the two apart, and there was no other field to compare against: `claimForSync` cleared the token rather than minting one.

So the fix is to give the first slice something to present. **`claimForSync` now mints an `ingestClaimToken` and returns it** instead of a bare boolean; `renewSyncClaim` compare-and-sets on that token in **both** arms, and the batch-pointer check narrows to a plain `$or` over the two states a legitimate holder can be in.

**Releasing (folded in).** With a claim identity in hand, the release side turned out to have the identical hole. `releaseSyncClaim` was guarded on `status: 'syncing'` alone - but the new owner of a reclaimed connection is *also* `'syncing'`, so a run that had already lost its claim would flip a live ingest back to `'connected'` and clear its chain on the way out, freeing the poll to walk the same folder.

Worse, that was only the error path. The **six** success and early-exit paths released through `updateHealth({ status: 'connected' })`, which is unguarded in exactly the same way - and the most common exit of all, a run that finishes every file, never renews, so it never learns it lost the claim. It would sail straight into `updateHealth` and release someone else's ingest.

A claim conjunct on `updateHealth` itself would be wrong: both its remaining callers (`common.ts:272`, a credential-refresh failure, and `disconnect.ts:44`) set `credential_error` and must be able to force it. So `releaseSyncClaim` becomes the single, token-guarded way an ingest run ends its own claim, and all seven exits move onto it behind one local helper.

## Changes

**`OrgGoogleDriveConnectionModel`**

- **`claimForSync`** mints an `ingestClaimToken` and returns it (`Promise<string | null>` rather than `Promise<boolean>`). It still clears `activeIngestBatchId` so a stale continuation cannot adopt a dead chain - the token is *replaced* rather than cleared, because a null token is what left the renew arm with nothing to compare against.
- **`renewSyncClaim`** hoists `ingestClaimToken: expectedToken` to the top level of the query, and `expectedToken` is now **required** - an optional CAS field is the bug. The `$or` covers only the batch pointer.
- **`releaseSyncClaim`** gains the same `ingestClaimToken` conjunct. `lastError` becomes **required and nullable** (`string | null`) rather than optional, because both exits now share the method and each has to state which it is: a string records the failure, `null` heals. The old "omitted leaves whatever is stored" arm had no production caller - it existed only in a test.
- **`updateHealth`** is unchanged, with a comment recording *why* it stays unguarded.
- **`renewSyncClaim`'s `$or` comment** no longer claims to enumerate every state a token-holder can be in - the rejected-but-still-holding case above is a reachable third. It now says what the arms actually cover (a holder renewing its *own* batch) and puts the "a null return means stop and release" obligation on the caller.

**`driveLakeIngest`**

- The claim token replaces the parallel `claimed` boolean. The two always had to agree (one recorded "we hold the claim", the other "here is the proof"), and holding a token now *is* holding the claim, so they collapse to one variable.
- A continuation whose adopt lost and fell back to a fresh claim carries the **newly minted** token forward rather than the consumed one from its payload. Without that, every subsequent renew in that chain would fail and the chain would collapse to a single slice.
- All seven exits go through one `releaseClaim(lastError)` helper, so the "we lost the claim" case gets a single diagnostic instead of six copies. The failure exit in the `catch` keeps its own inline call (it is outside the helper's scope) and distinguishes `null` (CAS lost) from a thrown error in the log.
- **The renew's rotated token is adopted before the enqueue can throw**, and cleared again once the continuation owns it. A renew rotates the stored token, so the pre-rotation value the run arrived with stops being the claim the moment the renew succeeds. If `sendToQueue` then threw, the `catch` released on that superseded token, the CAS missed, and the connection was left at `syncing` with no continuation enqueued and every recovery route closed - `findDueForPoll` filters on `connected`, the redrive budget (12 x 90s) expires well inside `CHAINED_SYNC_CLAIM_STALE_MS` (60 min), and disconnect 409s while syncing. A transient SQS blip became a wedge needing a human.
- **The renew-rejected branch now releases** rather than returning untouched. That branch predates release being a compare-and-set; now that it is, the release is safe on both readings. A run that genuinely lost the claim no-ops and logs, and a run that *still holds* it recovers the connection immediately - which is reachable: a continuation whose adopt WON but whose batch is no longer adoptable (settled meanwhile, or belonging to another lake) plans a fresh batch, then renews a batch id the connection's pointer does not match and misses both `$or` arms with a live token.

**`IOrgGoogleDriveConnectionRepository`** doc comments updated to match, including the `ingestClaimToken` field doc - it is no longer a companion to `activeIngestBatchId`, it is the claim identity in its own right.

Six new tests plus one rewritten, each verified to fail under its own mutation (see Regression Checks). The rewritten one is `does not heal the connection when the claim was taken away mid-slice`, which asserted `releaseSyncClaim` was never called - the behaviour the renew-rejected fix above deliberately changes. It now pins what actually matters there: the release runs, its CAS misses, and the handler tolerates the `null` instead of treating a lost release as a failure.

## Guide for Testers

This is a backend concurrency fix in a queue handler and two Mongo compare-and-sets. There is **no UI change** and the observable behaviour on the happy path is identical. The meaningful verification is the automated suite plus, optionally, a large-folder sync on a preview.

**Automated (the real gate):**

1. Check out this branch and run `pnpm install && pnpm turbo:core:build`.
2. Run `pnpm --filter @bike4mind/database exec vitest run src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts`. Expected: **35 passed**.
3. Run `pnpm --filter @bike4mind/client exec vitest run --project node server/queueHandlers/driveLakeIngest.test.ts`. Expected: **59 passed**.

**Optional live check on a preview** (only if you want to exercise the chain end to end):

4. Go to `app.pr<N>.preview.bike4mind.com` and sign in.
5. Navigate: **Sidebar -> Data Lakes -> (open a lake) -> Connect Google Drive**.
6. Connect a Drive folder containing **more than one run's worth of files** (enough that the ingest slices - a few hundred small files is comfortable). Expected: the connection shows `syncing`.
7. While it is still syncing, click **Re-sync** on the same connection. Expected: the second sync does **not** start a competing walk; it defers and the connection stays `syncing`.
8. Wait for the chain to finish. Expected: the connection returns to `connected`, and the lake's file count matches the folder's file count exactly, with **no duplicate files** - the same file name must not appear twice.
9. Disconnect the folder, then reconnect and re-sync it. Expected: it syncs cleanly and the connection ends at `connected` with no error banner.

### Regression Checks

10. The behaviour this PR fixes is only observable under a race, so it is pinned by three tests rather than by hand. To confirm each is load-bearing:
    - In `OrgGoogleDriveConnectionModel.ts`, temporarily move `ingestClaimToken: expectedToken` out of `renewSyncClaim`'s top-level query and back into the second `$or` arm only. Re-run step 2. Expected: **exactly one failure**, `a slice that lost its claim to a FRESH reclaim cannot renew over the new owner`. Revert.
    - In the same file, temporarily drop `ingestClaimToken: expectedToken` from `releaseSyncClaim`'s query. Re-run step 2. Expected: **exactly one failure**, `a run that lost its claim cannot RELEASE the new owner on its way out`. Revert.
    - In `driveLakeIngest.ts`, temporarily change the `renewSyncClaim` argument from `ingestClaimToken` to `payload.claimToken ?? ingestClaimToken`. Re-run step 3. Expected: **exactly one failure**, `renews against the token its FRESH claim minted, not the one its lost adopt presented`. Revert.
    - In `driveLakeIngest.ts`, temporarily delete the `ingestClaimToken = renewedToken;` line above the continuation `sendToQueue`. Re-run step 3. Expected: **exactly one failure**, `releases with the ROTATED token when the continuation enqueue fails after a successful renew`. Revert.
    - In `driveLakeIngest.ts`, temporarily delete the `await releaseClaim(null);` line in the renew-rejected branch. Re-run step 3. Expected: **exactly two failures**, `tolerates a release that loses its CAS when the claim was taken away mid-slice` and `releases when a renew is rejected while this run STILL holds the claim`. Revert.
    - In `driveLakeIngest.ts`, temporarily delete the `await releaseClaim(null);` line in the lake-not-found exit. Re-run step 3. Expected: **exactly one failure**, `settles an adopted batch even when the target data lake cannot be resolved`. (Before this round that exit's release was unasserted - `settleChainedBatch` runs first, so deleting the release kept the suite green.) Revert.
11. Full suites, since `claimForSync` and `releaseSyncClaim` both changed signature: `pnpm --filter @bike4mind/database test` (2280 passed, 1 skipped) and `pnpm --filter @bike4mind/client test` (11739 passed, 81 skipped).
12. Ordinary small-folder Drive sync (one that finishes inside a single run) still completes and releases the connection back to `connected`. This is the path where `claimForSync` mints a token used exactly once, by that run's own release.
13. The error path still records why a sync died: point a connection at a folder its credential cannot list, sync, and confirm the connection reads `connected` with a `lastError` rather than silently healthy.

### What NOT to test

- No UI, route, component or style changed - there is nothing visual to review.
- No API contract, request/response shape or DTO changed. `ingestClaimToken` is server-side only and never reaches a client: `pages/api/data-lakes/[id]/drive-connection.ts` returns an explicit allowlist DTO (`toSafeConnection`), not the raw document.
- No migration and no index change. `ingestClaimToken` already exists on the schema (added in #2262); only *when* it is written changed.
- No credit, billing, or storage-accounting path is touched.
- `updateHealth`'s own behaviour is unchanged - the disconnect and credential-failure paths that use it are untouched.

## Additional Information

**Two behaviours improve as a side effect of routing the six healthy exits through the guarded release**, and both are worth a second opinion:

- A release can no longer erase a `credential_error` that a concurrent disconnect set mid-run. `updateHealth` would have healed it back to `connected`; `releaseSyncClaim`'s `status: 'syncing'` conjunct refuses. I read this as strictly correct - it is the same reasoning the conjunct was originally added for - but it is a behaviour change beyond the reported bug.
- Losing the release race is now logged (`claim was taken away before release`) instead of being silent, so an operator can tell "released" from "someone took it".

**Still not fixed, deliberately.** `updateHealth` has no `status: 'syncing'` conjunct, so a *disconnect* landing mid-ingest still moves a live run's connection to `credential_error` underneath it. That is the intended behaviour for a disconnect (the credential really is gone), and the ingest run now degrades correctly rather than fighting it: its next renew or release simply loses. I do not think there is anything left to fix here, but flagging it since #2325's write-up called the window out.

**Interface change / changeset bump.** `claimForSync`, `renewSyncClaim` and `releaseSyncClaim` are members of `IOrgGoogleDriveConnectionRepository`, exported from `@bike4mind/common`, so tightening them is source-breaking for an out-of-repo implementer. I grepped all five overlay repos (`b4m-optihashi`, `b4m-pi`, `b4m-libreoncology`, `b4m-overwatch`, `b4m-tavern`) for `OrgGoogleDriveConnection` / `claimForSync` / `renewSyncClaim` / `releaseSyncClaim` and found **zero** references, and the in-repo implementation is compiler-bound via `implements`.

I have titled this `fix(data-lakes):` (patch). An earlier revision of this section cited #2262 as precedent for retyping a member under a non-`!` title - that was wrong, and I have dropped it. Before #2262 the interface had only `claimForSync(id): Promise<boolean>` and `releaseSyncClaim(id, lastError?)`; neither `renewSyncClaim` nor `adoptSyncClaim` existed. So #2262 *added* two required members (still source-breaking for an out-of-repo implementer, so not a worthless precedent) but retyped nothing, and it shipped as `feat(drive-lake):` - a **minor** bump. This PR is the first here to change an existing member's signature.

The patch title rests on its own argument instead: every change is an **arity** change, so an out-of-repo implementer gets a hard compile error rather than a silent behaviour shift - the loud failure you want - and every in-repo call site is fixed in this PR. `releaseSyncClaim` is the one to watch, since its second positional argument changes meaning from `lastError` to `expectedToken`. Shout if you would rather it went out as `fix(data-lakes)!:`.

**One gap worth knowing about.** `packages/database/tsconfig.json` excludes `**/*.test.ts`, so the repo's typecheck does not cover the database package's own tests. A test left calling the old `releaseSyncClaim(id)` arity would have compiled fine and passed *silently*, because Mongoose strips `undefined` from a query filter and the guard would have degraded to the old unguarded behaviour. I updated every call site by hand and confirmed via the mutations in step 10 that the guards are actually exercised. Not fixing the tsconfig here, but it is a sharp edge for anyone changing a repository signature.

## Developer Notes

- **`claimForSync` now returns a claim identity, not a yes/no.** That is the reusable shape: a lock acquisition that hands back proof of ownership lets every later operation on that lock be a compare-and-set instead of a bare guard. The old boolean forced the first renew to be guarded on "nobody else has started a chain", which is a weaker and differently-shaped question than "do I still hold this". Once the identity existed, the release-side hole became both visible and a two-line fix.
- **`ingestClaimToken` changed meaning** from "companion to `activeIngestBatchId`, only present mid-chain" to "the identity of whoever currently holds the claim, present for the whole claim". Its field doc now says so. Any future claim operation should compare-and-set on it rather than inventing a second guard.
- **One release primitive, not two plus six.** The success path releasing through a general-purpose health writer is what let the hole survive - it did not *look* like a claim operation, so it did not get a claim guard. Naming it as a release put all seven exits behind one contract.
- **One variable, not two.** `claimed` and `ingestClaimToken` were a boolean and its evidence, required to agree at every branch. Collapsing them removes a class of drift - a future exit that forgets to clear one can no longer leave the handler believing it holds a claim it does not.

Closes #2325

