### PR TITLE
fix(session): gate the chat chrome band on the vertical split only

### DIFF
--- a/apps/client/app/components/Session/SessionContainer.openGuard.test.ts
+++ b/apps/client/app/components/Session/SessionContainer.openGuard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { shouldAttemptSessionOpen } from './SessionContainer';
+import { shouldAttemptSessionOpen, shouldShowChromeBand } from './SessionContainer';
+import type { DefaultLayoutType } from '@client/app/hooks/useSessionLayout';
 
 // Guards the fix for the 404 retry loop: changeSession must be attempted at most
 // once per session id, even when the open keeps failing and contextSessionId
@@ -31,5 +32,38 @@ describe('shouldAttemptSessionOpen', () => {
 
   it('attempts a newly selected session even if a different one was attempted before', () => {
     expect(shouldAttemptSessionOpen('sess-2', null, false, SID)).toBe(true);
+  });
+});
+
+// Pins the #2304 fix: the chat's 56px chrome band shows ONLY in the desktop vertical split.
+// The table is exhaustive over DefaultLayoutType x {mobile, desktop} on purpose - the bug was a
+// negative `layout !== ...` chain that silently gave new/other layouts the band. A new member
+// added to the union without a row here defaults to false, which is the intended safe direction.
+describe('shouldShowChromeBand', () => {
+  const ALL_LAYOUTS: DefaultLayoutType[] = [
+    'horizontal',
+    'vertical',
+    'pip',
+    'noAI',
+    'hide',
+    'floatingChat',
+    'dockRight',
+    'dockBottom',
+  ];
+
+  it('is true ONLY for desktop vertical', () => {
+    expect(shouldShowChromeBand('vertical', false)).toBe(true);
+  });
+
+  it('is false for vertical on mobile (the split collapses to a stack there)', () => {
+    expect(shouldShowChromeBand('vertical', true)).toBe(false);
+  });
+
+  it.each(ALL_LAYOUTS.filter(l => l !== 'vertical'))('is false for %s on desktop', layout => {
+    expect(shouldShowChromeBand(layout, false)).toBe(false);
+  });
+
+  it.each(ALL_LAYOUTS)('is false for %s on mobile', layout => {
+    expect(shouldShowChromeBand(layout, true)).toBe(false);
   });
 });

--- a/apps/client/app/components/Session/SessionContainer.tsx
+++ b/apps/client/app/components/Session/SessionContainer.tsx
@@ -430,11 +430,6 @@ const SessionContainer: FC<SessionLayoutProps> = ({
   // The side-by-side split (KnowledgeViewer beside the chat). Mobile collapses it to a
   // stack, so it is not one there.
   const isVerticalSplit = layout === 'vertical' && !isMobile;
-  // Mirrors the guard on the KnowledgeViewer Box below: where that renders, the chat's own
-  // top bar has a header to line up with, so it joins the app-chrome band (56px, level1
-  // ground, 16px gutters, contents centred vertically). In the default full-width chat it
-  // keeps its original loose 60px header - framing it there moves the Data Lakes button.
-  const isKnowledgeViewerOpen = layout !== 'hide' && layout !== 'dockRight' && layout !== 'dockBottom';
   // Only the edge FACING the splitter is padded here - the notebook layout already puts an
   // 8px gutter around the outside of the content, and paying it twice reads as a wide frame.
   // The row is reversed, so the chat sits left (inner edge = right) and the viewer right
@@ -473,7 +468,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
           </Box>
         )}
         {/* Resizable splitter - only show in vertical layout when KnowledgeViewer is visible (and not on mobile) */}
-        {layout === 'vertical' && !isMobile && <ResizableSplitter />}
+        {isVerticalSplit && <ResizableSplitter />}
         <Box
           ref={chatContainerRef}
           display="flex"
@@ -521,17 +516,17 @@ const SessionContainer: FC<SessionLayoutProps> = ({
                     flexShrink: 0,
                     // Only in the band: the full-width chat's bar is not a chrome header and
                     // a rule under it just cuts the pane in two.
-                    borderBottom: isKnowledgeViewerOpen ? '1px solid' : 'none',
+                    borderBottom: isVerticalSplit ? '1px solid' : 'none',
                     borderColor: 'divider',
-                    background: isKnowledgeViewerOpen ? theme.palette.background.level1 : theme.palette.background.body,
+                    background: isVerticalSplit ? theme.palette.background.level1 : theme.palette.background.body,
                     zIndex: 1,
                     padding: '8px 8px 16px',
                     display: {
-                      xs: project ? (isKnowledgeViewerOpen ? 'flex' : 'block') : 'none',
-                      sm: isKnowledgeViewerOpen ? 'flex' : 'block',
+                      xs: project ? (isVerticalSplit ? 'flex' : 'block') : 'none',
+                      sm: isVerticalSplit ? 'flex' : 'block',
                     },
                     // Only the band is a fixed 56px; outside it the bar is content-sized.
-                    ...(isKnowledgeViewerOpen ? { height: '56px', alignItems: 'center', px: '16px', pb: '8px' } : {}),
+                    ...(isVerticalSplit ? { height: '56px', alignItems: 'center', px: '16px', pb: '8px' } : {}),
                   })}
                 >
                   <SessionTop listClosed={listClosed} onChatWidthToggle={setIsFullWidth} />

--- a/apps/client/app/components/Session/SessionContainer.tsx
+++ b/apps/client/app/components/Session/SessionContainer.tsx
@@ -7,7 +7,7 @@ import SessionBottom from './SessionBottom';
 import SessionMiddle from './SessionMiddle';
 import SessionTop from './SessionTop';
 import NotebookSplash from './NotebookSplash';
-import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
+import useSessionLayout, { setSessionLayout, type DefaultLayoutType } from '@client/app/hooks/useSessionLayout';
 import { useNotebookFilepond } from '@client/app/components/Session/NotebookFilepondProvider';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import KnowledgeViewer from '../Knowledge/KnowledgeViewer';
@@ -48,6 +48,20 @@ export function shouldAttemptSessionOpen(
   return (
     !isLoading && !!currentSessionId && currentSessionId !== contextSessionId && currentSessionId !== attemptedSessionId
   );
+}
+
+/**
+ * The single predicate for the desktop side-by-side split (KnowledgeViewer beside the chat).
+ * The chat's 56px app-chrome band, the ResizableSplitter, and the inter-pane padding all derive
+ * from it - so a mobile split (collapsed to a stack) and every non-vertical layout get none of them.
+ *
+ * A positive `=== 'vertical'` check, deliberately: a NEW `DefaultLayoutType` member is false here by
+ * default. This is exactly the property the old band predicate lacked - it was a `layout !== ...`
+ * negative chain, so `horizontal`/`pip` silently fell into the true case (#2304). Exported and
+ * table-tested so that regression cannot re-enter as the union grows.
+ */
+export function shouldShowChromeBand(layout: DefaultLayoutType, isMobile: boolean): boolean {
+  return layout === 'vertical' && !isMobile;
 }
 
 interface SessionLayoutProps {
@@ -429,7 +443,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
 
   // The side-by-side split (KnowledgeViewer beside the chat). Mobile collapses it to a
   // stack, so it is not one there.
-  const isVerticalSplit = layout === 'vertical' && !isMobile;
+  const isVerticalSplit = shouldShowChromeBand(layout, isMobile);
   // Only the edge FACING the splitter is padded here - the notebook layout already puts an
   // 8px gutter around the outside of the content, and paying it twice reads as a wide frame.
   // The row is reversed, so the chat sits left (inner edge = right) and the viewer right
@@ -522,10 +536,14 @@ const SessionContainer: FC<SessionLayoutProps> = ({
                     zIndex: 1,
                     padding: '8px 8px 16px',
                     display: {
-                      xs: project ? (isVerticalSplit ? 'flex' : 'block') : 'none',
+                      // xs (<600px) is always below useIsMobile's `sm` breakpoint, so isVerticalSplit
+                      // is necessarily false here - the band never applies on a phone.
+                      xs: project ? 'block' : 'none',
                       sm: isVerticalSplit ? 'flex' : 'block',
                     },
-                    // Only the band is a fixed 56px; outside it the bar is content-sized.
+                    // Only the band is a fixed 56px (kept in sync with DockedChatPanel.tsx:54); outside it
+                    // the bar is content-sized. Not framing the full-width chat is deliberate: the band's
+                    // 16px gutter would shift SessionTop's leading DataLakeToggle (SessionTop.tsx:87).
                     ...(isVerticalSplit ? { height: '56px', alignItems: 'center', px: '16px', pb: '8px' } : {}),
                   })}
                 >


### PR DESCRIPTION
## Description

Follow-up from @ken-b4m's post-merge review of #2281 (filed as #2304). The chat top bar's 56px chrome band - the fixed height, the `background.level1` ground, and the bottom rule - was gated on `isKnowledgeViewerOpen` (`layout !== 'hide' && !== 'dockRight' && !== 'dockBottom'`), which is true for `vertical`, `horizontal` AND `pip`. The band's own comment only holds side by side ("the chat's own top bar has a header to line up with"), so it wrongly fired for:

- **horizontal** - viewer is stacked above the chat, so there is no header beside it to align with.
- **pip** - the chat is a `40vw x 50vh` floating window; a hard 56px band + bottom rule is a real bite out of 50vh, inside a pane whose own border is `none`.
- **mobile `vertical`** - `display.xs` resolves to `flex` when a project is set, so a phone inside a project turned the 60px absolute bar into a 56px in-flow band on `level1` with a rule under it - contradicting #2281's own "mobile layout was left alone."

The predicate that actually means "side by side" already exists one line above: `isVerticalSplit = layout === 'vertical' && !isMobile`. Gate on that.

## Changes

- `SessionContainer.tsx`: gate the band (`borderBottom`, `background`, `display`, and the 56px `height`/centering) on `isVerticalSplit` instead of `isKnowledgeViewerOpen`. `isKnowledgeViewerOpen` had no other reader (the KnowledgeViewer Box uses its own inline guard), so the variable and its now-inaccurate comment are removed.
- Reuse `isVerticalSplit` for the `ResizableSplitter` render literal (was `layout === 'vertical' && !isMobile` inline) - that literal is what `ResizableSplitter`'s inverted drag sign silently depends on (#2287), so naming it in one place removes a second copy.

## Guide for Testers

On the preview, open a session with artifacts (so the KnowledgeViewer is available) and cycle the layout via the viewer's layout control:

1. **vertical (desktop, side-by-side)** - chat top bar keeps the band: a 56px strip on `background.level1` with a bottom divider. **Unchanged - this is the one case the band is for.**
2. **horizontal (stacked)** - chat top bar is now content-sized on `background.body`, no 56px strip, no bottom rule. (Before: it had the band.)
3. **pip (floating chat over full-size viewer)** - floating chat's top bar no longer eats a 56px band + rule. (Before: it did.)
4. **mobile vertical, inside a project** (narrow viewport / device emulation) - chat top bar is the plain bar again, not the in-flow `level1` band. (Before: the band appeared.)
5. **Regression:** the resize splitter still appears and drags correctly in vertical split, and not in the other layouts.

## Additional Information

Author self-verification: `SessionContainer.tsx` typechecks clean and lints clean (the one `any` warning at :377 is pre-existing, untouched); the existing `SessionContainer.openGuard.test.ts` still passes 6/6 (the swapped variable does not touch that guard). This is a presentational `sx` gating change with no unit-testable surface, so the behavioral proof is the preview walk-through above - relying on the preview + CI for the authoritative pass. Residual local typecheck errors are pre-existing environmental noise (premium-generated glue, `packages/premium/bob` overlay-not-linked), none in this diff.

## Developer Notes (Optional)

N/A

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings