### PR TITLE
fix(client): carry the console mode when a navigation button opens /opti

### DIFF
--- a/apps/client/app/hooks/useNavigationExecutor.test.tsx
+++ b/apps/client/app/hooks/useNavigationExecutor.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * The `navigate_view` suggestion buttons dispatch through this hook. The Opti branch is the
+ * one with a trap: `/opti` reads its surface from `?mode=`, so a navigate that omits `search`
+ * drops the param, the page falls back to its blank-state default, and the page-side consumer
+ * discards the pending family instead of opening the console the user clicked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { NavigationIntent } from '@bike4mind/common';
+
+// Hoisted: `optiRouteExists` is computed once when the hook module loads, so the route list has
+// to exist before the import below - and the open-core case needs a fresh module to re-read it.
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  setActiveTab: vi.fn(),
+  setFileBrowserOpen: vi.fn(),
+  premiumRoutes: [{ path: '/opti' }] as { path: string }[],
+}));
+
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => mocks.navigate }));
+vi.mock('@client/app/components/admin/useAdminModal', () => ({
+  useAdminModal: (selector: (s: unknown) => unknown) => selector({ setActiveTab: mocks.setActiveTab }),
+}));
+vi.mock('@client/app/components/Files/Browser', () => ({
+  useFileBrowser: (selector: (s: unknown) => unknown) => selector({ setOpen: mocks.setFileBrowserOpen }),
+}));
+// Gitignored codegen: absent in a fresh checkout, and its contents are what decides whether the
+// Opti branch runs at all, so both shapes have to be drivable from the test.
+vi.mock('@client/app/premium-generated/premiumRoutes.generated', () => ({
+  get premiumRoutes() {
+    return mocks.premiumRoutes;
+  },
+}));
+
+import { useNavigationExecutor } from './useNavigationExecutor';
+import { useOptiNavigation } from './useOptiNavigation';
+
+const intent = (over: Partial<NavigationIntent>): NavigationIntent => ({
+  viewId: 'opti.scheduling.gantt',
+  label: 'Gantt Chart',
+  description: '',
+  navigationType: 'action',
+  target: 'scheduling.gantt',
+  reason: '',
+  ...over,
+});
+
+const execute = (i: NavigationIntent) => renderHook(() => useNavigationExecutor()).result.current(i);
+
+/** The search value `navigate` was called with, applied to the params already on the URL. */
+const resolveSearch = (prev: Record<string, unknown>) => {
+  const { search } = mocks.navigate.mock.calls[0][0] as { search?: unknown };
+  return typeof search === 'function' ? (search as (p: Record<string, unknown>) => unknown)(prev) : search;
+};
+
+describe('useNavigationExecutor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.premiumRoutes = [{ path: '/opti' }];
+    useOptiNavigation.getState().clearPending();
+  });
+
+  describe('opti action intents', () => {
+    it('asks for the console mode so the target survives the navigate', () => {
+      execute(intent({}));
+
+      expect(mocks.navigate).toHaveBeenCalledWith(expect.objectContaining({ to: '/opti' }));
+      // The click IS the mode decision: without it the page defaults to its blank state, which
+      // consumes and drops the pending family (see QuantumPage's pendingFamily effect).
+      expect(resolveSearch({ mode: 'new' })).toMatchObject({ mode: 'optimize' });
+    });
+
+    it("does not carry the previous route's params along", () => {
+      execute(intent({}));
+
+      // `session` is not one vocabulary across routes - /agent-executions uses it as a replay
+      // key - and /opti would restore whatever id reached it. It reflects its own back in.
+      expect(resolveSearch({ session: 'not-an-opti-session' })).toEqual({ mode: 'optimize' });
+    });
+
+    it('splits a composite target into family and sub-tab', () => {
+      execute(intent({}));
+
+      expect(useOptiNavigation.getState()).toMatchObject({ pendingFamily: 'scheduling', pendingSubTab: 'gantt' });
+    });
+
+    it('leaves the sub-tab unset for a bare family target', () => {
+      execute(intent({ viewId: 'opti.routing', label: 'Routing', target: 'routing' }));
+
+      expect(useOptiNavigation.getState()).toMatchObject({ pendingFamily: 'routing', pendingSubTab: null });
+    });
+
+    it('no-ops on an open-core build that has no /opti route', async () => {
+      mocks.premiumRoutes = [];
+      vi.resetModules();
+      const [hook, store] = await Promise.all([import('./useNavigationExecutor'), import('./useOptiNavigation')]);
+
+      renderHook(() => hook.useNavigationExecutor()).result.current(intent({}));
+
+      expect(mocks.navigate).not.toHaveBeenCalled();
+      expect(store.useOptiNavigation.getState().pendingFamily).toBeNull();
+    });
+
+    it('opens the file browser without navigating', () => {
+      execute(intent({ viewId: 'global.files', label: 'Files', target: 'file_browser' }));
+
+      expect(mocks.setFileBrowserOpen).toHaveBeenCalledWith(true);
+      expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('routes a route intent to its target', () => {
+    execute(intent({ viewId: 'admin.home', label: 'Admin', navigationType: 'route', target: '/admin' }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/admin' });
+  });
+
+  it('selects the admin tab before navigating for a tab intent', () => {
+    execute(intent({ viewId: 'admin.users', label: 'Users', navigationType: 'tab', target: '3' }));
+
+    expect(mocks.setActiveTab).toHaveBeenCalledWith(3);
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/admin' });
+  });
+});

--- a/apps/client/app/hooks/useNavigationExecutor.ts
+++ b/apps/client/app/hooks/useNavigationExecutor.ts
@@ -54,8 +54,13 @@ export function useNavigationExecutor() {
           } else {
             requestFamily(intent.target);
           }
+          // Name the mode. Tanstack drops search params on a navigate that omits `search`, and
+          // bare /opti falls back to its blank-state surface - which consumes the pending
+          // family and discards it, so the button appeared to do nothing. Stated outright
+          // rather than merged over `prev`: `session` means a different thing on other routes
+          // (see agentExecutionHistoryRoute), and /opti reflects its own back into the URL.
           // @ts-expect-error - /opti is a premium route, not in static route tree
-          navigate({ to: '/opti' });
+          navigate({ to: '/opti', search: { mode: 'optimize' } });
           break;
         }
       }


### PR DESCRIPTION
# Pull Request

## Description

The "Suggested Navigation" buttons that follow an assistant reply do nothing useful when they point at the Optimizer. Clicking one returns you to the Optimizer's blank-state front door instead of the console it names, and the destination is silently discarded on the way.

Reported from a live session: buttons labelled `Gantt Chart` and `Q/Work` both bounced back to the front door.

**Root cause, in two steps.**

`useNavigationExecutor` dispatched the Opti branch with `navigate({ to: '/opti' })` and no `search`. Tanstack drops the existing search params on a navigate that omits it -- there is no `retainSearchParams` middleware in the app, and this surface's own navigation helper always passes an explicit `search: prev => ({ ...prev })` for exactly that reason. So the click landed on a bare `/opti`.

`/opti` reads `?mode=` to decide what to render and falls back to its blank state when the param is missing. That blank state is one of the two surfaces whose pending-navigation consumer deliberately *drops* what it is handed -- the guard exists so a replayed `navigate_view` side effect cannot yank someone out of a surface they are working in. It could not tell a live click from a replay, because the executor's own navigate had already destroyed the mode.

So this is not a race and not intermittent: every Opti suggestion button was dead, from every entry point.

**The fix** names the mode on the navigate. I did not merge it over the previous route's params: `session` does not mean the same thing on every route (`/agent-executions` uses it as a replay-store key, `router.tsx:531`) and `/opti` would restore whatever id reached it. `/opti` reflects its own `?session=` back into the URL after mount, so nothing is lost by stating the destination outright.

No change was needed on the consuming side -- with the mode present, the existing guard passes on its own and the existing sub-tab clamp already accepts every id the registry can produce.

## Changes

- `apps/client/app/hooks/useNavigationExecutor.ts` -- the `action` branch navigates with `search: { mode: 'optimize' }` instead of dropping the param.
- `apps/client/app/hooks/useNavigationExecutor.test.tsx` -- new. The hook had no test. Covers all three intent types (`route`, `tab`, `action`), the composite-vs-bare target split, the file-browser target, that the previous route's params are not carried in, and the open-core build where the route does not exist.

## Guide for Testers

Any environment with the Optimizer available. Steps use `app.staging.bike4mind.com`; substitute your host.

1. Log in and go to `app.staging.bike4mind.com/opti`. **Expected:** the URL settles to `/opti?mode=new` and you see the blank-state front door.
2. In the docked chat on the right, type `Our machine shop runs a job shop scheduling problem across 4 machines` and send. **Expected:** a reply arrives, and below it a bordered panel headed **Suggested Navigation** with one or more buttons.
3. Ask a follow-up in the same chat: `Show me the Gantt chart for that`. **Expected:** the reply carries a **Suggested Navigation** button labelled `Gantt Chart`.
4. Click the `Gantt Chart` button. **Expected:** the URL becomes `/opti?mode=optimize&session=<id>`, the Scheduling console opens, and its **Gantt** tab is selected. **This is the bug:** before this PR you landed back on the front door with nothing selected.
5. Ask `Where do I submit this to run?` and click the resulting `Q/Work` button. **Expected:** the Scheduling console's **Q/Work** tab is selected. Same before/after as step 4.
6. Note the session id in the URL. Click any Suggested Navigation button again. **Expected:** the same `session=<id>` is still in the URL afterwards -- the conversation you were in does not change.
7. Ask a question that produces a non-scheduling suggestion (e.g. `How would I optimize my delivery routes?`) and click the button. **Expected:** the matching family console opens. A family console has no Gantt or Q/Work tab, so those ids are correctly ignored rather than blanking the body.

### Regression Checks

8. From the Optimizer, open the file browser through its normal control. **Expected:** unchanged -- the modal opens and the URL does not change.
9. As an admin, get a reply that suggests an Admin destination and click it. **Expected:** `/admin` opens on the correct tab.
10. Navigate to the Optimizer from a regular chat (not from `/opti`) via a Suggested Navigation button. **Expected:** the Optimizer opens on the requested console, and the Optimizer session that opens is your own last-opened one -- not an id inherited from the route you came from.
11. Open a shared `/opti?session=<id>` link directly. **Expected:** unchanged -- that session loads.

### What NOT to test

- Anything about *which* buttons the assistant chooses to show. This PR does not touch how navigation suggestions are produced, only what happens when one is clicked. A reply that shows no buttons is a separate question.
- Open-core builds have no Optimizer route; the button cannot appear there. Covered by unit test rather than manually.

## Additional Information

`useNavigationExecutor` had no test file before this. The added one is deliberately wider than the fix, because the hook is the single dispatch point for every navigation suggestion in the app and three of its four branches were entirely uncovered.

The gitignored premium route manifest decides whether the Opti branch runs at all, and it is absent in a fresh checkout -- so the test mocks it and drives both shapes rather than depending on codegen having run.

## Developer Notes (Optional)

- The pattern worth copying: a navigate that changes *surface* should state its destination search params, not merge over `prev`. Search-param names are per-route vocabulary in this app and are not safe to carry across a surface change.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) -- n/a
