### PR TITLE
fix(infra): copy highs.wasm into the Lambdas that can run the tool set

### DIFF
--- a/apps/client/scripts/copy-highs-wasm.mjs
+++ b/apps/client/scripts/copy-highs-wasm.mjs
@@ -4,46 +4,24 @@
  * The b4m-optihashi premium overlay loads highs.wasm as a plain same-origin static asset:
  * its emscripten glue fetches `${location.origin}/highs.wasm`. Copying the wasm straight out
  * of the installed `highs` package guarantees the served binary always matches the `highs`
- * version resolved in node_modules, so the glue and the wasm can never drift. A mismatch
- * aborts instantiation with a WebAssembly LinkError (e.g. "Import #N requires a callable"),
- * which is exactly what a stale hand-copied binary caused.
+ * version resolved in node_modules, so the glue and the wasm can never drift.
  *
  * No-op when `highs` is not installed (open-core installs without the overlay). Runs via
  * pnpm postinstall / predev / prebuild so the binary is always present and current.
+ *
+ * The path itself comes from scripts/resolve-highs-wasm.mjs, shared with infra/ so the
+ * browser and the Lambda bundles cannot disagree about where the binary lives.
  */
 
-import { copyFileSync, mkdirSync, existsSync } from 'fs';
+import { copyFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { createRequire } from 'module';
 
-const require = createRequire(import.meta.url);
+import { resolveHighsWasm, isOptihashiOverlayPresent } from '../../../scripts/resolve-highs-wasm.mjs';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const WASM_FILE = 'highs.wasm';
-
-function resolveHighsWasm() {
-  // highs does not export ./package.json, so resolve the package entry (which lives in the
-  // build/ dir) and take the wasm sitting next to it. Search the workspace store + repo root
-  // so it resolves under pnpm's nested node_modules from the client package context.
-  const repoRoot = path.resolve(__dirname, '../../..');
-  let entry;
-  try {
-    entry = require.resolve('highs', {
-      paths: [
-        path.join(repoRoot, 'node_modules/.pnpm/node_modules'),
-        // The overlay engine is what declares highs; resolve from it too so a change in
-        // hoisting does not silently break the copy.
-        path.join(repoRoot, 'packages/premium/optihashi/engine'),
-        repoRoot,
-        __dirname,
-      ],
-    });
-  } catch {
-    return null; // highs not installed (overlay absent) -> nothing to serve
-  }
-  return path.join(path.dirname(entry), WASM_FILE);
-}
 
 function main() {
   const source = resolveHighsWasm();
@@ -51,8 +29,7 @@ function main() {
     // highs is pulled in by the b4m-optihashi overlay. Legitimately absent on open-core
     // installs (quiet skip). But if the overlay IS present and highs still will not resolve,
     // that is a real problem - the overlay would boot to a 404 wasm at runtime - so warn loudly.
-    const overlayPresent = existsSync(path.resolve(__dirname, '../../..', 'packages/premium/optihashi'));
-    if (overlayPresent) {
+    if (isOptihashiOverlayPresent()) {
       console.warn('[copy-highs-wasm] overlay present but highs did not resolve - public/highs.wasm will be MISSING at runtime');
     } else {
       console.log('[copy-highs-wasm] highs not installed (no overlay) - skipping');

--- a/apps/client/scripts/copy-highs-wasm.mjs
+++ b/apps/client/scripts/copy-highs-wasm.mjs
@@ -9,7 +9,7 @@
  * No-op when `highs` is not installed (open-core installs without the overlay). Runs via
  * pnpm postinstall / predev / prebuild so the binary is always present and current.
  *
- * The path itself comes from scripts/resolve-highs-wasm.mjs, shared with infra/ so the
+ * The path itself comes from ./resolve-highs-wasm.mjs, shared with infra/ so the
  * browser and the Lambda bundles cannot disagree about where the binary lives.
  */
 
@@ -17,7 +17,7 @@ import { copyFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { resolveHighsWasm, isOptihashiOverlayPresent } from '../../../scripts/resolve-highs-wasm.mjs';
+import { resolveHighsWasm, isOptihashiOverlayPresent } from './resolve-highs-wasm.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/apps/client/scripts/resolve-highs-wasm.mjs
+++ b/apps/client/scripts/resolve-highs-wasm.mjs
@@ -2,8 +2,14 @@
  * Single source of truth for locating the installed `highs` WASM binary.
  *
  * Two deploy surfaces need this same path and would otherwise each hard-code it:
- *  - the browser bundle (apps/client/scripts/copy-highs-wasm.mjs -> public/highs.wasm)
+ *  - the browser bundle (./copy-highs-wasm.mjs -> public/highs.wasm)
  *  - the plain SST Lambdas that can execute the premium tool set (infra/toolRuntimeAssets.ts)
+ *
+ * It lives under apps/client/scripts rather than the repo-root scripts/ because the client's
+ * postinstall imports it, and the ChatCompletion images install dependencies before copying
+ * the repo (they COPY only apps/client/scripts up front). A repo-root path is not on disk at
+ * install time there, and a failed import would bypass the no-op-when-highs-is-absent guard
+ * below. infra -> apps/client is the safe direction; apps/client -> repo root is not.
  *
  * The remaining two are covered for free and need nothing from here: the Next.js server and
  * the ChatCompletion container both ship real node_modules.
@@ -23,13 +29,13 @@ const require = createRequire(import.meta.url);
 const WASM_FILE = 'highs.wasm';
 
 /**
- * Default repo root: this file lives in `<root>/scripts`.
+ * Default repo root: this file lives in `<root>/apps/client/scripts`.
  *
  * Only correct while this module is executed from source, which is true for the pnpm scripts.
  * Callers running inside a bundle (SST evaluates sst.config.ts as one) must pass their own
  * root instead - see infra/toolRuntimeAssets.ts, which passes `$cli.paths.root`.
  */
-const DEFAULT_REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 
 /**
  * Absolute path to the installed `highs.wasm`, or null when `highs` is not installed.

--- a/infra/__tests__/toolRuntimeAssets.test.ts
+++ b/infra/__tests__/toolRuntimeAssets.test.ts
@@ -1,0 +1,293 @@
+/**
+ * @vitest-environment node
+ *
+ * Guard for the class of bug where a Lambda can execute the tool set but its bundle does not
+ * carry an asset one of those tools loads at runtime (see infra/toolRuntimeAssets.ts). In the
+ * instance that prompted it, both plain-Lambda surfaces copied only tiktoken_bg.wasm, so the
+ * highs solver ENOENT'd on /var/task/highs.wasm while the identical request on the chat path
+ * (Fargate, real node_modules) worked fine.
+ *
+ * "Can execute the tool set" is decided the same way the runtime decides it: the handler's
+ * static import graph reaches the generated premium tool map. That makes this guard fire for
+ * the NEXT such Lambda too, rather than pinning the two that exist today.
+ *
+ * Scope: functions declared in this repo's infra/. Overlays contribute their own functions
+ * through `contributeInfra`, and those live - and must be guarded - in the overlay repo.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync, readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { buildToolRuntimeAssets, toolRuntimeAssets } from '../toolRuntimeAssets';
+import { resolveHighsWasm } from '../../scripts/resolve-highs-wasm.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const INFRA_DIR = path.join(REPO_ROOT, 'infra');
+const CLIENT_DIR = path.join(REPO_ROOT, 'apps/client');
+
+/** The generated premium tool map. A handler that reaches it can execute the premium tools. */
+const PREMIUM_TOOL_MAP = 'premium-generated/premiumLlmTools.generated';
+
+/**
+ * Handlers re-exported from the overlay through the stable premium-generated seam. They do
+ * not exist in an open-core checkout, so their import graph is unwalkable here; the overlay
+ * repo owns their bundle contents. Anything else that fails to resolve is a real break (a
+ * moved or misspelled handler) and fails the test.
+ */
+const OVERLAY_HANDLER_PREFIX = 'apps/client/server/premium-generated/';
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts'];
+
+/** tsconfig `paths` from apps/client, which is where every Lambda handler lives. */
+const CLIENT_ALIASES: ReadonlyArray<readonly [string, string]> = [
+  ['@server/', path.join(CLIENT_DIR, 'server')],
+  ['@pages/', path.join(CLIENT_DIR, 'pages')],
+  ['@public/', path.join(CLIENT_DIR, 'public')],
+  ['@client/', CLIENT_DIR],
+  ['@/', CLIENT_DIR],
+];
+
+function resolveSourceFile(withoutExtension: string): string | null {
+  for (const extension of SOURCE_EXTENSIONS) {
+    const candidate = `${withoutExtension}${extension}`;
+    if (existsSync(candidate)) return candidate;
+    const indexCandidate = path.join(withoutExtension, `index${extension}`);
+    if (existsSync(indexCandidate)) return indexCandidate;
+  }
+  return null;
+}
+
+/** Resolves the local specifiers we can follow; returns null for node_modules and packages. */
+function resolveImport(specifier: string, fromFile: string): string | null {
+  if (specifier.startsWith('.')) {
+    return resolveSourceFile(path.resolve(path.dirname(fromFile), specifier));
+  }
+  for (const [prefix, base] of CLIENT_ALIASES) {
+    if (specifier.startsWith(prefix)) {
+      return resolveSourceFile(path.join(base, specifier.slice(prefix.length)));
+    }
+  }
+  return null;
+}
+
+/** Every module specifier in a source file: static, side-effect and dynamic imports alike. */
+function moduleSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(/(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g)) {
+    specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+/** Whether the handler module's import graph reaches the premium tool map. */
+function reachesPremiumToolMap(entryFile: string): boolean {
+  const visited = new Set<string>();
+  const queue = [entryFile];
+  while (queue.length > 0) {
+    const file = queue.shift() as string;
+    if (visited.has(file)) continue;
+    visited.add(file);
+    for (const specifier of moduleSpecifiers(readFileSync(file, 'utf8'))) {
+      if (specifier.includes(PREMIUM_TOOL_MAP)) return true;
+      const resolved = resolveImport(specifier, file);
+      if (resolved && !visited.has(resolved)) queue.push(resolved);
+    }
+  }
+  return false;
+}
+
+type HandlerDeclaration = {
+  /** infra file the declaration lives in, e.g. "agentExecutor.ts". */
+  infraFile: string;
+  /** SST handler string, e.g. "apps/client/server/queueHandlers/agentExecutor.handler". */
+  handler: string;
+  /** Source of the object literal declaring it, so `copyFiles` can be checked on it. */
+  config: string;
+};
+
+/**
+ * Every `handler: '...'` in infra/, paired with the source of the object literal it sits in.
+ *
+ * A brace-depth scan rather than a regex, because the config object holds nested objects and
+ * arrays; strings and comments are skipped so a brace inside either cannot desync the depth.
+ */
+function findHandlerDeclarations(infraFile: string): HandlerDeclaration[] {
+  const source = readFileSync(path.join(INFRA_DIR, infraFile), 'utf8');
+  const declarations: HandlerDeclaration[] = [];
+  const openBraces: number[] = [];
+  let index = 0;
+
+  while (index < source.length) {
+    const character = source[index];
+
+    if (character === '/' && source[index + 1] === '/') {
+      index = source.indexOf('\n', index);
+      if (index === -1) break;
+      continue;
+    }
+    if (character === '/' && source[index + 1] === '*') {
+      const end = source.indexOf('*/', index + 2);
+      index = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      index += 1;
+      while (index < source.length && source[index] !== character) {
+        index += source[index] === '\\' ? 2 : 1;
+      }
+      index += 1;
+      continue;
+    }
+    if (character === '{') {
+      openBraces.push(index);
+      index += 1;
+      continue;
+    }
+    if (character === '}') {
+      openBraces.pop();
+      index += 1;
+      continue;
+    }
+
+    // `startsWith` first: slicing the whole remainder at every index to feed the regex turns
+    // the scan quadratic on files the size of infra/queues.ts.
+    const handlerMatch = source.startsWith('handler:', index)
+      ? /^handler:\s*'([^']+)'/.exec(source.slice(index, index + 200))
+      : null;
+    if (handlerMatch && openBraces.length > 0) {
+      const start = openBraces[openBraces.length - 1];
+      declarations.push({
+        infraFile,
+        handler: handlerMatch[1],
+        config: sliceObjectLiteral(source, start),
+      });
+      index += handlerMatch[0].length;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return declarations;
+}
+
+/** Source from an opening brace through its match, skipping strings and comments. */
+function sliceObjectLiteral(source: string, openBraceIndex: number): string {
+  let depth = 0;
+  let index = openBraceIndex;
+  while (index < source.length) {
+    const character = source[index];
+    if (character === '/' && source[index + 1] === '/') {
+      index = source.indexOf('\n', index);
+      if (index === -1) break;
+      continue;
+    }
+    if (character === '/' && source[index + 1] === '*') {
+      const end = source.indexOf('*/', index + 2);
+      index = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      index += 1;
+      while (index < source.length && source[index] !== character) {
+        index += source[index] === '\\' ? 2 : 1;
+      }
+      index += 1;
+      continue;
+    }
+    if (character === '{') depth += 1;
+    if (character === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBraceIndex, index + 1);
+    }
+    index += 1;
+  }
+  return source.slice(openBraceIndex);
+}
+
+const handlerDeclarations = readdirSync(INFRA_DIR)
+  .filter((file) => file.endsWith('.ts'))
+  .flatMap(findHandlerDeclarations);
+
+describe('buildToolRuntimeAssets', () => {
+  const HIGHS_WASM = path.join(REPO_ROOT, 'node_modules/.pnpm/node_modules/highs/build/highs.wasm');
+
+  it('always copies the tiktoken binary', () => {
+    expect(buildToolRuntimeAssets(null, REPO_ROOT)).toEqual([
+      { from: 'apps/client/node_modules/tiktoken/tiktoken_bg.wasm', to: 'tiktoken_bg.wasm' },
+    ]);
+  });
+
+  it('copies highs.wasm to the bundle root, where the emscripten glue looks for it', () => {
+    expect(buildToolRuntimeAssets(HIGHS_WASM, REPO_ROOT)).toContainEqual({
+      from: 'node_modules/.pnpm/node_modules/highs/build/highs.wasm',
+      to: 'highs.wasm',
+    });
+  });
+
+  it('emits app-root-relative sources, since SST joins `from` onto the app root', () => {
+    for (const asset of buildToolRuntimeAssets(HIGHS_WASM, REPO_ROOT)) {
+      expect(path.isAbsolute(asset.from)).toBe(false);
+    }
+  });
+
+  it('names a source that exists whenever highs resolves in this checkout', () => {
+    // SST stat()s every copyFiles source, so a path that does not exist fails the deploy.
+    for (const asset of buildToolRuntimeAssets(resolveHighsWasm(REPO_ROOT), REPO_ROOT)) {
+      expect(existsSync(path.join(REPO_ROOT, asset.from))).toBe(true);
+    }
+  });
+
+  it('feeds the real resolver through to the list infra actually ships', () => {
+    // The wiring between resolver and list, which the pure builder above cannot cover.
+    expect(toolRuntimeAssets(REPO_ROOT)).toEqual(buildToolRuntimeAssets(resolveHighsWasm(REPO_ROOT), REPO_ROOT));
+  });
+});
+
+describe('Lambdas that can execute the premium tool set', () => {
+  it('finds handler declarations to check', () => {
+    expect(handlerDeclarations.length).toBeGreaterThan(0);
+  });
+
+  it('declares every handler as a resolvable module, or as an overlay re-export', () => {
+    const unresolvable = handlerDeclarations
+      .filter((declaration) => !declaration.handler.startsWith(OVERLAY_HANDLER_PREFIX))
+      .filter(
+        (declaration) =>
+          resolveSourceFile(path.join(REPO_ROOT, declaration.handler.split('.').slice(0, -1).join('.'))) === null
+      )
+      .map((declaration) => `${declaration.infraFile}: ${declaration.handler}`);
+    expect(unresolvable.join('\n')).toBe('');
+  });
+
+  it('copies the tool runtime assets on every Lambda whose handler reaches the tool map', () => {
+    const missing = handlerDeclarations
+      .filter((declaration) => !declaration.handler.startsWith(OVERLAY_HANDLER_PREFIX))
+      .filter((declaration) => {
+        const entry = resolveSourceFile(path.join(REPO_ROOT, declaration.handler.split('.').slice(0, -1).join('.')));
+        return entry !== null && reachesPremiumToolMap(entry);
+      })
+      // Deliberately not pinned to `copyFiles: toolRuntimeAssets()` exactly - a Lambda that
+      // later needs an extra asset should be free to spread the list.
+      .filter((declaration) => !(declaration.config.includes('copyFiles:') && declaration.config.includes('toolRuntimeAssets()')))
+      .map((declaration) => `${declaration.infraFile}: ${declaration.handler}`);
+
+    expect(missing.join('\n')).toBe('');
+  });
+
+  it('still recognises the two known tool-capable Lambdas', () => {
+    // Pins the detector itself: if the marker import moves and reachability silently returns
+    // false everywhere, the check above would pass vacuously.
+    const toolCapable = handlerDeclarations
+      .filter((declaration) => !declaration.handler.startsWith(OVERLAY_HANDLER_PREFIX))
+      .filter((declaration) => {
+        const entry = resolveSourceFile(path.join(REPO_ROOT, declaration.handler.split('.').slice(0, -1).join('.')));
+        return entry !== null && reachesPremiumToolMap(entry);
+      })
+      .map((declaration) => declaration.handler);
+
+    expect(toolCapable).toContain('apps/client/server/queueHandlers/agentExecutor.handler');
+    expect(toolCapable).toContain('apps/client/server/queueHandlers/slackQuestProcessor.handler');
+  });
+});

--- a/infra/__tests__/toolRuntimeAssets.test.ts
+++ b/infra/__tests__/toolRuntimeAssets.test.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { buildToolRuntimeAssets, toolRuntimeAssets } from '../toolRuntimeAssets';
-import { resolveHighsWasm } from '../../scripts/resolve-highs-wasm.mjs';
+import { resolveHighsWasm } from '../../apps/client/scripts/resolve-highs-wasm.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const INFRA_DIR = path.join(REPO_ROOT, 'infra');
@@ -30,10 +30,14 @@ const CLIENT_DIR = path.join(REPO_ROOT, 'apps/client');
 const PREMIUM_TOOL_MAP = 'premium-generated/premiumLlmTools.generated';
 
 /**
- * Handlers re-exported from the overlay through the stable premium-generated seam. They do
- * not exist in an open-core checkout, so their import graph is unwalkable here; the overlay
- * repo owns their bundle contents. Anything else that fails to resolve is a real break (a
- * moved or misspelled handler) and fails the test.
+ * Handlers re-exported from the overlay through the stable premium-generated seam. The stub
+ * files are codegen output and simply do not exist in an open-core checkout, so only the
+ * "every handler resolves" check below exempts them. Anything else that fails to resolve is a
+ * real break (a moved or misspelled handler) and fails the test.
+ *
+ * The rule itself - every tool-capable handler carries `toolRuntimeAssets()` - deliberately
+ * does NOT exempt them: `overwatchAnalytics`, `optihashiRunCompletion` and `bobRunWorker` are
+ * configured in this repo (infra/queues.ts) and so are this repo's to guard.
  */
 const OVERLAY_HANDLER_PREFIX = 'apps/client/server/premium-generated/';
 
@@ -107,46 +111,110 @@ type HandlerDeclaration = {
 };
 
 /**
- * Every `handler: '...'` in infra/, paired with the source of the object literal it sits in.
+ * Characters that can only precede a regex literal, never a division operator. Enough to tell
+ * the two `/` meanings apart without a real tokenizer, because infra/ only ever writes a regex
+ * as a call argument (`.replace(/x/, y)`), after `=>`, or on the right of an assignment.
+ */
+const REGEX_LITERAL_PRECEDERS = new Set([
+  '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '<', '>', '~', '^',
+]);
+
+/** Index just past the comment starting at `index`, or null when none starts there. */
+function skipComment(source: string, index: number): number | null {
+  if (source[index] !== '/') return null;
+  if (source[index + 1] === '/') {
+    const end = source.indexOf('\n', index);
+    return end === -1 ? source.length : end;
+  }
+  if (source[index + 1] === '*') {
+    const end = source.indexOf('*/', index + 2);
+    return end === -1 ? source.length : end + 2;
+  }
+  return null;
+}
+
+/**
+ * Index just past the string or regex literal starting at `index`, or null when none does.
+ *
+ * Regex literals have to be recognised as carefully as strings: an unhandled `/'/` reads as the
+ * start of a string and swallows source up to the next quote, silently dropping every handler
+ * declaration in between. A single `.replace(/'/g, '')` added to infra/websocket.ts takes this
+ * scan from 14 handlers to 3 - passing, just guarding almost nothing.
+ */
+function skipQuotedOrRegex(source: string, index: number, previousCharacter: string): number | null {
+  const character = source[index];
+
+  if (character === "'" || character === '"' || character === '`') {
+    let end = index + 1;
+    while (end < source.length && source[end] !== character) {
+      end += source[end] === '\\' ? 2 : 1;
+    }
+    return end + 1;
+  }
+
+  if (character !== '/' || !REGEX_LITERAL_PRECEDERS.has(previousCharacter)) return null;
+
+  let end = index + 1;
+  let inCharacterClass = false;
+  while (end < source.length) {
+    const current = source[end];
+    // An unterminated "regex" by end of line was a division after all; leave it to the caller
+    // rather than swallowing the rest of the file.
+    if (current === '\n') return null;
+    if (current === '\\') {
+      end += 2;
+      continue;
+    }
+    if (current === '[') inCharacterClass = true;
+    else if (current === ']') inCharacterClass = false;
+    else if (current === '/' && !inCharacterClass) return end + 1;
+    end += 1;
+  }
+  return null;
+}
+
+/**
+ * Every `handler: '...'` in one infra source, paired with the object literal it sits in.
  *
  * A brace-depth scan rather than a regex, because the config object holds nested objects and
- * arrays; strings and comments are skipped so a brace inside either cannot desync the depth.
+ * arrays; comments, strings and regex literals are skipped so a brace or quote inside any of
+ * them cannot desync the depth.
  */
-function findHandlerDeclarations(infraFile: string): HandlerDeclaration[] {
-  const source = readFileSync(path.join(INFRA_DIR, infraFile), 'utf8');
+function scanHandlerDeclarations(source: string, infraFile: string): HandlerDeclaration[] {
   const declarations: HandlerDeclaration[] = [];
   const openBraces: number[] = [];
   let index = 0;
+  let previousCharacter = '';
 
   while (index < source.length) {
     const character = source[index];
 
-    if (character === '/' && source[index + 1] === '/') {
-      index = source.indexOf('\n', index);
-      if (index === -1) break;
+    const afterComment = skipComment(source, index);
+    if (afterComment !== null) {
+      // Comments are transparent: `previousCharacter` must keep describing the last real code
+      // so a regex on the far side of one is still recognised.
+      index = afterComment;
       continue;
     }
-    if (character === '/' && source[index + 1] === '*') {
-      const end = source.indexOf('*/', index + 2);
-      index = end === -1 ? source.length : end + 2;
+
+    const afterLiteral = skipQuotedOrRegex(source, index, previousCharacter);
+    if (afterLiteral !== null) {
+      index = afterLiteral;
+      // A completed literal cannot be followed by another regex, so record it as a value.
+      previousCharacter = ')';
       continue;
     }
-    if (character === "'" || character === '"' || character === '`') {
-      index += 1;
-      while (index < source.length && source[index] !== character) {
-        index += source[index] === '\\' ? 2 : 1;
-      }
-      index += 1;
-      continue;
-    }
+
     if (character === '{') {
       openBraces.push(index);
       index += 1;
+      previousCharacter = character;
       continue;
     }
     if (character === '}') {
       openBraces.pop();
       index += 1;
+      previousCharacter = character;
       continue;
     }
 
@@ -163,47 +231,63 @@ function findHandlerDeclarations(infraFile: string): HandlerDeclaration[] {
         config: sliceObjectLiteral(source, start),
       });
       index += handlerMatch[0].length;
+      previousCharacter = ')';
       continue;
     }
 
+    if (!/\s/.test(character)) previousCharacter = character;
     index += 1;
   }
 
   return declarations;
 }
 
-/** Source from an opening brace through its match, skipping strings and comments. */
+function findHandlerDeclarations(infraFile: string): HandlerDeclaration[] {
+  return scanHandlerDeclarations(readFileSync(path.join(INFRA_DIR, infraFile), 'utf8'), infraFile);
+}
+
+/** Source from an opening brace through its match, skipping comments, strings and regexes. */
 function sliceObjectLiteral(source: string, openBraceIndex: number): string {
   let depth = 0;
   let index = openBraceIndex;
+  let previousCharacter = '';
+
   while (index < source.length) {
     const character = source[index];
-    if (character === '/' && source[index + 1] === '/') {
-      index = source.indexOf('\n', index);
-      if (index === -1) break;
+
+    const afterComment = skipComment(source, index);
+    if (afterComment !== null) {
+      index = afterComment;
       continue;
     }
-    if (character === '/' && source[index + 1] === '*') {
-      const end = source.indexOf('*/', index + 2);
-      index = end === -1 ? source.length : end + 2;
+
+    const afterLiteral = skipQuotedOrRegex(source, index, previousCharacter);
+    if (afterLiteral !== null) {
+      index = afterLiteral;
+      previousCharacter = ')';
       continue;
     }
-    if (character === "'" || character === '"' || character === '`') {
-      index += 1;
-      while (index < source.length && source[index] !== character) {
-        index += source[index] === '\\' ? 2 : 1;
-      }
-      index += 1;
-      continue;
-    }
+
     if (character === '{') depth += 1;
     if (character === '}') {
       depth -= 1;
       if (depth === 0) return source.slice(openBraceIndex, index + 1);
     }
+
+    if (!/\s/.test(character)) previousCharacter = character;
     index += 1;
   }
   return source.slice(openBraceIndex);
+}
+
+/**
+ * Independent count of handler declarations: a line-anchored regex over comment-stripped
+ * source, sharing no machinery with the brace scan above. It is the oracle for the test that
+ * catches the scan silently under-counting.
+ */
+function countDeclaredHandlerLines(source: string): number {
+  const withoutComments = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return (withoutComments.match(/^\s*handler:\s*'/gm) || []).length;
 }
 
 const handlerDeclarations = readdirSync(INFRA_DIR)
@@ -245,6 +329,63 @@ describe('buildToolRuntimeAssets', () => {
   });
 });
 
+describe('the infra handler scan', () => {
+  it('sees every handler declared in every infra file', () => {
+    // Pinned against an independent measurement rather than a hard-coded total, so adding a
+    // queue needs no test edit while a scan that desyncs - and therefore guards less than it
+    // appears to - still fails loudly.
+    const mismatched = readdirSync(INFRA_DIR)
+      .filter((file) => file.endsWith('.ts'))
+      .map((file) => {
+        const source = readFileSync(path.join(INFRA_DIR, file), 'utf8');
+        return { file, scanned: scanHandlerDeclarations(source, file).length, declared: countDeclaredHandlerLines(source) };
+      })
+      .filter(({ scanned, declared }) => scanned !== declared)
+      .map(({ file, scanned, declared }) => `${file}: scanned ${scanned}, declared ${declared}`);
+
+    expect(mismatched.join('\n')).toBe('');
+  });
+
+  it('does not lose declarations to a regex literal containing a quote', () => {
+    const source = [
+      "const sanitize = (value: string) => value.replace(/'/g, '');",
+      "const worker = { handler: 'apps/client/server/queueHandlers/agentExecutor.handler' };",
+    ].join('\n');
+
+    expect(scanHandlerDeclarations(source, 'synthetic.ts').map((declaration) => declaration.handler)).toEqual([
+      'apps/client/server/queueHandlers/agentExecutor.handler',
+    ]);
+  });
+
+  it('does not lose declarations to a regex literal containing braces', () => {
+    const source = [
+      "const isAccountId = (id: string) => /^\\d{12}$/.test(id);",
+      "const worker = { handler: 'apps/client/server/queueHandlers/agentExecutor.handler' };",
+    ].join('\n');
+
+    expect(scanHandlerDeclarations(source, 'synthetic.ts').map((declaration) => declaration.handler)).toEqual([
+      'apps/client/server/queueHandlers/agentExecutor.handler',
+    ]);
+  });
+
+  it('still reads a division expression as ordinary code', () => {
+    const source = [
+      'const share = total / count / 2;',
+      "const worker = { handler: 'apps/client/server/queueHandlers/agentExecutor.handler' };",
+    ].join('\n');
+
+    expect(scanHandlerDeclarations(source, 'synthetic.ts').map((declaration) => declaration.handler)).toEqual([
+      'apps/client/server/queueHandlers/agentExecutor.handler',
+    ]);
+  });
+
+  it('captures the whole config literal, braces inside a regex included', () => {
+    const source = "const worker = { handler: 'a.handler', filter: /^x{2}$/, copyFiles: toolRuntimeAssets() };";
+
+    expect(scanHandlerDeclarations(source, 'synthetic.ts')[0].config).toContain('toolRuntimeAssets()');
+  });
+});
+
 describe('Lambdas that can execute the premium tool set', () => {
   it('finds handler declarations to check', () => {
     expect(handlerDeclarations.length).toBeGreaterThan(0);
@@ -262,8 +403,13 @@ describe('Lambdas that can execute the premium tool set', () => {
   });
 
   it('copies the tool runtime assets on every Lambda whose handler reaches the tool map', () => {
+    // No overlay exemption here on purpose: a handler configured in this repo is this repo's
+    // to guard. What actually bounds coverage is `resolveImport`, which stops at the package
+    // edge - a generated stub is `export * from '@bike4mind/premium-<x>/...'`, so the walk
+    // ends there and the handler is skipped as unreachable rather than as exempt. Overlay
+    // bundles therefore still need their own guard in the overlay repo. Checked at the time
+    // of writing: none of the three overlay handlers reaches the tool map.
     const missing = handlerDeclarations
-      .filter((declaration) => !declaration.handler.startsWith(OVERLAY_HANDLER_PREFIX))
       .filter((declaration) => {
         const entry = resolveSourceFile(path.join(REPO_ROOT, declaration.handler.split('.').slice(0, -1).join('.')));
         return entry !== null && reachesPremiumToolMap(entry);
@@ -280,7 +426,6 @@ describe('Lambdas that can execute the premium tool set', () => {
     // Pins the detector itself: if the marker import moves and reachability silently returns
     // false everywhere, the check above would pass vacuously.
     const toolCapable = handlerDeclarations
-      .filter((declaration) => !declaration.handler.startsWith(OVERLAY_HANDLER_PREFIX))
       .filter((declaration) => {
         const entry = resolveSourceFile(path.join(REPO_ROOT, declaration.handler.split('.').slice(0, -1).join('.')));
         return entry !== null && reachesPremiumToolMap(entry);

--- a/infra/agentExecutor.ts
+++ b/infra/agentExecutor.ts
@@ -18,6 +18,7 @@ import { websocketApi } from './websocket';
 import { lambdaVpc } from './vpc';
 import { cdnUrlForLambdaEnv } from './router';
 import { agentContinuationQueue } from './queues';
+import { toolRuntimeAssets } from './toolRuntimeAssets';
 
 // Re-export websocketApi route setup for the agent_execute route.
 // Defined here (not in websocket.ts) to avoid circular dependency:
@@ -90,12 +91,7 @@ const SHARED_AGENT_EXECUTOR_CONFIG = {
       resources: [agentContinuationQueue.arn],
     },
   ],
-  copyFiles: [
-    {
-      from: 'apps/client/node_modules/tiktoken/tiktoken_bg.wasm',
-      to: 'tiktoken_bg.wasm',
-    },
-  ],
+  copyFiles: toolRuntimeAssets(),
 };
 
 export const agentExecutor = new sst.aws.Function('AgentExecutor', {

--- a/infra/functions.ts
+++ b/infra/functions.ts
@@ -8,6 +8,7 @@ import { allSecrets } from './secrets';
 import { websocketApi } from './websocket';
 import { lambdaVpc } from './vpc';
 import { cdnUrlForLambdaEnv } from './router';
+import { toolRuntimeAssets } from './toolRuntimeAssets';
 
 // Re-export imageProcessor for other files that import from functions.ts
 export { imageProcessor };
@@ -77,10 +78,5 @@ export const slackQuestProcessor = new sst.aws.Function('SlackQuestProcessor', {
     },
     { actions: ['events:PutEvents'], resources: ['*'] },
   ],
-  copyFiles: [
-    {
-      from: 'apps/client/node_modules/tiktoken/tiktoken_bg.wasm',
-      to: 'tiktoken_bg.wasm',
-    },
-  ],
+  copyFiles: toolRuntimeAssets(),
 });

--- a/infra/toolRuntimeAssets.ts
+++ b/infra/toolRuntimeAssets.ts
@@ -1,0 +1,69 @@
+/**
+ * Runtime assets that must sit next to the bundle of a Lambda able to execute the tool set.
+ *
+ * An `sst.aws.Function` ships one esbuild bundle plus whatever `copyFiles` names, and nothing
+ * else. Any dependency that loads a sibling binary at runtime - rather than importing it - is
+ * therefore invisible to the bundler and has to be listed here explicitly:
+ *
+ *  - `tiktoken` reads `tiktoken_bg.wasm` from the bundle root.
+ *  - `highs` (premium overlay) resolves `highs.wasm` through its emscripten `locateFile`,
+ *    which under Node returns a path next to the loader script, i.e. `/var/task/highs.wasm`.
+ *    Without the copy the solver aborts with `ENOENT ... /var/task/highs.wasm`, so agent mode
+ *    and the Slack quest path silently lose the solver while the chat path keeps it.
+ *
+ * The other compute surfaces are already covered by different mechanisms and need nothing
+ * here: the ChatCompletion Fargate image and the Next.js server both carry real node_modules,
+ * and the browser is served `apps/client/public/highs.wasm` by the postinstall copy.
+ *
+ * `infra/__tests__/toolRuntimeAssets.test.ts` fails the build if a Lambda whose handler can
+ * reach the premium tool map stops using this list.
+ */
+
+import path from 'path';
+
+import { resolveHighsWasm, isOptihashiOverlayPresent } from '../scripts/resolve-highs-wasm.mjs';
+
+/** An `sst.aws.Function` `copyFiles` entry. */
+export type RuntimeAsset = { from: string; to: string };
+
+/** Needed by every LLM-executing Lambda, tool-capable or not. */
+const TIKTOKEN_ASSET: RuntimeAsset = {
+  from: 'apps/client/node_modules/tiktoken/tiktoken_bg.wasm',
+  to: 'tiktoken_bg.wasm',
+};
+
+/**
+ * The asset list for a given `highs.wasm` location. Split out from `toolRuntimeAssets()` so
+ * both branches stay testable on a checkout where the overlay - and therefore highs - is absent.
+ *
+ * `appRoot` must be the same root SST resolves `copyFiles` against, since it does
+ * `path.join($cli.paths.root, entry.from)`: an absolute `from` would be joined onto the root
+ * rather than replacing it, so every entry has to be relative to it.
+ */
+export function buildToolRuntimeAssets(highsWasmPath: string | null, appRoot: string): RuntimeAsset[] {
+  if (!highsWasmPath) return [TIKTOKEN_ASSET];
+  return [TIKTOKEN_ASSET, { from: path.relative(appRoot, highsWasmPath), to: 'highs.wasm' }];
+}
+
+/**
+ * `copyFiles` for a Lambda that can execute the tool set.
+ *
+ * The highs entry stays conditional on purpose: `highs` ships with the premium overlay, and
+ * SST `stat()`s every `copyFiles` source, so an unconditional entry would fail `sst deploy`
+ * outright on an open-core build.
+ *
+ * `appRoot` defaults to `$cli.paths.root` - read at call time, so tests can pass a root
+ * without the SST global existing. Deriving it from `import.meta.url` instead would be wrong
+ * the moment SST bundles the config.
+ */
+export function toolRuntimeAssets(appRoot: string = $cli.paths.root): RuntimeAsset[] {
+  const highsWasm = resolveHighsWasm(appRoot);
+  if (!highsWasm && isOptihashiOverlayPresent(appRoot)) {
+    // A hydrated overlay whose highs did not resolve is a misconfiguration, not open-core:
+    // the deploy would succeed and the solver would ENOENT on first use. Say so at synth time.
+    console.warn(
+      '[toolRuntimeAssets] optihashi overlay present but highs did not resolve - the highs solver will ENOENT in AgentExecutor and SlackQuestProcessor'
+    );
+  }
+  return buildToolRuntimeAssets(highsWasm, appRoot);
+}

--- a/infra/toolRuntimeAssets.ts
+++ b/infra/toolRuntimeAssets.ts
@@ -21,7 +21,7 @@
 
 import path from 'path';
 
-import { resolveHighsWasm, isOptihashiOverlayPresent } from '../scripts/resolve-highs-wasm.mjs';
+import { resolveHighsWasm, isOptihashiOverlayPresent } from '../apps/client/scripts/resolve-highs-wasm.mjs';
 
 /** An `sst.aws.Function` `copyFiles` entry. */
 export type RuntimeAsset = { from: string; to: string };

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
-    "noEmit": true
+    "noEmit": true,
+    // toolRuntimeAssets.ts imports scripts/resolve-highs-wasm.mjs, the resolver shared with
+    // the client's postinstall copy. It stays .mjs because that script runs under plain node
+    // with no build step; allowJs lets infra consume it (types come from its JSDoc).
+    "allowJs": true
   },
   "include": [
     "../sst-env.d.ts",

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -4,9 +4,9 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    // toolRuntimeAssets.ts imports scripts/resolve-highs-wasm.mjs, the resolver shared with
-    // the client's postinstall copy. It stays .mjs because that script runs under plain node
-    // with no build step; allowJs lets infra consume it (types come from its JSDoc).
+    // toolRuntimeAssets.ts imports apps/client/scripts/resolve-highs-wasm.mjs, the resolver
+    // shared with the client's postinstall copy. It stays .mjs because that script runs under
+    // plain node with no build step; allowJs lets infra consume it (types come from its JSDoc).
     "allowJs": true
   },
   "include": [

--- a/scripts/resolve-highs-wasm.mjs
+++ b/scripts/resolve-highs-wasm.mjs
@@ -1,0 +1,79 @@
+/**
+ * Single source of truth for locating the installed `highs` WASM binary.
+ *
+ * Two deploy surfaces need this same path and would otherwise each hard-code it:
+ *  - the browser bundle (apps/client/scripts/copy-highs-wasm.mjs -> public/highs.wasm)
+ *  - the plain SST Lambdas that can execute the premium tool set (infra/toolRuntimeAssets.ts)
+ *
+ * The remaining two are covered for free and need nothing from here: the Next.js server and
+ * the ChatCompletion container both ship real node_modules.
+ *
+ * Resolving from the installed package rather than a committed path is what keeps the
+ * emscripten glue and the binary on the same version. A mismatch aborts instantiation with
+ * a WebAssembly LinkError, which is exactly what a stale hand-copied binary once caused.
+ */
+
+import path from 'path';
+import { existsSync } from 'fs';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+
+const WASM_FILE = 'highs.wasm';
+
+/**
+ * Default repo root: this file lives in `<root>/scripts`.
+ *
+ * Only correct while this module is executed from source, which is true for the pnpm scripts.
+ * Callers running inside a bundle (SST evaluates sst.config.ts as one) must pass their own
+ * root instead - see infra/toolRuntimeAssets.ts, which passes `$cli.paths.root`.
+ */
+const DEFAULT_REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Absolute path to the installed `highs.wasm`, or null when `highs` is not installed.
+ *
+ * `highs` ships with the b4m-optihashi premium overlay, not with open-core, so null is a
+ * normal result and every caller must treat it as a quiet no-op rather than an error.
+ *
+ * @param {string} [repoRoot]
+ * @returns {string | null}
+ */
+export function resolveHighsWasm(repoRoot = DEFAULT_REPO_ROOT) {
+  // highs does not export ./package.json, so resolve the package entry (which lives in the
+  // build/ dir) and take the wasm sitting next to it. Search the workspace store + repo root
+  // so it resolves regardless of which package context is asking.
+  let entry;
+  try {
+    entry = require.resolve('highs', {
+      paths: [
+        path.join(repoRoot, 'node_modules/.pnpm/node_modules'),
+        // The overlay engine is what declares highs; resolve from it too so a change in
+        // hoisting does not silently break the copy.
+        path.join(repoRoot, 'packages/premium/optihashi/engine'),
+        // The client is where the browser copy has always resolved it from; keep that root
+        // so a hoisting change cannot regress the surface that works today.
+        path.join(repoRoot, 'apps/client'),
+        repoRoot,
+      ],
+    });
+  } catch {
+    return null; // highs not installed (overlay absent)
+  }
+  return path.join(path.dirname(entry), WASM_FILE);
+}
+
+/**
+ * Whether the b4m-optihashi overlay is hydrated into this checkout.
+ *
+ * Lets callers tell the two very different "no highs.wasm" cases apart: an open-core install
+ * (expected, skip quietly) versus a hydrated overlay whose highs did not resolve (a real
+ * misconfiguration that would ship a solver which aborts at runtime).
+ *
+ * @param {string} [repoRoot]
+ * @returns {boolean}
+ */
+export function isOptihashiOverlayPresent(repoRoot = DEFAULT_REPO_ROOT) {
+  return existsSync(path.join(repoRoot, 'packages/premium/optihashi'));
+}


### PR DESCRIPTION
# Pull Request

## Description

An `sst.aws.Function` ships one esbuild bundle plus whatever `copyFiles` names, and nothing else. `highs` inlines its emscripten glue into that bundle, but the glue locates the binary through `locateFile`, which under Node returns a path next to the loader script - so the lookup resolves to `/var/task/highs.wasm` and ENOENTs:

```
Aborted(Error: ENOENT: no such file or directory, open '/var/task/highs.wasm')
```

Both Lambdas that can execute the premium tool set copied exactly one asset, `tiktoken_bg.wasm`:

- `infra/agentExecutor.ts` - `AgentExecutor` plus its continuation-queue subscriber (shared config object)
- `infra/functions.ts` - `SlackQuestProcessor`

Net effect: any run routed through agent mode or through a Slack quest could not use the `highs` solver at all, while the identical request on the chat path could. The other three surfaces were each already covered by a different mechanism - the ChatCompletion Fargate image and the Next.js server carry real `node_modules`, and the browser is served `apps/client/public/highs.wasm` by the postinstall copy. The plain-Lambda surface was the one never covered.

`apps/client/scripts/copy-highs-wasm.mjs` already solved this problem for the browser, so this lifts its resolver out into a shared module rather than adding a fourth hand-maintained copy of the path.

Closes #2373

## Changes

- **`apps/client/scripts/resolve-highs-wasm.mjs`** (new) - `resolveHighsWasm(repoRoot)` and `isOptihashiOverlayPresent(repoRoot)`, extracted verbatim in behaviour from the client copy script. Resolves `highs` from the workspace store, the package that declares it, the client, or the repo root, and returns `null` when it is absent.
  It lives next to its in-package caller rather than in the repo-root `scripts/`, because `apps/client`'s postinstall imports it and both ChatCompletion images install dependencies *before* copying the repo - `Dockerfile.chatcompletion:43` copies only `apps/client/scripts` up front, and the self-host `Dockerfile:31-34` never copies repo-root `scripts/` at all. A repo-root path is not on disk at install time there, and a failed static import throws `ERR_MODULE_NOT_FOUND` before the script's own "no-op when highs is absent" guard can run. `infra` -> `apps/client` is a safe import direction; `apps/client` -> repo root is not.
- **`infra/toolRuntimeAssets.ts`** (new) - the `copyFiles` list for a Lambda that can execute the tool set: `tiktoken_bg.wasm` always, `highs.wasm` only when it resolves.
- **`infra/agentExecutor.ts`, `infra/functions.ts`** - both now use `copyFiles: toolRuntimeAssets()`.
- **`apps/client/scripts/copy-highs-wasm.mjs`** - imports the shared resolver (-39 lines), behaviour unchanged.
- **`infra/__tests__/toolRuntimeAssets.test.ts`** (new) - the guard, see below.
- **`infra/tsconfig.json`** - `allowJs`, so infra can import the `.mjs` the pnpm scripts run under plain node.

### Two things worth a reviewer's attention

**The highs entry has to stay conditional.** `highs` is not a root dependency, and SST `stat()`s every `copyFiles` source, so an unconditional entry would fail `sst deploy` outright for anyone building without the overlay hydrated.

**`copyFiles.from` must be app-root-relative, not absolute.** SST does `path.join($cli.paths.root, entry.from)` (`.sst/platform/src/components/aws/function.ts:2014`), and `path.join` does not reset on an absolute segment - an absolute `from` would be appended to the root and then fail the `stat`. So `toolRuntimeAssets()` takes the app root and relativizes against it. It defaults to `$cli.paths.root` read at call time rather than deriving the root from `import.meta.url`, because SST bundles the config before evaluating it and that would put the root in the wrong place.

### The guard

Nothing asserted that a Lambda able to run these tools carried the assets they need, which is why this sat unnoticed. The new test decides "can execute the tool set" the same way the runtime does: it walks each infra handler's static import graph looking for the generated premium tool map, then asserts that function's config carries the shared asset list.

Run over all 103 `handler:` declarations in `infra/`, it flags exactly the two above and nothing else. It is checked both ways - removing the wiring from one function turns it red naming that handler, and renaming the marker turns the anti-vacuous pin red - so it cannot pass by finding nothing.

The scan itself is guarded too, because a guard that quietly stops seeing declarations is worse than no guard. It skips comments, strings **and regex literals** (disambiguated from division by the preceding character); without the last of those, a regex containing a quote reads as the start of a string and swallows source up to the next one. Injecting a single `.replace(/'/g, '')` into `infra/websocket.ts` takes its handler count from 14 to 3 with the suite still green. A separate test cross-checks the brace scan against an independent line-anchored count per infra file, so any future desync fails loudly and names the file. Pinned that way rather than to a hard-coded total, so adding a queue needs no test edit.

Scope limit, stated in the test's own header: it covers functions declared in this repo's `infra/`. Note what does *not* bound it - the three overlay-backed handlers configured here (`overwatchAnalytics`, `optihashiRunCompletion`, `bobRunWorker` in `infra/queues.ts`) are **not** exempted from the rule, since a handler configured in this repo is this repo's to guard. What actually bounds coverage is that the import walk stops at the package edge: a generated stub is `export * from '@bike4mind/premium-<x>/...'`, so those handlers are skipped as unreachable rather than as exempt, and overlay bundles still need their own guard in the overlay repo. The prefix exemption now applies only to the "every handler resolves to a module" check, where the generated stub genuinely does not exist in an open-core checkout.

## Guide for Testers

This is an infrastructure-only change. It alters what is inside a deployed Lambda zip and nothing else - no UI, no API, no schema, no behaviour that a browser can reach without a deploy.

### 1. Static gates (no environment needed)

1. Check out this branch and run `pnpm exec vitest run --dir infra`. Expected: `61 passed`, 3 test files.
2. Run `pnpm run typecheck`. Expected: no output, exit 0.
3. Run `pnpm lint:check`. Expected: no output, exit 0.

### 2. Prove the guard is load-bearing (no environment needed)

4. In `infra/functions.ts`, replace `copyFiles: toolRuntimeAssets(),` with the old literal:
   `copyFiles: [{ from: 'apps/client/node_modules/tiktoken/tiktoken_bg.wasm', to: 'tiktoken_bg.wasm' }],`
5. Run `pnpm exec vitest run --dir infra`. Expected: exactly one failure, `copies the tool runtime assets on every Lambda whose handler reaches the tool map`, and the message names `functions.ts: apps/client/server/queueHandlers/slackQuestProcessor.handler`.
6. Revert step 4 with `git checkout infra/functions.ts` and re-run. Expected: back to `61 passed`.

### 2b. Prove the scan cannot silently shrink (no environment needed)

7. Add this line near the top of `infra/websocket.ts`: `const sanitize = (value: string) => value.replace(/'/g, '');`
8. Run `pnpm exec vitest run --dir infra`. Expected: still `61 passed` - the scan skips the regex literal and still sees all 14 handlers in that file. On the previous revision of this PR the same injection dropped it to 3 handlers with the suite still green.
9. Now break the scan instead: in `infra/__tests__/toolRuntimeAssets.test.ts`, make the regex branch of `skipQuotedOrRegex` return `null`. Expected: `sees every handler declared in every infra file` fails and names `websocket.ts: scanned 3, declared 14`.
10. Revert both: `git checkout infra/websocket.ts infra/__tests__/toolRuntimeAssets.test.ts`.

### 2c. Prove the resolver survives the container install (no environment needed)

11. Simulate what the ChatCompletion image has on disk when `pnpm install` runs: copy `apps/client/scripts` into an empty directory as `<tmp>/apps/client/scripts`, with **no** repo-root `scripts/`, then run `node scripts/copy-highs-wasm.mjs` from `<tmp>/apps/client`. Expected: `[copy-highs-wasm] highs not installed (no overlay) - skipping`, exit 0. Before this revision the same run died with `ERR_MODULE_NOT_FOUND ... /scripts/resolve-highs-wasm.mjs`, which is what turned `Build amd64` red.

### 3. Confirm the binary actually ships (needs a deploy with the overlay hydrated)

This is the check that matters, and it cannot be done from an open-core checkout - `highs` is not installed, so the conditional entry is correctly a no-op here.

12. Deploy this branch to a preview stage with the overlay pinned.
13. Run `aws lambda get-function --function-name <stage>-AgentExecutorFunction-<suffix> --query 'Code.Location' --output text`, download the zip, and list it. Expected: `highs.wasm` is present at the root of the archive, alongside `bundle.mjs` and `tiktoken_bg.wasm`. Before this change the listing had 5 entries and no `highs.wasm`.
14. Repeat step 13 for `<stage>-SlackQuestProcessorFunction-<suffix>`. Same expectation.
15. In the app on that stage, run a solver request through **agent mode** (not the chat path). Expected: it solves rather than degrading, and CloudWatch logs for the AgentExecutor contain no `ENOENT ... /var/task/highs.wasm`.

### Regression Checks

16. `pnpm --filter @bike4mind/client build` (or any run of `predev`/`prebuild`) still emits `[copy-highs-wasm] highs not installed (no overlay) - skipping` on an open-core checkout, and `[copy-highs-wasm] Copied highs.wasm -> public/highs.wasm` when the overlay is hydrated. The script's behaviour is unchanged; only where its resolver lives moved.
17. The self-host image builds - the `Build amd64` leg of `selfhost-image.yml` gets past `pnpm install --frozen-lockfile`. That is the leg the previous revision broke.
18. On a hydrated-overlay build, the browser solver still works - `GET /highs.wasm` returns 200 and the solver instantiates with no `LinkError`.
19. `sst deploy` still succeeds on a stage built **without** the overlay. This is the failure mode the conditional exists to prevent; a regression here shows up as a `copyFiles` `ENOENT` at synth time, before anything is created.
20. AgentExecutor and SlackQuestProcessor still start and process work normally - the only change to either function is the contents of `copyFiles`.

### What NOT to test

- Any UI. There are no user-facing changes in this diff.
- The chat path, the Next.js `pages/api/*` routes, or the browser solver as a *fix* target - all three already had the binary by a different mechanism and are untouched here. They appear above only as regression checks.
- The three overlay-backed Lambdas (`overwatchAnalytics`, `optihashiRunCompletion`, `bobRunWorker`). Their SST config *is* in this repo, so the guard's rule covers them, but their handler source sits behind a package boundary the import walk cannot cross. All three were traced by hand (see below) and none reaches the tool map; their bundle contents remain the overlay repos' to audit.

## Additional Information

**What I verified, and what I did not.** The static gates, the guard's both-ways behaviour, and both branches of the copy script were run locally. The resolver was exercised end to end against a *planted* `highs` package, confirming it yields an app-root-relative `from` that SST's `path.join` + `stat` accepts.

I could **not** verify step 3 above: this worktree has no hydrated overlay and no AWS access, so "the binary lands at `/var/task/highs.wasm`" rests on reading SST's copy implementation, not on a `lambda get-function` listing. That listing is the acceptance check.

**The three overlay Lambdas, all traced by hand.** None declares `copyFiles` at all, so all three looked like candidates for the same bug. Following each generated stub back to its real handler through the overlay's `b4mContributions.serverHandlerStubs` manifest:

- `overwatchAnalytics.dispatch` -> `src/server/queueHandlers/overwatchAnalytics.ts` - repositories, CloudWatch and local queue utils only.
- `optihashiRunCompletion.dispatch` -> `src/server/queueHandlers/qworkRunCompletion.ts` - repositories, the websocket helper, metrics, its own reconciliation module, and `@bike4mind/services/creditService` (a subpath, not the tool-registry barrel).
- `bobRunWorker.dispatch` -> `src/server/handlers/bobRunWorker.ts` - reaches `@bike4mind/llm-adapters` directly through `getLlmByModel`, but never the agent tool-loop or `premiumLlmTools`.

None reaches the premium tool map, so none needs `highs.wasm`. This is a read of the overlay sources rather than a bundle listing - the same caveat as above.

**Not fixed here, deliberately.** The `tiktoken_bg.wasm` path is still hand-duplicated across 11 more `copyFiles` blocks in `infra/queues.ts` and `infra/mcp.ts`. None of those Lambdas is tool-capable, so folding them into the shared list would be scope creep on a P1. Happy to file a follow-up.

## Developer Notes

- **`infra/toolRuntimeAssets.ts` is a new extension point.** The next dependency that ships loader glue plus a sibling binary gets added there once, and every tool-capable Lambda picks it up. The pattern to copy: a pure `buildToolRuntimeAssets(assetPath, appRoot)` for the list, and a thin `toolRuntimeAssets(appRoot)` doing the resolution and the warning, so both branches stay testable on a checkout where the optional package is absent.
- **Reachability as a guard input.** `infra/__tests__/toolRuntimeAssets.test.ts` decides which functions a rule applies to by walking the handler's import graph, rather than hard-coding a list that goes stale. That shape generalises to any "every Lambda that does X must also declare Y" invariant - IAM permissions and environment variables are the obvious next candidates.
- **Fail-loud on the ambiguous case.** A missing `highs` is a quiet no-op on open-core but a `console.warn` at synth time when the overlay *is* hydrated, so "expected absence" and "broken install" do not look identical in a deploy log.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a

