### PR TITLE
fix(infra): normalize CDN_URL to a bare origin at the injection site

### DIFF
--- a/infra/router.ts
+++ b/infra/router.ts
@@ -193,12 +193,26 @@ const routerInstance = shouldUseSharedRouter
 export const LOCAL_FILE_PROXY_BASE = '/api/app-files/serve';
 
 /**
+ * `router.url` with any trailing slash removed. Shared by both URL injectors below so the
+ * two cannot disagree about what "a bare origin" means - they already did once, which is
+ * what this exists to prevent recurring.
+ */
+function bareOrigin(url: typeof routerInstance.url) {
+  return url.apply(u => u.replace(/\/+$/, ''));
+}
+
+/**
  * Returns the CDN base URL to inject into Lambda environment variables.
  * Personal `sst dev` stages (DEV_ROUTER_DISTRIBUTION_ID set) use the local
  * proxy; all deployed stages use the real CloudFront distribution URL.
+ *
+ * Normalized for the same reason as APP_URL (see appUrlForLambdaEnv): consumers treat
+ * NEXT_PUBLIC_CDN_URL as an origin and append their own path, so a trailing slash lands
+ * as a double slash in every URL built from it. LOCAL_FILE_PROXY_BASE is a literal with
+ * no trailing slash, so only the CloudFront arm needs normalizing.
  */
 export function cdnUrlForLambdaEnv() {
-  return $dev && process.env.DEV_ROUTER_DISTRIBUTION_ID ? LOCAL_FILE_PROXY_BASE : routerInstance.url;
+  return $dev && process.env.DEV_ROUTER_DISTRIBUTION_ID ? LOCAL_FILE_PROXY_BASE : bareOrigin(routerInstance.url);
 }
 
 // Export router for other infrastructure to use
@@ -222,7 +236,7 @@ export const router = routerInstance;
  * than each deciding for itself.
  */
 export function appUrlForLambdaEnv() {
-  return routerInstance.url.apply(u => u.replace(/\/+$/, ''));
+  return bareOrigin(routerInstance.url);
 }
 
 export const whatsNewDistributionId = new sst.Linkable('whatsNewDistributionId', {


### PR DESCRIPTION
# Pull Request

## Description

Closes #1748.

`appUrlForLambdaEnv` strips a trailing slash from `router.url` so `APP_URL` is always a bare
origin (added in #1732). Its CDN counterpart, `cdnUrlForLambdaEnv`, did not, so
`NEXT_PUBLIC_CDN_URL` could carry a trailing slash into all four injection sites
(`web.ts`, `functions.ts`, `chatCompletion.ts`, `agentExecutor.ts`).

Every consumer treats the value as an origin and appends its own path, so the slash lands as
a double slash in each URL built from it. One consumer (`toGeneratedFiles`) already worked
around it locally with its own strip and a regression test; the others emit the malformed URL
directly.

Fixed at the injection site rather than per-consumer, mirroring how #1732 handled `APP_URL`.

## Changes

- `infra/router.ts`: `cdnUrlForLambdaEnv` now normalizes the CloudFront arm.
- `infra/router.ts`: extracted the shared `bareOrigin` helper and pointed both
  `appUrlForLambdaEnv` and `cdnUrlForLambdaEnv` at it. The two silently drifting apart is the
  root cause of this issue, so a single definition is what stops it recurring. The change to
  `appUrlForLambdaEnv` is behavior-identical (same regex, same `.apply`).
- The `sst dev` local-proxy arm is deliberately returned verbatim: `LOCAL_FILE_PROXY_BASE` is
  a literal with no trailing slash, and `pages/api/app-files/serve/[...key].ts` gates on an
  exact string match against it.
- Consumer-side strips are left in place. `toGeneratedFiles` uses the same idempotent regex,
  so it is a no-op on an already-normalized value and its regression test still passes.

## Guide for Testers

Infra-only change. It alters the value injected into Lambda env vars at deploy time, so it is
verified by inspecting that value and the URLs built from it. No UI changed.

1. Open `https://app.pr<N>.preview.bike4mind.com/api/settings/serverConfig` in a browser (no
   auth required for this endpoint's public fields).
   Expected: the JSON `cdnUrl` field ends in the distribution host with **no** trailing slash,
   e.g. `https://d1234abcd.cloudfront.net` and not `https://d1234abcd.cloudfront.net/`.
2. Log in, open any chat session that has an attached image or generated file.
   Expected: images render. Inspect one image `src` in devtools.
3. Read that `src` value.
   Expected: exactly one `/` between the CDN origin and the path, e.g.
   `https://d1234abcd.cloudfront.net/generated/foo.png` - never `...cloudfront.net//generated/...`.
4. Go to Sidebar -> Admin -> Settings and upload a logo, then reload the page.
   Expected: the logo renders, and its URL contains no double slash after the origin.

### Regression Checks

5. Request `https://app.pr<N>.preview.bike4mind.com/api/app-files/serve/anything` on this
   deployed preview.
   Expected: HTTP 404. This route is gated by an exact match of `NEXT_PUBLIC_CDN_URL` against
   the local-proxy literal, and a deployed stage must not match it. A 200 here would mean the
   gate broke.
6. Confirm normal file/image loading elsewhere in the app still works (session attachments,
   avatars, the admin logo).
   Expected: unchanged from before this PR.

### What NOT to test

- The `sst dev` local-proxy arm (`DEV_ROUTER_DISTRIBUTION_ID` set). It is only reachable on a
  personal `sst dev` stage, not on a deployed preview, and that arm is intentionally untouched
  by this change.
- Whether `router.url` actually has a trailing slash on any given stage. It varies by SST/
  CloudFront and is not something this PR controls; the point is that the injected value is
  normalized either way.

## Additional Information

**Verification performed.** `infra/router.ts` constructs SST resources at module scope, so it
is not importable in a vitest the way `infra/wafPolicy.ts` is - which is also why the
`APP_URL` fix in #1732 shipped without one. Rather than restructure the module for
testability, the normalization was checked directly against its edge cases (trailing slash,
no slash, doubled slash, mid-path slash, and the local-proxy literal) and every
`NEXT_PUBLIC_CDN_URL` consumer was audited for conflicts:

- `server/utils/generatedFiles.ts` - idempotent regex strip, unaffected.
- `pages/api/app-files/serve/[...key].ts` - exact-equality gate, unaffected (literal arm
  untouched).
- All other consumers build `${cdnUrl}/${path}`, which is exactly what this repairs.
- No consumer performs a blind `slice`/`substring` that would eat a real character once the
  slash is gone.

Typecheck and lint are clean.

**If you would prefer a test over the audit**, extracting the normalizer into a small pure
module (e.g. `infra/urlNormalize.ts`) would make it unit-testable and would cover the `APP_URL`
path too. That is a slightly wider diff, so it was left out here - happy to add it.

## Developer Notes (Optional)

- `bareOrigin` in `infra/router.ts` is the single place that defines what "a bare origin" means
  for injected URL env vars. Any future URL injected into Lambda env should go through it
  rather than re-implementing the strip.
