### PR TITLE
fix(client): keep a clicked navigate_view request from being dropped as a replay

### DIFF
--- a/apps/client/app/hooks/useNavigationExecutor.test.ts
+++ b/apps/client/app/hooks/useNavigationExecutor.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useNavigationExecutor } from './useNavigationExecutor';
+import { useOptiNavigation } from './useOptiNavigation';
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@client/app/components/admin/useAdminModal', () => ({
+  useAdminModal: (selector: (s: unknown) => unknown) => selector({ setActiveTab: vi.fn() }),
+}));
+
+vi.mock('@client/app/components/Files/Browser', () => ({
+  useFileBrowser: (selector: (s: unknown) => unknown) => selector({ setOpen: vi.fn() }),
+}));
+
+// The executor no-ops on Opti intents unless an /opti route is present, and the
+// open-core route table is empty - so the overlay's route has to be stood in for.
+vi.mock('@client/app/premium-generated/premiumRoutes.generated', () => ({
+  premiumRoutes: [{ path: '/opti' }],
+}));
+
+const optiIntent = (target: string) =>
+  ({ navigationType: 'action', target }) as Parameters<ReturnType<typeof useNavigationExecutor>>[0];
+
+describe('useNavigationExecutor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useOptiNavigation.getState().clearPending();
+  });
+
+  it('marks an Opti click as user-initiated so the surface does not drop it as a replay', () => {
+    const { result } = renderHook(() => useNavigationExecutor());
+    result.current(optiIntent('scheduling.solvers'));
+
+    const { pendingFamily, pendingSubTab, pendingUserInitiated } = useOptiNavigation.getState();
+    expect(pendingFamily).toBe('scheduling');
+    expect(pendingSubTab).toBe('solvers');
+    expect(pendingUserInitiated).toBe(true);
+  });
+
+  // router-core hands a plain `search` object through untouched, so naming mode as a
+  // literal would drop every other param on the way to /opti - losing `article`
+  // outright, since nothing downstream puts it back.
+  it('merges mode into the existing search params instead of replacing them', () => {
+    const { result } = renderHook(() => useNavigationExecutor());
+    result.current(optiIntent('scheduling'));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const { to, search } = mockNavigate.mock.calls[0][0];
+    expect(to).toBe('/opti');
+    expect(typeof search).toBe('function');
+    expect(search({ mode: 'canvas', session: 'abc', article: 'xyz' })).toEqual({
+      mode: 'optimize',
+      session: 'abc',
+      article: 'xyz',
+    });
+  });
+});

--- a/apps/client/app/hooks/useNavigationExecutor.ts
+++ b/apps/client/app/hooks/useNavigationExecutor.ts
@@ -58,9 +58,10 @@ export function useNavigationExecutor() {
           }
           // Name the target view in the search params rather than leaving the route to
           // its default, which would render the wrong view for a frame before the
-          // consumer switches.
+          // consumer switches. The updater form is required: router-core passes a plain
+          // search object straight through, replacing every other param on the way in.
           // @ts-expect-error - /opti is a premium route, not in static route tree
-          navigate({ to: '/opti', search: { mode: 'optimize' } });
+          navigate({ to: '/opti', search: prev => ({ ...prev, mode: 'optimize' }) });
           break;
         }
       }

--- a/apps/client/app/hooks/useNavigationExecutor.ts
+++ b/apps/client/app/hooks/useNavigationExecutor.ts
@@ -48,14 +48,19 @@ export function useNavigationExecutor() {
           // Opti family action: dispatch via Zustand store, then navigate to /opti
           // Support composite targets: "scheduling.solvers" -> family + subTab
           if (!optiRouteExists) break;
+          // userInitiated marks this as a click rather than the replayed side effect, so
+          // the surface honours it instead of dropping it the way it drops a replay.
           const dotIdx = intent.target.indexOf('.');
           if (dotIdx !== -1) {
-            requestFamily(intent.target.slice(0, dotIdx), intent.target.slice(dotIdx + 1));
+            requestFamily(intent.target.slice(0, dotIdx), intent.target.slice(dotIdx + 1), { userInitiated: true });
           } else {
-            requestFamily(intent.target);
+            requestFamily(intent.target, undefined, { userInitiated: true });
           }
+          // Name the target view in the search params rather than leaving the route to
+          // its default, which would render the wrong view for a frame before the
+          // consumer switches.
           // @ts-expect-error - /opti is a premium route, not in static route tree
-          navigate({ to: '/opti' });
+          navigate({ to: '/opti', search: { mode: 'optimize' } });
           break;
         }
       }

--- a/apps/client/app/hooks/useOptiNavigation.test.ts
+++ b/apps/client/app/hooks/useOptiNavigation.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useOptiNavigation } from './useOptiNavigation';
 
 // pendingUserInitiated is the seam the /opti consumer reads to tell a clicked
-// navigate_view button apart from a side effect that replays on session load.
-// Defaulting it to true anywhere would let a replay yank the user off a view
-// that owns its own layout, which is the bug this flag exists to prevent.
+// navigate_view button apart from every other dispatch. Defaulting it to true
+// anywhere would let a replay yank the user off a view that owns its own layout,
+// which is the bug this flag exists to prevent.
 describe('useOptiNavigation', () => {
   beforeEach(() => {
     useOptiNavigation.getState().clearPending();

--- a/apps/client/app/hooks/useOptiNavigation.test.ts
+++ b/apps/client/app/hooks/useOptiNavigation.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useOptiNavigation } from './useOptiNavigation';
+
+// pendingUserInitiated is the seam the /opti consumer reads to tell a clicked
+// navigate_view button apart from a side effect that replays on session load.
+// Defaulting it to true anywhere would let a replay yank the user off a view
+// that owns its own layout, which is the bug this flag exists to prevent.
+describe('useOptiNavigation', () => {
+  beforeEach(() => {
+    useOptiNavigation.getState().clearPending();
+  });
+
+  it('defaults a request to not user-initiated', () => {
+    useOptiNavigation.getState().requestFamily('scheduling', 'problem');
+    const { pendingFamily, pendingSubTab, pendingUserInitiated } = useOptiNavigation.getState();
+    expect(pendingFamily).toBe('scheduling');
+    expect(pendingSubTab).toBe('problem');
+    expect(pendingUserInitiated).toBe(false);
+  });
+
+  it('marks a request user-initiated only when asked to', () => {
+    useOptiNavigation.getState().requestFamily('scheduling', 'problem', { userInitiated: true });
+    expect(useOptiNavigation.getState().pendingUserInitiated).toBe(true);
+  });
+
+  it('resets provenance along with the request', () => {
+    useOptiNavigation.getState().requestFamily('routing', undefined, { userInitiated: true });
+    useOptiNavigation.getState().clearPending();
+    const { pendingFamily, pendingSubTab, pendingUserInitiated } = useOptiNavigation.getState();
+    expect(pendingFamily).toBeNull();
+    expect(pendingSubTab).toBeNull();
+    expect(pendingUserInitiated).toBe(false);
+  });
+});

--- a/apps/client/app/hooks/useOptiNavigation.ts
+++ b/apps/client/app/hooks/useOptiNavigation.ts
@@ -11,6 +11,14 @@ interface OptiNavigationState {
   /** Optional sub-tab within the family (e.g., "solvers", "gantt") */
   pendingSubTab: string | null;
   /**
+   * True when the request came from someone clicking a navigate_view button, false when
+   * it came from a side effect that REPLAYS on session load. Consumers drop a replayed
+   * request on views that own their own layout but must honour a deliberate click, and
+   * they cannot tell the two apart by their own state: the click writes this store
+   * before its navigation commits, so the consumer still sees the view being left.
+   */
+  pendingUserInitiated: boolean;
+  /**
    * Prompt to send to the docked chat, dispatched by deck components
    * (FamilyConsole, PatternLearnTab, SchedulerTab). OptiHashiPage consumes it
    * via handleAskAbout, which creates the OptiHashi session first when none
@@ -19,7 +27,7 @@ interface OptiNavigationState {
    */
   pendingPrompt: string | null;
   /** Request navigation to a specific opti family, optionally with a sub-tab */
-  requestFamily: (familyId: string, subTab?: string) => void;
+  requestFamily: (familyId: string, subTab?: string, opts?: { userInitiated?: boolean }) => void;
   /** Ask OptiHashiPage to send a prompt to the chat, creating a session if needed */
   requestChatPrompt: (prompt: string) => void;
   /** Clear pending family and sub-tab after OptiHashiPage consumes them */
@@ -31,9 +39,11 @@ interface OptiNavigationState {
 export const useOptiNavigation = create<OptiNavigationState>(set => ({
   pendingFamily: null,
   pendingSubTab: null,
+  pendingUserInitiated: false,
   pendingPrompt: null,
-  requestFamily: (familyId: string, subTab?: string) => set({ pendingFamily: familyId, pendingSubTab: subTab ?? null }),
+  requestFamily: (familyId: string, subTab?: string, opts?: { userInitiated?: boolean }) =>
+    set({ pendingFamily: familyId, pendingSubTab: subTab ?? null, pendingUserInitiated: opts?.userInitiated === true }),
   requestChatPrompt: (prompt: string) => set({ pendingPrompt: prompt }),
-  clearPending: () => set({ pendingFamily: null, pendingSubTab: null }),
+  clearPending: () => set({ pendingFamily: null, pendingSubTab: null, pendingUserInitiated: false }),
   clearPendingPrompt: () => set({ pendingPrompt: null }),
 }));

--- a/apps/client/app/hooks/useOptiNavigation.ts
+++ b/apps/client/app/hooks/useOptiNavigation.ts
@@ -11,11 +11,17 @@ interface OptiNavigationState {
   /** Optional sub-tab within the family (e.g., "solvers", "gantt") */
   pendingSubTab: string | null;
   /**
-   * True when the request came from someone clicking a navigate_view button, false when
-   * it came from a side effect that REPLAYS on session load. Consumers drop a replayed
-   * request on views that own their own layout but must honour a deliberate click, and
-   * they cannot tell the two apart by their own state: the click writes this store
-   * before its navigation commits, so the consumer still sees the view being left.
+   * True only when the request came from someone clicking a navigate_view button.
+   * Consumers need it because they cannot tell a click apart by their own state: the
+   * click writes this store before its navigation commits, so the consumer still sees
+   * the view being left.
+   *
+   * False is NOT the same as "replayed on session load" - it also covers the live
+   * follow-to-console after a just-completed formulate/solve, because that path
+   * dispatches from a mount effect and cannot distinguish a fresh reply from a
+   * persisted one. A consumer that drops everything with `!pendingUserInitiated`
+   * therefore kills the intended live follow too; gate on the effect's own
+   * freshness for that, and use this flag only to force a click through.
    */
   pendingUserInitiated: boolean;
   /**


### PR DESCRIPTION
# Pull Request

https://github.com/user-attachments/assets/6238cb66-3412-4b61-9a73-4d2b6dc5e3da



## Description

Clicking a `navigate_view` "Suggested Navigation" button that targets an opti family landed on the route's default view instead of the named one, so the button appeared to do nothing useful.

Two stacked causes:

1. The executor navigated to bare `/opti` and left the view to the route's default, which is not the view the intent named.
2. `useOptiNavigation` is a Zustand store written synchronously, so the consuming view re-renders and runs its pending-navigation effect **before** the click's own navigation commits. That effect has a guard whose job is to drop the `navigate_view` side effect that replays from a session's last reply on load. It decided by inspecting its own current state - which at that instant still describes the view being left - so a deliberate click was indistinguishable from a replay and got cleared.

The fix is provenance rather than timing. `requestFamily` takes an optional `{ userInitiated }`, set only by the click path in `useNavigationExecutor`; the replaying side-effect caller does not set it, so the guard it was written for is unchanged. The consumer keys its guard on the flag instead of on its own state.

## Changes

- `useOptiNavigation`: new `pendingUserInitiated` field, `requestFamily(familyId, subTab?, opts?)` third argument, reset in `clearPending`.
- `useNavigationExecutor`: passes `{ userInitiated: true }` on both the composite (`family.subTab`) and bare target paths, and names the target view in the search params instead of relying on the route default.
- New unit test pinning the store contract: default is not user-initiated, the flag is set only when asked, and it resets with the rest of the request.

Consumer-side changes live in the corresponding premium overlay PR; this PR is the core half and is inert without it.

## Guide for Testers

Requires a build with the premium overlay mounted (open-core builds have no `/opti` route and the `action` intent is a deliberate no-op there).

1. Sign in and open a session that has previously produced a "Suggested Navigation" button, or ask the assistant in an opti session for a navigation button to a named view.
2. Confirm a "Suggested Navigation" heading with at least one button renders under the reply.
3. Click the button.
4. Expected: the URL gains the named view's search param and the app renders that view directly, with the breadcrumb reflecting it. It must NOT land on the bare starting view or on a picker.
5. Reload the page on that same session without clicking anything.
6. Expected (regression check): the replayed `navigate_view` from the session's last reply is still dropped - the page stays on the view the URL asked for and does not jump into the optimizer on its own.

### Regression Checks

- A `route`-type intent (e.g. a plain page link) still navigates normally.
- A `tab`-type intent still opens `/admin` on the right tab.
- The `file_browser` action intent still opens the file browser modal.

### What NOT to test

Nothing here changes server behaviour, the `navigate_view` tool itself, or the view registry - only client-side dispatch.

## Additional Information

Verified end-to-end against the self-host stack with the overlay hydrated: before the change the click landed on a picker with no selection; after it, on the named view with its content loaded.
