### PR TITLE
fix(data-lakes): order the purge storage sweep so a version failure cannot strand the current object

### DIFF
--- a/apps/client/app/components/DataLakeWizard/PurgeLakeDocumentAction.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/PurgeLakeDocumentAction.test.tsx
@@ -99,15 +99,26 @@ describe('PurgeLakeDocumentAction', () => {
     // The document is gone but the bytes are not, and nothing else can name them any more.
     const user = userEvent.setup();
     h.mutate.mockImplementation((_id: string, opts: { onSuccess: (r: DataLakeDocumentPurgeReceipt) => void }) =>
-      opts.onSuccess({ ...RECEIPT, storageObjectDeleted: false, storageObjectsRemaining: 1, verified: false })
+      // The shape the service now produces when a prior version's key fails: that key AND the
+      // current one are still stored, because the sweep skips the current object on purpose.
+      opts.onSuccess({
+        ...RECEIPT,
+        storageObjectDeleted: false,
+        storageObjectsTotal: 2,
+        storageObjectsRemaining: 2,
+        verified: false,
+      })
     );
     renderAction();
     await user.click(screen.getByTestId('datalake-purgefile-btn-f1'));
     await user.click(screen.getByTestId('datalake-purgefile-confirm-btn'));
 
-    expect((await screen.findByTestId('datalake-purgefile-receipt-storage')).textContent).toContain(
-      'could not be removed'
-    );
+    const note = (await screen.findByTestId('datalake-purgefile-receipt-storage')).textContent;
+    expect(note).toContain('2 of 2 stored copies of this file remain');
+    // The count is what is still STORED, not what the store refused: once one copy fails the sweep
+    // leaves the current object alone on purpose, and the copy says so rather than implying every
+    // remaining object was individually rejected.
+    expect(note).toContain('left in place deliberately');
   });
 
   it('leaves the storage note out of a clean receipt', async () => {

--- a/apps/client/app/components/DataLakeWizard/PurgeLakeDocumentAction.tsx
+++ b/apps/client/app/components/DataLakeWizard/PurgeLakeDocumentAction.tsx
@@ -130,8 +130,11 @@ export default function PurgeLakeDocumentAction({
                 sx={{ mt: 0.5, color: 'warning.500' }}
               >
                 {receipt.storageObjectsRemaining} of {receipt.storageObjectsTotal} stored cop
-                {receipt.storageObjectsTotal === 1 ? 'y' : 'ies'} of this file could not be removed, so the document was
-                left intact rather than stranded. The failure has been recorded; retry, or contact support.
+                {receipt.storageObjectsTotal === 1 ? 'y' : 'ies'} of this file{' '}
+                {receipt.storageObjectsRemaining === 1 ? 'remains' : 'remain'}, so the document was left intact rather
+                than stranded. Once one copy cannot be removed the others are left in place deliberately, which keeps
+                this file openable until a retry clears them all. The failure has been recorded; retry, or contact
+                support.
               </Typography>
             )}
             <Typography level="body-xs" sx={{ mt: 0.5, color: 'text.tertiary' }}>

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -939,7 +939,11 @@ export interface DataLakeDocumentPurgeReceipt {
   storageObjectDeleted: boolean;
   /** How many stored objects the document had (current revision plus every prior version). */
   storageObjectsTotal: number;
-  /** How many of them the object store refused. 0 whenever `storageObjectDeleted` is true. */
+  /**
+   * How many of them are still stored. 0 whenever `storageObjectDeleted` is true. Unreached rather
+   * than strictly refused: once any prior version's key fails, the sweep stops before the current
+   * `filePath` so the row it keeps stays addressable, and counts that un-attempted key here too.
+   */
   storageObjectsRemaining: number;
   /**
    * What happened to the separate retrieval index. NOT read back - the port has no read operation.

--- a/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.test.ts
+++ b/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.test.ts
@@ -438,6 +438,57 @@ describe('purgeDataLakeDocument', () => {
     expect(receipt.storageObjectDeleted).toBe(true);
   });
 
+  it('attempts the current filePath LAST, after every prior version key', async () => {
+    // Ordering is what makes the guard below possible: the kept row is addressed by the current
+    // key, so it must not be gone before the sweep knows every other key cleared.
+    const db = makeDb({
+      filePath: 'uploads/q3-v3.pdf',
+      versions: [
+        { version: 1, filePath: 'uploads/q3.pdf' },
+        { version: 2, filePath: 'uploads/q3-v2.pdf' },
+      ],
+    });
+    const storage = makeStorage();
+
+    await purgeDataLakeDocument(OWNER, 'lake-1', 'file-1', { db, storage });
+
+    expect(storage.delete.mock.calls.map(c => c[0])).toEqual([
+      'uploads/q3.pdf',
+      'uploads/q3-v2.pdf',
+      'uploads/q3-v3.pdf',
+    ]);
+  });
+
+  it('leaves the current object alone when a version key fails, so the kept row stays addressable', async () => {
+    // The partial outcome this exists to prevent: current key deleted, an older version refused.
+    // The sweep deliberately keeps the row for a retry, but a row naming an object that no longer
+    // exists presigns a dead key on download and cannot refetch its bytes to re-chunk.
+    const db = makeDb({
+      filePath: 'uploads/q3-v2.pdf',
+      fileSize: 27707,
+      versions: [{ version: 1, filePath: 'uploads/q3.pdf' }],
+    });
+    const storage = {
+      delete: vi.fn(async (path: string) =>
+        path === 'uploads/q3.pdf' ? Promise.reject(new Error('s3 down')) : ({} as never)
+      ),
+    };
+    const logger = { info: vi.fn(), error: vi.fn() };
+
+    const receipt = await purgeDataLakeDocument(OWNER, 'lake-1', 'file-1', { db, storage, logger });
+
+    // Never attempted, rather than attempted and failed.
+    expect(storage.delete.mock.calls.map(c => c[0])).toEqual(['uploads/q3.pdf']);
+    expect(receipt.storageObjectDeleted).toBe(false);
+    // Counted as unreached, so the number keeps meaning "objects still stored": both remain.
+    expect(receipt.storageObjectsRemaining).toBe(2);
+    expect(receipt.storageObjectsTotal).toBe(2);
+    // And the row survives, still naming a key that resolves.
+    expect(db.fabFiles.hardDeleteOneById).not.toHaveBeenCalled();
+    expect(receipt.documentDeleted).toBe(false);
+    expect(receipt.verified).toBe(false);
+  });
+
   it('withholds the refund when a concurrent purge removed the row first', async () => {
     // Deleting an already-absent object key succeeds, so without the atomic claim both callers
     // would refund the same bytes and halve the owner's recorded storage.

--- a/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.ts
+++ b/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.ts
@@ -207,20 +207,26 @@ export const purgeDataLakeDocument = async (
   // `versions[]`, each under its own object key (see appendEditedVersion), and `filePath` names only
   // the newest - so deleting that alone leaves the original document's bytes behind while the
   // receipt claims the file is gone.
-  const storageKeys = Array.from(
-    new Set(
-      [file.filePath, ...(file.versions ?? []).map(version => version?.filePath)].filter(
-        (path): path is string => typeof path === 'string' && path.length > 0
-      )
-    )
-  );
+  //
+  // ORDER MATTERS: prior versions first, `filePath` LAST. When the sweep cannot clear every key it
+  // deliberately keeps the row so a retry can still name them, and that row is only useful while
+  // `filePath` still resolves - download presigns it and reprocess refetches the bytes through it.
+  // Deleting the current object while an older version survived would keep a row addressing an
+  // object that is gone, which is worse than keeping both.
+  const isStorageKey = (path: unknown): path is string => typeof path === 'string' && path.length > 0;
+  const currentKey = isStorageKey(file.filePath) ? file.filePath : null;
+  const versionKeys = Array.from(
+    new Set((file.versions ?? []).map(version => version?.filePath).filter(isStorageKey))
+    // Deduped against the current key too: a version row may repeat it, and it must be attempted
+    // last, not at whichever position it first appears in `versions[]`.
+  ).filter(path => path !== currentKey);
 
   // BEFORE the chunks and the row: those two writes are the ones a retry cannot re-derive once
   // done (chunks feed the lake-health rollups, and the row is the only thing naming these keys).
   // If the object store refuses, nothing destructive has happened yet, so the document, its
   // chunks and its rollups stay consistent and a retry converges.
   const storageKeysUnreached: string[] = [];
-  for (const path of storageKeys) {
+  const deleteKey = async (path: string) => {
     try {
       await storage.delete(path);
     } catch (error) {
@@ -230,6 +236,25 @@ export const purgeDataLakeDocument = async (
         filePath: path,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
+    }
+  };
+
+  for (const path of versionKeys) {
+    await deleteKey(path);
+  }
+  if (currentKey) {
+    if (storageKeysUnreached.length > 0) {
+      // Not attempted, on purpose - see the ordering note above. Still counted as unreached so
+      // `storageObjectsRemaining` keeps meaning "objects still stored", which is what the receipt
+      // and its dialog copy report.
+      storageKeysUnreached.push(currentKey);
+      logger?.info('[dataLake] permanent deletion skipped the current object to keep the kept row addressable', {
+        fabFileId: file.id,
+        filePath: currentKey,
+        unreachedVersionKeys: storageKeysUnreached.length - 1,
+      });
+    } else {
+      await deleteKey(currentKey);
     }
   }
   const storageObjectDeleted = storageKeysUnreached.length === 0;
@@ -283,7 +308,7 @@ export const purgeDataLakeDocument = async (
     embeddingModels,
     documentDeleted,
     storageObjectDeleted,
-    storageObjectsTotal: storageKeys.length,
+    storageObjectsTotal: versionKeys.length + (currentKey ? 1 : 0),
     storageObjectsRemaining: storageKeysUnreached.length,
     retrievalIndexOutcome: retrievalIndex ? 'purged' : vectorsCollocated ? 'collocated' : 'unwired',
     verified,


### PR DESCRIPTION
# Pull Request

## Description

Closes #2302. Follow-up from #1932 (verifiable permanent deletion for one lake document).

`purgeDataLakeDocument` deletes every stored key for a document - the current `filePath` plus each
entry in `versions[]` - attempting each independently and recording only the failures. `filePath`
went first and the loop continued past a failure, so the likeliest partial outcome (current key
deleted, one older version refused) left a surviving `FabFile` row naming an object that no longer
exists.

That is the worst of both outcomes: the sweep keeps the row *deliberately* so a retry can still name
the bytes, but download presigns a dead key and reprocess cannot fetch the bytes to re-chunk. The row
it kept is no longer usable for anything.

## Changes

- `purgeDataLakeDocument.ts`: prior-version keys are attempted first and `filePath` last. Once any
  earlier key fails, the current key is **not attempted at all** - it is pushed straight onto
  `storageKeysUnreached`. That keeps the surviving row addressable, which is the whole reason the
  sweep keeps it.
- The current key is de-duplicated against the version keys explicitly rather than by a single
  `Set`, because a version row commonly repeats `filePath` and it has to land last, not at whichever
  position it first appears in `versions[]`.
- `storageObjectsTotal` is now derived from the two lists rather than the old combined array.
- `DataLakeTypes.ts`: `storageObjectsRemaining`'s docstring now says **unreached** rather than
  refused, since the count can include a key that was deliberately never attempted.
- `PurgeLakeDocumentAction.tsx`: the receipt dialog copy follows the same shift - it reports what is
  still stored and states that the remaining copies were left in place on purpose, instead of
  implying each one was individually rejected.
- Tests: two new cases in `purgeDataLakeDocument.test.ts`, plus the dialog test updated to the new
  copy and to the multi-copy shape the service now produces.

## Guide for Testers

Backend + one dialog string. The behaviour only differs when the object store **partially** fails, so
it cannot be exercised by clicking through a healthy environment - the automated tests below are the
real verification.

1. Run `pnpm --filter @bike4mind/services test -- src/dataLakeService/purgeDataLakeDocument.test.ts`.
   Expected: 34 passed, including `attempts the current filePath LAST, after every prior version key`
   and `leaves the current object alone when a version key fails, so the kept row stays addressable`.
2. Run `pnpm --filter @bike4mind/client test -- app/components/DataLakeWizard/PurgeLakeDocumentAction.test.tsx`.
   Expected: 10 passed.
3. In the app, open a data lake you own, pick any document, and use permanent delete. Confirm.
   Expected: unchanged from before - the document is destroyed and the receipt dialog reports the
   deletion verified, with no storage warning row.

### Regression Checks

4. Permanently delete a document that has prior AI-edited versions.
   Expected: still fully deleted; the receipt's stored-copies total counts the current revision plus
   every prior version, as before.
5. Confirm the receipt dialog for a clean purge shows no `datalake-purgefile-receipt-storage` note.

### What NOT to test

- Forcing a partial storage failure by hand. It needs the object store to refuse one specific key
  mid-sweep, which is not reachable from the UI; that path is covered by the unit tests in step 1.
- Quota refund behaviour - unchanged here. A partial sweep already withheld the refund before this PR
  and still does.

## Additional Information

**The new tests were checked against the pre-fix code.** With the source change reverted and the
tests kept, both new cases fail (`2 failed | 32 passed`) and the other 32 still pass - so they detect
this specific bug rather than passing vacuously.

Verification run: `purgeDataLakeDocument.test.ts` 34 passed; full `src/dataLakeService` suite 1508
passed across 65 files; `PurgeLakeDocumentAction.test.tsx` 10 passed; `pnpm turbo:typecheck` 40/40;
eslint clean on all changed files.

**One judgement call worth flagging:** the skip is logged at `info`, not `error`. The underlying
failure is already logged at `error` by the delete helper, and the skip itself is intended behaviour
rather than a fault - so an second `error` line would misreport a working safety mechanism as a
problem. (The logger adapter here exposes only `info` and `error`, no `warn`.)

## Developer Notes

- `storageObjectsRemaining` now means "objects still stored", which is a slightly weaker claim than
  "objects the store refused". Anything reading this field for alerting should treat it as a retry
  signal, not as a count of hard storage errors.
