### PR TITLE
fix(ci): assert help accessLevel parity across index and embeddings

### DIFF
--- a/.husky/check-help-content.sh
+++ b/.husky/check-help-content.sh
@@ -111,8 +111,10 @@ fi
 #      chunk is still scored and served on its own accessLevel.
 #   2. no slug in the admin category carries anything but 'admin', which catches the case
 #      where both artifacts agree on the wrong level.
-# Both artifacts are already known to parse and to hold the expected shape - the block
-# above exits non-zero otherwise - so this re-read can assume it.
+# Both artifacts are already known to parse and to hold array-shaped entries/chunks - the
+# block above exits non-zero otherwise - so this re-read can assume that much. It does NOT
+# verify per-record shape, so a record missing `slug` still throws here; the fail-closed
+# wrapper below is what turns that into a blocked commit rather than a pass.
 if ! LEVEL_VIOLATIONS=$(node -e "
     const idx = JSON.parse(require('fs').readFileSync('$INDEX_FILE','utf-8'));
     const emb = JSON.parse(require('fs').readFileSync('$EMBEDDINGS_FILE','utf-8'));
@@ -123,12 +125,16 @@ if ! LEVEL_VIOLATIONS=$(node -e "
     const counts = new Map();
     for (const c of emb.chunks) {
       const want = expected.get(c.slug);
+      // has() rather than a lone undefined check: an entry present but missing accessLevel
+      // would otherwise be misreported as having no entry at all.
       const problem =
-        want === undefined
+        !expected.has(c.slug)
           ? 'has no help-index.json entry, so nothing constrains its accessLevel'
-          : c.accessLevel !== want
-            ? 'embeddings say ' + c.accessLevel + ', index says ' + want
-            : null;
+          : want === undefined
+            ? 'has a help-index.json entry with no accessLevel, so parity cannot be checked'
+            : c.accessLevel !== want
+              ? 'embeddings say ' + c.accessLevel + ', index says ' + want
+              : null;
       if (problem !== null) {
         const key = c.slug + ': ' + problem;
         counts.set(key, (counts.get(key) || 0) + 1);

--- a/.husky/check-help-content.sh
+++ b/.husky/check-help-content.sh
@@ -97,4 +97,85 @@ if [ -n "$MISSING" ]; then
   exit 1
 fi
 
+# Block commit if the two artifacts disagree about accessLevel. That field is the only
+# gate keeping admin-only help docs out of a non-admin user's Help AI chat answers:
+# apps/client/server/help/retrieval.ts filters on it in both paths - embeddings chunks in
+# the vector search, index entries in the keyword fallback. The check above compares slug
+# SETS, so an artifact with every chunk relabeled 'public' is byte-indistinguishable from
+# a correct one as far as it is concerned, and a partial regenerate, a hand-edit, or a bad
+# merge resolution on a one-line-JSON artifact ships a silent access-control regression.
+# Two assertions close that:
+#   1. every chunk's accessLevel matches its index entry's. Requiring the entry to exist
+#      also covers the direction the check above does not: it asserts index -> embeddings,
+#      so a chunk whose slug is absent from the index is unguarded, and at runtime such a
+#      chunk is still scored and served on its own accessLevel.
+#   2. no slug in the admin category carries anything but 'admin', which catches the case
+#      where both artifacts agree on the wrong level.
+# Both artifacts are already known to parse and to hold the expected shape - the block
+# above exits non-zero otherwise - so this re-read can assume it.
+if ! LEVEL_VIOLATIONS=$(node -e "
+    const idx = JSON.parse(require('fs').readFileSync('$INDEX_FILE','utf-8'));
+    const emb = JSON.parse(require('fs').readFileSync('$EMBEDDINGS_FILE','utf-8'));
+    const expected = new Map(idx.entries.map(e => [e.slug, e.accessLevel]));
+
+    // Counted per slug rather than listed per chunk: a mislabeled article has dozens of
+    // chunks and one remedy, so a whole-artifact relabel stays readable.
+    const counts = new Map();
+    for (const c of emb.chunks) {
+      const want = expected.get(c.slug);
+      const problem =
+        want === undefined
+          ? 'has no help-index.json entry, so nothing constrains its accessLevel'
+          : c.accessLevel !== want
+            ? 'embeddings say ' + c.accessLevel + ', index says ' + want
+            : null;
+      if (problem !== null) {
+        const key = c.slug + ': ' + problem;
+        counts.set(key, (counts.get(key) || 0) + 1);
+      }
+    }
+
+    // Compares the top path segment, not an 'admin/' prefix: vectorize-help-content.ts
+    // collapses a directory index to the directory itself, so a docs-site/docs/admin/index.md
+    // yields the bare slug 'admin' and a prefix test would wave it through. Mirrors
+    // CATEGORY_ACCESS_LEVELS in packages/scripts/help/loadHelpArticles.ts - keep in sync.
+    const misfiled = new Set();
+    for (const [artifact, records] of [['help-index.json', idx.entries], ['help-embeddings.json', emb.chunks]]) {
+      for (const r of records) {
+        if (r.slug.split('/')[0] === 'admin' && r.accessLevel !== 'admin') {
+          misfiled.add(r.slug + ' in ' + artifact + ': accessLevel is ' + r.accessLevel + ', expected admin');
+        }
+      }
+    }
+
+    const lines = [
+      ...[...counts].map(([key, n]) => key + ' (' + n + (n === 1 ? ' chunk)' : ' chunks)')),
+      ...misfiled,
+    ];
+    if (lines.length) {
+      console.log(lines.join('\n'));
+    }
+  "); then
+  echo ""
+  echo "❌ Could not compare help accessLevel across the two artifacts (see the error above)."
+  echo "   The artifact is unreadable or malformed - regenerate it:"
+  echo "     pnpm --filter @bike4mind/scripts help:regenerate"
+  echo ""
+  exit 1
+fi
+
+if [ -n "$LEVEL_VIOLATIONS" ]; then
+  echo ""
+  echo "❌ Help artifacts disagree about accessLevel - it is the only thing keeping admin-only docs out of a non-admin user's Help AI chat answers:"
+  echo "$LEVEL_VIOLATIONS" | while read -r violation; do
+    echo "   • $violation"
+  done
+  echo ""
+  echo "   To fix, regenerate both artifacts from the corpus:"
+  echo "     OPENAI_API_KEY=sk-... pnpm --filter @bike4mind/scripts help:regenerate"
+  echo "   Then stage help-index.json and help-embeddings.json and commit again."
+  echo ""
+  exit 1
+fi
+
 exit 0

--- a/packages/scripts/src/checkHelpContentAccessLevelParity.test.ts
+++ b/packages/scripts/src/checkHelpContentAccessLevelParity.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Behaviour tests for the accessLevel assertions in .husky/check-help-content.sh.
+ *
+ * accessLevel is the only gate keeping admin-only help docs out of a non-admin user's Help AI
+ * chat answers - apps/client/server/help/retrieval.ts filters on it in both retrieval paths
+ * (embeddings chunks in the vector search, index entries in the keyword fallback). Every other
+ * guard on these artifacts compares slug SETS, so an artifact with chunks relabeled 'public' was
+ * byte-indistinguishable from a correct one as far as CI was concerned.
+ *
+ * Each case builds a throwaway repo under the OS temp dir holding only the two generated
+ * artifacts and runs the real script against it, so the assertions cover the shipped shell rather
+ * than a reimplementation. Same shape as checkNoSmartPunctuation.test.ts. Assertions match ASCII
+ * substrings of the script's output, because CLAUDE.md keeps this file ASCII-only while the
+ * script's own report uses glyphs.
+ *
+ * The pre-existing "every indexed article has a vector" and fail-closed-on-malformed assertions
+ * are pinned here too - the accessLevel checks were added alongside them and must not displace
+ * them.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const GUARD = path.join(REPO_ROOT, '.husky', 'check-help-content.sh');
+const GENERATED_DIR = path.join('apps', 'client', 'app', 'generated');
+
+/** One record of either artifact: an index entry or an embeddings chunk. */
+type HelpRecord = { slug: string; accessLevel?: string; sectionPath?: string };
+
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  while (sandboxes.length) fs.rmSync(sandboxes.pop()!, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+/**
+ * A repo holding just the two artifacts the script reads. It resolves them from relative paths,
+ * so cwd is what selects the fixtures over the real ones. A git repo rather than a bare
+ * directory because the script opens with `git diff --cached` for its staleness warning.
+ */
+function makeSandbox(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'help-level-guard-'));
+  sandboxes.push(dir);
+  git(dir, 'init', '-q', '.');
+  git(dir, 'config', 'user.email', 'test@example.test');
+  git(dir, 'config', 'user.name', 'test');
+  fs.mkdirSync(path.join(dir, GENERATED_DIR), { recursive: true });
+  return dir;
+}
+
+function writeArtifacts(dir: string, entries: Array<Partial<HelpRecord>>, chunks: Array<Partial<HelpRecord>>) {
+  writeRaw(dir, 'help-index.json', JSON.stringify({ entries }));
+  writeRaw(dir, 'help-embeddings.json', JSON.stringify({ chunks }));
+}
+
+function writeRaw(dir: string, name: string, contents: string) {
+  fs.writeFileSync(path.join(dir, GENERATED_DIR, name), contents, 'utf8');
+}
+
+/** `sh`, matching both entry points: .husky/pre-commit and the three ci.yml invocations. */
+function runGuard(cwd: string) {
+  const r = spawnSync('sh', [GUARD], { cwd, encoding: 'utf8' });
+  if (r.error) throw r.error; // a spawn failure is not a guard verdict; surface it as such
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+const chunk = (slug: string, accessLevel: string, sectionPath = 'Section'): HelpRecord => ({
+  slug,
+  accessLevel,
+  sectionPath,
+});
+const entry = (slug: string, accessLevel: string): HelpRecord => ({ slug, accessLevel });
+
+describe('check-help-content.sh accessLevel parity', () => {
+  it('passes on artifacts that agree', () => {
+    const dir = makeSandbox();
+    writeArtifacts(
+      dir,
+      [entry('features/foo', 'public'), entry('admin/bar', 'admin')],
+      [chunk('features/foo', 'public'), chunk('admin/bar', 'admin')]
+    );
+    expect(runGuard(dir).status).toBe(0);
+  });
+
+  it('passes against the real committed artifacts', () => {
+    // The false positive that would matter most: an assertion that blocks every commit in the
+    // repo. Runs the shipped script over the shipped artifacts, which is what CI does.
+    expect(runGuard(REPO_ROOT).status).toBe(0);
+  });
+
+  it("fails when a chunk's accessLevel disagrees with its index entry", () => {
+    const dir = makeSandbox();
+    writeArtifacts(dir, [entry('features/foo', 'public')], [chunk('features/foo', 'admin')]);
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    // Both sides named, so the reader can tell which artifact drifted.
+    expect(r.stdout).toContain('features/foo: embeddings say admin, index says public');
+  });
+
+  it('fails when a chunk has no index entry at all', () => {
+    // The direction the pre-existing check does not cover: it asserts index -> embeddings, and at
+    // runtime an unindexed chunk is still scored and served on its own accessLevel.
+    const dir = makeSandbox();
+    writeArtifacts(
+      dir,
+      [entry('features/foo', 'public')],
+      [chunk('features/foo', 'public'), chunk('features/ghost', 'public')]
+    );
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('features/ghost: has no help-index.json entry');
+  });
+
+  it('fails an admin article labeled public even when both artifacts agree', () => {
+    // Parity alone sees nothing here - the artifacts agree, on the wrong level. This is the
+    // shape a full regenerate against a tampered index would produce.
+    const dir = makeSandbox();
+    writeArtifacts(dir, [entry('admin/bar', 'public')], [chunk('admin/bar', 'public')]);
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('admin/bar in help-index.json: accessLevel is public, expected admin');
+    expect(r.stdout).toContain('admin/bar in help-embeddings.json: accessLevel is public, expected admin');
+  });
+
+  it('fails a bare "admin" slug labeled public, which an admin/ prefix test would miss', () => {
+    // vectorize-help-content.ts collapses a directory index to the directory itself, so a
+    // docs-site/docs/admin/index.md yields the slug 'admin' - no trailing slash to match. Pins
+    // the top-path-segment comparison against a refactor back to startsWith('admin/').
+    const dir = makeSandbox();
+    writeArtifacts(dir, [entry('admin', 'public')], [chunk('admin', 'public')]);
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('admin in help-index.json: accessLevel is public, expected admin');
+  });
+
+  it('allows a features article labeled admin, the over-restrictive direction', () => {
+    // Deliberately out of scope: the category rule covers only the direction that leaks. Fully
+    // validating the index's own levels against CATEGORY_ACCESS_LEVELS would mean duplicating
+    // that table into shell-embedded JS, and belongs with a rebuild-and-compare harness.
+    const dir = makeSandbox();
+    writeArtifacts(dir, [entry('features/foo', 'admin')], [chunk('features/foo', 'admin')]);
+    expect(runGuard(dir).status).toBe(0);
+  });
+
+  it('reports a mislabeled article once with a chunk count, not once per chunk', () => {
+    // A real article has dozens of chunks and one remedy. Per-chunk bullets would bury a
+    // whole-artifact relabel under hundreds of near-identical lines.
+    const dir = makeSandbox();
+    writeArtifacts(
+      dir,
+      [entry('features/foo', 'public')],
+      [
+        chunk('features/foo', 'admin', 'One'),
+        chunk('features/foo', 'admin', 'Two'),
+        chunk('features/foo', 'admin', 'Three'),
+      ]
+    );
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('features/foo: embeddings say admin, index says public (3 chunks)');
+  });
+
+  it('names every offending slug, not just the first', () => {
+    const dir = makeSandbox();
+    writeArtifacts(
+      dir,
+      [entry('features/a', 'public'), entry('features/b', 'public')],
+      [chunk('features/a', 'admin'), chunk('features/b', 'admin')]
+    );
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('features/a:');
+    expect(r.stdout).toContain('features/b:');
+  });
+
+  describe('pre-existing assertions still hold', () => {
+    it('still fails when an indexed article has no embeddings', () => {
+      const dir = makeSandbox();
+      writeArtifacts(
+        dir,
+        [entry('features/foo', 'public'), entry('features/novec', 'public')],
+        [chunk('features/foo', 'public')]
+      );
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('Help index has articles with no embeddings');
+    });
+
+    it.each(['help-index.json', 'help-embeddings.json'])('still fails closed on a malformed %s', name => {
+      const dir = makeSandbox();
+      writeArtifacts(dir, [entry('features/foo', 'public')], [chunk('features/foo', 'public')]);
+      writeRaw(dir, name, 'not json');
+      expect(runGuard(dir).status).toBe(1);
+    });
+
+    it.each(['help-index.json', 'help-embeddings.json'])('still fails when %s is missing entirely', name => {
+      const dir = makeSandbox();
+      writeArtifacts(dir, [entry('features/foo', 'public')], [chunk('features/foo', 'public')]);
+      fs.rmSync(path.join(dir, GENERATED_DIR, name));
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('A generated help artifact is missing');
+    });
+  });
+
+  // A record with no slug at all reaches `r.slug.split(...)`. That must throw into the script's
+  // fail-closed wrapper rather than skip the record: an unslugged chunk is unattributable, so
+  // "cannot check" is the only honest verdict. The fixture pairs it with a well-formed chunk
+  // covering the sole index entry, so the earlier slug-set check passes and this block is the
+  // one that decides.
+  it('fails closed on a record with no slug rather than skipping it', () => {
+    const dir = makeSandbox();
+    writeArtifacts(
+      dir,
+      [entry('features/foo', 'public')],
+      [chunk('features/foo', 'public'), { accessLevel: 'public', sectionPath: 'Orphan' }]
+    );
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('Could not compare help accessLevel across the two artifacts');
+  });
+});

--- a/packages/scripts/src/checkHelpContentAccessLevelParity.test.ts
+++ b/packages/scripts/src/checkHelpContentAccessLevelParity.test.ts
@@ -122,6 +122,17 @@ describe('check-help-content.sh accessLevel parity', () => {
     expect(r.stdout).toContain('features/ghost: has no help-index.json entry');
   });
 
+  it('distinguishes an index entry with no accessLevel from a missing entry', () => {
+    // Theoretical today - loadHelpArticles.ts defaults accessLevel at generation time - but a
+    // lone `want === undefined` check would file this under "no index entry", sending the reader
+    // after the wrong artifact. The slug IS indexed; what is missing is the field.
+    const dir = makeSandbox();
+    writeArtifacts(dir, [{ slug: 'features/foo' }], [chunk('features/foo', 'public')]);
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('features/foo: has a help-index.json entry with no accessLevel');
+  });
+
   it('fails an admin article labeled public even when both artifacts agree', () => {
     // Parity alone sees nothing here - the artifacts agree, on the wrong level. This is the
     // shape a full regenerate against a tampered index would produce.


### PR DESCRIPTION
## Description

Closes #2363

`accessLevel` is the only thing keeping admin-only help docs out of a non-admin user's Help AI chat answers. `apps/client/server/help/retrieval.ts` filters on it in both retrieval paths - embeddings chunks in the vector search (`retrieval.ts:130`), index entries in the keyword fallback (`retrieval.ts:223`).

Nothing compared the `accessLevel` written into the committed `help-embeddings.json` against the `help-index.json` it was derived from. Every guard on these artifacts compares slug **sets**: `.husky/check-help-content.sh` built `embSlugs` from `c.slug` and diffed it against `idx.entries`, and the word `accessLevel` appeared zero times in the whole script. So an artifact with chunks relabeled `public` was indistinguishable from a correct one as far as CI was concerned. Relabel every chunk, run every guard that existed, and both pass:

```
node -e "const fs=require('fs'),p='apps/client/app/generated/help-embeddings.json';const e=JSON.parse(fs.readFileSync(p,'utf-8'));e.chunks.forEach(c=>c.accessLevel='public');fs.writeFileSync(p,JSON.stringify(e));"
sh .husky/check-help-content.sh                                   # exit 0
pnpm --filter @bike4mind/scripts exec vitest run help/__tests__   # green
```

Flipping a **single** `admin/*` chunk is enough, and is the realistic shape: a partial regenerate, a hand-edit, or a bad merge resolution on a one-line-JSON artifact.

This was a **latent guard gap, not a live leak.** The committed artifacts are correct today and were verified before and after: 85 index entries (34 admin / 51 public), 703 chunks (251 admin / 452 public), zero disagreements, zero orphans. The follow-up hardening in #2365 made the *generator* fail loudly on an unresolvable slug; what remained open was any assertion on the artifact that actually gets committed and shipped. This PR adds that, and touches no runtime code.

The assertions went into `.husky/check-help-content.sh` rather than a new CI job because that script is already wired into every relevant shape: `core-build` runs it when `deployable == 'true'`, `help-docs` when `docs-changed == 'true'` (an artifacts-only PR is deployable-but-not-docs; a docs-only PR is the reverse), and `check-help-content-guard.yml` covers a diff that touches only the script itself. Extending it inherits all three plus the pre-commit hook - zero new CI wiring, and the developer finds out locally at the moment the artifact is generated.

## Changes

- `.husky/check-help-content.sh`: a second `node -e` block after the existing slug-set one, with its own fail-closed wrapper so a throw cannot read as "no violations". It asserts (1) every chunk's `accessLevel` equals its `help-index.json` entry's, and (2) no slug in the `admin` category carries anything but `admin`, checked on **both** artifacts.
- Requiring the index entry to exist also closes a direction the old check did not cover. It asserted index -> embeddings only ("every indexed article has a vector"), so a chunk whose slug was absent from the index was unguarded - and at runtime such a chunk is still scored and served on its own `accessLevel`.
- The category rule compares the **top path segment**, not an `admin/` prefix. `vectorize-help-content.ts` collapses a directory index to the directory itself, so a future `docs-site/docs/admin/index.md` yields the bare slug `admin`, which `startsWith('admin/')` would wave through. Mirrors `CATEGORY_ACCESS_LEVELS` in `packages/scripts/help/loadHelpArticles.ts`, with a keep-in-sync comment on both.
- Violations are counted per slug rather than listed per chunk. A mislabeled article has dozens of chunks and one remedy, so per-chunk bullets would bury a whole-artifact relabel under hundreds of near-identical lines. Output reads `admin/bar: embeddings say admin, index says public (2 chunks)`.
- `packages/scripts/src/checkHelpContentAccessLevelParity.test.ts`: 15 cases that spawn the **real** script with `sh` against fixture artifacts in a throwaway git repo under the OS temp dir, following the sandbox pattern in `checkNoSmartPunctuation.test.ts` - so the tests cover the shipped shell rather than a reimplementation. The three pre-existing assertions (slug-set, malformed-artifact fail-closed, missing-artifact) each get a pinning test too, so this change cannot displace them unnoticed.

## Guide for Testers

This is a CI/tooling PR with no UI and no runtime code. Everything below is run from a terminal at the repo root on this branch.

1. Run `pnpm install --frozen-lockfile` and then `pnpm turbo:core:build`. Expected: both complete successfully. (Required only if this is a fresh checkout - the `@bike4mind/scripts` test suite cannot import `@bike4mind/*` packages until core is built.)
2. Run `sh .husky/check-help-content.sh`. Expected: no output, and `echo $?` prints `0`. This is the most important check - the guard must not block commits against the real committed artifacts.
3. Run `pnpm --filter @bike4mind/scripts test src/checkHelpContentAccessLevelParity.test.ts`. Expected: `Test Files 1 passed (1)` and `Tests 15 passed (15)`.
4. Now prove the guard catches a real mislabel. Run `node -e "const fs=require('fs'),p='apps/client/app/generated/help-embeddings.json';const e=JSON.parse(fs.readFileSync(p,'utf-8'));const t=e.chunks.find(c=>c.accessLevel==='admin');t.accessLevel='public';fs.writeFileSync(p,JSON.stringify(e));"` to flip exactly one admin chunk to `public`.
5. Run `sh .husky/check-help-content.sh` again. Expected: it exits non-zero and prints `Help artifacts disagree about accessLevel`, followed by a bullet naming the offending slug in the form `admin/<slug>: embeddings say public, index says admin (1 chunk)`.
6. Restore the artifact with `git checkout -- apps/client/app/generated/help-embeddings.json`, then re-run `sh .husky/check-help-content.sh`. Expected: exit `0` again.
7. Now prove the case a naive prefix check would miss. Create a scratch directory, `cd` into it, run `git init -q .`, then `mkdir -p apps/client/app/generated`.
8. In that scratch directory, write the index with `echo '{"entries":[{"slug":"admin","accessLevel":"public"}]}' > apps/client/app/generated/help-index.json` and the embeddings with `echo '{"chunks":[{"slug":"admin","sectionPath":"Admin","accessLevel":"public"}]}' > apps/client/app/generated/help-embeddings.json`. This is the bare `admin` slug a `docs-site/docs/admin/index.md` would produce.
9. From that scratch directory, run the guard by absolute path: `sh /path/to/repo/.husky/check-help-content.sh`. Expected: exit non-zero, printing `admin in help-index.json: accessLevel is public, expected admin` and the same for `help-embeddings.json`. A `slug.startsWith('admin/')` implementation would print nothing and exit 0 here.
10. Delete the scratch directory.

### Regression Checks

11. Run `pnpm --filter @bike4mind/scripts test`. Expected: `572 passed`, with **one** pre-existing failure in `src/checkClientTestShards.test.ts > appends the shard args with no -- separator`. That failure is present on `origin/main`, is unrelated to this PR, and is a real CI regression worth its own fix - see Additional Information. Note that CI does not currently run this package at all, for the same underlying reason, so step 3 above is how the new test gets exercised.
12. Run `pnpm turbo:typecheck`. Expected: 40/40 tasks successful.
13. Run `pnpm lint:check`. Expected: no output.
14. Confirm the pre-existing guard behavior still fires. In a fresh scratch repo set up as in steps 7-8, write an index with an entry that has no matching chunk: `echo '{"entries":[{"slug":"features/foo","accessLevel":"public"},{"slug":"features/novec","accessLevel":"public"}]}' > apps/client/app/generated/help-index.json` and `echo '{"chunks":[{"slug":"features/foo","sectionPath":"Foo","accessLevel":"public"}]}' > apps/client/app/generated/help-embeddings.json`. Run the guard. Expected: exit non-zero with the **original** message `Help index has articles with no embeddings`, not the new one.
15. In that same scratch repo, corrupt an artifact: `echo 'not json' > apps/client/app/generated/help-embeddings.json`. Run the guard. Expected: exit non-zero, with node's own parse error visible followed by `Could not compare the help index against the embeddings`.

### What NOT to test

- There is nothing to click. No client, API, schema, or migration code is touched, and no help content or generated artifact is modified by this PR.
- Do not regenerate the help artifacts to test this. `help:vectorize` needs a live `OPENAI_API_KEY` and would rewrite a 10MB committed file for no benefit; the guard reads the artifacts as committed.
- No preview environment is needed.

## Additional Information

**A pre-existing failure on main that turns out to be a live CI regression - not from this PR, but worth acting on quickly.** `packages/scripts/src/checkClientTestShards.test.ts > appends the shard args with no -- separator` fails on `origin/main` as of `9c7282f4f`. Chasing why revealed the real problem: **the `misc` test shard currently runs zero packages.**

`9c7282f4f` moved the shard selection into the run step's `env:` block and word-splits it (`pnpm --recursive ... $SHARD_FILTER $SHARD_SCRIPT $SHARD_ARGS`). Every other leg's filter is a plain value (`--filter @bike4mind/client`), so word-splitting it is fine. The `misc` leg is the only one whose value carries **embedded single quotes**, because its exclusions need them in YAML: `--filter '!@bike4mind/client' --filter '!@bike4mind/services' ...`. Parameter expansion does not perform quote removal, so bash hands pnpm the literal argument `'!@bike4mind/client'`, quotes included. pnpm reads that as a positive pattern naming a package that does not exist rather than an exclusion, every filter matches nothing, and the leg exits 0 having run nothing at all.

This PR's own CI run is the evidence: `Run Tests (misc)` is green in 1m21s, and its log says `No projects matched the filters`.

That silently drops every package not named in another leg - `@bike4mind/scripts`, `@bike4mind/agents`, `@bike4mind/utils`, `@bike4mind/llm-adapters`, `@bike4mind/observability` and the rest (21 packages select when the filter is quoted correctly). `checkClientTestShards.test.ts` is precisely the guard meant to fail the build when shard wiring breaks, and it lives in `@bike4mind/scripts` - inside the shard that no longer runs - so it cannot fire in CI. Its local failure was the real alarm, and my first reading of it (that only a line-matching heuristic had broken) was wrong.

**What this means for reviewing this PR:** the guard script itself IS exercised in CI - `Help Content Guard` ran it against the real committed artifacts and passed, and `Core Build` runs it too. But `checkHelpContentAccessLevelParity.test.ts` lives in `@bike4mind/scripts`, so **it does not run in CI until the shard is fixed.** It passes locally (`pnpm --filter @bike4mind/scripts test src/checkHelpContentAccessLevelParity.test.ts`, 15/15), and step 3 of the Guide for Testers runs it directly. Not fixed here because it is an unrelated cause in an unrelated file and it deserves a focused PR, not a rider on this one.

**Why the Security Testing section is absent.** This closes a *missing assertion*, not a live vulnerability. There is nothing to reproduce on staging: the committed artifacts are correct today, and were verified as such before and after the change. The linked issue carries no security label.

**Two known gaps this PR deliberately does not close.**

- Two empty artifacts (`{"entries":[]}` + `{"chunks":[]}`) still pass the guard - `Array.isArray` is satisfied and there are no violations to find. That is a functional break (the Help AI chat would know nothing) rather than the access-control direction this PR is about, and `loadAccessLevelMap` already rejects an empty `entries[]` at generation time after #2365. Noted rather than fixed, to keep this diff to one concern.
- The over-restrictive direction is allowed on purpose: a `features/*` slug labeled `admin` in **both** artifacts passes, and there is an explicit test asserting that with a comment explaining why. Validating the index's own levels against `CATEGORY_ACCESS_LEVELS` in full would mean duplicating that table into shell-embedded JS (the script cannot import TS), and belongs with a rebuild-and-compare harness rather than here. The direction that leaks is covered.

**Separate, non-hypothetical finding worth its own issue.** `bundle-help-content.ts` copies **every** index entry into `apps/client/public/help-content/` with no `accessLevel` filter (`helpIndex.entries.map(entry => entry.filePath)`), so admin help markdown and its media appear to land in Next's public static directory, fetchable unauthenticated at `/help-content/admin/<slug>.md`. Same security boundary as this PR, different mechanism. The directory is gitignored and generated at build time, so it does not show up in the repo. Not investigated further here and out of scope for this PR, but unlike the gap this PR closes, that one is not theoretical.

## Developer Notes

- **The sandbox pattern now has a second user.** `checkHelpContentAccessLevelParity.test.ts` reuses the approach from `checkNoSmartPunctuation.test.ts`: build a throwaway git repo under the OS temp dir, run the shipped shell against it, assert on exit status and reported text. It generalizes to any `.husky/`-or-`scripts/` guard whose inputs are files, and it is the reason these tests can claim to cover the shipped script rather than a parallel reimplementation of its logic. The one wrinkle worth copying: the fixtures are selected by **cwd**, because the script resolves the artifacts from relative paths.
- **Two node blocks, not one, is deliberate.** The second re-reads both artifacts rather than folding into the first. It can safely assume they parse and hold the expected shape, because the first block exits non-zero otherwise - and in exchange each assertion keeps its own diagnosis and its own remedy (`help:bundle-content` + `help:vectorize` for a missing vector, `help:regenerate` for a level disagreement). The re-read of the 10MB artifact costs about 50ms.
- **Fail-closed is the house style in this script now.** Both node blocks use `if ! VAR=$(node -e "...")` so a throw fails the check rather than yielding an empty result that reads downstream as "nothing wrong". That shape is what the earlier `2>/dev/null || true` fix established, and any third assertion added here should follow it.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, the guard's rationale lives in comments beside it
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry
