### PR TITLE
fix(ci): resolve the merge_group diff range in the changes filter

### DIFF
--- a/.github/actions/changes-filter/README.md
+++ b/.github/actions/changes-filter/README.md
@@ -35,7 +35,10 @@ a code+docs PR is `true, true`; a `.changeset` or root-`README` change is
   semantics — not the per-push `before..after` range. Without this, a synchronize
   that also merges/rebases `main` in would carry all of main's deployable files and
   force a spurious deploy of a docs-only PR. `push` to main/prod keeps the per-push
-  range (no PR to scope to).
+  range (no PR to scope to), and `merge_group` uses the queue group's own
+  `base_sha..head_sha` — the whole batch's diff, which is the unit a queue run
+  tests. `base_sha` is by construction an ancestor of `head_sha`, so two-dot already
+  equals three-dot there and no `merge-base` call is needed.
 - **No third-party trust surface.** ~40 lines of `git diff`; nothing to SHA-pin or
   audit (cf. the 2025 `tj-actions/changed-files` supply-chain incident).
 
@@ -96,3 +99,15 @@ Every uncertain state resolves to "deploy + build docs": unresolved diff range
 `docs-changed=true`. A `changes` job that crashed without writing outputs would
 look identical to a skip to the downstream `if:` checks, so failing open trades one
 unnecessary deploy for never silently dropping one.
+
+That posture only holds for a *one-off* unresolved range. An event with no arm in the
+action's `case "$EVENT_NAME"` block fails open on **every** run of that trigger, and
+the run looks entirely normal — nothing errors, some extra jobs just run. That is what
+`merge_group` did before it was handled: the merge queue evaluated
+`deployable=true, docs-changed=true` unconditionally and so gated on a different signal
+than the PR's own CI, which lets a queue run fail a leg the PR legitimately skipped.
+`packages/scripts/src/checkChangesFilterEvents.test.ts` therefore cross-checks `ci.yml`'s
+trigger list against the arms, and checks that each arm's SHAs are actually plumbed
+through the step's `env:` block (an arm alone reads unset vars and fails open
+identically). Letting an event fail open on purpose is fine — write the arm explicitly
+(`BASE=""; HEAD=""`) so the choice is visible rather than inherited.

--- a/.github/actions/changes-filter/README.md
+++ b/.github/actions/changes-filter/README.md
@@ -35,10 +35,12 @@ a code+docs PR is `true, true`; a `.changeset` or root-`README` change is
   semantics — not the per-push `before..after` range. Without this, a synchronize
   that also merges/rebases `main` in would carry all of main's deployable files and
   force a spurious deploy of a docs-only PR. `push` to main/prod keeps the per-push
-  range (no PR to scope to), and `merge_group` uses the queue group's own
-  `base_sha..head_sha` — the whole batch's diff, which is the unit a queue run
-  tests. `base_sha` is by construction an ancestor of `head_sha`, so two-dot already
-  equals three-dot there and no `merge-base` call is needed.
+  range (no PR to scope to), and `merge_group` uses the queue entry's own
+  `base_sha..head_sha`, which is that entry's own change rather than the whole batch:
+  `base_sha` is the commit the entry was built on (the target-branch tip, or the
+  previous entry's speculative head in a stacked group), so each queue entry is gated on
+  exactly the diff its own PR CI evaluated. That also makes `base_sha` an ancestor of
+  `head_sha`, so two-dot already equals three-dot there and no `merge-base` call is needed.
 - **No third-party trust surface.** ~40 lines of `git diff`; nothing to SHA-pin or
   audit (cf. the 2025 `tj-actions/changed-files` supply-chain incident).
 
@@ -107,7 +109,7 @@ the run looks entirely normal — nothing errors, some extra jobs just run. That
 `deployable=true, docs-changed=true` unconditionally and so gated on a different signal
 than the PR's own CI, which lets a queue run fail a leg the PR legitimately skipped.
 `packages/scripts/src/checkChangesFilterEvents.test.ts` therefore cross-checks `ci.yml`'s
-trigger list against the arms, and checks that each arm's SHAs are actually plumbed
-through the step's `env:` block (an arm alone reads unset vars and fails open
-identically). Letting an event fail open on purpose is fine — write the arm explicitly
-(`BASE=""; HEAD=""`) so the choice is visible rather than inherited.
+trigger list against the arms, and checks that each arm's SHAs are both declared in the
+step's `env:` block and bound to that event's own payload (an arm alone reads unset vars
+and fails open identically). Letting an event fail open on purpose is fine — write the arm
+explicitly (`BASE=""; HEAD=""`) so the choice is visible rather than inherited.

--- a/.github/actions/changes-filter/README.md
+++ b/.github/actions/changes-filter/README.md
@@ -104,12 +104,14 @@ unnecessary deploy for never silently dropping one.
 
 That posture only holds for a *one-off* unresolved range. An event with no arm in the
 action's `case "$EVENT_NAME"` block fails open on **every** run of that trigger, and
-the run looks entirely normal — nothing errors, some extra jobs just run. That is what
+the run looks entirely normal - nothing errors, some extra jobs just run. That is what
 `merge_group` did before it was handled: the merge queue evaluated
 `deployable=true, docs-changed=true` unconditionally and so gated on a different signal
 than the PR's own CI, which lets a queue run fail a leg the PR legitimately skipped.
 `packages/scripts/src/checkChangesFilterEvents.test.ts` therefore cross-checks `ci.yml`'s
-trigger list against the arms, and checks that each arm's SHAs are both declared in the
-step's `env:` block and bound to that event's own payload (an arm alone reads unset vars
-and fails open identically). Letting an event fail open on purpose is fine — write the arm
+trigger list against the arms, and checks that each arm's SHAs are declared in the
+step's `env:` block, bound to that event's own payload, and bound to the end of the range
+their names claim (an arm alone reads unset vars and fails open identically; a base bound
+to a head fails closed, which is worse - the diff is empty and the legs the gate should
+trigger are skipped instead). Letting an event fail open on purpose is fine - write the arm
 explicitly (`BASE=""; HEAD=""`) so the choice is visible rather than inherited.

--- a/.github/actions/changes-filter/action.yml
+++ b/.github/actions/changes-filter/action.yml
@@ -129,11 +129,12 @@ runs:
             HEAD="$PR_HEAD_SHA"
             BASE="$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA" 2>/dev/null || true)" ;;
           merge_group)
-            # Merge-queue run: the group's own base..head. base_sha is by construction
-            # the base-branch commit the group was built on, so it is an ancestor of
-            # head_sha and two-dot already equals three-dot - no merge-base needed.
-            # The range covers the whole BATCH (any PRs queued ahead of this one too),
-            # which is the right unit: a queue run tests the speculative merge, not one PR.
+            # Merge-queue run: this entry's own base..head. base_sha is the commit this
+            # entry was built on (target-branch tip, or the previous entry's speculative
+            # head in a stacked group), so it is an ancestor of head_sha and two-dot
+            # equals three-dot. The range is this entry's own change: each queue entry is
+            # gated on exactly the diff its own PR CI evaluated, and a trailing entry that
+            # is wholly non-deployable skips the build legs - the batch is not re-tested.
             BASE="$MERGE_GROUP_BASE_SHA"; HEAD="$MERGE_GROUP_HEAD_SHA" ;;
           *)
             BASE=""; HEAD="" ;;

--- a/.github/actions/changes-filter/action.yml
+++ b/.github/actions/changes-filter/action.yml
@@ -3,16 +3,23 @@ description: >-
   Decide whether a workflow run touched deployable paths, and (separately)
   whether it touched the Docusaurus docs site. Evaluates the whole-PR diff vs
   its merge-base with the target branch on every pull_request event (the
-  "Files changed" three-dot semantics), and the push range on push. Returns
-  deployable=false only when every changed file matches the non-deployable
-  pathspec list; returns docs-changed=true when any changed file is under
-  docs-site/. Fails open (deployable=true) when the diff range can't be
-  resolved.
+  "Files changed" three-dot semantics), the push range on push, and the
+  queue group's base..head range on merge_group. Returns deployable=false only
+  when every changed file matches the non-deployable pathspec list; returns
+  docs-changed=true when any changed file is under docs-site/. Fails open
+  (deployable=true) when the diff range can't be resolved.
 
   PR events use the merge-base (not the per-push before..after range) so a
   docs-only PR stays non-deployable even on a push that also merges/rebases
   the base branch in - that range would otherwise carry all of main's
   deployable files and force a spurious deploy.
+
+  Every event ci.yml triggers on needs its own arm in the case block below.
+  An unhandled event falls through to the fail-open default on EVERY run of
+  that trigger, so the gate it produces diverges from the one the same content
+  got elsewhere - merge_group did exactly that until it was handled. The arms
+  are cross-checked against ci.yml's trigger list by
+  packages/scripts/src/checkChangesFilterEvents.test.ts.
 
   Requires the repo to be checked out first with fetch-depth: 0.
 
@@ -79,6 +86,11 @@ runs:
         PUSH_AFTER: ${{ github.event.after }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        # github.sha IS the merge-group head on this event, so the fallback is redundant when
+        # head_sha is present and the difference between a correct range and a permanent
+        # fail-open when it is not.
+        MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
         DOCS_PATHS: ${{ inputs.docs-paths }}
       run: |
@@ -116,6 +128,13 @@ runs:
             # An empty BASE (merge-base failed) trips the fail-open guard below.
             HEAD="$PR_HEAD_SHA"
             BASE="$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA" 2>/dev/null || true)" ;;
+          merge_group)
+            # Merge-queue run: the group's own base..head. base_sha is by construction
+            # the base-branch commit the group was built on, so it is an ancestor of
+            # head_sha and two-dot already equals three-dot - no merge-base needed.
+            # The range covers the whole BATCH (any PRs queued ahead of this one too),
+            # which is the right unit: a queue run tests the speculative merge, not one PR.
+            BASE="$MERGE_GROUP_BASE_SHA"; HEAD="$MERGE_GROUP_HEAD_SHA" ;;
           *)
             BASE=""; HEAD="" ;;
         esac

--- a/packages/scripts/src/checkChangesFilterEvents.test.ts
+++ b/packages/scripts/src/checkChangesFilterEvents.test.ts
@@ -228,8 +228,9 @@ describe('readCaseArms', () => {
     expect(arms.map(arm => arm.labels)).toEqual([['push']]);
   });
 
-  // The pre-fix shape: push and pull_request handled, merge_group left to the default arm. This is
-  // the exact state the cross-check above exists to fail on.
+  // The pre-fix shape: push and pull_request handled, merge_group left to the default arm. This
+  // pins how readCaseArms reports that shape - it rebuilds the comparison rather than calling it,
+  // so the guard itself is asserted only by the live cross-check above, against the real files.
   it('reports merge_group as unhandled when only push and pull_request have arms', () => {
     const arms = readCaseArms(
       dispatch(

--- a/packages/scripts/src/checkChangesFilterEvents.test.ts
+++ b/packages/scripts/src/checkChangesFilterEvents.test.ts
@@ -112,14 +112,12 @@ function readEnvRefs(body: string): string[] {
 }
 
 /**
- * Names assigned inside the dispatch itself (BASE, HEAD). Subtracted from the env-plumbing check
- * so an arm reading a value another arm set is not mistaken for a missing env var.
+ * The only names the dispatch sets for itself; everything else an arm reads must come from the
+ * step's `env:` block. Spelled out rather than derived from the assignments in the block: that
+ * inference let one self-defaulting line exempt a name from the plumbing check for good, which is
+ * the failure this file exists to catch. A genuine third local fails loudly here and gets added.
  */
-function readAssignedNames(contents: string): string[] {
-  const block = /case\s+"\$EVENT_NAME"\s+in\n([\s\S]*?)\n\s*esac/.exec(contents);
-  if (!block) return [];
-  return [...block[1].matchAll(/(?:^|;)\s*([A-Z_][A-Z0-9_]*)=/gm)].map(match => match[1]);
-}
+const DISPATCH_LOCALS = new Set(['BASE', 'HEAD']);
 
 describe('changes-filter event dispatch vs ci.yml triggers', () => {
   const ci = fs.readFileSync(CI_WORKFLOW, 'utf8');
@@ -155,10 +153,9 @@ describe('changes-filter event dispatch vs ci.yml triggers', () => {
 
   it('plumbs every env var the arms read through the step env block', () => {
     const declared = new Set(readStepEnvKeys(action));
-    const assigned = new Set(readAssignedNames(action));
     const missing = arms
       .flatMap(arm => readEnvRefs(arm.body))
-      .filter(name => !declared.has(name) && !assigned.has(name));
+      .filter(name => !declared.has(name) && !DISPATCH_LOCALS.has(name));
     expect(
       [...new Set(missing)],
       "vars read by a case arm but absent from the step's `env:` block; they expand empty and fail open"

--- a/packages/scripts/src/checkChangesFilterEvents.test.ts
+++ b/packages/scripts/src/checkChangesFilterEvents.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Cross-check ci.yml's trigger list against the changes-filter action's event dispatch.
+ *
+ * The action picks its diff range from a `case "$EVENT_NAME"` block, and falls through to a `*)`
+ * arm that blanks the range - which trips the action's own fail-open guard and forces
+ * deployable=true + docs-changed=true. That is the right call for a genuinely unresolvable range
+ * (force-push, brand-new branch). It is the wrong call for an event that simply has no arm,
+ * because then EVERY run of that trigger fails open, permanently, and the run looks entirely
+ * normal: nothing errors, some extra jobs just run. `merge_group` sat in that state, so the merge
+ * queue gated on a different signal than the PR's own CI - a queue run could fail a leg the PR
+ * legitimately skipped, ejecting the PR with no reproduction on the author's branch.
+ *
+ * Nothing else can catch this. The action only ever executes inside a real workflow run, and the
+ * `merge_group` path specifically cannot be reached from a `pull_request` run, so the PR that adds
+ * a trigger to ci.yml is green regardless of what the action does with it. Hence a static
+ * cross-check: every trigger ci.yml declares must have its own arm, and every env var an arm reads
+ * must actually be plumbed into the step's `env:` block. That second half is not redundant - an
+ * arm on its own is a no-op, reading unset variables and failing open exactly as before.
+ *
+ * Deliberately letting an event fail open is still allowed: write the arm explicitly
+ * (`BASE=""; HEAD=""`) so the decision is visible in the action rather than inherited by silence.
+ *
+ * Text-matched rather than YAML-parsed on purpose - the repo carries no YAML parser dependency,
+ * and the assertion wanted is over literal mapping keys and shell arm labels anyway.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const CI_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+const CHANGES_FILTER = path.join(REPO_ROOT, '.github', 'actions', 'changes-filter', 'action.yml');
+
+/**
+ * Top-level event names from a workflow's `on:` block.
+ *
+ * Requires the block-mapping form (`on:` on its own line, trigger keys two spaces in). The
+ * flow-sequence form (`on: [push, pull_request]`) yields nothing, which the "non-empty" test below
+ * turns into a loud failure rather than a guard that silently passes over an unparsed block.
+ * Comment lines are skipped instead of ending the block, so a column-0 comment inside `on:` cannot
+ * truncate the list either.
+ */
+function readWorkflowTriggers(contents: string): string[] {
+  const lines = contents.split('\n');
+  const start = lines.findIndex(line => /^on:\s*$/.test(line));
+  if (start === -1) return [];
+
+  const triggers: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*#/.test(line)) continue;
+    if (/^\S/.test(line)) break;
+    const match = /^ {2}([a-z_]+):/.exec(line);
+    if (match) triggers.push(match[1]);
+  }
+  return triggers;
+}
+
+/**
+ * Arms of the action's `case "$EVENT_NAME"` dispatch, each with its labels and body lines.
+ *
+ * Comment lines are dropped before labels are matched. The sibling shard guard learned this the
+ * hard way in reverse: prose that happens to fit the pattern must not count as a declaration, and
+ * these arms carry several paragraphs of it.
+ */
+function readCaseArms(contents: string): Array<{ labels: string[]; body: string }> {
+  const block = /case\s+"\$EVENT_NAME"\s+in\n([\s\S]*?)\n\s*esac/.exec(contents);
+  if (!block) return [];
+
+  const arms: Array<{ labels: string[]; body: string }> = [];
+  for (const line of block[1].split('\n')) {
+    if (/^\s*#/.test(line)) continue;
+    const label = /^\s*([a-z_*]+(?:\|[a-z_*]+)*)\)/.exec(line);
+    if (label) {
+      arms.push({ labels: label[1].split('|'), body: `${line}\n` });
+    } else if (arms.length > 0) {
+      arms[arms.length - 1].body += `${line}\n`;
+    }
+  }
+  return arms;
+}
+
+/** Env keys declared on the composite step (6-space `env:`, keys 8 spaces in). */
+function readStepEnvKeys(contents: string): string[] {
+  const lines = contents.split('\n');
+  const start = lines.findIndex(line => /^ {6}env:\s*$/.test(line));
+  if (start === -1) return [];
+
+  const keys: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*#/.test(line)) continue;
+    const match = /^ {8}([A-Z_][A-Z0-9_]*):/.exec(line);
+    if (!match) break;
+    keys.push(match[1]);
+  }
+  return keys;
+}
+
+/** Shell variable names an arm body reads, as `$NAME` or `${NAME}`. */
+function readEnvRefs(body: string): string[] {
+  return [...body.matchAll(/\$\{?([A-Z_][A-Z0-9_]*)\}?/g)].map(match => match[1]);
+}
+
+/**
+ * Names assigned inside the dispatch itself (BASE, HEAD). Subtracted from the env-plumbing check
+ * so an arm reading a value another arm set is not mistaken for a missing env var.
+ */
+function readAssignedNames(contents: string): string[] {
+  const block = /case\s+"\$EVENT_NAME"\s+in\n([\s\S]*?)\n\s*esac/.exec(contents);
+  if (!block) return [];
+  return [...block[1].matchAll(/(?:^|;)\s*([A-Z_][A-Z0-9_]*)=/gm)].map(match => match[1]);
+}
+
+describe('changes-filter event dispatch vs ci.yml triggers', () => {
+  const ci = fs.readFileSync(CI_WORKFLOW, 'utf8');
+  const action = fs.readFileSync(CHANGES_FILTER, 'utf8');
+  const triggers = readWorkflowTriggers(ci);
+  const arms = readCaseArms(action);
+  const handled = new Set(arms.flatMap(arm => arm.labels));
+
+  it('parses a non-empty trigger list out of ci.yml', () => {
+    expect(triggers, "no triggers parsed from ci.yml's `on:` block").not.toHaveLength(0);
+  });
+
+  it('parses a non-empty case block out of the action', () => {
+    expect(arms, "no arms parsed from the action's $EVENT_NAME dispatch").not.toHaveLength(0);
+  });
+
+  it('gives every event ci.yml triggers on its own arm', () => {
+    expect(
+      triggers.filter(trigger => !handled.has(trigger)),
+      'ci.yml triggers with no arm in the changes-filter case block; each one fails open on every run of that trigger'
+    ).toEqual([]);
+  });
+
+  it('keeps the fail-open default arm as the safety net', () => {
+    expect(handled.has('*'), 'the `*)` arm is what catches an event nobody anticipated').toBe(true);
+  });
+
+  it('plumbs every env var the arms read through the step env block', () => {
+    const declared = new Set(readStepEnvKeys(action));
+    const assigned = new Set(readAssignedNames(action));
+    const missing = arms
+      .flatMap(arm => readEnvRefs(arm.body))
+      .filter(name => !declared.has(name) && !assigned.has(name));
+    expect(
+      [...new Set(missing)],
+      "vars read by a case arm but absent from the step's `env:` block; they expand empty and fail open"
+    ).toEqual([]);
+  });
+});
+
+describe('readWorkflowTriggers', () => {
+  it('reads the trigger keys and ignores their nested config', () => {
+    const triggers = readWorkflowTriggers(
+      ['on:', '  push:', '    branches: [main]', '  merge_group:', '    branches: [main]', '', 'env:', '  X: 1'].join(
+        '\n'
+      )
+    );
+    expect(triggers).toEqual(['push', 'merge_group']);
+  });
+
+  it('ignores comments inside the block instead of stopping at them', () => {
+    const triggers = readWorkflowTriggers(
+      ['on:', '  push:', '# a column-0 comment', '  merge_group:', 'env:'].join('\n')
+    );
+    expect(triggers).toEqual(['push', 'merge_group']);
+  });
+
+  it('stops at the next top-level key', () => {
+    expect(readWorkflowTriggers(['on:', '  push:', 'jobs:', '  build:'].join('\n'))).toEqual(['push']);
+  });
+
+  it('finds nothing in the flow-sequence form, so the non-empty assertion fires', () => {
+    expect(readWorkflowTriggers('on: [push, pull_request]\n')).toEqual([]);
+  });
+});
+
+describe('readCaseArms', () => {
+  const dispatch = (...lines: string[]) => ['        case "$EVENT_NAME" in', ...lines, '        esac'].join('\n');
+
+  it('reads labels and bodies', () => {
+    const arms = readCaseArms(
+      dispatch('          push)', '            BASE="$PUSH_BEFORE" ;;', '          *)', '            BASE="" ;;')
+    );
+    expect(arms.map(arm => arm.labels)).toEqual([['push'], ['*']]);
+    expect(arms[0].body).toContain('PUSH_BEFORE');
+  });
+
+  it('splits an alternation label into both events', () => {
+    const arms = readCaseArms(dispatch('          push|merge_group)', '            BASE="$X" ;;'));
+    expect(arms[0].labels).toEqual(['push', 'merge_group']);
+  });
+
+  it('does not count a label-shaped phrase inside a comment as an arm', () => {
+    const arms = readCaseArms(
+      dispatch('          # merge_group) used to be missing here', '          push)', '            BASE="$X" ;;')
+    );
+    expect(arms.map(arm => arm.labels)).toEqual([['push']]);
+  });
+
+  // The pre-fix shape: push and pull_request handled, merge_group left to the default arm. This is
+  // the exact state the cross-check above exists to fail on.
+  it('reports merge_group as unhandled when only push and pull_request have arms', () => {
+    const arms = readCaseArms(
+      dispatch(
+        '          push)',
+        '            BASE="$PUSH_BEFORE" ;;',
+        '          pull_request)',
+        '            BASE="$PR_BASE_SHA" ;;',
+        '          *)',
+        '            BASE=""; HEAD="" ;;'
+      )
+    );
+    const handled = new Set(arms.flatMap(arm => arm.labels));
+    expect(handled.has('merge_group')).toBe(false);
+  });
+
+  it('finds nothing when the dispatch is absent', () => {
+    expect(readCaseArms('runs:\n  using: composite\n')).toEqual([]);
+  });
+});
+
+describe('readStepEnvKeys', () => {
+  it('reads the step env keys and stops at the next step key', () => {
+    const keys = readStepEnvKeys(
+      [
+        '    - id: filter',
+        '      env:',
+        '        EVENT_NAME: ${{ github.event_name }}',
+        '        PUSH_BEFORE: ${{ github.event.before }}',
+        '      run: |',
+        '        set -euo pipefail',
+      ].join('\n')
+    );
+    expect(keys).toEqual(['EVENT_NAME', 'PUSH_BEFORE']);
+  });
+});
+
+describe('readEnvRefs', () => {
+  it('picks up both the bare and braced forms and skips lowercase locals', () => {
+    expect(readEnvRefs('BASE="$MERGE_GROUP_BASE_SHA"; HEAD="${MERGE_GROUP_HEAD_SHA}"; x="$local"')).toEqual([
+      'MERGE_GROUP_BASE_SHA',
+      'MERGE_GROUP_HEAD_SHA',
+    ]);
+  });
+});

--- a/packages/scripts/src/checkChangesFilterEvents.test.ts
+++ b/packages/scripts/src/checkChangesFilterEvents.test.ts
@@ -19,8 +19,9 @@ import path from 'node:path';
  * `merge_group` path specifically cannot be reached from a `pull_request` run, so the PR that adds
  * a trigger to ci.yml is green regardless of what the action does with it. Hence a static
  * cross-check: every trigger ci.yml declares must have its own arm, and every env var an arm reads
- * must actually be plumbed into the step's `env:` block. That second half is not redundant - an
- * arm on its own is a no-op, reading unset variables and failing open exactly as before.
+ * must be plumbed into the step's `env:` block and bound to that event's own payload. That second
+ * half is not redundant - an arm on its own is a no-op, reading unset variables and failing open
+ * exactly as before.
  *
  * Deliberately letting an event fail open is still allowed: write the arm explicitly
  * (`BASE=""; HEAD=""`) so the decision is visible in the action rather than inherited by silence.
@@ -80,20 +81,29 @@ function readCaseArms(contents: string): Array<{ labels: string[]; body: string 
   return arms;
 }
 
-/** Env keys declared on the composite step (6-space `env:`, keys 8 spaces in). */
-function readStepEnvKeys(contents: string): string[] {
+/**
+ * Env bindings declared on the composite step, as key -> value expression (6-space `env:`, keys 8
+ * spaces in). The value is half the contract: a key bound to another event's payload is declared
+ * yet still expands empty on the event whose arm reads it.
+ */
+function readStepEnvBindings(contents: string): Array<{ key: string; value: string }> {
   const lines = contents.split('\n');
   const start = lines.findIndex(line => /^ {6}env:\s*$/.test(line));
   if (start === -1) return [];
 
-  const keys: string[] = [];
+  const bindings: Array<{ key: string; value: string }> = [];
   for (const line of lines.slice(start + 1)) {
     if (/^\s*#/.test(line)) continue;
-    const match = /^ {8}([A-Z_][A-Z0-9_]*):/.exec(line);
+    const match = /^ {8}([A-Z_][A-Z0-9_]*):\s*(.*)$/.exec(line);
     if (!match) break;
-    keys.push(match[1]);
+    bindings.push({ key: match[1], value: match[2].trim() });
   }
-  return keys;
+  return bindings;
+}
+
+/** Env keys declared on the composite step (6-space `env:`, keys 8 spaces in). */
+function readStepEnvKeys(contents: string): string[] {
+  return readStepEnvBindings(contents).map(binding => binding.key);
 }
 
 /** Shell variable names an arm body reads, as `$NAME` or `${NAME}`. */
@@ -135,6 +145,12 @@ describe('changes-filter event dispatch vs ci.yml triggers', () => {
 
   it('keeps the fail-open default arm as the safety net', () => {
     expect(handled.has('*'), 'the `*)` arm is what catches an event nobody anticipated').toBe(true);
+
+    const fallback = arms.find(arm => arm.labels.includes('*'));
+    const blanksRange =
+      'the `*)` safety net must blank the range, not just exist; any other range diffs the wrong commits';
+    expect(fallback?.body, blanksRange).toMatch(/BASE=""/);
+    expect(fallback?.body, blanksRange).toMatch(/HEAD=""/);
   });
 
   it('plumbs every env var the arms read through the step env block', () => {
@@ -146,6 +162,19 @@ describe('changes-filter event dispatch vs ci.yml triggers', () => {
     expect(
       [...new Set(missing)],
       "vars read by a case arm but absent from the step's `env:` block; they expand empty and fail open"
+    ).toEqual([]);
+  });
+
+  it("binds each event's SHA vars to that event's own payload", () => {
+    const misbound = readStepEnvBindings(action).filter(({ key, value }) => {
+      if (key.startsWith('MERGE_GROUP_')) return !value.includes('github.event.merge_group.');
+      if (key.startsWith('PR_')) return !value.includes('github.event.pull_request.');
+      if (key.startsWith('PUSH_')) return !/github\.event\.(before|after)/.test(value);
+      return false;
+    });
+    expect(
+      misbound.map(({ key, value }) => `${key}: ${value}`),
+      "env keys wired to another event's payload; declared, but empty on the event whose arm reads them"
     ).toEqual([]);
   });
 });
@@ -218,6 +247,26 @@ describe('readCaseArms', () => {
 
   it('finds nothing when the dispatch is absent', () => {
     expect(readCaseArms('runs:\n  using: composite\n')).toEqual([]);
+  });
+});
+
+describe('readStepEnvBindings', () => {
+  it('pairs each key with its value expression and stops at the next step key', () => {
+    const bindings = readStepEnvBindings(
+      [
+        '    - id: filter',
+        '      env:',
+        '        EVENT_NAME: ${{ github.event_name }}',
+        '        # a comment between keys does not end the block',
+        '        MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}',
+        '      run: |',
+        '        set -euo pipefail',
+      ].join('\n')
+    );
+    expect(bindings).toEqual([
+      { key: 'EVENT_NAME', value: '${{ github.event_name }}' },
+      { key: 'MERGE_GROUP_HEAD_SHA', value: '${{ github.event.merge_group.head_sha || github.sha }}' },
+    ]);
   });
 });
 

--- a/packages/scripts/src/checkChangesFilterEvents.test.ts
+++ b/packages/scripts/src/checkChangesFilterEvents.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 /**
@@ -19,9 +20,14 @@ import path from 'node:path';
  * `merge_group` path specifically cannot be reached from a `pull_request` run, so the PR that adds
  * a trigger to ci.yml is green regardless of what the action does with it. Hence a static
  * cross-check: every trigger ci.yml declares must have its own arm, and every env var an arm reads
- * must be plumbed into the step's `env:` block and bound to that event's own payload. That second
- * half is not redundant - an arm on its own is a no-op, reading unset variables and failing open
- * exactly as before.
+ * must be plumbed into the step's `env:` block, bound to that event's own payload, and bound to the
+ * end of the range its name claims. The plumbing half is not redundant - an arm on its own is a
+ * no-op, reading unset variables and failing open exactly as before. Nor is the binding half:
+ * declaring a key against the wrong payload field fails CLOSED, which is worse still, because an
+ * empty diff skips the very legs the gate exists to trigger and the run again looks normal.
+ *
+ * The trigger list comes from ci.yml because ci.yml is the action's only consumer, which is
+ * asserted here too - a second consumer with its own `on:` block would otherwise be unguarded.
  *
  * Deliberately letting an event fail open is still allowed: write the arm explicitly
  * (`BASE=""; HEAD=""`) so the decision is visible in the action rather than inherited by silence.
@@ -119,6 +125,34 @@ function readEnvRefs(body: string): string[] {
  */
 const DISPATCH_LOCALS = new Set(['BASE', 'HEAD']);
 
+/** Workflow files that call the changes-filter action. Both YAML extensions are in use here. */
+function readActionConsumers(workflowsDir: string): string[] {
+  return fs
+    .readdirSync(workflowsDir)
+    .filter(name => /\.ya?ml$/.test(name))
+    .filter(name => fs.readFileSync(path.join(workflowsDir, name), 'utf8').includes('actions/changes-filter'));
+}
+
+/**
+ * Which end of the diff range a SHA env key claims by its own name, or null if it names neither.
+ *
+ * Derived from the key rather than tabulated per event, so a key added for some future trigger is
+ * covered the day it lands - the same reason the trigger list is read from ci.yml instead of listed
+ * here. `push` predates the `_BASE_SHA`/`_HEAD_SHA` convention and names its endpoints after the
+ * payload fields (`before`/`after`).
+ */
+function readShaRole(key: string): 'base' | 'head' | null {
+  if (/_BASE_SHA$/.test(key) || key === 'PUSH_BEFORE') return 'base';
+  if (/_HEAD_SHA$/.test(key) || key === 'PUSH_AFTER') return 'head';
+  return null;
+}
+
+/** Payload fields that legitimately supply each end of the range, across all three events. */
+const ROLE_FIELDS: Record<'base' | 'head', RegExp> = {
+  base: /\.(base_sha|base\.sha|before)\b/,
+  head: /\.(head_sha|head\.sha|after)\b/,
+};
+
 describe('changes-filter event dispatch vs ci.yml triggers', () => {
   const ci = fs.readFileSync(CI_WORKFLOW, 'utf8');
   const action = fs.readFileSync(CHANGES_FILTER, 'utf8');
@@ -173,6 +207,28 @@ describe('changes-filter event dispatch vs ci.yml triggers', () => {
       misbound.map(({ key, value }) => `${key}: ${value}`),
       "env keys wired to another event's payload; declared, but empty on the event whose arm reads them"
     ).toEqual([]);
+  });
+
+  // The event check above is satisfied by any field of the right payload, so base and head can
+  // still cross within one event. That mutation fails CLOSED, which is worse than the fail-open
+  // this file exists to catch: BASE equals HEAD, every diff comes back empty, and the run skips
+  // the build and docs legs the gate exists to trigger - silently, on every run of that trigger.
+  it("binds each event's SHA vars to the end of the range their names claim", () => {
+    const crossed = readStepEnvBindings(action).filter(({ key, value }) => {
+      const role = readShaRole(key);
+      return role !== null && !ROLE_FIELDS[role].test(value);
+    });
+    expect(
+      crossed.map(({ key, value }) => `${key}: ${value}`),
+      'env keys bound to the opposite end of the range; BASE==HEAD makes every diff empty and skips the legs the gate should trigger'
+    ).toEqual([]);
+  });
+
+  it('is consumed only by ci.yml, whose triggers are the list checked above', () => {
+    expect(
+      readActionConsumers(path.join(REPO_ROOT, '.github', 'workflows')),
+      "another workflow calls changes-filter, so its own `on:` triggers need arms too; either union its trigger list into the check above or keep ci.yml the action's sole consumer"
+    ).toEqual(['ci.yml']);
   });
 });
 
@@ -281,6 +337,53 @@ describe('readStepEnvKeys', () => {
       ].join('\n')
     );
     expect(keys).toEqual(['EVENT_NAME', 'PUSH_BEFORE']);
+  });
+});
+
+describe('readActionConsumers', () => {
+  // Both extensions are live in .github/workflows, so a .yml-only scan would report a .yaml
+  // consumer as absent - the "silently partial" shape this whole file argues against.
+  it('finds consumers under either YAML extension and ignores unrelated workflows', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'changes-filter-consumers-'));
+    fs.writeFileSync(path.join(dir, 'ci.yml'), 'uses: ./.github/actions/changes-filter\n');
+    fs.writeFileSync(path.join(dir, 'release.yaml'), 'uses: ./.github/actions/changes-filter\n');
+    fs.writeFileSync(path.join(dir, 'unrelated.yml'), 'uses: actions/checkout@v4\n');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'uses: ./.github/actions/changes-filter\n');
+
+    expect(readActionConsumers(dir).sort()).toEqual(['ci.yml', 'release.yaml']);
+  });
+});
+
+describe('readShaRole', () => {
+  it('reads the range endpoint off the key name, including the push spelling', () => {
+    expect(readShaRole('MERGE_GROUP_BASE_SHA')).toBe('base');
+    expect(readShaRole('PR_HEAD_SHA')).toBe('head');
+    expect(readShaRole('PUSH_BEFORE')).toBe('base');
+    expect(readShaRole('PUSH_AFTER')).toBe('head');
+  });
+
+  it('claims no endpoint for a key that names none', () => {
+    expect(readShaRole('EVENT_NAME')).toBeNull();
+    expect(readShaRole('EXCLUDE_PATHS')).toBeNull();
+  });
+
+  // Each of these passed the event-prefix check while pointing at the wrong end of the range.
+  it('pairs with ROLE_FIELDS to catch base and head crossed inside one payload', () => {
+    const crossed: Array<[string, string]> = [
+      ['MERGE_GROUP_BASE_SHA', '${{ github.event.merge_group.head_sha }}'],
+      ['PR_BASE_SHA', '${{ github.event.pull_request.head.sha }}'],
+      ['PUSH_BEFORE', '${{ github.event.after }}'],
+    ];
+    for (const [key, value] of crossed) {
+      const role = readShaRole(key);
+      expect(role, key).not.toBeNull();
+      expect(ROLE_FIELDS[role!].test(value), `${key}: ${value}`).toBe(false);
+    }
+  });
+
+  it('accepts the head fallback expression the action actually ships', () => {
+    expect(ROLE_FIELDS.head.test('${{ github.event.merge_group.head_sha || github.sha }}')).toBe(true);
+    expect(ROLE_FIELDS.base.test('${{ github.event.merge_group.head_sha || github.sha }}')).toBe(false);
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Description

Closes #2383

`.github/actions/changes-filter/action.yml` dispatches its diff range on `github.event_name` but enumerated only `push` and `pull_request`. `merge_group` -- the event GitHub Actions fires when the merge queue tests a speculative merge -- fell through to the `*` arm, which blanks `BASE`/`HEAD` and so tripped the action's own fail-open guard. Every merge-queue run, for every PR, unconditionally got `deployable=true` and `docs-changed=true`.

The cost is not runner minutes; most batches contain deployable code and would run everything regardless. The cost is **gate divergence**: the queue evaluated a different signal than the PR's own CI did, so a queue run could fail a leg the PR legitimately skipped, ejecting the PR with `reason: failed_checks` and no reproduction on the author's branch. Confirmed on run `33842375990` (queue run for #2350, which touches zero `docs-site/**` paths): the `changes` job logged `Could not resolve a clean diff range (..)` and `Help Docs Guards` ran anyway.

The fix adds a `merge_group` arm using the group's own `base_sha..head_sha` and plumbs those SHAs through the step's `env:` block. **Both edits are required** -- an arm on its own reads unset variables and fails open identically, which is why the regression guard asserts the env plumbing too. `base_sha` is by construction the base-branch commit the group was built on, so it is an ancestor of `head_sha` and a two-dot `git diff` already equals three-dot semantics; no `merge-base` call is needed. The `*` arm and the fail-open guard are deliberately untouched -- they stay the safety net for a SHA that is ever missing or unreachable.

## Changes

- `.github/actions/changes-filter/action.yml`: added the `merge_group` case arm; plumbed `MERGE_GROUP_BASE_SHA` and `MERGE_GROUP_HEAD_SHA` through the step `env:`. `head_sha` falls back to `github.sha`, which *is* the group head on this event -- redundant when `head_sha` is present, and the difference between a correct range and a permanent fail-open if it ever is not.
- `.github/actions/changes-filter/action.yml`: updated the action `description:` to stop describing the event handling as push/pull_request-only, and to state the invariant that every trigger needs its own arm.
- `packages/scripts/src/checkChangesFilterEvents.test.ts` (new): static guard that reads the trigger list out of `ci.yml`'s `on:` block and asserts the action's case block has an arm for each, plus that every env var an arm reads is declared on the step, bound to that event's own payload, and bound to the end of the range its name claims. Written as the general invariant rather than a literal `merge_group` string check, so the *next* trigger added to `ci.yml` cannot silently inherit the fail-open default. The endpoint half exists because crossing base and head inside one payload fails *closed*, which is worse than the gap being fixed here: the diff comes back empty and the run skips the very legs the gate should trigger. `ci.yml` being the action's only consumer is asserted too, since that is where the trigger list comes from.
- `.github/actions/changes-filter/README.md`: updated the "Merge-base scoped" bullet and the "Fail-open posture" section to cover `merge_group` and to distinguish a one-off fail-open from a permanent one.

Note: the two `outputs:` descriptions needed no edit -- they never mentioned events, contrary to what the issue says.

## Guide for Testers

This is a CI-configuration-only PR. No application code changed, and there is nothing to click in the app.

**Regression Checks (anyone can run these)**

1. From the repo root, run `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/scripts test`. Expected: `51 passed`, `561 passed` tests, exit 0. Two setup notes, both unrelated to this PR: a fresh clone needs `pnpm turbo:core:build` first (without it, 21 files fail at import with `Failed to resolve entry for package "@bike4mind/database"`), and the worker cap keeps the `migrate/migrations/*.integration.test.ts` files off the MongoMemoryServer port race they flake on when the suite oversubscribes the box.
2. Run `pnpm --filter @bike4mind/scripts exec vitest run src/checkChangesFilterEvents.test.ts`. Expected: `25 passed`.
3. Confirm the guard actually guards: open `.github/actions/changes-filter/action.yml`, delete the two `MERGE_GROUP_*` lines from the `env:` block, and re-run step 2. Expected: it fails with `vars read by a case arm but absent from the step's env: block ... expected [ 'MERGE_GROUP_BASE_SHA', 'MERGE_GROUP_HEAD_SHA' ] to deeply equal []`. Restore the lines.
4. Confirm the other half: restore the env lines, then delete the whole `merge_group)` arm and re-run step 2. Expected: it fails with `ci.yml triggers with no arm in the changes-filter case block ... expected [ 'merge_group' ] to deeply equal []`. Restore the arm.
5. Confirm it catches a crossed range too: change `MERGE_GROUP_BASE_SHA` in that `env:` block to `${{ github.event.merge_group.head_sha }}` and re-run step 2. Expected: it fails with `env keys bound to the opposite end of the range ...`. Restore the value. (Same for `PR_BASE_SHA` -> `head.sha` and `PUSH_BEFORE` -> `github.event.after`.)
6. Run `pnpm lint:check`. Expected: exit 0, no output.

**The actual behaviour change is only observable in the merge queue.** A `pull_request` run cannot exercise the `merge_group` path at all -- which is precisely why the static guard above is not optional.

6. Merge this PR through the queue. While the queue run is in flight, open the `changes` job log for the `gh-readonly-queue/main/pr-<this PR>-...` run. Expected: the log reads `Diffing <base sha>..<head sha>` with two real 40-character SHAs, **not** `Could not resolve a clean diff range (..)`.
7. In the same queue run, check the job list. Expected: `Help Docs Guards` reports **SKIPPED** (this PR touches no `docs-site/**` path), and the required `CI Complete` check is **green**. GitHub counts a skipped required check as passing, and PR CI has always relied on that.
8. On the next docs-touching PR that goes through the queue, check the same job. Expected: `Help Docs Guards` **runs**. The fix must not turn the docs guard off.

**What NOT to test**

- No UI, no API, no database, no AdminSettings. Nothing in the running app changes.
- Do not test on staging or a preview env; workflow and composite-action changes take effect only in GitHub Actions runs.

## Additional Information

The shell logic was verified locally before push by extracting the action's `run:` body and executing it against a synthetic git history with the action's real pathspec defaults. Results, all as intended:

| scenario | range | `deployable` | `docs-changed` |
|---|---|---|---|
| non-docs batch (the #2350 shape) | resolved | `true` | `false` |
| code + docs batch | resolved | `true` | `true` |
| docs-only batch | resolved | `false` | `true` |
| unreachable `base_sha` | unresolved | `true` (fail open) | `true` (fail open) |
| unhandled event (`workflow_dispatch`) | unresolved | `true` (fail open) | `true` (fail open) |

**Blast radius of the fix.** A merge-queue batch whose entire diff is non-deployable will now skip `core-build`, `typecheck`, `lint`, `openapi`, `test` and `cli-e2e`. `ci-complete` already treats `skipped` as passing, so the required `CI Complete` context still reports green. Two things worth knowing: the merge-queue diff is the **batch's**, not one PR's, so a docs-only PR batched behind a code PR still gets the full treatment (correct for a queue run, which tests the speculative merge); and if `main` moves under an in-flight group, GitHub rebuilds the group -- in any pathological case where `base_sha` is unreachable, `git cat-file -e` trips the fail-open guard and behaviour degrades to exactly what happens today.

**One thing to confirm before merge:** this fix assumes the `main-protection` ruleset tolerates skipped required checks. GitHub counts a skipped required check as passing and PR CI already depends on that, and the queue uses the same `CI Complete` context -- but I did not read the ruleset directly. Worth a glance.

**Deliberately out of scope.** Issue #2383 bundles a second, genuinely distinct bug: `help-docs` runs `vitest run help/__tests__` with no core build, on the documented assumption that the help tooling imports only `glob`/`gray-matter`, and nothing enforces that assumption. I verified the assumption still holds on `main` today -- but three sibling modules in that directory (`vectorize-help-content.ts`, `build-help-index.ts`, `ingest-help-datalake.ts`) do import `@bike4mind/*`, so the next test file that reaches one of them breaks `help-docs` on any docs-touching PR, where this fix provides no shield at all. It needs its own decision (enforce the core-free closure with a guard vs. give `help-docs` a core build vs. split the suites) and is not a prerequisite here. Filing separately.

## Developer Notes

- **Reusable pattern: cross-checking a workflow's config against a script's behaviour.** `checkChangesFilterEvents.test.ts` joins `checkClientTestShards.test.ts` as the second static guard over `.github/` config, and follows the same idiom on purpose -- text-matched, no YAML-parser dependency, with a doc comment stating why nothing else can catch the failure. The generalizable trick here is asserting a *relationship between two files* (`ci.yml`'s triggers vs. the action's arms) rather than pinning a literal value, so the guard keeps holding as the config grows.
- **The escape hatch is explicitness, not an allowlist.** Letting an event fail open on purpose is still fine -- write the arm as `BASE=""; HEAD=""`. That keeps the decision visible in the action instead of inherited by silence, and avoids a second list to maintain in the test.
- The guard's helper functions are exercised by their own unit tests, including one that reproduces the pre-fix shape (`push` + `pull_request` arms only) and asserts `merge_group` reads as unhandled.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc

