### PR TITLE
test(scripts): assert help-embeddings title and accessLevel against docs-site

### DIFF
--- a/packages/scripts/help/__tests__/help-id-resolution.test.ts
+++ b/packages/scripts/help/__tests__/help-id-resolution.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { loadHelpArticles } from '../loadHelpArticles';
 import { chunkByHeadings, estimateTokenCount } from '../utils';
-import type { HelpIndex, HelpEmbeddingsIndex } from '../types';
+import type { HelpIndex, HelpEmbeddingsIndex, HelpAccessLevel } from '../types';
 import { ROUTE_HELP_SUGGESTIONS } from '../../../../apps/client/app/components/help/routeHelpSuggestions';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -170,6 +170,8 @@ describe('help id resolution', () => {
       slug: string;
       sectionPath: string;
       tokenCount: number;
+      title: string;
+      accessLevel: HelpAccessLevel;
     }
     const chunkKey = (chunk: { slug: string; sectionPath: string }): string => `${chunk.slug}::${chunk.sectionPath}`;
 
@@ -185,6 +187,12 @@ describe('help id resolution', () => {
           slug: entry.slug,
           sectionPath: section.sectionPath,
           tokenCount: estimateTokenCount(`# ${entry.title}\n\n${section.content}`),
+          // Read from the corpus rather than from `entry`: help-index.json and
+          // help-embeddings.json are generated from the same frontmatter, so comparing
+          // against docs-site catches both "index regenerated, embeddings not" and
+          // "neither regenerated". A title-less article is reported, not crashed on.
+          title: article.frontmatter.title ?? '<no frontmatter title>',
+          accessLevel: article.accessLevel,
         });
       }
     }
@@ -220,15 +228,57 @@ describe('help id resolution', () => {
     // Restricted to keys present on both sides - a missing/orphan key is already
     // reported above, and would otherwise show here too as a confusing
     // "committed=undefined" mismatch.
-    const embeddedTokenCountByKey = new Map(embeddings.chunks.map(chunk => [chunkKey(chunk), chunk.tokenCount]));
-    const tokenCountMismatches = derived
-      .filter(
-        chunk => embeddedKeys.has(chunkKey(chunk)) && embeddedTokenCountByKey.get(chunkKey(chunk)) !== chunk.tokenCount
-      )
-      .map(
-        chunk =>
-          `${chunkKey(chunk)}: committed=${embeddedTokenCountByKey.get(chunkKey(chunk))} derived=${chunk.tokenCount}`
-      )
+    const embeddedByKey = new Map(embeddings.chunks.map(chunk => [chunkKey(chunk), chunk]));
+    const comparable = derived
+      .filter(chunk => embeddedKeys.has(chunkKey(chunk)))
+      .map(chunk => ({ chunk, embedded: embeddedByKey.get(chunkKey(chunk))! }));
+
+    // `title` and `accessLevel` are article-level facts, so one drifted article would
+    // otherwise report once per chunk - 20 identical lines for the largest article today.
+    // Keyed by slug so each article is reported once.
+    const titleDriftBySlug = new Map<string, string>();
+    const accessLevelDriftBySlug = new Map<string, string>();
+    for (const { chunk, embedded } of comparable) {
+      if (embedded.title !== chunk.title) {
+        titleDriftBySlug.set(chunk.slug, `${chunk.slug}: committed="${embedded.title}" docs-site="${chunk.title}"`);
+      }
+      if (embedded.accessLevel !== chunk.accessLevel) {
+        accessLevelDriftBySlug.set(
+          chunk.slug,
+          `${chunk.slug}: committed=${embedded.accessLevel} docs-site=${chunk.accessLevel}`
+        );
+      }
+    }
+
+    // The key sets above cannot see a title rename: `chunkByHeadings` names each section
+    // after its H2, falling back to the article title only for an article with no H2 - and
+    // every article in the corpus has one. `retrieval.ts` writes the committed title
+    // straight into the Help AI chat context, so a stale one makes answers cite the old name.
+    const titleDrift = [...titleDriftBySlug.values()].sort();
+    expect(
+      titleDrift,
+      'help-embeddings.json holds an article title docs-site no longer uses. ' +
+        'Run `OPENAI_API_KEY=... pnpm --filter @bike4mind/scripts help:regenerate`.\n' +
+        titleDrift.join('\n')
+    ).toEqual([]);
+
+    // Worth asserting despite `accessLevel` being a function of the article's category:
+    // the vectorizer reads it from help-index.json, and `loadAccessLevelMap` falls back to
+    // 'public' for every chunk if that read fails (#2332) - which would publish the whole
+    // admin corpus. `retrieval.ts` filters on the committed value, so this is the
+    // authorization decision, and nothing else checks it.
+    const accessLevelDrift = [...accessLevelDriftBySlug.values()].sort();
+    expect(
+      accessLevelDrift,
+      'help-embeddings.json holds an accessLevel docs-site disagrees with - the Help AI chat ' +
+        'authorizes retrieval on this value. ' +
+        'Run `OPENAI_API_KEY=... pnpm --filter @bike4mind/scripts help:regenerate`.\n' +
+        accessLevelDrift.join('\n')
+    ).toEqual([]);
+
+    const tokenCountMismatches = comparable
+      .filter(({ chunk, embedded }) => embedded.tokenCount !== chunk.tokenCount)
+      .map(({ chunk, embedded }) => `${chunkKey(chunk)}: committed=${embedded.tokenCount} derived=${chunk.tokenCount}`)
       .sort();
 
     // Warn rather than fail: unlike the key sets above, this one is not clean on


### PR DESCRIPTION
# Pull Request

## Description

Closes #2331.

Follows up #2293, now merged. That gate compares only `(slug, sectionPath)` keys and `tokenCount`, which leaves two classes of drift shipping completely undetected.

**A title rename is invisible.** `chunkByHeadings` names each section after its H2 and falls back to the article title only for an article with no H2 - and all 85 articles in the corpus have at least one H2, so the key set never contains a title. A same-length rename leaves `tokenCount` untouched as well (`Math.ceil(text.length / 4)`), so nothing moves. Renaming `Data Lakes` to `Data Pools` and rebuilding the index passes the existing gate with 4 green tests and no new warning. This is user-visible: `retrieval.ts` writes the committed title straight into the Help AI chat context, so the assistant keeps calling the article by its old name.

**An `accessLevel` flip is invisible for a different reason.** `accessLevel` is not a pure function of the slug. `vectorize-help-content.ts` reads it from `help-index.json` via `loadAccessLevelMap`, which swallows any read/parse failure in a bare `catch` and then defaults every chunk to `'public'` (the fail-open tracked in #2332). `retrieval.ts` filters retrieval on the committed value, so it *is* the authorization decision - and 251 of 703 committed chunks are `admin`. A single failed index read at vectorize time would publish a quarter of the corpus, and nothing today would notice.

Both fields are derived from the **corpus**, not from the index entry. `article.frontmatter.title -> entry.title` and `article.accessLevel -> entry.accessLevel` are straight copies in `build-help-index.ts`, and `bundle-help-content.ts` copies the file byte for byte, so the vectorizer's values trace back to docs-site frontmatter. Comparing against the corpus therefore catches both "index regenerated, embeddings not" *and* "neither regenerated"; comparing against `entry.title` would catch only the first.

Both assertions are green on the current corpus (measured: 0 title drift, 0 `accessLevel` drift across all 703 chunks), so this adds no allowlist and cannot block unrelated PRs on pre-existing drift.

### Deliberately out of scope

#2331 also asks for `tokenCount` to be promoted from `console.warn` to a hard failure behind a `KNOWN_TOKEN_COUNT_DRIFT` allowlist. That half is **not** in this PR:

- #2337 / #2338 / #2339 are a phased plan to generate the help artifacts at deploy time and then `git rm` the committed copies *and these guards*; #2339 phase 2 already names tests in this file for removal.
- There is no CI `OPENAI_API_KEY`, so hard-failing `tokenCount` would require every docs *body* edit to ship a local `help:regenerate`, adding a fresh ~10 MB blob to public-repo history each time.
- Body drift is the least harmful class anyway: `resolveChunkContent` re-chunks from live markdown at query time, so the text handed to the LLM is always fresh - only the ranking vector and budget accounting go stale.

Title drift is wrong output and `accessLevel` drift is a fail-open, so those two are worth gating now regardless of how #2337 lands.

#2331 is closed by this PR rather than kept open for its remaining third. The `tokenCount` decision is recorded on #2339 instead - that is the issue that removes the committed artifacts and the guards over them, so it is where the question actually gets settled. Note that #2339's removal list predates #2293 and names only the `the generated index covers exactly the help corpus` test; the section-granularity test this PR extends will need adding to that list.

## Changes

- Widen the local `DerivedChunk` with `title` and `accessLevel`, populated from the corpus article (`article.frontmatter.title ?? '<no frontmatter title>'`, `article.accessLevel`). The sentinel keeps a title deleted from a still-indexed article as a readable mismatch rather than a crash.
- Add two hard assertions after the existing key-set assertion, each restricted to keys present on both sides so a missing/orphan key is not double-reported as a confusing `committed=undefined`.
- Dedupe both mismatch lists by slug - these are article-level facts, so a per-chunk assert would emit up to 20 identical lines for one renamed article.
- Consolidate `embeddedTokenCountByKey` into a single `embeddedByKey` map. `tokenCount` keeps its existing warn-only behaviour; this is a lookup change only, with no `expect` and no allowlist added.

## Guide for Testers

This is a test-only change in `@bike4mind/scripts`. No app, no UI, no runtime behaviour, no artifact regeneration - it is verified by running the suite and by deliberately breaking the corpus.

**Setup**

1. Check out this branch and run `pnpm install` from the repo root. Expected: install completes.

**1. The gate is green as-is**

2. Run `pnpm --filter @bike4mind/scripts exec vitest run help/__tests__/help-id-resolution.test.ts`. Expected: `Test Files 1 passed (1)`, `Tests 4 passed (4)`.
3. Re-run the same command with `--reporter=verbose` appended. Expected: the same 4 passes, plus a `tokenCount drift` warning on stderr listing exactly 4 chunks (2 under `features/data-lakes`, 2 under `features/knowledge-management`). Note this warning is only visible with `--reporter=verbose`; vitest 4's default reporter hides console output from passing tests.

**2. A title rename is now caught**

4. In `docs-site/docs/features/data-lakes.md`, change the frontmatter line `title: Data Lakes` to `title: Data Pools`. Expected: the file saves; the rename is deliberately the same length so `tokenCount` cannot move.
5. Run `pnpm --filter @bike4mind/scripts help:build-index`. Expected: `Total entries: 85`, index written.
6. Re-run the test command from step 2. Expected: **1 failed**, with the message `help-embeddings.json holds an article title docs-site no longer uses.` followed by exactly one line: `features/data-lakes: committed="Data Lakes" docs-site="Data Pools"`.
7. Confirm the line appears **once**, not six times, even though `features/data-lakes` has 6 committed chunks. Expected: exactly one reported line.
8. Revert with `git checkout -- docs-site/docs/features/data-lakes.md apps/client/app/generated/help-index.json`, then re-run the test. Expected: back to 4 passed.

**3. An accessLevel flip is now caught**

9. In `packages/scripts/help/loadHelpArticles.ts`, change `admin: 'admin'` to `admin: 'public'` in `CATEGORY_ACCESS_LEVELS`. Regenerate nothing.
10. Re-run the test command from step 2. Expected: **1 failed**, with `help-embeddings.json holds an accessLevel docs-site disagrees with` followed by 34 lines of the form `admin/<slug>: committed=admin docs-site=public` - one per admin article, deduped from 251 admin chunks.
11. Revert with `git checkout -- packages/scripts/help/loadHelpArticles.ts`, then re-run the test. Expected: back to 4 passed.

**Regression Checks**

12. Run `pnpm --filter @bike4mind/scripts exec vitest run help/`. Expected: `Test Files 7 passed (7)`, `Tests 73 passed (73)`.
13. Run `pnpm lint:check`. Expected: exit 0, no errors.
14. Run `git status`. Expected: clean - in particular no `help-index.json` or `help-embeddings.json` left modified from the steps above.

**What NOT to test**

- No UI to click through: the help panel and Help AI chat are unchanged. This PR only adds assertions to an existing test.
- Do not run `help:regenerate` - it needs an `OPENAI_API_KEY` and would rewrite the 10 MB `help-embeddings.json`. Nothing here requires it.
- The 4-chunk `tokenCount` warning is pre-existing and intentionally left as a warning; it is not a failure to investigate.

## Additional Information

Two corrections to #2331's description, found while verifying it:

- It hedges the title gap as affecting "any article with H2 headings". It is in fact **85 of 85** articles, so the existing key-set gate catches a title rename for *zero* articles, not merely some.
- It describes `accessLevel` as derived from the slug. It is read from `help-index.json` at vectorize time, which is exactly why it can drift at all (#2332) and why the assertion is worth having rather than tautological.

One more finding, recorded on #2339 as well: the warn-only block added by #2293 is invisible under vitest 4's default reporter, which hides console output from passing tests. It only surfaces with `--reporter=verbose`, so CI logs show nothing at all today. That matters because #2293's stated promotion path was "promote once a regenerate clears the warning" - nobody will see it clear, and the drift set has grown 2 -> 3 -> 4 across four commits that edited help docs without re-embedding.

This was originally stacked on #2293's branch, since the code it amends did not exist on `main`. #2293 has since merged (`135fd9c12`), so this is rebased onto `main` and targets it directly - a single commit, one file.

## Developer Notes (Optional)

- The "compare against the corpus, not the generated index" choice is the reusable idea here: for any artifact generated *from* docs-site, asserting against the source catches one more failure mode (nothing regenerated) than asserting against an intermediate artifact, at no extra cost.
- Mismatch lists for article-level facts are keyed by slug in a `Map` rather than collected per chunk, which keeps a single drifted article to a single line of failure output. Worth copying for any future per-chunk gate over article-level fields.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, test-only
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
