### PR TITLE
fix(llm): repair a model pin the catalog no longer serves

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.modelPin.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.modelPin.test.ts
@@ -21,6 +21,8 @@ describe('useSendMessage - model id reaches input validation', () => {
   });
 
   it('passes the active model so an unavailable pin can be named', () => {
-    expect(callMatch?.[0] ?? '').toMatch(/selectedModel:\s*model,/);
+    // Matches shorthand and any identifier, so renaming the local does not turn this red - the
+    // property being bound to something real is the contract, not what that something is called.
+    expect(callMatch?.[0] ?? '').toMatch(/selectedModel\s*(?::\s*(?!undefined|null)[A-Za-z_$][\w$.]*)?\s*[,}]/);
   });
 });

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.modelPin.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.modelPin.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guard: the send-path validation must hand validateChatInput the active model id.
+ *
+ * Without it, a pin the catalog no longer serves (a session's `lastUsedModel`, or the persisted
+ * llm-settings store, holding a model that has since been retired) is reported as "No AI model
+ * selected" - which describes the wrong problem and points at a picker that looks healthy.
+ *
+ * A source-level assertion is used rather than a full renderHook because useSendMessage consumes
+ * ~15 context providers; mirrors useSendMessage.stopMessageToast.test.ts.
+ */
+describe('useSendMessage - model id reaches input validation', () => {
+  const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
+  const callMatch = source.match(/validateChatInput\(\{[\s\S]*?\}\);/);
+
+  it('locates the validateChatInput call in the source', () => {
+    expect(callMatch).not.toBeNull();
+  });
+
+  it('passes the active model so an unavailable pin can be named', () => {
+    expect(callMatch?.[0] ?? '').toMatch(/selectedModel:\s*model,/);
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -373,6 +373,7 @@ export function useSendMessage({
       currentUser,
       effectiveCredits,
       enforceCredits,
+      selectedModel: model,
     });
     if (errorMessage) {
       console.error(errorMessage);

--- a/apps/client/app/contexts/LLMContext.staleModelPin.test.tsx
+++ b/apps/client/app/contexts/LLMContext.staleModelPin.test.tsx
@@ -84,6 +84,29 @@ describe('LLMProvider default-model effect - a model that goes unresolvable afte
     await waitFor(() => expect(useLLM.getState().model).toBe(MINI.id));
   });
 
+  it('preserves a lowered max_tokens while repairing the pin', async () => {
+    // The repair hands the refit effect a `from` id that effect never fitted (a dead pin is absent
+    // from modelInfoRepo, so it bails before recording it). If the handshake misses, the refit effect
+    // reads the landing as a user-initiated switch and raises the ceiling back to the new model's
+    // default - silently discarding a value the user lowered on purpose.
+    render(<LLMProvider />);
+    await waitFor(() => expect(useLLM.getState().model).toBe(MINI.id));
+
+    act(() => {
+      useLLM.getState().setLLM({ max_tokens: 4096 });
+    });
+    // Make the repair land on a DIFFERENT model than the one in refitModelRef, which is what turns
+    // the missed handshake into an observable raise.
+    h.adminDefaultModel = TERRA.id;
+
+    act(() => {
+      useLLM.getState().setLLM({ model: RETIRED_PIN });
+    });
+
+    await waitFor(() => expect(useLLM.getState().model).toBe(TERRA.id));
+    expect(useLLM.getState().max_tokens).toBe(4096);
+  });
+
   it('leaves a model the user picked after mount alone', async () => {
     // The guard against over-fixing: the repair must fire on unresolvable ids only, never undo a
     // deliberate switch to another accessible model.

--- a/apps/client/app/contexts/LLMContext.staleModelPin.test.tsx
+++ b/apps/client/app/contexts/LLMContext.staleModelPin.test.tsx
@@ -1,0 +1,100 @@
+import { render, waitFor, cleanup, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A model id can become unresolvable AFTER the default-model effect has already settled: session
+// hydration (useHydrateModelFromSession) writes `lastUsedModel` unvalidated, and the persisted store
+// rehydrates one on its own. The effect that repairs an inaccessible model must therefore watch the
+// model itself, not only the inputs it resolves one from - otherwise the bad id sticks for the life of
+// the tab, blanks the composer's model chip, and blocks every send with a zero context window.
+//
+// Fixture note (same contract as LLMContext.fallbackCeiling.test.tsx): `accessibleModels` must stay
+// consistent with `isModelAccessible`. The real hook builds the list BY that predicate, so a model
+// cannot be in the list while the predicate rejects it. A model absent from the catalog is exactly how
+// the predicate returns false.
+const h = vi.hoisted(() => ({
+  adminDefaultModel: 'gpt-5.4-mini',
+  accessibleIds: ['gpt-5.4-mini'] as string[],
+  liveCatalogIds: ['gpt-5.4-mini', 'gpt-5.6-terra'] as string[],
+}));
+
+const MINI = { id: 'gpt-5.4-mini', type: 'text', contextWindow: 400_000, max_tokens: 100_000 };
+const TERRA = { id: 'gpt-5.6-terra', type: 'text', contextWindow: 1_050_000, max_tokens: 128_000 };
+const ALL = [MINI, TERRA];
+
+// The id the session pins: a real model that the live catalog no longer serves.
+const RETIRED_PIN = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+
+vi.mock('@/app/contexts/UserSettingsContext', () => ({
+  useUserSettings: () => ({ settings: { experimentalFeatures: {} }, isHydrated: true }),
+}));
+vi.mock('@/app/hooks/useFeatureEnabled', () => ({
+  useFeatureEnabled: () => ({ isFeatureEnabled: () => false, isLoading: false }),
+}));
+// The real hooks useMemo their lists, so a re-render hands back the SAME array reference. Reproducing
+// that here is what makes this file a test of the effect's dep array rather than of the mock: a fresh
+// array per render would re-fire the effect on every commit and repair the pin for the wrong reason.
+const stableList = (() => {
+  const cache = new Map<string, typeof ALL>();
+  return (ids: string[]) => {
+    const key = ids.join(',');
+    const hit = cache.get(key);
+    if (hit) return hit;
+    const built = ALL.filter(m => ids.includes(m.id));
+    cache.set(key, built);
+    return built;
+  };
+})();
+
+vi.mock('../hooks/data/useModelInfo', () => ({
+  useModelInfo: () => ({ data: stableList(h.liveCatalogIds) }),
+}));
+vi.mock('../hooks/useAccessibleModels', () => ({
+  useAccessibleModels: () => ({
+    accessibleModels: stableList(h.accessibleIds),
+    isModelAccessible: (id: string) => h.accessibleIds.includes(id),
+    getFallbackModel: () => null,
+  }),
+}));
+vi.mock('./AdminSettingsContext', () => ({
+  useAdminSettings: () => ({ getSetting: () => h.adminDefaultModel, isLoading: false }),
+}));
+
+import { LLMProvider, useLLM } from './LLMContext';
+
+describe('LLMProvider default-model effect - a model that goes unresolvable after the effect settled', () => {
+  beforeEach(() => {
+    useLLM.getState().resetSettings();
+    h.adminDefaultModel = MINI.id;
+    h.accessibleIds = [MINI.id, TERRA.id];
+    h.liveCatalogIds = ALL.map(m => m.id);
+  });
+  afterEach(() => cleanup());
+
+  it('repairs a pin written after mount, so a session cannot strand the composer on a dead model', async () => {
+    render(<LLMProvider />);
+    // Let the effect resolve a real model first. Everything it keys on is settled from here on, which
+    // is the whole point: the repair below cannot come from any of those inputs changing.
+    await waitFor(() => expect(useLLM.getState().model).toBe(MINI.id));
+
+    // Session hydration: useHydrateModelFromSession applies `lastUsedModel` with no validation.
+    act(() => {
+      useLLM.getState().setLLM({ model: RETIRED_PIN });
+    });
+
+    await waitFor(() => expect(useLLM.getState().model).toBe(MINI.id));
+  });
+
+  it('leaves a model the user picked after mount alone', async () => {
+    // The guard against over-fixing: the repair must fire on unresolvable ids only, never undo a
+    // deliberate switch to another accessible model.
+    render(<LLMProvider />);
+    await waitFor(() => expect(useLLM.getState().model).toBe(MINI.id));
+
+    act(() => {
+      useLLM.getState().setLLM({ model: TERRA.id });
+    });
+
+    await waitFor(() => expect(useLLM.getState().model).toBe(TERRA.id));
+    expect(useLLM.getState().model).toBe(TERRA.id);
+  });
+});

--- a/apps/client/app/contexts/LLMContext.tsx
+++ b/apps/client/app/contexts/LLMContext.tsx
@@ -558,11 +558,16 @@ export const LLMProvider: React.FC = () => {
     // their identity is stable and they don't need to be in deps. accessibleModels
     // IS in deps so we re-run when models arrive after isAdminSettingsLoading has
     // already flipped false (see comment above).
+    // activeModel IS in deps because a model can go unresolvable AFTER this effect has settled -
+    // session hydration (useHydrateModelFromSession) applies `lastUsedModel` unvalidated, and the
+    // persisted store rehydrates a pin whose model has since left the catalog. Keyed only on the
+    // inputs it resolves FROM, the repair below could never see that. The body is idempotent, so
+    // re-running on a model the user picked themselves is a no-op.
     // modelInfoRepo is read (via modelInfoRepoRef) but deliberately NOT in deps: it and accessibleModels
     // derive from the same cached catalog query, so accessibleModels already covers its arrival. Adding
     // it would re-run this effect on every catalog refetch for no new decision.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setState, adminDefaultTextModel, isAdminSettingsLoading, accessibleModels]);
+  }, [setState, adminDefaultTextModel, isAdminSettingsLoading, accessibleModels, activeModel]);
 
   // Re-fit max_tokens whenever the active text/chat model changes (see refitMaxTokensForModel -
   // it corrects both a too-high carry-over and a too-low one). Skip image models: their catalog

--- a/apps/client/app/contexts/LLMContext.tsx
+++ b/apps/client/app/contexts/LLMContext.tsx
@@ -587,7 +587,15 @@ export const LLMProvider: React.FC = () => {
     if (!activeModel || !modelInfoRepo) return;
     if (isImageModel(activeModel)) return;
     const info = modelInfoRepo.find(m => m.id === activeModel);
-    if (!info) return;
+    if (!info) {
+      // A model absent from a LOADED catalog is a dead pin, and the effect above is about to replace
+      // it. Record it anyway: that effect stamps the dead id as the `from` of the transition, so the
+      // handshake below only matches if this ref names it too. Bailing without recording leaves the
+      // last GOOD model here, the landing then reads as a switch the user asked for, and a ceiling
+      // they lowered is raised to the replacement's default.
+      refitModelRef.current = activeModel;
+      return;
+    }
     const previousModel = refitModelRef.current;
     const modelChanged = previousModel !== null && previousModel !== activeModel;
     refitModelRef.current = activeModel;

--- a/apps/client/app/utils/validateChatInput.test.ts
+++ b/apps/client/app/utils/validateChatInput.test.ts
@@ -48,6 +48,25 @@ describe('validateChatInput', () => {
       const result = validateChatInput({ ...baseParams, maxInputTokens: 0 });
       expect(result).not.toMatch(/exceeds maximum/i);
     });
+
+    // A pin that outlived its model reads as "you didn't pick one", which sends the user to a picker
+    // that already looks fine and hides the fact that the id has to be REPLACED. The catalog is known
+    // loaded here - the accessibleModels branch above already rejected an empty one - so an id that
+    // yields no context window is genuinely gone, not still in flight.
+    it('names the model when the selected one is no longer in the catalog', () => {
+      const result = validateChatInput({
+        ...baseParams,
+        maxInputTokens: 0,
+        selectedModel: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      });
+      expect(result).toMatch(/us\.anthropic\.claude-sonnet-4-5-20250929-v1:0/);
+      expect(result).toMatch(/no longer available/i);
+    });
+
+    it('still says "no model selected" when nothing is selected at all', () => {
+      const result = validateChatInput({ ...baseParams, maxInputTokens: 0, selectedModel: '' });
+      expect(result).toMatch(/no ai model selected/i);
+    });
   });
 
   describe('input length check', () => {

--- a/apps/client/app/utils/validateChatInput.ts
+++ b/apps/client/app/utils/validateChatInput.ts
@@ -8,6 +8,8 @@ interface ValidateChatInputParams {
   currentUser: { currentCredits?: number; emailVerified?: boolean | null; tags?: string[] | null } | null;
   effectiveCredits: number;
   enforceCredits: boolean;
+  /** Active model id, so a pin the catalog no longer serves can be named rather than described as absent. */
+  selectedModel?: string;
 }
 
 /**
@@ -21,14 +23,22 @@ export function validateChatInput({
   currentUser,
   effectiveCredits,
   enforceCredits,
+  selectedModel,
 }: ValidateChatInputParams): string | null {
   if (!accessibleModels || accessibleModels.length === 0) {
     return "You don't have access to any AI models. Please contact your administrator to request the appropriate permissions.";
   } else if (maxInputTokens <= 0) {
-    // contextWindowLimit is 0 - the selected model isn't in modelInfo (still loading,
-    // or no model selected). Surface that directly instead of the misleading
-    // "Input exceeds maximum allowed (0 tokens)" message the next branch produces.
-    return 'No AI model selected. Please pick a model in AI Settings before sending.';
+    // contextWindowLimit is 0 - the selected model isn't in modelInfo. Surface that directly instead
+    // of the misleading "Input exceeds maximum allowed (0 tokens)" message the next branch produces.
+    //
+    // A model IS selected here when the catalog has dropped it (retired upstream, or pulled by the
+    // admin catalog overlay) while a session's `lastUsedModel` or the persisted store still pins it.
+    // Naming it says what actually has to happen - replace the pin - where "none selected" sends the
+    // user to a picker that looks fine. The catalog is known loaded: the branch above already
+    // rejected an empty accessibleModels, and that list is built from the same catalog.
+    return selectedModel
+      ? `The model ${selectedModel} is no longer available. Please pick a different model in AI Settings.`
+      : 'No AI model selected. Please pick a model in AI Settings before sending.';
   } else if (inputText.length > maxInputTokens) {
     return `Input exceeds maximum allowed (${maxInputTokens} tokens) for your current max output setting of ${effectiveMaxOutputTokens} tokens`;
   } else if (!inputText.trim()) {


### PR DESCRIPTION
# Pull Request

## Description

Reported from production: typing into a composer and sending failed with **"No AI model selected. Please pick a model in AI Settings before sending."** while the model picker looked perfectly healthy. The message describes the wrong problem, and the state it describes is not recoverable by the user without knowing to go re-pick a model.

The real condition is that the model id held in the picker is not present in the loaded `/api/models` catalog. `useTokenLimits` resolves `contextWindowLimit` to `0` for an id it cannot find, and `validateChatInput` reports that as "no model selected". The same failed lookup blanks the model name next to the composer's gear icon (`AdvancedAISettings` reads `modelInfoRepo.find(m => m.id === model)?.name`), which is the visible tell.

How the picker ends up holding an id the catalog does not serve: `useHydrateModelFromSession` applies a session's `lastUsedModel` to the store **without validating it against the catalog**, and the persisted `llm-settings` store rehydrates one the same way. Either is fine until the model leaves the catalog (retired upstream, or pulled by the admin catalog overlay), at which point the pin is dead.

Nothing put it right. `LLMProvider` already has an effect that replaces an inaccessible model, and `isModelAccessible` correctly returns `false` for an id missing from the catalog — but that effect was keyed only on the inputs it resolves a replacement *from* (`accessibleModels`, `adminDefaultTextModel`, `isAdminSettingsLoading`). Session hydration always lands *after* those have settled, so the effect never re-ran and never saw the bad write. Because the store is persisted, the dead pin then survived every reload and followed the user across surfaces, blocking every send.

The reported case additionally hit a surface that creates its session server-side, where `validateChatInput` runs *before* the session-creation call — so the stale global blocked the very first message, before any session existed.

Deliberately **not** included: an entry in `DEPRECATED_MODEL_MAP` for the specific id seen in production. That map is an unconditional live redirect applied in every environment (`resolveDeprecatedModelId`), and the model in question is still served by its backend's static table. Adding it would silently move every user pinned to that model onto a different one — worse than the bug. When a model is genuinely retired, the right lever is the catalog row's lifecycle (`status: retired` + `replacedBy`), which `catalogSuccessors` already feeds into the same resolution path.

## Changes

- `LLMContext.tsx` — key the default-model effect on the active model as well, so any write of an unresolvable id self-heals. The effect body was already idempotent (it returns state unchanged unless the model is missing or inaccessible), so re-running on a model the user picked themselves is a no-op.
- `validateChatInput.ts` — accept the active model id and, when one is set but unresolvable, report `The model <id> is no longer available. Please pick a different model in AI Settings.` The catalog is known loaded at that branch, because the preceding branch already rejected an empty `accessibleModels` and that list is built from the same catalog.
- `useSendMessage.ts` — pass the active model into the validation call.
- `LLMContext.tsx` (second commit, from review) - record the active model on the refit effect's `!info` early return. The repair stamps the dead id as the `from` of the transition, but the refit effect bailed on an id absent from the catalog *without* recording it, so its `previousModel` still named the last good model, the handshake missed, the landing read as a user-initiated switch, and a `max_tokens` the user had lowered was raised to the replacement's default. Both sides now name the same model. Only reachable with a loaded catalog: `modelInfoRepo` is `undefined` while the query is in flight, and the guard above already returns on that.
- Tests: `LLMContext.staleModelPin.test.tsx` (new) covers a pin written *after* the effect settled, a lowered `max_tokens` surviving the repair, and a guard that a deliberate user switch is left alone; `validateChatInput.test.ts` covers both message branches; `useSendMessage.modelPin.test.ts` (new) guards the wiring.

## Guide for Testers

**Read this first — the obvious test does not work.** Planting a bad model id in `localStorage` and reloading passes both with and without this fix: on a reload the bad pin is present at mount, so the effect's very first run repairs it. That path was never broken. The only discriminating scenario is a bad id written *after* the effect has settled, which is what session hydration does. Testing the reload path and seeing it pass proves nothing.

### Discriminating test (requires backend or admin access)

1. Sign in to `app.staging.bike4mind.com`.
2. Open any existing chat session. Confirm the composer's toolbar shows a model name next to the gear icon (e.g. `Claude 5 Sonnet`). This is the healthy state.
3. Note the session's id from the URL (`/notebooks/<id>`).
4. Set that session's `lastUsedModel` to an id the environment's catalog does not serve — patch the `sessionmodels` document directly, or pick a model, send one message, then retire that model in Admin. A convenient dead id in an environment without Bedrock is `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
5. In the browser, open DevTools → Console and run `JSON.parse(localStorage.getItem('llm-settings')).state.model`. Confirm it currently reports a **valid** model — this is what makes step 6 a real test.
6. Reload the page on that session.
7. **Expected (fixed):** the composer's toolbar still shows a real model name, `JSON.parse(localStorage.getItem('llm-settings')).state.model` reports a valid id, and typing a message and sending it works normally.
8. **Before the fix:** the toolbar shows only the gear icon with no model name, the console reports the dead id, and sending shows `No AI model selected...`.

### Regression checks

1. Open a chat and switch models in AI Settings. The new model must stick — it must not snap back after a send. (The self-heal must never undo a deliberate user choice.)
2. Send one message on the newly selected model and confirm it runs on that model.
3. Sign in as a user with **no** accessible models. Sending must still report `You don't have access to any AI models...`, not the new message.
4. Lower `max_tokens` in AI Settings below the model default, then switch to a model whose ceiling is lower still. The lowered value must be preserved or clamped down, never raised back to a default.
5. Lower `max_tokens`, then run the discriminating test above so the repair lands on a *different* model than the one you were on. The lowered value must survive the repair.
6. Open a chat on a fresh browser profile (empty `localStorage`). A default model must be selected automatically and the first send must work.
7. Switch to an image model and back to a text model. Both pickers must behave as before.

### What NOT to test

- The `localStorage`-plant-and-reload path, for the reason given above.
- Anything server-side: this is a client-state fix only. No API, schema, or model-catalog behavior changes.

## Additional Information

Verified against a running stack rather than tests alone, using a real session whose `lastUsedModel` was set to an id absent from that environment's catalog:

- **With the fix reverted:** the dead pin was written by hydration and held for the full 8 s poll window — reproducing the reported production state.
- **With the fix applied:** the store never settles on the dead pin; it is repaired immediately, and the composer's model chip renders normally while the session row still carries the dead pin.

`tsc --noEmit` over `apps/client` is clean. Test suites for `app/contexts/`, `app/utils/`, `app/hooks/` and `app/components/Session/SessionBottom/` all pass (1547 tests).

Two follow-ups, both out of scope here:

1. **Why the model left the production catalog is still open.** It is present in its backend's static table, so it was dropped either by an admin catalog-overlay row or by the listing fan-out. Worth confirming: if it was retired deliberately, the catalog row should carry `status: retired` + `replacedBy` so the existing superseded-upgrade prompt can offer the swap; if it was dropped accidentally, that is a separate live bug. This fix makes either case survivable, but does not diagnose it.
2. **Repairing a pin clears `isQuestMasterEnabled` and `isAgentsEnabled`.** That branch is unchanged here and already did this on the catalog-refetch path, but opening a session with a dead pin now silently turns both off. The alternative is a composer that cannot send at all, so this is a net improvement - noted rather than changed.
3. **The image-model effect (`LLMContext.tsx`, sibling of the one changed here) has the same latent gap** — an inaccessible `imageModel` written after it settles will not self-heal. Not touched, since it is not part of the reported failure and does not block sending, but it takes the same one-line fix.
