### PR TITLE
fix(attachments): resolve via lake membership, and report delivery on every door

### DIFF
--- a/apps/client/app/components/Session/AttachmentNotices.test.tsx
+++ b/apps/client/app/components/Session/AttachmentNotices.test.tsx
@@ -4,6 +4,18 @@ import { render, screen } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
 import AttachmentNotices from './AttachmentNotices';
+import type { IAttachmentDelivery } from '@bike4mind/common';
+
+const delivery = (over: Partial<IAttachmentDelivery> = {}): IAttachmentDelivery => ({
+  requested: 0,
+  delivered: 0,
+  fullyDelivered: 0,
+  dropped: 0,
+  droppedIds: [],
+  ...over,
+});
+
+const headingText = () => screen.getByTestId('attachment-notices-heading').textContent;
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -40,6 +52,91 @@ describe('AttachmentNotices', () => {
     const { container } = render(
       <Wrapper>
         <AttachmentNotices />
+      </Wrapper>
+    );
+
+    expect(container.textContent).toBe('');
+  });
+
+  it('heads the banner with the drop count over the denominator', () => {
+    render(
+      <Wrapper>
+        <AttachmentNotices
+          attachmentNotices={['"a.md" was not sent.']}
+          attachmentDelivery={delivery({
+            requested: 21,
+            delivered: 18,
+            fullyDelivered: 18,
+            dropped: 3,
+            droppedIds: ['a', 'b', 'c'],
+          })}
+        />
+      </Wrapper>
+    );
+
+    expect(headingText()).toBe('3 of 21 attached files did not reach the model intact');
+    expect(screen.getByTestId('WarningAmberRoundedIcon')).toBeTruthy();
+  });
+
+  it('does not claim a failure when everything arrived and some arrived in part', () => {
+    render(
+      <Wrapper>
+        <AttachmentNotices
+          attachmentNotices={['"a.md" was shortened to fit.']}
+          attachmentDelivery={delivery({ requested: 12, delivered: 12, fullyDelivered: 8 })}
+        />
+      </Wrapper>
+    );
+
+    expect(headingText()).toBe('All 12 attached files reached the model; 4 in part');
+    expect(headingText()).not.toContain('did not reach');
+    expect(screen.getByTestId('InfoOutlinedIcon')).toBeTruthy();
+    expect(screen.queryByTestId('WarningAmberRoundedIcon')).toBeNull();
+  });
+
+  it('drops the partial clause when nothing was truncated either', () => {
+    render(
+      <Wrapper>
+        <AttachmentNotices
+          attachmentNotices={['a caveat with no matching count']}
+          attachmentDelivery={delivery({ requested: 5, delivered: 5, fullyDelivered: 5 })}
+        />
+      </Wrapper>
+    );
+
+    expect(headingText()).toBe('All 5 attached files reached the model');
+  });
+
+  it('says "file" when the count is one', () => {
+    render(
+      <Wrapper>
+        <AttachmentNotices
+          attachmentNotices={['"a.md" was not sent.']}
+          attachmentDelivery={delivery({ requested: 1, dropped: 1, droppedIds: ['a'] })}
+        />
+      </Wrapper>
+    );
+
+    expect(headingText()).toBe('1 of 1 attached file did not reach the model intact');
+  });
+
+  it('keeps the countless wording on a quest written before the counts existed', () => {
+    render(
+      <Wrapper>
+        <AttachmentNotices attachmentNotices={['"a.md" was not sent.']} />
+      </Wrapper>
+    );
+
+    expect(headingText()).toBe('Some attachments did not reach the model intact');
+  });
+
+  it('stays silent on a clean turn - the report is not a success affordance', () => {
+    const { container } = render(
+      <Wrapper>
+        <AttachmentNotices
+          attachmentNotices={[]}
+          attachmentDelivery={delivery({ requested: 4, delivered: 4, fullyDelivered: 4 })}
+        />
       </Wrapper>
     );
 

--- a/apps/client/app/components/Session/AttachmentNotices.tsx
+++ b/apps/client/app/components/Session/AttachmentNotices.tsx
@@ -1,18 +1,43 @@
 import { FC } from 'react';
 import { Box, List, ListItem, Typography } from '@mui/joy';
-import { WarningAmberRounded as WarningIcon } from '@mui/icons-material';
+import { WarningAmberRounded as WarningIcon, InfoOutlined as InfoIcon } from '@mui/icons-material';
+import type { IAttachmentDelivery } from '@bike4mind/common';
 
 interface AttachmentNoticesProps {
   attachmentNotices?: string[];
+  attachmentDelivery?: IAttachmentDelivery;
 }
 
 /**
- * Per-file warnings for attachments that did not arrive intact on this turn. The same lines are
- * given to the model, so the reply and this banner agree - the point is that a dropped attachment is
- * never silent, which is how one used to look identical to never having been attached.
+ * "attached file" rather than "attachment" on purpose: on the chat door `requested` also counts the
+ * session and system files inlined beside the turn's own attachments, so a denominator phrased as
+ * what the caller just attached would overstate it.
  */
-const AttachmentNotices: FC<AttachmentNoticesProps> = ({ attachmentNotices }) => {
+const files = (n: number) => `${n} attached file${n === 1 ? '' : 's'}`;
+
+function heading(delivery?: IAttachmentDelivery): string {
+  // Absent on every quest written before the field existed - keep the countless wording there
+  // rather than rendering "0 of 0".
+  if (!delivery) return 'Some attachments did not reach the model intact';
+  if (delivery.dropped > 0) {
+    return `${delivery.dropped} of ${files(delivery.requested)} did not reach the model intact`;
+  }
+  const partial = delivery.delivered - delivery.fullyDelivered;
+  const arrived = `All ${files(delivery.requested)} reached the model`;
+  return partial > 0 ? `${arrived}; ${partial} in part` : arrived;
+}
+
+/**
+ * Per-file warnings for attachments that did not arrive intact on this turn, headed by the
+ * requested-vs-delivered count. The same lines are given to the model, so the reply and this banner
+ * agree - the point is that a dropped attachment is never silent, which is how one used to look
+ * identical to never having been attached.
+ */
+const AttachmentNotices: FC<AttachmentNoticesProps> = ({ attachmentNotices, attachmentDelivery }) => {
   if (!attachmentNotices || attachmentNotices.length === 0) return null;
+
+  // Nothing was refused, so the notices are truncation caveats: real, but not a failure to flag amber.
+  const informational = attachmentDelivery !== undefined && attachmentDelivery.dropped === 0;
 
   return (
     <Box
@@ -22,18 +47,19 @@ const AttachmentNotices: FC<AttachmentNoticesProps> = ({ attachmentNotices }) =>
         p: 1.5,
         borderRadius: 'md',
         border: '1px solid',
-        borderColor: 'warning.outlinedBorder',
-        bgcolor: 'warning.softBg',
+        borderColor: informational ? 'neutral.outlinedBorder' : 'warning.outlinedBorder',
+        bgcolor: informational ? 'neutral.softBg' : 'warning.softBg',
         maxHeight: 220,
         overflowY: 'auto',
       }}
     >
       <Typography
         level="body-xs"
-        startDecorator={<WarningIcon sx={{ fontSize: 16 }} />}
+        data-testid="attachment-notices-heading"
+        startDecorator={informational ? <InfoIcon sx={{ fontSize: 16 }} /> : <WarningIcon sx={{ fontSize: 16 }} />}
         sx={{ mb: 0.5, fontWeight: 600 }}
       >
-        Some attachments did not reach the model intact
+        {heading(attachmentDelivery)}
       </Typography>
       <List size="sm" marker="disc" sx={{ '--ListItem-minHeight': '0px', py: 0 }}>
         {attachmentNotices.map((notice, index) => (

--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -578,6 +578,7 @@ const PromptReplies: FC<PromptReplyProps> = ({
         attachmentList={messageData.attachmentList}
         navigationIntents={messageData.navigationIntents}
         attachmentNotices={messageData.attachmentNotices}
+        attachmentDelivery={messageData.attachmentDelivery}
         uiSideEffects={messageData.uiSideEffects}
         jupyterNotebook={messageData.jupyterNotebook}
         notebookContent={notebookContent}
@@ -1127,6 +1128,7 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
   attachmentList,
   navigationIntents,
   attachmentNotices,
+  attachmentDelivery,
   uiSideEffects,
   jupyterNotebook,
   notebookContent,
@@ -1916,7 +1918,7 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
 
       {/* Deliberately not gated on `completed`: a failed attachment is known before the reply
           starts, and waiting hides it for exactly as long as the model is answering without it. */}
-      <AttachmentNotices attachmentNotices={attachmentNotices} />
+      <AttachmentNotices attachmentNotices={attachmentNotices} attachmentDelivery={attachmentDelivery} />
 
       {uiSideEffects && uiSideEffects.length > 0 && completed && (
         <UiSideEffectDispatcher effects={uiSideEffects} completed={completed} dedupeKey={messageId} />

--- a/apps/client/app/components/Session/types/UserPromptTypes.ts
+++ b/apps/client/app/components/Session/types/UserPromptTypes.ts
@@ -87,6 +87,8 @@ export interface ReplyContainerProps {
   navigationIntents?: IChatHistoryItem['navigationIntents'];
   /** Per-file warnings for attachments that did not arrive intact (also stated to the model) */
   attachmentNotices?: IChatHistoryItem['attachmentNotices'];
+  /** Requested-vs-delivered counts for the same turn; heads the notices banner */
+  attachmentDelivery?: IChatHistoryItem['attachmentDelivery'];
   /** Generalized UI side-effects from tool results */
   uiSideEffects?: IChatHistoryItem['uiSideEffects'];
   /** Jupyter notebook execution state and content */

--- a/apps/client/pages/api/quests/[id]/__tests__/index.integration.test.ts
+++ b/apps/client/pages/api/quests/[id]/__tests__/index.integration.test.ts
@@ -204,6 +204,74 @@ describe('GET /api/quests/[id] (integration — scope enforcement via real middl
     expect(res._getJSONData()).toMatchObject({ images: [], files: [] });
   });
 
+  describe('attachment report (#1576 ask 1: a caller can tell whether the corpus contributed)', () => {
+    it('returns BOTH halves - the notices and the affirmative counts', async () => {
+      mockQuestFindById.mockResolvedValue({
+        id: 'quest-1',
+        sessionId: 'sess-1',
+        status: 'completed',
+        reply: {},
+        replies: [],
+        promptMeta: {},
+        attachmentNotices: ['"a.md" was not sent: it could not be read.'],
+        attachmentDelivery: { requested: 3, delivered: 2, fullyDelivered: 1, dropped: 1, droppedIds: ['f-a'] },
+      });
+      validateWithScopes([ApiKeyScope.READ_NOTEBOOKS]);
+      const { req, res } = fire();
+      await handler(req, res);
+
+      const body = res._getJSONData();
+      expect(body.attachmentNotices).toEqual(['"a.md" was not sent: it could not be read.']);
+      expect(body.attachmentDelivery).toEqual({
+        requested: 3,
+        delivered: 2,
+        fullyDelivered: 1,
+        dropped: 1,
+        droppedIds: ['f-a'],
+      });
+    });
+
+    // The case the whole ask turns on. Nothing failed, so there are no notices at all, and before
+    // `attachmentDelivery` this response was byte-identical to a turn that attached nothing - which
+    // is how a 600-answer eval ran in the wrong configuration without anyone noticing.
+    it('reports a fully successful turn, which produces no notices to infer from', async () => {
+      mockQuestFindById.mockResolvedValue({
+        id: 'quest-1',
+        sessionId: 'sess-1',
+        status: 'completed',
+        reply: {},
+        replies: [],
+        promptMeta: {},
+        attachmentDelivery: { requested: 4, delivered: 4, fullyDelivered: 4, dropped: 0, droppedIds: [] },
+      });
+      validateWithScopes([ApiKeyScope.READ_NOTEBOOKS]);
+      const { req, res } = fire();
+      await handler(req, res);
+
+      const body = res._getJSONData();
+      expect(body.attachmentNotices).toBeUndefined();
+      expect(body.attachmentDelivery).toMatchObject({ requested: 4, delivered: 4, dropped: 0 });
+    });
+
+    it('serves the report to a sharee - it describes the turn, not the owner\'s private corpus', async () => {
+      mockQuestFindById.mockResolvedValue({
+        id: 'quest-1',
+        sessionId: 'sess-1',
+        status: 'completed',
+        reply: {},
+        replies: [],
+        promptMeta: {},
+        attachmentDelivery: { requested: 1, delivered: 0, fullyDelivered: 0, dropped: 1, droppedIds: ['f-a'] },
+      });
+      // `userId: 'owner'` on the session and 'user-1' only in `users` - a share, not ownership.
+      validateWithScopes([ApiKeyScope.READ_NOTEBOOKS]);
+      const { req, res } = fire();
+      await handler(req, res);
+
+      expect(res._getJSONData().attachmentDelivery).toMatchObject({ requested: 1, dropped: 1 });
+    });
+  });
+
   describe('toolPayloads (structured tool output for programmatic callers)', () => {
     const PROBLEM = { name: 'shop', jobs: [], machines: [] };
 

--- a/apps/client/pages/api/quests/[id]/index.ts
+++ b/apps/client/pages/api/quests/[id]/index.ts
@@ -106,8 +106,11 @@ const handler = baseApi({
     // The attachment report, both halves. `attachmentNotices` explains what did not arrive;
     // `attachmentDelivery` is the affirmative count, and is the only field that separates "the
     // caller attached nothing" from "the caller attached files and none arrived" - the exact
-    // ambiguity #1576 was filed about. Neither is viewer-redacted: both describe the caller's own
-    // submission and already reach every participant's client off the loaded quest.
+    // ambiguity #1576 was filed about. Neither is viewer-redacted, and that is a parity decision
+    // rather than an omission: GET /api/sessions/[id]/chat (getMessagesFromSession) already spreads
+    // the whole quest document to everyone `findAccessibleById` admits, share holders included, and
+    // it redacts only promptMeta. Redacting here alone would hide these two fields from a sharee who
+    // reads them off the very next call the SPA makes.
     // `promptMeta.context.tokensBySource.fabFiles` is NOT a substitute; it folds the turn's own
     // attachments in with message and system files under one token count, so it cannot tell those
     // two states apart.

--- a/apps/client/pages/api/quests/[id]/index.ts
+++ b/apps/client/pages/api/quests/[id]/index.ts
@@ -103,6 +103,20 @@ const handler = baseApi({
     createdAt: quest.createdAt,
     updatedAt: quest.updatedAt,
     promptMeta,
+    // The attachment report, both halves. `attachmentNotices` explains what did not arrive;
+    // `attachmentDelivery` is the affirmative count, and is the only field that separates "the
+    // caller attached nothing" from "the caller attached files and none arrived" - the exact
+    // ambiguity #1576 was filed about. Neither is viewer-redacted: both describe the caller's own
+    // submission and already reach every participant's client off the loaded quest.
+    // `promptMeta.context.tokensBySource.fabFiles` is NOT a substitute; it folds the turn's own
+    // attachments in with message and system files under one token count, so it cannot tell those
+    // two states apart.
+    //
+    // Keep the bare word "session" followed by a comma or brace out of this literal:
+    // server/__tests__/sessionRedactionGuard.test.ts regex-scans the whole res.json({...}) span,
+    // comments included, and reads that shape as a raw session document being serialized.
+    attachmentNotices: quest.attachmentNotices,
+    attachmentDelivery: quest.attachmentDelivery,
     executionTracking: quest.promptMeta?.executionTracking,
   });
 });

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
@@ -150,6 +150,16 @@ export async function resolveRetrievalLakeScopeForUser(
     entitlementKeys?: string[];
     /** Pre-memoized membership lookup; falls back to the repository when absent. */
     findMembershipOrgIds?: (uid: string) => Promise<string[]>;
+    /**
+     * Default `true` - today's behaviour for every existing caller, none of which passes this
+     * flag. Pass `false` to opt a caller OUT of the privileged static-registry widening below.
+     * The attachment door does this: that widening escalates registry reach from passages
+     * (semantic-search) to whole inlined documents, and the chat attachment door structurally
+     * cannot follow it (`b4m-core/services` cannot import `@server/*`), so inheriting it here
+     * would ship the two attachment doors disagreeing for exactly the caller class most likely
+     * to notice.
+     */
+    staticRegistryBypass?: boolean;
   } = {}
 ): Promise<RetrievalLakeScope> {
   // Resolved for every caller, including admins. The static-registry bypass below covers only STATIC
@@ -173,5 +183,5 @@ export async function resolveRetrievalLakeScopeForUser(
   });
 
   const isPrivileged = !!user.isAdmin || hasDeveloperUserTag(user.tags);
-  return isPrivileged ? withStaticRegistryBypass(scope) : scope;
+  return isPrivileged && (opts.staticRegistryBypass ?? true) ? withStaticRegistryBypass(scope) : scope;
 }

--- a/apps/client/server/queueHandlers/agentExecutor.attachmentContent.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.attachmentContent.test.ts
@@ -7,6 +7,7 @@ import {
   attachmentNoticeBlock,
   attachmentNoticeStrings,
   MAX_INLINED_IMAGE_BYTES,
+  unmaterializedAttachments,
 } from './agentExecutor.attachmentContent';
 
 function makeLogger() {
@@ -181,13 +182,22 @@ describe('materializeAttachmentContent', () => {
     );
   });
 
-  it('still reports unresolved ids when extraction of the rest throws', async () => {
+  it('notices every dropped id when extraction throws, not just the unresolved ones', async () => {
     const logger = makeLogger();
     const extract = vi.fn().mockRejectedValue(new Error('storage down'));
 
     const result = await materializeAttachmentContent([file('a')], ['ghost'], extract, logger);
 
-    expect(result.notices).toEqual([expect.objectContaining({ fabFileId: 'ghost', band: 'unresolved' })]);
+    // The delivery contract says every id in `droppedIds` has a line in the notices. The catch
+    // path drops both the unresolvable id AND the file it never got to read, so both are owed one.
+    expect(result.delivery.droppedIds.sort()).toEqual(['a', 'ghost']);
+    expect(result.notices.map(n => n.fabFileId).sort()).toEqual(['a', 'ghost']);
+    expect(result.notices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fabFileId: 'ghost', band: 'unresolved' }),
+        expect.objectContaining({ fabFileId: 'a', band: 'read_failed' }),
+      ])
+    );
   });
 });
 
@@ -346,5 +356,35 @@ describe('attachmentNoticeBlock', () => {
     expect(out).toContain('"f19.md"');
     expect(out).not.toContain('"f20.md"');
     expect(out).toContain('5 more attachment(s) not listed here');
+  });
+});
+
+describe('unmaterializedAttachments (the agent door skip paths)', () => {
+  it('reports every requested id as dropped, with a notice each', () => {
+    const out = unmaterializedAttachments(['a', 'b']);
+
+    expect(out.delivery).toEqual({
+      requested: 2,
+      delivered: 0,
+      fullyDelivered: 0,
+      dropped: 2,
+      droppedIds: ['a', 'b'],
+    });
+    expect(out.notices.map(n => n.fabFileId)).toEqual(['a', 'b']);
+    expect(out.notices.every(n => n.delivered === false)).toBe(true);
+  });
+
+  it('carries no content, so composing it into the first iteration leaves the query untouched', () => {
+    // This is what makes the two skip paths safe to turn from `undefined` into a value: the run
+    // still gets exactly the query it got before, and gains only the record.
+    const out = unmaterializedAttachments(['a']);
+
+    expect(composeFirstIterationMessage('the query', out)).toBe('the query');
+    expect(out.inlinedFileIds).toEqual([]);
+    expect(out.fullyInlinedFileIds).toEqual([]);
+  });
+
+  it('reports nothing for a turn that requested nothing', () => {
+    expect(unmaterializedAttachments([]).delivery.requested).toBe(0);
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.attachmentContent.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.attachmentContent.test.ts
@@ -5,6 +5,7 @@ import {
   materializeAttachmentContent,
   composeFirstIterationMessage,
   attachmentNoticeBlock,
+  attachmentNoticeStrings,
   MAX_INLINED_IMAGE_BYTES,
 } from './agentExecutor.attachmentContent';
 
@@ -187,6 +188,106 @@ describe('materializeAttachmentContent', () => {
     const result = await materializeAttachmentContent([file('a')], ['ghost'], extract, logger);
 
     expect(result.notices).toEqual([expect.objectContaining({ fabFileId: 'ghost', band: 'unresolved' })]);
+  });
+});
+
+describe('materializeAttachmentContent delivery report (#1576 ask 1, agent door)', () => {
+  it('counts every requested id, delivered and dropped alike', async () => {
+    const logger = makeLogger();
+    const extract = vi.fn().mockResolvedValue(
+      extractorResult({
+        userMessages: [{ role: 'user', content: 'A BODY' }],
+        deliveredFileIds: ['a', 'b'],
+        fullyDeliveredFileIds: ['a'],
+      })
+    );
+
+    const result = await materializeAttachmentContent([file('a'), file('b'), file('c')], ['ghost'], extract, logger);
+
+    expect(result.delivery).toEqual({
+      requested: 4,
+      delivered: 2,
+      fullyDelivered: 1,
+      dropped: 2,
+      droppedIds: ['c', 'ghost'],
+    });
+  });
+
+  // The state the whole ask turns on: nothing failed, so `notices` is empty and carries no signal
+  // at all. Only the report distinguishes this from a run that was given no attachments.
+  it('reports a wholly successful run, which produces no notices to infer from', async () => {
+    const logger = makeLogger();
+    const extract = vi.fn().mockResolvedValue(
+      extractorResult({
+        userMessages: [{ role: 'user', content: 'A BODY' }],
+        deliveredFileIds: ['a', 'b'],
+        fullyDeliveredFileIds: ['a', 'b'],
+      })
+    );
+
+    const result = await materializeAttachmentContent([file('a'), file('b')], [], extract, logger);
+
+    expect(result.notices).toEqual([]);
+    expect(result.delivery).toEqual({
+      requested: 2,
+      delivered: 2,
+      fullyDelivered: 2,
+      dropped: 0,
+      droppedIds: [],
+    });
+  });
+
+  it('reports every id as dropped when extraction throws, rather than reporting nothing', async () => {
+    const logger = makeLogger();
+    const extract = vi.fn().mockRejectedValue(new Error('storage down'));
+
+    const result = await materializeAttachmentContent([file('a')], ['ghost'], extract, logger);
+
+    expect(result.delivery).toEqual({
+      requested: 2,
+      delivered: 0,
+      fullyDelivered: 0,
+      dropped: 2,
+      droppedIds: ['a', 'ghost'],
+    });
+  });
+
+  it('reports unresolved-only ids as dropped when the extractor is never reached', async () => {
+    const logger = makeLogger();
+    const extract = vi.fn();
+
+    const result = await materializeAttachmentContent([], ['ghost-1', 'ghost-2'], extract, logger);
+
+    expect(extract).not.toHaveBeenCalled();
+    expect(result.delivery).toMatchObject({ requested: 2, delivered: 0, dropped: 2 });
+  });
+});
+
+describe('attachmentNoticeStrings', () => {
+  it('is the message text alone, matching what the chat door persists', () => {
+    const notices: FabFileNotice[] = [
+      { fabFileId: 'a', fileName: 'a.md', band: 'unresolved', message: '"a.md" was not sent.', delivered: false },
+    ];
+    expect(attachmentNoticeStrings(notices)).toEqual(['"a.md" was not sent.']);
+  });
+
+  it('caps the list and says how many it left out, so a large workbench cannot flood the banner', () => {
+    const notices: FabFileNotice[] = Array.from({ length: 25 }, (_, i) => ({
+      fabFileId: `f${i}`,
+      fileName: `f${i}.md`,
+      band: 'unresolved' as const,
+      message: `"f${i}.md" was not sent.`,
+      delivered: false,
+    }));
+
+    const lines = attachmentNoticeStrings(notices);
+
+    expect(lines).toHaveLength(21);
+    expect(lines[20]).toBe('...and 5 more attachment(s) not listed here.');
+  });
+
+  it('is empty when nothing went wrong', () => {
+    expect(attachmentNoticeStrings([])).toEqual([]);
   });
 });
 

--- a/apps/client/server/queueHandlers/agentExecutor.attachmentContent.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.attachmentContent.test.ts
@@ -375,8 +375,9 @@ describe('unmaterializedAttachments (the agent door skip paths)', () => {
   });
 
   it('carries no content, so composing it into the first iteration leaves the query untouched', () => {
-    // This is what makes the two skip paths safe to turn from `undefined` into a value: the run
-    // still gets exactly the query it got before, and gains only the record.
+    // What makes the two skip paths safe to turn from `undefined` into a value: the fold adds no
+    // content of its own. The prompt does still change on those paths - the caller appends the
+    // notice block before it gets here - but this step contributes nothing to it.
     const out = unmaterializedAttachments(['a']);
 
     expect(composeFirstIterationMessage('the query', out)).toBe('the query');
@@ -384,7 +385,18 @@ describe('unmaterializedAttachments (the agent door skip paths)', () => {
     expect(out.fullyInlinedFileIds).toEqual([]);
   });
 
-  it('reports nothing for a turn that requested nothing', () => {
-    expect(unmaterializedAttachments([]).delivery.requested).toBe(0);
+  // The caller guards against an empty request, so this pins the helper's own contract rather
+  // than a live path: no notices invented, and a well-formed zeroed report rather than a partial.
+  it('is total: an empty request yields an empty report, not a malformed one', () => {
+    const out = unmaterializedAttachments([]);
+
+    expect(out.notices).toEqual([]);
+    expect(out.delivery).toEqual({
+      requested: 0,
+      delivered: 0,
+      fullyDelivered: 0,
+      dropped: 0,
+      droppedIds: [],
+    });
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.attachmentContent.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.attachmentContent.ts
@@ -1,4 +1,4 @@
-import type { MessageContentObject, IMessage, IFabFileDocument } from '@bike4mind/common';
+import type { MessageContentObject, IMessage, IFabFileDocument, IAttachmentDelivery } from '@bike4mind/common';
 // Type-only, so it is erased at compile time and this module carries no runtime dependency on
 // `@bike4mind/utils` (whose native deps the client test resolver cannot load).
 import type { FabFileNotice } from '@bike4mind/utils';
@@ -56,6 +56,10 @@ export interface MaterializedAttachments {
   fullyInlinedFileIds: string[];
   /** Per-file delivery problems, already phrased for a reader. */
   notices: FabFileNotice[];
+  /** Requested-vs-delivered counts for the run, persisted onto the linked quest so the agent path
+   *  records attachment outcomes the way the chat path does. Present on every return, including
+   *  the fallbacks - a run whose extraction failed wholesale still owes the caller that report. */
+  delivery: IAttachmentDelivery;
 }
 
 const EMPTY: MaterializedAttachments = {
@@ -64,7 +68,19 @@ const EMPTY: MaterializedAttachments = {
   inlinedFileIds: [],
   fullyInlinedFileIds: [],
   notices: [],
+  delivery: { requested: 0, delivered: 0, fullyDelivered: 0, dropped: 0, droppedIds: [] },
 };
+
+/** Nothing arrived, so every requested id is a drop. Shared by both fallback returns. */
+function allDropped(requestedIds: string[]): IAttachmentDelivery {
+  return {
+    requested: requestedIds.length,
+    delivered: 0,
+    fullyDelivered: 0,
+    dropped: requestedIds.length,
+    droppedIds: requestedIds,
+  };
+}
 
 interface MinimalLogger {
   info: (message: string, meta?: Record<string, unknown>) => void;
@@ -103,8 +119,12 @@ export async function materializeAttachmentContent(
     delivered: false,
   }));
 
+  // Every id the turn was given, in one list: the drop set of both fallbacks below, and the
+  // denominator of the delivery report.
+  const requestedIds = [...files.map(file => file.id), ...missingIds];
+
   if (files.length === 0) {
-    return { ...EMPTY, notices: unresolvedNotices };
+    return { ...EMPTY, notices: unresolvedNotices, delivery: allDropped(requestedIds) };
   }
 
   let result: Awaited<ReturnType<ProcessFabFiles>>;
@@ -115,7 +135,7 @@ export async function materializeAttachmentContent(
       fileCount: files.length,
       error: err instanceof Error ? err.message : String(err),
     });
-    return { ...EMPTY, notices: unresolvedNotices };
+    return { ...EMPTY, notices: unresolvedNotices, delivery: allDropped(requestedIds) };
   }
 
   const textParts: string[] = [];
@@ -176,10 +196,17 @@ export async function materializeAttachmentContent(
     });
   }
 
+  const fullyInlinedFileIds = result.fullyDeliveredFileIds.filter(id => inlined.has(id));
+  const delivery: IAttachmentDelivery = {
+    requested: requestedIds.length,
+    delivered: inlined.size,
+    fullyDelivered: fullyInlinedFileIds.length,
+    dropped: requestedIds.length - inlined.size,
+    droppedIds: requestedIds.filter(id => !inlined.has(id)),
+  };
+
   logger.info('[AttachmentContent] Materialized attachment content for the agent run', {
-    requested: files.length + missingIds.length,
-    delivered: result.deliveredFileIds.length,
-    fullyDelivered: result.fullyDeliveredFileIds.length,
+    ...delivery,
     textParts: textParts.length,
     inlinedImageBytes: imageBytes,
     notices: notices.length,
@@ -190,8 +217,9 @@ export async function materializeAttachmentContent(
     imageBlocks,
     inlinedFileIds: Array.from(inlined),
     // Intersected with `inlined` so the two sets cannot disagree; see the limitation noted there.
-    fullyInlinedFileIds: result.fullyDeliveredFileIds.filter(id => inlined.has(id)),
+    fullyInlinedFileIds,
     notices,
+    delivery,
   };
 }
 
@@ -219,6 +247,20 @@ export function composeFirstIterationMessage(
  * under a line per file. Change one, change the other.
  */
 const MAX_NOTICE_LINES = 20;
+
+/**
+ * The transcript lines persisted onto the linked quest, mirroring `toAttachmentNoticeStrings` in
+ * `b4m-core/services/src/llm/attachmentNotices.ts` - the chat path's version of the same list.
+ * Duplicated rather than imported for the reason MAX_NOTICE_LINES is: this module's imports stay
+ * type-only. Same cap, same one-sentence-per-file shape, so a reader cannot tell which door a
+ * notice came from. Change one, change the other.
+ */
+export function attachmentNoticeStrings(notices: FabFileNotice[]): string[] {
+  const overflow = Math.max(0, notices.length - MAX_NOTICE_LINES);
+  const lines = notices.slice(0, MAX_NOTICE_LINES).map(notice => notice.message);
+  if (overflow > 0) lines.push(`...and ${overflow} more attachment(s) not listed here.`);
+  return lines;
+}
 
 /**
  * The block appended to the query for attachments that did NOT arrive intact. Mirrors the chat

--- a/apps/client/server/queueHandlers/agentExecutor.attachmentContent.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.attachmentContent.ts
@@ -82,6 +82,26 @@ function allDropped(requestedIds: string[]): IAttachmentDelivery {
   };
 }
 
+/**
+ * The report a caller owes when materialization never ran at all - no model to size a budget
+ * against, or the attempt threw before it could produce one. Content-free, so composing it into
+ * the first iteration is a no-op; what it carries is the record that these ids were asked for and
+ * none of them reached the prompt.
+ */
+export function unmaterializedAttachments(requestedIds: string[]): MaterializedAttachments {
+  return {
+    ...EMPTY,
+    notices: requestedIds.map(id => ({
+      fabFileId: id,
+      fileName: id,
+      band: 'read_failed' as const,
+      message: `An attached file (id ${id}) was not inlined: its content could not be prepared for this run.`,
+      delivered: false,
+    })),
+    delivery: allDropped(requestedIds),
+  };
+}
+
 interface MinimalLogger {
   info: (message: string, meta?: Record<string, unknown>) => void;
   warn: (message: string, meta?: Record<string, unknown>) => void;
@@ -135,7 +155,21 @@ export async function materializeAttachmentContent(
       fileCount: files.length,
       error: err instanceof Error ? err.message : String(err),
     });
-    return { ...EMPTY, notices: unresolvedNotices, delivery: allDropped(requestedIds) };
+    // `allDropped` counts these files as drops too, and the delivery contract requires every drop
+    // to carry a notice - so state the wholesale failure per file rather than only for the ids
+    // that were already unresolvable.
+    const failedNotices: FabFileNotice[] = files.map(file => ({
+      fabFileId: file.id,
+      fileName: file.fileName,
+      band: 'read_failed' as const,
+      message: `"${file.fileName}" was not sent: its content could not be extracted.`,
+      delivered: false,
+    }));
+    return {
+      ...EMPTY,
+      notices: [...unresolvedNotices, ...failedNotices],
+      delivery: allDropped(requestedIds),
+    };
   }
 
   const textParts: string[] = [];

--- a/apps/client/server/queueHandlers/agentExecutor.attachmentLakeAccess.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.attachmentLakeAccess.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const resolveRetrievalLakeScopeForUser = vi.fn();
+const lakeMembershipsFrom = vi.fn();
+const warnIfManyLakeMemberships = vi.fn();
+
+vi.mock('@server/dataLakes/resolveRetrievalLakeScope', () => ({
+  resolveRetrievalLakeScopeForUser: (...args: unknown[]) => resolveRetrievalLakeScopeForUser(...args),
+}));
+vi.mock('@bike4mind/services', () => ({
+  dataLakeService: {
+    lakeMembershipsFrom: (...args: unknown[]) => lakeMembershipsFrom(...args),
+    warnIfManyLakeMemberships: (...args: unknown[]) => warnIfManyLakeMemberships(...args),
+  },
+}));
+
+import { createAttachmentLakeAccess } from './agentExecutor.attachmentLakeAccess';
+
+const MEMBERSHIP = {
+  kind: 'owned' as const,
+  datalakeTag: 'datalake:acme',
+  fileTagPrefix: 'acme:',
+  creatorUserId: 'creator-1',
+};
+
+const makeLogger = () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn(), log: vi.fn() });
+const USER = { id: 'u1', tags: [] } as never;
+
+describe('createAttachmentLakeAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lakeMembershipsFrom.mockReturnValue([MEMBERSHIP]);
+  });
+
+  it('opts out of the privileged static-registry bypass', async () => {
+    resolveRetrievalLakeScopeForUser.mockResolvedValue({ lakes: [], dataLakeTags: [], dataLakeTagPrefixes: [] });
+    const logger = makeLogger();
+
+    await createAttachmentLakeAccess(USER, logger as never)();
+
+    expect(resolveRetrievalLakeScopeForUser).toHaveBeenCalledWith(
+      USER,
+      expect.objectContaining({ staticRegistryBypass: false })
+    );
+  });
+
+  it('derives lakeMemberships through lakeMembershipsFrom and forwards the tag buckets verbatim', async () => {
+    resolveRetrievalLakeScopeForUser.mockResolvedValue({
+      lakes: [{ id: 'l1' }],
+      dataLakeTags: ['datalake:acme'],
+      dataLakeTagPrefixes: ['reg:'],
+    });
+    const logger = makeLogger();
+
+    const access = await createAttachmentLakeAccess(USER, logger as never)();
+
+    expect(lakeMembershipsFrom).toHaveBeenCalledWith([{ id: 'l1' }]);
+    expect(access).toEqual({
+      lakeMemberships: [MEMBERSHIP],
+      dataLakeTags: ['datalake:acme'],
+      dataLakeTagPrefixes: ['reg:'],
+    });
+  });
+
+  // The load-bearing one: this resolver has no fail-safe of its own, so without the catch an
+  // unhandled rejection fails the whole agent run instead of degrading to ownership-only.
+  it('degrades to ownership-only when the resolver throws, and never widens', async () => {
+    resolveRetrievalLakeScopeForUser.mockRejectedValue(new Error('lake read failed'));
+    const logger = makeLogger();
+
+    const access = await createAttachmentLakeAccess(USER, logger as never)();
+
+    // {} means "no lake arms" downstream - byte-identical to the pre-#1576 ownership-only query.
+    expect(access).toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[AttachmentLakeAccess] Resolution failed; falling back to ownership-only',
+      expect.objectContaining({ error: 'lake read failed' })
+    );
+  });
+
+  it('rejecting once does not poison later calls into an unhandled rejection', async () => {
+    resolveRetrievalLakeScopeForUser.mockRejectedValue(new Error('lake read failed'));
+    const thunk = createAttachmentLakeAccess(USER, makeLogger() as never);
+
+    await expect(thunk()).resolves.toEqual({});
+    await expect(thunk()).resolves.toEqual({});
+  });
+
+  it('memoizes: the resolver runs once however many times the thunk is called', async () => {
+    resolveRetrievalLakeScopeForUser.mockResolvedValue({ lakes: [], dataLakeTags: [], dataLakeTagPrefixes: [] });
+    const thunk = createAttachmentLakeAccess(USER, makeLogger() as never);
+
+    await Promise.all([thunk(), thunk(), thunk()]);
+
+    expect(resolveRetrievalLakeScopeForUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('is lazy: constructing the thunk resolves nothing', () => {
+    resolveRetrievalLakeScopeForUser.mockResolvedValue({ lakes: [], dataLakeTags: [], dataLakeTagPrefixes: [] });
+
+    createAttachmentLakeAccess(USER, makeLogger() as never);
+
+    expect(resolveRetrievalLakeScopeForUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutor.attachmentLakeAccess.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.attachmentLakeAccess.ts
@@ -1,0 +1,54 @@
+import { type AttachmentLakeAccess, type IUserDocument } from '@bike4mind/common';
+import { dataLakeService } from '@bike4mind/services';
+import { resolveRetrievalLakeScopeForUser } from '@server/dataLakes/resolveRetrievalLakeScope';
+import type { Logger } from '@bike4mind/observability';
+
+/**
+ * The agent door's lake arms, as a lazy memo (parity with the chat door's `attachmentLakeAccess`).
+ * Resolved through `resolveRetrievalLakeScopeForUser` since the executor has no `req`.
+ *
+ * Opted OUT of the privileged static-registry bypass (`staticRegistryBypass: false`): that widening
+ * escalates registry reach from passages (semantic-search) to whole inlined documents, and the chat
+ * attachment door structurally cannot follow it, so inheriting it here would ship the two
+ * attachment doors disagreeing for exactly the caller class most likely to notice.
+ *
+ * Returns a THUNK, and the caller must keep it one: a handoff is a FRESH invocation (published to
+ * the continuation queue, not an in-process resume), so laziness - not the memo - is what avoids
+ * resolving on a wake that will not use it. Build one per invocation and never hoist it to module
+ * scope, where it would survive warm-container reuse keyed on nothing and leak one user's lake
+ * buckets into the next user's run.
+ *
+ * `resolveRetrievalLakeScopeForUser` has no fail-safe of its own (unlike the chat door's
+ * `getAccessibleDataLakeAccess`), so the catch is load-bearing: an unhandled throw would fail the
+ * whole run rather than degrading to ownership-only.
+ */
+export function createAttachmentLakeAccess(
+  user: IUserDocument,
+  logger: Logger
+): () => Promise<AttachmentLakeAccess> {
+  let memo: Promise<AttachmentLakeAccess> | undefined;
+
+  return () =>
+    (memo ??= (async (): Promise<AttachmentLakeAccess> => {
+      try {
+        const scope = await resolveRetrievalLakeScopeForUser(user, {
+          logger,
+          staticRegistryBypass: false,
+        });
+        const lakeMemberships = dataLakeService.lakeMembershipsFrom(scope.lakes);
+        dataLakeService.warnIfManyLakeMemberships(lakeMemberships, logger, 'attachment-resolution:agent');
+        return {
+          lakeMemberships,
+          dataLakeTags: scope.dataLakeTags,
+          dataLakeTagPrefixes: scope.dataLakeTagPrefixes,
+        };
+      } catch (err) {
+        // Degrade to today's ownership-only behaviour. Widening on error is never correct here,
+        // and neither is failing the run.
+        logger.warn('[AttachmentLakeAccess] Resolution failed; falling back to ownership-only', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return {};
+      }
+    })());
+}

--- a/apps/client/server/queueHandlers/agentExecutor.buildFirstIterationQuery.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.buildFirstIterationQuery.test.ts
@@ -193,7 +193,8 @@ describe('buildFirstIterationQuery', () => {
     // Guards against regressing to an owner-only `{ userId }` scope - chat
     // completion passes the CASL `accessibleBy(...).ofType(FabFile)` filter
     // so org/group/shared files surface, and this helper must do the same.
-    expect(getAccessibleFiles).toHaveBeenCalledWith(['id1'], SCOPE);
+    // The trailing `undefined` is the omitted `lakeAccess` param, forwarded as-is.
+    expect(getAccessibleFiles).toHaveBeenCalledWith(['id1'], SCOPE, undefined);
   });
 
   it('dedupes across sessionFabFileIds, messageFileIds, and sessionKnowledgeIds before lookup', async () => {
@@ -634,5 +635,100 @@ describe('maybeBuildFirstIterationQuery (gate)', () => {
 
     // Proves the gate is not dropping the toolbelt on the floor and defaulting to "readable".
     expect(result).toContain('METADATA ONLY');
+  });
+
+  describe('lakeAccess (#1576 attachment door lake-membership arm)', () => {
+    const MEMBERSHIP = {
+      kind: 'owned' as const,
+      datalakeTag: 'datalake:acme',
+      fileTagPrefix: 'acme:',
+      creatorUserId: 'creator-1',
+    };
+
+    it('is only resolved (the thunk is only called) when the gate actually builds a preamble', async () => {
+      const repo = makeRepo(vi.fn());
+      const logger = makeLogger();
+      const lakeAccess = vi.fn().mockResolvedValue({ lakeMemberships: [MEMBERSHIP] });
+
+      await maybeBuildFirstIterationQuery(
+        { ...baseArgs, isNewExecution: false, iterationIndex: 0, lakeAccess },
+        logger,
+        repo
+      );
+      await maybeBuildFirstIterationQuery(
+        { ...baseArgs, isNewExecution: true, iterationIndex: 1, lakeAccess },
+        logger,
+        repo
+      );
+
+      expect(lakeAccess).not.toHaveBeenCalled();
+    });
+
+    it('forwards the thunk-resolved lakeAccess to getAccessibleFiles as the fourth argument on the building iteration', async () => {
+      const getAccessibleFiles = vi.fn().mockResolvedValue([makeFile('id1', 'spec.pdf', 'application/pdf')]);
+      const repo = makeRepo(getAccessibleFiles);
+      const logger = makeLogger();
+      const resolvedLakeAccess = { lakeMemberships: [MEMBERSHIP], dataLakeTags: ['datalake:acme'] };
+      const lakeAccess = vi.fn().mockResolvedValue(resolvedLakeAccess);
+
+      await maybeBuildFirstIterationQuery(
+        { ...baseArgs, isNewExecution: true, iterationIndex: 0, lakeAccess },
+        logger,
+        repo
+      );
+
+      expect(lakeAccess).toHaveBeenCalledTimes(1);
+      expect(getAccessibleFiles).toHaveBeenCalledWith(['id1'], SCOPE, resolvedLakeAccess);
+    });
+
+    it("propagates a rejecting thunk rather than swallowing it here - the fail-safe degrade lives in the thunk itself (agentExecutor's memo), not this gate", async () => {
+      const getAccessibleFiles = vi.fn().mockResolvedValue([makeFile('id1', 'spec.pdf', 'application/pdf')]);
+      const repo = makeRepo(getAccessibleFiles);
+      const logger = makeLogger();
+      const lakeAccess = vi.fn().mockRejectedValue(new Error('resolver down'));
+
+      await expect(
+        maybeBuildFirstIterationQuery(
+          { ...baseArgs, isNewExecution: true, iterationIndex: 0, lakeAccess },
+          logger,
+          repo
+        )
+      ).rejects.toThrow('resolver down');
+    });
+
+    it('a prefix-only creator-owned member resolves through the forwarded lakeAccess (catches an unconverted-scope silent failure)', async () => {
+      const getAccessibleFiles = vi.fn().mockResolvedValue([makeFile('id1', 'report.pdf', 'application/pdf')]);
+      const repo = makeRepo(getAccessibleFiles);
+      const logger = makeLogger();
+      const lakeAccess = vi.fn().mockResolvedValue({ lakeMemberships: [MEMBERSHIP] });
+
+      const result = await maybeBuildFirstIterationQuery(
+        { ...baseArgs, isNewExecution: true, iterationIndex: 0, lakeAccess },
+        logger,
+        repo
+      );
+
+      expect(result).toContain('"report.pdf"');
+    });
+
+    it('agent-supplied execution input cannot substitute for the resolved lakeAccess - only the thunk result is forwarded', async () => {
+      const getAccessibleFiles = vi.fn().mockResolvedValue([]);
+      const repo = makeRepo(getAccessibleFiles);
+      const logger = makeLogger();
+      const lakeAccess = vi.fn().mockResolvedValue({ lakeMemberships: [MEMBERSHIP] });
+      // A forged bucket smuggled into execution - the args type has no field for this, but a
+      // caller building `execution` from request-derived data could still attach one.
+      const forgedExecution = { ...baseArgs.execution, lakeMemberships: [{ ...MEMBERSHIP, creatorUserId: 'anyone' }] };
+
+      await maybeBuildFirstIterationQuery(
+        { ...baseArgs, execution: forgedExecution, isNewExecution: true, iterationIndex: 0, lakeAccess },
+        logger,
+        repo
+      );
+
+      const forwardedLakeAccess = getAccessibleFiles.mock.calls[0][2];
+      expect(forwardedLakeAccess).toEqual({ lakeMemberships: [MEMBERSHIP] });
+      expect(JSON.stringify(forwardedLakeAccess)).not.toContain('anyone');
+    });
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.buildFirstIterationQuery.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.buildFirstIterationQuery.test.ts
@@ -696,7 +696,10 @@ describe('maybeBuildFirstIterationQuery (gate)', () => {
       ).rejects.toThrow('resolver down');
     });
 
-    it('a prefix-only creator-owned member resolves through the forwarded lakeAccess (catches an unconverted-scope silent failure)', async () => {
+    // Deliberately NOT titled as catching an unconverted scope: the repo is a mock that returns the
+    // file whatever `lakeAccess` holds, so the query-level predicate is out of its reach. That is
+    // pinned against a real Mongo in FabFileModel.dataLakeLifecycle.test.ts.
+    it('names a prefix-only creator-owned member in the preamble when lakeAccess is forwarded', async () => {
       const getAccessibleFiles = vi.fn().mockResolvedValue([makeFile('id1', 'report.pdf', 'application/pdf')]);
       const repo = makeRepo(getAccessibleFiles);
       const logger = makeLogger();

--- a/apps/client/server/queueHandlers/agentExecutor.firstIterationQuery.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.firstIterationQuery.ts
@@ -1,4 +1,4 @@
-import { isImageAttachment, type IFabFileDocument } from '@bike4mind/common';
+import { isImageAttachment, type AttachmentLakeAccess, type IFabFileDocument } from '@bike4mind/common';
 
 /**
  * Minimal structural Logger contract - kept here so this module doesn't have
@@ -89,7 +89,11 @@ function escapePreambleFilename(name: string): string {
 }
 
 interface FabFileAccessibleRepo {
-  getAccessibleFiles: (fabFileIds: string[], scope: Record<string, unknown>) => Promise<IFabFileDocument[]>;
+  getAccessibleFiles: (
+    fabFileIds: string[],
+    scope: Record<string, unknown>,
+    lakeAccess?: AttachmentLakeAccess
+  ) => Promise<IFabFileDocument[]>;
 }
 
 /**
@@ -139,7 +143,9 @@ export async function buildFirstIterationQuery(
   scope: Record<string, unknown>,
   availableToolNames: readonly string[],
   /** Ids whose content was already inlined into this run's first message; never marked unreadable. */
-  inlinedFileIds: readonly string[] = []
+  inlinedFileIds: readonly string[] = [],
+  /** The attachment door's lake arms - see `maybeBuildFirstIterationQuery`'s `lakeAccess`. */
+  lakeAccess?: AttachmentLakeAccess
 ): Promise<string> {
   // `sessionFabFileIds` + `messageFileIds` are client-snapshotted at dispatch
   // (stable across Lambda handoffs), while `sessionKnowledgeIds` is re-read
@@ -160,7 +166,7 @@ export async function buildFirstIterationQuery(
 
   let files: PreambleFile[];
   try {
-    files = await repo.getAccessibleFiles(requestedIds, scope);
+    files = await repo.getAccessibleFiles(requestedIds, scope, lakeAccess);
   } catch (err) {
     // Don't fail the run if file lookup errors - the agent still has the
     // user's query and can ask the user for missing context. Log loud so
@@ -274,6 +280,12 @@ export async function maybeBuildFirstIterationQuery(
     availableToolNames: readonly string[];
     /** See `buildFirstIterationQuery`. */
     inlinedFileIds?: readonly string[];
+    /**
+     * A THUNK, not an awaited value: this call site is UNgated (the gate below lives inside this
+     * function), so an awaited value here would force the resolution on every iteration instead of
+     * only on the one that actually builds the preamble.
+     */
+    lakeAccess?: () => Promise<AttachmentLakeAccess>;
   },
   logger: MinimalLogger,
   repo: FabFileAccessibleRepo
@@ -287,6 +299,7 @@ export async function maybeBuildFirstIterationQuery(
     repo,
     args.scope,
     args.availableToolNames,
-    args.inlinedFileIds ?? []
+    args.inlinedFileIds ?? [],
+    await args.lakeAccess?.()
   );
 }

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -91,9 +91,9 @@ import {
   type ToolBuilderDeps,
   type ToolBuilderCallbacks,
 } from '@bike4mind/services';
-import { creditService, apiKeyService, estimateGeneratedMediaUsd, dataLakeService } from '@bike4mind/services';
+import { creditService, apiKeyService, estimateGeneratedMediaUsd } from '@bike4mind/services';
 import { mergeRetrievalSummary, type RetrievalSummary } from '@bike4mind/services';
-import { resolveRetrievalLakeScopeForUser } from '@server/dataLakes/resolveRetrievalLakeScope';
+import { createAttachmentLakeAccess } from './agentExecutor.attachmentLakeAccess';
 // Lattice launch-gate. `resolveLatticeTools` owns the `enableLattice` flag
 // resolution and the Lattice tool contribution (names + `externalTools`
 // definitions); see that module's header for the Next-tracing split and the
@@ -134,6 +134,7 @@ import {
   materializeAttachmentContent,
   composeFirstIterationMessage,
   attachmentNoticeBlock,
+  attachmentNoticeStrings,
 } from './agentExecutor.attachmentContent';
 import { applySessionToolPolicy, delegationOffer, runHasAttachments } from './agentExecutor.sessionToolPolicy';
 import { toUserFacingFailureMessage } from './agentExecutor.failureMessage';
@@ -2191,46 +2192,10 @@ async function processExecution(
     // rebuilding the ability set every iteration.
     const fabFileReadScope = accessibleBy(defineAbilitiesFor(user as IUserDocument), Permission.read).ofType(FabFile);
 
-    // The attachment door's lake arms (parity with the chat door's `attachmentLakeAccess`), resolved
-    // through `resolveRetrievalLakeScopeForUser` since this executor has no `req`. Opted OUT of the
-    // privileged static-registry bypass (`staticRegistryBypass: false`): that widening escalates
-    // registry reach from passages (semantic-search) to whole inlined documents, and the chat
-    // attachment door structurally cannot follow it, so inheriting it here would ship the two
-    // attachment doors disagreeing for exactly the caller class most likely to notice.
-    //
-    // A FUNCTION-LOCAL lazy memo, not module-scoped: a handoff is a FRESH invocation (published to
-    // Resource.agentContinuationQueue, not an in-process resume), so this memo neither spans nor
-    // needs to span wakes - laziness, not the memo, is what avoids resolving on a wake that will not
-    // use it. Hoisted to module scope it would survive Lambda warm-container reuse keyed on
-    // nothing, leaking one user's lake buckets into the next user's run.
-    //
-    // This resolver has no fail-safe of its own (unlike the chat door's `getAccessibleDataLakeAccess`),
-    // so the catch here is load-bearing: an unhandled throw would fail the whole run rather than
-    // degrading to today's ownership-only behaviour.
-    let lakeAccessMemo: Promise<AttachmentLakeAccess> | undefined;
-    const attachmentLakeAccess = () =>
-      (lakeAccessMemo ??= (async (): Promise<AttachmentLakeAccess> => {
-        try {
-          const scope = await resolveRetrievalLakeScopeForUser(user as IUserDocument, {
-            logger,
-            staticRegistryBypass: false,
-          });
-          const lakeMemberships = dataLakeService.lakeMembershipsFrom(scope.lakes);
-          dataLakeService.warnIfManyLakeMemberships(lakeMemberships, logger, 'attachment-resolution:agent');
-          return {
-            lakeMemberships,
-            dataLakeTags: scope.dataLakeTags,
-            dataLakeTagPrefixes: scope.dataLakeTagPrefixes,
-          };
-        } catch (err) {
-          // Degrade to today's ownership-only behaviour. Widening on error is never correct here,
-          // and neither is failing the run.
-          logger.warn('[AttachmentLakeAccess] Resolution failed; falling back to ownership-only', {
-            error: err instanceof Error ? err.message : String(err),
-          });
-          return {};
-        }
-      })());
+    // The attachment door's lake arms, parity with the chat door's `attachmentLakeAccess`. Built
+    // per invocation and kept a thunk on purpose - see `createAttachmentLakeAccess` for why the
+    // memo must not be hoisted and why its catch is load-bearing.
+    const attachmentLakeAccess = createAttachmentLakeAccess(user as IUserDocument, logger);
 
     // --- Iteration loop ---
     let iterationResult: IterationResult | undefined;
@@ -2379,6 +2344,21 @@ async function processExecution(
         // the empty array.
         inlinedAttachmentIds.push(...materialized.inlinedFileIds);
         fullyInlinedAttachmentIds.push(...materialized.fullyInlinedFileIds);
+
+        // Parity with the chat door, which persists the same two values on its quest before the
+        // completion runs. Best-effort on purpose: content materialization is an enhancement over
+        // the metadata preamble, so failing to RECORD its outcome must not take the run down.
+        await questRepository
+          .recordAttachmentOutcomeByAgentExecutionId(executionId, {
+            notices: attachmentNoticeStrings(materialized.notices),
+            delivery: materialized.delivery,
+          })
+          .catch(err =>
+            logger.warn('[AttachmentContent] Could not record the attachment outcome on the quest', {
+              executionId,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          );
       }
 
       let firstIterationQuery = await maybeBuildFirstIterationQuery(

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -71,7 +71,13 @@ import {
   type IterationResult,
   type ServerAgentDefinition,
 } from '@bike4mind/agents';
-import { getTextModelCost, CreditHolderType, type IAgent, type IUserDocument } from '@bike4mind/common';
+import {
+  getTextModelCost,
+  CreditHolderType,
+  type AttachmentLakeAccess,
+  type IAgent,
+  type IUserDocument,
+} from '@bike4mind/common';
 import { usdToCreditsStochastic } from '@bike4mind/utils';
 import {
   buildSharedTools,
@@ -85,8 +91,9 @@ import {
   type ToolBuilderDeps,
   type ToolBuilderCallbacks,
 } from '@bike4mind/services';
-import { creditService, apiKeyService, estimateGeneratedMediaUsd } from '@bike4mind/services';
+import { creditService, apiKeyService, estimateGeneratedMediaUsd, dataLakeService } from '@bike4mind/services';
 import { mergeRetrievalSummary, type RetrievalSummary } from '@bike4mind/services';
+import { resolveRetrievalLakeScopeForUser } from '@server/dataLakes/resolveRetrievalLakeScope';
 // Lattice launch-gate. `resolveLatticeTools` owns the `enableLattice` flag
 // resolution and the Lattice tool contribution (names + `externalTools`
 // definitions); see that module's header for the Next-tracing split and the
@@ -685,11 +692,12 @@ async function materializeAttachmentsForRun(args: {
   execution: { userId: string; query: string; messageFileIds?: string[]; sessionFabFileIds?: string[] };
   sessionKnowledgeIds: string[];
   scope: Record<string, unknown>;
+  lakeAccess: AttachmentLakeAccess;
   modelInfo?: ModelInfo;
   apiKeyTable: ApiKeyTable;
   logger: Logger;
 }) {
-  const { execution, sessionKnowledgeIds, scope, modelInfo, apiKeyTable, logger } = args;
+  const { execution, sessionKnowledgeIds, scope, lakeAccess, modelInfo, apiKeyTable, logger } = args;
 
   const requestedIds = Array.from(
     new Set([...(execution.messageFileIds ?? []), ...(execution.sessionFabFileIds ?? []), ...sessionKnowledgeIds])
@@ -709,7 +717,7 @@ async function materializeAttachmentsForRun(args: {
     const storage = getFilesStorage();
     const { files, missingIds } = await fetchAndConvertFabFiles(
       requestedIds,
-      { scope },
+      { scope, lakeAccess },
       { db: { fabfiles: fabFileRepository, caches: cacheRepository }, storage, logger }
     );
 
@@ -2183,6 +2191,47 @@ async function processExecution(
     // rebuilding the ability set every iteration.
     const fabFileReadScope = accessibleBy(defineAbilitiesFor(user as IUserDocument), Permission.read).ofType(FabFile);
 
+    // The attachment door's lake arms (parity with the chat door's `attachmentLakeAccess`), resolved
+    // through `resolveRetrievalLakeScopeForUser` since this executor has no `req`. Opted OUT of the
+    // privileged static-registry bypass (`staticRegistryBypass: false`): that widening escalates
+    // registry reach from passages (semantic-search) to whole inlined documents, and the chat
+    // attachment door structurally cannot follow it, so inheriting it here would ship the two
+    // attachment doors disagreeing for exactly the caller class most likely to notice.
+    //
+    // A FUNCTION-LOCAL lazy memo, not module-scoped: a handoff is a FRESH invocation (published to
+    // Resource.agentContinuationQueue, not an in-process resume), so this memo neither spans nor
+    // needs to span wakes - laziness, not the memo, is what avoids resolving on a wake that will not
+    // use it. Hoisted to module scope it would survive Lambda warm-container reuse keyed on
+    // nothing, leaking one user's lake buckets into the next user's run.
+    //
+    // This resolver has no fail-safe of its own (unlike the chat door's `getAccessibleDataLakeAccess`),
+    // so the catch here is load-bearing: an unhandled throw would fail the whole run rather than
+    // degrading to today's ownership-only behaviour.
+    let lakeAccessMemo: Promise<AttachmentLakeAccess> | undefined;
+    const attachmentLakeAccess = () =>
+      (lakeAccessMemo ??= (async (): Promise<AttachmentLakeAccess> => {
+        try {
+          const scope = await resolveRetrievalLakeScopeForUser(user as IUserDocument, {
+            logger,
+            staticRegistryBypass: false,
+          });
+          const lakeMemberships = dataLakeService.lakeMembershipsFrom(scope.lakes);
+          dataLakeService.warnIfManyLakeMemberships(lakeMemberships, logger, 'attachment-resolution:agent');
+          return {
+            lakeMemberships,
+            dataLakeTags: scope.dataLakeTags,
+            dataLakeTagPrefixes: scope.dataLakeTagPrefixes,
+          };
+        } catch (err) {
+          // Degrade to today's ownership-only behaviour. Widening on error is never correct here,
+          // and neither is failing the run.
+          logger.warn('[AttachmentLakeAccess] Resolution failed; falling back to ownership-only', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return {};
+        }
+      })());
+
     // --- Iteration loop ---
     let iterationResult: IterationResult | undefined;
     let iterationIndex = isNewExecution ? 0 : ((execution.checkpoint as AgentCheckpoint)?.iteration ?? 0);
@@ -2318,6 +2367,7 @@ async function processExecution(
               execution,
               sessionKnowledgeIds: session.knowledgeIds ?? [],
               scope: fabFileReadScope,
+              lakeAccess: await attachmentLakeAccess(),
               modelInfo,
               apiKeyTable: apiKeyTable as ApiKeyTable,
               logger,
@@ -2339,6 +2389,7 @@ async function processExecution(
           execution,
           sessionKnowledgeIds: session.knowledgeIds ?? [],
           scope: fabFileReadScope,
+          lakeAccess: attachmentLakeAccess,
           availableToolNames: resolvedToolNames,
           inlinedFileIds: materialized?.inlinedFileIds ?? [],
         },

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -135,6 +135,7 @@ import {
   composeFirstIterationMessage,
   attachmentNoticeBlock,
   attachmentNoticeStrings,
+  unmaterializedAttachments,
 } from './agentExecutor.attachmentContent';
 import { applySessionToolPolicy, delegationOffer, runHasAttachments } from './agentExecutor.sessionToolPolicy';
 import { toUserFacingFailureMessage } from './agentExecutor.failureMessage';
@@ -711,7 +712,9 @@ async function materializeAttachmentsForRun(args: {
     logger.warn('[AttachmentContent] No resolved modelInfo; skipping content materialization', {
       requested: requestedIds.length,
     });
-    return undefined;
+    // Report-only: the turn still owes a record that these ids were asked for and none arrived,
+    // or the quest is indistinguishable from one with no attachments at all.
+    return unmaterializedAttachments(requestedIds);
   }
 
   try {
@@ -769,7 +772,7 @@ async function materializeAttachmentsForRun(args: {
       requested: requestedIds.length,
       error: err instanceof Error ? err.message : String(err),
     });
-    return undefined;
+    return unmaterializedAttachments(requestedIds);
   }
 }
 

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -652,13 +652,32 @@ export type DataLakeMembershipScope =
     };
 
 /**
+ * The lake arms an attachment resolution may add to its CASL scope. Server-supplied only - a
+ * `creatorUserId` inside a membership scope widens what the query matches, so a value reaching this
+ * from request input would let a caller name any user and read their files. Same contract as
+ * `IFabFileRepository.search`'s `lakeMemberships` (fabFileSearchQuery.ts).
+ *
+ * All three fields optional and an absent object means "no lake arms": the fail-safe direction for
+ * every door that cannot resolve its buckets is to omit them, never to widen.
+ */
+export interface AttachmentLakeAccess {
+  lakeMemberships?: DataLakeMembershipScope[];
+  dataLakeTags?: string[];
+  dataLakeTagPrefixes?: string[];
+}
+
+/**
  * The model interface for the FabFile model.
  *
  * Defines the database methods that are available on the FabFile model.
  */
 export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   shareable: IShareableStaticMethods<IFabFileDocument>;
-  getAccessibleFiles: (fabFileIds: string[], scope: Record<string, unknown>) => Promise<IFabFileDocument[]>;
+  getAccessibleFiles: (
+    fabFileIds: string[],
+    scope: Record<string, unknown>,
+    lakeAccess?: AttachmentLakeAccess
+  ) => Promise<IFabFileDocument[]>;
 
   /**
    * Persist the chunk-policy outcome for a file (#1662): the effective target its current chunks

--- a/b4m-core/common/src/types/entities/SessionTypes.ts
+++ b/b4m-core/common/src/types/entities/SessionTypes.ts
@@ -106,7 +106,14 @@ export type QuestErrorCode = (typeof QUEST_ERROR_CODES)[number];
  * message and system files into one count alongside the turn's own attachments.
  */
 export interface IAttachmentDelivery {
-  /** Ids submitted with the turn, after dedup. */
+  /**
+   * Ids the turn tried to inline, after dedup - NOT just what the caller attached. The chat door
+   * counts session and message fab files plus the user's enabled and the admin's global system
+   * files plus the inline knowledge subset; the agent door counts message and session fab files
+   * plus every session knowledge id, and no system files. So `requested` is a denominator for
+   * "what this turn tried to put in the prompt", and the two doors do not compute it the same way.
+   * `droppedIds` is what answers "did MY file arrive" exactly, and is per-id exact on both.
+   */
   requested: number;
   /** Of `requested`, how many placed any content into the prompt. */
   delivered: number;

--- a/b4m-core/common/src/types/entities/SessionTypes.ts
+++ b/b4m-core/common/src/types/entities/SessionTypes.ts
@@ -98,6 +98,26 @@ export const QUEST_ERROR_CODES = [
 ] as const satisfies readonly ApiErrorCode[];
 export type QuestErrorCode = (typeof QUEST_ERROR_CODES)[number];
 
+/**
+ * Requested-vs-delivered counts for one turn's attachments. `IChatHistoryItem.attachmentNotices`
+ * explains the failures; this is the affirmative half, and it is the only thing that separates
+ * "nothing was attached" from "everything attached was refused" - a distinction
+ * `promptMeta.context.tokensBySource.fabFiles` cannot make, because it aggregates session,
+ * message and system files into one count alongside the turn's own attachments.
+ */
+export interface IAttachmentDelivery {
+  /** Ids submitted with the turn, after dedup. */
+  requested: number;
+  /** Of `requested`, how many placed any content into the prompt. */
+  delivered: number;
+  /** Of `delivered`, how many placed their ENTIRE content - the rest are excerpts or head slices. */
+  fullyDelivered: number;
+  /** `requested - delivered`. Every one of these also has a line in `attachmentNotices`. */
+  dropped: number;
+  /** The undelivered ids, so a caller can react without parsing the notice prose. */
+  droppedIds: string[];
+}
+
 export interface IChatHistoryItem {
   id?: string;
   sessionId: string;
@@ -311,6 +331,13 @@ export interface IChatHistoryItem {
    * and never surface-specific.
    */
   attachmentNotices?: string[];
+
+  /**
+   * Affirmative delivery report for this turn's attachments - see {@link IAttachmentDelivery}.
+   * Written whenever the turn carried any attachment, including the all-succeeded case that
+   * produces no notices at all; that case is exactly the one nothing else records.
+   */
+  attachmentDelivery?: IAttachmentDelivery;
 
   /**
    * Navigation intents from the navigate_view tool.

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -403,6 +403,7 @@ describe('ChatCompletionProcess', () => {
         dataLakeTags: opts.dataLakeTags,
         dataLakeTagPrefixes: [],
         scopedTagPrefixes: [],
+        lakes: [],
       };
       (service as any).getScopeFilter = vi.fn().mockReturnValue({});
       (service as any).db = { fabfiles: { getAccessibleFiles: vi.fn().mockResolvedValue(opts.files) } };
@@ -647,6 +648,7 @@ describe('ChatCompletionProcess', () => {
         dataLakeTags: ['datalake:corpus'],
         dataLakeTagPrefixes: [],
         scopedTagPrefixes: [],
+        lakes: [],
       };
       (service as any).getScopeFilter = vi.fn().mockReturnValue({});
       const getAccessibleFiles = vi.fn().mockResolvedValue(files);
@@ -669,6 +671,7 @@ describe('ChatCompletionProcess', () => {
         dataLakeTags: ['datalake:corpus'],
         dataLakeTagPrefixes: [],
         scopedTagPrefixes: [],
+        lakes: [],
       };
       (service as any).getScopeFilter = vi.fn().mockReturnValue({});
       (service as any).db = { fabfiles: { getAccessibleFiles: vi.fn().mockRejectedValue(new Error('db down')) } };
@@ -728,6 +731,79 @@ describe('ChatCompletionProcess', () => {
 
       const count = await (service as any).countLakeReachableAttachments(['f1']);
       expect(count).toBe(1);
+    });
+  });
+
+  describe('attachmentLakeAccess (#1576 attachment door lake-membership arm)', () => {
+    const OWNED_LAKE = {
+      id: 'lake1',
+      name: 'Acme',
+      slug: 'acme',
+      datalakeTag: 'datalake:acme',
+      fileTagPrefix: 'acme:',
+      source: 'dynamic' as const,
+      membership: {
+        kind: 'owned' as const,
+        datalakeTag: 'datalake:acme',
+        fileTagPrefix: 'acme:',
+        creatorUserId: 'creator-1',
+      },
+    };
+    const REGISTRY_LAKE = {
+      id: 'lake2',
+      name: 'Registry',
+      slug: 'reg',
+      datalakeTag: 'datalake:reg',
+      fileTagPrefix: 'reg:',
+      source: 'registry' as const,
+      membership: { kind: 'registry' as const, datalakeTag: 'datalake:reg', fileTagPrefix: 'reg:' },
+    };
+
+    it('derives lakeMemberships via lakeMembershipsFrom (owned only) and forwards tags/prefixes verbatim', async () => {
+      (service as any).accessibleDataLakeAccessMemo = {
+        dataLakeTags: ['datalake:acme', 'datalake:reg'],
+        dataLakeTagPrefixes: ['reg:'],
+        lakes: [OWNED_LAKE, REGISTRY_LAKE],
+      };
+
+      const access = await (service as any).attachmentLakeAccess();
+
+      // Only the owned lake's membership crosses - the registry lake's unanchored prefix arm
+      // stays out of lakeMemberships and rides dataLakeTagPrefixes instead.
+      expect(access.lakeMemberships).toEqual([OWNED_LAKE.membership]);
+      expect(access.dataLakeTags).toEqual(['datalake:acme', 'datalake:reg']);
+      expect(access.dataLakeTagPrefixes).toEqual(['reg:']);
+    });
+
+    it('a lake-resolution failure degrades to ownership-only, never widens', async () => {
+      (service as any).accessibleDataLakeAccessMemo = { dataLakeTags: [], dataLakeTagPrefixes: [], lakes: [] };
+
+      const access = await (service as any).attachmentLakeAccess();
+
+      expect(access).toEqual({ lakeMemberships: [], dataLakeTags: [], dataLakeTagPrefixes: [] });
+    });
+
+    it('getAttachedKnowledgeFiles forwards the resolved lakeAccess as the getAccessibleFiles third argument', async () => {
+      (service as any).accessibleDataLakeAccessMemo = {
+        dataLakeTags: ['datalake:acme'],
+        dataLakeTagPrefixes: [],
+        lakes: [OWNED_LAKE],
+      };
+      (service as any).getScopeFilter = vi.fn().mockReturnValue({ userId: 'u1' });
+      const getAccessibleFiles = vi.fn().mockResolvedValue([]);
+      (service as any).db = { fabfiles: { getAccessibleFiles } };
+
+      await (service as any).getAttachedKnowledgeFiles(['f1']);
+
+      expect(getAccessibleFiles).toHaveBeenCalledWith(
+        ['f1'],
+        { userId: 'u1' },
+        {
+          lakeMemberships: [OWNED_LAKE.membership],
+          dataLakeTags: ['datalake:acme'],
+          dataLakeTagPrefixes: [],
+        }
+      );
     });
   });
 
@@ -2478,6 +2554,7 @@ describe('ChatCompletionProcess', () => {
         dataLakeTags: opts.dataLakeTags ?? [],
         dataLakeTagPrefixes: [],
         scopedTagPrefixes: [],
+        lakes: [],
       };
       (service as any).getScopeFilter = vi.fn().mockReturnValue({});
 
@@ -2763,6 +2840,64 @@ describe('ChatCompletionProcess', () => {
 
     beforeEach(() => {
       (service as any).getScopeFilter = vi.fn().mockReturnValue({});
+    });
+
+    /**
+     * Agreement between the chat door's two attachment call sites (#1576): both
+     * `getAttachedKnowledgeFiles` (getAccessibleFiles) and `fabFilesToMessages`
+     * (fetchAndConvertFabFiles) must resolve `attachmentLakeAccess()` off the SAME
+     * memoized per-turn access, or an id reachable through one door could silently
+     * disagree with the other.
+     */
+    it('forwards the same attachmentLakeAccess to fetchAndConvertFabFiles as getAttachedKnowledgeFiles gets from getAccessibleFiles', async () => {
+      const membership = {
+        kind: 'owned' as const,
+        datalakeTag: 'datalake:acme',
+        fileTagPrefix: 'acme:',
+        creatorUserId: 'creator-1',
+      };
+      (service as any).accessibleDataLakeAccessMemo = {
+        dataLakeTags: ['datalake:acme'],
+        dataLakeTagPrefixes: [],
+        lakes: [
+          {
+            id: 'lake1',
+            name: 'Acme',
+            slug: 'acme',
+            datalakeTag: 'datalake:acme',
+            fileTagPrefix: 'acme:',
+            source: 'dynamic' as const,
+            membership,
+          },
+        ],
+      };
+      mockedFetchAndConvertFabFiles.mockResolvedValue({
+        files: [{ id: 'f1', fileName: 'context.md', mimeType: 'text/markdown' } as any],
+        missingIds: [],
+      });
+      mockedProcessFabFilesServer.mockResolvedValue({
+        userMessages: [],
+        deliveredFileIds: ['f1'],
+        fullyDeliveredFileIds: ['f1'],
+        fileNotices: [],
+      });
+      const getAccessibleFiles = vi.fn().mockResolvedValue([]);
+      (service as any).db = { fabfiles: { getAccessibleFiles } };
+
+      await callReal(['f1']);
+      await (service as any).getAttachedKnowledgeFiles(['f1']);
+
+      const expectedLakeAccess = {
+        lakeMemberships: [membership],
+        dataLakeTags: ['datalake:acme'],
+        dataLakeTagPrefixes: [],
+      };
+      expect(mockedFetchAndConvertFabFiles).toHaveBeenCalledWith(
+        ['f1'],
+        { scope: {}, lakeAccess: expectedLakeAccess },
+        expect.anything()
+      );
+      expect(getAccessibleFiles).toHaveBeenCalledWith(['f1'], {}, expectedLakeAccess);
     });
 
     it('prepends a system message naming the file and the reason it was not delivered', async () => {

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -776,10 +776,25 @@ describe('ChatCompletionProcess', () => {
     });
 
     it('a lake-resolution failure degrades to ownership-only, never widens', async () => {
-      (service as any).accessibleDataLakeAccessMemo = { dataLakeTags: [], dataLakeTagPrefixes: [], lakes: [] };
+      // The memo must stay undefined: pre-setting it to the fallback value skips the try/catch in
+      // getAccessibleDataLakeAccess entirely and asserts nothing about degradation. Reject inside
+      // the resolver instead - findMembershipOrgIds propagates by design (see the placement note in
+      // getDynamicDataLakeAccess), which is the outage this door's catch exists to absorb.
+      const findMembershipOrgIds = vi.fn().mockRejectedValue(new Error('org read failed'));
+      (service as any).accessibleDataLakeAccessMemo = undefined;
+      (service as any).user = { ...(service as any).user, id: 'user-1' };
+      (service as any).db = {
+        ...(service as any).db,
+        dataLakes: { findActiveByUserTagsAndEntitlements: vi.fn() },
+        organizations: { findMembershipOrgIds },
+      };
 
       const access = await (service as any).attachmentLakeAccess();
 
+      // Proves the resolver was really entered and really rejected - without this the assertion
+      // below would also pass on a resolver that quietly returned no lakes.
+      expect(findMembershipOrgIds).toHaveBeenCalled();
+      // Remove the catch and this call rejects instead of returning the ownership-only shape.
       expect(access).toEqual({ lakeMemberships: [], dataLakeTags: [], dataLakeTagPrefixes: [] });
     });
 
@@ -2651,11 +2666,36 @@ describe('ChatCompletionProcess', () => {
         expect(saved[0]).toEqual(['"context.md" could not be read and was not sent.']);
       });
 
-      it('leaves the quest untouched when every attachment delivered', async () => {
+      it('writes no notice when every attachment delivered - there is nothing to warn about', async () => {
         await runKnowledgeGatingCase({ knowledgeIds: ['f1'], fabPromptMessages: [] });
 
         const saved = mockDb.quests.update.mock.calls.map((c: any[]) => c[0]?.attachmentNotices).filter(Boolean);
         expect(saved).toEqual([]);
+      });
+
+      // #1576 ask 1. The turn above writes no notice, and before the delivery report that silence
+      // was the ONLY thing on the quest - indistinguishable from a turn that attached nothing at
+      // all, which is how a 600-answer eval ran in the wrong configuration unnoticed. The report is
+      // the affirmative half, so it must be written on exactly the path that produces no notices.
+      it('still records the delivery report on a turn where nothing failed', async () => {
+        await runKnowledgeGatingCase({ knowledgeIds: ['f1'], fabPromptMessages: [] });
+
+        const reports = mockDb.quests.update.mock.calls
+          .map((c: any[]) => c[0]?.attachmentDelivery)
+          .filter(Boolean);
+        expect(reports.length).toBeGreaterThan(0);
+        expect(reports[0]).toMatchObject({ requested: expect.any(Number), delivered: expect.any(Number) });
+      });
+
+      it('names the undelivered ids in the report, not just a count', async () => {
+        await runKnowledgeGatingCase({ knowledgeIds: ['f1'], fabFileNotices: [notice] });
+
+        const reports = mockDb.quests.update.mock.calls
+          .map((c: any[]) => c[0]?.attachmentDelivery)
+          .filter(Boolean);
+        expect(reports.length).toBeGreaterThan(0);
+        expect(reports[0].droppedIds).toContain('f1');
+        expect(reports[0].dropped).toBeGreaterThan(0);
       });
 
       // The no-regression half: surfacing failures must not cost a healthy attachment its delivery.

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -2677,12 +2677,10 @@ describe('ChatCompletionProcess', () => {
       // was the ONLY thing on the quest - indistinguishable from a turn that attached nothing at
       // all, which is how a 600-answer eval ran in the wrong configuration unnoticed. The report is
       // the affirmative half, so it must be written on exactly the path that produces no notices.
-      it('still records the delivery report on a turn where nothing failed', async () => {
+      it('writes the delivery report on a turn with no notices - the API-only affirmative half', async () => {
         await runKnowledgeGatingCase({ knowledgeIds: ['f1'], fabPromptMessages: [] });
 
-        const reports = mockDb.quests.update.mock.calls
-          .map((c: any[]) => c[0]?.attachmentDelivery)
-          .filter(Boolean);
+        const reports = mockDb.quests.update.mock.calls.map((c: any[]) => c[0]?.attachmentDelivery).filter(Boolean);
         expect(reports.length).toBeGreaterThan(0);
         expect(reports[0]).toMatchObject({ requested: expect.any(Number), delivered: expect.any(Number) });
       });
@@ -2690,9 +2688,7 @@ describe('ChatCompletionProcess', () => {
       it('names the undelivered ids in the report, not just a count', async () => {
         await runKnowledgeGatingCase({ knowledgeIds: ['f1'], fabFileNotices: [notice] });
 
-        const reports = mockDb.quests.update.mock.calls
-          .map((c: any[]) => c[0]?.attachmentDelivery)
-          .filter(Boolean);
+        const reports = mockDb.quests.update.mock.calls.map((c: any[]) => c[0]?.attachmentDelivery).filter(Boolean);
         expect(reports.length).toBeGreaterThan(0);
         expect(reports[0].droppedIds).toContain('f1');
         expect(reports[0].dropped).toBeGreaterThan(0);

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -1,4 +1,5 @@
 import {
+  type AttachmentLakeAccess,
   IChatHistoryItemDocument,
   IFabFileDocument,
   IMessage,
@@ -954,10 +955,11 @@ export class ChatCompletionProcess {
   /**
    * How many of `ids` are reachable AS LAKE CONTENT by this caller.
    *
-   * Deliberately a second read rather than reusing `getAttachedKnowledgeFiles`, whose CASL scope has
-   * no lake arm: an organization lake widens reach through the lake creator's identity, so a member
-   * attaching a teammate's lake file is invisible to an ownership/share-based reader. Classifying a
-   * corpus as "personal" off that reader alone is how such a session lost its grounding.
+   * Deliberately a second read rather than reusing `getAttachedKnowledgeFiles`: that method now also
+   * carries a lake arm (see `attachmentLakeAccess`), but it answers a different question - ownership-
+   * OR-lake reachability - while this one asks whether the file is lake content AT ALL. A file that
+   * resolves through `getAttachedKnowledgeFiles` might have matched purely on ownership, so its
+   * success can't tell "personal" from "lake"; running LAKE-ONLY here is what can.
    *
    * Runs LAKE-ONLY: `restrictToDataLake` makes buildOwnershipConditions start from no ownership
    * arms at all (fabFileSearchQuery: `restrictToDataLake ? [] : [...baseAccess]`), so only the lake
@@ -994,8 +996,13 @@ export class ChatCompletionProcess {
           //   longer counts, since the arm now requires the lake creator's userId.
           //   WIDENS only where the attachment is readable by a route buildOwnershipConditions'
           //   baseAccess lacks: `isGlobalRead` is in the CASL FabFile read scope (ability.ts) but
-          //   NOT in baseAccess. Every other caller fails resolvePersonalCorpusOnly's
-          //   full-resolution guard first, so this count is never reached at all.
+          //   NOT in baseAccess. `getAttachedKnowledgeFiles` now also carries a lake arm (see
+          //   `attachmentLakeAccess`), so a lake reader attaching lake files they do not own now
+          //   resolves fully there too - resolvePersonalCorpusOnly's full-resolution guard
+          //   (`resolvePersonalCorpusOnly.ts:62`) passes, and this count IS reached for exactly that
+          //   caller. It is what correctly classifies the corpus as non-personal: the residual
+          //   affected set is a lake reader attaching lake files in a session that is neither
+          //   lake-scoped nor in `retrieve` mode.
           lakeMemberships,
           restrictToDataLake: true,
           excludeContent: true,
@@ -1011,6 +1018,33 @@ export class ChatCompletionProcess {
   }
 
   /**
+   * The lake arms the attachment door adds to its CASL scope.
+   *
+   * Owner-wide and deliberately NOT narrowed to `session.retrievalTags`: unlike every retrieval
+   * surface (which narrows via `narrowLakeAccessToSession`), the caller here named the file ids
+   * explicitly, and narrowing would turn an explicit request into a silent refusal.
+   *
+   * `lakeMembershipsFrom` must stay the source for `lakeMemberships` - it allow-lists
+   * `kind === 'owned'`, and an unanchored registry prefix arm sitting beside other lakes' arms in
+   * one `$or` is the cross-tenant promotion the SCOPED/OPEN split forbids. Registry lakes are
+   * covered by `dataLakeTagPrefixes` instead. Never construct `lakeMemberships` any other way here.
+   *
+   * Fail direction is inherited from `getAccessibleDataLakeAccess`, which catches its own failures
+   * and returns an empty access set - so a lake-resolution outage degrades to today's
+   * ownership-only behaviour. Never widen on error.
+   */
+  private async attachmentLakeAccess(): Promise<AttachmentLakeAccess> {
+    const access = await this.getAccessibleDataLakeAccess();
+    const lakeMemberships = lakeMembershipsFrom(access.lakes);
+    warnIfManyLakeMemberships(lakeMemberships, this.logger, 'attachment-resolution');
+    return {
+      lakeMemberships,
+      dataLakeTags: access.dataLakeTags,
+      dataLakeTagPrefixes: access.dataLakeTagPrefixes,
+    };
+  }
+
+  /**
    * The session's attached-knowledge file docs (`session.knowledgeIds`), memoized per turn.
    * Returns `null` on a lookup failure rather than throwing - callers decide their own fail
    * direction (the tool-offer gate fails toward offering; `resolveCorpusInlinePlan` fails toward
@@ -1023,7 +1057,8 @@ export class ChatCompletionProcess {
     if (this.attachedKnowledgeFilesMemo === undefined) {
       try {
         const scope = this.getScopeFilter(this.user, Permission.read, 'FabFile');
-        this.attachedKnowledgeFilesMemo = await this.db.fabfiles.getAccessibleFiles(ids, scope);
+        const lakeAccess = await this.attachmentLakeAccess();
+        this.attachedKnowledgeFilesMemo = await this.db.fabfiles.getAccessibleFiles(ids, scope, lakeAccess);
       } catch (err) {
         this.logger.warn(
           `[knowledge] attached-file lookup failed; treating attached knowledge as indexed (fail open): ${(err as Error)?.message}`
@@ -5574,9 +5609,10 @@ export class ChatCompletionProcess {
     modelInfo: ModelInfo
   ) {
     const scope = this.getScopeFilter(this.user, Permission.read, 'FabFile');
+    const lakeAccess = await this.attachmentLakeAccess();
     const { files: convertedFabFiles, missingIds } = await fetchAndConvertFabFiles(
       fabFileIds,
-      { scope },
+      { scope, lakeAccess },
       { db: this.db, storage: this.storage, logger: this.logger }
     );
     const {

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -172,7 +172,13 @@ import {
   AnomalyAlertService,
   aggregateWebFetchContentTelemetry,
 } from '../telemetry';
-import type { ToolTelemetry, ToolErrorCategory, SystemPromptDetail, DataLakeGroundingMode } from '@bike4mind/common';
+import type {
+  ToolTelemetry,
+  ToolErrorCategory,
+  SystemPromptDetail,
+  DataLakeGroundingMode,
+  IAttachmentDelivery,
+} from '@bike4mind/common';
 import {
   buildAlwaysOnFloorDetails,
   buildInjectedBlockDetails,
@@ -2451,12 +2457,17 @@ export class ChatCompletionProcess {
         actuallyInlinedKnowledgeIds,
         fullyInlinedAttachmentIds,
         attachmentNotices,
+        attachmentDelivery,
       } = dataSources;
 
       // Persisted before the completion runs: an attachment that failed to arrive is worth showing
       // even on a turn that later errors out, and this is the only durable record the user sees.
-      if (attachmentNotices.length > 0) {
-        quest.attachmentNotices = attachmentNotices;
+      // The delivery report goes with it and is written even when nothing failed - a turn whose
+      // attachments all arrived produces no notices, and that silence is exactly what #1576 is
+      // about: it reads identically to a turn that attached nothing.
+      if (attachmentNotices.length > 0 || attachmentDelivery) {
+        if (attachmentNotices.length > 0) quest.attachmentNotices = attachmentNotices;
+        if (attachmentDelivery) quest.attachmentDelivery = attachmentDelivery;
         await saveQuest(quest);
       }
 
@@ -5955,6 +5966,10 @@ When using tools that require file IDs (like edit_image), use the ID shown above
      *  in a system message inside `fabMessages`. Stored on the quest so the transcript says the same
      *  thing - an attachment must never fail silently (#2228). */
     attachmentNotices: string[];
+    /** Affirmative delivery report - the counts behind the notices, and the only record of a turn
+     *  whose attachments ALL arrived (which produces no notices at all). `undefined` when the turn
+     *  carried no attachments, so a caller can tell "none sent" from "none arrived". */
+    attachmentDelivery?: IAttachmentDelivery;
   }> {
     // Load feature contexts in parallel with data sources
     const featureContextPromise = Promise.all(
@@ -6103,6 +6118,7 @@ When using tools that require file IDs (like edit_image), use the ID shown above
     const fullyInlinedAttachmentIds = actuallyInlinedKnowledgeIds.filter(id => fullyDeliveredKnowledgeIds.has(id));
 
     const fileNotices: FabFileNotice[] = fabResult?.fileNotices ?? [];
+    let attachmentDelivery: IAttachmentDelivery | undefined;
     if (dedupedFileIds.length > 0) {
       // The one line a production attachment report is read from: what was asked for, what actually
       // reached the model, and why the rest did not. Requested-minus-delivered is computed here (not
@@ -6113,14 +6129,17 @@ When using tools that require file IDs (like edit_image), use the ID shown above
         acc[notice.band] = (acc[notice.band] ?? 0) + 1;
         return acc;
       }, {});
-      const summary = {
+      attachmentDelivery = {
+        // Counts everything handed to fabFilesToMessages - the turn's own attachments AND the
+        // session/message/system files inlined alongside them. So `delivered > 0` is not by itself
+        // proof that a CALLER's attachment arrived; `droppedIds` is what answers that exactly.
         requested: dedupedFileIds.length,
         delivered: delivered.size,
         fullyDelivered: fullyDeliveredKnowledgeIds.size,
         dropped: droppedIds.length,
         droppedIds,
-        bands: bandTally,
       };
+      const summary = { ...attachmentDelivery, bands: bandTally };
       if (droppedIds.length > 0 || fileNotices.length > 0) {
         logger.warn('📎 Attachment delivery summary', summary);
       } else {
@@ -6141,6 +6160,7 @@ When using tools that require file IDs (like edit_image), use the ID shown above
       actuallyInlinedKnowledgeIds,
       fullyInlinedAttachmentIds,
       attachmentNotices: toAttachmentNoticeStrings(fileNotices),
+      attachmentDelivery,
     };
   }
 }

--- a/b4m-core/utils/src/llm/fetchAndConvertFabFiles.test.ts
+++ b/b4m-core/utils/src/llm/fetchAndConvertFabFiles.test.ts
@@ -60,4 +60,31 @@ describe('fetchAndConvertFabFiles reports ids it could not resolve', () => {
 
     expect(missingIds).toEqual([]);
   });
+
+  it('forwards lakeAccess to getAccessibleFiles unchanged, and omits it when absent', async () => {
+    vi.clearAllMocks();
+    const d = deps([{ id: 'a' }]);
+    const lakeAccess = { lakeMemberships: [{ kind: 'owned' as const, datalakeTag: 'datalake:org1:acme' }] };
+
+    await fetchAndConvertFabFiles(['a'], { scope: { userId: 'u1' }, lakeAccess }, d);
+    expect(d.db.fabfiles.getAccessibleFiles).toHaveBeenCalledWith(['a'], { userId: 'u1' }, lakeAccess);
+
+    d.db.fabfiles.getAccessibleFiles.mockClear();
+    await fetchAndConvertFabFiles(['a'], { scope: { userId: 'u1' } }, d);
+    expect(d.db.fabfiles.getAccessibleFiles).toHaveBeenCalledWith(['a'], { userId: 'u1' }, undefined);
+  });
+
+  it('still reports missingIds correctly when lakeAccess widens what resolves', async () => {
+    vi.clearAllMocks();
+    const lakeAccess = { dataLakeTags: ['datalake:org1:acme'] };
+
+    const { files, missingIds } = await fetchAndConvertFabFiles(
+      ['keep-1', 'gone-1'],
+      { scope: {}, lakeAccess },
+      deps([{ id: 'keep-1' }])
+    );
+
+    expect(files.map(f => f.id)).toEqual(['keep-1']);
+    expect(missingIds).toEqual(['gone-1']);
+  });
 });

--- a/b4m-core/utils/src/llm/utils.ts
+++ b/b4m-core/utils/src/llm/utils.ts
@@ -1,5 +1,6 @@
 import { assemblyTokenBuffer, MIN_ATTACHED_CONTENT_TOKEN_ALLOCATION } from './contextBudget';
 import {
+  type AttachmentLakeAccess,
   dayjs,
   extractSnippetMeta,
   FORMAT_PROMPT_TEMPLATE,
@@ -800,7 +801,7 @@ export async function fetchAgentConversationHistory(
  */
 export async function fetchAndConvertFabFiles(
   fabFileIds: string[],
-  { scope }: { scope: Record<string, unknown> },
+  { scope, lakeAccess }: { scope: Record<string, unknown>; lakeAccess?: AttachmentLakeAccess },
   {
     db,
     storage,
@@ -814,7 +815,7 @@ export async function fetchAndConvertFabFiles(
     logger?: Logger;
   }
 ): Promise<{ files: IFabFileDocument[]; missingIds: string[] }> {
-  const fabFiles = await db.fabfiles.getAccessibleFiles(fabFileIds, scope);
+  const fabFiles = await db.fabfiles.getAccessibleFiles(fabFileIds, scope, lakeAccess);
 
   const files: IFabFileDocument[] = await Promise.all(
     fabFiles.map(async (file: any) => {

--- a/packages/database/src/__test__/utils.ts
+++ b/packages/database/src/__test__/utils.ts
@@ -1,6 +1,6 @@
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { connectDB } from '../utils/mongo';
-import { createMongoServer } from './createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from './createMongoServer';
 import mongoose from 'mongoose';
 import { beforeAll, afterAll, beforeEach } from 'vitest';
 // Import models to ensure they're registered
@@ -31,6 +31,13 @@ export const cleanupTestDB = async () => {
   }
 };
 
+// This hook does strictly more than boot mongod: it also builds four models' index sets on a cold
+// connection, and both costs scale with how contended the runner is. A bare literal here would also
+// override any per-file `vi.setConfig` budget, so it is derived from the shared lever rather than
+// pinned beside it. Doubled because the shared budget covers booting mongod alone; raising the
+// shared constant instead would hand the same slack to every suite that only boots.
+const SETUP_HOOK_TIMEOUT_MS = MONGO_TEST_TIMEOUT_MS * 2;
+
 export async function setupMongoTest() {
   let mongoServer: MongoMemoryServer;
 
@@ -49,10 +56,7 @@ export async function setupMongoTest() {
 
     // Force the models to be registered by accessing them
     await Promise.resolve([researchTaskRepository, taskScheduleRepository, researchAgentRepository]);
-    // 60s (not 30s): under parallel shards a cold mongodb-memory-server start - binary
-    // resolution plus the port-collision retry loop in createMongoServer - can exceed
-    // 30s and time the hook out (a transient red, not a real failure).
-  }, 60000);
+  }, SETUP_HOOK_TIMEOUT_MS);
 
   afterAll(async () => {
     if (mongoServer) {

--- a/packages/database/src/__test__/utils.ts
+++ b/packages/database/src/__test__/utils.ts
@@ -58,11 +58,14 @@ export async function setupMongoTest() {
     await Promise.resolve([researchTaskRepository, taskScheduleRepository, researchAgentRepository]);
   }, SETUP_HOOK_TIMEOUT_MS);
 
+  // No timeout literal: this hook inherits the package's hookTimeout, which is larger than any
+  // number that would fit here. The literal this replaces HALVED it under a comment claiming the
+  // opposite.
   afterAll(async () => {
     if (mongoServer) {
       await disconnectTestDB(mongoServer);
     }
-  }, 30000); // Increase timeout for cleanup
+  });
 
   beforeEach(async () => {
     await cleanupTestDB();

--- a/packages/database/src/__tests__/fabFileSearchQuery.test.ts
+++ b/packages/database/src/__tests__/fabFileSearchQuery.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { CHUNK_STALL_REASONS, LEGACY_CHUNK_STALL_NOTES } from '@bike4mind/common';
 import {
   buildFabFileSearchQuery,
+  buildLakeArms,
   buildOwnershipConditions,
   escapeRegex,
   getMimeTypeFilter,
@@ -451,6 +452,42 @@ describe('buildFabFileSearchQuery', () => {
         expect(conditions[2]).toEqual({ 'tags.name': 'datalake:org1:orphan' });
         expect(JSON.stringify(conditions[2])).not.toContain('$regex');
       });
+    });
+  });
+
+  // ── buildLakeArms (#1576) - total, never throws; restrictToDataLake's zero-arms guard ──
+  describe('buildLakeArms', () => {
+    it('returns [] for no options at all', () => {
+      expect(buildLakeArms({})).toEqual([]);
+    });
+
+    it('returns [] when every bucket is present but empty', () => {
+      expect(buildLakeArms({ lakeMemberships: [], dataLakeTags: [], dataLakeTagPrefixes: [] })).toEqual([]);
+    });
+
+    it('returns [] when dataLakeTagPrefixes normalizes every entry away, rather than throwing', () => {
+      expect(buildLakeArms({ dataLakeTagPrefixes: [''] })).toEqual([]);
+    });
+
+    it('emits arms in order: lakeMemberships, then dataLakeTags, then dataLakeTagPrefixes', () => {
+      const SCOPE_A = { datalakeTag: 'datalake:org1:acme', fileTagPrefix: 'acme:', creatorUserId: 'creator-1' };
+      const arms = buildLakeArms({
+        lakeMemberships: [SCOPE_A],
+        dataLakeTags: ['datalake:org1:meta'],
+        dataLakeTagPrefixes: ['opti:'],
+      });
+      expect(arms).toHaveLength(3);
+      expect(arms[0]).toEqual(buildDataLakeMembershipFilter(SCOPE_A));
+      expect(arms[1]).toEqual({ tags: { $elemMatch: { name: { $in: ['datalake:org1:meta'] } } } });
+      expect(JSON.stringify(arms[2])).toContain('$regex');
+    });
+
+    it('buildOwnershipConditions still throws under restrictToDataLake when buildLakeArms produces zero arms', () => {
+      // buildLakeArms itself stays total (see above) - the throw belongs to buildOwnershipConditions,
+      // which needs at least one arm to avoid handing MongoDB an empty `$or`.
+      expect(() => buildOwnershipConditions('user1', { restrictToDataLake: true, dataLakeTagPrefixes: [''] })).toThrow(
+        /requires lakeMemberships, dataLakeTags or dataLakeTagPrefixes/
+      );
     });
   });
 

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -450,6 +450,44 @@ describe('FabFile data lake lifecycle membership', () => {
       expect(result.map(f => f.fileName)).toEqual(['own-archived.txt']);
     });
 
+    it('forwards the dataLakeTags bucket: a non-owner reaches a meta-tagged member by tag alone', async () => {
+      const rows = await seedLakeRows();
+      const viewerCaslScope = { userId: VIEWER };
+
+      const result = await fabFileRepository.getAccessibleFiles(
+        [rows.metaTagged._id.toString(), rows.prefixOwned._id.toString(), ...rows.strangerIds],
+        viewerCaslScope,
+        { dataLakeTags: [DATALAKE_TAG] }
+      );
+
+      // The exact meta-tag arm only: prefix-owned.txt carries no datalake: tag, so this bucket
+      // alone must not reach it, and no stranger carries the tag either.
+      expect(result.map(f => f.fileName)).toEqual(['meta.txt']);
+    });
+
+    it('forwards the dataLakeTagPrefixes bucket, which is UNANCHORED - it reaches prefix matches the caller does not own', async () => {
+      const rows = await seedLakeRows();
+      const viewerCaslScope = { userId: VIEWER };
+
+      const result = await fabFileRepository.getAccessibleFiles(
+        [rows.metaTagged._id.toString(), rows.prefixOwned._id.toString(), ...rows.strangerIds],
+        viewerCaslScope,
+        { dataLakeTagPrefixes: ['acme:'] }
+      );
+
+      // Pinning the widest arm this door can be handed. Unlike a `lakeMemberships` scope, the
+      // prefix bucket carries NO creator conjunct, so every acme:-tagged file matches regardless
+      // of owner - which is why it is only ever supplied for a registry lake on an access-gated
+      // path, and why lakeMembershipsFrom's `owned` allow-list must keep registry scopes out of
+      // lakeMemberships. A regression that widened this bucket's source would show up here.
+      expect(result.map(f => f.fileName).sort()).toEqual([
+        'prefix-group.txt',
+        'prefix-owned.txt',
+        'prefix-shared.txt',
+        'unrelated.txt',
+      ]);
+    });
+
     it('an absent lakeAccess, or one with empty buckets, reproduces the byte-identical legacy result set', async () => {
       const rows = await seedLakeRows();
       const creatorCaslScope = { userId: CREATOR };

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -384,6 +384,88 @@ describe('FabFile data lake lifecycle membership', () => {
     });
   });
 
+  describe('getAccessibleFiles - lake membership arm (#1576)', () => {
+    const VIEWER = 'u-viewer-not-creator';
+
+    it('a non-owner reaches a meta-tagged member and a creator-owned prefix-only member, never a colliding-prefix stranger', async () => {
+      const rows = await seedLakeRows();
+      const viewerCaslScope = { userId: VIEWER };
+
+      const result = await fabFileRepository.getAccessibleFiles(
+        [rows.metaTagged._id.toString(), rows.prefixOwned._id.toString(), ...rows.strangerIds],
+        viewerCaslScope,
+        { lakeMemberships: [scope] }
+      );
+
+      expect(result.map(f => f.fileName).sort()).toEqual(['meta.txt', 'prefix-owned.txt']);
+    });
+
+    it('two lakes sharing a prefix under different creators never cross on the attachment door either', async () => {
+      await seedLakeRows();
+      const otherCreator = 'u-other-creator-attach';
+      const otherPrefixOwned = await makeFile({
+        fileName: 'other-prefix-owned-attach.txt',
+        userId: otherCreator,
+        tags: [{ name: 'acme:other-report-attach' }], // same prefix as `scope`, different creator
+      });
+      const viewerCaslScope = { userId: VIEWER };
+
+      const result = await fabFileRepository.getAccessibleFiles(
+        [otherPrefixOwned._id.toString()],
+        viewerCaslScope,
+        { lakeMemberships: [scope] } // only the ORIGINAL creator's arm, not `otherCreator`'s
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('a file matching both the CASL scope and a lake arm is returned once, not duplicated', async () => {
+      const rows = await seedLakeRows();
+      const creatorCaslScope = { userId: CREATOR };
+
+      const result = await fabFileRepository.getAccessibleFiles([rows.prefixOwned._id.toString()], creatorCaslScope, {
+        lakeMemberships: [scope],
+      });
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("an archived lake member is not returned through the lake arm, while the caller's OWN archived file still is", async () => {
+      const rows = await seedLakeRows();
+      await FabFile.updateOne({ _id: rows.metaTagged._id }, { $set: { archivedAt: new Date() } });
+      const ownArchived = await makeFile({
+        fileName: 'own-archived.txt',
+        userId: VIEWER,
+        tags: [],
+        archivedAt: new Date(),
+      });
+      const viewerCaslScope = { userId: VIEWER };
+
+      const result = await fabFileRepository.getAccessibleFiles(
+        [rows.metaTagged._id.toString(), ownArchived._id.toString()],
+        viewerCaslScope,
+        { lakeMemberships: [scope] }
+      );
+
+      expect(result.map(f => f.fileName)).toEqual(['own-archived.txt']);
+    });
+
+    it('an absent lakeAccess, or one with empty buckets, reproduces the byte-identical legacy result set', async () => {
+      const rows = await seedLakeRows();
+      const creatorCaslScope = { userId: CREATOR };
+      const ids = [rows.metaTagged._id.toString(), rows.prefixOwned._id.toString(), ...rows.strangerIds];
+
+      const withoutLakeAccess = await fabFileRepository.getAccessibleFiles(ids, creatorCaslScope);
+      const withEmptyBuckets = await fabFileRepository.getAccessibleFiles(ids, creatorCaslScope, {});
+
+      const names = (rows: typeof withoutLakeAccess) => rows.map(f => f.fileName).sort();
+      // CREATOR owns both member files outright, so ownership alone (no lake arm) already
+      // reaches them - this pins that adding the parameter changes nothing when it's unused.
+      expect(names(withoutLakeAccess)).toEqual(['meta.txt', 'prefix-owned.txt']);
+      expect(names(withEmptyBuckets)).toEqual(names(withoutLakeAccess));
+    });
+  });
+
   describe('archiveByDataLakeTag / unarchiveByDataLakeTag', () => {
     it('archives the members and leaves every stranger-owned prefix match live', async () => {
       const rows = await seedLakeRows();

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -1,4 +1,5 @@
 import {
+  type AttachmentLakeAccess,
   CHUNK_STALL_REASONS,
   CHUNKLESS_STALL_REASONS,
   type ChunkStallReason,
@@ -23,7 +24,12 @@ import { convertId, convertIds, softDeletePlugin, usableObjectIds } from '../../
 import BaseRepository from '@bike4mind/db-core';
 import { addLowercaseField } from '../../utils/documentdb-compat';
 import { ShareableDocumentRepository, ShareableDocumentSchema } from './SharableDocumentModel';
-import { buildFabFileSearchQuery, buildOwnershipConditions, escapeRegex } from '../../queries/fabFileSearchQuery';
+import {
+  buildFabFileSearchQuery,
+  buildLakeArms,
+  buildOwnershipConditions,
+  escapeRegex,
+} from '../../queries/fabFileSearchQuery';
 import {
   buildDataLakeMembershipFilter,
   buildDataLakeMembershipQuery,
@@ -666,18 +672,44 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     await this.fabFileModel.deleteMany({ _id: { $in: ids } });
   }
 
-  async getAccessibleFiles(fabFileIds: string[], scope: Record<string, unknown>) {
+  /**
+   * Files matching `scope` (the caller's CASL read ability) OR any lake arm named by
+   * `lakeAccess` - so an attached file the caller can reach only through lake membership still
+   * resolves, not just files they own or were shared. Lake arms are built by `buildLakeArms`, the
+   * same builder retrieval uses, so the two doors can never disagree about what a lake arm matches.
+   *
+   * `archivedAt: null` is ANDed onto the LAKE ARMS ONLY, never at top level: `scope` already
+   * reflects the caller's real ability and has no `archivedAt` filter of its own (an owner's own
+   * archived file must stay reachable here, exactly as before), while an archived lake's members
+   * must stop resolving through the new arm the moment the lake is archived - otherwise archiving a
+   * lake would stop retrieval, browse and counting but not inline delivery of a file the caller does
+   * not own.
+   *
+   * Absent or empty `lakeAccess` reproduces the byte-identical legacy query.
+   */
+  async getAccessibleFiles(fabFileIds: string[], scope: Record<string, unknown>, lakeAccess?: AttachmentLakeAccess) {
     // Filter out invalid ObjectIds to prevent BSONError crashes
     const validIds = fabFileIds.filter(id => mongoose.Types.ObjectId.isValid(id));
 
-    // const accessible = accessibleBy(ability, Permission.update).ofType(FabFile);
-    const filter = {
-      _id: {
-        $in: convertIds(validIds),
-      },
-      ...scope,
-      // ...accessible,
-    };
+    const lakeArms = buildLakeArms({
+      lakeMemberships: lakeAccess?.lakeMemberships,
+      dataLakeTags: lakeAccess?.dataLakeTags,
+      dataLakeTagPrefixes: lakeAccess?.dataLakeTagPrefixes,
+    });
+
+    const filter = lakeArms.length
+      ? {
+          $and: [
+            { _id: { $in: convertIds(validIds) } },
+            { $or: [scope, ...lakeArms.map(arm => ({ $and: [arm, { archivedAt: null }] }))] },
+          ],
+        }
+      : {
+          _id: {
+            $in: convertIds(validIds),
+          },
+          ...scope,
+        };
     return await super.find(filter, { content: 0 });
   }
 

--- a/packages/database/src/models/content/QuestModel.test.ts
+++ b/packages/database/src/models/content/QuestModel.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { IAttachmentDelivery } from '@bike4mind/common';
+import { createMongoServer } from '../../__test__/createMongoServer';
+import { Quest, questRepository } from './QuestModel';
+
+let server: Awaited<ReturnType<typeof createMongoServer>>;
+
+beforeAll(async () => {
+  server = await createMongoServer();
+  await mongoose.connect(server.getUri());
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server.stop();
+});
+beforeEach(async () => {
+  await Quest.deleteMany({}, { hardDelete: true } as Record<string, unknown>);
+});
+
+const makeQuest = (overrides: Record<string, unknown> = {}) =>
+  Quest.create({
+    sessionId: 'session-1',
+    type: 'message',
+    timestamp: new Date(),
+    prompt: 'hello',
+    ...overrides,
+  });
+
+const fullDelivery: IAttachmentDelivery = {
+  requested: 3,
+  delivered: 2,
+  fullyDelivered: 1,
+  dropped: 1,
+  droppedIds: ['file-a', 'file-b'],
+};
+
+// Fresh read from the DB, not the in-memory doc a write just returned - the whole point of this
+// suite is to catch a schema path that Mongoose accepts on write but silently drops on the way in.
+const readRaw = async (id: string) => Quest.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+
+describe('Quest.attachmentDelivery persistence', () => {
+  it('round-trips every sub-field through a real write and a fresh read', async () => {
+    const quest = await makeQuest({ attachmentDelivery: fullDelivery });
+
+    const raw = await readRaw(quest._id.toString());
+
+    // Deep equality against the literal covers every sub-field and its type: a dropped path reads
+    // back as undefined, and a mis-declared droppedIds reads back as something other than an array.
+    expect(raw?.attachmentDelivery).toEqual(fullDelivery);
+  });
+});
+
+describe('QuestRepository.recordAttachmentOutcomeByAgentExecutionId', () => {
+  it('writes both attachmentNotices and attachmentDelivery when notices are non-empty', async () => {
+    const quest = await makeQuest({ agentExecutionId: 'exec-1' });
+
+    await questRepository.recordAttachmentOutcomeByAgentExecutionId('exec-1', {
+      notices: ['file-b could not be delivered'],
+      delivery: fullDelivery,
+    });
+
+    const raw = await readRaw(quest._id.toString());
+
+    expect(raw?.attachmentNotices).toEqual(['file-b could not be delivered']);
+    expect(raw?.attachmentDelivery).toEqual(fullDelivery);
+  });
+
+  it('writes attachmentDelivery but leaves a pre-set attachmentNotices untouched when notices is empty', async () => {
+    const quest = await makeQuest({
+      agentExecutionId: 'exec-2',
+      attachmentNotices: ['earlier writer left this notice'],
+    });
+
+    await questRepository.recordAttachmentOutcomeByAgentExecutionId('exec-2', {
+      notices: [],
+      delivery: fullDelivery,
+    });
+
+    const raw = await readRaw(quest._id.toString());
+
+    expect(raw?.attachmentNotices).toEqual(['earlier writer left this notice']);
+    expect(raw?.attachmentDelivery).toEqual(fullDelivery);
+  });
+
+  it('is a silent no-op when no quest matches the agentExecutionId', async () => {
+    await expect(
+      questRepository.recordAttachmentOutcomeByAgentExecutionId('no-such-execution', {
+        notices: [],
+        delivery: fullDelivery,
+      })
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -1,5 +1,11 @@
 import mongoose, { Model, Schema } from 'mongoose';
-import { IChatHistoryItem, IChatHistoryItemRepository, IChatHistoryItemDocument, PromptMeta } from '@bike4mind/common';
+import {
+  IChatHistoryItem,
+  IChatHistoryItemRepository,
+  IChatHistoryItemDocument,
+  PromptMeta,
+  IAttachmentDelivery,
+} from '@bike4mind/common';
 import { softDeletePlugin } from '../../utils/mongo';
 import BaseRepository from '@bike4mind/db-core';
 
@@ -572,6 +578,20 @@ export const ChatHistoryItemSchema = new Schema<IChatHistoryItemDocument>(
     // Per-file attachment delivery problems, shown under the reply. Must stay in the
     // findPageBySessionId projection below or the banner vanishes on reload.
     attachmentNotices: { type: [String], required: false },
+    // The affirmative half of the same report: written even when every attachment succeeded and
+    // there are no notices, which is the case nothing else on the quest records. Same projection
+    // requirement as attachmentNotices.
+    attachmentDelivery: {
+      type: {
+        requested: { type: Number, required: true },
+        delivered: { type: Number, required: true },
+        fullyDelivered: { type: Number, required: true },
+        dropped: { type: Number, required: true },
+        droppedIds: { type: [String], required: true },
+      },
+      required: false,
+      _id: false,
+    },
     // Generalized UI side-effects extracted from tool __uiSideEffect sentinels
     uiSideEffects: {
       type: [
@@ -675,7 +695,7 @@ class QuestRepository extends BaseRepository<IChatHistoryItemDocument> implement
     const result = await this.model
       .find({ sessionId, deletedAt: null })
       .select(
-        'sessionId timestamp type status errorCode prompt reply replies fabFileIds images promptMeta creditsUsed attachmentNotices'
+        'sessionId timestamp type status errorCode prompt reply replies fabFileIds images promptMeta creditsUsed attachmentNotices attachmentDelivery'
       )
       .sort({ timestamp: sort, _id: sort })
       .skip(limit * (page - 1))
@@ -816,6 +836,33 @@ class QuestRepository extends BaseRepository<IChatHistoryItemDocument> implement
    * subagents, each in its own Lambda - accumulate into the same array instead of clobbering
    * each other. No-op if no Quest matches (best-effort; the files also persist as FabFiles).
    */
+  /**
+   * Record one agent run's attachment outcome on the quest it is linked to.
+   *
+   * The agent path builds the same notices the chat path does but had nowhere to put them, so an
+   * agent run's attachment failures left no durable record at all. Keyed on `agentExecutionId`
+   * because the executor knows its execution, not its quest; a run with no linked quest matches
+   * nothing and is a no-op, which is the correct outcome rather than an error.
+   *
+   * `notices` is only written when non-empty so a clean run cannot blank a value another writer
+   * set; `delivery` is written unconditionally, since the all-succeeded case is the one it exists
+   * to record.
+   */
+  async recordAttachmentOutcomeByAgentExecutionId(
+    agentExecutionId: string,
+    outcome: { notices: string[]; delivery: IAttachmentDelivery }
+  ) {
+    await this.model.updateOne(
+      { agentExecutionId },
+      {
+        $set: {
+          ...(outcome.notices.length > 0 ? { attachmentNotices: outcome.notices } : {}),
+          attachmentDelivery: outcome.delivery,
+        },
+      }
+    );
+  }
+
   async addImagesByAgentExecutionId(agentExecutionId: string, images: string[]) {
     if (!images.length) return;
     await this.model.updateOne({ agentExecutionId }, { $addToSet: { images: { $each: images } } });

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -831,12 +831,6 @@ class QuestRepository extends BaseRepository<IChatHistoryItemDocument> implement
   }
 
   /**
-   * Append generated-file names to a Quest's `images` array, keyed by the agent execution
-   * that produced them. Uses `$addToSet` so concurrent writers - the parent run and any
-   * subagents, each in its own Lambda - accumulate into the same array instead of clobbering
-   * each other. No-op if no Quest matches (best-effort; the files also persist as FabFiles).
-   */
-  /**
    * Record one agent run's attachment outcome on the quest it is linked to.
    *
    * The agent path builds the same notices the chat path does but had nowhere to put them, so an
@@ -863,6 +857,12 @@ class QuestRepository extends BaseRepository<IChatHistoryItemDocument> implement
     );
   }
 
+  /**
+   * Append generated-file names to a Quest's `images` array, keyed by the agent execution
+   * that produced them. Uses `$addToSet` so concurrent writers - the parent run and any
+   * subagents, each in its own Lambda - accumulate into the same array instead of clobbering
+   * each other. No-op if no Quest matches (best-effort; the files also persist as FabFiles).
+   */
   async addImagesByAgentExecutionId(agentExecutionId: string, images: string[]) {
     if (!images.length) return;
     await this.model.updateOne({ agentExecutionId }, { $addToSet: { images: { $each: images } } });

--- a/packages/database/src/queries/fabFileSearchQuery.ts
+++ b/packages/database/src/queries/fabFileSearchQuery.ts
@@ -275,7 +275,10 @@ export function buildOwnershipConditions(
  * The lake-membership $or arms for a set of access buckets - one arm per `lakeMemberships` scope,
  * one for `dataLakeTags` (exact meta-tag match), one for `dataLakeTagPrefixes` (open prefix match).
  * Shared by `buildOwnershipConditions` (retrieval) and `FabFileModel.getAccessibleFiles`
- * (attachment), so the two doors can never disagree about what a lake arm matches.
+ * (attachment), so the two doors can never disagree about what this builder RETURNS. They may
+ * still post-process it: the attachment door ANDs `archivedAt: null` onto each arm it gets back
+ * (see the docblock on `getAccessibleFiles`), which retrieval gets from its top-level `baseFilter`
+ * instead. Shared construction, per-door post-processing - do not read this as identical queries.
  *
  * TOTAL: returns `[]` for absent, empty, or all-unusable buckets, and never throws. A prefix can
  * normalize away to zero arms (see `normalizeTagPrefix`), and a caller that needs to distinguish

--- a/packages/database/src/queries/fabFileSearchQuery.ts
+++ b/packages/database/src/queries/fabFileSearchQuery.ts
@@ -248,25 +248,61 @@ export function buildOwnershipConditions(
   // below select files, so a single-lake view can't fall back to "all files the user owns".
   const conditions: object[] = options?.restrictToDataLake ? [] : [...baseAccess];
 
+  conditions.push(
+    ...buildLakeArms({
+      lakeMemberships: options?.lakeMemberships,
+      dataLakeTags: options?.dataLakeTags,
+      dataLakeTagPrefixes: options?.dataLakeTagPrefixes,
+    })
+  );
+
+  // Guard the footgun: in lake-scoped mode we drop the broad ownership arms, so if the
+  // caller set restrictToDataLake but supplied no lake tag/prefix arm, `conditions` is
+  // empty and downstream would build `{ $or: [] }` - which MongoDB rejects at query time
+  // ($or must be a non-empty array). Fail fast here with a descriptive error instead. Kept here
+  // rather than in `buildLakeArms`, which must stay total (a misconfigured prefix can normalize
+  // away to zero arms with no way to distinguish "absent" from "unusable" at that layer).
+  if (options?.restrictToDataLake && conditions.length === 0) {
+    throw new Error(
+      'buildOwnershipConditions: restrictToDataLake requires lakeMemberships, dataLakeTags or dataLakeTagPrefixes'
+    );
+  }
+
+  return conditions;
+}
+
+/**
+ * The lake-membership $or arms for a set of access buckets - one arm per `lakeMemberships` scope,
+ * one for `dataLakeTags` (exact meta-tag match), one for `dataLakeTagPrefixes` (open prefix match).
+ * Shared by `buildOwnershipConditions` (retrieval) and `FabFileModel.getAccessibleFiles`
+ * (attachment), so the two doors can never disagree about what a lake arm matches.
+ *
+ * TOTAL: returns `[]` for absent, empty, or all-unusable buckets, and never throws. A prefix can
+ * normalize away to zero arms (see `normalizeTagPrefix`), and a caller that needs to distinguish
+ * "no arms because nothing was asked for" from "no arms because what was asked for was unusable"
+ * must guard at its own call site - see the `restrictToDataLake` throw in `buildOwnershipConditions`.
+ */
+export function buildLakeArms(options: {
+  lakeMemberships?: DataLakeMembershipScope[];
+  dataLakeTags?: string[];
+  dataLakeTagPrefixes?: string[];
+}): object[] {
+  const arms: object[] = [];
+
   // One arm per lake. An `owned` scope ANDs THAT lake's prefix with THAT lake's creator, never the
   // caller's, so a colliding prefix can't cross a tenant boundary; a `registry` scope's prefix arm
   // is unanchored by design and is only ever supplied on the access-gated single-lake browse (see
-  // the `lakeMemberships` docblock). Same predicate the browse, health, archive and permanent
-  // delete run on - drift between them is what #2243 was.
-  for (const scope of options?.lakeMemberships ?? []) {
-    conditions.push(buildDataLakeMembershipFilter(scope));
+  // the `lakeMemberships` docblock on `buildOwnershipConditions`). Same predicate the browse,
+  // health, archive and permanent delete run on - drift between them is what #2243 was.
+  for (const scope of options.lakeMemberships ?? []) {
+    arms.push(buildDataLakeMembershipFilter(scope));
   }
-
-  // Shared with the single-file removal write path (see normalizeTagPrefix): the prefixes
-  // matched here are exactly the ones a removal is allowed to clear.
-  const validPrefixes = (prefixes: string[] | undefined) =>
-    (prefixes ?? []).map(normalizeTagPrefix).filter((p): p is string => p !== null);
 
   // Include data lake files accessible to this user (by exact meta-tag). The meta-tag
   // (`datalake:<org>:<slug>`) is uniquely namespaced and the accessible set is resolved
   // upstream, so matching it is a SAFE ownership bypass (can't collide across tenants).
-  if (options?.dataLakeTags && options.dataLakeTags.length > 0) {
-    conditions.push({
+  if (options.dataLakeTags && options.dataLakeTags.length > 0) {
+    arms.push({
       tags: {
         $elemMatch: {
           name: { $in: options.dataLakeTags },
@@ -275,11 +311,15 @@ export function buildOwnershipConditions(
     });
   }
 
-  // OPEN prefix arm (static registry) - bypasses ownership, by design (shared KB).
-  const openPrefixes = validPrefixes(options?.dataLakeTagPrefixes);
+  // OPEN prefix arm (static registry) - bypasses ownership, by design (shared KB). Shared with the
+  // single-file removal write path (see normalizeTagPrefix): the prefixes matched here are exactly
+  // the ones a removal is allowed to clear.
+  const openPrefixes = (options.dataLakeTagPrefixes ?? [])
+    .map(normalizeTagPrefix)
+    .filter((p): p is string => p !== null);
   if (openPrefixes.length > 0) {
     const prefixPattern = openPrefixes.map(p => escapeRegex(p)).join('|');
-    conditions.push({
+    arms.push({
       tags: {
         $elemMatch: {
           name: { $regex: new RegExp(`^(${prefixPattern})`) },
@@ -288,17 +328,7 @@ export function buildOwnershipConditions(
     });
   }
 
-  // Guard the footgun: in lake-scoped mode we drop the broad ownership arms, so if the
-  // caller set restrictToDataLake but supplied no lake tag/prefix arm, `conditions` is
-  // empty and downstream would build `{ $or: [] }` - which MongoDB rejects at query time
-  // ($or must be a non-empty array). Fail fast here with a descriptive error instead.
-  if (options?.restrictToDataLake && conditions.length === 0) {
-    throw new Error(
-      'buildOwnershipConditions: restrictToDataLake requires lakeMemberships, dataLakeTags or dataLakeTagPrefixes'
-    );
-  }
-
-  return conditions;
+  return arms;
 }
 
 export type FabFileFilterType =


### PR DESCRIPTION
# Pull Request

## Description

Whether an attached file reaches the model depended on **file ownership**, not on **lake access**. A
caller who passes a data lake's access gate can browse the lake and retrieve from it, but attaching a
member file by id delivered nothing unless they personally owned it or it had been shared with them
directly. Same principal, same file, two doors, opposite answers.

The cause is a single primitive: `FabFileModel.getAccessibleFiles(ids, scope)` matched
`{_id: {$in: ids}, ...scope}` where `scope` is the caller's CASL read ability, which has no lake arm.
The retrieval door got its lake arm in #2243/#2273; this does the same for the attachment door, using
the *same* arm builder so the two can never disagree about what a lake arm matches.

Closes #1576

Plan: `~/Dev/planning/bike4mind/1576-attachment-lake-membership-arm.md` (no milestones - steps 1-5
are one coherent change, all landed here).

Related, already shipped, not re-done here: #1576's "surface the drop" and "warn" asks landed in
**#2234**; the retrieval-door twin of this change is issue **#2243**, fixed by PR **#2273**; **#2324**
made `ResolvedLakeAccess.membership` required.

**This PR now closes all three asks, not just ask 2.** The scope grew deliberately after review.
#2234 shipped only the *negative* half of ask 1 - a notice per undelivered id - and ask 1 also asked
for a positive signal: a response that says whether the attached corpus contributed. Three concrete
gaps were found and are fixed here:

- **A wholly successful turn produced no record at all.** Notices only exist for failures, so a turn
  where every attachment arrived was byte-identical to one that attached nothing. That is the exact
  ambiguity the issue was filed about - it is how a 600-answer eval ran in the retrieval-only
  configuration unnoticed.
- **`GET /api/quests/{id}` returned neither half.** `attachmentNotices` was persisted and rendered in
  the UI but omitted from that route's response, so the documented poll endpoint gave a headless
  caller the token counts and never the explanation. (The rescope comment on #1576 says the notices
  reach "an API consumer, through that same projection" - that was wrong; the projection feeds the
  session chat-history page. This PR makes the claim true.)
- **The agent door never persisted notices at all.** It builds them and injects them into the
  prompt, then drops them - an agent run's attachment failures left no durable record anywhere.

`promptMeta.context.tokensBySource.fabFiles` is deliberately NOT the signal: it aggregates session,
message and system files into one token count, so it cannot distinguish "attached nothing" from
"attached twenty and received none".

**Deliberately not done here:** no `quests.contract.ts`. That route has no contract today, so
authoring one means satisfying `CONVENTIONS.md`, spec generation and the typed client - separate
work. Ask 1 needs the fields present, which they now are.

## Changes

- **Widen the port** (`b4m-core/common/.../FabFileTypes.ts`) - new `AttachmentLakeAccess`
  (`lakeMemberships?` / `dataLakeTags?` / `dataLakeTagPrefixes?`) beside `DataLakeMembershipScope`,
  added as an **optional third argument** to `IFabFileRepository.getAccessibleFiles`. Optional so
  every existing caller and test mock compiles unchanged; an absent object means "no lake arms".
- **Extract `buildLakeArms`** (`packages/database/src/queries/fabFileSearchQuery.ts`) out of
  `buildOwnershipConditions`. It is **total** - returns `[]` for absent/empty/unusable buckets and
  never throws. The `restrictToDataLake` empty-`$or` guard stays behind in `buildOwnershipConditions`,
  which is the only layer that can tell "nothing asked for" from "what was asked for is unusable".
- **Implement the arm** (`FabFileModel.getAccessibleFiles`) - ORs the lake arms against the full CASL
  scope. Parity with retrieval is **plus one conjunct**: `archivedAt: null` is ANDed onto the *lake
  arms only*, never at top level, so archiving a lake stops inline delivery of a member file the
  caller does not own while the caller's own archived file stays reachable exactly as before.
  With no `lakeAccess`, the query is byte-identical to the old one.
- **Forward it** (`b4m-core/utils/src/llm/utils.ts`) - `fetchAndConvertFabFiles` threads `lakeAccess`
  to the repo call; `missingIds` semantics unchanged.
- **Chat door** (`ChatCompletionProcess.ts`) - one memoized `attachmentLakeAccess()` feeding both
  `getAttachedKnowledgeFiles` and `fabFilesToMessages`. Inherits the fail-safe in
  `getAccessibleDataLakeAccess`, so a lake-resolution outage degrades to today's ownership-only
  behaviour and never widens. Two stale docblocks repaired to match.
- **Agent door** (`agentExecutor.ts`) - a **function-local** lazy memo (module scope would leak one
  user's buckets across a warm-container reuse) in an explicit `try/catch`, since
  `resolveRetrievalLakeScopeForUser` has no fail-safe of its own and an unhandled throw would fail
  the whole run. Feeds the direct `getAccessibleFiles` call in
  `agentExecutor.firstIterationQuery.ts` as a **thunk** (that call site is ungated, so an awaited
  value would resolve on every iteration) and the `fetchAndConvertFabFiles` call as an awaited value
  (that one is already gated).
- **New `staticRegistryBypass?: boolean` opt** on `resolveRetrievalLakeScopeForUser`, default `true`
  so its four existing callers are unaffected. The agent door passes `false`: that widening escalates
  registry reach from passages to whole inlined documents, and the chat attachment door structurally
  cannot follow it (`b4m-core/services` cannot import `@server/*`), so inheriting it would ship the
  two attachment doors disagreeing.
- **Shared test harness** (`packages/database/src/__test__/utils.ts`) - `setupMongoTest`'s
  `beforeAll` budget now derives from `MONGO_TEST_TIMEOUT_MS` instead of a bare `60000` literal. A
  literal there silently overrode any per-file `vi.setConfig` budget for all ~87 suites that use
  this helper, which is the anti-pattern that constant's own docblock warns against. Doubled,
  because this hook also builds four models' index sets on a cold connection. Unrelated to the lake
  arm; it is the recurring `Hook timed out in 60000ms` flake that reproduces on `main`.
- **Tests** in all five files the plan names, mirroring the #2243 estate - including a real-Mongo
  `getAccessibleFiles` suite (non-owner reaches a meta-tagged / prefix-owned member; cross-lake
  isolation; archived-lake-member vs. caller's-own-archived-file; byte-identical legacy path).

### Ask 1: the affirmative delivery report

- **New `IAttachmentDelivery`** (`b4m-core/common/.../SessionTypes.ts`) - `{ requested, delivered,
  fullyDelivered, dropped, droppedIds }`, with `attachmentDelivery` added to `IChatHistoryItem`
  beside `attachmentNotices`.
- **Persisted** (`QuestModel.ts`) - schema field plus the `findPageBySessionId` projection, so it
  survives a reload the way the notices do.
- **Chat door** (`ChatCompletionProcess.ts`) - the summary was already computed and handed to
  `logger.info`; it is now returned from `buildDataSources` and written to the quest. Written even
  when nothing failed, which is the only case that produces no notices.
- **Agent door** - `materializeAttachmentContent` now returns the same report on every path,
  including both fallbacks (extraction throwing reports every id as dropped rather than reporting
  nothing), and `agentExecutor` persists it plus the notices through a new
  `recordAttachmentOutcomeByAgentExecutionId`. Best-effort: failing to record an outcome must not
  take the run down.
- **API** (`GET /api/quests/{id}`) - returns `attachmentNotices` and `attachmentDelivery`. Neither
  is viewer-redacted; both describe the caller's own submission.
- **UI** (`AttachmentNotices.tsx`) - the banner leads with the count rather than "some", and stops
  styling a turn as a failure when everything arrived and some of it arrived truncated. It still
  renders only when there is a notice to show: the report refines the warning, it is not a success
  affordance on a clean turn. The heading says "attached file" rather than "attachment" because the
  chat door's `requested` also covers the session and system files inlined beside the turn's own
  attachments, so caller-facing phrasing would overstate what was just submitted.
- **Tests** - the delivery report on both doors (including the no-notice success path, mutation-
  tested), the four agent-door paths, `attachmentNoticeStrings` including its cap, and the API
  surface for owner and sharee. One pre-existing test title was corrected: "leaves the quest
  untouched when every attachment delivered" was true of notices only, and is no longer true of the
  quest.

## Guide for Testers

The lake arm is a backend behaviour change with no UI. The attachment report adds two response
fields and rewords the existing attachment banner. Two accounts are needed: **A** (a lake owner) and **B** (a user who
can read the lake but owns none of its files).

**Setup**
1. As **A**, create a data lake and upload one file into it. Confirm the file carries the lake's
   `datalake:<org>:<slug>` meta-tag.
2. Grant **B** read access to that lake through any arm of the access gate (org membership, tag,
   entitlement - whichever your environment uses).
3. As **B**, open `https://app.staging.bike4mind.com` and `GET /api/data-lakes/<lakeId>/articles`.
   Expected: the file from step 1 is listed. (This already worked before this PR - it confirms B
   passes the gate.)

**Chat door**
4. As **B**, start a new session and attach that file by id (add it to the session's knowledge /
   attached files).
5. Send `Summarize the attached document in one sentence.`
   Expected **after this PR**: the model answers from the file's actual content, and the turn carries
   **no** attachment notice for that id.
   Before this PR the turn carried an attachment notice ("could not be read") and the model had no
   content to answer from.

**Agent door**
6. As **B**, run the same attachment through an agent execution (a session with agent mode on and the
   same file attached).
   Expected: the `[ATTACHED FILES]` preamble lists the file by name, and the agent can quote its
   content.

**Prefix-owned member**
7. Repeat steps 4-5 with a file that is a *prefix-only* member of the lake (tagged by prefix, owned by
   the lake creator, not by B). Expected: same result - content delivered.

**Attachment report (ask 1)**
8. Note the quest id from step 5 and `GET /api/quests/<questId>` with an API key.
   Expected: an `attachmentDelivery` object with `requested`/`delivered`/`fullyDelivered` counts and
   `dropped: 0`. On `main` the field does not exist at all - and because a fully successful turn
   writes no notices, that response was indistinguishable from a turn with no attachments.
9. Repeat with a file id **B** genuinely cannot reach (any random id works).
   Expected: `dropped: 1`, the id in `droppedIds`, and an `attachmentNotices` line explaining it.
   On `main` the notice is rendered in the UI but absent from this response.

**Archive revocation (the important negative)**
10. Open the same session in the browser and look at the turn from step 9 (the unreachable id).
    Expected: the amber banner now leads with a count - `1 of 1 attached file did not reach the model
    intact` - where before it read "Some attachments did not reach the model intact". On a turn where
    every file arrived but one was shortened to fit, the same banner goes neutral and reads
    `All N attached files reached the model; K in part`. On a turn where nothing failed it stays
    absent, which is deliberate: the report is not a success affordance.

11. With **B**'s session still holding those ids, archive the lake as **A**.
12. As **B**, send another message in that same session.
    Expected: **no** content from the archived lake reaches the model, and the attachment notice for
    that id is back.
13. If **B** has an archived file of their **own** attached to any session, confirm it is *still*
    delivered. The `archivedAt` conjunct is lake-arm-only; B's own archived files must be unaffected.

**Regression check**
14. As a third user **C** who owns nothing and reaches no lake, attach one of A's file ids and send a
    message. Expected: attachment notice, no content. A genuine permission denial must not have
    become a silent success.
15. As **A** (the owner), attach and ask about a file A owns and that is in no lake at all. Expected:
    unchanged behaviour - content delivered, no notice.

**What NOT to test**
- No UI changed; no screenshots apply.
- No migration, backfill, infra or admin-setting change. Nothing persisted survives a revert.
- Do not test semantic retrieval / citations - the retrieval door already had this arm (#2243/#2273)
  and is untouched here.

## Additional Information

**Not covered by this PR.** Per-file inline *depth* is deliberately out of scope: resolving more
attachments means more files sharing the same per-turn token budget, so a previously fully-inlined
owned document may now be delivered but not *fully* delivered. That is a measurement to take
(`fullyDeliveredFileIds` vs `deliveredFileIds`, plus `tokensBySource.fabFiles`), not a regression this
PR caps. Raising `CorpusRetrievalMinInlineTokensPerDoc` and choosing a grounding mode for lake-tagged
attachments on a non-lake session are both explicitly deferred.

Attachment resolution is **not** narrowed to `session.retrievalTags`, unlike every retrieval surface:
the caller named these file ids explicitly, and narrowing would turn an explicit request into a silent
refusal.

**Index risk was measured, not assumed.** On a 30k-doc collection with the real `FabFileSchema`
indexes, a four-arm CASL `$or`, 50 owned-lake arms and a 20-id `_id: {$in}`,
`explain('executionStats')` returned `FETCH <- IXSCAN idx:_id_`, 21 keys, 20 docs, zero rejected
plans, no `SUBPLAN`, no `COLLSCAN` - on this door the `_id` list is the bound and the lake arms are a
residual filter, so they produce no index bounds at all.

Shipping unflagged matches precedent: #2273 and #2254 widened the same primitive against the same
collection with no flag.

**Merge-order note for reviewers:** #2282 has since merged, so the re-check this note asked for has
been done. The branch merges clean against current `origin/main`, and #2282's additions to the two
overlapping files (`FabFileTypes.ts`, `FabFileModel.ts`) are pure additions that touch neither
`getAccessibleFiles` nor the arm-building path. No action.

## Developer Notes (Optional)

- **`buildLakeArms`** (`fabFileSearchQuery.ts`) is now the single shared builder for lake `$or` arms.
  Any future door that needs "files reachable through lake membership" should call it rather than
  re-deriving the predicate - drift between two copies of this predicate is exactly what #2243 was.
- **`AttachmentLakeAccess`** is a server-supplied-only type. A `creatorUserId` inside a membership
  scope widens what the query matches, so a value reaching it from request input would let a caller
  name any user and read their files.
- **Never hand-roll `scope.lakes.map(l => l.membership)`.** Use
  `dataLakeService.lakeMembershipsFrom()`, whose `kind === 'owned'` allow-list is the only guard
  against a registry scope entering `lakeMemberships` - where it becomes an unanchored prefix arm
  with no ownership conjunct sitting in the same `$or` as other tenants' arms. The hand-rolled form
  compiles clean.
- **`resolveRetrievalLakeScopeForUser`** now takes `staticRegistryBypass?: boolean` (default `true`),
  so a caller can opt out of the privileged static-registry widening without forking the resolver.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - the attachment banner
  gains a count and loses the amber styling when nothing was actually refused; it stays absent
  on a clean turn, so no new surface appears on the happy path
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [ ] If adding/modifying telemetry fields - n/a, no new telemetry fields



