### PR TITLE
fix(ci): scope the SST deploy roles to a GitHub Environment

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -49,6 +49,12 @@ jobs:
     # Only run if Deploy workflow succeeded OR manually triggered
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    # The deploy role's OIDC trust policy matches on the Environment, so this
+    # has to resolve to the same account the `config` step picks the role ARN
+    # for. `environment:` cannot read the `steps` context, hence the duplicated
+    # condition rather than reusing that step's output.
+    environment:
+      name: ${{ (github.event_name == 'workflow_run' || github.ref == 'refs/heads/prod') && 'production' || 'dev' }}
     env:
       NODE_OPTIONS: --max-old-space-size=14336
     permissions:

--- a/scripts/setup-github-actions.sh
+++ b/scripts/setup-github-actions.sh
@@ -37,7 +37,18 @@ read -p "GitHub repository name: " GITHUB_REPO
 setup_account() {
     local account_name=$1
     local profile_name=$2
-    
+
+    # The trust policy below admits only tokens minted for this GitHub
+    # Environment, so the name has to match the `environment:` key on the job
+    # that assumes the role. The Environment must already exist in repository
+    # settings; the role is unassumable until it does.
+    local github_environment
+    if [ "$account_name" = "prod" ]; then
+        github_environment="production"
+    else
+        github_environment="$account_name"
+    fi
+
     echo -e "${BLUE}Setting up $account_name account...${NC}"
     
     # Get AWS account ID
@@ -73,10 +84,8 @@ setup_account() {
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-        },
-        "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:GITHUB_ORG/GITHUB_REPO:*"
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:GITHUB_ORG/GITHUB_REPO:environment:GITHUB_ENVIRONMENT"
         }
       }
     }
@@ -90,7 +99,8 @@ EOF
     echo -e "${BLUE}  ACCOUNT_ID -> ${AWS_ACCOUNT_ID}${NC}"
     echo -e "${BLUE}  GITHUB_ORG -> ${GITHUB_ORG}${NC}"
     echo -e "${BLUE}  GITHUB_REPO -> ${GITHUB_REPO}${NC}"
-    TRUST_POLICY=$(echo "$TRUST_POLICY" | sed "s/ACCOUNT_ID/${AWS_ACCOUNT_ID}/g" | sed "s/GITHUB_ORG/${GITHUB_ORG}/g" | sed "s/GITHUB_REPO/${GITHUB_REPO}/g")
+    echo -e "${BLUE}  GITHUB_ENVIRONMENT -> ${github_environment}${NC}"
+    TRUST_POLICY=$(echo "$TRUST_POLICY" | sed "s/ACCOUNT_ID/${AWS_ACCOUNT_ID}/g" | sed "s/GITHUB_ORG/${GITHUB_ORG}/g" | sed "s/GITHUB_REPO/${GITHUB_REPO}/g" | sed "s/GITHUB_ENVIRONMENT/${github_environment}/g")
     
     # Validate JSON before writing to file
     echo -e "${BLUE}Validating trust policy JSON...${NC}"
@@ -118,7 +128,19 @@ EOF
     echo -e "${BLUE}Checking if role already exists...${NC}"
     echo -e "${BLUE}Command: aws iam get-role --role-name $ROLE_NAME --profile $profile_name${NC}"
     if aws iam get-role --role-name "$ROLE_NAME" --profile "$profile_name" >/dev/null 2>&1; then
-        echo -e "${YELLOW}IAM role already exists in $account_name, continuing...${NC}"
+        echo -e "${YELLOW}IAM role already exists in $account_name, updating its trust policy...${NC}"
+        echo -e "${BLUE}Command: aws iam update-assume-role-policy --role-name $ROLE_NAME --policy-document (inline) --profile $profile_name${NC}"
+        if aws iam update-assume-role-policy \
+            --role-name "$ROLE_NAME" \
+            --policy-document "$TRUST_POLICY" \
+            --profile "$profile_name"; then
+            echo -e "${GREEN}Trust policy updated for $account_name${NC}"
+        else
+            echo -e "${RED}Failed to update trust policy for $account_name${NC}"
+            echo -e "${RED}Trust policy content:${NC}"
+            echo "$TRUST_POLICY"
+            exit 1
+        fi
     else
         echo -e "${BLUE}Role does not exist, creating it...${NC}"
         # Create the role
@@ -398,6 +420,10 @@ echo -e "${GREEN}Dev Role ARN: $DEV_ROLE_ARN${NC}"
 echo -e "${GREEN}Prod Role ARN: $PROD_ROLE_ARN${NC}"
 echo ""
 echo -e "${YELLOW}Important Note:${NC}"
+echo "Each role trusts exactly one GitHub Environment: 'dev' for the dev role, 'production' for the prod role."
+echo "Create those Environments in the repository settings and give every job that assumes a role the matching"
+echo "'environment:' key, or AssumeRoleWithWebIdentity will be denied."
+echo ""
 echo "The script automatically updates existing policies with the latest permissions from the script."
 echo "This ensures your policies always have the most current permissions needed for deployment."
 echo ""


### PR DESCRIPTION
## What

Two independent changes, both moving GitHub Actions OIDC identity from "any workflow in this repository" to "a named GitHub Environment".

**`.github/workflows/prod-release.yml`** — the `create-release` job declares `environment:`, so the OIDC token it presents carries `repo:<org>/<repo>:environment:production` instead of a ref-derived subject. This is the live half of the change.

**`scripts/setup-github-actions.sh`** — the trust policy this helper generates moves the subject claim out of `StringLike` and into the `StringEquals` block that already carries `aud`, as `repo:<org>/<repo>:environment:<name>`: `dev` for the dev role, `production` for the prod role. The `aud` condition is unchanged.

## On the script

This is a self-service setup helper. It provisions its own roles from scratch and is not where the roles behind this repository's `AWS_*_ROLE_ARN` secrets come from — those are managed in the private infra repo. Anyone standing up their own deployment from this open-core repo runs this script and inherits whatever default it ships, which is the reason to fix it here rather than treat it as dead code. It is not the mechanism by which this repository's own deploys are identified.

While in there: the script only ever wrote a trust policy on the path that *creates* a role. The already-exists path printed "continuing..." and moved on, so a re-run left an existing role on whatever policy it was created with. It now calls `aws iam update-assume-role-policy` there, so the script converges rather than only applying to fresh roles.

## Why an Environment and not a branch ref

`prod-release.yml`'s own header comment records that the `prod` branch is being retired and production is promoted from the deploy console via `workflow_dispatch`. A dispatched run's OIDC subject is the ref it was dispatched on, so pinning to `refs/heads/prod` would describe a path that is going away and would resolve to `main` for the path that replaces it. The Environment claim is stable across both.

## What a human has to do

The workflow change is compatible with the current trust policy on both accounts, so nothing breaks on merge. Two things still need a person, and neither can live in a diff:

1. **Required reviewers on the `production` Environment**, in this repository's Settings → Environments. The Environment determines which token AWS will accept; required reviewers are what put a human in front of a production release. Deployment branch rules on the same Environment are the other knob worth setting at the same time. The equivalent decision exists on the deploy console repository for actual deploys.
2. **Narrowing the corresponding trust policy** to the exact Environment name, which is a change in the private infra repo and is tracked on bike4mind/b4m-internal#77 along with the verification detail for this change.

The `production` and `dev` Environments already exist here — they were created 2026-07-05, before the deploy pipeline that made them was removed in #485 — so this PR reuses those names rather than introducing new ones. No Environment needs creating.

## Notes

`environment:` cannot read the `steps` context, so the expression on the job repeats the `config` step's event/ref condition rather than reusing `steps.config.outputs.stage`. The two have to stay in step; a comment on the job says so.

Every other `environment:` key in the workflow tree is a reusable-workflow input named "environment", not Environment protection. This is the first job in the repo to use the real key.

Scoping the policy attached to these roles down from `Action:*` / `Resource:*` to the concrete permissions the deploy scripts use is separate, larger work and is not here. That and criterion 4 stay open on bike4mind/b4m-internal#77.
