### PR TITLE
chore(deps): upgrade pdfjs-dist to v6

### DIFF
--- a/apps/client/app/components/PdfViewer.test.tsx
+++ b/apps/client/app/components/PdfViewer.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// pdf.js v6 removed the two calling conventions this component used to rely on: `getDocument`
+// no longer accepts a bare URL string, and `PDFDocumentProxy.destroy` is gone in favour of
+// `loadingTask.destroy`. The real v6 build cannot run here (its worker needs browser-only
+// features jsdom lacks), so the double is shaped like v6 exactly: a string argument or a
+// `pdf.destroy()` call would be a hard failure against the real library.
+const destroy = vi.fn().mockResolvedValue(undefined);
+const cancel = vi.fn();
+const getPage = vi.fn();
+const getDocument = vi.fn();
+
+vi.mock('pdfjs-dist', () => ({
+  GlobalWorkerOptions: { workerSrc: '' },
+  getDocument: (...args: unknown[]) => getDocument(...args),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<unknown>) => {
+    let Loaded: React.FC<Record<string, unknown>> | null = null;
+    void Promise.resolve(loader()).then(mod => {
+      Loaded = (mod as { default?: React.FC }).default ?? (mod as React.FC);
+    });
+    return (props: Record<string, unknown>) => (Loaded ? <Loaded {...props} /> : null);
+  },
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const importViewer = async () => (await import('./PdfViewer')).default;
+
+describe('PdfViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getPage.mockImplementation(async () => ({
+      getViewport: () => ({ width: 120, height: 160 }),
+      render: () => ({ promise: Promise.resolve(), cancel }),
+    }));
+
+    getDocument.mockImplementation(() => {
+      const loadingTask: Record<string, unknown> = { destroy };
+      loadingTask.promise = Promise.resolve({ numPages: 2, getPage, loadingTask });
+      return loadingTask;
+    });
+
+    // jsdom has no 2D backend; the component bails out when getContext returns null.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({} as CanvasRenderingContext2D);
+  });
+
+  it('passes the file to getDocument as a parameter object', async () => {
+    const PdfViewer = await importViewer();
+    render(<PdfViewer file="https://example.test/doc.pdf" filename="doc.pdf" />, { wrapper: TestWrapper });
+
+    await waitFor(() => expect(getDocument).toHaveBeenCalledTimes(1));
+    expect(getDocument).toHaveBeenCalledWith({ url: 'https://example.test/doc.pdf' });
+  });
+
+  it('renders every page and reports the page count', async () => {
+    const PdfViewer = await importViewer();
+    const { container } = render(<PdfViewer file="https://example.test/doc.pdf" filename="doc.pdf" />, {
+      wrapper: TestWrapper,
+    });
+
+    await waitFor(() => expect(screen.getByText(/doc\.pdf - 2 pages/)).toBeInTheDocument());
+    expect(getPage.mock.calls.map(([n]) => n)).toEqual([1, 2]);
+    expect(container.querySelectorAll('canvas')).toHaveLength(2);
+  });
+
+  it('tears the document down through the loading task on unmount', async () => {
+    const PdfViewer = await importViewer();
+    const { unmount } = render(<PdfViewer file="https://example.test/doc.pdf" />, { wrapper: TestWrapper });
+
+    await waitFor(() => expect(getPage).toHaveBeenCalled());
+    unmount();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('reports an error when no file is supplied', async () => {
+    const PdfViewer = await importViewer();
+    render(<PdfViewer file={undefined} />, { wrapper: TestWrapper });
+
+    await waitFor(() => expect(screen.getByText(/Unable to load PDF|No file provided/)).toBeInTheDocument());
+    expect(getDocument).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/PdfViewer.test.tsx
+++ b/apps/client/app/components/PdfViewer.test.tsx
@@ -1,21 +1,27 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PDFDocumentLoadingTask, PDFDocumentProxy, PDFPageProxy, PageViewport, RenderTask } from 'pdfjs-dist';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// pdf.js v6 removed the two calling conventions this component used to rely on: `getDocument`
-// no longer accepts a bare URL string, and `PDFDocumentProxy.destroy` is gone in favour of
-// `loadingTask.destroy`. The real v6 build cannot run here (its worker needs browser-only
-// features jsdom lacks), so the double is shaped like v6 exactly: a string argument or a
-// `pdf.destroy()` call would be a hard failure against the real library.
-const destroy = vi.fn().mockResolvedValue(undefined);
-const cancel = vi.fn();
-const getPage = vi.fn();
-const getDocument = vi.fn();
+// pdf.js v6 removed the two calling conventions this component used to rely on: `getDocument` no
+// longer accepts a bare URL string, and `PDFDocumentProxy.destroy` is gone. The real build cannot
+// run here (its worker needs browser features jsdom lacks), so the doubles below are keyed off the
+// real v6 types with `Pick`: if pdf.js renames or drops a member the component calls, these stop
+// compiling rather than silently passing against a hand-rolled shape.
+type LoadingTaskDouble = Pick<PDFDocumentLoadingTask, 'promise' | 'destroy'>;
+type DocumentDouble = Pick<PDFDocumentProxy, 'numPages' | 'getPage'>;
+type PageDouble = Pick<PDFPageProxy, 'getViewport' | 'render'>;
+type RenderTaskDouble = Pick<RenderTask, 'promise' | 'cancel'>;
 
-vi.mock('pdfjs-dist', () => ({
+const destroy = vi.fn<LoadingTaskDouble['destroy']>();
+const cancel = vi.fn<RenderTaskDouble['cancel']>();
+const getPage = vi.fn<(pageNumber: number) => void>();
+const getDocument = vi.fn<(src: { url: string }) => LoadingTaskDouble>();
+
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
   GlobalWorkerOptions: { workerSrc: '' },
-  getDocument: (...args: unknown[]) => getDocument(...args),
+  getDocument: (src: { url: string }) => getDocument(src),
 }));
 
 vi.mock('next/dynamic', () => ({
@@ -33,40 +39,57 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
 );
 
+// `PageViewport` and the others carry far more than the component reads, so each double is widened
+// to the real type at the single point it is handed over. Assertions only, never `as unknown as`.
+const viewport = { width: 120, height: 160 } as PageViewport;
+
+const makePage = (): PageDouble => ({
+  getViewport: () => viewport,
+  render: () => ({ promise: Promise.resolve(), cancel }) as RenderTask,
+});
+
+const makeDocument = (numPages: number): DocumentDouble => ({
+  numPages,
+  getPage: async pageNumber => {
+    getPage(pageNumber);
+    return makePage() as PDFPageProxy;
+  },
+});
+
+const loadsDocument = (numPages = 2) =>
+  getDocument.mockImplementation(() => ({
+    destroy,
+    promise: Promise.resolve(makeDocument(numPages) as PDFDocumentProxy),
+  }));
+
+const FILE = 'https://example.test/doc.pdf';
 const importViewer = async () => (await import('./PdfViewer')).default;
 
 describe('PdfViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    getPage.mockImplementation(async () => ({
-      getViewport: () => ({ width: 120, height: 160 }),
-      render: () => ({ promise: Promise.resolve(), cancel }),
-    }));
-
-    getDocument.mockImplementation(() => {
-      const loadingTask: Record<string, unknown> = { destroy };
-      loadingTask.promise = Promise.resolve({ numPages: 2, getPage, loadingTask });
-      return loadingTask;
-    });
-
+    destroy.mockResolvedValue(undefined);
+    loadsDocument();
     // jsdom has no 2D backend; the component bails out when getContext returns null.
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({} as CanvasRenderingContext2D);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('passes the file to getDocument as a parameter object', async () => {
     const PdfViewer = await importViewer();
-    render(<PdfViewer file="https://example.test/doc.pdf" filename="doc.pdf" />, { wrapper: TestWrapper });
+    render(<PdfViewer file={FILE} filename="doc.pdf" />, { wrapper: TestWrapper });
 
     await waitFor(() => expect(getDocument).toHaveBeenCalledTimes(1));
-    expect(getDocument).toHaveBeenCalledWith({ url: 'https://example.test/doc.pdf' });
+    expect(getDocument).toHaveBeenCalledWith({ url: FILE });
   });
 
   it('renders every page and reports the page count', async () => {
     const PdfViewer = await importViewer();
-    const { container } = render(<PdfViewer file="https://example.test/doc.pdf" filename="doc.pdf" />, {
-      wrapper: TestWrapper,
-    });
+    const { container } = render(<PdfViewer file={FILE} filename="doc.pdf" />, { wrapper: TestWrapper });
 
     await waitFor(() => expect(screen.getByText(/doc\.pdf - 2 pages/)).toBeInTheDocument());
     expect(getPage.mock.calls.map(([n]) => n)).toEqual([1, 2]);
@@ -75,7 +98,7 @@ describe('PdfViewer', () => {
 
   it('tears the document down through the loading task on unmount', async () => {
     const PdfViewer = await importViewer();
-    const { unmount } = render(<PdfViewer file="https://example.test/doc.pdf" />, { wrapper: TestWrapper });
+    const { unmount } = render(<PdfViewer file={FILE} />, { wrapper: TestWrapper });
 
     await waitFor(() => expect(getPage).toHaveBeenCalled());
     unmount();
@@ -84,11 +107,48 @@ describe('PdfViewer', () => {
     expect(cancel).toHaveBeenCalled();
   });
 
+  it('terminates the worker when unmounted before the document resolves', async () => {
+    getDocument.mockImplementation(() => ({ destroy, promise: new Promise(() => {}) }));
+
+    const PdfViewer = await importViewer();
+    const { unmount } = render(<PdfViewer file={FILE} />, { wrapper: TestWrapper });
+
+    await waitFor(() => expect(getDocument).toHaveBeenCalled());
+    expect(getPage).not.toHaveBeenCalled();
+    unmount();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a teardown rejection rather than leaving it unhandled', async () => {
+    destroy.mockRejectedValue(new Error('worker never set up'));
+
+    const PdfViewer = await importViewer();
+    const { unmount } = render(<PdfViewer file={FILE} />, { wrapper: TestWrapper });
+
+    await waitFor(() => expect(getPage).toHaveBeenCalled());
+    expect(() => unmount()).not.toThrow();
+    await expect(destroy.mock.results[0]!.value).rejects.toThrow('worker never set up');
+  });
+
+  it('shows the error message when the document fails to load', async () => {
+    getDocument.mockImplementation(() => ({
+      destroy,
+      promise: Promise.reject(new Error('Invalid parameter object')),
+    }));
+
+    const PdfViewer = await importViewer();
+    render(<PdfViewer file={FILE} filename="doc.pdf" />, { wrapper: TestWrapper });
+
+    await waitFor(() => expect(screen.getByText(/Unable to load PDF document/)).toBeInTheDocument());
+    expect(screen.queryByText(/Loading PDF/)).not.toBeInTheDocument();
+  });
+
   it('reports an error when no file is supplied', async () => {
     const PdfViewer = await importViewer();
     render(<PdfViewer file={undefined} />, { wrapper: TestWrapper });
 
-    await waitFor(() => expect(screen.getByText(/Unable to load PDF|No file provided/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/No file provided/)).toBeInTheDocument());
     expect(getDocument).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/components/PdfViewer.tsx
+++ b/apps/client/app/components/PdfViewer.tsx
@@ -53,7 +53,7 @@ const BasePdfViewer: FC<PdfViewerProps> = ({ file, filename }) => {
         setLoading(true);
         setError(null);
 
-        const loadingTask = pdfjsLib.getDocument(file);
+        const loadingTask = pdfjsLib.getDocument({ url: file });
         const pdf = await loadingTask.promise;
 
         if (cancelled) return;
@@ -97,7 +97,7 @@ const BasePdfViewer: FC<PdfViewerProps> = ({ file, filename }) => {
 
             canvasContainerRef.current?.appendChild(canvas);
 
-            // pdf.js v5's RenderParameters requires the canvas element itself, not just
+            // pdf.js's RenderParameters requires the canvas element itself, not just
             // the 2D context, so pass both.
             const renderContext = {
               canvas,
@@ -129,7 +129,8 @@ const BasePdfViewer: FC<PdfViewerProps> = ({ file, filename }) => {
         renderTaskRef.current.cancel?.();
       }
       if (pdfDocRef.current) {
-        pdfDocRef.current.destroy();
+        // pdf.js v6 removed PDFDocumentProxy.destroy(); the loading task owns teardown.
+        pdfDocRef.current.loadingTask.destroy();
         pdfDocRef.current = null;
       }
     };

--- a/apps/client/app/components/PdfViewer.tsx
+++ b/apps/client/app/components/PdfViewer.tsx
@@ -1,12 +1,19 @@
 import { Box, Button, CircularProgress, Typography, useTheme } from '@mui/joy';
 import { FC, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-import * as pdfjsLib from 'pdfjs-dist';
-import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+import type { PDFDocumentLoadingTask, RenderTask } from 'pdfjs-dist';
 
+// We import the `legacy/` entry point, not pdfjs-dist's default build. The default build is
+// compiled for "the latest" browsers and reaches for globals well above this app's Next target:
+// it touches `Iterator.prototype` at module scope (a ReferenceError below Safari 18.4) and calls
+// `Uint8Array.prototype.toHex` while computing a document fingerprint (Chrome 140 / Firefox 133 /
+// Safari 18.2). `legacy/` exposes the identical API with core-js polyfills for both, costing about
+// 60KB on a chunk that is only fetched when someone opens a PDF.
+//
 // Load the worker as a plain same-origin static asset (copied into /public from the installed
-// pdfjs-dist by scripts/copy-pdf-worker.mjs). pdf.js instantiates the module worker itself from
-// this URL.
+// pdfjs-dist by scripts/copy-pdf-worker.mjs, which must copy out of the same build directory this
+// import points at). pdf.js instantiates the module worker itself from this URL.
 //
 // We intentionally do NOT use `new Worker(new URL('pdfjs-dist/build/pdf.worker.min.mjs',
 // import.meta.url), { type: 'module' })`: Turbopack rewrites that into its own worker helper,
@@ -37,7 +44,7 @@ const BasePdfViewer: FC<PdfViewerProps> = ({ file, filename }) => {
   const [error, setError] = useState<string | null>(null);
   const [numPages, setNumPages] = useState(0);
   const renderTaskRef = useRef<RenderTask | null>(null);
-  const pdfDocRef = useRef<PDFDocumentProxy | null>(null);
+  const loadingTaskRef = useRef<PDFDocumentLoadingTask | null>(null);
 
   useEffect(() => {
     if (!file) {
@@ -53,13 +60,15 @@ const BasePdfViewer: FC<PdfViewerProps> = ({ file, filename }) => {
         setLoading(true);
         setError(null);
 
+        // Held before the await: the loading task is the only teardown handle that exists while
+        // the document is still loading, so an unmount mid-load can still terminate the worker.
         const loadingTask = pdfjsLib.getDocument({ url: file });
+        loadingTaskRef.current = loadingTask;
+
         const pdf = await loadingTask.promise;
 
         if (cancelled) return;
 
-        // Store PDF reference for cleanup
-        pdfDocRef.current = pdf;
         setNumPages(pdf.numPages);
 
         if (canvasContainerRef.current) {
@@ -128,10 +137,11 @@ const BasePdfViewer: FC<PdfViewerProps> = ({ file, filename }) => {
       if (renderTaskRef.current) {
         renderTaskRef.current.cancel?.();
       }
-      if (pdfDocRef.current) {
-        // pdf.js v6 removed PDFDocumentProxy.destroy(); the loading task owns teardown.
-        pdfDocRef.current.loadingTask.destroy();
-        pdfDocRef.current = null;
+      if (loadingTaskRef.current) {
+        // Destroying the loading task destroys the document and terminates the worker. It rejects
+        // if the worker never finished setting up, which is not actionable once we are unmounting.
+        loadingTaskRef.current.destroy().catch(() => {});
+        loadingTaskRef.current = null;
       }
     };
   }, [file, theme.palette.divider]);

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -186,7 +186,7 @@
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "passport-oauth2": "^1.8.0",
-    "pdfjs-dist": "5.6.205",
+    "pdfjs-dist": "6.3.289",
     "pretty-bytes": "^7.0.0",
     "prismjs": "^1.30.0",
     "pyodide": "^0.29.4",

--- a/apps/client/scripts/copy-pdf-worker.mjs
+++ b/apps/client/scripts/copy-pdf-worker.mjs
@@ -24,10 +24,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const WORKER_FILE = 'pdf.worker.min.mjs';
 
+// Must stay in step with PdfViewer's `pdfjs-dist/legacy/build/pdf.mjs` import: pdf.js refuses to
+// run an API and a worker from different builds, and the polyfills the legacy build relies on live
+// in the legacy worker.
+const BUILD_DIR = path.join('legacy', 'build');
+
 function main() {
   // Resolve the worker from the installed package (works with pnpm's nested node_modules).
   const pdfjsPkg = require.resolve('pdfjs-dist/package.json');
-  const source = path.join(path.dirname(pdfjsPkg), 'build', WORKER_FILE);
+  const source = path.join(path.dirname(pdfjsPkg), BUILD_DIR, WORKER_FILE);
 
   const destinationDir = path.resolve(__dirname, '../public');
   const destination = path.join(destinationDir, WORKER_FILE);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,8 +564,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       pdfjs-dist:
-        specifier: 5.6.205
-        version: 5.6.205
+        specifier: 6.3.289
+        version: 6.3.289
       pretty-bytes:
         specifier: ^7.0.0
         version: 7.1.0
@@ -4128,8 +4128,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@napi-rs/canvas-android-arm64@1.0.8':
+    resolution: {integrity: sha512-5+nkh8i3gt6lqS/d2jTZ1xAn6tdgtB4Lf1mW6T0Qm5/rXNwBuV1sAEyLEWan5o9gJPU/GuvHR3rvSeZ+FaGrbw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
   '@napi-rs/canvas-darwin-arm64@0.1.100':
     resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.8':
+    resolution: {integrity: sha512-7jQ47gi+fZ7KJmfc/5rNyy1CYw/cu4kZ0KPIYbo9UUgSdW0bKQJpt+WihEor6s4Lyp7+xc3a+3HeyXmAEbbnPg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -4140,14 +4152,33 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@napi-rs/canvas-darwin-x64@1.0.8':
+    resolution: {integrity: sha512-rRjDMZs9pIRKGxgijwezplKc1RnJsqUokrA9h88bbTkqQ+7ePj0ZN4ZnZDy8Vu0tXs7KRlI2tQLaK4mx9QlxHg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
     resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.8':
+    resolution: {integrity: sha512-jGcCd+8ra6Q61xKqZeiItujTpp9a9eRLcQ0jW6qYNku+WpupqOPFPY0SrsuSnXFviJwkpKYT9p7QrB4lsf3LNQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
   '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
     resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.8':
+    resolution: {integrity: sha512-od6I2Y7kU7i1SwZYG2EKW8rWz6JiedtPpko4WEe1DDsiikrfaotVBCRaUTM5/yeZKaZ92EatoAS+5xG+6uJlYA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4160,8 +4191,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@napi-rs/canvas-linux-arm64-musl@1.0.8':
+    resolution: {integrity: sha512-yYkPbJDJiWj6N0gASA3CAvRypZmVpJnxU0DQg3aBhneLDQde9TPLKADsQkobNoJUtTT/lj46aWpzT48PDb3Qcg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.8':
+    resolution: {integrity: sha512-PB00MSKAp4VwK/xwe6duKxRKmH8UH4GIl1pqHSbxng0jnU9Dr7FwaDypDiqwNFZ774N+8G7mJLGuLtg9NTcQsg==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
@@ -4174,8 +4219,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@napi-rs/canvas-linux-x64-gnu@1.0.8':
+    resolution: {integrity: sha512-TWM2XWJoitLiIPCvgJh7SriC+L/T9qkYCVzC66AidsZy0QP1hkKzBzVwshCdcA3q6fIn3yE0ISbq4lMJSy8jFw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.8':
+    resolution: {integrity: sha512-hb20MxKXXb5IB7AAwN8UHz9WRsa2HmdZfjsDCzjElwJoeV1aotVEwFU4FrFQcYQVzsJQLeaCc/2Qdt/0Q72mMg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4187,14 +4246,30 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.8':
+    resolution: {integrity: sha512-WwPN08IXE4SkL+FhJyPz/iFnycMAUkbphFIT4cmKLlvbSU0Zfn1R7BGJ3Hqky1S89QUYc0Q4IOScXb/42Re9wQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@napi-rs/canvas-win32-x64-msvc@0.1.100':
     resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
+  '@napi-rs/canvas-win32-x64-msvc@1.0.8':
+    resolution: {integrity: sha512-XkrVqKb+pxyba7kjy2LJvABFVBTE0DNpEl7MrG4OYUmaWarrXH+t54z/Czj2YxCKtizYTV4mg6phNm3x24qjhQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/canvas@0.1.100':
     resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/canvas@1.0.8':
+    resolution: {integrity: sha512-/SaLcvlqGWdm0HSCWMgHu7cjJiQXfP8/mOY+6dUyV9flQz7sPBBZ+ed2zYtoukojPmxOaL7bm+d/G4GeWWoN7g==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.6':
@@ -9902,9 +9977,6 @@ packages:
       '@types/node':
         optional: true
 
-  node-readable-to-web-readable-stream@0.4.2:
-    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
-
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -10282,9 +10354,9 @@ packages:
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
-  pdfjs-dist@5.6.205:
-    resolution: {integrity: sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==}
-    engines: {node: '>=20.19.0 || >=22.13.0 || >=24'}
+  pdfjs-dist@6.3.289:
+    resolution: {integrity: sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   peberminta@0.10.0:
     resolution: {integrity: sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==}
@@ -15304,34 +15376,67 @@ snapshots:
   '@napi-rs/canvas-android-arm64@0.1.100':
     optional: true
 
+  '@napi-rs/canvas-android-arm64@1.0.8':
+    optional: true
+
   '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.8':
     optional: true
 
   '@napi-rs/canvas-darwin-x64@0.1.100':
     optional: true
 
+  '@napi-rs/canvas-darwin-x64@1.0.8':
+    optional: true
+
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.8':
     optional: true
 
   '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
     optional: true
 
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.8':
+    optional: true
+
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.8':
     optional: true
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     optional: true
 
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.8':
+    optional: true
+
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.8':
     optional: true
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     optional: true
 
+  '@napi-rs/canvas-linux-x64-musl@1.0.8':
+    optional: true
+
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     optional: true
 
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.8':
+    optional: true
+
   '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.8':
     optional: true
 
   '@napi-rs/canvas@0.1.100':
@@ -15347,6 +15452,21 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 0.1.100
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
       '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
+
+  '@napi-rs/canvas@1.0.8':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.8
+      '@napi-rs/canvas-darwin-arm64': 1.0.8
+      '@napi-rs/canvas-darwin-x64': 1.0.8
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.8
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.8
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.8
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.8
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.8
+      '@napi-rs/canvas-linux-x64-musl': 1.0.8
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.8
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.8
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -17318,7 +17438,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1(canvas@3.2.1))(vite@8.1.4(@types/node@25.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1(canvas@3.2.1))(vite@8.1.4(@types/node@24.12.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -17372,7 +17492,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1(canvas@3.2.1))(vite@8.1.4(@types/node@25.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1(canvas@3.2.1))(vite@8.1.4(@types/node@24.12.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -21888,9 +22008,6 @@ snapshots:
       '@types/express': 4.17.23
       '@types/node': 24.12.3
 
-  node-readable-to-web-readable-stream@0.4.2:
-    optional: true
-
   node-releases@2.0.27: {}
 
   node-releases@2.0.47: {}
@@ -22261,10 +22378,9 @@ snapshots:
 
   pause@0.0.1: {}
 
-  pdfjs-dist@5.6.205:
+  pdfjs-dist@6.3.289:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.100
-      node-readable-to-web-readable-stream: 0.4.2
+      '@napi-rs/canvas': 1.0.8
 
   peberminta@0.10.0: {}
 


### PR DESCRIPTION
# Pull Request

## Description

Part of the Dependabot / GHAS security-update queue for this repo. The upstream advisory this tracks is GHSA-hq66-cqwq-w95j, and the remediation Dependabot asks for is a `pdfjs-dist` major.

So this moves `apps/client` from `pdfjs-dist` 5.6.205 to 6.3.289. v6 is a real major, not a lockfile-only bump: two of the calling conventions `PdfViewer` used no longer exist, and the default build's browser floor moved. Both are handled here.

I kept the exact pin rather than moving to a caret. The comment trail on `scripts/copy-pdf-worker.mjs` and `PdfViewer.tsx` leans on the served worker never drifting from the resolved package, and an exact pin is the lower-risk way to keep that property obvious to the next reader. The copy script resolves the worker out of `node_modules` either way, so the pin is about legibility, not correctness.

## Changes

- `apps/client/package.json`: `pdfjs-dist` 5.6.205 -> 6.3.289 (still an exact pin).
- `PdfViewer.tsx`: `getDocument(file)` -> `getDocument({ url: file })`. v6 removed support for calling `getDocument` with anything other than a parameter object, so a bare URL string now resolves to a document with no source.
- `PdfViewer.tsx`: teardown now goes through a `loadingTaskRef` assigned synchronously at the `getDocument` call, replacing `pdfDocRef`. v6 removed `PDFDocumentProxy.prototype.destroy` (it was only ever an alias for the loading task's own `destroy`), and the loading task is additionally the only teardown handle that exists before `loadingTask.promise` resolves, so unmounting mid-load now terminates the worker instead of running cleanup against a ref that was never set.
- `PdfViewer.tsx`: imports the `legacy/` entry point instead of the default build. See the browser-floor section below.
- `scripts/copy-pdf-worker.mjs`: copies from `legacy/build` via a named `BUILD_DIR`, with a comment tying it to the import, since pdf.js will not run an API and a worker from different builds and the polyfills live in the legacy worker.
- `PdfViewer.test.tsx`: new. Covers both call shapes, both teardown paths, the load-failure branch, a rejecting teardown, and the no-file path.
- `pnpm-lock.yaml`: `pdfjs-dist` and its own subtree only. `@napi-rs/canvas` moves 0.1.100 -> 1.0.8 as pdfjs-dist's optional dep, and `node-readable-to-web-readable-stream` drops out because v6 no longer depends on it. That last removal also takes `@types/node@25.4.0` out of the graph (it was that package's optional peer), which collapses two vitest peer-resolution keys onto the `@types/node@24.12.3` that everything else already resolves to. No `pnpm.overrides` were touched.

Things I checked and deliberately did not change: `render`, `RenderTask.cancel` and `GlobalWorkerOptions.workerSrc` have identical signatures in v6; the worker filename is unchanged, so `workerSrc` still points at `/pdf.worker.min.mjs`; and `pdfjs-dist` is still ESM-only with no CJS entry and no `exports` map, so it stays in `transpilePackages`. The static-asset worker arrangement that the comment block in `PdfViewer.tsx` describes is preserved exactly.

v6 declares `engines: { node: ">=22.13.0 || >=24" }`. The root `package.json` requires `>=24.0.0`, `.nvmrc` is `24`, and every workflow pins `NODE_VERSION: '24'`, so nothing about CI Node needed to move.

## Why the legacy build

pdfjs-dist ships two builds. The default one is compiled for "the latest" browsers and reaches for two globals without guarding either: `build/pdf.mjs` touches `Iterator.prototype` at module scope, and its worker calls `Uint8Array.prototype.toHex` while computing a document fingerprint. This repo declares no browserslist, so Next's default target admits browsers well below both. `legacy/` exposes the identical API with core-js polyfills for both globals, so that is what this PR imports.

Worth stating the size of the problem accurately, because it is narrower than "v6 introduces a browser floor". The `toHex` dependency is already present in the pinned 5.6.205 worker, in the same `fingerprints` getter, so on the current default build no PDF loads below roughly Chrome 140 / Firefox 133 / Safari 18.2 - it fails at document load rather than at module import. `Iterator` has a lower floor than that on Chrome and Firefox, so those two do not move. What v6 genuinely adds is Safari 18.2 to 18.4, and a failure that happens at import instead of at load. The legacy build is the right call regardless, since it also repairs the older floor.

I verified this rather than reasoning about it, by deleting both globals in Chromium and importing each build against the same PDF:

```
build: default   after downlevel: {"Iterator":"undefined","toHex":"undefined"}
                 RESULT: FAILED -> Iterator is not defined

build: legacy    after downlevel: {"Iterator":"undefined","toHex":"undefined"}
                 module imported, version 6.3.289
                 numPages: 1
                 non-white pixels: 1263
                 loadingTask.destroy() OK
                 RESULT: RENDERED
```

Cost of the switch is about 60KB on the API chunk (458KB -> 518KB minified) and 52KB on the worker (1265KB -> 1317KB). Both are only fetched when someone opens a PDF: `PdfViewer` is loaded through `next/dynamic` with `ssr: false`, and the worker is a separate static asset pdf.js requests on demand.

## Guide for Testers

Note that `PdfViewer` is reached through the Knowledge surfaces, and the file it is handed is a signed URL, so testing needs a real uploaded PDF rather than a local file path.

1. Open `app.staging.bike4mind.com` and sign in.
2. Open a notebook and upload a multi-page PDF (3 or more pages) through the file upload control.
3. Wait for the upload to finish, then click the uploaded PDF to open the Knowledge viewer.
4. Expected: the "Loading PDF..." spinner clears within a few seconds and every page renders as an image, one after another, with a thin border around each page.
5. Expected: the header above the pages reads the filename followed by the page count, for example `report.pdf - 4 pages`.
6. Click the Download button in that header. Expected: the browser downloads the same PDF.
7. Close the viewer and immediately reopen the same PDF. Expected: it renders again with no console errors and no stuck spinner.
8. Open a PDF with more than 50 pages. Expected: the first 50 pages render, and a warning line reads `Showing first 50 pages. Download for full PDF.`
9. Open the browser devtools Network tab and reload with a PDF open. Expected: a request for `/pdf.worker.min.mjs` returns 200 from the app's own origin, not from a CDN.
10. Open a PDF, then close the viewer within the first half second, before any page has rendered. Expected: no console error, and the Network tab shows no request still in flight for the worker or the PDF.
11. Check the devtools Console across all of the above. Expected: no `Iterator is not defined`, no `Setting up fake worker failed`, no `Invalid parameter object`, no `toHex is not a function`, and no `destroy is not a function`.
12. If a Safari or iOS device is available, repeat steps 2 to 5 there. Expected: identical behaviour to Chrome. This is the case the build switch is for, and a Chrome-only walkthrough will not surface it.

Regression checks:

1. A PDF that fails to load (revoke the signed URL, or open a corrupt file) still shows `Unable to load PDF document. Please try again or download the file.` rather than an indefinite spinner.
2. Navigating away mid-render does not leave a hung request or throw in the console.

What NOT to test: nothing outside the PDF viewer changes. Other file previews, chat, and every server route are untouched by this PR.

## Additional Information

Verification run locally, all from a clean `pnpm install`:

- `pnpm turbo:typecheck` - exit 0, 40/40 tasks.
- `pnpm --filter @bike4mind/client test` - exit 0, 1112 files / 12002 tests passed, 10 files / 81 tests skipped.
- `pnpm lint:check` - exit 0.
- Worker copy: deleted `apps/client/public/pdf.worker.min.mjs`, re-ran `node apps/client/scripts/copy-pdf-worker.mjs`, and got a 1,317,034-byte file whose sha256 matches `node_modules/pdfjs-dist/legacy/build/pdf.worker.min.mjs` exactly.

I also did a real render check rather than relying on the typecheck, because a signature change that TypeScript accepts can still be wrong at runtime. I served the build together with the copied worker as static files and drove it in Chromium against a one-page PDF, mirroring what `PdfViewer` does line for line: set `workerSrc` to the same-origin worker, `getDocument({ url })`, `getPage(1)`, `getViewport({ scale: 1.5 })`, `render({ canvas, canvasContext, viewport })`, then `loadingTask.destroy()`. The page rasterized, `renderTask.cancel` was a function, and `pdf.destroy` came back `undefined` - which is what caught the removed method in the first place. That harness is scratch and is not part of this PR; the committed regression guard is the vitest file.

Each committed guard was checked by breaking the source and watching it fail, not just by watching it pass:

- Restoring `getDocument(file)` and `pdf.destroy()` turns 3 of the 7 tests red.
- Moving the `loadingTaskRef` assignment back to after `await loadingTask.promise` turns the unmount-during-load test red with `destroy` called 0 times.

The committed test uses a double for `pdfjs-dist` rather than the real library, and I want to be straight about why: the v6 worker needs browser features jsdom does not have, so the real build cannot run under vitest. The doubles are now derived from the real v6 types with `Pick`, so a renamed or removed member fails to compile rather than passing against a hand-rolled shape, and the widening assertions are plain type assertions with no `as unknown as`. The real-library evidence is the Chromium runs above, not the unit test.

## Developer Notes (Optional)

`PdfViewer.test.tsx` is the first test here to render a component that depends on `pdfjs-dist`. Three pieces are worth reusing: stubbing `next/dynamic` down to a plain component so the `ssr: false` wrapper does not have to be awaited; stubbing `HTMLCanvasElement.prototype.getContext`, since jsdom has no 2D backend and the component bails out early when it returns null; and typing hand-rolled doubles as `Pick<RealType, 'the' | 'members' | 'used'>` so the double stays coupled to the dependency's types without having to satisfy the whole interface.

The `legacy/` import and the `BUILD_DIR` in `copy-pdf-worker.mjs` have to move together. Each side carries a comment pointing at the other.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
