### PR TITLE
fix(ci): pass the test-shard filters to pnpm as separate arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,8 +534,13 @@ jobs:
           - name: data
             filter: '--filter @bike4mind/common --filter @bike4mind/database --filter @bike4mind/db-core --filter @bike4mind/core'
             workers: '25%'
+          # The catch-all: every workspace package the buckets above do not name. A `filter`
+          # value reaches the step as an env var and is split on whitespace into argv, so the
+          # tokens here must be BARE. Quotes around a pattern are not shell quoting at this
+          # point, they are characters inside the argument pnpm receives, and pnpm then matches
+          # nothing. `!` needs no quoting either: history expansion is interactive-only.
           - name: misc
-            filter: "--filter '!@bike4mind/client' --filter '!@bike4mind/services' --filter '!@bike4mind/cli' --filter '!@bike4mind/slack' --filter '!@bike4mind/voice' --filter '!@bike4mind/common' --filter '!@bike4mind/database' --filter '!@bike4mind/db-core' --filter '!@bike4mind/core'"
+            filter: '--filter !@bike4mind/client --filter !@bike4mind/services --filter !@bike4mind/cli --filter !@bike4mind/slack --filter !@bike4mind/voice --filter !@bike4mind/common --filter !@bike4mind/database --filter !@bike4mind/db-core --filter !@bike4mind/core'
             workers: '25%'
 
     steps:
@@ -635,12 +640,32 @@ jobs:
         env:
           CI: true
           VITEST_MAX_WORKERS: ${{ matrix.shard.workers }}
+          SHARD_NAME: ${{ matrix.shard.name }}
           SHARD_FILTER: ${{ matrix.shard.filter }}
           SHARD_SCRIPT: ${{ matrix.shard.script || 'test' }}
           SHARD_ARGS: ${{ matrix.shard.args }}
         run: |
-          # shellcheck disable=SC2086 # each carries several args; word splitting is the point
-          pnpm --recursive --workspace-concurrency=4 $SHARD_FILTER $SHARD_SCRIPT $SHARD_ARGS
+          # Split each env var on whitespace into a real argv array, so every token arrives at
+          # pnpm as its own argument. The matrix values stay in `env:` and are never interpolated
+          # into this command line, and there is no `eval`, so a matrix value is only ever data.
+          # `read -ra` does no quote processing - the tokens in the matrix must be bare, and
+          # checkClientTestShards.test.ts fails the build if one grows a quote character.
+          read -ra filter_args <<< "$SHARD_FILTER"
+          read -ra script_args <<< "$SHARD_ARGS"
+
+          # A filter set matching no project is not an error to pnpm: it prints "No projects
+          # matched the filters" and exits 0, so the leg runs nothing and still reports green -
+          # the same silent-success shape the `--dir` note below exists to close. Resolve the set
+          # up front and fail loudly when it is empty. `pnpm ls` counts the workspace root as a
+          # match where `pnpm run` does not, so drop it: only real packages count.
+          matched=$(pnpm --recursive "${filter_args[@]}" ls --depth -1 --parseable | grep -cvxF "$PWD" || true)
+          echo "${SHARD_NAME} matches ${matched} package(s)"
+          if [ "$matched" -eq 0 ]; then
+            echo "::error title=Empty test shard::The ${SHARD_NAME} leg's filters match no workspace package, so it would run no tests. Check the --filter tokens in the matrix."
+            exit 1
+          fi
+
+          pnpm --recursive --workspace-concurrency=4 "${filter_args[@]}" "$SHARD_SCRIPT" "${script_args[@]}"
 
       # Tests that live outside every pnpm workspace, which the sharded run above cannot reach:
       # infra/ has no package.json, and scripts/codemods is not in pnpm-workspace.yaml, so

--- a/packages/scripts/src/checkClientTestShards.test.ts
+++ b/packages/scripts/src/checkClientTestShards.test.ts
@@ -39,6 +39,24 @@ function readShardLegs(contents: string): Array<{ index: number; count: number }
   }));
 }
 
+/**
+ * Every leg's matrix `filter:` value, in file order, as YAML hands it to the runner - so the
+ * outer quote pair, which belongs to the YAML parser, is stripped here too.
+ *
+ * The step passes this value to pnpm by splitting it on whitespace into argv. Nothing in that
+ * path processes quotes, so a quote character left INSIDE the value is a character in the
+ * argument pnpm receives: it looks for a package literally named `'!@bike4mind/client'`, finds
+ * none, prints "No projects matched the filters" and exits 0. Zero tests run and the leg is
+ * green, which is why the assertion below pins bare tokens.
+ */
+function readShardFilters(contents: string): string[] {
+  return [...contents.matchAll(/^\s*filter:\s*(\S.*?)\s*$/gm)].map(match => {
+    const raw = match[1];
+    const unquoted = /^'(.*)'$/.exec(raw) ?? /^"(.*)"$/.exec(raw);
+    return unquoted ? unquoted[1] : raw;
+  });
+}
+
 describe('apps/client test-shard legs in ci.yml', () => {
   const contents = fs.readFileSync(CI_WORKFLOW, 'utf8');
   const legs = readShardLegs(contents);
@@ -66,12 +84,42 @@ describe('apps/client test-shard legs in ci.yml', () => {
   // `pnpm ... test -- --shard=1/3` forwards the literal `--` to vitest, which then reads the
   // rest as positional path filters: the shard is ignored and the leg runs the WHOLE suite, at
   // 3x the total cost, without erroring. Measured, not hypothetical. Pin the bare form.
+  //
+  // The matrix value no longer reaches the command by `${{ }}` interpolation; it goes through
+  // an `env:` entry and a bash array. So walk that chain rather than assuming any link in it:
+  // matrix.shard.args -> SHARD_ARGS -> the array the step splits it into -> the pnpm argv. A
+  // guard that only matched a fixed name would pass vacuously the next time the shape moves,
+  // which is exactly how this assertion went stale before.
   it('appends the shard args with no `--` separator', () => {
-    const runLine = contents
-      .split('\n')
-      .find(line => line.includes('matrix.shard.script') && line.includes('matrix.shard.args'));
-    expect(runLine, 'the sharded test command should reference matrix.shard.args').toBeDefined();
+    expect(contents, 'SHARD_ARGS should carry matrix.shard.args into the step').toMatch(
+      /^\s*SHARD_ARGS:\s*\$\{\{\s*matrix\.shard\.args\s*\}\}\s*$/m
+    );
+    const binding = /read\s+-ra\s+(\w+)\s*<<<\s*"\$SHARD_ARGS"/.exec(contents);
+    expect(binding, 'the step should split SHARD_ARGS into an argv array').not.toBeNull();
+    const argsArray = binding![1];
+    const runLine = contents.split('\n').find(line => /\bpnpm\b/.test(line) && line.includes(`\${${argsArray}[@]}`));
+    expect(runLine, `the sharded test command should pass ${argsArray} to pnpm`).toBeDefined();
     expect(runLine).not.toMatch(/\s--\s/);
+  });
+
+  // The other half of the same env hop. Word splitting is what turns one env var back into
+  // several arguments, and it does not strip quotes - so a quoted token here silently matches
+  // no package rather than erroring. Pin bare `--filter <pattern>` pairs.
+  it('declares every leg filter as bare `--filter <pattern>` pairs', () => {
+    const filters = readShardFilters(contents);
+    expect(filters, 'no shard filters declared in ci.yml').not.toHaveLength(0);
+    for (const filter of filters) {
+      expect(filter, `quote character inside a shard filter: ${filter}`).not.toMatch(/['"]/);
+      const tokens = filter.split(/\s+/);
+      expect(tokens.length % 2, `unpaired --filter in: ${filter}`).toBe(0);
+      for (let i = 0; i < tokens.length; i += 2) {
+        expect(tokens[i], `expected --filter at token ${i} of: ${filter}`).toBe('--filter');
+        // `!` prefix is pnpm's exclusion form; the catch-all leg is built entirely from those.
+        expect(tokens[i + 1], `not a workspace package pattern: ${tokens[i + 1]}`).toMatch(
+          /^!?@bike4mind\/[a-z0-9-]+$/
+        );
+      }
+    }
   });
 });
 
@@ -106,5 +154,44 @@ describe('readShardLegs', () => {
       ['          # `pnpm ... test -- --shard=1/3` silently ignores it.', "            args: '--shard=1/3'"].join('\n')
     );
     expect(legs).toEqual([{ index: 1, count: 3 }]);
+  });
+});
+
+describe('readShardFilters', () => {
+  it('strips the YAML quote pair, which belongs to the parser and not to bash', () => {
+    expect(readShardFilters("            filter: '--filter @bike4mind/client'\n")).toEqual([
+      '--filter @bike4mind/client',
+    ]);
+    expect(readShardFilters('            filter: "--filter @bike4mind/client"\n')).toEqual([
+      '--filter @bike4mind/client',
+    ]);
+  });
+
+  it('keeps quotes that are inside the value', () => {
+    // The exact shape that made a leg match nothing: YAML strips only the outer double quotes,
+    // so pnpm is handed `'!@bike4mind/client'` with the single quotes still attached.
+    expect(readShardFilters('            filter: "--filter \'!@bike4mind/client\'"\n')).toEqual([
+      "--filter '!@bike4mind/client'",
+    ]);
+  });
+
+  it('reads an unquoted value as-is', () => {
+    expect(readShardFilters('            filter: --filter @bike4mind/client\n')).toEqual([
+      '--filter @bike4mind/client',
+    ]);
+  });
+
+  it('finds every leg, in file order', () => {
+    const contents = [
+      '          - name: services',
+      "            filter: '--filter @bike4mind/services'",
+      '          - name: misc',
+      "            filter: '--filter !@bike4mind/services'",
+    ].join('\n');
+    expect(readShardFilters(contents)).toEqual(['--filter @bike4mind/services', '--filter !@bike4mind/services']);
+  });
+
+  it('finds nothing when no filters are declared', () => {
+    expect(readShardFilters("name: client\nargs: '--shard=1/3'\n")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Description

Each leg of the `test-shards` matrix declares a pnpm `--filter` list, which the workflow hands to the run step through the `SHARD_FILTER` environment variable rather than interpolating it into the command line. This makes the filters arrive at pnpm as separate arguments, so each leg selects the packages its matrix entry names.

The value has to survive one hop that quoting does not: an env var expanded on a command line is word-split, but it is not re-parsed for quotes. A quote written around a pattern in the matrix is therefore a character inside the argument pnpm receives, not shell syntax. The catch-all leg's tokens are now written bare, and the step splits each variable into a real argv array with `read -ra` before use. The values still travel by `env:` and are never templated into the command line, and there is no `eval`, so a matrix value remains data throughout.

The step also gained a guard. A `--filter` set that matches no workspace project is not an error to pnpm: it prints `No projects matched the filters` and exits 0. That makes "selected nothing" and "everything passed" the same signal. The step now resolves the matched set first, logs how many packages a leg matched, and fails the leg when that number is zero. This is the same shape as the neighbouring note about `vitest run --dir`, where an empty directory exits non-zero so a moved file reddens CI instead of quietly reporting success.

## Changes

- `.github/workflows/ci.yml`: the `misc` leg's `--filter` tokens are written bare rather than individually quoted, with a comment on why quoting is wrong at that layer.
- `.github/workflows/ci.yml`: the shard run step splits `SHARD_FILTER` and `SHARD_ARGS` into argv arrays with `read -ra` and passes them quoted, replacing the unquoted-expansion form and its `shellcheck disable=SC2086`.
- `.github/workflows/ci.yml`: new empty-shard guard that resolves the matched package set, logs its size per leg, and fails the leg with an annotation when it is empty.
- `packages/scripts/src/checkClientTestShards.test.ts`: the "no bare `--` before the shard args" assertion looked for a single line naming both `matrix.shard.script` and `matrix.shard.args`. Those are separate `env:` entries, so it had stopped matching any line and could no longer fail. It now walks the actual chain, `matrix.shard.args` to `SHARD_ARGS` to the array the step splits it into to the pnpm argv, and reads the array's name out of the workflow instead of hard-coding it, so it does not go stale the next time that shape moves. What it pins is unchanged: a `--` there makes vitest read the rest as positional path filters, so the leg silently runs the whole suite.
- `packages/scripts/src/checkClientTestShards.test.ts`: new assertion pinning every leg's `filter:` value to bare `--filter <pattern>` pairs, plus a `readShardFilters` helper and its unit tests.

## Guide for Testers

This is a CI-configuration change with no runtime, API or UI surface. There is nothing to click. The evidence lives on this PR's own checks.

1. Open the Checks tab and select each `Run Tests (...)` job.
2. Confirm the first line of the "Run Tests" step reads `<leg> matches N package(s)` with N greater than zero. Expected: `client 1/3`, `client 2/3`, `client 3/3` and `client-integration` 1; `services` 1; `cli-slack` 3; `data` 4; `misc` 14.
3. Confirm no job log contains `No projects matched the filters`.
4. Confirm each leg's vitest summary reports a non-zero number of test files.
5. Confirm `Run Tests`, the fan-in aggregate, is green.

Regression checks:

1. The three `client i/3` legs must still each report roughly a third of the client suite, not the whole of it. A leg that jumped to the full file count means the shard flag stopped being applied.
2. `packages/scripts` tests must pass, including `checkClientTestShards.test.ts`.

### What NOT to test

Application behaviour, staging, or a preview environment. No product code changed here, so no preview deploy is needed for this PR.

## Additional Information

Context is recorded on bike4mind/b4m-internal#77.

Verified before pushing, by running the step body extracted from the workflow itself rather than a paraphrase of it, so the simulation cannot drift from what CI executes:

- Every leg resolves to the package set its matrix entry names, with `misc` at 14.
- The empty-shard guard exits 1, with an error annotation, on a filter set that resolves to nothing.
- `pnpm --filter @bike4mind/scripts exec vitest run src/checkClientTestShards.test.ts` passes. Each assertion was then mutation-checked to confirm it still fails for its own reason: a bare `--` reintroduced before the args array, the args array dropped from the pnpm line, `SHARD_ARGS` unwired from `matrix.shard.args`, and a quote character put back into a leg's filter value.
- `actionlint` reports nothing on the changed step.

One thing to expect on the run: the `misc` leg now has real work to do, so its duration will be materially higher than it has been. `SHARD_SOFT_BUDGET_SECONDS` is 600 and crossing it annotates the run rather than failing it, so a warning there is informational. The job timeout is 30 minutes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
