### PR TITLE
feat(data-lakes): record injected lake prompts and let a maintainer test a lake's scoping

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -110,6 +110,7 @@ export default function DataLakeManagerPanel() {
     return l
       ? {
           id: l.id,
+          datalakeTag: l.datalakeTag,
           name: l.name,
           description: l.description ?? '',
           requiredUserTag: l.requiredUserTag ?? '',

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -110,7 +110,6 @@ export default function DataLakeManagerPanel() {
     return l
       ? {
           id: l.id,
-          datalakeTag: l.datalakeTag,
           name: l.name,
           description: l.description ?? '',
           requiredUserTag: l.requiredUserTag ?? '',

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { toast } from 'sonner';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { DataLakeSettingsModal } from './DataLakeSettingsModal';
 
@@ -41,6 +42,19 @@ const useDataLakeProposalsMock = vi.fn(() => ({
 }));
 const reviewProposalMutate = vi.fn();
 
+// Steady state for tests that don't exercise the "Test this lake" picker: two reachable lakes,
+// loaded. The Test-scope suite below overrides this per test.
+type MockPickerLake = { id: string; name: string; datalakeTag: string; isOwn?: boolean };
+const useGetDataLakesMock = vi.fn(() => ({
+  data: [
+    { id: 'lake-1', name: 'Test Lake', datalakeTag: 'lake-1' },
+    { id: 'lake-2', name: 'Open Lake', datalakeTag: 'lake-2' },
+  ] as MockPickerLake[],
+  isLoading: false,
+  isError: false,
+  refetch: vi.fn(),
+}));
+
 vi.mock('@client/app/hooks/data/dataLakes', () => ({
   useUpdateDataLake: () => ({ mutate: updateMutate, isPending: false }),
   useSetLakeVisibility: () => ({ mutate: visibilityMutate, isPending: false }),
@@ -48,6 +62,12 @@ vi.mock('@client/app/hooks/data/dataLakes', () => ({
   useLakeConfigHistory: (...args: unknown[]) => useLakeConfigHistoryMock(...args),
   useDataLakeProposals: (...args: unknown[]) => useDataLakeProposalsMock(...args),
   useReviewDataLakeProposal: () => ({ mutate: reviewProposalMutate, isPending: false, variables: undefined }),
+  useGetDataLakes: (...args: unknown[]) => useGetDataLakesMock(...args),
+}));
+
+const startChatWithLakesMock = vi.fn();
+vi.mock('@client/app/hooks/useStartChatWithLake', () => ({
+  useStartChatWithLakes: () => startChatWithLakesMock,
 }));
 
 // The picker's options come from an async react-query hook. Mock it so the modal renders
@@ -91,6 +111,17 @@ beforeEach(() => {
   activatablePrompts = [TRIAGE_ROUTER];
   activatableLoading = false;
   activatableError = false;
+  startChatWithLakesMock.mockReset();
+  useGetDataLakesMock.mockClear();
+  useGetDataLakesMock.mockReturnValue({
+    data: [
+      { id: 'lake-1', name: 'Test Lake', datalakeTag: 'lake-1' },
+      { id: 'lake-2', name: 'Open Lake', datalakeTag: 'lake-2' },
+    ],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
   useDataLakeSpendMock.mockClear();
   useDataLakeSpendMock.mockReturnValue({
     data: undefined,
@@ -113,6 +144,7 @@ beforeEach(() => {
 
 const gatedLake = {
   id: 'lake-1',
+  datalakeTag: 'lake-1',
   name: 'Test Lake',
   description: 'desc',
   requiredUserTag: 'Opti',
@@ -128,6 +160,7 @@ const gatedLake = {
 
 const openLake = {
   id: 'lake-2',
+  datalakeTag: 'lake-2',
   name: 'Open Lake',
   description: 'desc',
   requiredUserTag: '',
@@ -143,6 +176,7 @@ const openLake = {
 
 const entitlementGatedLake = {
   id: 'lake-3',
+  datalakeTag: 'lake-3',
   name: 'Entitled Lake',
   description: 'desc',
   requiredUserTag: '',
@@ -1057,5 +1091,63 @@ describe('DataLakeSettingsModal - Proposals tab visibility', () => {
 
     await user.click(screen.getByTestId('datalake-settings-tab-settings'));
     expect(screen.getByTestId('datalake-settings-save-btn')).toBeInTheDocument();
+  });
+});
+
+describe('DataLakeSettingsModal - Test this lake', () => {
+  it('hides the action for a reader (canManage: false)', () => {
+    const readerLake = { ...openLake, id: 'lake-11', canManage: false };
+    render(
+      <Wrapper>
+        <DataLakeSettingsModal lake={readerLake} onClose={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId(`datalake-settings-test-btn-${readerLake.id}`)).not.toBeInTheDocument();
+  });
+
+  it('opens the scope dialog pre-selecting the lake under test, and starts a scoped chat on confirm', async () => {
+    startChatWithLakesMock.mockResolvedValue({ id: 'session-1' });
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeSettingsModal lake={openLake} onClose={onClose} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByTestId(`datalake-settings-test-btn-${openLake.id}`));
+    expect(screen.getByTestId('test-lake-scope-dialog')).toBeInTheDocument();
+    // openLake.id === 'lake-2', so its checkbox starts checked; the other lake does not.
+    expect(screen.getByTestId('test-lake-scope-checkbox-lake-2').querySelector('input')).toBeChecked();
+    expect(screen.getByTestId('test-lake-scope-checkbox-lake-1').querySelector('input')).not.toBeChecked();
+
+    await user.click(screen.getByTestId('test-lake-scope-checkbox-lake-1').querySelector('input')!);
+    await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
+
+    // Tags come back in the fetched-lakes list order (lake-1, lake-2), not selection order.
+    expect(startChatWithLakesMock).toHaveBeenCalledWith({
+      retrievalTags: ['lake-1', 'lake-2'],
+      corpusGroundingMode: openLake.groundingMode,
+    });
+    // The scope dialog is a separate flow from the settings form - confirming it must not also
+    // close the settings modal out from under the caller.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a toast and keeps the dialog open when the session create fails', async () => {
+    startChatWithLakesMock.mockRejectedValue(new Error('boom'));
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <DataLakeSettingsModal lake={openLake} onClose={vi.fn()} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByTestId(`datalake-settings-test-btn-${openLake.id}`));
+    await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Could not start a test chat for this lake'));
+    expect(screen.getByTestId('test-lake-scope-dialog')).toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
@@ -47,8 +47,8 @@ const reviewProposalMutate = vi.fn();
 type MockPickerLake = { id: string; name: string; datalakeTag: string; isOwn?: boolean };
 const useGetDataLakesMock = vi.fn(() => ({
   data: [
-    { id: 'lake-1', name: 'Test Lake', datalakeTag: 'lake-1' },
-    { id: 'lake-2', name: 'Open Lake', datalakeTag: 'lake-2' },
+    { id: 'lake-1', name: 'Test Lake', datalakeTag: 'datalake:test-lake' },
+    { id: 'lake-2', name: 'Open Lake', datalakeTag: 'datalake:open-lake' },
   ] as MockPickerLake[],
   isLoading: false,
   isError: false,
@@ -115,8 +115,8 @@ beforeEach(() => {
   useGetDataLakesMock.mockClear();
   useGetDataLakesMock.mockReturnValue({
     data: [
-      { id: 'lake-1', name: 'Test Lake', datalakeTag: 'lake-1' },
-      { id: 'lake-2', name: 'Open Lake', datalakeTag: 'lake-2' },
+      { id: 'lake-1', name: 'Test Lake', datalakeTag: 'datalake:test-lake' },
+      { id: 'lake-2', name: 'Open Lake', datalakeTag: 'datalake:open-lake' },
     ],
     isLoading: false,
     isError: false,
@@ -1122,10 +1122,14 @@ describe('DataLakeSettingsModal - Test this lake', () => {
     await user.click(screen.getByTestId('test-lake-scope-checkbox-lake-1').querySelector('input')!);
     await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
 
-    // Tags come back in the fetched-lakes list order (lake-1, lake-2), not selection order. The
-    // exact-object match also pins that no `corpusGroundingMode` rides along: /api/sessions/create
-    // strips it off any request without a `dataLakeId`, so sending one would be a silent no-op.
-    expect(startChatWithLakesMock).toHaveBeenCalledWith({ retrievalTags: ['lake-1', 'lake-2'] });
+    // Tags come back in the fetched-lakes list order, not selection order. The fixture tags are
+    // deliberately unequal to the lake ids and carry the `datalake:` prefix, so this discriminates
+    // both an id-for-tag mixup and a dropped prefix. The exact-object match also pins that no
+    // `corpusGroundingMode` rides along: /api/sessions/create strips it off any request without a
+    // `dataLakeId`, so sending one would be a silent no-op.
+    expect(startChatWithLakesMock).toHaveBeenCalledWith({
+      retrievalTags: ['datalake:test-lake', 'datalake:open-lake'],
+    });
     // The scope dialog is a separate flow from the settings form - confirming it must not also
     // close the settings modal out from under the caller.
     expect(onClose).not.toHaveBeenCalled();

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
@@ -144,7 +144,6 @@ beforeEach(() => {
 
 const gatedLake = {
   id: 'lake-1',
-  datalakeTag: 'lake-1',
   name: 'Test Lake',
   description: 'desc',
   requiredUserTag: 'Opti',
@@ -160,7 +159,6 @@ const gatedLake = {
 
 const openLake = {
   id: 'lake-2',
-  datalakeTag: 'lake-2',
   name: 'Open Lake',
   description: 'desc',
   requiredUserTag: '',
@@ -176,7 +174,6 @@ const openLake = {
 
 const entitlementGatedLake = {
   id: 'lake-3',
-  datalakeTag: 'lake-3',
   name: 'Entitled Lake',
   description: 'desc',
   requiredUserTag: '',
@@ -1125,11 +1122,10 @@ describe('DataLakeSettingsModal - Test this lake', () => {
     await user.click(screen.getByTestId('test-lake-scope-checkbox-lake-1').querySelector('input')!);
     await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
 
-    // Tags come back in the fetched-lakes list order (lake-1, lake-2), not selection order.
-    expect(startChatWithLakesMock).toHaveBeenCalledWith({
-      retrievalTags: ['lake-1', 'lake-2'],
-      corpusGroundingMode: openLake.groundingMode,
-    });
+    // Tags come back in the fetched-lakes list order (lake-1, lake-2), not selection order. The
+    // exact-object match also pins that no `corpusGroundingMode` rides along: /api/sessions/create
+    // strips it off any request without a `dataLakeId`, so sending one would be a silent no-op.
+    expect(startChatWithLakesMock).toHaveBeenCalledWith({ retrievalTags: ['lake-1', 'lake-2'] });
     // The scope dialog is a separate flow from the settings form - confirming it must not also
     // close the settings modal out from under the caller.
     expect(onClose).not.toHaveBeenCalled();

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
@@ -21,6 +21,7 @@ import {
   Tabs,
   Textarea,
 } from '@mui/joy';
+import { toast } from 'sonner';
 import {
   useDataLakeProposals,
   useDataLakeSpend,
@@ -40,9 +41,11 @@ import {
   OVERSIZED_PASSAGE_TOKEN_THRESHOLD,
 } from '@bike4mind/common';
 import type { DataLakeGroundingMode } from '@bike4mind/common';
+import { useStartChatWithLakes } from '@client/app/hooks/useStartChatWithLake';
 import { DataLakeSpendPanel } from './DataLakeSpendPanel';
 import { LakeConfigHistorySection } from './LakeConfigHistorySection';
 import { DataLakeProposalsPanel } from './DataLakeProposalsPanel';
+import { TestLakeScopeDialog } from './TestLakeScopeDialog';
 
 /** The modal's tabs. Settings is always present; the other three are each permission-gated and only
  *  appear when they have content - see showSpendTab / showHistoryTab / showProposalsTab. */
@@ -57,6 +60,8 @@ const GROUNDING_MODE_LABELS: Record<DataLakeGroundingMode, string> = {
 
 export interface EditableLake {
   id: string;
+  /** Scope tag (`datalake:<tag>`'s bare form), the same identifier `retrievalTags` narrows on. */
+  datalakeTag: string;
   name: string;
   description: string;
   requiredUserTag: string;
@@ -177,6 +182,9 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
   const hasGate = !!(lake?.requiredUserTag || lake?.requiredEntitlement);
   // Publishing exposes every file in the lake to all users, so it takes an explicit confirm.
   const [confirmPublicOpen, setConfirmPublicOpen] = useState(false);
+  const [testScopeOpen, setTestScopeOpen] = useState(false);
+  const startChatWithLakes = useStartChatWithLakes();
+  const [startingTestChat, setStartingTestChat] = useState(false);
   // The org the lake is CURRENTLY scoped to - which for a multi-org owner may not be the
   // active switcher org. Name it from the account list so the "Shared" copy is unambiguous.
   const lakeOrgName = lake?.organizationId
@@ -294,6 +302,22 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
       },
       { onSuccess: onClose }
     );
+  };
+
+  const handleConfirmTestScope = async (retrievalTags: string[]) => {
+    if (!lake) return;
+    setStartingTestChat(true);
+    try {
+      await startChatWithLakes({
+        retrievalTags,
+        corpusGroundingMode: lake.groundingMode ?? DEFAULT_DATA_LAKE_GROUNDING_MODE,
+      });
+      setTestScopeOpen(false);
+    } catch {
+      toast.error('Could not start a test chat for this lake');
+    } finally {
+      setStartingTestChat(false);
+    }
   };
 
   // A plain JSX value (not a nested component function): a component DEFINED inside another
@@ -611,10 +635,29 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
               <Button variant="plain" color="neutral" onClick={onClose}>
                 Cancel
               </Button>
+              {lake?.canManage && (
+                <Button
+                  variant="outlined"
+                  color="neutral"
+                  onClick={() => setTestScopeOpen(true)}
+                  data-testid={`datalake-settings-test-btn-${lake.id}`}
+                  sx={{ mr: 'auto' }}
+                >
+                  Test this lake
+                </Button>
+              )}
             </DialogActions>
           )}
         </ModalDialog>
       </Modal>
+      {testScopeOpen && lake && (
+        <TestLakeScopeDialog
+          anchorLakeId={lake.id}
+          onClose={() => setTestScopeOpen(false)}
+          onConfirm={handleConfirmTestScope}
+          confirming={startingTestChat}
+        />
+      )}
       <Modal open={confirmPublicOpen} onClose={() => setConfirmPublicOpen(false)}>
         <ModalDialog role="alertdialog" data-testid="datalake-publish-confirm" sx={{ maxWidth: '28rem' }}>
           <DialogTitle>Make this data lake public?</DialogTitle>

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
@@ -60,8 +60,6 @@ const GROUNDING_MODE_LABELS: Record<DataLakeGroundingMode, string> = {
 
 export interface EditableLake {
   id: string;
-  /** Scope tag (`datalake:<tag>`'s bare form), the same identifier `retrievalTags` narrows on. */
-  datalakeTag: string;
   name: string;
   description: string;
   requiredUserTag: string;
@@ -308,10 +306,7 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
     if (!lake) return;
     setStartingTestChat(true);
     try {
-      await startChatWithLakes({
-        retrievalTags,
-        corpusGroundingMode: lake.groundingMode ?? DEFAULT_DATA_LAKE_GROUNDING_MODE,
-      });
+      await startChatWithLakes({ retrievalTags });
       setTestScopeOpen(false);
     } catch {
       toast.error('Could not start a test chat for this lake');

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { TestLakeScopeDialog } from './TestLakeScopeDialog';
+
+type MockLake = { id: string; name: string; datalakeTag: string; isOwn?: boolean };
+
+const useGetDataLakesMock = vi.fn<
+  [],
+  { data: MockLake[] | undefined; isLoading: boolean; isError: boolean; refetch: () => void }
+>();
+vi.mock('@client/app/hooks/data/dataLakes', () => ({
+  useGetDataLakes: () => useGetDataLakesMock(),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const LAKES: MockLake[] = [
+  { id: 'lake-a', name: 'Alpha Lake', datalakeTag: 'alpha' },
+  { id: 'lake-b', name: 'Beta Lake', datalakeTag: 'beta', isOwn: false },
+];
+
+beforeEach(() => {
+  useGetDataLakesMock.mockReset();
+  useGetDataLakesMock.mockReturnValue({ data: LAKES, isLoading: false, isError: false, refetch: vi.fn() });
+});
+
+describe('TestLakeScopeDialog', () => {
+  it('pre-selects the anchor lake and confirms with only that tag', async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={onConfirm} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('test-lake-scope-checkbox-lake-a').querySelector('input')).toBeChecked();
+    expect(screen.getByTestId('test-lake-scope-checkbox-lake-b').querySelector('input')).not.toBeChecked();
+
+    await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
+    expect(onConfirm).toHaveBeenCalledWith(['alpha']);
+  });
+
+  it('marks a not-owned lake with the owner icon', () => {
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('test-lake-scope-owner-icon-lake-b')).toBeInTheDocument();
+    expect(screen.queryByTestId('test-lake-scope-owner-icon-lake-a')).not.toBeInTheDocument();
+  });
+
+  it('disables confirm once every lake is unchecked', async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={vi.fn()} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByTestId('test-lake-scope-checkbox-lake-a').querySelector('input')!);
+    expect(screen.getByTestId('test-lake-scope-confirm-btn')).toBeDisabled();
+  });
+
+  it('shows a retry action on load failure instead of an empty list', () => {
+    const refetch = vi.fn();
+    useGetDataLakesMock.mockReturnValue({ data: undefined, isLoading: false, isError: true, refetch });
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('test-lake-scope-error')).toBeInTheDocument();
+  });
+
+  it('calls onClose from the cancel action', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={onClose} onConfirm={vi.fn()} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByTestId('test-lake-scope-cancel-btn'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
@@ -86,6 +86,20 @@ describe('TestLakeScopeDialog', () => {
     expect(screen.getByTestId('test-lake-scope-confirm-btn')).toBeDisabled();
   });
 
+  // A failed REFETCH keeps `data` from cache while flipping isError, so the error branch renders
+  // over a populated list. Tags alone stay non-empty there, which is why the gate needs isError.
+  it('disables confirm on a failed refetch that still has cached lakes', () => {
+    useGetDataLakesMock.mockReturnValue({ data: LAKES, isLoading: false, isError: true, refetch: vi.fn() });
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('test-lake-scope-error')).toBeInTheDocument();
+    expect(screen.getByTestId('test-lake-scope-confirm-btn')).toBeDisabled();
+  });
+
   it('disables confirm while the lakes are still loading', () => {
     useGetDataLakesMock.mockReturnValue({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() });
     render(

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
@@ -22,8 +22,8 @@ const Wrapper = ({ children }: { children: ReactNode }) => (
 );
 
 const LAKES: MockLake[] = [
-  { id: 'lake-a', name: 'Alpha Lake', datalakeTag: 'alpha' },
-  { id: 'lake-b', name: 'Beta Lake', datalakeTag: 'beta', isOwn: false },
+  { id: 'lake-a', name: 'Alpha Lake', datalakeTag: 'datalake:alpha' },
+  { id: 'lake-b', name: 'Beta Lake', datalakeTag: 'datalake:beta', isOwn: false },
 ];
 
 beforeEach(() => {
@@ -45,7 +45,7 @@ describe('TestLakeScopeDialog', () => {
     expect(screen.getByTestId('test-lake-scope-checkbox-lake-b').querySelector('input')).not.toBeChecked();
 
     await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
-    expect(onConfirm).toHaveBeenCalledWith(['alpha']);
+    expect(onConfirm).toHaveBeenCalledWith(['datalake:alpha']);
   });
 
   it('marks a not-owned lake with the owner icon', () => {
@@ -81,6 +81,21 @@ describe('TestLakeScopeDialog', () => {
     );
 
     expect(screen.getByTestId('test-lake-scope-error')).toBeInTheDocument();
+    // An empty retrievalTags list is NOT "no lakes" - it is no scoping at all, so confirming here
+    // would start an unnarrowed session while the anchor still reads as checked.
+    expect(screen.getByTestId('test-lake-scope-confirm-btn')).toBeDisabled();
+  });
+
+  it('disables confirm while the lakes are still loading', () => {
+    useGetDataLakesMock.mockReturnValue({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() });
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('test-lake-scope-loading')).toBeInTheDocument();
+    expect(screen.getByTestId('test-lake-scope-confirm-btn')).toBeDisabled();
   });
 
   it('calls onClose from the cancel action', async () => {

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Input,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/joy';
+import SearchIcon from '@mui/icons-material/Search';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import { useGetDataLakes } from '@client/app/hooks/data/dataLakes';
+
+/** Below this many lakes a filter box is noise rather than help - mirrors DataLakeLakePicker. */
+const SEARCH_THRESHOLD = 8;
+
+export interface TestLakeScopeDialogProps {
+  /** The lake whose settings modal opened this dialog - checked by default. */
+  anchorLakeId: string;
+  onClose: () => void;
+  /** One `datalakeTag` per checked lake, the exact shape `retrievalTags` expects. */
+  onConfirm: (retrievalTags: string[]) => void;
+  confirming?: boolean;
+}
+
+/**
+ * Multi-select over the lakes the caller can reach, for building a test session's `retrievalTags`
+ * (the same field an API-key caller sends to narrow a session to a lake subset). Mirrors
+ * DataLakeLakePicker's row presentation (search past the threshold, owner-icon marker) but writes
+ * a set of ids rather than a single browse-tree selection - a new writer over the same accessible
+ * lake list, not a second copy of that list's fetch/loading/error handling.
+ */
+export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirming }: TestLakeScopeDialogProps) {
+  const { data: lakes, isLoading, isError, refetch } = useGetDataLakes();
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(() => new Set([anchorLakeId]));
+
+  const filtered = useMemo(() => {
+    if (!lakes) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return lakes;
+    return lakes.filter(l => l.name.toLowerCase().includes(q));
+  }, [lakes, query]);
+
+  const toggle = (id: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    const tags = (lakes ?? []).filter(l => selected.has(l.id)).map(l => l.datalakeTag);
+    onConfirm(tags);
+  };
+
+  return (
+    <Modal open onClose={onClose}>
+      <ModalDialog data-testid="test-lake-scope-dialog" sx={{ minWidth: 340, maxWidth: 420 }}>
+        <ModalClose data-testid="test-lake-scope-close-btn" />
+        <DialogTitle>Test this lake</DialogTitle>
+        <DialogContent>
+          <Typography level="body-sm" sx={{ color: 'text.tertiary', mb: 1.5 }}>
+            Starts a chat narrowed to only the lakes checked below, on both the retrieval and injection doors - the same
+            scope an API key gets by sending these lakes&apos; tags as <code>retrievalTags</code>. Lake scope only: this
+            does not simulate a different entitlement, organization membership, or file-level access for the caller.
+          </Typography>
+          {(lakes?.length ?? 0) >= SEARCH_THRESHOLD && (
+            <Input
+              size="sm"
+              placeholder="Filter lakes"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              startDecorator={<SearchIcon sx={{ fontSize: 16 }} />}
+              sx={{ mb: 1 }}
+              data-testid="test-lake-scope-search"
+            />
+          )}
+          <Box sx={{ maxHeight: 320, overflowY: 'auto' }}>
+            {isLoading ? (
+              <Stack gap={1} data-testid="test-lake-scope-loading">
+                {[0, 1, 2].map(i => (
+                  <Skeleton key={i} variant="text" level="body-sm" />
+                ))}
+              </Stack>
+            ) : isError ? (
+              <Stack gap={1} data-testid="test-lake-scope-error">
+                <Typography level="body-sm" sx={{ color: 'danger.400' }}>
+                  Could not load lakes.
+                </Typography>
+                <Button size="sm" variant="outlined" color="neutral" onClick={() => refetch()}>
+                  Retry
+                </Button>
+              </Stack>
+            ) : filtered.length === 0 ? (
+              <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                {query ? 'No matches' : 'No lakes yet'}
+              </Typography>
+            ) : (
+              <Stack gap={0.5}>
+                {filtered.map(lake => (
+                  <Checkbox
+                    key={lake.id}
+                    size="sm"
+                    checked={selected.has(lake.id)}
+                    onChange={() => toggle(lake.id)}
+                    data-testid={`test-lake-scope-checkbox-${lake.id}`}
+                    label={
+                      <Stack direction="row" gap={0.5} alignItems="center">
+                        <Typography level="body-sm">{lake.name}</Typography>
+                        {lake.isOwn === false && (
+                          <PersonOutlineIcon
+                            data-testid={`test-lake-scope-owner-icon-${lake.id}`}
+                            sx={{ fontSize: 14, color: 'warning.400' }}
+                          />
+                        )}
+                      </Stack>
+                    }
+                  />
+                ))}
+              </Stack>
+            )}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            loading={confirming}
+            disabled={selected.size === 0}
+            onClick={handleConfirm}
+            data-testid="test-lake-scope-confirm-btn"
+          >
+            Start test chat
+          </Button>
+          <Button variant="plain" color="neutral" onClick={onClose} data-testid="test-lake-scope-cancel-btn">
+            Cancel
+          </Button>
+        </DialogActions>
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
@@ -59,9 +59,11 @@ export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirmi
   };
 
   // Resolved against the fetched list, not the id set: an empty `retrievalTags` means NO scoping
-  // (the session sees the caller's full entitled set), so confirming before the lakes load - or
-  // after the fetch failed - would silently invert the very narrowing this dialog exists to apply.
-  // The confirm button gates on this, not on `selected.size`.
+  // (the session sees the caller's full entitled set), so confirming before the lakes load would
+  // silently invert the very narrowing this dialog exists to apply. The confirm button gates on
+  // this rather than on `selected.size` - and additionally on `isError`, because a failed REFETCH
+  // keeps the cached list populated, leaving tags non-empty while the list is hidden behind the
+  // error branch.
   const selectedTags = useMemo(
     () => (lakes ?? []).filter(l => selected.has(l.id)).map(l => l.datalakeTag),
     [lakes, selected]
@@ -76,7 +78,8 @@ export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirmi
           <Typography level="body-sm" sx={{ color: 'text.tertiary', mb: 1.5 }}>
             Starts a chat narrowed to only the lakes checked below, on both the retrieval and injection doors - the same
             scope an API key gets by sending these lakes&apos; tags as <code>retrievalTags</code>. Lake scope only: this
-            does not simulate a different entitlement, organization membership, or file-level access for the caller.
+            does not simulate a different entitlement, organization membership, or file-level access for the caller, and
+            the test session uses the default grounding mode rather than each lake&apos;s configured one.
           </Typography>
           {(lakes?.length ?? 0) >= SEARCH_THRESHOLD && (
             <Input
@@ -138,7 +141,7 @@ export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirmi
         <DialogActions>
           <Button
             loading={confirming}
-            disabled={selectedTags.length === 0}
+            disabled={selectedTags.length === 0 || isError}
             onClick={() => onConfirm(selectedTags)}
             data-testid="test-lake-scope-confirm-btn"
           >

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
@@ -58,10 +58,14 @@ export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirmi
     });
   };
 
-  const handleConfirm = () => {
-    const tags = (lakes ?? []).filter(l => selected.has(l.id)).map(l => l.datalakeTag);
-    onConfirm(tags);
-  };
+  // Resolved against the fetched list, not the id set: an empty `retrievalTags` means NO scoping
+  // (the session sees the caller's full entitled set), so confirming before the lakes load - or
+  // after the fetch failed - would silently invert the very narrowing this dialog exists to apply.
+  // The confirm button gates on this, not on `selected.size`.
+  const selectedTags = useMemo(
+    () => (lakes ?? []).filter(l => selected.has(l.id)).map(l => l.datalakeTag),
+    [lakes, selected]
+  );
 
   return (
     <Modal open onClose={onClose}>
@@ -134,8 +138,8 @@ export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirmi
         <DialogActions>
           <Button
             loading={confirming}
-            disabled={selected.size === 0}
-            onClick={handleConfirm}
+            disabled={selectedTags.length === 0}
+            onClick={() => onConfirm(selectedTags)}
             data-testid="test-lake-scope-confirm-btn"
           >
             Start test chat

--- a/apps/client/app/hooks/useStartChatWithLake.test.tsx
+++ b/apps/client/app/hooks/useStartChatWithLake.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import useStartChatWithLake, { useStartChatWithLakes } from './useStartChatWithLake';
+
+const mockNavigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const setCurrentSession = vi.fn();
+const setCurrentSessionId = vi.fn();
+vi.mock('@client/app/contexts/SessionsContext', () => ({
+  useSessions: () => ({ setCurrentSession, setCurrentSessionId }),
+}));
+
+const closeManager = vi.fn();
+vi.mock('@client/app/stores/useDataLakeWizardStore', () => ({
+  useDataLakeWizardStore: (selector: (s: { closeManager: () => void }) => unknown) => selector({ closeManager }),
+}));
+
+const apiPost = vi.fn();
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { post: (...args: unknown[]) => apiPost(...args) },
+}));
+
+const renderWithClient = <T,>(hook: () => T) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return renderHook(hook, { wrapper });
+};
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  setCurrentSession.mockClear();
+  setCurrentSessionId.mockClear();
+  closeManager.mockClear();
+  apiPost.mockReset();
+});
+
+describe('useStartChatWithLake (single lake)', () => {
+  it('posts dataLakeId and opens the created session', async () => {
+    apiPost.mockResolvedValue({ data: { id: 'session-1' } });
+    const { result } = renderWithClient(() => useStartChatWithLake());
+
+    let created: unknown;
+    await act(async () => {
+      created = await result.current('lake-1');
+    });
+
+    expect(apiPost).toHaveBeenCalledWith('/api/sessions/create', { name: 'New Notebook', dataLakeId: 'lake-1' });
+    expect(created).toEqual({ id: 'session-1' });
+    expect(setCurrentSession).toHaveBeenCalledWith({ id: 'session-1' });
+    expect(setCurrentSessionId).toHaveBeenCalledWith('session-1');
+    expect(closeManager).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/notebooks/$id', params: { id: 'session-1' }, replace: true });
+  });
+});
+
+describe('useStartChatWithLakes (multi-lake subset)', () => {
+  it('sends retrievalTags, forceKnowledgeRetrieval and corpusGroundingMode explicitly - no dataLakeId', async () => {
+    apiPost.mockResolvedValue({ data: { id: 'session-2' } });
+    const { result } = renderWithClient(() => useStartChatWithLakes());
+
+    await act(async () => {
+      await result.current({ retrievalTags: ['datalake:a', 'datalake:b'], corpusGroundingMode: 'inline' });
+    });
+
+    expect(apiPost).toHaveBeenCalledWith('/api/sessions/create', {
+      name: 'New Notebook',
+      retrievalTags: ['datalake:a', 'datalake:b'],
+      forceKnowledgeRetrieval: true,
+      corpusGroundingMode: 'inline',
+    });
+    expect(setCurrentSession).toHaveBeenCalledWith({ id: 'session-2' });
+  });
+
+  it('propagates a request failure so the caller can surface its own error UX', async () => {
+    apiPost.mockRejectedValue(new Error('network down'));
+    const { result } = renderWithClient(() => useStartChatWithLakes());
+
+    await expect(
+      act(async () => {
+        await result.current({ retrievalTags: ['datalake:a'], corpusGroundingMode: 'retrieve' });
+      })
+    ).rejects.toThrow('network down');
+    expect(setCurrentSession).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/hooks/useStartChatWithLake.test.tsx
+++ b/apps/client/app/hooks/useStartChatWithLake.test.tsx
@@ -60,19 +60,18 @@ describe('useStartChatWithLake (single lake)', () => {
 });
 
 describe('useStartChatWithLakes (multi-lake subset)', () => {
-  it('sends retrievalTags, forceKnowledgeRetrieval and corpusGroundingMode explicitly - no dataLakeId', async () => {
+  it('sends retrievalTags and forceKnowledgeRetrieval only - no dataLakeId, no corpusGroundingMode', async () => {
     apiPost.mockResolvedValue({ data: { id: 'session-2' } });
     const { result } = renderWithClient(() => useStartChatWithLakes());
 
     await act(async () => {
-      await result.current({ retrievalTags: ['datalake:a', 'datalake:b'], corpusGroundingMode: 'inline' });
+      await result.current({ retrievalTags: ['datalake:a', 'datalake:b'] });
     });
 
     expect(apiPost).toHaveBeenCalledWith('/api/sessions/create', {
       name: 'New Notebook',
       retrievalTags: ['datalake:a', 'datalake:b'],
       forceKnowledgeRetrieval: true,
-      corpusGroundingMode: 'inline',
     });
     expect(setCurrentSession).toHaveBeenCalledWith({ id: 'session-2' });
   });
@@ -83,7 +82,7 @@ describe('useStartChatWithLakes (multi-lake subset)', () => {
 
     await expect(
       act(async () => {
-        await result.current({ retrievalTags: ['datalake:a'], corpusGroundingMode: 'retrieve' });
+        await result.current({ retrievalTags: ['datalake:a'] });
       })
     ).rejects.toThrow('network down');
     expect(setCurrentSession).not.toHaveBeenCalled();

--- a/apps/client/app/hooks/useStartChatWithLake.ts
+++ b/apps/client/app/hooks/useStartChatWithLake.ts
@@ -1,11 +1,34 @@
 import { useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
-import type { ISessionDocument } from '@bike4mind/common';
+import type { ISessionDocument, DataLakeGroundingMode } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
 import { useSessions } from '@client/app/contexts/SessionsContext';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { updateAllQueryData } from '@client/app/utils/react-query';
+
+type SessionCreateDeps = {
+  queryClient: ReturnType<typeof useQueryClient>;
+  setCurrentSession: (session: ISessionDocument) => void;
+  setCurrentSessionId: (id: string) => void;
+  closeManager: () => void;
+  navigate: ReturnType<typeof useNavigate>;
+};
+
+async function createAndOpenSession(
+  body: Record<string, unknown>,
+  { queryClient, setCurrentSession, setCurrentSessionId, closeManager, navigate }: SessionCreateDeps
+): Promise<ISessionDocument> {
+  const res = await api.post<ISessionDocument>('/api/sessions/create', body);
+  const created = res.data;
+  queryClient.setQueryData(['sessions', created.id], created);
+  updateAllQueryData(queryClient, 'sessions', 'write', created, { keysAllowedToCreate: [['sessions', 'own']] });
+  setCurrentSession(created);
+  setCurrentSessionId(created.id);
+  closeManager();
+  navigate({ to: '/notebooks/$id', params: { id: created.id }, replace: true });
+  return created;
+}
 
 /**
  * Starts a chat scoped to a SINGLE data lake: creates a session with `dataLakeId`, so the
@@ -28,20 +51,45 @@ export default function useStartChatWithLake() {
   const closeManager = useDataLakeWizardStore(s => s.closeManager);
 
   return useCallback(
-    async (dataLakeId: string): Promise<ISessionDocument> => {
-      const res = await api.post<ISessionDocument>('/api/sessions/create', {
-        name: 'New Notebook',
-        dataLakeId,
-      });
-      const created = res.data;
-      queryClient.setQueryData(['sessions', created.id], created);
-      updateAllQueryData(queryClient, 'sessions', 'write', created, { keysAllowedToCreate: [['sessions', 'own']] });
-      setCurrentSession(created);
-      setCurrentSessionId(created.id);
-      closeManager();
-      navigate({ to: '/notebooks/$id', params: { id: created.id }, replace: true });
-      return created;
-    },
+    async (dataLakeId: string): Promise<ISessionDocument> =>
+      createAndOpenSession(
+        { name: 'New Notebook', dataLakeId },
+        { queryClient, setCurrentSession, setCurrentSessionId, closeManager, navigate }
+      ),
+    [navigate, queryClient, setCurrentSession, setCurrentSessionId, closeManager]
+  );
+}
+
+/**
+ * Multi-lake counterpart, for testing a lake's scoping alongside (or against) its neighbors.
+ * There is no `dataLakeId` for a subset, so this sends the same request shape an API-key caller
+ * sends to reach the same scope: `retrievalTags` (one `datalakeTag` per lake) plus
+ * `forceKnowledgeRetrieval` and `corpusGroundingMode` set explicitly. Both are required here
+ * because resolveLakeSessionDefaults only derives them for the single-lake `dataLakeId` path
+ * (sessionService/resolveLakeSessionDefaults.ts), and /api/sessions/create deletes any
+ * client-sent `corpusGroundingMode` unless `dataLakeId` is present - a subset request that omitted
+ * these would silently create an unscoped, non-retrieving session.
+ */
+export function useStartChatWithLakes() {
+  const { setCurrentSession, setCurrentSessionId } = useSessions();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const closeManager = useDataLakeWizardStore(s => s.closeManager);
+
+  return useCallback(
+    async (params: {
+      retrievalTags: string[];
+      corpusGroundingMode: DataLakeGroundingMode;
+    }): Promise<ISessionDocument> =>
+      createAndOpenSession(
+        {
+          name: 'New Notebook',
+          retrievalTags: params.retrievalTags,
+          forceKnowledgeRetrieval: true,
+          corpusGroundingMode: params.corpusGroundingMode,
+        },
+        { queryClient, setCurrentSession, setCurrentSessionId, closeManager, navigate }
+      ),
     [navigate, queryClient, setCurrentSession, setCurrentSessionId, closeManager]
   );
 }

--- a/apps/client/app/hooks/useStartChatWithLake.ts
+++ b/apps/client/app/hooks/useStartChatWithLake.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
-import type { ISessionDocument, DataLakeGroundingMode } from '@bike4mind/common';
+import type { ISessionDocument } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
 import { useSessions } from '@client/app/contexts/SessionsContext';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
@@ -64,11 +64,15 @@ export default function useStartChatWithLake() {
  * Multi-lake counterpart, for testing a lake's scoping alongside (or against) its neighbors.
  * There is no `dataLakeId` for a subset, so this sends the same request shape an API-key caller
  * sends to reach the same scope: `retrievalTags` (one `datalakeTag` per lake) plus
- * `forceKnowledgeRetrieval` and `corpusGroundingMode` set explicitly. Both are required here
- * because resolveLakeSessionDefaults only derives them for the single-lake `dataLakeId` path
- * (sessionService/resolveLakeSessionDefaults.ts), and /api/sessions/create deletes any
- * client-sent `corpusGroundingMode` unless `dataLakeId` is present - a subset request that omitted
- * these would silently create an unscoped, non-retrieving session.
+ * `forceKnowledgeRetrieval`, set explicitly because resolveLakeSessionDefaults only derives them
+ * for the single-lake `dataLakeId` path (sessionService/resolveLakeSessionDefaults.ts). Omitting
+ * them would silently create an unscoped, non-retrieving session.
+ *
+ * `corpusGroundingMode` is deliberately NOT sent: /api/sessions/create strips any client-sent value
+ * before the merge and only the `dataLakeId` arm re-supplies one, so a subset request cannot set it
+ * at all. The test session inherits the size-only deferral default instead of the lake's configured
+ * mode - invisible on the empty session created here, and only divergent once files are attached to
+ * it. Carrying the mode through needs that server-side strip relaxed, not another client field.
  */
 export function useStartChatWithLakes() {
   const { setCurrentSession, setCurrentSessionId } = useSessions();
@@ -77,16 +81,12 @@ export function useStartChatWithLakes() {
   const closeManager = useDataLakeWizardStore(s => s.closeManager);
 
   return useCallback(
-    async (params: {
-      retrievalTags: string[];
-      corpusGroundingMode: DataLakeGroundingMode;
-    }): Promise<ISessionDocument> =>
+    async (params: { retrievalTags: string[] }): Promise<ISessionDocument> =>
       createAndOpenSession(
         {
           name: 'New Notebook',
           retrievalTags: params.retrievalTags,
           forceKnowledgeRetrieval: true,
-          corpusGroundingMode: params.corpusGroundingMode,
         },
         { queryClient, setCurrentSession, setCurrentSessionId, closeManager, navigate }
       ),

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -423,6 +423,16 @@ export const RetrievalSummarySchema = z.object({
   surfaces: z.array(z.string()),
   /** Lakes resolved at the moment retrieval ran, stamped point-in-time (not read live from the session). */
   dataLakeTags: z.array(z.string()),
+  /**
+   * Ids of the lakes whose `systemPrompt` was injected this turn (getAccessibleDataLakePrompts),
+   * across every injection site (forced retrieval and the model-driven knowledge tools). NOT the
+   * prompt text itself - that already reaches the model in the completion, and copying it here
+   * widens exposure for nothing. Absent means no injection site ran; present-and-empty means one
+   * ran but nothing qualified (untrusted, or an empty systemPrompt).
+   */
+  injectedLakePromptIds: z.array(z.string()).optional(),
+  /** mementoCount/mementoIds precedent: mirrors injectedLakePromptIds.length. */
+  injectedLakePromptCount: z.number().optional(),
 });
 
 /**

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -1623,6 +1623,42 @@ describe('KnowledgeRetrievalFeature scoped lake-prompt injection (#1108)', () =>
     expect(contents[0]).toContain('[Data Lake - Lake Y]\nY rules.');
     expect(contents[0].match(/\[Data Lake Instructions\]/g)).toHaveLength(1);
   });
+
+  it('records the injected lake id in promptMeta.retrieval when injection fired', async () => {
+    const quest = makeQuest();
+    const feature = new KnowledgeRetrievalFeature(
+      makeCtx([lakeFile('fA', 'datalake:x')], [makeLake()]) as unknown as ConstructorParameters<
+        typeof KnowledgeRetrievalFeature
+      >[0]
+    );
+    await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'anything'
+    );
+    expect(quest.promptMeta?.retrieval?.injectedLakePromptIds).toEqual(['lakeX']);
+    expect(quest.promptMeta?.retrieval?.injectedLakePromptCount).toBe(1);
+  });
+
+  it('leaves promptMeta.retrieval unset when no lake-tagged file was grounded on (site never ran)', async () => {
+    const quest = makeQuest();
+    const feature = new KnowledgeRetrievalFeature(
+      makeCtx([{ id: 'plain', fileName: 'plain.pdf', tags: [] }], [makeLake()]) as unknown as ConstructorParameters<
+        typeof KnowledgeRetrievalFeature
+      >[0]
+    );
+    await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'anything'
+    );
+    // No datalake-tagged file was grounded on, so resolveRetrievedLakePromptMessage's own write
+    // never runs (contrast prependRetrievedLakePrompts, whose site runs even when its scoped tags
+    // resolve to no qualifying prompt) - only the coarser outcome-tracking write elsewhere in this
+    // feature touches promptMeta.retrieval here.
+    expect(quest.promptMeta?.retrieval?.injectedLakePromptIds).toBeUndefined();
+    expect(quest.promptMeta?.retrieval?.injectedLakePromptCount).toBeUndefined();
+  });
 });
 
 /**

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -1784,6 +1784,7 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
    * a lake-prompt failure must not drop the retrieved grounding this feature exists to provide.
    */
   private async resolveRetrievedLakePromptMessage(
+    quest: IChatHistoryItemDocument,
     sourceFileIds: string[],
     fileById: ReadonlyMap<string, { tags?: Array<{ name: string }> }>
   ): Promise<IMessage | null> {
@@ -1798,6 +1799,15 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         { db, user, entitlementKeys, logger: this.logger },
         { restrictToDatalakeTags: datalakeTags }
       );
+      // Recorded whenever this injection site ran, even if nothing qualified (present-and-empty
+      // is distinct from absent - see the field's own comment in promptMeta.ts).
+      quest.promptMeta = quest.promptMeta ?? {};
+      quest.promptMeta.retrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, {
+        attempted: true,
+        surfaces: [],
+        dataLakeTags: [],
+        injectedLakePromptIds: prompts.map(p => p.id),
+      });
       const section = renderDataLakePromptSection(prompts);
       if (!section) return null;
 
@@ -2451,7 +2461,7 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       // provenance tags on the injected source files. A turn that grounds on no lake injects no lake
       // prompt. Ahead of the retrieved content so it frames how to use it. Fail-safe: any failure
       // here degrades to no lake prompt and never drops the retrieved context.
-      const lakePromptMessage = await this.resolveRetrievedLakePromptMessage(sourceFileIds, fileById);
+      const lakePromptMessage = await this.resolveRetrievedLakePromptMessage(quest, sourceFileIds, fileById);
 
       // Best-effort audit write, attributed via the tags on the files this turn actually
       // grounded on (sourceFileIds), not the wider scanned candidate pool. The candidate search

--- a/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getAccessibleDataLakePromptsMock = vi.fn();
+vi.mock('../../../dataLakeService/getDataLakePrompts', () => ({
+  getAccessibleDataLakePrompts: (...args: unknown[]) => getAccessibleDataLakePromptsMock(...args),
+}));
+
+import { prependRetrievedLakePrompts } from './retrievedLakePrompts';
+import type { ToolContext } from './base/types';
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() } as never;
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    userId: 'u1',
+    user: { id: 'u1' } as never,
+    logger,
+    statusUpdate: vi.fn().mockResolvedValue(undefined),
+    db: {} as never,
+    ...overrides,
+  } as ToolContext;
+}
+
+describe('prependRetrievedLakePrompts', () => {
+  beforeEach(() => {
+    getAccessibleDataLakePromptsMock.mockReset();
+  });
+
+  it('records injectedLakePromptIds via statusUpdate when a prompt qualifies', async () => {
+    getAccessibleDataLakePromptsMock.mockResolvedValueOnce([{ id: 'lake1', name: 'Lake One', systemPrompt: 'obey' }]);
+    const context = makeContext();
+    const result = await prependRetrievedLakePrompts(context, 'result text', ['datalake:lake1'], new Set());
+
+    expect(result).toContain('result text');
+    expect(context.statusUpdate).toHaveBeenCalledWith({
+      promptMeta: {
+        retrieval: {
+          attempted: true,
+          surfaces: [],
+          dataLakeTags: [],
+          injectedLakePromptIds: ['lake1'],
+        },
+      },
+    });
+  });
+
+  it('records a present-and-empty array when the site ran but nothing qualified', async () => {
+    getAccessibleDataLakePromptsMock.mockResolvedValueOnce([]);
+    const context = makeContext();
+    const result = await prependRetrievedLakePrompts(context, 'result text', ['datalake:lake1'], new Set());
+
+    expect(result).toBe('result text');
+    expect(context.statusUpdate).toHaveBeenCalledWith({
+      promptMeta: {
+        retrieval: {
+          attempted: true,
+          surfaces: [],
+          dataLakeTags: [],
+          injectedLakePromptIds: [],
+        },
+      },
+    });
+  });
+
+  it('does not call statusUpdate when every tag was already injected this tool', async () => {
+    const context = makeContext();
+    const result = await prependRetrievedLakePrompts(
+      context,
+      'result text',
+      ['datalake:lake1'],
+      new Set(['datalake:lake1'])
+    );
+
+    expect(result).toBe('result text');
+    expect(context.statusUpdate).not.toHaveBeenCalled();
+    expect(getAccessibleDataLakePromptsMock).not.toHaveBeenCalled();
+  });
+
+  it('fails safe: a resolution error leaves the result text unchanged and skips the status write', async () => {
+    getAccessibleDataLakePromptsMock.mockRejectedValueOnce(new Error('boom'));
+    const context = makeContext();
+    const result = await prependRetrievedLakePrompts(context, 'result text', ['datalake:lake1'], new Set());
+
+    expect(result).toBe('result text');
+  });
+});

--- a/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.ts
+++ b/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.ts
@@ -31,6 +31,19 @@ export async function prependRetrievedLakePrompts(
     for (const tag of fresh) injectedLakeTags.add(tag);
 
     const prompts = await getAccessibleDataLakePrompts(context, { restrictToDatalakeTags: fresh });
+    // Recorded whenever this injection site ran, even if nothing qualified - see the field's own
+    // comment in promptMeta.ts. Merges onto whatever the tool's own retrieval outcome write already
+    // set (applyQuestStatusChanges / mergeRetrievalSummary), not a replacement.
+    await context.statusUpdate({
+      promptMeta: {
+        retrieval: {
+          attempted: true,
+          surfaces: [],
+          dataLakeTags: [],
+          injectedLakePromptIds: prompts.map(p => p.id),
+        },
+      },
+    } as any);
     const section = renderDataLakePromptSection(prompts);
     if (!section) return resultText;
 

--- a/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.ts
+++ b/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.ts
@@ -14,8 +14,9 @@ import { renderDataLakePromptSection } from '../../../dataLakeService/renderData
  * so a lake used by both within one turn is injected once per tool (idempotent, ~a few extra tokens).
  * The block rides INSIDE a tool RESULT, which is model-facing content, so it MUST carry the
  * renderDataLakePromptSection defenses (org-deference header + block-marker defang) - that is what
- * keeps a lake owner from forging an organization block. Fail-safe: any failure (and the agent-
- * scoped case, which passes no tags) returns the tool result unchanged.
+ * keeps a lake owner from forging an organization block. Fail-safe: any RESOLUTION failure (and the
+ * agent-scoped case, which passes no tags) returns the tool result unchanged; the telemetry write is
+ * separately guarded, so recording can never drop the injection it records.
  */
 export async function prependRetrievedLakePrompts(
   context: ToolContext,
@@ -33,17 +34,24 @@ export async function prependRetrievedLakePrompts(
     const prompts = await getAccessibleDataLakePrompts(context, { restrictToDatalakeTags: fresh });
     // Recorded whenever this injection site ran, even if nothing qualified - see the field's own
     // comment in promptMeta.ts. Merges onto whatever the tool's own retrieval outcome write already
-    // set (applyQuestStatusChanges / mergeRetrievalSummary), not a replacement.
-    await context.statusUpdate({
-      promptMeta: {
-        retrieval: {
-          attempted: true,
-          surfaces: [],
-          dataLakeTags: [],
-          injectedLakePromptIds: prompts.map(p => p.id),
+    // set (applyQuestStatusChanges / mergeRetrievalSummary), not a replacement. Its own try/catch:
+    // the fresh tags are marked injected above, so a recording failure reaching the outer catch
+    // would drop this turn's section with no way to re-resolve it. It stays ABOVE the render so the
+    // ran-but-nothing-qualified case is still recorded as present-and-empty.
+    try {
+      await context.statusUpdate({
+        promptMeta: {
+          retrieval: {
+            attempted: true,
+            surfaces: [],
+            dataLakeTags: [],
+            injectedLakePromptIds: prompts.map(p => p.id),
+          },
         },
-      },
-    } as any);
+      });
+    } catch (err) {
+      context.logger.warn('\u{1F4CB} KB tool: lake-prompt telemetry write failed; injecting anyway:', err);
+    }
     const section = renderDataLakePromptSection(prompts);
     if (!section) return resultText;
 

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
@@ -131,4 +131,33 @@ describe('mergeRetrievalSummary', () => {
     expect(merged?.surfaces).toEqual(['forced-retrieval', 'knowledgeBaseSearch']);
     expect(merged?.dataLakeTags).toEqual(['a', 'b']);
   });
+
+  describe('injectedLakePromptIds', () => {
+    it('unions ids without duplicates and derives the count from the union', () => {
+      const merged = mergeRetrievalSummary(
+        base({ injectedLakePromptIds: ['lake1'] }),
+        base({ injectedLakePromptIds: ['lake1', 'lake2'] })
+      );
+      expect(merged?.injectedLakePromptIds).toEqual(['lake1', 'lake2']);
+      expect(merged?.injectedLakePromptCount).toBe(2);
+    });
+
+    it('stays absent when neither side injected a lake prompt', () => {
+      const merged = mergeRetrievalSummary(base(), base());
+      expect(merged?.injectedLakePromptIds).toBeUndefined();
+      expect(merged && 'injectedLakePromptIds' in merged).toBe(false);
+    });
+
+    it('is present-and-empty when an injection site ran but nothing qualified', () => {
+      const merged = mergeRetrievalSummary(base(), base({ injectedLakePromptIds: [] }));
+      expect(merged?.injectedLakePromptIds).toEqual([]);
+      expect(merged?.injectedLakePromptCount).toBe(0);
+    });
+
+    it('survives a side that never asserted the field', () => {
+      const merged = mergeRetrievalSummary(base({ injectedLakePromptIds: ['lake1'] }), base());
+      expect(merged?.injectedLakePromptIds).toEqual(['lake1']);
+      expect(merged?.injectedLakePromptCount).toBe(1);
+    });
+  });
 });

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
@@ -47,7 +47,8 @@ function outcomeSeverity(outcome: RetrievalSummary['outcome']): number {
  * - forcedSkipReason: first defined survives. The forced arm takes exactly one skip per turn, so
  *   a second value would mean two arms disagreeing about the same fact; keeping the earlier one
  *   makes the merge order-independent rather than last-writer-wins.
- * - surfaces / dataLakeTags: union, deduped.
+ * - surfaces / dataLakeTags / injectedLakePromptIds: union, deduped. injectedLakePromptCount is
+ *   derived from the merged ids, not merged independently, so the two can never disagree.
  */
 export function mergeRetrievalSummary(
   existing: RetrievalSummary | undefined,
@@ -60,6 +61,10 @@ export function mergeRetrievalSummary(
     outcomeSeverity(incoming.outcome) > outcomeSeverity(existing.outcome) ? incoming.outcome : existing.outcome;
   const mode = existing.mode === 'forced' || incoming.mode === 'forced' ? 'forced' : (existing.mode ?? incoming.mode);
   const forcedSkipReason = existing.forcedSkipReason ?? incoming.forcedSkipReason;
+  const injectedLakePromptIds =
+    existing.injectedLakePromptIds || incoming.injectedLakePromptIds
+      ? [...new Set([...(existing.injectedLakePromptIds ?? []), ...(incoming.injectedLakePromptIds ?? [])])]
+      : undefined;
 
   // Keys are spread in only when defined: the shape is absent-or-fully-present on the Mongoose
   // side, and an explicit `undefined` would persist as a set-but-empty path.
@@ -70,5 +75,6 @@ export function mergeRetrievalSummary(
     ...(forcedSkipReason !== undefined ? { forcedSkipReason } : {}),
     surfaces: [...new Set([...existing.surfaces, ...incoming.surfaces])],
     dataLakeTags: [...new Set([...existing.dataLakeTags, ...incoming.dataLakeTags])],
+    ...(injectedLakePromptIds ? { injectedLakePromptIds, injectedLakePromptCount: injectedLakePromptIds.length } : {}),
   };
 }

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
@@ -46,9 +46,18 @@ function outcomeSeverity(outcome: RetrievalSummary['outcome']): number {
  *   'optional' must not downgrade a turn the forced arm already claimed. Order-independent.
  * - forcedSkipReason: first defined survives. The forced arm takes exactly one skip per turn, so
  *   a second value would mean two arms disagreeing about the same fact; keeping the earlier one
- *   makes the merge order-independent rather than last-writer-wins.
+ *   makes this first-writer-wins under the accumulator convention (`existing` is the earlier
+ *   write), not last-writer-wins. Unlike the fields above it is NOT commutative when both sides
+ *   carry a different reason.
  * - surfaces / dataLakeTags / injectedLakePromptIds: union, deduped. injectedLakePromptCount is
- *   derived from the merged ids, not merged independently, so the two can never disagree.
+ *   derived from the merged ids, not merged independently, so a two-sided merge can never leave
+ *   the two disagreeing.
+ *
+ * The one-sided returns below are a verbatim passthrough, and both injection sites emit a PARTIAL
+ * summary (ids with no count; `attempted` with no `outcome`) meant only as a merge delta. So a
+ * delta survives as-written if it is ever a turn's FIRST retrieval write - reachable only if
+ * nothing seeded `retrieval` first, which every caller of both doors already does. Readers should
+ * still derive the count from the ids rather than assume it is present.
  */
 export function mergeRetrievalSummary(
   existing: RetrievalSummary | undefined,

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -63,6 +63,9 @@ const RetrievalSummarySchema = subSchema({
   forcedSkipReason: { type: String, required: false },
   surfaces: [{ type: String, required: false }],
   dataLakeTags: [{ type: String, required: false }],
+  // default: undefined for the same auto-vivification reason as dataLakeTags above.
+  injectedLakePromptIds: { type: [String], required: false, default: undefined },
+  injectedLakePromptCount: { type: Number, required: false },
 });
 
 // Partial-grounding-coverage detail. subSchema + default:undefined for the same reason as


### PR DESCRIPTION
# Pull Request

> **Partial.** This is phases 1 and 2 of a three-phase change; phase 3 (admitting a lake you manage
> but are not a member of, at the injection and retrieval doors) is **not** in this PR.
> It is therefore **not** on its own sufficient to complete issue #2405 - see "Additional
> Information" for exactly which acceptance criteria remain.

## Optional Screenshot/Video

Not attached. The UI addition is a button plus a checkbox dialog described step-by-step under
"Guide for Testers"; screenshots are owed before this leaves draft.

## Description

A data lake's `systemPrompt` only reaches turns that the injection gate trusts, and there is no way
to see, after the fact, whether it fired. Two separate problems fall out of that:

1. **Nothing records what grounded an answer.** `promptMeta.retrieval` already stamps which lake
   tags were resolved, but not which lake prompts were actually injected - so "did the lake's
   `systemPrompt` reach this turn?" was unanswerable from the stored quest, on either injection
   site. That makes it impossible to tell a policy problem from a plumbing one.
2. **A maintainer cannot reproduce a narrower caller's scope.** An API-key caller can pin a session
   to a subset of lakes by sending `retrievalTags`; the UI had no equivalent, so a lake maintainer
   could not start a chat scoped to the lake they are configuring and see what a consumer of that
   lake sees. The two surfaces were not at parity.

This PR fixes both, without changing who is trusted for injection. **No authorization behavior
changes here**: the same lakes are injected for the same callers, and the new UI action can only
narrow the caller's own existing reach, never widen it.

Related issue: #2405. Deliberately linked without a closing keyword - this PR covers only part of
it; see "Additional Information".

## Changes

**Recording what grounded the answer**

- `RetrievalSummarySchema` (`b4m-core/common/src/schemas/promptMeta.ts`) gains
  `injectedLakePromptIds` and `injectedLakePromptCount`. Ids and a count, never the prompt text -
  that text already reaches the model in the completion, and copying it into telemetry would widen
  exposure for nothing. Absent means no injection site ran; present-and-empty means one ran and
  nothing qualified.
- The hand-maintained Mongoose mirror in `packages/database/.../QuestModel.ts` is updated in
  lockstep, with `default: undefined` on the array field (the parity test and the
  auto-vivification behavior both require it).
- Both injection sites now write the field: `resolveRetrievedLakePromptMessage` in
  `ChatCompletionFeatures.ts` (the forced-retrieval door) and `prependRetrievedLakePrompts` in
  `tools/implementation/retrievedLakePrompts.ts` (the model-driven tool door).
- `mergeRetrievalSummary` unions the ids across sites and *derives* the count from the union rather
  than merging it separately, so the two fields cannot disagree.
- Visibility needs no new route: the value rides the `promptMeta` that
  `pages/api/quests/[id]/index.ts` already returns.

**Testing a lake's scope from the UI**

- `DataLakeSettingsModal` gains a **Test this lake** action, gated on `canManage`.
- New `TestLakeScopeDialog`: a multi-select over the lakes the caller can already reach, with the
  lake being configured checked by default. It mirrors `DataLakeLakePicker`'s row presentation
  (filter box past a threshold, owner marker) but writes a set rather than a single selection.
- New `useStartChatWithLakes` hook, a sibling to the existing single-lake `useStartChatWithLake`,
  sharing its create-and-open-session path. It sends `retrievalTags` (one `datalakeTag` per checked
  lake) **plus** `forceKnowledgeRetrieval: true` and `corpusGroundingMode` explicitly - the
  single-lake defaults resolver only derives those for the `dataLakeId` path, and session-create
  drops a client-sent `corpusGroundingMode` when `dataLakeId` is absent.
- `EditableLake` carries `datalakeTag` so the modal can build those tags.

**Not in this PR**

- Phase 3: `preauthorizedLakeIds` on the API-key model, session-create authorization via
  `canManageLake`, the union-plus-short-circuit at both injection filters, the vetted-array
  plumbing, the audit writes, and the named regression tests. None of it is started.
- The production data migration that org-scopes the lake in question. That is an operational
  sequence with a hard ordering constraint, not code, and it is still outstanding.

## Guide for Testers

Requires an account that can manage at least one data lake, and at least two data lakes visible to
that account (one of which has files with distinguishable content).

**A. Test this lake - the new action**

1. Sign in at `app.staging.bike4mind.com`.
2. In the chat composer, open the **Upload Files** menu and choose the **Data Lakes** entry.
   Expected: a full-screen "Data Lakes" manager opens with a list of lakes on the left.
3. Click a lake you manage in the left-hand list.
   Expected: the right pane shows that lake's details, with a **Settings** button.
4. Click **Settings**.
   Expected: the lake's settings modal opens. A **Test this lake** button is present at the left of
   the modal's footer, alongside Cancel.
5. Click **Test this lake**.
   Expected: a "Test this lake" dialog opens listing the lakes you can reach, each with a checkbox.
   The lake you opened Settings from is already checked. The dialog states that the test covers lake
   scope only.
6. Leave only that one lake checked and click **Start test chat**.
   Expected: the dialog and the manager close, and a new chat session opens.
7. In that new session, type `What do you know about the contents of this lake?` and send.
   Expected: a grounded answer citing files from the checked lake, within about 30 seconds, with no
   error toast.
8. Repeat steps 2-6, but this time also check a **second** lake before clicking **Start test
   chat**, and ask a question that only the second lake can answer.
   Expected: the answer draws on the second lake too.
9. Repeat steps 2-6 with only the first lake checked, and ask the same question from step 8 (the one
   only the second lake can answer).
   Expected: the model does **not** answer from the second lake's content - the session is narrowed.

**B. Permission gating**

10. Sign in as a user who can *see* a lake but not manage it, and repeat steps 2-4 for that lake.
    Expected: no **Settings** button, or if Settings opens, **no "Test this lake" button**.

**C. Recording what was injected**

11. As the managing user, open the lake's **Settings** and set a non-empty **system prompt** for the
    lake, then save.
12. Start a chat using **Test this lake** with only that lake checked, and ask any question that
    causes it to retrieve.
13. With an API key for the same account, fetch the resulting quest:
    `curl -H "x-api-key: $B4M_API_KEY" https://app.staging.bike4mind.com/api/quests/<questId>`
    Expected: the JSON response's `promptMeta.retrieval` object contains
    `injectedLakePromptIds` (an array containing that lake's id) and a matching
    `injectedLakePromptCount`.
14. Repeat step 13 for a chat in a session with **no** lake scope at all and no retrieval.
    Expected: `injectedLakePromptIds` is absent (not present-and-empty).

**Regression checks**

15. Start a chat the old way - the existing single-lake path (open a lake and use its existing
    start-chat affordance rather than **Test this lake**).
    Expected: unchanged behavior; the session grounds on that lake as before.
16. Ask a question in an ordinary chat with no data lake involved.
    Expected: unchanged behavior, no errors, no new fields required to be present.

**What NOT to test**

- Any behavior around *who* is allowed to receive a lake's system prompt. This PR deliberately does
  not change the injection trust rule; a non-member maintainer still does not get the lake's
  `systemPrompt` injected. That is phase 3.
- Simulating a different entitlement, organization, or file-level access. The test dialog narrows
  lake scope only and says so in its own copy.

## Additional Information

**This PR alone is not sufficient to complete issue #2405.** Of its four acceptance criteria, this PR satisfies
the observability one (the injected-prompt record, on both doors) and leaves the settings-modal copy
correct as-is. The other two - a manager seeing their `systemPrompt` in `promptMeta` on a retrieving
turn, and a regression test that fails if the trust set stops admitting managers - both depend on
phase 3 admitting the manager in the first place. The issue is therefore referenced rather than auto-closed; it should stay open when this merges.

Follow-up work, in order:

1. Phase 3 - admit a lake you manage but are not a member of, at both injection filters and both
   narrowing retrieval sites, authorized through the existing `canManageLake` rungs rather than a
   new bespoke rule.
2. The operational sequence that org-scopes the lake. It must land **after** phase 3, because
   org-scoping introduces a hard org prerequisite in front of the tag-based grant and would
   otherwise revoke every non-creator maintainer's retrieval access.

## Developer Notes (Optional)

- **Data model** - `promptMeta.retrieval.injectedLakePromptIds` / `injectedLakePromptCount` are new
  and optional. Anything reading `promptMeta` gets them for free. The absent / present-and-empty
  distinction is load-bearing and documented on the field itself: it separates "no injection site
  ran" from "one ran and nothing qualified", which is exactly the distinction that made the original
  problem hard to diagnose.
- **Merge semantics** - `mergeRetrievalSummary` is the single place the two injection sites'
  telemetry reconciles. Deriving the count from the merged id set rather than merging it as its own
  field is a deliberate invariant; a future field of the same shape should follow it.
- **Reusable pattern** - `useStartChatWithLakes` is the multi-lake sibling of
  `useStartChatWithLake`. Any surface that needs to open a session pinned to a lake *subset* should
  use it rather than re-deriving `retrievalTags`, and note that it must pass
  `corpusGroundingMode` explicitly - the single-lake defaults resolver does not cover the subset
  case, and session-create silently drops the field without a `dataLakeId`.
- **Known review item** - the `statusUpdate` call in `retrievedLakePrompts.ts` uses an `as any` cast
  that is not accompanied by the justification comment this repo's standards ask for. Worth
  resolving (either a proper type or the comment) before this leaves draft.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - **N/A**: this PR does add telemetry fields, but the doc the template links (`docs-site/docs/security/telemetry-data-classification.md`) does not exist in this repo. Flagging rather than silently ticking.
