### PR TITLE
fix(image): forward size and mask to OpenAI gpt-image edits

### DIFF
--- a/b4m-core/utils/src/imageGeneration/OpenAIImageService.test.ts
+++ b/b4m-core/utils/src/imageGeneration/OpenAIImageService.test.ts
@@ -1,6 +1,33 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import OpenAI from 'openai';
-import { buildModerationBlockedError } from './OpenAIImageService';
+import { Logger } from '@bike4mind/observability';
+import { ImageModels } from '@bike4mind/common';
+
+// The service builds its OpenAI client inside each call, so there is no instance to
+// stub - the SDK module is mocked instead. The spies are only dereferenced when a
+// method is invoked, which is well after this module has finished initialising.
+const imagesEdit = vi.fn();
+const imagesGenerate = vi.fn();
+vi.mock('openai', () => {
+  class MockAPIError extends Error {}
+  class MockOpenAI {
+    images = {
+      edit: (...args: unknown[]) => imagesEdit(...args),
+      generate: (...args: unknown[]) => imagesGenerate(...args),
+    };
+    static APIError = MockAPIError;
+  }
+  return { default: MockOpenAI };
+});
+
+// invokeImageProcessor normally round-trips through a Lambda; these tests only care
+// what reaches images.edit, so the buffer passes straight through.
+vi.mock('./imageProcessorUtils', () => ({
+  invokeImageProcessor: vi.fn(async (buffer: Buffer) => buffer),
+  downloadImageAsBuffer: vi.fn(),
+}));
+
+import { buildModerationBlockedError, isSupportedEditSize, OpenAIImageService } from './OpenAIImageService';
 
 // The helper only reads `code`, `status`, and `requestID` off the error, so a
 // minimal object cast to the APIError instance type is sufficient and avoids
@@ -64,5 +91,182 @@ describe('buildModerationBlockedError', () => {
   it('returns null for non-400 errors (e.g. rate limits, server errors)', () => {
     expect(buildModerationBlockedError(makeApiError({ status: 429, code: 'rate_limit_exceeded' }))).toBeNull();
     expect(buildModerationBlockedError(makeApiError({ status: 500 }))).toBeNull();
+  });
+});
+
+describe('isSupportedEditSize', () => {
+  it('accepts the gpt-image-1 family presets', () => {
+    for (const size of ['1024x1024', '1024x1536', '1536x1024']) {
+      expect(isSupportedEditSize(ImageModels.GPT_IMAGE_1_5, size)).toBe(true);
+    }
+  });
+
+  it('rejects a dall-e-2 size for the gpt-image-1 family', () => {
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_1_5, '512x512')).toBe(false);
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_1, '256x256')).toBe(false);
+  });
+
+  it('rejects a custom resolution for the gpt-image-1 family, which has fixed sizes', () => {
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_1_5, '1920x1088')).toBe(false);
+  });
+
+  it('accepts the gpt-image-2 presets and auto', () => {
+    for (const size of ['1024x1024', '2048x2048', '2048x1152', '3840x2160', '2160x3840', 'auto']) {
+      expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, size)).toBe(true);
+    }
+  });
+
+  it('accepts a custom gpt-image-2 resolution that meets every constraint', () => {
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, '1920x1088')).toBe(true);
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, '1280x1024')).toBe(true);
+  });
+
+  it('rejects a custom gpt-image-2 resolution for each individual constraint', () => {
+    // Each of these violates exactly one rule from IMAGE_SIZE_CONSTRAINTS.GPT_IMAGE_2.
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, '1920x1080')).toBe(false); // 1080 is not a multiple of 16
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, '800x800')).toBe(false); // under the minimum pixel count
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, '3840x2224')).toBe(false); // over the maximum pixel count
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, '3072x768')).toBe(false); // aspect ratio beyond 3:1
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, '3856x2144')).toBe(false); // long edge beyond 3840
+  });
+
+  it('rejects a size that is absent or not a WIDTHxHEIGHT pair', () => {
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, undefined)).toBe(false);
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, null)).toBe(false);
+    expect(isSupportedEditSize(ImageModels.GPT_IMAGE_2, 'wide')).toBe(false);
+  });
+});
+
+const PNG_DATA_URL = `data:image/png;base64,${Buffer.from('fake-png').toString('base64')}`;
+
+function makeService() {
+  return new OpenAIImageService('test-key', new Logger(), 'image-processor-lambda');
+}
+
+type EditOptions = Parameters<OpenAIImageService['edit']>[2];
+
+/** Runs edit() against the mocked SDK and returns the params it sent to images.edit. */
+async function editParams(options: EditOptions): Promise<Record<string, unknown>> {
+  imagesEdit.mockResolvedValue({ data: [{ b64_json: 'RURJVA==' }] });
+  await makeService().edit(PNG_DATA_URL, 'make it blue', options);
+  expect(imagesEdit).toHaveBeenCalledTimes(1);
+  return imagesEdit.mock.calls[0][0] as Record<string, unknown>;
+}
+
+describe('OpenAIImageService.edit', () => {
+  beforeEach(() => {
+    imagesEdit.mockReset();
+  });
+
+  it('forwards a valid preset size for a gpt-image-1 family model', async () => {
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_1_5, size: '1536x1024' });
+
+    expect(params.model).toBe(ImageModels.GPT_IMAGE_1_5);
+    expect(params.size).toBe('1536x1024');
+  });
+
+  it('omits a dall-e-2 size when the edit model is a gpt-image model', async () => {
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_1_5, size: '512x512' });
+
+    expect(params).not.toHaveProperty('size');
+  });
+
+  it('forwards a gpt-image-2 preset size', async () => {
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_2, size: '2048x2048' });
+
+    expect(params.size).toBe('2048x2048');
+  });
+
+  it('forwards an arbitrary gpt-image-2 resolution that meets the constraints', async () => {
+    // gpt-image-2 accepts any conforming WIDTHxHEIGHT, so validating against the preset
+    // list alone dropped custom sizes and silently fell back to OpenAI's default.
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_2, size: '1920x1088' });
+
+    expect(params.size).toBe('1920x1088');
+  });
+
+  it('omits a gpt-image-2 resolution that violates the constraints', async () => {
+    // 1080 is not a multiple of 16, so this common video size is genuinely unsupported.
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_2, size: '1920x1080' });
+
+    expect(params).not.toHaveProperty('size');
+  });
+
+  it('sends the image as an array and no dall-e-2 only parameters for gpt-image models', async () => {
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_2, size: '1024x1024' });
+
+    expect(Array.isArray(params.image)).toBe(true);
+    expect(params).not.toHaveProperty('n');
+    expect(params).not.toHaveProperty('response_format');
+    expect(params).not.toHaveProperty('user');
+  });
+
+  it('forwards the mask when one is supplied to a gpt-image model', async () => {
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_2, mask: PNG_DATA_URL });
+
+    expect(params.mask).toBeInstanceOf(File);
+  });
+
+  it('omits the mask key entirely when none is supplied to a gpt-image model', async () => {
+    const params = await editParams({ model: ImageModels.GPT_IMAGE_2 });
+
+    expect(params).not.toHaveProperty('mask');
+  });
+
+  it('leaves the dall-e-2 request shape unchanged', async () => {
+    const params = await editParams({
+      model: ImageModels.DALL_E_2,
+      size: '512x512',
+      mask: PNG_DATA_URL,
+      n: 2,
+      response_format: 'url',
+      user: 'user-1',
+    });
+
+    expect(params.model).toBe(ImageModels.DALL_E_2);
+    expect(params.image).toBeInstanceOf(File);
+    expect(Array.isArray(params.image)).toBe(false);
+    expect(params.mask).toBeInstanceOf(File);
+    expect(params.n).toBe(2);
+    expect(params.size).toBe('512x512');
+    expect(params.response_format).toBe('url');
+    expect(params.user).toBe('user-1');
+  });
+});
+
+describe('OpenAIImageService.generate gpt-image-2 sizing', () => {
+  beforeEach(() => {
+    imagesGenerate.mockReset();
+  });
+
+  /** Runs generate() against the mocked SDK and returns the params it sent. */
+  async function generateParams(options: Record<string, unknown>): Promise<Record<string, unknown>> {
+    imagesGenerate.mockResolvedValue({ data: [{ b64_json: 'R0VO' }] });
+    await makeService().generate('a bicycle', options);
+    return imagesGenerate.mock.calls[0][0] as Record<string, unknown>;
+  }
+
+  it('keeps a custom resolution that meets the constraints', async () => {
+    const params = await generateParams({ model: ImageModels.GPT_IMAGE_2, size: '1920x1088' });
+
+    expect(params.size).toBe('1920x1088');
+  });
+
+  it('falls back to 1024x1024 for a resolution that violates a constraint', async () => {
+    const params = await generateParams({ model: ImageModels.GPT_IMAGE_2, size: '1920x1080' });
+
+    expect(params.size).toBe('1024x1024');
+  });
+
+  it('leaves a size it cannot parse untouched', async () => {
+    const params = await generateParams({ model: ImageModels.GPT_IMAGE_2, size: 'wide' });
+
+    expect(params.size).toBe('wide');
+  });
+
+  it("defaults to 'auto' when no size is supplied", async () => {
+    const params = await generateParams({ model: ImageModels.GPT_IMAGE_2 });
+
+    expect(params.size).toBe('auto');
   });
 });

--- a/b4m-core/utils/src/imageGeneration/OpenAIImageService.ts
+++ b/b4m-core/utils/src/imageGeneration/OpenAIImageService.ts
@@ -3,6 +3,7 @@ import OpenAI from 'openai';
 import { ImageGenerateParams } from 'openai/resources/images';
 import { Logger } from '@bike4mind/observability';
 import {
+  IMAGE_SIZE_CONSTRAINTS,
   ImageModels,
   isGPTImageModel,
   isGPTImage2Model,
@@ -56,6 +57,72 @@ export function buildModerationBlockedError(error: InstanceType<typeof OpenAI.AP
       `Tip: Switch to an alternative model with different content policies — e.g. ${ALTERNATIVE_IMAGE_MODELS} — which may accept this prompt.\n\n` +
       `If you believe this is an error, you can report it to OpenAI with request ID: ${requestId}`
   );
+}
+
+/**
+ * Splits a WIDTHxHEIGHT size into its two edges, or null when the value is not a
+ * pair of non-zero numbers (e.g. 'auto', '', 'wide'). Null means "not a custom
+ * resolution" rather than "invalid": generate() has always left such values
+ * untouched, and that behaviour is preserved.
+ */
+function parseSizeEdges(size?: string | null): { width: number; height: number } | null {
+  if (typeof size !== 'string') {
+    return null;
+  }
+  const [width, height] = size.split('x').map(Number);
+  if (!width || !height) {
+    return null;
+  }
+  return { width, height };
+}
+
+/**
+ * True when a custom gpt-image-2 resolution meets OpenAI's documented limits.
+ * gpt-image-2 accepts any resolution satisfying these, not only the presets in
+ * OPENAI_GPT_IMAGE_2_IMAGE_SIZES, so a flat preset check would reject valid
+ * custom sizes. Must stay the single source of this rule for generate() and edit().
+ */
+function satisfiesGptImage2Constraints({ width, height }: { width: number; height: number }): boolean {
+  const { maxEdge, minTotalPixels, maxTotalPixels, edgeMultiple, maxAspectRatio } =
+    IMAGE_SIZE_CONSTRAINTS.GPT_IMAGE_2.constraints;
+  const longEdge = Math.max(width, height);
+  const shortEdge = Math.min(width, height);
+  const totalPixels = width * height;
+
+  return (
+    longEdge <= maxEdge &&
+    width % edgeMultiple === 0 &&
+    height % edgeMultiple === 0 &&
+    longEdge / shortEdge <= maxAspectRatio &&
+    totalPixels >= minTotalPixels &&
+    totalPixels <= maxTotalPixels
+  );
+}
+
+/**
+ * True when `size` may be forwarded to images.edit for `model`. gpt-image-2 takes
+ * its presets (including 'auto') or any custom WIDTHxHEIGHT meeting the same
+ * constraints generate() enforces; the gpt-image-1 family is limited to its three
+ * fixed sizes. An unsupported size is dropped by the caller so OpenAI applies its
+ * own default instead of rejecting the whole request with a 400.
+ *
+ * GPT-Image tiers only: dall-e-2 has its own size list and passes size through
+ * untouched, so do not route that model here.
+ */
+export function isSupportedEditSize(model?: string | null, size?: string | null): boolean {
+  if (typeof size !== 'string') {
+    return false;
+  }
+
+  if (isGPTImage2Model(model)) {
+    if ((OPENAI_GPT_IMAGE_2_IMAGE_SIZES as readonly string[]).includes(size)) {
+      return true;
+    }
+    const edges = parseSizeEdges(size);
+    return edges !== null && satisfiesGptImage2Constraints(edges);
+  }
+
+  return (OPENAI_GPT_IMAGE_1_IMAGE_SIZES as readonly string[]).includes(size);
 }
 
 export type OpenAIImageGenerationOptions = Omit<ImageGenerateParams, 'prompt'> & {
@@ -114,25 +181,11 @@ export class OpenAIImageService extends AIImageService {
         if (isGPTImage2Model(options.model)) {
           // gpt-image-2 supports flexible sizes - validate constraints instead of fixed list
           if (openaiOptions.size && openaiOptions.size !== 'auto') {
-            const [w, h] = openaiOptions.size.split('x').map(Number);
-            if (w && h) {
-              const maxEdge = Math.max(w, h);
-              const minEdge = Math.min(w, h);
-              const totalPixels = w * h;
-              if (
-                maxEdge > 3840 ||
-                w % 16 !== 0 ||
-                h % 16 !== 0 ||
-                maxEdge / minEdge > 3 ||
-                totalPixels < 655_360 ||
-                totalPixels > 8_294_400
-              ) {
-                const originalSize = openaiOptions.size;
-                openaiOptions.size = '1024x1024';
-                parameterWarnings.push(
-                  `Size '${originalSize}' violates gpt-image-2 constraints, changed to '1024x1024'`
-                );
-              }
+            const edges = parseSizeEdges(openaiOptions.size);
+            if (edges && !satisfiesGptImage2Constraints(edges)) {
+              const originalSize = openaiOptions.size;
+              openaiOptions.size = '1024x1024';
+              parameterWarnings.push(`Size '${originalSize}' violates gpt-image-2 constraints, changed to '1024x1024'`);
             }
           } else if (!openaiOptions.size) {
             // gpt-image-2 defaults to 'auto' if no size provided
@@ -344,14 +397,12 @@ export class OpenAIImageService extends AIImageService {
       }
 
       // GPT-Image models (1, 1.5, 1-mini, 2) also accept `size` and `mask`, but only a size
-      // from the resolved model's own supported set - passing a dall-e-2 size (e.g.
-      // 256x256/512x512) or an arbitrary string is a 400 from OpenAI. An invalid/absent size
-      // is omitted so OpenAI's `auto` sizing applies, same as before this validation existed.
+      // their own tier supports - a dall-e-2 size (e.g. 256x256/512x512) or an out-of-range
+      // resolution is a 400 from OpenAI. gpt-image-2 also takes any custom WIDTHxHEIGHT
+      // meeting its constraints, so this must not be a flat preset check. An unsupported or
+      // absent size is omitted so OpenAI's own default sizing applies, as it did before.
       // dall-e-2 supports: model, image (single), prompt, mask, n, size, response_format, user
-      const gptImageSizes: readonly string[] = isGPTImage2Model(editModel)
-        ? OPENAI_GPT_IMAGE_2_IMAGE_SIZES
-        : OPENAI_GPT_IMAGE_1_IMAGE_SIZES;
-      const isValidGptImageSize = typeof size === 'string' && gptImageSizes.includes(size);
+      const forwardSize = isSupportedEditSize(editModel, size);
 
       const response = await openai.images.edit(
         isGPTImageModel(editModel)
@@ -359,7 +410,7 @@ export class OpenAIImageService extends AIImageService {
               model: editModel as 'gpt-image-1' | 'gpt-image-1.5' | 'gpt-image-1-mini' | 'gpt-image-2',
               image: [imageFile],
               prompt,
-              ...(isValidGptImageSize ? { size } : {}),
+              ...(forwardSize ? { size } : {}),
               ...(maskFile ? { mask: maskFile } : {}),
             }
           : {

--- a/b4m-core/utils/src/imageGeneration/OpenAIImageService.ts
+++ b/b4m-core/utils/src/imageGeneration/OpenAIImageService.ts
@@ -2,7 +2,13 @@ import { AIImageService, ImageEditOptions, ImageEditResponse } from './AIImageSe
 import OpenAI from 'openai';
 import { ImageGenerateParams } from 'openai/resources/images';
 import { Logger } from '@bike4mind/observability';
-import { ImageModels, isGPTImageModel, isGPTImage2Model } from '@bike4mind/common';
+import {
+  ImageModels,
+  isGPTImageModel,
+  isGPTImage2Model,
+  OPENAI_GPT_IMAGE_1_IMAGE_SIZES,
+  OPENAI_GPT_IMAGE_2_IMAGE_SIZES,
+} from '@bike4mind/common';
 import { invokeImageProcessor, downloadImageAsBuffer } from './imageProcessorUtils';
 
 // The image-generation Lambda has a 10-minute timeout. The OpenAI SDK's default
@@ -337,14 +343,24 @@ export class OpenAIImageService extends AIImageService {
         editModel = ImageModels.GPT_IMAGE_2;
       }
 
-      // IMPORTANT: GPT-Image models (1, 1.5, 1-mini) only support: model, image (array), prompt
+      // GPT-Image models (1, 1.5, 1-mini, 2) also accept `size` and `mask`, but only a size
+      // from the resolved model's own supported set - passing a dall-e-2 size (e.g.
+      // 256x256/512x512) or an arbitrary string is a 400 from OpenAI. An invalid/absent size
+      // is omitted so OpenAI's `auto` sizing applies, same as before this validation existed.
       // dall-e-2 supports: model, image (single), prompt, mask, n, size, response_format, user
+      const gptImageSizes: readonly string[] = isGPTImage2Model(editModel)
+        ? OPENAI_GPT_IMAGE_2_IMAGE_SIZES
+        : OPENAI_GPT_IMAGE_1_IMAGE_SIZES;
+      const isValidGptImageSize = typeof size === 'string' && gptImageSizes.includes(size);
+
       const response = await openai.images.edit(
         isGPTImageModel(editModel)
           ? {
               model: editModel as 'gpt-image-1' | 'gpt-image-1.5' | 'gpt-image-1-mini' | 'gpt-image-2',
               image: [imageFile],
               prompt,
+              ...(isValidGptImageSize ? { size } : {}),
+              ...(maskFile ? { mask: maskFile } : {}),
             }
           : {
               model: editModel as 'dall-e-2',


### PR DESCRIPTION
## What
The OpenAI image-**edit** adapter (`b4m-core/utils/src/imageGeneration/OpenAIImageService.ts`) dropped `size` and `mask` for gpt-image models — the branch sent only `{model, image, prompt}`. This forwards both, guarded.

## Why it matters
- **Size:** gpt-image edits ran with OpenAI's `auto` sizing, so the model picked the aspect (a 1600×1000 source came back 1024×1536 portrait). Callers that pass a valid gpt-image `size` now get it.
- **Mask (bigger):** the mask was silently discarded. The workbench **"paint a mask + edit"** flow (`ImageEdit.ts`, always gpt-image-1 with a mask present) has therefore been doing a **whole-image regeneration** regardless of what the user painted. This restores real masked inpainting.

## The change (guarded, backwards-safe)
- `size` forwarded **only** when valid for the resolved model's own supported set (`OPENAI_GPT_IMAGE_1_IMAGE_SIZES` / `OPENAI_GPT_IMAGE_2_IMAGE_SIZES`) — dall-e sizes never leak to gpt-image; invalid/absent → omitted → `auto` as before.
- `mask` forwarded **only** when present.
- Callers passing neither behave byte-identically. dall-e-2 branch untouched. openai@6.47.0 edit params already accept size/mask for gpt-image (no cast); the old "only model/image/prompt" comment was wrong and is removed.

## Blast radius
- **`ImageEdit.ts` (workbench mask-paint):** universal — every call now honors the mask. **Please sanity-check the mask-paint UI end-to-end before deploying.**
- **`edit_image` LLM tool (OpenAI fallback):** mask is opt-in per call; only affected when the model supplies one.

## Verification
`cd b4m-core/utils && pnpm typecheck` → exit 0 (narrowest check; CI runs the full gate).

## Context
Unblocks canvas-aspect image generation in the intent-canvas app, which sends a `size` derived from the canvas — inert until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)