### PR TITLE
chore(scripts): add a supersession-collapse retrieval probe

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -52,7 +52,8 @@
     "backfill:fabfile-moderation-status": "tsx src/backfill-fabfile-moderation-status.ts",
     "tavern:upload-icons": "tsx src/uploadTavernIcons.ts",
     "count-tokens-probe": "tsx count-tokens-probe.ts",
-    "retrieval:recall-probe": "tsx retrieval/recall-probe.ts"
+    "retrieval:recall-probe": "tsx retrieval/recall-probe.ts",
+    "retrieval:supersession-probe": "tsx retrieval/supersession-probe.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.111.0",

--- a/packages/scripts/retrieval/supersession-probe.ts
+++ b/packages/scripts/retrieval/supersession-probe.ts
@@ -6,9 +6,9 @@
  * WHAT IT SEEDS. A dedicated, gate-less data lake (slug `supersession-probe`, never `system-help`)
  * holding three documents, each uploaded twice under the SAME `fileName` with different content -
  * a policy value that changed. The older generation's `createdAt` is force-backdated ~90 days so
- * the two generations are distinguishable by age, and the identity key `partitionBySupersession`
- * groups them on lands on the weakest (`fileName`) tier, since neither generation carries a
- * `relativePath` or `driveFileId` - see `b4m-core/services/src/dataLakeService/supersession.ts`.
+ * the two generations are distinguishable by age. The identity key that `partitionBySupersession`
+ * groups them on is the weakest (`fileName`) tier, since neither generation carries a
+ * `relativePath` or a `driveFileId` - see `b4m-core/services/src/dataLakeService/supersession.ts`.
  *
  * WHY THE OLDER TEXT SCORES AT LEAST AS WELL. Each query is phrased close to the OLD sentence's own
  * wording, and the NEW generation only appends a trailing clause ("effective 2026"). Without
@@ -82,6 +82,14 @@ import {
   type SettingKey,
   type SupportedEmbeddingModel,
 } from '@bike4mind/common';
+import {
+  assertAllAttributed,
+  attributeChunks,
+  tallyGenerations,
+  type ChunkAttribution,
+  type Generation,
+  type SeededFile,
+} from './supersessionAttribution';
 
 /** This file is packages/scripts/retrieval/, so the package root is two levels up. */
 const SCRIPTS_PACKAGE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -109,8 +117,6 @@ const COLLAPSE_SETTING: SettingKey = 'EnableRetrievalSupersessionCollapse';
  *  contend with each other over an unrelated setting. */
 const LEASE_SETTING = '__supersessionProbeLease';
 const LEASE_STALE_AFTER_MS = 30 * 60 * 1000;
-
-type Generation = 'OLD' | 'NEW';
 
 /**
  * One document, seeded as two FabFiles under the same `fileName`. `query` is phrased close to
@@ -146,14 +152,6 @@ const PROBE_DOCS: ProbeDoc[] = [
   },
 ];
 
-/** What seeding recorded about one FabFile, so attribution never has to re-derive it from a tag. */
-type SeededFile = {
-  fabFileId: string;
-  fileName: string;
-  generation: Generation;
-  docIndex: number;
-};
-
 // ---------------------------------------------------------------------------
 // Settings lease (single setting) - same mechanics as recall-probe.ts's acquireSettingsLease,
 // narrowed to the one knob this probe touches.
@@ -175,7 +173,11 @@ async function writeSetting(name: string, value: string | null): Promise<void> {
   if (value === null) {
     await AdminSettings.deleteOne({ settingName: name }, { hardDelete: true });
   } else {
-    await AdminSettings.updateOne({ settingName: name }, { $set: { settingValue: value, deletedAt: null } }, { upsert: true });
+    await AdminSettings.updateOne(
+      { settingName: name },
+      { $set: { settingValue: value, deletedAt: null } },
+      { upsert: true }
+    );
   }
   invalidateSettingsCache();
   invalidateScopedSettingsCache();
@@ -183,9 +185,15 @@ async function writeSetting(name: string, value: string | null): Promise<void> {
 
 /**
  * `getSettingsValue` is typed as the union of EVERY admin setting's value shape, so it does not
- * narrow to this setting's boolean on its own. Narrow it here rather than casting: if the row ever
- * holds a non-boolean, the probe must refuse to measure instead of coercing it and reporting a
- * config it never actually exercised.
+ * narrow to this setting's boolean on its own. Narrow it here rather than casting.
+ *
+ * The throw is a TYPE guard, not a data-integrity check, and deliberately promises nothing about the
+ * row: `EnableRetrievalSupersessionCollapse` is a `makeBooleanSetting` (`settings.ts`), whose schema
+ * preprocesses the strings "true"/"false" and prefaults, and `getSettingsValue`
+ * (`AdminSettingsModel.ts`) falls back to `defaultValue` whenever `safeParse` fails - so a garbage
+ * row reads as `false` here rather than surfacing as a string. What actually catches a row this
+ * probe cannot trust is the write-then-read-back assertion in `runOneConfig`, which compares this
+ * value against what was just written.
  */
 async function readCollapseSettingAsBoolean(): Promise<boolean> {
   const raw: unknown = await adminSettingsRepository.getSettingsValue(COLLAPSE_SETTING);
@@ -199,6 +207,11 @@ async function readCollapseSettingAsBoolean(): Promise<boolean> {
   return raw;
 }
 
+/** Mongo duplicate key on the unique `settingName` index - the ONE error that means someone else
+ *  won the race for the lease row. */
+const isDuplicateKeyError = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 11000;
+
 async function acquireCollapseSettingLease(): Promise<{ originalValue: string | null; restore: () => Promise<void> }> {
   const holder = `${process.pid}@supersession-probe`;
   const now = Date.now();
@@ -211,7 +224,11 @@ async function acquireCollapseSettingLease(): Promise<{ originalValue: string | 
       { upsert: true }
     );
     acquired = result.upsertedCount === 1;
-  } catch {
+  } catch (err) {
+    // Only a duplicate key means another run holds the lease. A connection reset, timeout or auth
+    // failure must NOT be reported as a held lease: the operator would be told to go clear a row
+    // that may not exist, with `holder unknown` because the read below failed for the same reason.
+    if (!isDuplicateKeyError(err)) throw err;
     acquired = false;
   }
 
@@ -245,11 +262,19 @@ async function acquireCollapseSettingLease(): Promise<{ originalValue: string | 
       await writeSetting(COLLAPSE_SETTING, originalValue);
       logger.log(`Restored ${COLLAPSE_SETTING} to ${originalValue === null ? '(unset)' : originalValue}.`);
     } catch (err) {
+      // Return WITHOUT releasing the lease. While the setting is stranded, that row is the only
+      // marker that this stage is mid-probe, and it is the only thing stopping the next run from
+      // reading the stranded value as its own `originalValue` and restoring it on exit - which
+      // would flip collapse on permanently for everyone on the stage, with no error anywhere. Same
+      // invariant as recall-probe.ts's "released last" block; it is the part of those mechanics
+      // this narrowing had dropped.
       logger.error(
         `FAILED to restore ${COLLAPSE_SETTING} to ${originalValue === null ? '(unset)' : originalValue} on stage ` +
-          `${Resource.App.stage}. Restore it BY HAND before anyone else relies on this setting.`,
+          `${Resource.App.stage}. Restore it BY HAND, then clear the "${LEASE_SETTING}" row - it is left ` +
+          `behind on purpose to block the next run until you have.`,
         err
       );
+      return;
     }
     try {
       await writeSetting(LEASE_SETTING, null);
@@ -396,7 +421,8 @@ async function resolveEmbeddingHandle(userId: string): Promise<EmbeddingHandle> 
     getSettingsByNames,
   });
   const provider = getProviderFromModel(embeddingModel);
-  const embeddingConfig: { openaiApiKey?: string | null; voyageApiKey?: string | null; ollamaBaseUrl?: string | null } = {};
+  const embeddingConfig: { openaiApiKey?: string | null; voyageApiKey?: string | null; ollamaBaseUrl?: string | null } =
+    {};
   if (provider === 'openai') {
     embeddingConfig.openaiApiKey = apiKeyTable?.openai;
     if (!embeddingConfig.openaiApiKey) throw new Error(`No OpenAI API key resolved for user ${userId}.`);
@@ -469,10 +495,6 @@ async function seedOneGeneration(
 
   await fabFileChunkRepository.bulkInsert([{ ...chunkPayload, fabFileId: fabFile.id }]);
 
-  if (generation === 'OLD') {
-    await backdateAndVerify(fabFile.id, doc.fileName);
-  }
-
   return { fabFileId: fabFile.id, fileName: doc.fileName, generation, docIndex };
 }
 
@@ -484,10 +506,20 @@ async function seedCorpus(userId: string): Promise<SeededFile[]> {
   for (let docIndex = 0; docIndex < PROBE_DOCS.length; docIndex++) {
     const doc = PROBE_DOCS[docIndex];
     logger.log(`Seeding "${doc.fileName}"...`);
-    // NEW first, then OLD: order does not matter to Mongo, but seeding NEW first means a failure
-    // partway through never leaves an OLD generation backdated with no NEW sibling to compare it to.
-    seeded.push(await seedOneGeneration(doc, 'NEW', doc.newText, userId, embedding, docIndex));
-    seeded.push(await seedOneGeneration(doc, 'OLD', doc.oldText, userId, embedding, docIndex));
+    // OLD first, NEW second, and backdate only once BOTH rows exist. The order is what makes the
+    // measurement attributable: `winsOver` (supersession.ts) compares `createdAt` and falls back to
+    // ASCENDING id on a tie, so whichever generation is inserted first also wins the tiebreaker.
+    // Seeding OLD first therefore points the tiebreaker at OLD while the recency arm points at NEW,
+    // so an observed "0 old / N new" is reachable ONLY through `createdAt`. Seeding NEW first would
+    // aim both arms at NEW: if a refactor ever dropped `createdAt` from the rankable file (it is
+    // threaded through `semanticDataLakeSearch`), every timestamp would read -Infinity, the tie
+    // would fall to id, NEW would still win, and this probe would print the same pass it prints
+    // today while measuring nothing. Backdating last preserves the original reason for NEW-first:
+    // a failure partway through never leaves a backdated OLD with no NEW sibling to compare it to.
+    const older = await seedOneGeneration(doc, 'OLD', doc.oldText, userId, embedding, docIndex);
+    const newer = await seedOneGeneration(doc, 'NEW', doc.newText, userId, embedding, docIndex);
+    await backdateAndVerify(older.fabFileId, doc.fileName);
+    seeded.push(older, newer);
   }
   return seeded;
 }
@@ -552,14 +584,6 @@ async function resolveApiKeyTable(userId: string): Promise<ApiKeyTable> {
 // One query -> chunk-level attribution, via semanticDataLakeSearch directly.
 // ---------------------------------------------------------------------------
 
-type ChunkAttribution = {
-  chunkId: string;
-  fabFileId: string;
-  fileName: string;
-  generation: Generation | 'UNKNOWN';
-  score: number;
-};
-
 type SupersessionSummary = {
   count: number;
   sample: { fileId: string; fileName?: string; tier: string; supersededBy: string }[];
@@ -580,7 +604,8 @@ async function runQuery(
   scope: ProbeScope,
   embeddingModel: SupportedEmbeddingModel,
   apiKeyTable: ApiKeyTable,
-  byFabFileId: Map<string, SeededFile>
+  byFabFileId: Map<string, SeededFile>,
+  collapseEnabled: boolean
 ): Promise<QueryResult> {
   const search = await dataLakeService.semanticDataLakeSearch(
     {
@@ -595,7 +620,7 @@ async function runQuery(
       dataLakeTagPrefixes: scope.dataLakeTagPrefixes,
       lakeMemberships: scope.lakeMemberships,
       lakes: scope.lakes,
-      supersessionCollapseEnabled: await readCollapseSettingAsBoolean(),
+      supersessionCollapseEnabled: collapseEnabled,
       logger,
     },
     {
@@ -603,16 +628,8 @@ async function runQuery(
     }
   );
 
-  const chunks: ChunkAttribution[] = search.results.map(r => {
-    const meta = byFabFileId.get(r.fileId);
-    return {
-      chunkId: r.chunkId,
-      fabFileId: r.fileId,
-      fileName: meta?.fileName ?? r.fileName,
-      generation: meta?.generation ?? 'UNKNOWN',
-      score: r.score,
-    };
-  });
+  const chunks: ChunkAttribution[] = attributeChunks(search.results, byFabFileId);
+  assertAllAttributed(chunks, `collapse=${collapseEnabled ? 'on' : 'off'} query "${doc.query}"`);
 
   return {
     docIndex,
@@ -641,8 +658,6 @@ type ConfigRun = {
 };
 
 function printConfigTable(run: ConfigRun): { oldCount: number; newCount: number; supersededCount: number } {
-  let oldCount = 0;
-  let newCount = 0;
   let supersededCount = 0;
   logger.log(`\n--- collapse=${run.collapseEnabled ? 'on' : 'off'} ---`);
   logger.log(['docIndex', 'fileName', 'generation', 'score', 'fabFileId', 'chunkId'].join('  |  '));
@@ -651,8 +666,6 @@ function printConfigTable(run: ConfigRun): { oldCount: number; newCount: number;
       logger.log(`  (query "${q.query}" -> no chunks served)`);
     }
     for (const c of q.chunks) {
-      if (c.generation === 'OLD') oldCount++;
-      if (c.generation === 'NEW') newCount++;
       logger.log(
         [String(q.docIndex), c.fileName, c.generation, c.score.toFixed(4), c.fabFileId, c.chunkId].join('  |  ')
       );
@@ -667,6 +680,8 @@ function printConfigTable(run: ConfigRun): { oldCount: number; newCount: number;
       );
     }
   }
+  // `runQuery` has already refused any UNKNOWN chunk, so oldCount + newCount is the full total.
+  const { oldCount, newCount } = tallyGenerations(run.queries.flatMap(q => q.chunks));
   logger.log(
     `collapse=${run.collapseEnabled ? 'on ' : 'off'}  ${oldCount + newCount} chunks: ${oldCount} old / ${newCount} new` +
       `  (${supersededCount} superseded across ${run.queries.length} queries)`
@@ -704,7 +719,7 @@ async function runOneConfig(
   const queries: QueryResult[] = [];
   for (let docIndex = 0; docIndex < PROBE_DOCS.length; docIndex++) {
     queries.push(
-      await runQuery(PROBE_DOCS[docIndex], docIndex, user, scope, embeddingModel, apiKeyTable, byFabFileId)
+      await runQuery(PROBE_DOCS[docIndex], docIndex, user, scope, embeddingModel, apiKeyTable, byFabFileId, readBack)
     );
   }
 
@@ -722,10 +737,10 @@ async function runOneConfig(
   return { collapseEnabled, queries };
 }
 
-async function main(): Promise<void> {
-  await connectDB(Resource.MONGODB_URI.value.replace('%STAGE%', Resource.App.stage));
-  logger.log(`Connected (stage: ${Resource.App.stage})`);
-
+/**
+ * The measurement itself. Runs entirely under the settings lease its caller holds - see `main`.
+ */
+async function runProbe(): Promise<void> {
   const user = await findOrCreateProbeUser();
   await findOrCreateProbeLake(user.id);
   await clearPreviousRun();
@@ -750,26 +765,11 @@ async function main(): Promise<void> {
   }
   logger.log(`Lake scope: dataLakeTags=[${scope.dataLakeTags.join(', ')}], embeddingModel=${embeddingModel}`);
 
-  const { originalValue, restore } = await acquireCollapseSettingLease();
-  logger.log(`Leased ${COLLAPSE_SETTING} (was ${originalValue === null ? '(unset)' : originalValue}).`);
+  const offRun = await runOneConfig(false, user, scope, embeddingModel, apiKeyTable, byFabFileId);
+  const offSummary = printConfigTable(offRun);
 
-  // Definite-assignment (`!`): both are set inside the try block below, before any of their reads
-  // - if the try throws before either assignment, `finally` still runs (restoring the setting) and
-  // then the throw propagates, so the reads after the block are never reached in that case.
-  let offRun!: ConfigRun;
-  let onRun!: ConfigRun;
-  let offSummary!: { oldCount: number; newCount: number; supersededCount: number };
-  let onSummary!: { oldCount: number; newCount: number; supersededCount: number };
-
-  try {
-    offRun = await runOneConfig(false, user, scope, embeddingModel, apiKeyTable, byFabFileId);
-    offSummary = printConfigTable(offRun);
-
-    onRun = await runOneConfig(true, user, scope, embeddingModel, apiKeyTable, byFabFileId);
-    onSummary = printConfigTable(onRun);
-  } finally {
-    await restore();
-  }
+  const onRun = await runOneConfig(true, user, scope, embeddingModel, apiKeyTable, byFabFileId);
+  const onSummary = printConfigTable(onRun);
 
   logger.log('\n=== Summary ===');
   logger.log(
@@ -803,6 +803,29 @@ async function main(): Promise<void> {
     )
   );
   logger.log(`Wrote ${outPath}`);
+}
+
+async function main(): Promise<void> {
+  await connectDB(Resource.MONGODB_URI.value.replace('%STAGE%', Resource.App.stage));
+  logger.log(`Connected (stage: ${Resource.App.stage})`);
+
+  // Lease BEFORE any of the run, not just before the setting writes. `clearPreviousRun` deletes
+  // every FabFile carrying this probe's datalake tag and `seedCorpus` spends live embedding calls
+  // recreating them, so a second run that only took the lease later would wipe an in-flight run's
+  // corpus out from under it and refuse to start afterwards. The in-flight run's collapse=on pass
+  // would then be querying the intruder's FabFiles, attribute none of them, and print a
+  // clean-looking "0 old" - a stronger-looking version of the result the probe is trying to
+  // demonstrate, which is the direction a failure must never fall. recall-probe.ts can afford to
+  // acquire late because it only READS an existing lake; this script mutates shared corpus state,
+  // so the lease has to cover the whole run.
+  const { originalValue, restore } = await acquireCollapseSettingLease();
+  logger.log(`Leased ${COLLAPSE_SETTING} (was ${originalValue === null ? '(unset)' : originalValue}).`);
+
+  try {
+    await runProbe();
+  } finally {
+    await restore();
+  }
 }
 
 main()

--- a/packages/scripts/retrieval/supersession-probe.ts
+++ b/packages/scripts/retrieval/supersession-probe.ts
@@ -47,7 +47,7 @@
  * anyone else.
  *
  * Usage (needs DB + an embedding key, which `sst shell` provides):
- *   for-env dev pnpm sst shell --stage dev -- tsx packages/scripts/retrieval/supersession-probe.ts
+ *   for-env dev pnpm sst shell --stage dev -- pnpm --filter @bike4mind/scripts retrieval:supersession-probe
  *
  * No CLI flags: the probe user, lake and documents are fixed and idempotent (see SETUP below), so
  * the whole thing is safe to re-run - every run deletes and recreates its own FabFiles first.
@@ -84,7 +84,9 @@ import {
 } from '@bike4mind/common';
 import {
   assertAllAttributed,
+  assertSupersessionSampleAttributed,
   attributeChunks,
+  supersededCountFor,
   tallyGenerations,
   type ChunkAttribution,
   type Generation,
@@ -363,13 +365,20 @@ async function clearPreviousRun(): Promise<void> {
   if (existingIds.length === 0) return;
   logger.log(`Removing ${existingIds.length} FabFile(s) from a previous run...`);
   for (const id of existingIds) await fabFileChunkRepository.deleteManyByFabFileId(id);
-  await fabFileRepository.deleteManyInIds(existingIds);
+  // hardDeleteByIds, NOT deleteManyInIds: `FabFileSchema` carries the soft-delete plugin, whose
+  // `deleteMany` override only stamps `deletedAt`, while `findIdsByDataLakeTag` above reads with
+  // `includeDeleted`. A soft delete therefore leaves every prior run's rows in that id list forever,
+  // so the count logged above becomes an all-time total rather than this clear's work and the probe
+  // lake accumulates tombstones on a shared stage. The measurement itself was never at risk - chunks
+  // are hard-deleted and the search's scoped-file read is plugin-filtered, so a stale generation has
+  // no chunks and is out of scope - but the log line was wrong and the growth was unbounded.
+  await fabFileRepository.hardDeleteByIds(existingIds);
 }
 
 /**
- * Backdate the OLD generation's `createdAt` with the raw Mongoose model, bypassing the
- * `timestamps: true` hook via `{ timestamps: false }`, then READ IT BACK. `fabFileRepository.create`
- * cannot do this itself - its signature is `Omit<T, 'id' | 'updatedAt' | 'createdAt'>`
+ * Backdate the OLD generation's `createdAt` through the NATIVE driver, which is the only thing that
+ * actually bypasses the `timestamps: true` hook here (see the comment below), then READ IT BACK.
+ * `fabFileRepository.create` cannot do this itself - its signature is `Omit<T, 'id' | 'updatedAt' | 'createdAt'>`
  * (`b4m-core/db-core/src/models/BaseModel.ts`), which exists specifically so Mongoose's own
  * timestamp hook stamps every normal write. Unverified in code review, so it is verified HERE,
  * at runtime, every run: if the write did not stick, the two generations are not actually
@@ -518,6 +527,19 @@ async function seedCorpus(userId: string): Promise<SeededFile[]> {
     // a failure partway through never leaves a backdated OLD with no NEW sibling to compare it to.
     const older = await seedOneGeneration(doc, 'OLD', doc.oldText, userId, embedding, docIndex);
     const newer = await seedOneGeneration(doc, 'NEW', doc.newText, userId, embedding, docIndex);
+    // Assert the ordering rather than trust it: it is the entire load-bearing precondition of the
+    // comment above, and a bson counter wrap or a backwards clock step between the two inserts would
+    // hand OLD the LARGER id, silently re-aiming the tiebreaker at NEW and restoring exactly the
+    // over-determined measurement the ordering exists to prevent. `backdateAndVerify` below already
+    // sets the standard of verifying its own precondition at runtime; this is the same one line.
+    if (!(older.fabFileId < newer.fabFileId)) {
+      throw new Error(
+        `Seeded OLD (${older.fabFileId}) does not sort BEFORE NEW (${newer.fabFileId}) for ` +
+          `"${doc.fileName}". winsOver breaks a createdAt tie on the SMALLER id, so this ordering is what ` +
+          `points the tiebreaker at OLD and keeps "0 old / N new" attributable to createdAt alone. Refusing ` +
+          `to measure with both arms aimed at NEW.`
+      );
+    }
     await backdateAndVerify(older.fabFileId, doc.fileName);
     seeded.push(older, newer);
   }
@@ -628,24 +650,25 @@ async function runQuery(
     }
   );
 
+  const context = `collapse=${collapseEnabled ? 'on' : 'off'} query "${doc.query}"`;
   const chunks: ChunkAttribution[] = attributeChunks(search.results, byFabFileId);
-  assertAllAttributed(chunks, `collapse=${collapseEnabled ? 'on' : 'off'} query "${doc.query}"`);
+  assertAllAttributed(chunks, context);
 
-  return {
-    docIndex,
-    fileName: doc.fileName,
-    query: doc.query,
-    chunks,
-    supersession: {
-      count: search.supersession.count,
-      sample: search.supersession.sample.map(s => ({
-        fileId: s.fileId,
-        fileName: s.fileName,
-        tier: s.tier,
-        supersededBy: s.supersededBy,
-      })),
-    },
+  const supersession: SupersessionSummary = {
+    count: search.supersession.count,
+    sample: search.supersession.sample.map(s => ({
+      fileId: s.fileId,
+      fileName: s.fileName,
+      tier: s.tier,
+      supersededBy: s.supersededBy,
+    })),
   };
+  // The second output needs its own guard. The chunk guard above sees only what was SERVED, and a
+  // superseded file is suppressed before ranking by definition, so foreign content can inflate the
+  // count below without ever showing up in a result row.
+  assertSupersessionSampleAttributed(supersession.sample, byFabFileId, context);
+
+  return { docIndex, fileName: doc.fileName, query: doc.query, chunks, supersession };
 }
 
 // ---------------------------------------------------------------------------
@@ -658,7 +681,6 @@ type ConfigRun = {
 };
 
 function printConfigTable(run: ConfigRun): { oldCount: number; newCount: number; supersededCount: number } {
-  let supersededCount = 0;
   logger.log(`\n--- collapse=${run.collapseEnabled ? 'on' : 'off'} ---`);
   logger.log(['docIndex', 'fileName', 'generation', 'score', 'fabFileId', 'chunkId'].join('  |  '));
   for (const q of run.queries) {
@@ -670,21 +692,25 @@ function printConfigTable(run: ConfigRun): { oldCount: number; newCount: number;
         [String(q.docIndex), c.fileName, c.generation, c.score.toFixed(4), c.fabFileId, c.chunkId].join('  |  ')
       );
     }
-    supersededCount += q.supersession.count;
-    if (q.supersession.count > 0) {
-      logger.log(
-        `  supersession (doc ${q.docIndex}): ${q.supersession.count} suppressed - ` +
-          q.supersession.sample
-            .map(s => `${s.fileName ?? s.fileId} (tier=${s.tier}, kept ${s.supersededBy})`)
-            .join('; ')
-      );
-    }
   }
   // `runQuery` has already refused any UNKNOWN chunk, so oldCount + newCount is the full total.
   const { oldCount, newCount } = tallyGenerations(run.queries.flatMap(q => q.chunks));
+  // Chunks accumulate across queries; the superseded report does NOT - it is built once from the
+  // scoped file set before ranking, so every query returns the same one. See `supersededCountFor`.
+  // Reported here, once, rather than inside the loop above: printing it per query labelled the same
+  // corpus-wide constant as `doc 0`, `doc 1`, `doc 2`, which reads as three separate suppressions.
+  const supersededCount = supersededCountFor(run.queries, `collapse=${run.collapseEnabled ? 'on' : 'off'}`);
+  if (supersededCount > 0) {
+    logger.log(
+      `  supersession: ${supersededCount} file(s) suppressed for this configuration - ` +
+        run.queries[0].supersession.sample
+          .map(s => `${s.fileName ?? s.fileId} (tier=${s.tier}, kept ${s.supersededBy})`)
+          .join('; ')
+    );
+  }
   logger.log(
     `collapse=${run.collapseEnabled ? 'on ' : 'off'}  ${oldCount + newCount} chunks: ${oldCount} old / ${newCount} new` +
-      `  (${supersededCount} superseded across ${run.queries.length} queries)`
+      `  (${supersededCount} superseded)`
   );
   return { oldCount, newCount, supersededCount };
 }

--- a/packages/scripts/retrieval/supersession-probe.ts
+++ b/packages/scripts/retrieval/supersession-probe.ts
@@ -1,0 +1,813 @@
+#!/usr/bin/env tsx
+/**
+ * Supersession-collapse probe: proves on a live DB that `EnableRetrievalSupersessionCollapse`
+ * changes which GENERATION of a re-uploaded document semantic search serves.
+ *
+ * WHAT IT SEEDS. A dedicated, gate-less data lake (slug `supersession-probe`, never `system-help`)
+ * holding three documents, each uploaded twice under the SAME `fileName` with different content -
+ * a policy value that changed. The older generation's `createdAt` is force-backdated ~90 days so
+ * the two generations are distinguishable by age, and the identity key `partitionBySupersession`
+ * groups them on lands on the weakest (`fileName`) tier, since neither generation carries a
+ * `relativePath` or `driveFileId` - see `b4m-core/services/src/dataLakeService/supersession.ts`.
+ *
+ * WHY THE OLDER TEXT SCORES AT LEAST AS WELL. Each query is phrased close to the OLD sentence's own
+ * wording, and the NEW generation only appends a trailing clause ("effective 2026"). Without
+ * collapse, a purely relevance-ranked search has no reason to prefer the newer generation - it may
+ * in fact prefer the older, more literal match. That is what makes the comparison meaningful: any
+ * shift toward the NEW generation when the setting flips on is attributable to the collapse, not to
+ * the ranking having favored it anyway.
+ *
+ * HOW IT MEASURES. Calls `semanticDataLakeSearch` (`b4m-core/services/src/dataLakeService`) DIRECTLY
+ * rather than going through the `search_knowledge_base` chat tool: that tool's audit-event seam
+ * (`RecordLakeAccessEventInput`) turned out to report `outcome: "unknown"` for a search that had, in
+ * fact, served content - so `readRetrievalStatus` could never reach `served-content` even though the
+ * logs showed real passages returned. `semanticDataLakeSearch` is also the layer that actually owns
+ * `compareByScore` and the supersession partition, so calling it directly measures the mechanism
+ * under test instead of a seam wrapped two layers above it. Its result already carries structured
+ * `{chunkId, fileId, fileName, score}` per hit plus its own `supersession: SupersessionReport` - no
+ * audit event, no model-facing text, no polling. Lake scope (`dataLakeTags`/`dataLakeTagPrefixes`/
+ * `lakes`) is resolved the same way the known-working callers do: via
+ * `dataLakeService.getDynamicDataLakeAccess`, the same core function
+ * `apps/client/pages/api/data-lakes/semantic-search.ts` and the chat tool both sit on top of - see
+ * that route's `resolveRetrievalLakeScope` -> `getDynamicDataLakeAccess` chain.
+ *
+ * Each served chunk is attributed to OLD/NEW by its `fileId`, looked up against the map built while
+ * SEEDING - never by tag, since a tag is not what supersession collapses on and would misreport if
+ * it ever drifted from the identity key.
+ *
+ * SETTINGS. `EnableRetrievalSupersessionCollapse` is read straight from `getSettingsValue` by
+ * `semanticDataLakeSearch`'s caller (this script passes the read-back value explicitly, matching how
+ * every real caller reads it once and passes it in - `semanticDataLakeSearch` itself never reads
+ * settings). Toggling it in Mongo and dropping the settings cache (exactly as `recall-probe.ts` does
+ * for its own two knobs) takes effect on the very next in-process call; this script also reads the
+ * value BACK through `adminSettingsRepository.getSettingsValue` immediately after writing it and
+ * asserts it matches, so a caching or wiring regression fails loudly here instead of silently
+ * measuring the wrong configuration. The prior value is leased and restored in a `finally` and on
+ * SIGINT/SIGTERM - this stage is shared, and this script must never leave the setting flipped for
+ * anyone else.
+ *
+ * Usage (needs DB + an embedding key, which `sst shell` provides):
+ *   for-env dev pnpm sst shell --stage dev -- tsx packages/scripts/retrieval/supersession-probe.ts
+ *
+ * No CLI flags: the probe user, lake and documents are fixed and idempotent (see SETUP below), so
+ * the whole thing is safe to re-run - every run deletes and recreates its own FabFiles first.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Resource } from 'sst';
+import {
+  AdminSettings,
+  FabFile,
+  adminSettingsRepository,
+  apiKeyRepository,
+  connectDB,
+  dataLakeRepository,
+  fabFileChunkRepository,
+  fabFileRepository,
+  organizationRepository,
+  userRepository,
+} from '@bike4mind/database';
+import { getSettingsByNames, invalidateScopedSettingsCache, invalidateSettingsCache } from '@bike4mind/utils';
+import { Logger } from '@bike4mind/observability';
+import { apiKeyService, dataLakeService, userService } from '@bike4mind/services';
+import { EmbeddingFactory, getProviderFromModel } from '@bike4mind/fab-pipeline';
+import {
+  KnowledgeType,
+  countCodePoints,
+  isSupportedEmbeddingModel,
+  type IFabFileChunkDocument,
+  type IUserDocument,
+  type SettingKey,
+  type SupportedEmbeddingModel,
+} from '@bike4mind/common';
+
+/** This file is packages/scripts/retrieval/, so the package root is two levels up. */
+const SCRIPTS_PACKAGE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const logger = new Logger();
+
+// ---------------------------------------------------------------------------
+// Fixed, idempotent test-data identity - all obviously probe-owned.
+// ---------------------------------------------------------------------------
+
+const LAKE_SLUG = 'supersession-probe';
+const DATALAKE_TAG = `datalake:${LAKE_SLUG}`;
+const FILE_TAG_PREFIX = 'supersession:';
+
+const PROBE_USER_USERNAME = 'supersession-probe';
+const PROBE_USER_EMAIL = 'supersession-probe@test.com';
+const PROBE_USER_NAME = 'Supersession Probe (retrieval test data - safe to delete)';
+
+/** How much older the OLD generation is stamped, in days. Comfortably outside any clock skew. */
+const OLD_GENERATION_AGE_DAYS = 90;
+
+const COLLAPSE_SETTING: SettingKey = 'EnableRetrievalSupersessionCollapse';
+
+/** This script's own settings-lease row, distinct from recall-probe.ts's, so the two never
+ *  contend with each other over an unrelated setting. */
+const LEASE_SETTING = '__supersessionProbeLease';
+const LEASE_STALE_AFTER_MS = 30 * 60 * 1000;
+
+type Generation = 'OLD' | 'NEW';
+
+/**
+ * One document, seeded as two FabFiles under the same `fileName`. `query` is phrased close to
+ * `oldText`'s own wording (design rule: the OLD generation must score at least as well as NEW, so a
+ * shift toward NEW after collapse is attributable to the setting, not to ranking already preferring
+ * it). Real policy-style content, not lorem ipsum, so the embedding model has something to grip.
+ */
+type ProbeDoc = {
+  fileName: string;
+  oldText: string;
+  newText: string;
+  query: string;
+};
+
+const PROBE_DOCS: ProbeDoc[] = [
+  {
+    fileName: 'Expense Policy.txt',
+    oldText: 'The expense reimbursement limit is $500 per month.',
+    newText: 'The expense reimbursement limit is $750 per month, effective 2026.',
+    query: 'What is the expense reimbursement limit?',
+  },
+  {
+    fileName: 'PTO Carryover.txt',
+    oldText: 'Employees may carry over up to 5 unused PTO days into the next calendar year.',
+    newText: 'Employees may carry over up to 10 unused PTO days into the next calendar year, effective 2026.',
+    query: 'How many unused PTO days can employees carry over into the next year?',
+  },
+  {
+    fileName: 'Laptop Refresh.txt',
+    oldText: 'Company laptops are refreshed every 4 years.',
+    newText: 'Company laptops are refreshed every 3 years, effective 2026.',
+    query: 'How often are company laptops refreshed?',
+  },
+];
+
+/** What seeding recorded about one FabFile, so attribution never has to re-derive it from a tag. */
+type SeededFile = {
+  fabFileId: string;
+  fileName: string;
+  generation: Generation;
+  docIndex: number;
+};
+
+// ---------------------------------------------------------------------------
+// Settings lease (single setting) - same mechanics as recall-probe.ts's acquireSettingsLease,
+// narrowed to the one knob this probe touches.
+// ---------------------------------------------------------------------------
+
+async function readSetting(name: string): Promise<string | null> {
+  const row = await AdminSettings.findOne({ settingName: name }).lean<{ settingValue?: string } | null>();
+  return row?.settingValue ?? null;
+}
+
+/**
+ * Write a setting and drop the in-process settings caches, exactly as recall-probe.ts's
+ * `writeSetting` does - including the hard-delete path, for the same reason: the soft-delete
+ * plugin does not hook `updateOne`/`findOneAndUpdate`, so a plain `deleteOne` would tombstone a row
+ * that still carries this probe's last value and break every future read AND write of this setting
+ * on the stage. See `AdminSettingsModel.ts` (`softDeletePlugin`) and `db-core/src/utils/mongo.ts`.
+ */
+async function writeSetting(name: string, value: string | null): Promise<void> {
+  if (value === null) {
+    await AdminSettings.deleteOne({ settingName: name }, { hardDelete: true });
+  } else {
+    await AdminSettings.updateOne({ settingName: name }, { $set: { settingValue: value, deletedAt: null } }, { upsert: true });
+  }
+  invalidateSettingsCache();
+  invalidateScopedSettingsCache();
+}
+
+/**
+ * `getSettingsValue` is typed as the union of EVERY admin setting's value shape, so it does not
+ * narrow to this setting's boolean on its own. Narrow it here rather than casting: if the row ever
+ * holds a non-boolean, the probe must refuse to measure instead of coercing it and reporting a
+ * config it never actually exercised.
+ */
+async function readCollapseSettingAsBoolean(): Promise<boolean> {
+  const raw: unknown = await adminSettingsRepository.getSettingsValue(COLLAPSE_SETTING);
+  if (raw === undefined || raw === null) return false;
+  if (typeof raw !== 'boolean') {
+    throw new Error(
+      `${COLLAPSE_SETTING} read back as a non-boolean (${typeof raw}: ${String(raw)}). Refusing to ` +
+        `measure: the probe cannot establish whether collapse was on for this configuration.`
+    );
+  }
+  return raw;
+}
+
+async function acquireCollapseSettingLease(): Promise<{ originalValue: string | null; restore: () => Promise<void> }> {
+  const holder = `${process.pid}@supersession-probe`;
+  const now = Date.now();
+
+  let acquired = false;
+  try {
+    const result = await AdminSettings.updateOne(
+      { settingName: LEASE_SETTING },
+      { $setOnInsert: { settingValue: JSON.stringify({ holder, startedAt: now }), deletedAt: null } },
+      { upsert: true }
+    );
+    acquired = result.upsertedCount === 1;
+  } catch {
+    acquired = false;
+  }
+
+  if (!acquired) {
+    const existing = await readSetting(LEASE_SETTING);
+    let startedAt = 0;
+    try {
+      startedAt = Number(JSON.parse(existing ?? '{}')?.startedAt ?? 0);
+    } catch {
+      startedAt = 0;
+    }
+    const ageMs = now - startedAt;
+    const staleHint =
+      startedAt > 0 && ageMs > LEASE_STALE_AFTER_MS
+        ? ` That lease is older than ${LEASE_STALE_AFTER_MS / 60_000} minutes, so the run holding it probably ` +
+          `died. Confirm no probe is running, verify ${COLLAPSE_SETTING} by hand, then clear the ` +
+          `"${LEASE_SETTING}" row to release it.`
+        : '';
+    throw new Error(
+      `Another supersession-probe run holds the settings lease on this stage (${existing ?? 'holder unknown'}). ` +
+        `Refusing to start: a second run would capture the first run's mutated ${COLLAPSE_SETTING} as its ` +
+        `baseline and restore that on exit, permanently discarding the stage's real configuration.${staleHint}`
+    );
+  }
+
+  const originalValue = await readSetting(COLLAPSE_SETTING);
+
+  let inFlight: Promise<void> | null = null;
+  const runRestore = async (): Promise<void> => {
+    try {
+      await writeSetting(COLLAPSE_SETTING, originalValue);
+      logger.log(`Restored ${COLLAPSE_SETTING} to ${originalValue === null ? '(unset)' : originalValue}.`);
+    } catch (err) {
+      logger.error(
+        `FAILED to restore ${COLLAPSE_SETTING} to ${originalValue === null ? '(unset)' : originalValue} on stage ` +
+          `${Resource.App.stage}. Restore it BY HAND before anyone else relies on this setting.`,
+        err
+      );
+    }
+    try {
+      await writeSetting(LEASE_SETTING, null);
+    } catch (err) {
+      logger.warn(`Could not release the "${LEASE_SETTING}" row. Clear it by hand before the next run.`, err);
+    }
+  };
+  const restore = (): Promise<void> => (inFlight ??= runRestore());
+
+  const onSignal = (signal: NodeJS.Signals): void => {
+    void (async () => {
+      logger.warn(`\nReceived ${signal}. Restoring ${COLLAPSE_SETTING} before exiting.`);
+      await restore();
+      process.removeListener('SIGINT', onSignal);
+      process.removeListener('SIGTERM', onSignal);
+      process.kill(process.pid, signal);
+    })();
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+
+  return {
+    originalValue,
+    restore: async () => {
+      process.removeListener('SIGINT', onSignal);
+      process.removeListener('SIGTERM', onSignal);
+      await restore();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup: probe user, lake, and the six FabFiles (idempotent).
+// ---------------------------------------------------------------------------
+
+async function findOrCreateProbeUser(): Promise<IUserDocument> {
+  const existing = await userRepository.findByEmail(PROBE_USER_EMAIL);
+  if (existing) {
+    logger.log(`Reusing probe user ${existing.id} (${PROBE_USER_EMAIL}).`);
+    return existing;
+  }
+  // userService.createUser fills in every other required IUser field with the same defaults the
+  // real signup path uses (see b4m-core/services/src/userService/create.ts) - reused rather than
+  // reimplemented so this script never has to independently guess IUser's required shape.
+  const created = await userService.createUser(
+    {
+      username: PROBE_USER_USERNAME,
+      email: PROBE_USER_EMAIL,
+      name: PROBE_USER_NAME,
+      tags: ['test-data'],
+      emailVerified: true,
+    },
+    { db: { users: userRepository } }
+  );
+  logger.log(`Created probe user ${created.id} (${PROBE_USER_EMAIL}).`);
+  return created as IUserDocument;
+}
+
+async function findOrCreateProbeLake(userId: string): Promise<{ lakeId: string }> {
+  const existing = await dataLakeRepository.findBySlug(LAKE_SLUG);
+  if (existing) {
+    if (existing.status !== 'active') {
+      logger.log(`Reactivating data lake "${LAKE_SLUG}" (was ${existing.status}).`);
+      await dataLakeRepository.update({ id: existing.id, status: 'active' });
+    } else {
+      logger.log(`Reusing data lake "${LAKE_SLUG}" (${existing.id}).`);
+    }
+    return { lakeId: existing.id };
+  }
+  const created = await dataLakeRepository.create({
+    name: 'Supersession Probe',
+    slug: LAKE_SLUG,
+    description: 'One-off measurement lake for the supersession-collapse probe. Safe to delete.',
+    fileTagPrefix: FILE_TAG_PREFIX,
+    datalakeTag: DATALAKE_TAG,
+    createdByUserId: userId,
+    status: 'active',
+  });
+  logger.log(`Created data lake "${LAKE_SLUG}" (${created.id}).`);
+  return { lakeId: created.id };
+}
+
+/** Idempotency: wipe any FabFiles (and their chunks) this probe left behind on a prior run. */
+async function clearPreviousRun(): Promise<void> {
+  const existingIds = await fabFileRepository.findIdsByDataLakeTag({ kind: 'registry', datalakeTag: DATALAKE_TAG });
+  if (existingIds.length === 0) return;
+  logger.log(`Removing ${existingIds.length} FabFile(s) from a previous run...`);
+  for (const id of existingIds) await fabFileChunkRepository.deleteManyByFabFileId(id);
+  await fabFileRepository.deleteManyInIds(existingIds);
+}
+
+/**
+ * Backdate the OLD generation's `createdAt` with the raw Mongoose model, bypassing the
+ * `timestamps: true` hook via `{ timestamps: false }`, then READ IT BACK. `fabFileRepository.create`
+ * cannot do this itself - its signature is `Omit<T, 'id' | 'updatedAt' | 'createdAt'>`
+ * (`b4m-core/db-core/src/models/BaseModel.ts`), which exists specifically so Mongoose's own
+ * timestamp hook stamps every normal write. Unverified in code review, so it is verified HERE,
+ * at runtime, every run: if the write did not stick, the two generations are not actually
+ * distinguishable by age and the whole comparison would be silently measuring nothing.
+ */
+async function backdateAndVerify(fabFileId: string, fileName: string): Promise<Date> {
+  const backdatedAt = new Date(Date.now() - OLD_GENERATION_AGE_DAYS * 24 * 60 * 60 * 1000);
+  // Native driver, NOT FabFile.updateOne({ timestamps: false }): the Mongoose option does not
+  // suppress the timestamp hook here (verified against stage dev - the read-back below caught it
+  // stamping createdAt to now). Going through .collection bypasses all Mongoose middleware, which
+  // is the only reliable way to force an explicit createdAt on a `timestamps: true` schema.
+  await FabFile.collection.updateOne(
+    { _id: new FabFile.base.Types.ObjectId(fabFileId) },
+    { $set: { createdAt: backdatedAt } }
+  );
+
+  const verifyDoc = await FabFile.findById(fabFileId).lean<{ createdAt?: Date } | null>();
+  const persistedMs = verifyDoc?.createdAt ? new Date(verifyDoc.createdAt).getTime() : NaN;
+  const driftMs = Number.isFinite(persistedMs) ? Math.abs(persistedMs - backdatedAt.getTime()) : Infinity;
+
+  if (driftMs > 5_000) {
+    throw new Error(
+      `Backdating createdAt did NOT persist for FabFile ${fabFileId} ("${fileName}", OLD generation). ` +
+        `Expected ~${backdatedAt.toISOString()}, read back ${verifyDoc?.createdAt ?? 'undefined'}. Refusing to ` +
+        `continue: the OLD and NEW generations would not be distinguishable by age, and ` +
+        `partitionBySupersession's "newest wins" rule (see supersession.ts) would then pick a winner at ` +
+        `random rather than by generation - the measurement would be garbage, not a real comparison.`
+    );
+  }
+  logger.log(`  backdated + verified: ${fileName} (OLD) createdAt = ${verifyDoc?.createdAt?.toString()}`);
+  return backdatedAt;
+}
+
+type EmbeddingHandle = {
+  embeddingModel: string;
+  generateEmbedding: (text: string) => Promise<number[]>;
+};
+
+/** Mirrors ingest-help-datalake.ts's credential resolution exactly, for the probe user. */
+async function resolveEmbeddingHandle(userId: string): Promise<EmbeddingHandle> {
+  const embeddingModelRaw = await adminSettingsRepository.getSettingsValue('defaultEmbeddingModel');
+  if (!embeddingModelRaw || !isSupportedEmbeddingModel(embeddingModelRaw)) {
+    throw new Error(`defaultEmbeddingModel is unset or unsupported on this stage: ${String(embeddingModelRaw)}`);
+  }
+  const embeddingModel = embeddingModelRaw;
+
+  const apiKeyTable = await apiKeyService.getEffectiveLLMApiKeys(userId, {
+    db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository },
+    getSettingsByNames,
+  });
+  const provider = getProviderFromModel(embeddingModel);
+  const embeddingConfig: { openaiApiKey?: string | null; voyageApiKey?: string | null; ollamaBaseUrl?: string | null } = {};
+  if (provider === 'openai') {
+    embeddingConfig.openaiApiKey = apiKeyTable?.openai;
+    if (!embeddingConfig.openaiApiKey) throw new Error(`No OpenAI API key resolved for user ${userId}.`);
+  } else if (provider === 'voyageai') {
+    embeddingConfig.voyageApiKey = apiKeyTable?.voyageai;
+    if (!embeddingConfig.voyageApiKey) throw new Error(`No Voyage API key resolved for user ${userId}.`);
+  } else if (provider === 'ollama') {
+    embeddingConfig.ollamaBaseUrl = apiKeyTable?.ollama;
+    if (!embeddingConfig.ollamaBaseUrl) throw new Error(`No Ollama base URL resolved for user ${userId}.`);
+  }
+  // Other providers (e.g. Bedrock) are keyless/IAM-based and need no credential here - same
+  // guard as ingest-help-datalake.ts.
+  const embeddingService = new EmbeddingFactory(embeddingConfig).createEmbeddingService(embeddingModel);
+  return {
+    embeddingModel,
+    generateEmbedding: (text: string) => embeddingService.generateEmbedding(text),
+  };
+}
+
+/** Rough token estimate (chars/4); parity with ingest-help-datalake.ts's heuristic. */
+const estimateTokens = (text: string): number => Math.max(1, Math.ceil(text.length / 4));
+
+async function seedOneGeneration(
+  doc: ProbeDoc,
+  generation: Generation,
+  text: string,
+  userId: string,
+  embedding: EmbeddingHandle,
+  docIndex: number
+): Promise<SeededFile> {
+  const vector = await embedding.generateEmbedding(text);
+  const now = new Date();
+  const chunkPayload: Omit<IFabFileChunkDocument, 'id'> = {
+    fabFileId: '',
+    text,
+    tokenCount: estimateTokens(text),
+    charLength: countCodePoints(text),
+    vector,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const fabFile = await fabFileRepository.create({
+    userId,
+    fileName: doc.fileName,
+    fileSize: Buffer.byteLength(text),
+    mimeType: 'text/plain',
+    type: KnowledgeType.TEXT,
+    tags: [
+      { name: DATALAKE_TAG, strength: 1 },
+      // Same content tag on both generations - a re-upload of the same document keeps the same
+      // tag in real usage. Generation is tracked in-memory (SeededFile), never via a tag, so
+      // attribution below cannot accidentally read this as the identity signal.
+      { name: `${FILE_TAG_PREFIX}${docIndex}`, strength: 1 },
+    ],
+    primaryTag: DATALAKE_TAG,
+    system: true,
+    chunked: true,
+    chunkCount: 1,
+    chunkedCharCount: chunkPayload.charLength ?? 0,
+    vectorized: true,
+    vectorizedChunkCount: 1,
+    embeddingModel: embedding.embeddingModel,
+    status: 'complete',
+    isGlobalRead: true,
+    isGlobalWrite: false,
+    users: [],
+    groups: [],
+  });
+
+  await fabFileChunkRepository.bulkInsert([{ ...chunkPayload, fabFileId: fabFile.id }]);
+
+  if (generation === 'OLD') {
+    await backdateAndVerify(fabFile.id, doc.fileName);
+  }
+
+  return { fabFileId: fabFile.id, fileName: doc.fileName, generation, docIndex };
+}
+
+async function seedCorpus(userId: string): Promise<SeededFile[]> {
+  const embedding = await resolveEmbeddingHandle(userId);
+  logger.log(`Embedding model: ${embedding.embeddingModel}`);
+
+  const seeded: SeededFile[] = [];
+  for (let docIndex = 0; docIndex < PROBE_DOCS.length; docIndex++) {
+    const doc = PROBE_DOCS[docIndex];
+    logger.log(`Seeding "${doc.fileName}"...`);
+    // NEW first, then OLD: order does not matter to Mongo, but seeding NEW first means a failure
+    // partway through never leaves an OLD generation backdated with no NEW sibling to compare it to.
+    seeded.push(await seedOneGeneration(doc, 'NEW', doc.newText, userId, embedding, docIndex));
+    seeded.push(await seedOneGeneration(doc, 'OLD', doc.oldText, userId, embedding, docIndex));
+  }
+  return seeded;
+}
+
+// ---------------------------------------------------------------------------
+// Lake scope + credentials for semanticDataLakeSearch - resolved the same way the known-working
+// callers do (apps/client/pages/api/data-lakes/semantic-search.ts), not invented here.
+// ---------------------------------------------------------------------------
+
+const SEARCH_TOP_K = 20;
+const SEARCH_MIN_SCORE = 0;
+
+type ProbeScope = {
+  dataLakeTags: string[];
+  dataLakeTagPrefixes: string[];
+  lakeMemberships: ReturnType<typeof dataLakeService.lakeMembershipsFrom>;
+  lakes: Parameters<typeof dataLakeService.semanticDataLakeSearch>[0]['lakes'];
+};
+
+/**
+ * `getDynamicDataLakeAccess` is the core resolver both `resolveRetrievalLakeScope` (the semantic-
+ * search route) and the chat tool's `resolveSessionLakeAccess` sit on top of - calling it directly
+ * for the probe user reproduces the same lake scope those callers would get, without needing an
+ * Express request to hang it off. `lakes` is passed straight through to `semanticDataLakeSearch`
+ * as `AttributableLake[]`; `ResolvedLakeAccess` is a strict superset of that shape.
+ */
+async function resolveProbeScope(user: IUserDocument): Promise<ProbeScope> {
+  const access = await dataLakeService.getDynamicDataLakeAccess({
+    db: {
+      dataLakes: dataLakeRepository,
+      organizations: organizationRepository,
+    },
+    user: { id: user.id, tags: user.tags ?? [] },
+  });
+  const lakeMemberships = dataLakeService.lakeMembershipsFrom(access.lakes);
+  dataLakeService.warnIfManyLakeMemberships(lakeMemberships, logger, 'supersession-probe');
+  return {
+    dataLakeTags: access.dataLakeTags,
+    dataLakeTagPrefixes: access.dataLakeTagPrefixes,
+    lakeMemberships,
+    lakes: access.lakes,
+  };
+}
+
+type ApiKeyTable = { openai?: string | null; voyageai?: string | null; ollama?: string | null };
+
+/** Same shape semantic-search.ts builds: all three keys, not narrowed to the embedding model's own
+ *  provider - semanticDataLakeSearch can embed an ALTERNATE model under a different provider. */
+async function resolveApiKeyTable(userId: string): Promise<ApiKeyTable> {
+  const effectiveKeys = await apiKeyService.getEffectiveLLMApiKeys(userId, {
+    db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository },
+    getSettingsByNames,
+  });
+  return {
+    openai: effectiveKeys?.openai,
+    voyageai: effectiveKeys?.voyageai,
+    ollama: effectiveKeys?.ollama,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// One query -> chunk-level attribution, via semanticDataLakeSearch directly.
+// ---------------------------------------------------------------------------
+
+type ChunkAttribution = {
+  chunkId: string;
+  fabFileId: string;
+  fileName: string;
+  generation: Generation | 'UNKNOWN';
+  score: number;
+};
+
+type SupersessionSummary = {
+  count: number;
+  sample: { fileId: string; fileName?: string; tier: string; supersededBy: string }[];
+};
+
+type QueryResult = {
+  docIndex: number;
+  fileName: string;
+  query: string;
+  chunks: ChunkAttribution[];
+  supersession: SupersessionSummary;
+};
+
+async function runQuery(
+  doc: ProbeDoc,
+  docIndex: number,
+  user: IUserDocument,
+  scope: ProbeScope,
+  embeddingModel: SupportedEmbeddingModel,
+  apiKeyTable: ApiKeyTable,
+  byFabFileId: Map<string, SeededFile>
+): Promise<QueryResult> {
+  const search = await dataLakeService.semanticDataLakeSearch(
+    {
+      userId: user.id,
+      userGroups: user.groups ?? [],
+      query: doc.query,
+      topK: SEARCH_TOP_K,
+      minScore: SEARCH_MIN_SCORE,
+      embeddingModel,
+      apiKeyTable,
+      dataLakeTags: scope.dataLakeTags,
+      dataLakeTagPrefixes: scope.dataLakeTagPrefixes,
+      lakeMemberships: scope.lakeMemberships,
+      lakes: scope.lakes,
+      supersessionCollapseEnabled: await readCollapseSettingAsBoolean(),
+      logger,
+    },
+    {
+      db: { fabfiles: fabFileRepository, fabfilechunks: fabFileChunkRepository },
+    }
+  );
+
+  const chunks: ChunkAttribution[] = search.results.map(r => {
+    const meta = byFabFileId.get(r.fileId);
+    return {
+      chunkId: r.chunkId,
+      fabFileId: r.fileId,
+      fileName: meta?.fileName ?? r.fileName,
+      generation: meta?.generation ?? 'UNKNOWN',
+      score: r.score,
+    };
+  });
+
+  return {
+    docIndex,
+    fileName: doc.fileName,
+    query: doc.query,
+    chunks,
+    supersession: {
+      count: search.supersession.count,
+      sample: search.supersession.sample.map(s => ({
+        fileId: s.fileId,
+        fileName: s.fileName,
+        tier: s.tier,
+        supersededBy: s.supersededBy,
+      })),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+type ConfigRun = {
+  collapseEnabled: boolean;
+  queries: QueryResult[];
+};
+
+function printConfigTable(run: ConfigRun): { oldCount: number; newCount: number; supersededCount: number } {
+  let oldCount = 0;
+  let newCount = 0;
+  let supersededCount = 0;
+  logger.log(`\n--- collapse=${run.collapseEnabled ? 'on' : 'off'} ---`);
+  logger.log(['docIndex', 'fileName', 'generation', 'score', 'fabFileId', 'chunkId'].join('  |  '));
+  for (const q of run.queries) {
+    if (q.chunks.length === 0) {
+      logger.log(`  (query "${q.query}" -> no chunks served)`);
+    }
+    for (const c of q.chunks) {
+      if (c.generation === 'OLD') oldCount++;
+      if (c.generation === 'NEW') newCount++;
+      logger.log(
+        [String(q.docIndex), c.fileName, c.generation, c.score.toFixed(4), c.fabFileId, c.chunkId].join('  |  ')
+      );
+    }
+    supersededCount += q.supersession.count;
+    if (q.supersession.count > 0) {
+      logger.log(
+        `  supersession (doc ${q.docIndex}): ${q.supersession.count} suppressed - ` +
+          q.supersession.sample
+            .map(s => `${s.fileName ?? s.fileId} (tier=${s.tier}, kept ${s.supersededBy})`)
+            .join('; ')
+      );
+    }
+  }
+  logger.log(
+    `collapse=${run.collapseEnabled ? 'on ' : 'off'}  ${oldCount + newCount} chunks: ${oldCount} old / ${newCount} new` +
+      `  (${supersededCount} superseded across ${run.queries.length} queries)`
+  );
+  return { oldCount, newCount, supersededCount };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function runOneConfig(
+  collapseEnabled: boolean,
+  user: IUserDocument,
+  scope: ProbeScope,
+  embeddingModel: SupportedEmbeddingModel,
+  apiKeyTable: ApiKeyTable,
+  byFabFileId: Map<string, SeededFile>
+): Promise<ConfigRun> {
+  await writeSetting(COLLAPSE_SETTING, String(collapseEnabled));
+
+  // Read the setting back through the product's OWN accessor (not the raw row) and assert it
+  // matches what was just written. This is what preserves the claim that the flag read is wired to
+  // behavior, now that the boolean is passed to semanticDataLakeSearch explicitly rather than read
+  // by the tool itself - a caching or wiring regression must fail loudly here, not measure silently.
+  const readBack = await readCollapseSettingAsBoolean();
+  if (readBack !== collapseEnabled) {
+    throw new Error(
+      `Wrote ${COLLAPSE_SETTING}=${collapseEnabled} but adminSettingsRepository.getSettingsValue read back ` +
+        `${String(readBack)}. The setting is not wired the way this probe assumes - refusing to measure this ` +
+        `configuration.`
+    );
+  }
+
+  const queries: QueryResult[] = [];
+  for (let docIndex = 0; docIndex < PROBE_DOCS.length; docIndex++) {
+    queries.push(
+      await runQuery(PROBE_DOCS[docIndex], docIndex, user, scope, embeddingModel, apiKeyTable, byFabFileId)
+    );
+  }
+
+  const totalChunks = queries.reduce((sum, q) => sum + q.chunks.length, 0);
+  if (totalChunks === 0) {
+    throw new Error(
+      `collapse=${collapseEnabled} returned ZERO chunks across all ${queries.length} queries. That is not a ` +
+        `valid "collapse suppressed everything" result - minScore is ${SEARCH_MIN_SCORE} and topK is ` +
+        `${SEARCH_TOP_K}, so an empty result means the corpus or lake scope is wrong (dataLakeTags: ` +
+        `${scope.dataLakeTags.join(', ') || '(none)'}), not that collapse worked. Refusing to report a ` +
+        `zero-vs-zero comparison as a pass.`
+    );
+  }
+
+  return { collapseEnabled, queries };
+}
+
+async function main(): Promise<void> {
+  await connectDB(Resource.MONGODB_URI.value.replace('%STAGE%', Resource.App.stage));
+  logger.log(`Connected (stage: ${Resource.App.stage})`);
+
+  const user = await findOrCreateProbeUser();
+  await findOrCreateProbeLake(user.id);
+  await clearPreviousRun();
+
+  const seeded = await seedCorpus(user.id);
+  const byFabFileId = new Map<string, SeededFile>(seeded.map(f => [f.fabFileId, f]));
+  logger.log(`Seeded ${seeded.length} FabFiles (${PROBE_DOCS.length} documents x 2 generations).`);
+
+  const embeddingModelRaw = await adminSettingsRepository.getSettingsValue('defaultEmbeddingModel');
+  if (!embeddingModelRaw || !isSupportedEmbeddingModel(embeddingModelRaw)) {
+    throw new Error(`defaultEmbeddingModel is unset or unsupported on this stage: ${String(embeddingModelRaw)}`);
+  }
+  const embeddingModel = embeddingModelRaw;
+  const apiKeyTable = await resolveApiKeyTable(user.id);
+  const scope = await resolveProbeScope(user);
+  if (scope.dataLakeTags.length === 0) {
+    throw new Error(
+      `Probe user ${user.id} resolves to zero accessible data lakes (getDynamicDataLakeAccess returned an ` +
+        `empty dataLakeTags). The probe lake "${LAKE_SLUG}" should be owner-reachable regardless of gating - ` +
+        `check that dataLakeRepository.create persisted createdByUserId correctly.`
+    );
+  }
+  logger.log(`Lake scope: dataLakeTags=[${scope.dataLakeTags.join(', ')}], embeddingModel=${embeddingModel}`);
+
+  const { originalValue, restore } = await acquireCollapseSettingLease();
+  logger.log(`Leased ${COLLAPSE_SETTING} (was ${originalValue === null ? '(unset)' : originalValue}).`);
+
+  // Definite-assignment (`!`): both are set inside the try block below, before any of their reads
+  // - if the try throws before either assignment, `finally` still runs (restoring the setting) and
+  // then the throw propagates, so the reads after the block are never reached in that case.
+  let offRun!: ConfigRun;
+  let onRun!: ConfigRun;
+  let offSummary!: { oldCount: number; newCount: number; supersededCount: number };
+  let onSummary!: { oldCount: number; newCount: number; supersededCount: number };
+
+  try {
+    offRun = await runOneConfig(false, user, scope, embeddingModel, apiKeyTable, byFabFileId);
+    offSummary = printConfigTable(offRun);
+
+    onRun = await runOneConfig(true, user, scope, embeddingModel, apiKeyTable, byFabFileId);
+    onSummary = printConfigTable(onRun);
+  } finally {
+    await restore();
+  }
+
+  logger.log('\n=== Summary ===');
+  logger.log(
+    `collapse=off  ${offSummary.oldCount + offSummary.newCount} chunks: ${offSummary.oldCount} old / ` +
+      `${offSummary.newCount} new  (${offSummary.supersededCount} superseded)`
+  );
+  logger.log(
+    `collapse=on   ${onSummary.oldCount + onSummary.newCount} chunks: ${onSummary.oldCount} old / ` +
+      `${onSummary.newCount} new  (${onSummary.supersededCount} superseded)`
+  );
+
+  const results = { off: offRun, on: onRun };
+  const summary = { off: offSummary, on: onSummary };
+
+  const outDir = path.resolve(SCRIPTS_PACKAGE_DIR, 'out');
+  mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, 'supersession-probe.json');
+  writeFileSync(
+    outPath,
+    JSON.stringify(
+      {
+        lakeSlug: LAKE_SLUG,
+        probeUserId: user.id,
+        embeddingModel,
+        seededFiles: seeded,
+        results,
+        summary,
+      },
+      null,
+      2
+    )
+  );
+  logger.log(`Wrote ${outPath}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    logger.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });

--- a/packages/scripts/retrieval/supersessionAttribution.test.ts
+++ b/packages/scripts/retrieval/supersessionAttribution.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertAllAttributed,
+  attributeChunks,
+  tallyGenerations,
+  type ChunkAttribution,
+  type SearchHit,
+  type SeededFile,
+} from './supersessionAttribution';
+
+const seeded = (fabFileId: string, generation: 'OLD' | 'NEW'): SeededFile => ({
+  fabFileId,
+  fileName: 'Expense Policy.txt',
+  generation,
+  docIndex: 0,
+});
+
+const hit = (chunkId: string, fileId: string, overrides: Partial<SearchHit> = {}): SearchHit => ({
+  chunkId,
+  fileId,
+  fileName: 'Expense Policy.txt',
+  score: 0.9,
+  ...overrides,
+});
+
+const chunk = (generation: ChunkAttribution['generation'], fabFileId = 'f1'): ChunkAttribution => ({
+  chunkId: `c-${fabFileId}`,
+  fabFileId,
+  fileName: 'Expense Policy.txt',
+  generation,
+  score: 0.9,
+});
+
+const byId = (...files: SeededFile[]) => new Map(files.map(f => [f.fabFileId, f]));
+
+describe('attributeChunks', () => {
+  it('attributes a hit to the generation seeding recorded for its fileId', () => {
+    const chunks = attributeChunks(
+      [hit('c1', 'old-1'), hit('c2', 'new-1')],
+      byId(seeded('old-1', 'OLD'), seeded('new-1', 'NEW'))
+    );
+    expect(chunks.map(c => c.generation)).toEqual(['OLD', 'NEW']);
+  });
+
+  it('marks a hit from an unseeded file UNKNOWN rather than guessing a generation', () => {
+    const chunks = attributeChunks([hit('c1', 'stranger')], byId(seeded('old-1', 'OLD')));
+    expect(chunks[0]).toMatchObject({ generation: 'UNKNOWN', fabFileId: 'stranger' });
+  });
+
+  it('prefers the seeded fileName over the search result, so a mid-run rename cannot split a document', () => {
+    const chunks = attributeChunks([hit('c1', 'old-1', { fileName: 'Renamed.txt' })], byId(seeded('old-1', 'OLD')));
+    expect(chunks[0].fileName).toBe('Expense Policy.txt');
+  });
+
+  it('falls back to the search result fileName when there is nothing seeded to name it', () => {
+    const chunks = attributeChunks([hit('c1', 'stranger', { fileName: 'Other Lake.txt' })], byId());
+    expect(chunks[0].fileName).toBe('Other Lake.txt');
+  });
+
+  it('carries chunkId and score through untouched', () => {
+    const chunks = attributeChunks([hit('c1', 'old-1', { score: 0.4242 })], byId(seeded('old-1', 'OLD')));
+    expect(chunks[0]).toMatchObject({ chunkId: 'c1', score: 0.4242 });
+  });
+});
+
+describe('assertAllAttributed', () => {
+  it('passes on a clean run', () => {
+    expect(() => assertAllAttributed([chunk('OLD', 'a'), chunk('NEW', 'b')], 'collapse=off')).not.toThrow();
+  });
+
+  it('passes on an empty result, which the probe guards separately', () => {
+    expect(() => assertAllAttributed([], 'collapse=on')).not.toThrow();
+  });
+
+  it('refuses a run carrying an unattributed chunk, naming the offending file', () => {
+    expect(() => assertAllAttributed([chunk('NEW', 'b'), chunk('UNKNOWN', 'stranger')], 'collapse=on')).toThrow(
+      /stranger/
+    );
+  });
+
+  it('names the context so the operator knows which configuration was contaminated', () => {
+    expect(() => assertAllAttributed([chunk('UNKNOWN', 'stranger')], 'collapse=on')).toThrow(/^collapse=on/);
+  });
+
+  it('deduplicates offenders by file, since one file contributes many chunks', () => {
+    const chunks = [
+      { ...chunk('UNKNOWN', 'stranger'), chunkId: 'c1' },
+      { ...chunk('UNKNOWN', 'stranger'), chunkId: 'c2' },
+    ];
+    expect(() => assertAllAttributed(chunks, 'collapse=off')).toThrow(/served 2 chunk\(s\) from 1 FabFile\(s\)/);
+  });
+});
+
+describe('tallyGenerations', () => {
+  it('counts each generation separately', () => {
+    const tally = tallyGenerations([chunk('OLD', 'a'), chunk('OLD', 'b'), chunk('NEW', 'c')]);
+    expect(tally).toEqual({ oldCount: 2, newCount: 1, unknownCount: 0 });
+  });
+
+  it('reports UNKNOWN chunks instead of dropping them, so they cannot hide inside a total', () => {
+    const tally = tallyGenerations([chunk('NEW', 'a'), chunk('UNKNOWN', 'stranger')]);
+    expect(tally).toEqual({ oldCount: 0, newCount: 1, unknownCount: 1 });
+  });
+
+  it('is all zeroes on an empty result', () => {
+    expect(tallyGenerations([])).toEqual({ oldCount: 0, newCount: 0, unknownCount: 0 });
+  });
+});

--- a/packages/scripts/retrieval/supersessionAttribution.test.ts
+++ b/packages/scripts/retrieval/supersessionAttribution.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   assertAllAttributed,
+  assertSupersessionSampleAttributed,
   attributeChunks,
+  supersededCountFor,
   tallyGenerations,
   type ChunkAttribution,
   type SearchHit,
@@ -89,6 +91,18 @@ describe('assertAllAttributed', () => {
     ];
     expect(() => assertAllAttributed(chunks, 'collapse=off')).toThrow(/served 2 chunk\(s\) from 1 FabFile\(s\)/);
   });
+
+  it('enumerates every distinct offender, not just the first, so the operator chases all of them', () => {
+    const chunks = [
+      { ...chunk('UNKNOWN', 'stranger'), chunkId: 'c1' },
+      { ...chunk('UNKNOWN', 'stranger'), chunkId: 'c2' },
+      { ...chunk('UNKNOWN', 'interloper'), chunkId: 'c3' },
+    ];
+    const refuse = () => assertAllAttributed(chunks, 'collapse=off');
+    expect(refuse).toThrow(/served 3 chunk\(s\) from 2 FabFile\(s\)/);
+    expect(refuse).toThrow(/stranger/);
+    expect(refuse).toThrow(/interloper/);
+  });
 });
 
 describe('tallyGenerations', () => {
@@ -104,5 +118,53 @@ describe('tallyGenerations', () => {
 
   it('is all zeroes on an empty result', () => {
     expect(tallyGenerations([])).toEqual({ oldCount: 0, newCount: 0, unknownCount: 0 });
+  });
+});
+
+describe('assertSupersessionSampleAttributed', () => {
+  const sample = (fileId: string, fileName?: string) => ({ fileId, fileName });
+
+  it('passes when every superseded file was seeded by this run', () => {
+    expect(() =>
+      assertSupersessionSampleAttributed([sample('old-1')], byId(seeded('old-1', 'OLD')), 'collapse=on')
+    ).not.toThrow();
+  });
+
+  it('passes on an empty report, which collapse=off produces by definition', () => {
+    expect(() => assertSupersessionSampleAttributed([], byId(seeded('old-1', 'OLD')), 'collapse=off')).not.toThrow();
+  });
+
+  it('refuses a superseded file this run did not seed, since no served chunk can reveal it', () => {
+    expect(() =>
+      assertSupersessionSampleAttributed(
+        [sample('old-1'), sample('foreign-1', 'Other Lake.txt')],
+        byId(seeded('old-1', 'OLD')),
+        'collapse=on'
+      )
+    ).toThrow(/foreign-1/);
+  });
+
+  it('names the context and counts the offenders', () => {
+    expect(() =>
+      assertSupersessionSampleAttributed([sample('foreign-1'), sample('foreign-2')], byId(), 'collapse=on')
+    ).toThrow(/^collapse=on reported 2 superseded file\(s\) from 2 FabFile\(s\)/);
+  });
+});
+
+describe('supersededCountFor', () => {
+  const q = (count: number) => ({ supersession: { count } });
+
+  it('reports the single per-configuration count rather than the sum across queries', () => {
+    expect(supersededCountFor([q(3), q(3), q(3)], 'collapse=on')).toBe(3);
+  });
+
+  it('is zero when a configuration ran no queries', () => {
+    expect(supersededCountFor([], 'collapse=off')).toBe(0);
+  });
+
+  it('refuses a divergent count rather than picking one, naming the query that disagreed', () => {
+    expect(() => supersededCountFor([q(3), q(3), q(4)], 'collapse=on')).toThrow(
+      /query 0 reported 3, query 2 reported 4/
+    );
   });
 });

--- a/packages/scripts/retrieval/supersessionAttribution.ts
+++ b/packages/scripts/retrieval/supersessionAttribution.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure attribution + tallying for `supersession-probe.ts`: which GENERATION served each chunk, and
+ * whether a configuration measured anything at all. Extracted from the probe so the arithmetic the
+ * whole measurement rests on is testable without a live DB or an embedding key, matching the sibling
+ * probe's split (`corpus.ts`, `metrics.ts`, `sweep.ts` next to `recall-probe.ts`).
+ */
+
+/** A generation this probe seeded on purpose. */
+export type Generation = 'OLD' | 'NEW';
+
+/** A seeded generation, or `UNKNOWN` for a served chunk this run did not seed. */
+export type AttributedGeneration = Generation | 'UNKNOWN';
+
+/** What seeding recorded about one FabFile, so attribution never has to re-derive it from a tag. */
+export type SeededFile = {
+  fabFileId: string;
+  fileName: string;
+  generation: Generation;
+  docIndex: number;
+};
+
+export type ChunkAttribution = {
+  chunkId: string;
+  fabFileId: string;
+  fileName: string;
+  generation: AttributedGeneration;
+  score: number;
+};
+
+/** The subset of a `semanticDataLakeSearch` result row that attribution needs. */
+export type SearchHit = {
+  chunkId: string;
+  fileId: string;
+  fileName: string;
+  score: number;
+};
+
+/**
+ * Attribute each served chunk to the generation SEEDING recorded for its `fileId` - never to a tag,
+ * since a tag is not what supersession collapses on and would misreport if it ever drifted from the
+ * identity key.
+ */
+export function attributeChunks(hits: SearchHit[], byFabFileId: Map<string, SeededFile>): ChunkAttribution[] {
+  return hits.map(hit => {
+    const seeded = byFabFileId.get(hit.fileId);
+    return {
+      chunkId: hit.chunkId,
+      fabFileId: hit.fileId,
+      fileName: seeded?.fileName ?? hit.fileName,
+      generation: seeded?.generation ?? 'UNKNOWN',
+      score: hit.score,
+    };
+  });
+}
+
+/**
+ * Refuse to report a configuration that served a chunk this run did not seed. An `UNKNOWN` chunk
+ * counts toward neither generation tally, so tolerating one lets a contaminated run summarise as
+ * `0 old / 0 new` - a stronger-looking version of the very result the probe exists to demonstrate,
+ * which is the direction a failure must never fall. Two ways in: a concurrent run re-seeding the
+ * corpus mid-measurement, and a scope leak (the probe user's resolved lake set is not narrowed to
+ * the probe lake, so any other globally-readable lake on the stage can contribute hits to a
+ * `minScore: 0` search).
+ */
+export function assertAllAttributed(chunks: ChunkAttribution[], context: string): void {
+  const unknown = chunks.filter(c => c.generation === 'UNKNOWN');
+  if (unknown.length === 0) return;
+  const offenders = [...new Set(unknown.map(c => `${c.fabFileId} ("${c.fileName}")`))];
+  throw new Error(
+    `${context} served ${unknown.length} chunk(s) from ${offenders.length} FabFile(s) this run did not seed: ` +
+      `${offenders.join(', ')}. Refusing to measure: an unattributed chunk counts toward neither the OLD nor ` +
+      `the NEW tally, so the summary would understate both. Either another probe run re-seeded the corpus ` +
+      `mid-measurement, or the lake scope reached beyond "supersession-probe".`
+  );
+}
+
+/** Chunk counts per generation. `UNKNOWN` is reported separately so it can never hide inside a total. */
+export function tallyGenerations(chunks: ChunkAttribution[]): {
+  oldCount: number;
+  newCount: number;
+  unknownCount: number;
+} {
+  return {
+    oldCount: chunks.filter(c => c.generation === 'OLD').length,
+    newCount: chunks.filter(c => c.generation === 'NEW').length,
+    unknownCount: chunks.filter(c => c.generation === 'UNKNOWN').length,
+  };
+}

--- a/packages/scripts/retrieval/supersessionAttribution.ts
+++ b/packages/scripts/retrieval/supersessionAttribution.ts
@@ -86,3 +86,61 @@ export function tallyGenerations(chunks: ChunkAttribution[]): {
     unknownCount: chunks.filter(c => c.generation === 'UNKNOWN').length,
   };
 }
+
+/** The part of a per-query supersession report this probe's arithmetic reads. */
+export type SupersededSample = { fileId: string; fileName?: string };
+
+/**
+ * Refuse a supersession report naming a file this run did not seed. `assertAllAttributed` cannot
+ * cover this: superseded files are partitioned OUT before ranking, so they never appear in the
+ * served results at all, and the partition is fed the caller's FULL resolved lake set rather than
+ * just the probe lake. A foreign file PAIR in any other lake in scope therefore inflates the
+ * superseded count with nothing anywhere in the served results to refuse - and it inflates it in
+ * the flattering direction, toward "collapse suppressed more". The upstream sample is capped
+ * (`supersession.ts`), so this is not a complete check on a large corpus; on the six files this
+ * probe seeds it is.
+ */
+export function assertSupersessionSampleAttributed(
+  sample: SupersededSample[],
+  byFabFileId: Map<string, SeededFile>,
+  context: string
+): void {
+  const foreign = sample.filter(s => !byFabFileId.has(s.fileId));
+  if (foreign.length === 0) return;
+  const offenders = [...new Set(foreign.map(s => `${s.fileId} ("${s.fileName ?? '(unnamed)'}")`))];
+  throw new Error(
+    `${context} reported ${foreign.length} superseded file(s) from ${offenders.length} FabFile(s) this run did ` +
+      `not seed: ${offenders.join(', ')}. Refusing to measure: a superseded file never reaches the served ` +
+      `results, so the served-chunk guard cannot see it and the inflated count would print as a larger, ` +
+      `better-looking number. The lake scope reached beyond "supersession-probe".`
+  );
+}
+
+/**
+ * The ONE superseded count for a configuration. `count` is not per-query: `semanticDataLakeSearch`
+ * builds the report from the model-matched scoped file set BEFORE any ranking or scoring
+ * (`semanticDataLakeSearch.ts`), so it does not depend on the query text and every query in a
+ * configuration reports the same number. Summing it across queries multiplies it by the query count
+ * - a 3-document corpus reporting 9 - and the error runs toward looking like collapse suppressed
+ * more than it did, which is the direction that argues for flipping the flag on.
+ *
+ * Divergence REFUSES rather than reconciles. A per-query count would mean the report had moved to
+ * somewhere query-dependent, and this function's whole premise, along with the number the probe
+ * exists to produce, would no longer describe it.
+ */
+export function supersededCountFor(queries: { supersession: { count: number } }[], context: string): number {
+  if (queries.length === 0) return 0;
+  const [first, ...rest] = queries;
+  const expected = first.supersession.count;
+  const divergentIndex = rest.findIndex(q => q.supersession.count !== expected);
+  if (divergentIndex >= 0) {
+    throw new Error(
+      `${context}: the superseded count differs across queries (query 0 reported ${expected}, query ` +
+        `${divergentIndex + 1} reported ${rest[divergentIndex].supersession.count}). This probe reports one ` +
+        `count per configuration because the supersession report is built from the scoped file set before ` +
+        `ranking and cannot depend on the query. If it now does, the reported number no longer means what ` +
+        `this probe claims - refusing to pick one.`
+    );
+  }
+  return expected;
+}


### PR DESCRIPTION
# Pull Request

## Description

Adds a one-off measurement script that answers a question we could not otherwise answer: **does supersession collapse actually change which document generation retrieval serves?**

This exists because issue #2241 ("Weight retrieval ranking by document recency") is gated on a re-measurement, and the baseline that gate was supposed to re-run does not exist anywhere. The score series #2241 quotes appears only in its own body, with no environment, lake, probe query or code path recorded. The one traceable predecessor measurement (the 10/10, 10/10, 7/10 figure in the epic) was retracted by #2235 as "showing scope, not score". So the gate as written -- "re-run the same probe queries on the same path used for the baseline" -- had nothing to re-run.

Rather than close that issue on a code-reading argument, this script constructs the condition on demand and measures it. It is deliberately committed rather than thrown away, because the same instrument is what the `EnableRetrievalSupersessionCollapse` flag flip will need before collapse can be turned on anywhere.

**No runtime behaviour changes.** This adds two files under `packages/scripts/` (plus a test) and touches nothing that ships in an application bundle.

## Changes

- Adds `packages/scripts/retrieval/supersession-probe.ts`. It seeds a dedicated lake with three documents in two generations each (same `fileName`, so the identity key lands on the `fileName` tier), backdates the older generation, then runs identical probe queries through `semanticDataLakeSearch` with `EnableRetrievalSupersessionCollapse` off and then on, reporting generation composition and the supersession report per configuration.
- Adds `packages/scripts/retrieval/supersessionAttribution.ts` and `supersessionAttribution.test.ts`: the pure chunk-to-generation attribution, the refusal on any served chunk the run did not seed, and the per-generation tally. Split out so the arithmetic the whole measurement rests on is unit-testable without a live DB or an embedding key, matching the `corpus.ts` / `metrics.ts` / `sweep.ts` split that already sits next to `recall-probe.ts`.

Two properties of the script are worth stating up front, because they are what make its output trustworthy rather than merely plausible:

- **The settings lease covers the whole run, not just the setting writes.** It is acquired before the script deletes or seeds anything, so a second concurrent run refuses to start before it can disturb the first run's corpus.
- **The lease row is deliberately NOT released if restoring the setting fails.** While the setting is stranded, that row is the only marker that the stage is mid-probe, and it is what stops the next run from adopting the stranded value as its own baseline.

## Guide for Testers

This is a developer script with no UI. It requires the company VPN (the staging Atlas cluster is IP-allowlisted) and AWS credentials for the staging account.

1. Connect to the company VPN.
2. From a clone with `node_modules` installed, run:
   ```
   for-env dev pnpm sst shell --stage dev -- tsx packages/scripts/retrieval/supersession-probe.ts
   ```
3. Expect the run to take roughly 2 minutes and exit 0.
4. Expect a line `Leased EnableRetrievalSupersessionCollapse (was ...)` **first**, before any seeding output. The lease is taken before the script touches shared corpus state, not just before it writes the setting.
5. Expect a line confirming the older generation was backdated and verified, once per document, for example:
   `backdated + verified: Expense Policy.txt (OLD) createdAt = Tue Jun 09 2026 ...`
   If instead it throws `Backdating createdAt did NOT persist`, stop -- the measurement is invalid by design rather than silently comparing two same-age files.
6. Expect two tables, `--- collapse=off ---` and `--- collapse=on ---`, each row showing `docIndex | fileName | generation | score | fabFileId | chunkId`. Every row's `generation` must read `OLD` or `NEW`; the script refuses to report a configuration that served a chunk it did not seed.
7. Expect the final summary to show the old generation present with collapse off and absent with collapse on:
   ```
   collapse=off  18 chunks: 9 old / 9 new  (0 superseded)
   collapse=on   9 chunks: 0 old / 9 new  (3 superseded)
   ```
8. Expect a line `Restored EnableRetrievalSupersessionCollapse to ...` naming the value it put back.
9. Confirm the stage was left clean. The setting must be back to its prior value and no `__supersessionProbeLease` row may remain. If the run was interrupted, expect the same restore line from the SIGINT/SIGTERM handler.
10. Run it a second time. Expect it to reuse the existing probe user and lake, remove the previous run's FabFiles, and produce the same summary -- it is idempotent.

### Regression Checks

None in the product. This adds a script and changes no shipped code path. The only shared state it touches is the `EnableRetrievalSupersessionCollapse` admin setting, which it leases and restores, and its own FabFiles.

To confirm those safety properties specifically:

1. Start the script and interrupt it with Ctrl-C partway through the `collapse=on` table.
2. Expect a `Restored ...` line before the process exits.
3. Query the `AdminSettings` collection for `EnableRetrievalSupersessionCollapse` and `__supersessionProbeLease` and expect both to match their pre-run state.
4. Start two runs concurrently. Expect the second to refuse with an error about the settings lease **before it prints any seeding output**, and expect the first run to complete with an intact `9 old / 9 new` off-table. The refusal has to come before `clearPreviousRun`, or the refusing run destroys the other run's corpus on its way out.
5. Optional, and the awkward one to stage: make the restore write fail (drop the DB connection right after the `collapse=on` table). Expect a `FAILED to restore ...` error naming the setting, **and expect the `__supersessionProbeLease` row to still be there afterwards**. Then expect a fresh run to refuse to start until that row is cleared by hand. A run that cleans up the lease here would let the next run adopt the stranded `true` as its baseline and make it permanent.

### What NOT to test

- No UI, no routes, no chat behaviour. Nothing to click.
- Do not run this against production. It seeds files and mutates an admin setting.
- Do not expect the flag to be on afterwards. `EnableRetrievalSupersessionCollapse` still defaults to `false`; this script only borrows it for the duration of a run.
- Do not treat the seeded lake as junk to clean up. It is reused across runs by design.

## Additional Information

The measurement result, run against stage `dev` on 2026-09-07:

| config | chunks | old | new | superseded |
|---|---|---|---|---|
| `collapse=off` | 18 | 9 | 9 | 0 |
| `collapse=on` | 9 | 0 | 9 | 3 |

With collapse off, the older generation beat the newer **on score** in the top slot of all three queries (0.9158 vs 0.9041, 0.9322 vs 0.9238, 0.9218 vs 0.8950), which is the mechanism #2241 describes. One query produced an exact tie (0.7506 vs 0.7506) -- the only case where the `chunkId` tiebreaker fires at all, and it resolved by id ordering rather than by recency.

With collapse on, composition moves to 100% newer generation and the report names each suppressed file at `tier=fileName`.

**This table predates both the seeding-order change and the superseded-count fix, and needs one confirming re-run before merge.** It was produced when the script seeded NEW before OLD, and when the script summed a per-query constant into the `superseded` column. The script now seeds OLD first so that `winsOver`'s ascending-id tiebreaker points at OLD while the recency arm points at NEW, which is what makes `0 old / 9 new` attributable to `createdAt` alone rather than to two arms that happen to agree. The 90-day backdate means `createdAt` is still the deciding comparison, so the same figures are expected -- but expected is not measured, and this table should not be quoted as a baseline until a run on the committed code reproduces it.

The `superseded` column has been corrected from 9 to 3 by derivation rather than by measurement. The supersession report is built from the model-matched scoped file set before any ranking, so it does not depend on the query text and every query in a configuration returns the same count; summing it across the three probe queries multiplied it by three. 3 OLD files are seeded and 3 are suppressed. The script now takes the one count and refuses a divergent one, so a future report that did vary per query would fail loudly rather than silently print a larger number. That correction is arithmetic, not evidence -- it is the other reason the confirming re-run has to land before this table is quoted anywhere.

Three limits worth stating plainly:

1. The score inversion is **constructed** -- the older text is phrased closer to the query on purpose. This demonstrates that collapse handles the mechanism; it is not evidence that production corpora exhibit it.
2. This measures the `semanticDataLakeSearch` comparator (`compareByScore`). The forced-retrieval comparator in `ChatCompletionFeatures` is a separate loop and was not exercised here, though both call `partitionBySupersession` before ranking.
3. It runs in-process against the staging database, not through the deployed HTTP route.

## Developer Notes (Optional)

- **Forcing `createdAt` on a `timestamps: true` schema requires the native driver.** Mongoose's `{ timestamps: false }` option on `updateOne` does not suppress the hook on `FabFileSchema` -- verified against stage `dev`, where it stamped `createdAt` to now regardless. Going through `FabFile.collection.updateOne` bypasses all Mongoose middleware. Anything else that needs to backdate a document will hit this.
- **`winsOver`'s tiebreaker means insertion order is part of a supersession experiment's design.** `winsOver` (`supersession.ts`) compares `createdAt` and falls back to *ascending id* on a tie, so whichever generation is inserted first also wins the tiebreaker. Any probe that wants a result attributable to recency has to insert the generation it expects to LOSE first, so the two arms disagree - otherwise the experiment still passes when the recency arm is broken, which is the one outcome an instrument must never produce.
- **The admin-settings lease is a reusable pattern for scripts that mutate shared stages.** Acquire with an atomic `$setOnInsert` and check `upsertedCount === 1`; narrow the acquisition catch to a duplicate key (Mongo `11000`) so a transient DB error is not reported as a held lease; capture the original value only *after* acquiring, so a second run cannot record the first run's mutation as its baseline; acquire before any destructive work, not merely before the setting writes; restore in a `finally` and on `SIGINT`/`SIGTERM` with an idempotent guard; and **do not release the lease row if the restore itself failed** -- leaving it behind is what blocks the next run from adopting a stranded value. This mirrors `recall-probe.ts` and is narrowed here to a single setting.
- **Restoring an unset setting means hard-deleting the row.** The soft-delete plugin does not hook `updateOne`, so a plain delete would tombstone a row that still carries a value and break later reads and writes of that setting on the stage.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a, adds no setting; borrows an existing one at runtime
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) -- n/a, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) -- the gotchas above are captured in code comments at the sites that depend on them
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc -- n/a, no telemetry fields

