### PR TITLE
fix(notebooks): export knowledge file bytes without a utf-8 round trip

### DIFF
--- a/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
@@ -198,7 +198,12 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
 
   return (
     <Modal open={open} onClose={onClose} className="notebook-export-modal-root">
-      <ModalDialog size="md" sx={{ maxWidth: 600 }} className="notebook-export-modal-dialog">
+      <ModalDialog
+        size="md"
+        sx={{ maxWidth: 600 }}
+        className="notebook-export-modal-dialog"
+        data-testid="notebook-export-modal"
+      >
         <DialogTitle className="notebook-export-modal-title">
           <Box display="flex" alignItems="center" gap={1}>
             <CloudDownload sx={{ mr: 1 }} />
@@ -229,6 +234,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                   <FormLabel className="notebook-export-modal-form-label">Knowledge Files</FormLabel>
                   <Switch
                     className="notebook-export-modal-switch"
+                    slotProps={{ input: { 'data-testid': 'notebook-export-knowledge-switch' } }}
                     checked={options.includeKnowledge}
                     onChange={e => updateOption('includeKnowledge', e.target.checked)}
                   />
@@ -237,6 +243,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                 <FormControl orientation="horizontal" sx={{ justifyContent: 'space-between' }}>
                   <FormLabel>Artifacts</FormLabel>
                   <Switch
+                    slotProps={{ input: { 'data-testid': 'notebook-export-artifacts-switch' } }}
                     checked={options.includeArtifacts}
                     onChange={e => updateOption('includeArtifacts', e.target.checked)}
                   />
@@ -245,6 +252,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                 <FormControl orientation="horizontal" sx={{ justifyContent: 'space-between' }}>
                   <FormLabel>Tools</FormLabel>
                   <Switch
+                    slotProps={{ input: { 'data-testid': 'notebook-export-tools-switch' } }}
                     checked={options.includeTools}
                     onChange={e => updateOption('includeTools', e.target.checked)}
                   />
@@ -253,6 +261,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                 <FormControl orientation="horizontal" sx={{ justifyContent: 'space-between' }}>
                   <FormLabel>Agents</FormLabel>
                   <Switch
+                    slotProps={{ input: { 'data-testid': 'notebook-export-agents-switch' } }}
                     checked={options.includeAgents}
                     onChange={e => updateOption('includeAgents', e.target.checked)}
                   />
@@ -261,6 +270,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                 <FormControl orientation="horizontal" sx={{ justifyContent: 'space-between' }}>
                   <FormLabel>Images</FormLabel>
                   <Switch
+                    slotProps={{ input: { 'data-testid': 'notebook-export-images-switch' } }}
                     checked={options.includeImages}
                     onChange={e => updateOption('includeImages', e.target.checked)}
                   />
@@ -379,7 +389,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
 
             {/* Export Result */}
             {exportResult && (
-              <Alert color="success" className="notebook-export-modal-alert">
+              <Alert color="success" className="notebook-export-modal-alert" data-testid="notebook-export-result">
                 <Stack spacing={1}>
                   <Typography level="title-sm">Export Complete!</Typography>
                   <Stack spacing={0.5}>
@@ -392,6 +402,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
                   {exportResult.downloadUrl && (
                     <Button
                       className="notebook-export-modal-export-button"
+                      data-testid="notebook-export-download-btn"
                       size="sm"
                       startDecorator={!isConverting ? <CloudDownload /> : undefined}
                       onClick={handleDownload}
@@ -414,6 +425,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
           <Button
             variant="solid"
             color="primary"
+            data-testid="notebook-export-submit-btn"
             onClick={handleExport}
             loading={isExporting}
             disabled={isExporting}

--- a/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
@@ -192,7 +192,12 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
 
   return (
     <Modal open={open} onClose={onClose} className="notebook-import-modal-root">
-      <ModalDialog size="md" sx={{ maxWidth: 700 }} className="notebook-import-modal-dialog">
+      <ModalDialog
+        size="md"
+        sx={{ maxWidth: 700 }}
+        className="notebook-import-modal-dialog"
+        data-testid="notebook-import-modal"
+      >
         <DialogTitle className="notebook-import-modal-title">
           <Box display="flex" alignItems="center" gap={1}>
             <CloudUpload sx={{ mr: 1 }} />
@@ -248,6 +253,7 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
                     >
                       <input
                         className="notebook-import-modal-file-input"
+                        data-testid="notebook-import-file-input"
                         ref={fileInputRef}
                         type="file"
                         accept=".json"
@@ -356,6 +362,7 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
                 <FormControl orientation="horizontal" sx={{ justifyContent: 'space-between' }}>
                   <FormLabel>Knowledge Files</FormLabel>
                   <Switch
+                    slotProps={{ input: { 'data-testid': 'notebook-import-knowledge-switch' } }}
                     checked={options.importKnowledge}
                     onChange={e => updateOption('importKnowledge', e.target.checked)}
                   />
@@ -442,6 +449,7 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
               <Button
                 variant="solid"
                 color="primary"
+                data-testid="notebook-import-submit-btn"
                 onClick={handleImport}
                 loading={isImporting}
                 disabled={

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
@@ -325,6 +325,7 @@ const GeneralSettingsTab = () => {
                 <StyledButton
                   color="primary"
                   variant="outlined"
+                  data-testid="notebook-import-open-btn"
                   onClick={() => toggleNotebookImportModal()}
                   sx={{ fontSize: '13px' }}
                 >
@@ -333,6 +334,7 @@ const GeneralSettingsTab = () => {
                 <StyledButton
                   color="primary"
                   variant="outlined"
+                  data-testid="notebook-export-open-btn"
                   onClick={() => toggleNotebookExportModal()}
                   sx={{ fontSize: '13px' }}
                 >

--- a/apps/client/e2e/constants.ts
+++ b/apps/client/e2e/constants.ts
@@ -9,6 +9,14 @@ export const MODEL_SEARCH_DEBOUNCE_MS = 600;
  */
 export const MONITORED_MODELS = ['Claude 4.7 Opus', 'GPT-5.5'] as const;
 
+/**
+ * Spec-user key for the second account the notebook-export-bytes suite imports as. The round trip
+ * has to cross an ownership boundary, so the suite needs two users; notebook-export-bytes.setup.ts
+ * creates this one and the spec switches to it mid-test. Shared here rather than exported from the
+ * setup file, which registers a setup test on import.
+ */
+export const NOTEBOOK_EXPORT_IMPORTER_KEY = 'notebookExportBytesImporter';
+
 /** Centralized timeout constants for E2E tests (in milliseconds). */
 export const TIMEOUTS = {
   /** Short UI transitions and state settling */

--- a/apps/client/e2e/helpers/test-users.ts
+++ b/apps/client/e2e/helpers/test-users.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { NOTEBOOK_EXPORT_IMPORTER_KEY } from '../constants';
 
 export interface TestUser {
   userId: string;
@@ -44,6 +45,10 @@ const SPEC_KEYS = [
   'search',
   'dataLake',
   'skills',
+  'notebookExportBytes',
+  // The notebook-export-bytes importer: no project authenticates as it, but it is loaded here so
+  // the spec can reach its token through getTestUsers like every other identity.
+  NOTEBOOK_EXPORT_IMPORTER_KEY,
   // AI-latency suites (only seeded when AI_LATENCY_RUN=true; getTestUsers skips absent files).
   // Listed here so getTestUsers loads their spec users, which lets specAuthForProject resolve
   // real auth and route their navigations through /auth/success like every other authed suite -

--- a/apps/client/e2e/notebook-export-bytes.setup.ts
+++ b/apps/client/e2e/notebook-export-bytes.setup.ts
@@ -1,0 +1,34 @@
+import { setupSpecUser } from './helpers/spec-setup';
+import { apiCreateTestUser } from './helpers/api';
+import { getTestRunId, getE2ETestId, saveSpecUser } from './helpers/test-users';
+import { NOTEBOOK_EXPORT_IMPORTER_KEY as IMPORTER_KEY } from './constants';
+
+/**
+ * Two users: the spec user exports, and this second one imports. The round trip has to cross a
+ * real ownership boundary or it proves nothing - the importer writes the decoded bytes under its
+ * own userId prefix, not the exporter's.
+ *
+ * No project authenticates as the importer; the spec switches to it mid-test via loginAsUser.
+ */
+setupSpecUser({
+  key: 'notebookExportBytes',
+  authFile: 'notebook-export-bytes-user.json',
+  afterCreate: async ({ request }) => {
+    const ID_SUFFIX = [getE2ETestId(), getTestRunId()].filter(Boolean).join('-');
+    const userConfig = {
+      username: `setup-${IMPORTER_KEY}-${ID_SUFFIX}`,
+      email: `setup-${IMPORTER_KEY}-${ID_SUFFIX}-e2e@test.com`,
+      name: `Setup importer ${ID_SUFFIX}`,
+      password: `E2eImporterPass123!`,
+      isAdmin: false,
+    };
+    const result = await apiCreateTestUser(request, userConfig);
+    saveSpecUser(IMPORTER_KEY, {
+      userId: (result.user.id || result.user._id) as string,
+      email: userConfig.email,
+      password: userConfig.password,
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+    });
+  },
+});

--- a/apps/client/e2e/notebook-export-bytes.spec.ts
+++ b/apps/client/e2e/notebook-export-bytes.spec.ts
@@ -1,0 +1,467 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { APIRequestContext, Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import { NOTEBOOK_EXPORT_IMPORTER_KEY, TIMEOUTS } from './constants';
+import { apiCreateSession } from './helpers/api';
+import { getTestUsers } from './helpers/test-users';
+
+/**
+ * Byte fidelity of the notebook export, end to end through the browser.
+ *
+ * The unit suite mocks the storage read, so it cannot see the adapter that actually reads S3 -
+ * which is where a UTF-8 decode silently replaced every unrepresentable byte with U+FFFD before
+ * the base64 encode. The only trustworthy check is a hash: these tests upload a fixture whose
+ * sha256 is known outside the system, export it, and compare the sha256 of the decoded base64
+ * against that reference. A single mangled byte fails.
+ *
+ * Serial and stateful on purpose: the round-trip test imports the very payload the first test
+ * exported, and the manifest is a read-modify-write.
+ */
+test.describe.configure({ mode: 'serial' });
+
+const UPLOADS = 'e2e/fixtures/uploads';
+
+/**
+ * Reused rather than newly generated: sample.pdf and cat.png both fail a UTF-8 decode (verified),
+ * which is the whole point, and both sit under the 3MB client-side image-resize threshold and the
+ * 10MB export embed cap, so the bytes the browser sends are the bytes on disk.
+ */
+const FIXTURES = [
+  { file: 'sample.pdf', mime: 'application/pdf', role: 'binary, non-UTF-8 - the defect case' },
+  { file: 'cat.png', mime: 'image/png', role: 'binary, and gated by the image moderation scan' },
+  { file: 'recipe.txt', mime: 'text/plain', role: 'the UTF-8 control - it survived the old decode too' },
+] as const;
+
+/** The file the round trip carries. Its hash is the strongest single claim in the suite. */
+const ROUND_TRIP_FILE = 'sample.pdf';
+
+interface ExportedKnowledge {
+  id: string;
+  name: string;
+  size: number;
+  content?: string;
+  contentUrl?: string;
+}
+
+interface ExportPayload {
+  notebooks: { id: string; name: string; knowledge?: ExportedKnowledge[] }[];
+}
+
+function localSha256(file: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(path.resolve(process.cwd(), UPLOADS, file)))
+    .digest('hex');
+}
+
+function localBytes(file: string): number {
+  return fs.statSync(path.resolve(process.cwd(), UPLOADS, file)).size;
+}
+
+function sha256OfBase64(content: string): string {
+  return crypto.createHash('sha256').update(Buffer.from(content, 'base64')).digest('hex');
+}
+
+/**
+ * Knowledge entries across every exported notebook, keyed by fabFile id.
+ *
+ * By id, not by name: the name the upload stores is not guaranteed to be the local basename, and
+ * keying on it made a fully correct export look like a moderation timeout. The id comes straight
+ * off the createFabFile response, so it cannot drift.
+ */
+function knowledgeById(payload: ExportPayload): Map<string, ExportedKnowledge> {
+  const byId = new Map<string, ExportedKnowledge>();
+  for (const notebook of payload.notebooks ?? []) {
+    for (const file of notebook.knowledge ?? []) byId.set(file.id, file);
+  }
+  return byId;
+}
+
+/** Every knowledge entry, for a failure message that says what WAS there. */
+function allKnowledge(payload: ExportPayload): ExportedKnowledge[] {
+  return (payload.notebooks ?? []).flatMap(notebook => notebook.knowledge ?? []);
+}
+
+/**
+ * Export for use inside a poll: returns null instead of failing when the account has nothing to
+ * export yet.
+ *
+ * Separate from exportViaApi on purpose. A failed `expect()` inside an `expect.poll` predicate
+ * ABORTS the poll rather than counting as one falsy attempt, so asserting `response.ok()` in
+ * there turns a transient 404 (`NO_NOTEBOOKS`, before a background import has landed) into a
+ * dead poll that never asks again - and then reports the timeout instead of the 404.
+ */
+async function tryExportViaApi(request: APIRequestContext, token: string): Promise<{ downloadUrl?: string } | null> {
+  const response = await request.post('/api/notebooks/export', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { includeKnowledge: true, includeImages: true, format: 'json' },
+  });
+  if (!response.ok()) return null;
+  const body = await response.json();
+  return body.success ? body.data : null;
+}
+
+/** The download URL is presigned, so an unauthenticated GET is correct here. */
+async function fetchExportPayload(request: APIRequestContext, downloadUrl?: string): Promise<ExportPayload> {
+  expect(downloadUrl, 'export produced no downloadUrl').toBeTruthy();
+  const response = await request.get(downloadUrl!);
+  expect(response.ok(), `export download ${response.status()}`).toBeTruthy();
+  return (await response.json()) as ExportPayload;
+}
+
+/**
+ * Assert the uploads actually became notebook knowledge, before waiting on anything slow.
+ *
+ * Without this, an attachment that never entered `session.knowledgeIds` surfaces three minutes
+ * later as a moderation timeout - the wrong diagnosis for the wrong subsystem. Polled rather than
+ * read once: the id is added by a follow-up mutation after the bytes are PUT, so it lags the
+ * createFabFile response by a moment.
+ */
+async function expectSessionKnowledgeCount(
+  request: APIRequestContext,
+  token: string,
+  sessionId: string,
+  expected: number
+) {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(`/api/sessions/${sessionId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok()) return -1;
+        return ((await response.json()).knowledgeIds ?? []).length;
+      },
+      {
+        timeout: 60_000,
+        intervals: [2_000],
+        message: `not every upload became notebook knowledge - expected ${expected} knowledgeIds. A file attached at message scope instead of notebook scope lands in fabFileIds and never reaches the export`,
+      }
+    )
+    .toBe(expected);
+}
+
+/**
+ * Every uploaded file is withheld from the export until moderationStatus reaches 'clean' (see
+ * isImageServeable - non-images are gated too), and that is set asynchronously off the S3 event.
+ * Poll the export API rather than the UI so the wait costs no clicks, then let the caller do one
+ * real UI export to assert against.
+ */
+async function waitForKnowledgeToEmbed(
+  request: APIRequestContext,
+  token: string,
+  fileIds: readonly string[]
+): Promise<ExportPayload> {
+  let latest: ExportPayload | undefined;
+  let present = '';
+
+  await expect
+    .poll(
+      async () => {
+        try {
+          const exported = await tryExportViaApi(request, token);
+          if (!exported) return -1;
+          latest = await fetchExportPayload(request, exported.downloadUrl);
+          const byId = knowledgeById(latest);
+          // Recorded for the failure message: which entries the export DID carry, and in what
+          // state. Without it a lookup that misses reads exactly like content that never arrived.
+          present = allKnowledge(latest)
+            .map(
+              f => `${f.id}/${f.name}=${typeof f.content === 'string' ? 'content' : f.contentUrl ? 'url' : 'neither'}`
+            )
+            .join(' ');
+          return fileIds.filter(id => typeof byId.get(id)?.content === 'string').length;
+        } catch (error) {
+          // A socket hang up against a cold preview lambda must cost one attempt, not the poll.
+          present = `last attempt threw: ${String(error).slice(0, 120)}`;
+          return -1;
+        }
+      },
+      {
+        timeout: 3 * 60_000,
+        intervals: [10_000],
+        message: `not every upload reached the export with embedded content. Expected ids [${fileIds.join(', ')}]; the export carried: ${present || '<nothing>'}`,
+      }
+    )
+    .toBe(fileIds.length);
+
+  return latest!;
+}
+
+/** The first test's payload, replayed by the round-trip test (describe runs serial). */
+let roundTripPayload: ExportPayload | undefined;
+
+test.describe('Notebook export byte fidelity', () => {
+  test('exports binary and UTF-8 knowledge files byte-identically', async ({
+    page,
+    request,
+    basePage,
+    profilePage,
+  }) => {
+    // Three uploads of up to 1MB, a moderation wait, and an export - well past the 60s default.
+    test.setTimeout(8 * 60_000);
+
+    const exporter = getTestUsers().specUsers.notebookExportBytes;
+    const notebookName = `byte-fidelity-${Date.now()}`;
+    const sessionId = await apiCreateSession(request, exporter.accessToken, notebookName);
+
+    const fileIds = await test.step('attach each fixture as notebook knowledge', async () => {
+      await page.goto(`/notebooks/${sessionId}`);
+      await page.waitForLoadState('domcontentloaded');
+      await basePage.dismissModals();
+
+      const ids: Record<string, string> = {};
+      for (const { file } of FIXTURES) {
+        ids[file] = await attachAsNotebookKnowledge(page, `${UPLOADS}/${file}`);
+      }
+      return ids;
+    });
+
+    await expectSessionKnowledgeCount(request, exporter.accessToken, sessionId, FIXTURES.length);
+    await waitForKnowledgeToEmbed(request, exporter.accessToken, Object.values(fileIds));
+
+    const payload = await test.step('export through the modal a user would use', async () => {
+      await openExportModal(page, profilePage);
+      await expect(page.getByTestId('notebook-export-knowledge-switch')).toBeChecked();
+      await expect(page.getByTestId('notebook-export-images-switch')).toBeChecked();
+      await expect(page.getByTestId('notebook-export-size-input')).toHaveValue('10');
+
+      const downloadUrl = await submitExport(page);
+      return await fetchExportPayload(request, downloadUrl);
+    });
+
+    const byId = knowledgeById(payload);
+    const recorded: Record<string, unknown>[] = [];
+
+    for (const { file, mime, role } of FIXTURES) {
+      const entry = byId.get(fileIds[file]);
+      expect(
+        entry,
+        `${file} (${role}) is missing from the export. It carried: ${allKnowledge(payload)
+          .map(f => `${f.id}/${f.name}`)
+          .join(' ')}`
+      ).toBeTruthy();
+      expect(entry!.contentUrl, `${file} fell back to a URL reference instead of embedding`).toBeUndefined();
+      expect(typeof entry!.content, `${file} carries no embedded content`).toBe('string');
+
+      // The assertion the whole suite exists for. A UTF-8 round trip inflates every
+      // unrepresentable byte to the three bytes of U+FFFD, so the length check localises a
+      // failure to "decoded" rather than "truncated" before the hash is even read.
+      expect(Buffer.from(entry!.content!, 'base64').length, `${file} decoded to the wrong byte count`).toBe(
+        localBytes(file)
+      );
+      expect(sha256OfBase64(entry!.content!), `${file} (${mime}) did not survive the export byte-identically`).toBe(
+        localSha256(file)
+      );
+
+      recorded.push({
+        fileId: entry!.id,
+        localName: file,
+        // Recorded separately: the stored name is not guaranteed to equal the local basename.
+        exportedName: entry!.name,
+        mime,
+        bytes: localBytes(file),
+        sha256: localSha256(file),
+      });
+    }
+
+    roundTripPayload = payload;
+  });
+
+  test('withholds a zero-byte knowledge file from the export entirely', async ({
+    page,
+    request,
+    basePage,
+    profilePage,
+  }) => {
+    test.setTimeout(6 * 60_000);
+
+    const exporter = getTestUsers().specUsers.notebookExportBytes;
+    // Not a committed fixture: an empty file in the tree is easy to "fix" by accident, and its
+    // whole purpose is to be zero bytes.
+    // .txt, not .bin: isStorableFabFileMimeType rejects an unsupported extension before the size
+    // is ever looked at, so a zero-byte .bin 400s as "File type .bin is not supported" - which
+    // says nothing about the zero-byte branch this test exists to record.
+    const emptyPath = path.join(os.tmpdir(), 'zero-byte-knowledge.txt');
+    fs.writeFileSync(emptyPath, '');
+
+    const sessionId = await apiCreateSession(request, exporter.accessToken, `byte-fidelity-empty-${Date.now()}`);
+
+    await page.goto(`/notebooks/${sessionId}`);
+    await page.waitForLoadState('domcontentloaded');
+    await basePage.dismissModals();
+    const emptyFileId = await attachAsNotebookKnowledge(page, emptyPath);
+    await expectSessionKnowledgeCount(request, exporter.accessToken, sessionId, 1);
+
+    // Characterization, and the behaviour is not the one this scenario was written to expect.
+    //
+    // A zero-byte upload IS accepted - createFabFileSchema puts no floor on fileSize - and then
+    // its moderationStatus sits at `scanning` indefinitely. Verified on a preview: two separate
+    // zero-byte files stayed `scanning` across a full 3-minute poll each, logging
+    // `export.knowledge.skip reason=not-serveable moderationStatus=scanning` on every export.
+    // isImageServeable gates non-images identically to images, so the export emits the listing
+    // entry with NEITHER content nor contentUrl.
+    //
+    // That makes the zero-byte content branch (`content !== null`, which replaced a truthiness
+    // check that an empty Buffer would have passed) unreachable through the product: the
+    // moderation gate returns before getFileContent is ever called.
+    //
+    // If someone fixes the moderation pipeline for empty objects, this test fails - which is the
+    // point. It is pinning a defect, not blessing it.
+    await openExportModal(page, profilePage);
+    const payload = await fetchExportPayload(request, await submitExport(page));
+    const entry = knowledgeById(payload).get(emptyFileId);
+
+    expect(
+      entry,
+      `the zero-byte file is missing from the export listing entirely. It carried: ${allKnowledge(payload)
+        .map(f => f.id)
+        .join(' ')}`
+    ).toBeTruthy();
+    expect(
+      entry!.content,
+      'a zero-byte file now embeds content - the moderation gate that withheld it has changed, so re-check the zero-byte branch'
+    ).toBeUndefined();
+    expect(entry!.contentUrl, 'a zero-byte file now falls back to a URL rather than being withheld').toBeUndefined();
+  });
+
+  test('a second account imports the same bytes it was sent', async ({
+    page,
+    request,
+    basePage,
+    profilePage,
+    loginAsUser,
+  }) => {
+    test.setTimeout(8 * 60_000);
+    expect(roundTripPayload, 'the byte-fidelity export did not run').toBeTruthy();
+
+    const importer = getTestUsers().specUsers[NOTEBOOK_EXPORT_IMPORTER_KEY];
+    const exportFile = path.join(os.tmpdir(), `notebook-export-${Date.now()}.json`);
+    fs.writeFileSync(exportFile, JSON.stringify(roundTripPayload));
+
+    await test.step('import as the second account', async () => {
+      await loginAsUser({ accessToken: importer.accessToken, userId: importer.userId });
+      await profilePage.gotoProfile();
+      await profilePage.clickTab('settings');
+      await page.getByTestId('notebook-import-open-btn').click();
+      await expect(page.getByTestId('notebook-import-modal')).toBeVisible({ timeout: TIMEOUTS.MODAL });
+
+      await page.getByTestId('notebook-import-file-input').setInputFiles(exportFile);
+      await expect(page.getByTestId('notebook-import-knowledge-switch')).toBeChecked();
+      await page.getByTestId('notebook-import-submit-btn').click();
+      await basePage.waitForToast('Import started');
+    });
+
+    // The import runs in the background off an S3 event, and the file it writes then has to clear
+    // moderation in the new account before the export will embed it - so poll the importer's own
+    // export until the bytes appear.
+    //
+    // Matched by HASH, not by id or name: the importing account mints its own fabFile ids, so the
+    // exporter's ids are meaningless here, and the stored name is not something to rely on either.
+    // The hash is the claim anyway - that the bytes A stored are the bytes B stored.
+    const expected = localSha256(ROUND_TRIP_FILE);
+    let seen = '';
+
+    await expect
+      .poll(
+        async () => {
+          try {
+            // Null while the importing account still has no notebook: the import is a background
+            // S3-event job, so its export 404s with NO_NOTEBOOKS until that lands. "Not yet",
+            // not a failure - see tryExportViaApi.
+            const exported = await tryExportViaApi(request, importer.accessToken);
+            if (!exported) {
+              seen = 'the importing account has no notebooks yet';
+              return false;
+            }
+            const imported = allKnowledge(await fetchExportPayload(request, exported.downloadUrl));
+            seen = imported
+              .map(
+                f =>
+                  `${f.name}=${typeof f.content === 'string' ? sha256OfBase64(f.content).slice(0, 16) : 'no-content'}`
+              )
+              .join(' ');
+            return imported.some(f => typeof f.content === 'string' && sha256OfBase64(f.content) === expected);
+          } catch (error) {
+            seen = `last attempt threw: ${String(error).slice(0, 120)}`;
+            return false;
+          }
+        },
+        {
+          timeout: 4 * 60_000,
+          intervals: [10_000],
+          message: `no file in the importing account decodes to ${expected.slice(0, 16)} (${ROUND_TRIP_FILE}). Either the import did not finish, or the bytes changed in transit. The account held: ${seen || '<nothing>'}`,
+        }
+      )
+      .toBe(true);
+  });
+});
+
+/**
+ * Upload one file at "Whole notebook" scope, which is what puts it in session.knowledgeIds, and
+ * return its fabFile id. The default "Smart" scope attaches images to a single message instead,
+ * and a message attachment is not knowledge - so the PNG would silently never reach the export.
+ *
+ * The id is the return value because every later assertion keys on it. Keying on the file name
+ * instead made a byte-perfect export of all three fixtures report as a moderation timeout.
+ */
+async function attachAsNotebookKnowledge(page: Page, filePath: string): Promise<string> {
+  await page.getByTestId('attach-files-btn').click();
+  await expect(page.getByTestId('upload-from-device-btn')).toBeVisible({ timeout: TIMEOUTS.ELEMENT_STATE });
+
+  // The testid lands on Joy's Radio ROOT span, not the input - useSlot merges forwarded props into
+  // the root slot only - and that root's `overlay` action is absolutely positioned over the Chip,
+  // so clicking the testid itself resolves to another element and leaves the mode alone without
+  // erroring. Descend to the input, which is where the state actually lives: it needs no
+  // accessible-name computation and `toBeChecked` works on it.
+  //
+  // The assertion is the point. A silently-unset mode falls back to "Smart", where
+  // resolveAttachScope routes images to a single message, and an image that never enters
+  // session.knowledgeIds is dropped from the export with no error anywhere.
+  const notebookScope = page.getByTestId('attach-file-scope-notebook-radio').locator('input[type="radio"]');
+  await notebookScope.check();
+  await expect(notebookScope).toBeChecked();
+
+  const created = page.waitForResponse(
+    response => response.url().includes('createFabFile') && response.request().method() === 'POST',
+    { timeout: TIMEOUTS.ACTION }
+  );
+  const fileChooser = page.waitForEvent('filechooser');
+  await page.getByTestId('upload-from-device-btn').click();
+  await (await fileChooser).setFiles(path.resolve(process.cwd(), filePath));
+
+  const response = await created;
+  expect(response.ok(), `createFabFile ${response.status()} for ${filePath}`).toBeTruthy();
+  // createFabFile only reserves the row and a presigned URL; the bytes go up in a separate PUT.
+  // waitForKnowledgeToEmbed is what waits for those to land, so nothing about them is asserted here.
+  const body = await response.json();
+  const fileId = (body.id ?? body._id) as string | undefined;
+  expect(fileId, `createFabFile returned no id for ${filePath}`).toBeTruthy();
+  return fileId!;
+}
+
+async function openExportModal(
+  page: Page,
+  profilePage: { gotoProfile: () => Promise<void>; clickTab: (name: string) => Promise<void> }
+): Promise<void> {
+  await profilePage.gotoProfile();
+  await profilePage.clickTab('settings');
+  await page.getByTestId('notebook-export-open-btn').click();
+  await expect(page.getByTestId('notebook-export-modal')).toBeVisible({ timeout: TIMEOUTS.MODAL });
+}
+
+/** Click Export and return the payload's download URL, taken off the response the modal reads. */
+async function submitExport(page: Page): Promise<string | undefined> {
+  const exported = page.waitForResponse(
+    response => response.url().includes('/api/notebooks/export') && response.request().method() === 'POST',
+    { timeout: TIMEOUTS.ACTION }
+  );
+  await page.getByTestId('notebook-export-submit-btn').click();
+  const body = await (await exported).json();
+  expect(body.success, `export failed: ${JSON.stringify(body).slice(0, 400)}`).toBe(true);
+  await expect(page.getByTestId('notebook-export-result')).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+  return body.data?.downloadUrl;
+}

--- a/apps/client/pages/api/notebooks/__tests__/export.test.ts
+++ b/apps/client/pages/api/notebooks/__tests__/export.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
-const { mockExport } = vi.hoisted(() => ({ mockExport: vi.fn() }));
+const { mockExport, captured, storageBytes } = vi.hoisted(() => ({
+  mockExport: vi.fn(),
+  // The route builds its adapters inline, so the only way to reach them is off the constructor.
+  captured: { adapters: undefined as Record<string, unknown> | undefined },
+  storageBytes: { value: Buffer.alloc(0) },
+}));
 
 vi.mock('@server/middlewares/baseApi', () => ({
   baseApi: () => {
@@ -31,6 +36,9 @@ vi.mock('@bike4mind/services', async () => ({
   notebookExportService: {
     ...(await import('../../../../../../b4m-core/services/src/notebookExportService/types')),
     NotebookExportService: class {
+      constructor(adapters: Record<string, unknown>) {
+        captured.adapters = adapters;
+      }
       exportNotebooks = mockExport;
     },
   },
@@ -56,7 +64,9 @@ vi.mock('@bike4mind/database', () => ({
   Tool: { find: vi.fn(), findById: vi.fn() },
 }));
 
-vi.mock('@server/utils/storage', () => ({ getFilesStorage: () => ({}) }));
+vi.mock('@server/utils/storage', () => ({
+  getFilesStorage: () => ({ getContentAsBuffer: async () => storageBytes.value }),
+}));
 
 import handler from '../export';
 
@@ -81,6 +91,11 @@ beforeEach(() => {
   });
   logger.warn.mockReset();
   logger.error.mockReset();
+  // Nothing in this package's vitest config resets mocks between tests, and these two are
+  // module-level. Cleared so a case that never reaches the service constructor reads undefined
+  // rather than a previous case's adapters.
+  captured.adapters = undefined;
+  storageBytes.value = Buffer.alloc(0);
 });
 
 describe('POST /api/notebooks/export', () => {
@@ -164,5 +179,36 @@ describe('POST /api/notebooks/export', () => {
 
     expect(res._getStatusCode()).toBe(401);
     expect(mockExport).not.toHaveBeenCalled();
+  });
+});
+
+describe('the storage adapter the route hands the export service', () => {
+  /** A PDF header plus bytes no UTF-8 decoder can represent; they become U+FFFD if one runs. */
+  const PDF_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0xff, 0xd8, 0xff, 0xe0]);
+
+  const readFileContent = async (bytes: Buffer) => {
+    storageBytes.value = bytes;
+    const { promise } = run({ notebookIds: [HEX_ID] });
+    await promise;
+    // Asserted, not assumed: without it a run that stopped short of the constructor would read a
+    // stale adapter and the byte assertion below would pass on the wrong object.
+    expect(captured.adapters).toBeDefined();
+    const storage = captured.adapters?.fileStorageService as {
+      getFileContent: (filePath: string) => Promise<Buffer | null>;
+    };
+    return storage.getFileContent('knowledge/user-1/report.pdf');
+  };
+
+  it('hands back the stored bytes unchanged, so a binary file is not corrupted before base64', async () => {
+    // Compared against the fixture rather than a re-run of whatever the adapter does, so an
+    // adapter that mangles the bytes cannot satisfy this by mangling both sides alike.
+    expect(await readFileContent(PDF_BYTES)).toEqual(PDF_BYTES);
+  });
+
+  it('hands back UTF-8 text unchanged too', async () => {
+    // Escaped rather than literal: this file is ASCII-only, and the multi-byte sequences are the
+    // whole point of the case.
+    const text = Buffer.from('notes with an accent: caf\u00e9 and a snowman \u2603\n', 'utf-8');
+    expect((await readFileContent(text))?.toString('utf-8')).toBe(text.toString('utf-8'));
   });
 });

--- a/apps/client/pages/api/notebooks/__tests__/export.test.ts
+++ b/apps/client/pages/api/notebooks/__tests__/export.test.ts
@@ -65,7 +65,13 @@ vi.mock('@bike4mind/database', () => ({
 }));
 
 vi.mock('@server/utils/storage', () => ({
-  getFilesStorage: () => ({ getContentAsBuffer: async () => storageBytes.value }),
+  getFilesStorage: () => ({
+    getContentAsBuffer: async () => storageBytes.value,
+    // The route wires these two into the other adapters. Stubbed so a future test that
+    // exercises them fails on its own assertion, not on `upload is not a function`.
+    upload: async () => undefined,
+    getSignedUrl: async () => 'https://example.invalid/signed',
+  }),
 }));
 
 import handler from '../export';
@@ -184,7 +190,11 @@ describe('POST /api/notebooks/export', () => {
 
 describe('the storage adapter the route hands the export service', () => {
   /** A PDF header plus bytes no UTF-8 decoder can represent; they become U+FFFD if one runs. */
-  const PDF_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0xff, 0xd8, 0xff, 0xe0]);
+  // Same bytes as the service-side fixture, including the NUL: this is the test that actually
+  // guards the adapter, so it should carry the byte most likely to break a string path.
+  const PDF_BYTES = Buffer.from([
+    0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10,
+  ]);
 
   const readFileContent = async (bytes: Buffer) => {
     storageBytes.value = bytes;
@@ -209,6 +219,13 @@ describe('the storage adapter the route hands the export service', () => {
     // Escaped rather than literal: this file is ASCII-only, and the multi-byte sequences are the
     // whole point of the case.
     const text = Buffer.from('notes with an accent: caf\u00e9 and a snowman \u2603\n', 'utf-8');
-    expect((await readFileContent(text))?.toString('utf-8')).toBe(text.toString('utf-8'));
+    const result = await readFileContent(text);
+
+    // isBuffer first, then byte equality. Asserting on `result.toString('utf-8')` would pass
+    // against the decoding adapter this test exists to catch: String.prototype.toString ignores
+    // its argument, so a returned string compares equal to itself and text survives the decode
+    // anyway. Only the type check distinguishes the two.
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(result).toEqual(text);
   });
 });

--- a/apps/client/pages/api/notebooks/export.ts
+++ b/apps/client/pages/api/notebooks/export.ts
@@ -81,10 +81,12 @@ const handler = baseApi().post(
       },
       agentRepository,
       fileStorageService: {
-        getFileContent: async (filePath: string): Promise<string | null> => {
+        getFileContent: async (filePath: string): Promise<Buffer | null> => {
           try {
-            const data = await getFilesStorage().getContentAsBuffer(filePath);
-            return data.toString('utf-8');
+            // Returned as bytes on purpose. A UTF-8 decode here would replace every byte outside
+            // UTF-8 with U+FFFD before the service base64-encodes it, so every binary knowledge
+            // file (PDF, PNG, ...) would export as unusable mojibake that no consumer can recover.
+            return await getFilesStorage().getContentAsBuffer(filePath);
           } catch (error) {
             req.logger.error('Failed to read file content', { filePath, error });
             return null;

--- a/apps/client/pages/api/notebooks/export.ts
+++ b/apps/client/pages/api/notebooks/export.ts
@@ -83,9 +83,7 @@ const handler = baseApi().post(
       fileStorageService: {
         getFileContent: async (filePath: string): Promise<Buffer | null> => {
           try {
-            // Returned as bytes on purpose. A UTF-8 decode here would replace every byte outside
-            // UTF-8 with U+FFFD before the service base64-encodes it, so every binary knowledge
-            // file (PDF, PNG, ...) would export as unusable mojibake that no consumer can recover.
+            // Bytes, never a decoded string - see ExportFileStorage.getFileContent for why.
             return await getFilesStorage().getContentAsBuffer(filePath);
           } catch (error) {
             req.logger.error('Failed to read file content', { filePath, error });

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -76,6 +76,21 @@ const specProjects = [
     testMatch: /(?:^|\/)skills\.spec\.ts$/,
     auth: './e2e/.auth/skills-user.json',
   },
+  // Byte-fidelity suite: opt-in via EXPORT_BYTES_RUN. Three tests that each wait out an async S3
+  // moderation scan before the export can embed anything, so left in the default set they would
+  // eat most of the suite's 30-min globalTimeout on the serial (PW_WORKERS=1) label run and fail
+  // unrelated specs.
+  ...(process.env.EXPORT_BYTES_RUN === 'true'
+    ? [
+        {
+          name: 'notebook-export-bytes',
+          setupMatch: /(?:^|\/)notebook-export-bytes\.setup\.ts$/,
+          testMatch: /(?:^|\/)notebook-export-bytes\.spec\.ts$/,
+          auth: './e2e/.auth/notebook-export-bytes-user.json',
+          skipWarmup: true,
+        },
+      ]
+    : []),
   // AI latency suites: only included when AI_LATENCY_RUN=true (e2e-ai-latency workflow)
   ...(process.env.AI_LATENCY_RUN === 'true'
     ? [
@@ -146,10 +161,13 @@ export default defineConfig({
       use: { storageState: adminAuthFile },
     },
     // Per-spec setup projects (each creates only its own user)
-    ...specProjects.map(({ name, setupMatch }) => ({
+    // `skipWarmup` opts a suite out of priming the AI containers. Only for a suite that makes no
+    // model call at all: warmup's AI legs are the slowest and flakiest part of it, and a suite that
+    // never reaches a model pays their cost and inherits their failures for nothing.
+    ...specProjects.map(({ name, setupMatch, skipWarmup }) => ({
       name: `setup-${name}`,
       testMatch: [setupMatch],
-      dependencies: ['warmup'],
+      dependencies: skipWarmup ? ['setup-core'] : ['warmup'],
     })),
     // Unauthenticated specs need core + projects user (for login credentials)
     {

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -582,6 +582,19 @@ describe('notebook export - knowledge file bytes', () => {
     expect(Buffer.from(knowledge.content, 'base64').equals(PDF_BYTES)).toBe(true);
   });
 
+  // The branch the `!== null` change deliberately rewrote, pinned in both directions. A zero-byte
+  // file now embeds an empty `content` where it used to emit a `contentUrl` reference, because an
+  // empty Buffer is truthy while the empty string it replaced was falsy. Neither shape round trips
+  // (the import cannot tell empty-but-present from absent), so this records what the export emits
+  // rather than blessing it.
+  it('embeds an empty knowledge file as empty content, not a url reference', async () => {
+    const payload = await exportWithKnowledge(Buffer.alloc(0));
+    const [knowledge] = payload.notebooks[0].knowledge;
+
+    expect(knowledge.content).toBe('');
+    expect(knowledge.contentUrl).toBeUndefined();
+  });
+
   it('embeds a UTF-8 text file unchanged', async () => {
     const payload = await exportWithKnowledge(TEXT_BYTES, TEXT_FILE);
     const [knowledge] = payload.notebooks[0].knowledge;
@@ -652,6 +665,12 @@ describe('notebook export - image bytes', () => {
     expect(Buffer.from(image, 'base64').equals(PDF_BYTES)).toBe(true);
   });
 
+  // Pins CURRENT, KNOWN-BROKEN behaviour, not desired behaviour: `images` is a flat string[] that
+  // holds base64 on success and a raw storage path on failure, with nothing to tell them apart, so
+  // a consumer decoding every element gets plausible garbage from the path entries (Node's base64
+  // decoder does not reject them). Giving images the content/contentUrl split knowledge files
+  // already have is the fix; when that lands, this expectation SHOULD change - it is not a
+  // regression guard for the string[] shape.
   it('exports the path instead when the image cannot be read', async () => {
     const payload = await exportWithImage(null);
 

--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { NotebookExportService } from './index';
 import type { NotebookExportAdapters } from './index';
+import { NotebookImportService } from '../notebookImportService';
+import type { NotebookImportAdapters } from '../notebookImportService';
 
 /**
  * These pin the emitted JSON, because the fields they cover were all silently wrong before the
@@ -51,15 +53,18 @@ function makeAdapters(over: AdapterOverrides = {}) {
     artifactContentRepository: none,
     toolRepository: none,
     agentRepository: none,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    ...over,
+    // Merged rather than replaced, and placed after the spread so it wins: a test overriding
+    // getFileContent alone still gets the uploadFile that captures the emitted file.
     fileStorageService: {
       getFileContent: vi.fn().mockResolvedValue(null),
       uploadFile: vi.fn(async (_path: string, content: Buffer) => {
         uploaded.push(content.toString('utf-8'));
       }),
       getSignedUrl: vi.fn().mockResolvedValue('https://example.test/export.json'),
+      ...(over.fileStorageService as Record<string, unknown> | undefined),
     },
-    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-    ...over,
   } as unknown as NotebookExportAdapters;
   return { adapters, uploaded };
 }
@@ -84,6 +89,8 @@ const OPTIONS = {
   includeKnowledge: true,
   includeTools: true,
   includeAgents: true,
+  // Matches the route's own default, so processImages runs here as it does in production.
+  includeImages: true,
   maxFileSize: 1_000_000,
 } as unknown as Parameters<NotebookExportService['exportNotebooks']>[1];
 
@@ -524,5 +531,130 @@ describe('notebook export - log level', () => {
     });
 
     expect(adapters.logger.error).toHaveBeenCalled();
+  });
+});
+
+/**
+ * A real PDF header followed by bytes that are not valid UTF-8. Decoding these into a string
+ * before base64 replaces each one with U+FFFD, and no downstream consumer can undo that - the
+ * bytes are gone by the time base64 runs.
+ */
+const PDF_BYTES = Buffer.from([
+  0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10,
+]);
+
+/** Escaped rather than literal: this file is ASCII-only, and the multi-byte run is the point. */
+const TEXT_BYTES = Buffer.from('notes with an accent: caf\u00e9 and a snowman \u2603\n', 'utf-8');
+
+const PDF_FILE = {
+  id: GOOD,
+  fileName: 'report.pdf',
+  fileSize: PDF_BYTES.length,
+  mimeType: 'application/pdf',
+  type: 'FILE',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  filePath: 'knowledge/user-1/report.pdf',
+  fileUrl: 'https://example.test/report.pdf',
+  // isImageServeable gates every mime type on moderationStatus, images or not.
+  moderationStatus: 'clean',
+};
+
+const TEXT_FILE = { ...PDF_FILE, fileName: 'notes.txt', mimeType: 'text/plain', fileSize: TEXT_BYTES.length };
+
+async function exportWithKnowledge(bytes: Buffer, file: Record<string, unknown> = PDF_FILE) {
+  return exportOnce({
+    sessionRepository: { find: vi.fn().mockResolvedValue([{ ...SESSION, knowledgeIds: [GOOD] }]) },
+    knowledgeRepository: {
+      find: vi.fn().mockResolvedValue([file]),
+      findOne: vi.fn().mockResolvedValue(null),
+    },
+    fileStorageService: { getFileContent: vi.fn().mockResolvedValue(bytes) },
+  });
+}
+
+describe('notebook export - knowledge file bytes', () => {
+  it('embeds a binary knowledge file as base64 that decodes back byte-identical', async () => {
+    const payload = await exportWithKnowledge(PDF_BYTES);
+    const [knowledge] = payload.notebooks[0].knowledge;
+
+    // Compared against the fixture, not against a re-run of the production expression, so an
+    // encoder that mangles the bytes cannot satisfy this by mangling both sides the same way.
+    expect(Buffer.from(knowledge.content, 'base64').equals(PDF_BYTES)).toBe(true);
+  });
+
+  it('embeds a UTF-8 text file unchanged', async () => {
+    const payload = await exportWithKnowledge(TEXT_BYTES, TEXT_FILE);
+    const [knowledge] = payload.notebooks[0].knowledge;
+
+    expect(Buffer.from(knowledge.content, 'base64').toString('utf-8')).toBe(TEXT_BYTES.toString('utf-8'));
+  });
+
+  it('round trips a binary knowledge file through import with the stored bytes intact', async () => {
+    const payload = await exportWithKnowledge(PDF_BYTES);
+
+    const uploads: Buffer[] = [];
+    const importAdapters = {
+      sessionRepository: {
+        find: vi.fn().mockResolvedValue([]),
+        create: vi.fn(async (data: Record<string, unknown>) => ({ ...data, id: 'new-session-id' })),
+        updateById: vi.fn(),
+      },
+      chatHistoryRepository: { bulkCreate: vi.fn(), deleteMany: vi.fn() },
+      knowledgeRepository: { create: vi.fn().mockResolvedValue({ id: 'new-knowledge-id' }) },
+      artifactRepository: { create: vi.fn() },
+      toolRepository: { create: vi.fn(), find: vi.fn(), findById: vi.fn() },
+      agentRepository: { create: vi.fn() },
+      userRepository: { findById: vi.fn().mockResolvedValue({ id: 'user-2' }) },
+      fileStorageService: {
+        uploadFile: vi.fn(async (_path: string, content: Buffer) => {
+          uploads.push(content);
+        }),
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      generateId: () => 'generated-id',
+    } as unknown as NotebookImportAdapters;
+
+    const result = await new NotebookImportService(importAdapters).importNotebooks('user-2', payload, {
+      conflictResolution: 'rename',
+      importKnowledge: true,
+      importArtifacts: false,
+      importTools: false,
+      importAgents: false,
+    } as never);
+
+    expect(result.warnings).toEqual([]);
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].equals(PDF_BYTES)).toBe(true);
+  });
+});
+
+describe('notebook export - image bytes', () => {
+  async function exportWithImage(bytes: Buffer | null) {
+    return exportOnce({
+      chatHistoryRepository: {
+        find: vi
+          .fn()
+          .mockResolvedValueOnce([
+            { id: 'msg-1', timestamp: new Date('2026-01-01T00:00:00Z'), images: ['images/user-1/shot.png'] },
+          ])
+          .mockResolvedValue([]),
+      },
+      fileStorageService: { getFileContent: vi.fn().mockResolvedValue(bytes) },
+    });
+  }
+
+  it('embeds an image as base64 that decodes back byte-identical', async () => {
+    // Same guard as the knowledge path: this call site encodes separately, so it needs its own
+    // fixture comparison rather than inheriting the other one's coverage.
+    const payload = await exportWithImage(PDF_BYTES);
+    const [image] = payload.notebooks[0].chatHistory[0].images;
+
+    expect(Buffer.from(image, 'base64').equals(PDF_BYTES)).toBe(true);
+  });
+
+  it('exports the path instead when the image cannot be read', async () => {
+    const payload = await exportWithImage(null);
+
+    expect(payload.notebooks[0].chatHistory[0].images).toEqual(['images/user-1/shot.png']);
   });
 });

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -407,9 +407,8 @@ export class NotebookExportService {
             const storagePath = file.filePath;
             if (storagePath) {
               const content = await this.adapters.fileStorageService.getFileContent(storagePath);
-              // `=== null` rather than truthiness, matching processImages below. An empty Buffer is
-              // a truthy object where the old `string` was falsy, so relying on truthiness here
-              // would make a zero-byte file's branch an accident of the return type.
+              // `=== null`, matching processImages below: an empty Buffer is truthy where the old
+              // `string` was falsy, so truthiness would make the zero-byte branch an accident.
               if (content !== null) {
                 exportedFile.content = content.toString('base64');
               } else {

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -121,7 +121,12 @@ type ChatMessageRow = Pick<
 
 /** Only the three storage calls this service makes, not a whole storage client. */
 interface ExportFileStorage {
-  getFileContent(filePath: string): Promise<string | null>;
+  /**
+   * Bytes, never a string: an implementation that decodes to UTF-8 on the way out replaces every
+   * byte it cannot represent with U+FFFD, and the base64 below then preserves the damage rather
+   * than the file. Buffer here makes such an adapter a compile error.
+   */
+  getFileContent(filePath: string): Promise<Buffer | null>;
   uploadFile(path: string, content: Buffer): Promise<void>;
   getSignedUrl(filePath: string, expiresIn?: number): Promise<string | null>;
 }
@@ -402,8 +407,11 @@ export class NotebookExportService {
             const storagePath = file.filePath;
             if (storagePath) {
               const content = await this.adapters.fileStorageService.getFileContent(storagePath);
-              if (content) {
-                exportedFile.content = Buffer.from(content).toString('base64');
+              // `=== null` rather than truthiness, matching processImages below. An empty Buffer is
+              // a truthy object where the old `string` was falsy, so relying on truthiness here
+              // would make a zero-byte file's branch an accident of the return type.
+              if (content !== null) {
+                exportedFile.content = content.toString('base64');
               } else {
                 exportedFile.contentUrl = file.fileUrl ?? storagePath; // Fallback to URL or path reference
               }
@@ -602,13 +610,14 @@ export class NotebookExportService {
 
         try {
           const imageContent = await this.adapters.fileStorageService.getFileContent(imagePath);
-          // getFileContent reports a failed read as null. Buffer.from(null) throws, so without
-          // this the miss would surface as an exception and take the same path as a real error.
+          // getFileContent reports a failed read as null, which has no toString('base64'), so
+          // without this the miss would surface as an exception and take the same path as a real
+          // error.
           if (imageContent === null) {
             this.adapters.logger.warn('Image content unavailable, exporting the path instead', { imagePath });
             return imagePath;
           }
-          return Buffer.from(imageContent).toString('base64');
+          return imageContent.toString('base64');
         } catch (error) {
           this.adapters.logger.warn('Failed to export image', { imagePath, error });
           return imagePath; // Fallback to path reference


### PR DESCRIPTION
# Pull Request

## Description

Closes #2427

Notebook export corrupted every binary knowledge file, silently.

The export route's storage adapter read a file with `getContentAsBuffer` and then decoded it with `toString('utf-8')` before handing it to the export service, which base64-encoded the result. Any byte not representable in UTF-8 became U+FFFD at the decode, so base64 preserved the damage rather than the file. Measured on real file signatures:

```
PNG      | 16 bytes -> 18 after utf8 round trip | CORRUPT
PDF      | 15 bytes -> 22 after utf8 round trip | CORRUPT
ZIP/docx | 10 bytes -> 10                       | INTACT
UTF8 text| 25 bytes -> 25                       | INTACT
```

Plain text and pure ASCII survive; binary does not. Length grows because each unrepresentable byte becomes a 3-byte replacement character.

Nothing gated the embed path by mime type, so this reached every knowledge file with a storage path under `maxFileSize` (default 10 MB, user-selectable 1-100 MB), PDFs and images included. The export reported success with a populated-looking `content` field and nothing warned.

**Blast radius:** the export payload only. The source file in storage was never touched, so this is a broken export/backup rather than data destruction. Import already decoded correctly (`Buffer.from(file.content, 'base64')`), so it faithfully wrote the mojibake wherever the knowledge import succeeded.

`S3Storage` already offers both `getContentAsBuffer` and `getContentAsString`, so the bug was purely the call site discarding the bytes it had asked for.

## Changes

- `ExportFileStorage.getFileContent` returns `Buffer | null` instead of `string | null`. Chosen over "return an already-base64 string" deliberately: a string return cannot distinguish raw bytes from base64 from utf-8-decoded text, so the bug could reappear silently. `Buffer` makes a decoding adapter a compile error.

  `ExportFileStorage` itself is unexported, but it is referenced by `NotebookExportAdapters`, which is exported and re-exported from the package root (`b4m-core/services/src/index.ts`), so this method signature is structurally part of `@bike4mind/services`' API. Any implementer returning `Promise<string | null>` stops typechecking on upgrade. There are none in this repo beyond the route and its tests, and none under `packages/premium`, but private overlays cannot be checked from here.
- The route adapter returns `getContentAsBuffer`'s buffer directly.
- Both embed sites (knowledge and images) drop the now-redundant `Buffer.from(content)` re-encode. This also removes two full-size intermediate copies per file, each of which scaled with `maxFileSize`.
- Both embed sites check `content !== null`. The old truthiness check happened to work only because an empty Buffer, unlike the empty string it replaced, is a truthy object; making it explicit stops the branch depending on the return type.

### Tests

Each guard compares against a byte fixture rather than re-deriving the production expression, which would pass either way.

Only the **route-level** tests fail against the old adapter, and that is inherent: the defect was in the adapter, and the service tests necessarily mock `getFileContent`, which hands the service a Buffer that the old `Buffer.from(content).toString('base64')` copied byte-identically. So the service-level and round-trip guards would stay green if only `export.ts` regressed. They earn their place against a regression in the service's own encoding (verified by reintroducing a decode there), and the return type is what stops the adapter regressing. Stated precisely because an earlier revision of this description overclaimed it.

- Route-level: exercises the adapter closure itself, captured off the service constructor. Fails before the fix with `Received: "%PDF-1.4\n????"`.
- Service-level: byte-identity for a binary fixture, and a UTF-8 text file unchanged.
- Round trip: export then import a binary knowledge file through the real `NotebookImportService`, asserting the stored bytes match the source.
- The image embed path encodes separately and had **no test coverage of any kind** — the shared options fixture never set `includeImages`, so `processImages` returned `[]` in every existing test. It now has its own byte-identity test plus a read-failure case.

## Guide for Testers

Backend-only. No UI changed.

1. Open `app.staging.bike4mind.com` and sign in.
2. Create a notebook, or open an existing one.
3. Upload a **PDF** and a **PNG** as knowledge files on that notebook. Expected: both appear in the knowledge list.
4. Also upload a **plain .txt** file containing `hello world`. Expected: appears in the list.
5. Export the notebook with knowledge included. Expected: the export completes and returns a download URL.
6. Download the export JSON and open it.
7. For the PDF entry under `notebooks[0].knowledge`, base64-decode its `content` field and save it as `check.pdf`. Expected: `check.pdf` opens in a PDF reader and renders identically to the file uploaded in step 3.
8. Repeat step 7 for the PNG. Expected: the image opens and renders correctly.
9. Repeat step 7 for the .txt. Expected: the decoded bytes read exactly `hello world`.
10. Import the same export file into a different account. Expected: the import reports success, and the PDF and PNG in the importing account open correctly.

**Before this fix**, steps 7 and 8 produce files that no reader will open (the bytes are replaced with U+FFFD sequences), while step 9 passes — that asymmetry is the signature of the bug.

### Regression Checks

11. Export a notebook with knowledge **excluded**. Expected: unchanged behavior, `knowledge` is empty.
12. Export a notebook whose knowledge file exceeds `maxFileSize`. Expected: unchanged behavior, the file appears in the listing with `contentUrl` rather than `content`.
13. Export a notebook containing chat messages with attached images. Expected: no change in behavior from before this PR, and **no image embeds as base64 at all**. Every generated image comes back as a bare path string - see the bucket mismatch under known gaps. An image attached to a message is not a counter-example either: it lands in `message.fabFileIds`, which the export emits as `attachedFiles?: string[]` - ids only, never bytes, never through `processImages`. Only `quest.images` reaches the image encode, and every writer of that field stores a generated-file key. An uploaded image only embeds when it is notebook **knowledge**, which is step 8's path (the knowledge embed branch), not the image path.

### What NOT to test

No UI, routing, styling, or auth behavior changed. The export request/response shape is unchanged except that a binary file's `content` now decodes to the real bytes.

## Additional Information

Verification run locally:

- `pnpm turbo:typecheck` — 44/44 pass
- `@bike4mind/services` — 6068 pass
- `apps/client` `--project node` — 6973 pass
- ASCII guards (`check-no-smart-punctuation.sh`, `check-no-control-bytes.sh`) clean. The text fixture uses `é`/`☃` escapes so the multi-byte case is exercised without non-ASCII source bytes.

Reviewed for test coverage, silent failures, comment accuracy, type design, reuse, simplification, efficiency, and altitude, then again for correctness after opening. The second pass is what produced the test fix in the follow-up commit and the three corrections above.

Known gaps deliberately left out of scope, each worth its own change:

- The image embed path reads the wrong bucket, so it does not work in production **at all** - not merely for generated images, because generated images are the only kind that reach it. Every writer of `quest.images` (`imageEdit`, `audioGeneration`, `musicGeneration`, `excelGeneration`, `persistRunAsQuest`, `QuestModel.addImagesByAgentExecutionId`) stores a generated-file key, and an uploaded image attached to a message goes to `fabFileIds` instead. `processImages`' base64 embed branch is therefore dead code. `getFileContent` resolves through `getFilesStorage()` (`Resource.fabFileBucket`), but `quest.images` holds bare uuid keys written by `context.imageGenerateStorage.upload(...)` into `Resource.generatedImagesBucket` - `processImages`' own comment already notes generated images have no FabFile row. The read misses, the catch logs at `error` level, and `processImages` exports the raw path. Two costs: images silently do not embed, and a routine export writes one error-level line per generated image, which by this route's own documented convention trips the CloudWatch filter. `getStorageForUrl` in `apps/client/server/queueHandlers/questExport.ts` resolves per path but keys off the URL, so a bare uuid key gives it nothing to match; the FabFile lookup `processImages` already performs is the available signal. Pre-existing, and the new image test is a unit test of the encode step that mocks storage, so it neither covers nor claims this.
- `(exportedFile.size || 0) <= options.maxFileSize` treats a missing or zero recorded `fileSize` as under the cap, so such a row embeds regardless of the object's real size. `size` comes off the FabFile row, not the read buffer.
- `processImages` re-checks `options.includeImages`, which its only caller already gated on. Dead in every reachable path.
- `processImages` returns `string[]` where a success is base64 and a read failure is the raw storage path, and the type documents only "Base64 encoded images or references". Node's base64 decoder is lenient, so a consumer decoding every element gets plausible-looking garbage instead of an error — the same failure shape this PR fixes, one function down. Giving images the `content`/`contentUrl` split that knowledge files already have means changing the export format and `importChatHistory`.
- `contentUrl` conflates four causes (too large, read returned null, read threw, no storage path) with no distinguishing field, and the size-skip branch is the only one that logs nothing at all.
- `contentUrl` can hold a bare storage path despite the field documenting a URL.
- A zero-byte knowledge file does not round trip, before or after this change: export now emits `content: ''`, and the import's `if (file.content)` cannot tell empty-but-present from absent. Both the old and new paths end at "warned and skipped", so this PR neither fixes nor worsens it.
- Export and import each hand-declare their own storage-adapter contract, translated ad hoc at each call site. `apps/client/server/s3/notebookImportComplete.ts` carries a third shape (a base64 string) that is currently dead code.
- At upload time `JSON.stringify` plus `storeExportFile`'s `Buffer.from(content)` hold roughly three simultaneous copies of the combined embedded content.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc




