### PR TITLE
fix(data-lakes): pin the chunkless-stall read sites and stop down() erasing a marker

### DIFF
--- a/apps/client/server/managers/fabFileManager.test.ts
+++ b/apps/client/server/managers/fabFileManager.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  findOneAndUpdate: vi.fn(),
+  upload: vi.fn(),
+  getMetadata: vi.fn(),
+  warn: vi.fn(),
+}));
+
+// fabFileManager pulls the whole DB/storage/pipeline graph at module load; stub it down to the two
+// collaborators this path actually drives.
+vi.mock('@bike4mind/database', () => ({ mongoose: {}, FabFile: { findOneAndUpdate: h.findOneAndUpdate } }));
+vi.mock('@server/utils/storage', () => ({
+  getFilesStorage: () => ({ upload: h.upload, getMetadata: h.getMetadata }),
+}));
+vi.mock('@casl/mongoose', () => ({ accessibleBy: () => ({ ofType: () => ({}) }) }));
+vi.mock('@server/auth/ability', () => ({ Ability: class {} }));
+vi.mock('@bike4mind/observability', () => ({ Logger: { warn: h.warn } }));
+vi.mock('@bike4mind/fab-pipeline', () => ({ EmbeddingService: class {} }));
+
+import { updateFabFile } from './fabFileManager';
+
+const filePath = 'files/contract.pdf';
+const session = {} as never;
+const ability = {} as never;
+
+// The shape findOneAndUpdate hands back: a hydrated doc, so `save()` runs schema validators where the
+// findOneAndUpdate above it does not.
+const hydratedFile = () => ({ filePath, mimeType: 'application/pdf', fileSize: 1, save: vi.fn() });
+
+const updateWithSameFilePath = (doc: ReturnType<typeof hydratedFile>) => {
+  h.findOneAndUpdate.mockReturnValue({ exec: async () => doc });
+  return updateFabFile('f1', { filePath }, 'body', ability, session);
+};
+
+describe('updateFabFile - recording the size S3 reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.getMetadata.mockResolvedValue({ size: 4096 });
+  });
+
+  // The save intends `fileSize` alone, and validating the untouched paths is what let an enum widened
+  // by a newer deploy (CHUNK_STALL_REASONS gaining a member) fail this write on an instance still
+  // running the old schema - swallowed by the catch below, so the size was silently never recorded.
+  it('validates only the modified path, so a value a newer schema added cannot fail the write', async () => {
+    const doc = hydratedFile();
+    await updateWithSameFilePath(doc);
+
+    expect(doc.fileSize).toBe(4096);
+    expect(doc.save).toHaveBeenCalledWith({ session, validateModifiedOnly: true });
+  });
+
+  // Why this is a lost update and not an error the caller sees: the main record already persisted via
+  // findOneAndUpdate, so the request succeeds either way. Anything failing here must therefore be
+  // legible in the log, which is the other half of the fix.
+  it('swallows a failure and still returns the record the update already persisted', async () => {
+    const doc = hydratedFile();
+    const validationError = new Error('chunkStallReason: `unchunkedPaused` is not a valid enum value');
+    doc.save.mockRejectedValue(validationError);
+
+    await expect(updateWithSameFilePath(doc)).resolves.toBe(doc);
+    expect(h.warn).toHaveBeenCalledWith(expect.stringContaining('file size'), validationError);
+  });
+
+  it('records nothing when S3 reports no size', async () => {
+    const doc = hydratedFile();
+    h.getMetadata.mockResolvedValue({});
+
+    await updateWithSameFilePath(doc);
+
+    expect(doc.save).not.toHaveBeenCalled();
+    expect(doc.fileSize).toBe(1);
+  });
+});

--- a/apps/client/server/managers/fabFileManager.ts
+++ b/apps/client/server/managers/fabFileManager.ts
@@ -95,10 +95,16 @@ export const updateFabFile = async (
       const metadata = await getFilesStorage().getMetadata(fileKey);
       if (metadata.size !== undefined) {
         updatedFabFile.fileSize = metadata.size;
-        await updatedFabFile.save({ session });
+        // Modified-only: this save intends `fileSize` alone, and mongoose otherwise validates every
+        // path on the hydrated doc. During a staggered deploy that means an old instance loading a row
+        // whose enum-valued field carries a value only the NEW schema lists (e.g. chunkStallReason)
+        // fails validation here and silently drops the size.
+        await updatedFabFile.save({ session, validateModifiedOnly: true });
       }
     } catch (error) {
-      Logger.warn('Failed to retrieve file metadata from S3:', error);
+      // Names this block, not S3: a mongoose ValidationError never reached the network, and blaming
+      // the download sent readers looking in the wrong place.
+      Logger.warn('Failed to record file size from S3 metadata:', error);
     }
   }
 

--- a/b4m-core/common/src/constants/lakeHealth.test.ts
+++ b/b4m-core/common/src/constants/lakeHealth.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_PASSAGE_TOKEN_TARGET, CHARS_PER_TOKEN_SERVE_BOUND, SERVE_CHUNK_CHARS_CEILING } from './chunking';
+import {
+  DEFAULT_PASSAGE_TOKEN_TARGET,
+  CHARS_PER_TOKEN_SERVE_BOUND,
+  CHUNKLESS_STALL_REASONS,
+  SERVE_CHUNK_CHARS_CEILING,
+} from './chunking';
 import {
   resolveLakeHealthPolicy,
   evaluateMemberHealth,
+  selectLakeHealthMembers,
   summarizeLakeHealth,
   findDuplicateMembers,
   type LakeHealthMemberInput,
@@ -451,12 +457,18 @@ describe('evaluateMemberHealth - passages DELETED by a halted wave must fail, no
     ...over,
   });
 
-  it('fails P3 on its proven zero rather than grading unknown', () => {
-    const r = evaluateMemberHealth(stranded(), DEFAULT_POLICY);
-    expect(r.status.fullyVectorized).toBe('fail');
-    expect(r.failed).toContain('fullyVectorized');
-    expect(r.reachableChars).toBe(0);
-    expect(r.measured).toBe(true);
+  // Driven from the subset rather than `stranded()`'s default alone. A file that arrived empty
+  // (`unchunkedPaused`) and one a wave emptied (`rechunkPaused`) are the same halted state by the time
+  // they reach this grader, so they must grade identically - and a loop keeps a future chunk-arm
+  // reason covered without editing this test.
+  it('fails P3 on its proven zero rather than grading unknown, for every chunk-arm reason', () => {
+    for (const chunkStallReason of CHUNKLESS_STALL_REASONS) {
+      const r = evaluateMemberHealth(stranded({ chunkStallReason }), DEFAULT_POLICY);
+      expect(r.status.fullyVectorized).toBe('fail');
+      expect(r.failed).toContain('fullyVectorized');
+      expect(r.reachableChars).toBe(0);
+      expect(r.measured).toBe(true);
+    }
   });
 
   it('is named in the drill-down, and drops the lake off a fully-passing predicate tally', () => {
@@ -486,6 +498,18 @@ describe('evaluateMemberHealth - passages DELETED by a halted wave must fail, no
   it('leaves the vectorize-arm marker alone - it has chunks, so it grades on its real rollups', () => {
     const r = evaluateMemberHealth(stranded({ chunkCount: 0, chunkStallReason: 'vectorizePaused' }), DEFAULT_POLICY);
     expect(r.status.fullyVectorized).toBe('unknown');
+  });
+
+  // The ADMISSION half of the same fix, and inert without it either way round: grading a chunkless
+  // member correctly buys nothing if the selector drops it before the grader sees it, which is why
+  // both key on the same subset. The unmarked row is the control - nothing distinguishes it from an
+  // image or a pending upload, so it stays out.
+  it('admits every chunk-arm reason into the graded set, and still leaves an unmarked chunkless member out', () => {
+    for (const chunkStallReason of CHUNKLESS_STALL_REASONS) {
+      expect(selectLakeHealthMembers([stranded({ chunkStallReason })])).toHaveLength(1);
+    }
+    expect(selectLakeHealthMembers([stranded({ chunkStallReason: 'vectorizePaused' })])).toEqual([]);
+    expect(selectLakeHealthMembers([stranded({ chunkStallReason: null })])).toEqual([]);
   });
 });
 

--- a/packages/database/src/models/content/FabFileModel.lakeHealthRollups.test.ts
+++ b/packages/database/src/models/content/FabFileModel.lakeHealthRollups.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { KnowledgeType } from '@bike4mind/common';
+import { CHUNKLESS_STALL_REASONS, KnowledgeType } from '@bike4mind/common';
 import { FabFile, FabFileChunk, fabFileChunkRepository, fabFileRepository } from './FabFileModel';
 import { setupMongoTest } from '../../__test__/utils';
 
@@ -191,6 +191,34 @@ describe('lake-health rollup primitives (#1666)', () => {
 
       const converge = await fabFileRepository.findLakeConvergenceMembers(scope);
       expect(converge.map(m => m.fileName).sort()).toEqual(['mine-by-prefix-paused.txt', 'mine-paused.txt']);
+    });
+
+    // The other dimension of that same `$or` arm: WHICH reasons it admits. Driven from the shared
+    // subset because an `$in` that drifts back to a single literal fails SILENTLY - it just selects
+    // the wrong set, with no type error and no runtime error, which is how a chunkless member
+    // disappears from health and from the convergence plan at once.
+    it('admits every chunk-arm reason into both reads, and no chunkless member of the vectorize arm', async () => {
+      for (const chunkStallReason of CHUNKLESS_STALL_REASONS) {
+        await makeFile(`mine-${chunkStallReason}.txt`, {
+          chunkCount: 0,
+          chunkStallReason,
+          tags: [{ name: tag, strength: 1 }],
+        });
+      }
+      // A vectorize-paused file still HAS its passages, so `chunkCount > 0` is what admits it and this
+      // arm must not: folding the arms together here would grade it as chunkless.
+      await makeFile('mine-vectorize-paused.txt', {
+        chunkCount: 0,
+        chunkStallReason: 'vectorizePaused',
+        tags: [{ name: tag, strength: 1 }],
+      });
+
+      const expected = CHUNKLESS_STALL_REASONS.map(reason => `mine-${reason}.txt`).sort();
+      const health = await fabFileRepository.findDataLakeHealthMembers(scope);
+      expect(health.map(m => m.fileName).sort()).toEqual(expected);
+
+      const converge = await fabFileRepository.findLakeConvergenceMembers(scope);
+      expect(converge.map(m => m.fileName).sort()).toEqual(expected);
     });
 
     // #1939's arm of the same `$or`, with the same scoping obligation. A member mid-rebuild is

--- a/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts
@@ -191,6 +191,23 @@ describe('split-chunk-stall-markers-off-notes migration (real DB)', () => {
     }
   });
 
+  // A marker `up()` can never itself produce: the runtime gained `unchunkedPaused` after this
+  // migration, so the honest scenario is a row the post-split runtime stamped once `up()` had already
+  // run. Seeded with the raw driver for that reason - routing through `up()` like the tests above
+  // cannot reach this state. Before the third arm the sweep below dropped the field with no prose
+  // written in its place, so the file read as healthy to every pre-split reader.
+  it('down restores the closest prose for a marker up() never wrote, rather than erasing it', async () => {
+    const file = await insertLegacyFile({ chunkStallReason: 'unchunkedPaused' });
+
+    await migration.down();
+
+    const row = await rawFabFiles().findOne({ _id: file._id });
+    // The `rechunkPaused` wording, deliberately: it mislabels the file but keeps it visible as
+    // stalled, and it is prose the transitional read arms already honor. See `down()`.
+    expect(row?.notes).toBe(RECHUNK_PAUSED_NOTE);
+    expect('chunkStallReason' in (row ?? {})).toBe(false);
+  });
+
   it('down restores the prose only where notes is free, and always drops the new fields', async () => {
     const stalled = await insertLegacyFile({ notes: VECTORIZE_PAUSED_NOTE });
     await migration.up();

--- a/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
+import { LEGACY_CHUNK_STALL_NOTES } from '@bike4mind/common';
 import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
 
 vi.mock('../../utils/config', () => ({ Config: {} }));
@@ -205,6 +206,11 @@ describe('split-chunk-stall-markers-off-notes migration (real DB)', () => {
     // The `rechunkPaused` wording, deliberately: it mislabels the file but keeps it visible as
     // stalled, and it is prose the transitional read arms already honor. See `down()`.
     expect(row?.notes).toBe(RECHUNK_PAUSED_NOTE);
+    // Restoring prose no transitional reader honors would make this arm cosmetic - the file would
+    // still read as healthy, which is the bug it exists to prevent. NOT covered by the reword guard
+    // in `chunking.test.ts`: that pins this file's literals against a reword of `CHUNK_STALL_NOTICES`
+    // and stays green if someone "fixes" the mislabelling by giving this arm a wording of its own.
+    expect(LEGACY_CHUNK_STALL_NOTES).toContain(row?.notes);
     expect('chunkStallReason' in (row ?? {})).toBe(false);
   });
 

--- a/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts
+++ b/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts
@@ -56,7 +56,9 @@ import { type MigrationFile } from './index';
  * arms honor the prose it restores, so the still-new stack keeps working until it is gone. It is a
  * PARTIAL restore by design (see its comment): a row whose owner typed a note after `up()` keeps
  * that note and loses its marker with the dropped field, so audit those rather than assume `down()`
- * recovered every row.
+ * recovered every row. A row carrying a stall reason this migration never backfilled - the runtime
+ * gained `unchunkedPaused` after it - is restored with the closest available wording rather than
+ * erased; `down()` says why that is the right way round.
  */
 
 /** Applied to the two stall notes only; they are fixed literals but contain a regex metacharacter ('.'). */
@@ -181,9 +183,19 @@ const migration: MigrationFile = {
     // exact harm this migration exists to undo - so its marker survives only in the dropped field.
     // Such a row grades as unstalled after a rollback, which is the same reading it had before the
     // marker was ever written.
+    //
+    // The third arm is deliberately NOT symmetric restoration: `unchunkedPaused` postdates this
+    // migration, so `up()` never wrote its prose and there is none to put back. It gets the
+    // `rechunkPaused` wording as the closest a pre-#2016 reader can understand, which MISLABELS the
+    // file - it never had passages to remove - but the alternative is writing nothing and then
+    // dropping the field below, leaving a kill-switch-stalled file that reads as healthy to every one
+    // of those readers. Mislabelled-but-visible beats invisible (FabFileTypes.ts makes the same trade
+    // for the same reason). That wording is also already in `LEGACY_CHUNK_STALL_NOTES`, so a stack
+    // still running new code keeps honoring what this restores instead of ignoring it.
     for (const [reason, note] of [
       ['vectorizePaused', VECTORIZE_PAUSED_NOTE],
       ['rechunkPaused', RECHUNK_PAUSED_NOTE],
+      ['unchunkedPaused', RECHUNK_PAUSED_NOTE],
     ] as const) {
       const result = await fabFiles.updateMany(
         { chunkStallReason: reason, $or: [{ notes: { $exists: false } }, { notes: '' }] },


### PR DESCRIPTION
Closes #2440

## Description

Three P3 follow-ups from #2369, which added the `unchunkedPaused` stall reason so a file that arrived empty is no longer told its passages were removed. That PR was approved with no P0/P1/P2 findings; these are the loose ends, and the first was called out in #2369's own body as worth a follow-up.

They ship together because they are small and share one subject: the consequences of widening `CHUNK_STALL_REASONS`.

**1. None of the four widened read sites was pinned by a test.** `unchunkedPaused` was never driven through any of the four sites #2369 moved onto `CHUNKLESS_STALL_REASONS`, so all four could silently regress to their pre-PR `rechunkPaused`-only behaviour with nothing failing. The literal appeared in only three test files repo-wide, none of which covers these sites: `markConvergencePaused.test.ts` tests the WRITER, `chunking.test.ts` tests `isChunklessStall` in isolation (it passes whether or not any caller uses it), and `chunkScan.test.ts` exercises a site that reads the FULL reason set. `lakeHealth.test.ts` pinned only the EXCLUSION of the vectorize arm, which a bare equality check also satisfies. Confirmed by mutating all four sites and watching the suites stay green.

**2. The #2016 migration's `down()` erased an `unchunkedPaused` marker.** The restore loop iterated `vectorizePaused` and `rechunkPaused` only, so such a row matched neither arm and got no prose written back - but the `$unset` sweep that follows, filtered on `chunkStallReason: { $exists: true }`, did match it. After a rollback past #2016 the file had neither the field nor any marker prose, so it graded as unstalled to every pre-#2016 reader: no `abandonedByKillSwitch` health signal, a permanent "still indexing" from `partitionByIndexAvailability`, and no "Rebuild passages" repair from `findConvergencePausedFilesByScope`. Pre-#2369 that same file carried `rechunkPaused` and DID get its prose restored, so this is a rollback-only regression introduced by the split.

**3. `.save()` validated untouched paths.** During a staggered deploy, an instance on the old schema loading a FabFile already carrying `unchunkedPaused` threw a `ValidationError` on `.save()` even though only `fileSize` was modified. `.save()` runs schema validators where the `findOneAndUpdate` above it does not, and the schema enum derives from `CHUNK_STALL_REASONS`, so widening the constant widened the validator on the new deploy only. Verified against a real `mongod` on mongoose 8.24.1: `modifiedPaths` is `["fileSize"]`, the save throws on `chunkStallReason`, and the size is never persisted. Mongoose's default is not modified-only.

## Changes

- **`b4m-core/common/src/constants/lakeHealth.test.ts`** - the grading assertion for a stranded member now loops `CHUNKLESS_STALL_REASONS` instead of relying on the fixture's default `rechunkPaused`, and a new case pins the ADMISSION half: `selectLakeHealthMembers` admits every chunk-arm reason, excludes a chunkless vectorize-arm row, and still excludes an unmarked chunkless member (the control - nothing distinguishes it from an image or a pending upload).
- **`packages/database/src/models/content/FabFileModel.lakeHealthRollups.test.ts`** - one case seeds a member per chunk-arm reason and asserts both `findDataLakeHealthMembers` and `findLakeConvergenceMembers` return all of them, plus a chunkless `vectorizePaused` row that neither may admit.
- **`packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.ts`** - `down()` gains a third arm mapping `unchunkedPaused` to the `rechunkPaused` prose. `up()` is untouched, so no forward migration changes. The file header now names the erasure so the rollback story stays complete in one place.
- **`apps/client/server/managers/fabFileManager.ts`** - `save({ session, validateModifiedOnly: true })`, and the catch's warning now names this block instead of blaming an S3 download that never failed.
- **`apps/client/server/managers/fabFileManager.test.ts`** - new file. Pins the save option, that a failure here is swallowed and still returns the record `findOneAndUpdate` already persisted, and that nothing is saved when S3 reports no size.

Reason sets are driven from `CHUNKLESS_STALL_REASONS` wherever a loop reads naturally, which is the idiom #2369 established elsewhere (`retrievalUnavailable.test.ts` and `chunk.test.ts` both loop `CHUNK_STALL_REASONS`). Nothing looped the chunkless subset outside `chunking.test.ts` before this; these are the first, which is the point - a future fourth chunk-arm reason is covered without editing a test.

## Additional Information

**Why `down()` writes prose `up()` never wrote.** This is deliberately NOT symmetric restoration: `unchunkedPaused` postdates the migration, so there is no original prose to put back. Writing the `rechunkPaused` wording mislabels the file - it never had passages to remove - but the alternative is writing nothing and then dropping the field, leaving a kill-switch-stalled file that reads as healthy to every pre-#2016 reader. Mislabelled-but-visible beats invisible, which is the trade the codebase already makes in `FabFileTypes.ts`. The comment on the arm says so explicitly, so nobody later "fixes" it into silence.

**It does not contradict the `LEGACY_CHUNK_STALL_NOTES` guard.** That guard pins the legacy note list to the two reasons the migration backfilled, because a migration's predicate is a historical fact. It constrains the set of prose the RUNTIME reads back, and `up()`'s own two literals are unchanged. A `down()`-only third arm touches neither - and because the arm writes prose already in the pinned set, it does not widen the list either. The restored note is therefore honoured by the transitional read arms (`isChunkStalledFile`) and by `buildFabFileSearchQuery`'s legacy arm rather than being inert, which is what makes the restore worth doing at all.

**The `upload.ts` caveat behind item 3's P3 grade.** The patched `.save()` is the only REACHABLE one on a FabFile document in non-test source, and a status guard is what makes that true. There is a second in `pages/api/files/[id]/upload.ts` with no `try`/`catch`, where a `ValidationError` would surface as a 500 and lose the status write - but that handler 400s unless `status === 'pending'`, and a file carrying `unchunkedPaused` has been through chunking, so its status is `complete`. Worth knowing, because relaxing that guard would turn this into a 500. (Two more live in an unrelated 2025 migration, which only matters if an old migrator runs against new data - the rollback path item 2 covers.)

Item 3 is a general property of widening any enum against a staggered deploy, not something specific to `unchunkedPaused`; #2369 is just the first change to widen `CHUNK_STALL_REASONS` since that `.save()` existed. `validateModifiedOnly` covers every future widening at that site and is independently correct there, since the save only intends `fileSize`. A general answer - a lint rule, or dropping the schema enum in favour of the shared predicate - is a bigger conversation and deliberately out of scope.

## Guide for Testers

Backend-only, no UI. Item 3 is reachable only during a staggered deploy with a platform kill switch on, and item 2 only on a manual rollback, so verification is by test.

### Automated

1. Run `pnpm --filter @bike4mind/common test src/constants/lakeHealth.test.ts`. Expected: all passed.
2. Run `pnpm --filter @bike4mind/database test src/models/content/FabFileModel.lakeHealthRollups.test.ts`. Expected: 9 passed.
3. Run `pnpm --filter @bike4mind/scripts test migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts`. Expected: 10 passed.
4. Run `pnpm --filter @bike4mind/client exec vitest run --project node server/managers/fabFileManager.test.ts`. Expected: 3 passed.

### Proving each test actually bites

1. In `lakeHealth.ts`, change `passagesRemoved` to `member.chunkCount === 0 && member.chunkStallReason === 'rechunkPaused'` and re-run step 1. Expected: the grading case fails. Do the same to `selectLakeHealthMembers` and the admission case fails.
2. In `FabFileModel.ts`, change either `$match`'s `{ chunkStallReason: { $in: [...CHUNKLESS_STALL_REASONS] } }` to `{ chunkStallReason: 'rechunkPaused' }` and re-run step 2. Expected: failure on whichever read you broke.
3. Remove the `['unchunkedPaused', RECHUNK_PAUSED_NOTE]` arm from `down()` and re-run step 3. Expected: the new case fails with `notes` coming back undefined.
4. Drop `validateModifiedOnly: true` and re-run step 4. Expected: two cases fail.

### Regression Checks

1. A lake's health headline and `Reachable %` are unchanged for a lake containing a halted chunkless member - it stays in the denominator and still grades its real zero.
2. Editing a file's content still records the new `fileSize` (the item-3 path's happy case).
3. Running the #2016 migration forward is unchanged - `up()` was not touched, and its idempotency cases still pass.

### What NOT to test

No UI was added or moved, no route or contract changed, no admin setting was added, and no forward migration behaviour changed. Nothing to check on responsiveness, toasters, or navigation.

## Developer Notes

- **A `Record`-derived subset constant only pays off if the read sites are pinned to it.** `CHUNKLESS_STALL_REASONS` cannot compile until a new reason is classified, which guards the DEFINITION - but nothing stopped a caller drifting back to a bare literal, and in a Mongo `$in` that fails silently by selecting the wrong set. Looping the constant in the tests is what closes the other half; it is the cheap habit to copy wherever a shared subset drives a query.
- **`validateModifiedOnly` is the default worth reaching for on any partial `.save()` of a hydrated document.** Mongoose validates every path by default, so a document loaded on an old deploy carries the new deploy's enum values into a validator that rejects them - a staggered-deploy hazard that has nothing to do with the field being written.
- **A migration's `down()` can legitimately be asymmetric, and should say so.** Restoring the closest available prose rather than nothing is a visibility decision, not a bug, and it needs a comment to survive the next reader.
