### PR TITLE
fix(client): stop a collapsed accordion panel from swallowing clicks

### DIFF
--- a/apps/client/app/components/admin/AdminPage.tsx
+++ b/apps/client/app/components/admin/AdminPage.tsx
@@ -188,15 +188,7 @@ const SidebarNav = ({
         const { Icon: SectionIcon } = section;
         const visibleItems = section.items.filter(item => !item.gate || gates[item.gate]);
         return (
-          <Accordion
-            key={section.key}
-            expanded={isExpanded(section.key)}
-            onChange={() => toggleSection(section.key)}
-            // raise an expanded panel above its neighbors so a neighboring
-            // header cannot intercept clicks on this section's nav items. Joy
-            // elevates a summary to zIndex 1 on focus/hover, so beat that.
-            sx={{ position: 'relative', ...(isExpanded(section.key) && { zIndex: 2 }) }}
-          >
+          <Accordion key={section.key} expanded={isExpanded(section.key)} onChange={() => toggleSection(section.key)}>
             <AccordionSummary>
               <SectionIcon color="primary" />
               <Typography color="primary" level="body-md">

--- a/apps/client/app/utils/themes/customizations/navigation.test.tsx
+++ b/apps/client/app/utils/themes/customizations/navigation.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { Accordion, AccordionDetails, AccordionGroup, AccordionSummary, Button } from '@mui/joy';
+import AppTheme from '../AppTheme';
+
+const renderAccordion = (expanded: boolean) =>
+  render(
+    <AppTheme>
+      <AccordionGroup>
+        <Accordion expanded={expanded}>
+          <AccordionSummary>Section</AccordionSummary>
+          <AccordionDetails data-testid="accordion-panel">
+            <Button data-testid="accordion-nav-btn">Nav item</Button>
+          </AccordionDetails>
+        </Accordion>
+      </AccordionGroup>
+    </AppTheme>
+  );
+
+describe('JoyAccordionDetails theme override', () => {
+  // Joy marks a collapsed panel with the native `hidden` attribute but then sets
+  // `display: grid` on the same element, which beats the user-agent `[hidden]` rule. The
+  // attribute alone is therefore inert: the panel is clipped to a zero-height grid row
+  // while its children keep full-size, hit-testable boxes that swallow clicks aimed at
+  // whatever sits below them. Asserting on the computed visibility, not the attribute, is
+  // what pins the override down.
+  it('takes a collapsed panel out of hit-testing, not just out of view', () => {
+    renderAccordion(false);
+
+    const panel = screen.getByTestId('accordion-panel');
+    expect(panel).toHaveAttribute('hidden');
+    expect(getComputedStyle(panel).visibility).toBe('hidden');
+  });
+
+  it('leaves an expanded panel interactive', () => {
+    renderAccordion(true);
+
+    const panel = screen.getByTestId('accordion-panel');
+    expect(panel).not.toHaveAttribute('hidden');
+    expect(getComputedStyle(panel).visibility).not.toBe('hidden');
+    expect(screen.getByTestId('accordion-nav-btn')).toBeVisible();
+  });
+});

--- a/apps/client/app/utils/themes/customizations/navigation.tsx
+++ b/apps/client/app/utils/themes/customizations/navigation.tsx
@@ -2,6 +2,24 @@ import { gray } from '../colors';
 import type { Theme } from '@mui/joy/styles';
 
 export const navigationCustomizations = {
+  /**
+   * A collapsed AccordionDetails is clipped to a zero-height grid row, but its children
+   * keep their full boxes and stay hit-testable, so they intercept clicks aimed at
+   * whatever renders below them - typically the next section's header. Joy already sets
+   * the native `hidden` attribute on a collapsed panel, but its own `display: grid`
+   * overrides the user-agent `[hidden] { display: none }` rule, so the attribute has no
+   * effect. Honour it with `visibility` rather than `display` so the panel stays
+   * animatable if an AccordionGroup is ever given a `transition`.
+   */
+  JoyAccordionDetails: {
+    styleOverrides: {
+      root: {
+        '&[hidden]': {
+          visibility: 'hidden' as const,
+        },
+      },
+    },
+  },
   JoyMenu: {
     styleOverrides: {
       root: ({ theme }: { theme: Theme }) => {

--- a/apps/client/e2e/admin-settings-secrets.spec.ts
+++ b/apps/client/e2e/admin-settings-secrets.spec.ts
@@ -32,9 +32,10 @@ type SettingDoc = { settingName: string; settingValue: unknown };
 async function gotoAdminSettings(page: Page, adminPage: { gotoAdmin: () => Promise<void> }) {
   await adminPage.gotoAdmin();
 
-  // Admin Settings lives in the "General Ops" accordion, which is collapsed on load - its
-  // summary swallows the click otherwise. The nav also renders twice (desktop rail and
-  // mobile drawer), so every lookup takes the on-screen one.
+  // Admin Settings lives in the "General Ops" accordion, which is collapsed on load, and a
+  // collapsed panel's contents are not visible - so the section has to be opened before the
+  // nav button can be clicked. The nav also renders twice (desktop rail and mobile drawer),
+  // so every lookup takes the on-screen one.
   const section = page.getByRole('button', { name: 'General Ops' }).filter({ visible: true }).first();
   await expect(section).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
   if ((await section.getAttribute('aria-expanded')) !== 'true') {


### PR DESCRIPTION
## Description

Closes #2346

Closing on the basis that no remaining defect is demonstrable: the sequence in the issue does not fail on this branch, and it did not fail before the fix either (see Additional Information). A real, adjacent defect was found and is fixed here. If anyone can still produce a failing first click in a genuinely expanded panel, please reopen with the sidebar state at the time - that would be a different bug from the one fixed here.

The reported symptom class is real - clicks going astray around these accordions - but the cause named in the issue is not. The issue hypothesises that a section label wrapping to three lines makes the `AccordionSummary` box overflow downward into its own expanded `AccordionDetails`, and that Joy's `zIndex: 1` on the summary then wins the hit test. Measured in a real browser against the actual `SidebarNav` (real `SIDEBAR_SECTIONS`, real `AppTheme`, real Joy, the production 176px rail width), both halves are false: a 3-line header grows the summary correctly to 82px, with `summaryBottom - detailsTop == 0` exactly, at every label length and on every section; and Joy elevates the summary under `&:focus-visible` only, so on a mouse click the summary's computed `z-index` stays `auto` and the existing mitigation never engaged for mouse users at all.

The real defect sits right next to it. A collapsed `AccordionDetails` is clipped to a zero-height grid row (`grid-template-rows: 0fr` plus `overflow: hidden`), but its children keep their full-size, hit-testable boxes. Those phantom boxes land on top of whatever renders below the collapsed panel - normally the next section's header - so a click aimed at an item in a collapsed panel is intercepted, and only a JS-dispatched `el.click()`, which bypasses hit testing, gets through. Joy is already trying to prevent exactly this: `AccordionDetails` sets the native `hidden` attribute on a collapsed root. But it also sets `display: grid` on that same element, which beats the user-agent `[hidden] { display: none }` rule, so the attribute is inert.

A workaround for this same class of bug already existed in the repo, which is good corroboration: before this PR, `apps/client/e2e/admin-settings-secrets.spec.ts` had to expand the "General Ops" section before it could click a nav button, under a comment reading "its summary swallows the click otherwise".

(Correcting an earlier revision of this description, which claimed *two* independent workarounds and also cited `apps/client/e2e/pages/ModelSelectorPage.ts`'s `await modelCard.evaluate(el => el.click())`. That one is a different problem - its own docblock attributes it to coordinate-based clicking inside a nested `overflow:auto` scroll container, not to a collapsed panel - so it is not corroboration and has been dropped from the argument. Only one workaround actually corroborates.)

Fixed at theme level on purpose: the defect is in Joy's shared `AccordionDetails`, and this app has 18 accordion call sites. A local `sx` on the admin sidebar would fix the reported symptom and leave the same landmine everywhere else. Easy to scale down to one `sx` if a reviewer prefers that.

## Changes

- `apps/client/app/utils/themes/customizations/navigation.tsx` - new `JoyAccordionDetails` override: `&[hidden] { visibility: hidden }`. It honours the attribute Joy already sets, which takes a collapsed panel out of hit testing and out of the accessibility tree. `visibility` rather than `display: none` so the panel stays animatable if an `AccordionGroup` is ever given a `transition`.
- `apps/client/app/components/admin/AdminPage.tsx` - removed the `sx={{ position: 'relative', ...(isExpanded && { zIndex: 2 }) }}` mitigation and its comment. The comment's premise is factually wrong (Joy elevates on `:focus-visible`, not focus/hover), `position: relative` was already redundant because Joy's `StyledListItem` base sets it, and all four browser scenarios stay green with it removed. It is dead weight once the real cause is fixed.
- `apps/client/app/utils/themes/customizations/navigation.test.tsx` (new) - regression test. It asserts computed `visibility`, not the `hidden` attribute, because the attribute is present and passing even with the bug - that is the whole point. Confirmed red without the fix.
- `apps/client/e2e/admin-settings-secrets.spec.ts` - comment only. It encoded the same misdiagnosis; rewritten to state the requirement (open the section first) without the wrong mechanism. Logic untouched.

## Guide for Testers

Log in with an account that has admin access. Everything below happens in the admin left rail, reached via **Sidebar -> Admin**. Leave the sidebar at its default (non-widened) width for the whole pass - widening it is the workaround the issue describes and would mask the behaviour under test.

1. Open the app and log in as an admin.
2. Click **Sidebar -> Admin**. Expected: the admin page loads with a left rail of collapsed section headers - **User Ops**, **Security**, **Reliability / Incident Ops**, **AI & Agents**, and the rest.
3. Look at the **Reliability / Incident Ops** header. Expected: its label wraps to three lines, and it does not visually overlap the header below it.
4. Click **Reliability / Incident Ops**. Expected: the section expands and its items appear - **SRE Agent**, **DLQ Management**, **Rate Limits**, **System Health**, **Event Metrics**.
5. Click the **first** item in that panel - **SRE Agent** (or **LiveOps Triage**, if that gate is on for your account). Expected: the tab opens on the first click. No second click needed, and no need to click a lower item first.
6. Click **Reliability / Incident Ops** again to collapse it. Expected: the panel closes and none of its items are visible.
7. With that section collapsed, click **AI & Agents** - the header directly below it. Expected: it expands on the first click.
8. Click the first item in that panel, **Agent Operations**. Expected: the tab opens on the first click.
9. Repeat steps 4 and 5 for **User Ops** (first item **Users**) and for **Security** (first item **SecOps Triage**). Expected: the first item opens on the first click in both.
10. Expand every section at once, then click the first item of each in turn. Expected: every one opens on the first click.
11. Keyboard pass: with all sections collapsed, press `Tab` repeatedly to walk focus through the admin rail. Expected: focus visits the section headers only - it never lands on an item inside a collapsed section.
12. Put focus on a collapsed section's header and press `Enter`. Expected: the section expands, and its items are visible and clickable with the mouse.

**Known gap - do not log this against this PR.** After that expand, pressing `Tab` does *not* move focus into the section's items; it skips to the next section's header. This is a pre-existing MUI Joy defect, present on `main` too: `AccordionDetails` sets `tabindex="-1"` on every focusable descendant when the panel collapses, and its restore path fails for elements that had no `tabindex` to begin with, so the `-1` is never removed. An earlier revision of this step asked testers to `Tab` once and press `Enter` to open the first item - that step could never have passed on any build, and it has been corrected here. Tracked separately.

### Regression Checks

13. **Sidebar -> Admin -> General Ops -> Admin Settings** opens as before. Expected: unchanged.
14. Open the chat model picker and expand one of its backend groups. Expected: unchanged - collapsed groups reveal their cards on expand, and a card is clickable once its group is open.
15. Scan any other accordion you use regularly (for example **Profile -> API Keys**, or the Help panel). Expected: no visual difference anywhere. This change affects hit testing on collapsed panels only, not layout or styling.

### What NOT to test

- Do not test open/close animation. Nothing in this repo passes a `transition` to an `AccordionGroup`, so no accordion animates today. The fix is written with `visibility` rather than `display` so it stays compatible if one is ever added.
- Do not test the three-line **Reliability / Incident Ops** label itself. It is untouched here. It is ugly at the default rail width, but it is not the bug, and tidying it (shorter label, `noWrap` plus tooltip, or a wider rail) is a separate UI-polish call.
- Do not test the floating **AI Chat** panel reopening over admin pages. That is the separate pre-existing annoyance noted at the bottom of #2346 and is not addressed here.

## Additional Information

**Please read this before approving: the issue's stated repro was not reproduced.** The sequence as written - expand a 3-line section, then find the first item in the panel that just opened unclickable - works fine under measurement, at every label length, with mouse and with keyboard. What does reproduce deterministically, on every section, is the collapsed-panel interception. It produces the same observable symptoms the reporter described (a header swallows the click; only a synthetic click gets through) and it was already worked around once in this repo's own e2e suite.

The best reading of the reporter's session is that the section they clicked was already expanded, so their click *collapsed* it, and their next click then landed on a phantom item in the now-collapsed panel. That is consistent with everything in the report except their stated belief about which state they were in.

So this PR removes a real, measured, reproducible defect, plus the misleading hack that was aimed at it. If anyone can still produce a failing click in a genuinely *expanded* panel after this lands, that is a second, separate bug - please reopen #2346 with the sidebar state at the time rather than assuming this change regressed.

**Scope, stated plainly:** this is more an accessibility and automation-reliability fix than a "your clicks land now" fix. The phantom item loses the hit test to the header painted over it, so a mouse user clicking that spot hits the header - visibly the wrong thing happens, but the click is not swallowed. What the fix actually repairs is that collapsed panel content is no longer in the accessibility tree and no longer an interception target for automated clicks. That last part is why `admin-settings-secrets.spec.ts` already had to expand its section before clicking.

Correcting one more claim from an earlier revision of this description: it also said the fix takes collapsed content out of the **tab order**. That was already true before this PR - Joy's own `AccordionDetails` effect sets `tabindex="-1"` on collapse. `visibility: hidden` makes it robust for content mounted after that effect runs, but removing collapsed items from the tab order was not this fix's doing, and it should not be counted as one of its benefits.

**How it was verified.** The browser measurements came from a throwaway Vite plus Playwright harness (headless Chromium) rendering a faithful copy of the `SidebarNav` JSX with the real `SIDEBAR_SECTIONS`, real `AppTheme`, real Joy and the real 176px rail width. It was deleted before committing, so it is not in this diff. It differed from production in three ways judged immaterial to geometry: gated items filtered out, no waiting-subscribers badge, and local `useState` instead of `useAdminSidebarSections`. Before the fix, every collapsed section reproduced the interception. After it, across all 7 sections: collapsed panels report `visibility: hidden` with no interception, and the first item hit-tests to itself and the click lands when mouse-expanded, when all 7 sections are expanded at once, and when keyboard-expanded - which is the only path where Joy's `zIndex: 1` actually engages.

Also green: `pnpm turbo:typecheck` (40/40), the full `@bike4mind/client` unit suite, `pnpm lint:check`, `pnpm turbo:core:build` (18/18), and both the control-byte and smart-punctuation guards.

**e2e was not run** - it needs a deployed environment and credentials. One thing worth a glance in CI: this fix makes collapsed accordion content honestly invisible, so any e2e assertion that relied on a phantom being "visible" now fails loudly instead of passing for the wrong reason. Both candidates were checked and look safe - `admin-settings-secrets.spec.ts` expands the section before asserting, and `ModelSelectorPage.clickModelCardByExactName` fills the search box first, which expands every backend, so its cards are always inside an expanded panel.

## Developer Notes

- **Latent bug found here but deliberately not fixed.** `apps/client/app/utils/themes/AppTheme.tsx` spreads `...getThemeConfig()` and then sets `components:` wholesale, silently discarding `getThemeConfig().components`. Every override under `app/utils/themes/components/` is therefore dead in the running app - including a `JoyButton`/`JoyIconButton` block that removes all focus rings - while still applying in unit tests that use the documented `extendTheme({ ...getThemeConfig() })` wrapper. Tests and the app consequently disagree about component styling. Fixing it would suddenly activate a pile of dormant overrides app-wide and would strip focus rings, an accessibility regression, so it wants its own issue and its own decision. It is also why this fix had to go in a `customizations/*` map rather than in `themes/components/`.
- The `&[hidden] { visibility: hidden }` pattern is reusable for any Joy component that sets the native `hidden` attribute and then overrides it with its own `display` value.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry changes


