### PR TITLE
refactor(client): share the floating menu list and Select listbox recipe

### DIFF
--- a/apps/client/app/components/Session/ChatPanelControls.tsx
+++ b/apps/client/app/components/Session/ChatPanelControls.tsx
@@ -6,8 +6,7 @@ import { selectClasses } from '@mui/joy/Select';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { menuSurfaceSx } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
-import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
+import { menuSurfaceSx, selectListboxSx } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
 import { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 import { useCopySessionMarkdown } from './useCopySessionMarkdown';
 
@@ -75,41 +74,12 @@ const ChatPanelControls: React.FC<ChatPanelControlsProps> = ({ testIdPrefix, act
             'data-testid': `${testIdPrefix}-layout-listbox`,
             sx: theme => ({
               ...menuSurfaceSx(theme),
-              borderRadius: '8px',
+              ...selectListboxSx(theme),
               // minWidth, not width: Joy's Select popper writes an inline width on this
               // element from the anchor's own box, and an inline style beats any class.
               minWidth: 180,
               maxHeight: 360,
               overflowY: 'auto',
-              // The app's own 4px thumb (sidenav, Data Lake tree) rather than the platform
-              // bar, which lands a chunky light-grey rail on the dark menu.
-              ...scrollbarStyles,
-              '--List-padding': '8px',
-              '--List-radius': '8px',
-              '--List-gap': '4px',
-              '--ListItem-radius': '8px',
-              // Same hover and selected grounds as the app's other menus instead of Joy's
-              // default primary fill. Joy paints its hover from --variant-plainHoverBg, so
-              // pointing the variable at the colour is what actually wins - a bare :hover
-              // rule does not.
-              '& [role="option"]': {
-                borderRadius: '8px',
-                transition: 'background 0.15s',
-                '--variant-plainHoverBg': theme.palette.notebooklist.hoverBg,
-                '&:hover': { backgroundColor: theme.palette.notebooklist.hoverBg },
-                '&[aria-selected="true"]': {
-                  backgroundColor: theme.palette.notebooklist.focusedBackground,
-                  fontWeight: 600,
-                  // Joy tints a selected Option with the primary palette; the row is already
-                  // marked by its ground, so the text stays ordinary ink.
-                  color: 'inherit',
-                  '&:hover': { backgroundColor: theme.palette.notebooklist.focusedBackground },
-                },
-                '&:focus-visible': {
-                  outline: `2px solid ${theme.palette.primary[500]}`,
-                  outlineOffset: '-2px',
-                },
-              },
             }),
           },
         }}

--- a/apps/client/app/components/datalake/DataLakeLakePicker.tsx
+++ b/apps/client/app/components/datalake/DataLakeLakePicker.tsx
@@ -24,7 +24,7 @@ import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SearchIcon from '@mui/icons-material/Search';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
-import { menuSurfaceSx } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
+import { menuListSx, menuSurfaceSx } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
 import { useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
 import { lakeVisibilityLabelShort } from '@client/app/components/datalake/lakeVisibility';
 import type { ManageableDataLakeConfig } from '@bike4mind/common';
@@ -164,14 +164,12 @@ export default function DataLakeLakePicker({
           data-testid="datalake-lake-picker-menu"
           sx={theme => ({
             ...menuSurfaceSx(theme),
-            borderRadius: '8px',
+            // 2px, matching the row action menu: this list is dense and can run long.
+            ...menuListSx({ gap: '2px' }),
             minWidth: 236,
             maxWidth: 300,
             maxHeight: 360,
             overflowY: 'auto',
-            '--List-padding': '8px',
-            '--List-radius': '8px',
-            '--List-gap': '2px',
           })}
         >
           {showSearch && (

--- a/apps/client/app/components/datalake/rowActionsMenu.tsx
+++ b/apps/client/app/components/datalake/rowActionsMenu.tsx
@@ -2,6 +2,7 @@ import { Box, Dropdown, IconButton, Menu, MenuButton, MenuItem, Typography } fro
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import {
   MENU_ROW_ICON_SX,
+  menuListSx,
   menuRowSx,
   menuSurfaceSx,
 } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
@@ -126,17 +127,13 @@ export function RowActionsMenu({
         placement="bottom-end"
         sx={menuTheme => ({
           ...menuSurfaceSx(menuTheme),
-          borderRadius: '8px',
+          // 2px, not the Select listbox's 4px: these rows are 32px in a narrow rail.
+          ...menuListSx({ gap: '2px' }),
           minWidth: 180,
           // Above a Joy Modal: the manager panel is modal-hosted, and this menu portals to body,
           // so at the default z-index it opens BEHIND the dialog and reads as a dead button.
           // Same remedy the organizations member menu uses; matches the sidebar's floating layers.
           zIndex: 10001,
-          // Joy's List vars, pinned for the same reason as the row's: p:1 from the shared recipe
-          // would otherwise fight --List-padding.
-          '--List-padding': '8px',
-          '--List-radius': '8px',
-          '--List-gap': '2px',
         })}
       >
         {children}

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -261,10 +261,6 @@ const ProfileMenu = () => {
   const planLabel =
     selectedAccount && !selectedAccount.personal ? t('account.team', 'Team') : t('account.personal', 'Personal');
 
-  // menuSurfaceSx is shared with the Data Lake row menu. 12px is the flyout's radius; the
-  // main panel below tightens it to 8px.
-  const panelSx = (t2: typeof theme) => ({ ...menuSurfaceSx(t2), borderRadius: '12px' });
-
   return (
     <Box ref={rootRef} sx={{ position: 'relative' }}>
       {open && (
@@ -272,8 +268,7 @@ const ProfileMenu = () => {
           data-testid="profile-menu-panel"
           role="menu"
           sx={theme2 => ({
-            ...panelSx(theme2),
-            borderRadius: '8px',
+            ...menuSurfaceSx(theme2),
             position: 'absolute',
             bottom: 'calc(100% + 8px)',
             left: 0,
@@ -487,7 +482,9 @@ const ProfileMenu = () => {
                 data-testid="profile-menu-more-flyout"
                 role="menu"
                 sx={theme2 => ({
-                  ...panelSx(theme2),
+                  // 12px, one step softer than the main panel's 8px: the flyout floats clear of
+                  // the panel rather than reading as part of it.
+                  ...menuSurfaceSx(theme2, '12px'),
                   position: 'absolute',
                   left: 'calc(100% + 16px)',
                   bottom: 0,

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { menuListSx, menuSurfaceSx, selectListboxSx } from './menuSurfaceSx';
+
+const theme = extendTheme({ ...getThemeConfig() });
+
+describe('menuSurfaceSx', () => {
+  it('defaults to the 8px corner the panels and menus share', () => {
+    expect(menuSurfaceSx(theme).borderRadius).toBe('8px');
+  });
+
+  it('takes the corner as an argument, for the profile More flyout', () => {
+    expect(menuSurfaceSx(theme, '12px').borderRadius).toBe('12px');
+  });
+});
+
+describe('menuListSx', () => {
+  // Joy derives --ListItem-radius from --List-radius and --List-padding (8/8 comes out at 4px),
+  // so leaving it unpinned is what made menus disagree about their row corners.
+  it('pins the row corner rather than letting Joy derive a smaller one', () => {
+    expect(menuListSx()['--ListItem-radius']).toBe('8px');
+    expect(menuListSx()['--List-radius']).toBe('8px');
+    expect(menuListSx()['--List-padding']).toBe('8px');
+  });
+
+  it('spaces a Select listbox at 4px and takes a denser gap for action menus', () => {
+    expect(menuListSx()['--List-gap']).toBe('4px');
+    expect(menuListSx({ gap: '2px' })['--List-gap']).toBe('2px');
+  });
+
+  it('carries the app scrollbar so a long menu does not fall back to the platform bar', () => {
+    expect(Object.keys(menuListSx())).toContain('&::-webkit-scrollbar-thumb');
+  });
+});
+
+describe('selectListboxSx', () => {
+  const optionSx = selectListboxSx(theme)['& [role="option"]'];
+
+  it('keeps the list tokens it layers on', () => {
+    expect(selectListboxSx(theme)['--List-gap']).toBe('4px');
+    expect(selectListboxSx(theme, { gap: '2px' })['--List-gap']).toBe('2px');
+  });
+
+  it('routes hover and press through the variables Joy actually paints from', () => {
+    expect(optionSx['--variant-plainHoverBg']).toBe(theme.palette.notebooklist.hoverBg);
+    expect(optionSx['--variant-plainActiveBg']).toBe(theme.palette.notebooklist.hoverBg);
+  });
+
+  it('marks the selected row by its ground and leaves the text as ordinary ink', () => {
+    expect(optionSx['&[aria-selected="true"]']).toMatchObject({
+      backgroundColor: theme.palette.notebooklist.focusedBackground,
+      color: 'inherit',
+    });
+  });
+
+  it('styles option rows only, so it is inert on a Joy Menu (rows are role="menuitem")', () => {
+    const roleSelectors = Object.keys(selectListboxSx(theme)).filter(key => key.includes('role='));
+    expect(roleSelectors).toEqual(['& [role="option"]']);
+  });
+});

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
@@ -32,6 +32,12 @@ describe('menuListSx', () => {
   it('carries the app scrollbar so a long menu does not fall back to the platform bar', () => {
     expect(Object.keys(menuListSx())).toContain('&::-webkit-scrollbar-thumb');
   });
+
+  // The surface pads with the same constant, so content sits the same distance from the edge
+  // whether the surface is a List or a plain Box. Two independent literals could drift.
+  it('insets the list by the same amount the surface pads with', () => {
+    expect(menuListSx()['--List-padding']).toBe(menuSurfaceSx(theme).p);
+  });
 });
 
 describe('selectListboxSx', () => {

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
@@ -1,14 +1,19 @@
 import type { Theme } from '@mui/joy/styles';
+import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 
 /**
  * Shared look for the app's floating menu surfaces (the profile menu, its "More" flyout, the
- * Data Lake file-row menu). One recipe so a tweak to the ground or the lift reaches all of
- * them. Callers own placement and corner radius - the profile panel and the Data Lake menu
- * use 8px, the More flyout 12px.
+ * Data Lake row and lake menus, the chat panel's layout Select). One recipe so a tweak to the
+ * ground or the lift reaches all of them. `radius` is the surface's own corner: the profile
+ * panel and the Data Lake menus use 8px, the More flyout 12px.
+ *
+ * Anything on this ground that renders as a Joy List - a Menu, a Select listbox - wants
+ * menuListSx too, and a Select's listbox wants selectListboxSx.
  */
-export const menuSurfaceSx = (theme: Theme) => ({
+export const menuSurfaceSx = (theme: Theme, radius = '8px') => ({
   backgroundColor: theme.palette.background.surface,
   border: `1px solid ${theme.palette.divider}`,
+  borderRadius: radius,
   // Soft, diffuse lift (same recipe as the tutorial frame): a wide low-opacity ambient layer
   // plus a tighter contact layer, stronger in dark mode where light shadows disappear.
   boxShadow:
@@ -16,6 +21,69 @@ export const menuSurfaceSx = (theme: Theme) => ({
       ? '0 24px 70px rgba(0, 0, 0, 0.28), 0 8px 20px rgba(0, 0, 0, 0.14)'
       : '0 24px 30px rgba(0, 0, 0, 0.03), 0 8px 20px rgba(0, 0, 0, 0.02)',
   p: 1,
+});
+
+/**
+ * List-container half of a menuSurfaceSx panel: Joy's --List-* tokens plus the app's own 4px
+ * scrollbar thumb. Joy gives both its Menu and its Select listbox `overflow: auto`, so any of
+ * these can scroll, and without the thumb a long menu falls back to the platform's chunky
+ * light-grey rail. Joy drives a List's padding and its rows' geometry from variables, so these
+ * have to be set as variables and not as plain padding/gap.
+ *
+ * --ListItem-radius is pinned rather than left to Joy, which DERIVES a smaller child radius from
+ * --List-radius and --List-padding (8/8 comes out at 4px) - the reason the menus disagreed about
+ * their row corners. Rows are 8px whatever the surface's own corner is, so both stay literals:
+ * --List-radius is only the derivation's input, and menuSurfaceSx owns the corner you see.
+ *
+ * `gap` is the only knob: 4px for a Select's listbox, 2px for the denser action menus. The
+ * 8px --List-padding is the same 8px menuSurfaceSx applies as `p: 1`, deliberately - one inset
+ * whether the surface is a List or a plain Box.
+ */
+export const menuListSx = ({ gap = '4px' }: { gap?: string } = {}) => ({
+  '--List-padding': '8px',
+  '--List-radius': '8px',
+  '--List-gap': gap,
+  '--ListItem-radius': '8px',
+  ...scrollbarStyles,
+});
+
+/**
+ * A Select's listbox on a menuSurfaceSx ground: menuListSx plus the option rows' hover, selected
+ * and focus states, so every Select in the app marks a row the same way.
+ *
+ * Joy paints an Option's hover, its keyboard-highlighted row and its press from
+ * --variant-plain*Bg, so pointing those variables at the colour is what wins - a bare `&:hover`
+ * rule loses to Joy's own. The selected ground cannot go through a variable, because Joy's
+ * Option (unlike its AutocompleteOption) has no rule for the selected row at all; it is a plain
+ * declaration that outweighs Joy's `:active` on specificity.
+ *
+ * Scoped to [role="option"], so spreading it on a Joy Menu is inert - Menu rows are
+ * role="menuitem" and take menuRowSx per item, which owns the danger variant too.
+ *
+ * Not every Select in the app belongs here: the model-filter, file-browser and upload dropdowns
+ * (Session/ModelSelection, Files/Browser/MobileSearchFilter, Files/Browser/UploadActionsSelect)
+ * deliberately sit on background.body with no border, which is a different surface, not a
+ * drifted copy of this one.
+ */
+export const selectListboxSx = (theme: Theme, opts?: { gap?: string }) => ({
+  ...menuListSx(opts),
+  '& [role="option"]': {
+    borderRadius: '8px',
+    transition: 'background 0.15s',
+    '--variant-plainHoverBg': theme.palette.notebooklist.hoverBg,
+    '--variant-plainActiveBg': theme.palette.notebooklist.hoverBg,
+    '&[aria-selected="true"]': {
+      backgroundColor: theme.palette.notebooklist.focusedBackground,
+      fontWeight: 600,
+      // Joy repaints an Option's ink from --variant-plainActiveColor while it is pressed; the
+      // row is already marked by its ground, so the text stays ordinary ink through the press.
+      color: 'inherit',
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary[500]}`,
+      outlineOffset: '-2px',
+    },
+  },
 });
 
 /**

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
@@ -2,6 +2,13 @@ import type { Theme } from '@mui/joy/styles';
 import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 
 /**
+ * The one inset a menu surface and the list on it both use - menuSurfaceSx as padding,
+ * menuListSx as Joy's --List-padding. Shared rather than restated so the two cannot drift:
+ * the content sits the same distance from the edge whether the surface is a List or a Box.
+ */
+const MENU_INSET = '8px';
+
+/**
  * Shared look for the app's floating menu surfaces (the profile menu, its "More" flyout, the
  * Data Lake row and lake menus, the chat panel's layout Select). One recipe so a tweak to the
  * ground or the lift reaches all of them. `radius` is the surface's own corner: the profile
@@ -20,7 +27,7 @@ export const menuSurfaceSx = (theme: Theme, radius = '8px') => ({
     theme.palette.mode === 'dark'
       ? '0 24px 70px rgba(0, 0, 0, 0.28), 0 8px 20px rgba(0, 0, 0, 0.14)'
       : '0 24px 30px rgba(0, 0, 0, 0.03), 0 8px 20px rgba(0, 0, 0, 0.02)',
-  p: 1,
+  p: MENU_INSET,
 });
 
 /**
@@ -36,11 +43,11 @@ export const menuSurfaceSx = (theme: Theme, radius = '8px') => ({
  * --List-radius is only the derivation's input, and menuSurfaceSx owns the corner you see.
  *
  * `gap` is the only knob: 4px for a Select's listbox, 2px for the denser action menus. The
- * 8px --List-padding is the same 8px menuSurfaceSx applies as `p: 1`, deliberately - one inset
- * whether the surface is a List or a plain Box.
+ * padding is MENU_INSET, the same constant menuSurfaceSx pads with, so the two stay equal by
+ * construction.
  */
 export const menuListSx = ({ gap = '4px' }: { gap?: string } = {}) => ({
-  '--List-padding': '8px',
+  '--List-padding': MENU_INSET,
   '--List-radius': '8px',
   '--List-gap': gap,
   '--ListItem-radius': '8px',
@@ -75,8 +82,9 @@ export const selectListboxSx = (theme: Theme, opts?: { gap?: string }) => ({
     '&[aria-selected="true"]': {
       backgroundColor: theme.palette.notebooklist.focusedBackground,
       fontWeight: 600,
-      // Joy repaints an Option's ink from --variant-plainActiveColor while it is pressed; the
-      // row is already marked by its ground, so the text stays ordinary ink through the press.
+      // Joy's base plain variant paints EVERY Option's ink from --variant-plainColor; `inherit`
+      // drops the selected row back to the listbox's own ink, so the bold weight marks it rather
+      // than a different colour. (Nothing repaints on press - plainActive carries no `color`.)
       color: 'inherit',
     },
     '&:focus-visible': {


### PR DESCRIPTION
# Pull Request

## Description

Closes #2297

Scope of the close: this lands the closed set the issue is about - the four surfaces built on `menuSurfaceSx`. The second listbox cluster described below (`Session/ModelSelection.tsx` plus five siblings on `background.body`) is deliberately not part of it. That is a different surface rather than a drifted copy of this one, so moving it changes how those controls look and is a design call; it is tracked separately in #2460 rather than holding this one open.

`menuSurfaceSx` already shared the *ground* of the app's floating menus (surface colour, border, the two-layer shadow, the 8px inset). The *list* that sits on that ground did not: Joy's `--List-*` geometry variables, the app's 4px scrollbar thumb, and the `[role="option"]` hover / selected / focus rules were restated by hand at every call site, and the copies had drifted apart. This adds the list half to the same module and moves the four surfaces built on `menuSurfaceSx` onto it.

Scope note: both greps in the issue over-collect. Audited every hit. Most are not listbox recipes at all - tree/nav *row* hover (`datalake/treeChrome.ts`, `DataLakeWizard/manager/navChrome.tsx`), IconButtons and an Accordion summary in `Session/ModelSelection.tsx`, a `TabList`, and three `List`s that only zero their padding inside a Menu. The real closed set is the four surfaces already built on `menuSurfaceSx`, and that is what moved.

Deliberately left out: a second, genuinely separate dropdown cluster (`Session/ModelSelection.tsx`, `Files/Browser/MobileSearchFilter.tsx` x3, `Files/Browser/UploadActionsSelect.tsx`, `Session/AISettings/ResearchConfigPanel.tsx`) - six listboxes that sit on `background.body` with `border: none !important`. That is a different surface, not a drifted copy of this one, and folding it in would change ModelSelection's radius, scrollbar and selected-row weight on a control documented as mirroring the sidenav Filters panel. Consolidating it means first deciding whether that surface should exist separately, which is a design call rather than a mechanical one. `selectListboxSx`'s docblock names those files so the omission stays visible to the next reader, and the surface question is tracked in #2460.

## Changes

`apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts`:

- `menuSurfaceSx(theme, radius = '8px')` - the corner is now the surface's own argument instead of something each call site re-declared after spreading.
- `menuListSx({ gap })` (new) - `--List-padding` / `--List-radius` / `--List-gap` / `--ListItem-radius` plus `scrollbarStyles`. `gap` is the only knob: 4px for a Select listbox, 2px for the denser action menus.
- `selectListboxSx(theme, opts)` (new) - `menuListSx` plus the `[role="option"]` hover / selected / focus rules. Scoped to `[role="option"]`, so spreading it on a Joy Menu is inert: Menu rows are `role="menuitem"` and stay on `menuRowSx`.

Call sites:

- `Session/ChatPanelControls.tsx` - the whole hand-written recipe becomes `menuSurfaceSx` + `selectListboxSx` plus its own geometry (-32 lines).
- `datalake/rowActionsMenu.tsx` and `datalake/DataLakeLakePicker.tsx` - `menuListSx({ gap: '2px' })`.
- `layouts/Notebook/Sidenav/ProfileMenu.tsx` - drops the local `panelSx` wrapper, which set 12px only for the main panel to immediately override it with 8px. The flyout is now `menuSurfaceSx(theme2, '12px')`, the panel `menuSurfaceSx(theme2)`.

- `MENU_INSET` (module-private) - the 8px inset the surface pads with and the list sets as `--List-padding`. They were two independent literals a docblock merely asserted were equal; now they are equal by construction. Both were already 8px, so nothing moves.

New test `menuSurfaceSx.test.ts` (10 cases): the radius default and argument, the pinned `--ListItem-radius`, the gap knob, the surface/list inset invariant, the hover/press variables, the selected-row contract, and that the recipe is inert on a Joy Menu.

**Two intended visual changes** - the drift the issue was about:

1. **Data Lake lake picker rows: 4px -> 8px corners.** It set `--List-radius` and `--List-padding` but not `--ListItem-radius`, and Joy *derives* a smaller child radius from those two (8/8 comes out at 4px). Every other menu pinned 8px.
2. **The lake picker and the row actions menu now get the app's 4px scrollbar thumb.** Joy gives both `Menu` and the Select listbox `overflow: auto`, so both could already scroll - with the platform's chunky light-grey rail on a dark menu.

Everything else should render identically; ProfileMenu and ChatPanelControls compute the same CSS as before, with two exceptions that are fixes rather than drift. `--variant-plainActiveBg` is folded in alongside `--variant-plainHoverBg`, so a pressed option no longer flashes the **brand tint** - this app overrides Joy's `neutral.plainActiveBg` to `brand[700]` in dark and `brand[100]` in light (`themePrimitives.ts:185,292`), measured as `#2A4159` in dark on the preview, so the fall-through was blue rather than the grey an earlier draft of this description claimed. And two belt-and-braces `&:hover` declarations were dropped, since Joy paints hover from `--variant-plainHoverBg` and that variable also covers the keyboard-highlighted row, which a bare `:hover` never did.

The same defect still affects the two Data Lake menus, whose rows are `role="menuitem"` and so run through `menuRowSx` rather than this recipe. That is pre-existing on `main` and tracked in #2477, not introduced or fixed here.

The issue asked two open questions; both are answered from the Joy 5.0.0-beta.52 source:

1. **Should the radius be a parameter?** Yes - `menuSurfaceSx(theme, radius)`. `--List-radius` / `--ListItem-radius` stay literal 8px inside `menuListSx`: rows are 8px whatever the surface's corner is (the 12px flyout already has 8px rows), and `--List-radius` only feeds Joy's child-radius derivation - the visible corner comes from `menuSurfaceSx`.
2. **Is `color: 'inherit'` on the selected row still needed?** Yes - but for a different reason than *either* earlier explanation gave, and the second wrong one shipped in this PR's first two commits before review caught it. There is no selected-state paint on a Joy `Option` to override (`Option/Option.js:41` only excludes the selected row from hover; the `.MuiListItemButton-selected` rule never matches, because an Option emits `MuiOption-selected`) - unlike `AutocompleteOption`, which does paint on `[aria-selected="true"]`. And there is no press-time ink repaint either: **`--variant-plainActiveColor` does not exist in beta.52.** Joy's plain variant carries only `plainColor`, `plainHoverColor`, `plainHoverBg`, `plainActiveBg` and `plainDisabledColor` (`styles/variantUtils.js:96-100`), and `createVariantStyle` (`:51`) emits only keys that are present and truthy, so nothing can repaint an Option's ink on press. What `inherit` actually overrides is the **base** plain variant's own `color: var(--variant-plainColor)`, which `StyledListItemButton` applies to every Option unconditionally - so `inherit` drops the selected row back to the listbox's own ink and lets the bold weight be what marks it. The comment says that now.

## Guide for Testers

Preconditions: sign in as an **admin** user (section 1 uses the Admin page), with the `EnableDataLakes` feature flag on (sections 2 and 3). Run the whole guide once in **dark mode** and once in **light mode** - the shared shadow and the hover grounds differ between them.

**1. Chat panel layout Select** - the one surface whose entire recipe moved.

1. Go to `app.staging.bike4mind.com` and sign in.
2. Navigate to **Sidebar -> Admin**. Expected: a floating "AI Chat" window appears over the admin page.
3. In that window's header, click the **Layout** dropdown (immediately left of the copy icon). Expected: a dropdown opens on a bordered, softly shadowed panel with 8px corners, listing "Dock left" and "Dock bottom".
4. Hover each row. Expected: a subtle grey-blue hover ground fills the row with 8px rounded corners. No square corners, no blue/primary fill.
5. Press and hold the mouse on a row without releasing. Expected: the ground stays that same hover colour - **it must NOT flash blue** (the brand tint Joy would fall through to) - and the label ink does not change colour.
6. Press `Escape` to close. Reopen with the keyboard: `Tab` to the Layout button, `Enter`, then `ArrowDown`. Expected: the highlighted row shows the same hover ground as the mouse hover, and the highlight moves with each `ArrowDown`.
7. Click **Dock bottom**. Expected: the chat docks to the bottom of the window, and its header now offers three options.
8. Reopen the **Layout** dropdown in the docked panel. Expected: "Dock bottom" is the selected row - **bold** text, with the label in ordinary body ink, not blue/primary. Note the ground differs by theme and both are intended: in **light** mode the selected ground reads a step stronger than a hover, but in **dark** mode `notebooklist` sets `focusedBackground` to the same colour as `hoverBg` on purpose, so there the bold weight is the only tell. A dark-mode selected row that looks identical to a hovered one is correct, not a bug. Repeat steps 4-6 here.

**2. Data Lake lake picker** - intended change: row corners and scrollbar.

9. Open any notebook session from the sidebar.
10. In the session header, turn on the **Data Lakes** toggle. Expected: a Data Lake tree panel appears alongside the chat.
11. At the top of that panel, click the lake picker button (it shows the current lake name, or "All lakes"). Expected: a menu opens with 8px corners on the same bordered, shadowed panel.
12. Hover the rows. Expected: **each row's hover ground has 8px rounded corners.** This is the intended change - on `main` they are noticeably tighter (4px).
13. If the account has enough lakes to overflow the menu's 360px height, scroll inside it. Expected: **a thin 4px rounded scrollbar thumb matching the sidebar and the Data Lake tree**, not the platform's wide light-grey rail. This is the second intended change.

**3. Data Lake row actions menu** - intended change: scrollbar only.

14. In the same Data Lake tree, hover a file row and click its **"..."** button. Expected: the action menu opens with 8px corners, tight 2px gaps between rows, and each row's hover ground rounded to 8px - unchanged from `main`.
15. Confirm the destructive row (Remove / Delete) is still tinted red on hover.
16. Open the Data Lake **manager** from the tree's Manage action, then click the **"..."** on a lake row in its left nav. Expected: the menu opens **above** the modal, not behind it. If it opens behind, it reads as a dead button - that is a regression.

**4. Profile menu** - should be pixel-identical to `main`.

17. Click the profile/avatar row at the **bottom of the sidebar**. Expected: the panel opens above it with **8px** corners.
18. Inside that panel, click **More**. Expected: the flyout opens to the right with **12px** corners, one step softer than the panel. Both radii must match `main` exactly.

### Regression Checks

- The Layout dropdown still changes the layout (dock left / dock bottom / float), and the choice survives a page reload.
- The lake picker still filters the tree, and its search box, Create and Discover rows still work.
- The row actions menu still fires every action, and still opens above the manager modal.
- No menu changed its outer padding: the gap between a menu's border and its first row is still 8px on all four surfaces.
- Profile menu and its More flyout: corners, shadow, border and hover grounds identical to `main`.

### What NOT to test

- The model selection dropdown, the file-browser search filters, upload actions, and the research config panel. Deliberately untouched - see Description.
- **Both Data Lake menus' *pressed* ground.** Their rows are `role="menuitem"`, so they run through `menuRowSx`, which never sets `--variant-plainActiveBg` - press-and-hold falls through to Joy's `neutral.plainActiveBg`, i.e. the brand tint. Pre-existing on `main`, confirmed by measurement in review, and tracked in #2477. Not this PR's to fix.
- The Data Lake tree's own row hover, and the lake picker rows' hover *colour*. The picker's rows are `role="menuitem"`, so `selectListboxSx` is inert there by design and they still use Joy's neutral defaults rather than the app's `notebooklist` tokens. Only their corner radius changed here. Giving those rows the app's colours wants a `menuRowSx` sibling that tolerates two-line rows with decorators and counts, which is not in this PR.

## Additional Information

Both intended visual changes were originally reasoned from the Joy 5.0.0-beta.52 source (`List/List.js:108-110`, `Menu/Menu.js:53`, `Select/Select.js:235-237`, `Option/Option.js:41`, `ListItemButton/ListItemButton.js:95-104`) rather than observed. **Review has since confirmed them on the pr2445 preview off computed styles**: panel 8px, flyout 12px, option rows 8px, lake picker rows 8px (the intended 4 -> 8px), option hover measured `rgba(42, 44, 56, 0.7)` = `notebooklist.hoverBg`, and press-and-hold holding that ground instead of falling through to the brand tint.

One thing still unverified in a browser: the **selected-vs-non-selected ink** on the Layout dropdown. Reaching it needs the docked panel, and picking "Dock bottom" currently renders that panel off-screen - a pre-existing bug reproducible on `main` and unrelated to this PR.

Verified locally against the final tree: `pnpm --filter @bike4mind/client typecheck` passes, `pnpm lint:check` passes, and the full `@bike4mind/client` vitest suite passes (1079 files / 11585 tests passed, 10 files / 81 skipped, exit 0). The review amendments were re-verified the same way, plus the touched projects on their own (`Sidenav/` + `datalake/`: 26 files / 234 tests).

## Developer Notes (Optional)

- **New extension points**: `menuSurfaceSx(theme, radius)` takes the corner as an argument; `menuListSx({ gap })` and `selectListboxSx(theme, { gap })` are new exports from the same module.
- **Reusable pattern**: a floating menu is now composed rather than restated - `menuSurfaceSx` for the ground, `menuListSx` if it renders as a Joy List, `selectListboxSx` if it is a Select listbox, `menuRowSx` per row for a Joy Menu. A new dropdown spreads three helpers instead of copying thirty lines.
- **Gotcha now captured in a docblock**: Joy *derives* `--ListItem-radius` from `--List-radius` and `--List-padding` when you do not pin it (8/8 comes out at 4px). That derivation is exactly how these four menus drifted apart on row corners, so pin it.
- **Architecture decision**: `selectListboxSx` is scoped to `[role="option"]` on purpose, so it is safe to spread on a Joy Menu whose rows are `role="menuitem"` and keep their own `menuRowSx` (which owns the danger variant). The obvious next step - a `menuRowSx` sibling for two-line menu rows with decorators, so the lake picker's rows get the app's hover colours too - is deliberately not in this PR.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - N/A, no telemetry changes


