### PR TITLE
fix(services): add org-admin arm to data-lake access mirror

### DIFF
--- a/apps/client/app/components/organizations/OrganizationGroups.test.tsx
+++ b/apps/client/app/components/organizations/OrganizationGroups.test.tsx
@@ -46,13 +46,21 @@ const renderGroups = (org: WithId<IOrganizationDocument>, canSetAdmins: boolean)
 
 // `users` carries the real member rows. The billing owner is deliberately NOT among them (the
 // server never puts the owner in users[]), which is what the picker filter keys on.
+//
+// `permissions: ['read']` is load-bearing, not decoration: the admins picker offers only rows that
+// CONFER membership, matching what the appointment route accepts (#2005). Every app write path
+// persists ['read'], so this is the realistic row - a bare `{ userId }` is the out-of-band shape
+// covered on its own below.
 const org = {
   id: 'org1',
   name: 'Acme',
   personal: false,
   adminUserIds: [],
   userId: 'owner1',
-  users: [{ userId: 'u1' }, { userId: 'u2' }],
+  users: [
+    { userId: 'u1', permissions: ['read'] },
+    { userId: 'u2', permissions: ['read'] },
+  ],
 } as unknown as WithId<IOrganizationDocument>;
 
 describe('OrganizationGroups', () => {
@@ -157,6 +165,29 @@ describe('OrganizationGroups', () => {
     expect(options).toContain('Alice');
     expect(options).toContain('Bob');
     expect(options).not.toContain('Olivia Owner');
+  });
+
+  // A row that exists but confers no membership is not appointable server-side (#2005), so offering
+  // it here would surface a save that 400s "not organization members with read access" about
+  // someone the operator can see in the member list - an error they cannot act on.
+  it('excludes a member whose ACL row confers no membership from the admins picker', async () => {
+    const withPermissionlessRow = {
+      ...org,
+      users: [{ userId: 'u1', permissions: ['read'] }, { userId: 'u2' }],
+    } as typeof org;
+    renderGroups(withPermissionlessRow, true);
+
+    const admins = await screen.findByTestId('org-admins-input');
+    const input = admins.querySelector('input')!;
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBeGreaterThan(0));
+
+    const options = screen.getAllByRole('option').map(o => o.textContent);
+    // Alice is the positive control: without her, an empty listbox would satisfy the negative
+    // assertion whether or not the filter keys off permissions at all.
+    expect(options).toContain('Alice');
+    expect(options).not.toContain('Bob');
   });
 
   // The admins roster must follow the persisted set. PUT /admins is a full replace, so a stale

--- a/apps/client/app/components/organizations/OrganizationGroups.test.tsx
+++ b/apps/client/app/components/organizations/OrganizationGroups.test.tsx
@@ -190,6 +190,25 @@ describe('OrganizationGroups', () => {
     expect(options).not.toContain('Bob');
   });
 
+  // The eligibility filter governs the OPTIONS only. Resolving the chips through it too would hide
+  // an admin appointed before the filter existed: they stay in the selection but render nothing, so
+  // the next unrelated edit rebuilds the selection from the visible chips and the full-replace save
+  // silently revokes them - the operator asked to add one admin and revoked another (#2005).
+  it('still shows a sitting admin whose ACL row confers no membership', async () => {
+    const withLegacyAdmin = {
+      ...org,
+      users: [{ userId: 'u1', permissions: ['read'] }, { userId: 'u2' }],
+      adminUserIds: ['u2'],
+    } as typeof org;
+    renderGroups(withLegacyAdmin, true);
+
+    const card = await screen.findByTestId('org-admins-card');
+    // Bob's name can only reach this card as a chip; Alice is the negative control proving the card
+    // renders the appointed set rather than the whole roster.
+    await waitFor(() => expect(card).toHaveTextContent('Bob'));
+    expect(card).not.toHaveTextContent('Alice');
+  });
+
   // The admins roster must follow the persisted set. PUT /admins is a full replace, so a stale
   // local selection would silently de-appoint whoever was added elsewhere.
   it('resyncs the admins selection when the persisted set changes', async () => {

--- a/apps/client/app/components/organizations/OrganizationGroups.tsx
+++ b/apps/client/app/components/organizations/OrganizationGroups.tsx
@@ -57,7 +57,12 @@ const OrganizationGroups: FC<OrganizationGroupsProps> = ({ organization, canSetA
   return (
     <Stack spacing={3} data-testid="org-groups-section">
       {canSetAdmins && (
-        <OrgAdminsEditor organization={organization} members={assignableMembers} adminsMutation={adminsMutation} />
+        <OrgAdminsEditor
+          organization={organization}
+          members={members}
+          assignableMembers={assignableMembers}
+          adminsMutation={adminsMutation}
+        />
       )}
 
       <OrganizationGroupsList organization={organization} />
@@ -68,9 +73,12 @@ const OrganizationGroups: FC<OrganizationGroupsProps> = ({ organization, canSetA
 /** Appoint/remove org admins (billing owner + platform admin only). */
 const OrgAdminsEditor: FC<{
   organization: WithId<IOrganizationDocument>;
+  /** The whole org roster - resolves the CURRENT appointments to chips, eligible or not. */
   members: IUserDocument[];
+  /** The subset that may be newly appointed (see `orgAclRowConfersMembership` at the call site). */
+  assignableMembers: IUserDocument[];
   adminsMutation: { mutate: (ids: string[]) => void; isPending: boolean };
-}> = ({ organization, members, adminsMutation }) => {
+}> = ({ organization, members, assignableMembers, adminsMutation }) => {
   const current = organization.adminUserIds ?? [];
   const [selected, setSelected] = useState<string[]>(current);
 
@@ -86,7 +94,16 @@ const OrgAdminsEditor: FC<{
   }
 
   const isDirty = selected.length !== current.length || selected.some(id => !current.includes(id));
+  // Eligibility narrows the OPTIONS only; the chips resolve against the full roster. Narrowing both
+  // would turn a display filter into a write: an admin appointed before the eligibility rule existed
+  // stays in `selected` but renders no chip, so the next unrelated edit rebuilds `selected` from the
+  // visible chips and the full-replace PUT silently revokes them (#2005). Appending them to the
+  // options as well keeps removal an explicit act and keeps MUI's value/option identity matching.
   const selectedMembers = members.filter(member => selected.includes(member.id));
+  const options = [
+    ...assignableMembers,
+    ...selectedMembers.filter(member => !assignableMembers.some(assignable => assignable.id === member.id)),
+  ];
 
   return (
     <Card variant="outlined" sx={{ p: 2 }} data-testid="org-admins-card">
@@ -96,7 +113,7 @@ const OrgAdminsEditor: FC<{
           <FormLabel>Appointed admins</FormLabel>
           <Autocomplete
             multiple
-            options={members}
+            options={options}
             value={selectedMembers}
             getOptionLabel={member => member.name || member.email || member.id}
             isOptionEqualToValue={(option, value) => option.id === value.id}

--- a/apps/client/app/components/organizations/OrganizationGroups.tsx
+++ b/apps/client/app/components/organizations/OrganizationGroups.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo, useState } from 'react';
 import { Autocomplete, Box, Button, Card, FormControl, FormHelperText, FormLabel, Stack, Typography } from '@mui/joy';
-import { IOrganizationDocument, IUserDocument, WithId } from '@bike4mind/common';
+import { IOrganizationDocument, IUserDocument, WithId, orgAclRowConfersMembership } from '@bike4mind/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useGetOrganizationUsers } from '@client/app/hooks/data/user';
@@ -30,8 +30,17 @@ const OrganizationGroups: FC<OrganizationGroupsProps> = ({ organization, canSetA
   // The admins route validates against organization.users alone (the billing owner is never a
   // member row), so the picker must offer only real members or the owner would 400. Mirrors the
   // filter the shared list applies to its assign picker.
+  //
+  // `orgAclRowConfersMembership`, not a bare userId match: the route requires a row that actually
+  // grants membership, so a row with no read/write permission is NOT appointable. Offering one
+  // anyway would surface a member in the picker whose save then 400s "not organization members" -
+  // an error the user cannot act on, about someone they can see in the member list. Both sides read
+  // the same predicate for that reason (#2005).
   const assignableMembers = useMemo(
-    () => members.filter(member => (organization.users ?? []).some(row => row.userId === member.id)),
+    () =>
+      members.filter(member =>
+        (organization.users ?? []).some(row => row.userId === member.id && orgAclRowConfersMembership(row))
+      ),
     [members, organization.users]
   );
 

--- a/apps/client/pages/api/organizations/[id]/__tests__/admins.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/admins.test.ts
@@ -110,6 +110,51 @@ describe('PUT /api/organizations/[id]/admins - appointee eligibility', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  // Eligibility binds what this call ADDS, not the roster's history. PUT is a full replace, so a
+  // sitting admin is resent on every save; refusing them would let one row appointed before the
+  // check existed block every later edit of the roster (#2005).
+  it('grandfathers a sitting admin whose ACL row confers no membership', async () => {
+    findById.mockResolvedValue({
+      ...org([{ userId: 'legacy1' }, { userId: 'member1', permissions: ['read'] }]),
+      adminUserIds: ['legacy1'],
+    });
+
+    const { res, run } = put(['legacy1', 'member1']);
+    await run();
+
+    expect(update).toHaveBeenCalledWith({ id: 'org1', adminUserIds: ['legacy1', 'member1'] });
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  // The grandfather clause must not become a hole: it waives the permissions requirement for an
+  // existing appointment only, never for a new one arriving in the same batch.
+  it('still refuses a NEW permission-less appointee alongside a grandfathered one', async () => {
+    findById.mockResolvedValue({
+      ...org([{ userId: 'legacy1' }, { userId: 'bad1' }]),
+      adminUserIds: ['legacy1'],
+    });
+
+    const { run } = put(['legacy1', 'bad1']);
+
+    // Names bad1 and only bad1 - the grandfathered id is not an error the operator must act on.
+    await expect(run()).rejects.toThrow(/^Not organization members with read access: bad1$/);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  // Roster membership is not waived by the grandfather clause. A sitting admin removed from the org
+  // entirely has no users[] row, so resending them is still an outsider reference.
+  it('does not grandfather a sitting admin who has been removed from the roster', async () => {
+    findById.mockResolvedValue({
+      ...org([{ userId: 'member1', permissions: ['read'] }]),
+      adminUserIds: ['departed1'],
+    });
+
+    const { run } = put(['departed1', 'member1']);
+
+    await expect(run()).rejects.toThrow(/departed1/);
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('still refuses a user with no ACL row at all (the pre-existing outsider check)', async () => {
     findById.mockResolvedValue(org([{ userId: 'member1', permissions: ['read'] }]));
 

--- a/apps/client/pages/api/organizations/[id]/__tests__/admins.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/admins.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { BadRequestError, ForbiddenError } from '@server/utils/errors';
+
+/**
+ * PUT /api/organizations/[id]/admins sets `adminUserIds`, gated to the billing owner or a platform
+ * admin. The eligibility half is the interesting one: an appointee must hold an ACL row that
+ * actually CONFERS membership, not merely a row that exists.
+ *
+ * That is the write-time half of #2005. Checking `userId` alone let a permission-less row pass
+ * appointment and then fail `findMembershipOrgIds`, minting a principal with admin rights over an
+ * org that was unselectable in their own account switcher. The read-time half - such a principal
+ * still being able to DISCOVER the org's lakes - is pinned in
+ * `DataLakeModel.orgScopeAgreement.test.ts`.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  putHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    post: () => chain,
+    delete: () => chain,
+    put: (fn: any) => {
+      mockRefs.putHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const findById = vi.hoisted(() => vi.fn());
+const update = vi.hoisted(() => vi.fn());
+vi.mock('@bike4mind/database/infra', () => ({ organizationRepository: { findById, update } }));
+vi.mock('@bike4mind/database/auth', () => ({ userRepository: {} }));
+vi.mock('@server/utils/auditLog', () => ({
+  AdminOrgAuditEvents: { ORG_ADMINS_UPDATED: 'ORG_ADMINS_UPDATED' },
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import '@pages/api/organizations/[id]/admins';
+
+/** An org owned by `owner1`, whose `users[]` roster is supplied per test. */
+const org = (users: { userId: string; permissions?: string[] }[]) => ({
+  id: 'org1',
+  userId: 'owner1',
+  users,
+});
+
+const put = (adminUserIds: string[], user = { id: 'owner1', isAdmin: false }) => {
+  const { req, res } = createMocks({ method: 'PUT', query: { id: 'org1' }, body: { adminUserIds } });
+  (req as any).user = user;
+  return { req: req as any, res, run: () => mockRefs.putHandler!(req, res) };
+};
+
+describe('PUT /api/organizations/[id]/admins - appointee eligibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    update.mockImplementation(async ({ adminUserIds }: { adminUserIds: string[] }) => ({ adminUserIds }));
+  });
+
+  it('appoints a member whose ACL row grants read', async () => {
+    findById.mockResolvedValue(org([{ userId: 'member1', permissions: ['read'] }]));
+
+    const { res, run } = put(['member1']);
+    await run();
+
+    expect(update).toHaveBeenCalledWith({ id: 'org1', adminUserIds: ['member1'] });
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  // The #2005 write-time gap. The appointment route is the only way to reach `adminUserIds`, so
+  // refusing here is what stops the divergent state from being created at all.
+  it('refuses a member whose ACL row carries no permissions, and does not write', async () => {
+    findById.mockResolvedValue(org([{ userId: 'member1' }]));
+
+    const { run } = put(['member1']);
+
+    await expect(run()).rejects.toThrow(BadRequestError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  // A share-only row is not membership either - `orgMembershipFilter` excludes it, and this route
+  // has to agree or the same divergence reappears through a different permission value.
+  it('refuses a member whose ACL row grants only share', async () => {
+    findById.mockResolvedValue(org([{ userId: 'member1', permissions: ['share'] }]));
+
+    const { run } = put(['member1']);
+
+    await expect(run()).rejects.toThrow(BadRequestError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('names only the ineligible appointees in the error, and rejects the whole batch', async () => {
+    findById.mockResolvedValue(
+      org([
+        { userId: 'good1', permissions: ['read'] },
+        { userId: 'bad1', permissions: [] },
+      ])
+    );
+
+    const { run } = put(['good1', 'bad1']);
+
+    // Whole-batch refusal, not a partial write: the route is a full REPLACE of adminUserIds, so
+    // persisting the eligible half would silently de-appoint whoever the caller did not resend.
+    await expect(run()).rejects.toThrow(/bad1/);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('still refuses a user with no ACL row at all (the pre-existing outsider check)', async () => {
+    findById.mockResolvedValue(org([{ userId: 'member1', permissions: ['read'] }]));
+
+    const { run } = put(['outsider']);
+
+    await expect(run()).rejects.toThrow(BadRequestError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-owner, non-admin before reading the roster', async () => {
+    findById.mockResolvedValue(org([{ userId: 'member1', permissions: ['read'] }]));
+
+    const { run } = put(['member1'], { id: 'intruder', isAdmin: false });
+
+    await expect(run()).rejects.toThrow(ForbiddenError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('lets a platform admin appoint an eligible member', async () => {
+    findById.mockResolvedValue(org([{ userId: 'member1', permissions: ['read'] }]));
+
+    const { run } = put(['member1'], { id: 'someone-else', isAdmin: true });
+    await run();
+
+    expect(update).toHaveBeenCalledWith({ id: 'org1', adminUserIds: ['member1'] });
+  });
+});

--- a/apps/client/pages/api/organizations/[id]/admins.ts
+++ b/apps/client/pages/api/organizations/[id]/admins.ts
@@ -38,7 +38,19 @@ const handler = baseApi().put(
     const memberIds = new Set(
       organization.users.filter(member => orgAclRowConfersMembership(member)).map(member => member.userId)
     );
-    const notMembers = adminUserIds.filter(userId => !memberIds.has(userId));
+
+    // The membership requirement binds the appointments this call ADDS. Because the endpoint is a
+    // full replace, every sitting admin is resent on every save, so validating the whole set would
+    // let one row appointed before this check existed block every later edit of the roster until the
+    // operator de-appointed them - a stricter rule turning into a retroactive revocation. Resends of
+    // an existing appointment are grandfathered instead; that mints no new principal, and it agrees
+    // with the read side, which still serves such an admin. Roster membership itself is NOT waived:
+    // a grandfathered id must still hold a users[] row, so removal from the org still ejects them.
+    const rosterUserIds = new Set(organization.users.map(member => member.userId));
+    const sittingAdminIds = new Set(organization.adminUserIds ?? []);
+    const notMembers = adminUserIds.filter(
+      userId => !memberIds.has(userId) && !(sittingAdminIds.has(userId) && rosterUserIds.has(userId))
+    );
     if (notMembers.length > 0) {
       throw new BadRequestError(`Not organization members with read access: ${notMembers.join(', ')}`);
     }

--- a/apps/client/pages/api/organizations/[id]/admins.ts
+++ b/apps/client/pages/api/organizations/[id]/admins.ts
@@ -6,6 +6,7 @@ import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { BadRequestError, ForbiddenError, NotFoundError } from '@server/utils/errors';
 import { organizationRepository } from '@bike4mind/database/infra';
+import { orgAclRowConfersMembership } from '@bike4mind/common';
 import { AdminOrgAuditEvents, logAuditEvent } from '@server/utils/auditLog';
 import { z } from 'zod';
 
@@ -28,11 +29,18 @@ const handler = baseApi().put(
       throw new ForbiddenError('Only the billing owner or a platform admin can set org admins');
     }
 
-    // An appointed admin must be a member of the org - don't reference outsiders.
-    const memberIds = new Set(organization.users.map(member => member.userId));
+    // An appointed admin must be a member of the org - don't reference outsiders. Membership means
+    // an ACL row that actually CONFERS it, not merely a row that exists: checking `userId` alone
+    // admitted a row carrying no permissions, which `findMembershipOrgIds` then refused to count as
+    // membership, so the appointment silently created a principal that held admin rights over the
+    // org while the org was unselectable in their own account switcher (#2005). Same predicate as
+    // the read gate, from the shared constant, so the two cannot drift apart again.
+    const memberIds = new Set(
+      organization.users.filter(member => orgAclRowConfersMembership(member)).map(member => member.userId)
+    );
     const notMembers = adminUserIds.filter(userId => !memberIds.has(userId));
     if (notMembers.length > 0) {
-      throw new BadRequestError(`Not organization members: ${notMembers.join(', ')}`);
+      throw new BadRequestError(`Not organization members with read access: ${notMembers.join(', ')}`);
     }
 
     const updated = await organizationRepository.update({ id: organizationId, adminUserIds });

--- a/b4m-core/common/src/constants/organization.ts
+++ b/b4m-core/common/src/constants/organization.ts
@@ -35,3 +35,19 @@ export const ORGANIZATION_SUBSCRIPTION_MAX_SEATS = 100;
  * in the client.
  */
 export const ORG_MEMBERSHIP_ACL_PERMISSIONS = ['read', 'write'] as const;
+
+/**
+ * Does this `users[]` ACL row confer membership? The in-memory twin of `orgMembershipFilter`'s
+ * `$elemMatch` (`OrganizationModel`), for the app-side layers the docstring above anticipates -
+ * anywhere that has to answer "is X a member" without issuing the Mongo query. Keep the two in
+ * lockstep: they are one rule, and #2005 is what a divergence costs.
+ *
+ * Deliberately loose about its input rather than taking `IUserShare`: `permissions` is required by
+ * the TYPE but absent on real stored rows (the appointment route could persist an admin whose row
+ * had none), and the set includes 'write', which is not a `Permission` enum member. A predicate
+ * that only accepted well-typed rows could not be asked about the rows that actually break.
+ */
+export const orgAclRowConfersMembership = (row: { permissions?: readonly string[] | null }): boolean =>
+  (row.permissions ?? []).some(permission =>
+    (ORG_MEMBERSHIP_ACL_PERMISSIONS as readonly string[]).includes(permission)
+  );

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -375,10 +375,17 @@ export interface IDataLakeRepository extends IBaseRepository<IDataLakeDocument> 
   ): Promise<IDataLakeDocument[]>;
   findByOrganizationId(orgId: string): Promise<IDataLakeDocument[]>;
   /**
-   * Datastore-side accessibility filter - owner OR public OR (org-match AND requirement-match
-   * AND not-private). The org and requirement constraints are BOTH required for a non-owner: a
-   * tag/entitlement-holder in a different org is excluded, and a lake with no org and no gate
-   * stays owner-only. Defaults to the active+draft statuses.
+   * Datastore-side accessibility filter - owner OR org-admin OR public OR (org-match AND
+   * requirement-match AND not-private). The org and requirement constraints are BOTH required for
+   * a non-owner reaching a lake by membership: a tag/entitlement-holder in a different org is
+   * excluded, and a lake with no org and no gate stays owner-only. Defaults to the active+draft
+   * statuses.
+   *
+   * `ctx.administeredOrgIds` is the org-ADMIN arm and is not interchangeable with
+   * `ctx.organizationIds`: it grants no more than the single gate already grants (`canManageLake`
+   * rung 4 admits the same principal, and manage implies read), it exists so the succession roles -
+   * team manager, appointed admin - can DISCOVER the org lakes they may already manage. Absent or
+   * empty simply adds no arm.
    */
   findAccessible(
     ctx: AccessContext,

--- a/b4m-core/services/src/dataLakeService/assembleLakeAccessView.ts
+++ b/b4m-core/services/src/dataLakeService/assembleLakeAccessView.ts
@@ -14,19 +14,11 @@ import type {
   LakeCandidateCapPressure,
   LakeGrantStatus,
 } from '@bike4mind/common';
-import { ORG_MEMBERSHIP_ACL_PERMISSIONS } from '@bike4mind/common';
+import { orgAclRowConfersMembership } from '@bike4mind/common';
 import { normalizeId } from '@bike4mind/utils';
 
 /** Default cap on audit events read for the history aggregation - see `historyTruncated`. */
 export const LAKE_ACCESS_VIEW_HISTORY_LIMIT = 2000;
-
-/**
- * The org `users[]` permissions that count as membership, DERIVED from the one shared definition
- * rather than hand-copied: the org channel's `holderCount` must count exactly the members the DB gate
- * (`OrganizationModel`'s `findMembershipOrgIds`) would admit, or an owner is shown a member total
- * larger than the set that can actually read - false reassurance a compliance reader cannot detect.
- */
-const ORG_MEMBER_PERMISSIONS = new Set<string>(ORG_MEMBERSHIP_ACL_PERMISSIONS);
 
 /**
  * Whether a grant is live at `now`. IDENTICAL boundary to the DB `buildActiveGrantFilter` and the
@@ -229,13 +221,13 @@ export async function assembleLakeAccessView(
     const org = orgById.get(orgChannel.value);
     if (org) {
       orgChannel.label = org.name;
-      // Members = the billing owner plus the users[] entries the gate would ADMIT (read/write
-      // permission), de-duplicated - see ORG_MEMBER_PERMISSIONS. Counting the raw ACL would overstate
-      // the total by including share-only members the gate denies, and an over-stated count is exactly
-      // the kind of false reassurance a compliance reader cannot detect.
-      const admitted = (org.users ?? []).filter(
-        u => u.userId && (u.permissions ?? []).some(p => ORG_MEMBER_PERMISSIONS.has(p))
-      );
+      // Members = the billing owner plus the users[] entries the gate would ADMIT, de-duplicated.
+      // Counting the raw ACL would overstate the total by including share-only members the gate
+      // denies, and an over-stated count is exactly the kind of false reassurance a compliance
+      // reader cannot detect. `orgAclRowConfersMembership` is the shared in-memory twin of the DB
+      // gate's own `$elemMatch` (`orgMembershipFilter`), so this count cannot drift from what
+      // `findMembershipOrgIds` admits - the drift the shared predicate exists to prevent.
+      const admitted = (org.users ?? []).filter(u => u.userId && orgAclRowConfersMembership(u));
       const memberIds = new Set<string>([org.userId, ...admitted.map(u => u.userId)].filter(Boolean));
       orgChannel.holderCount = memberIds.size;
     }

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -619,6 +619,28 @@ describe('listDataLakes - pending proposal count is the queue discovery surface'
     expect(result.find(l => l.id === 'mine')?.canManage).toBe(true);
     expect(result.find(l => l.id === 'mine')?.pendingProposalCount).toBeUndefined();
   });
+
+  // #2005: the queue's reviewer of last resort is an org admin who did NOT create the lake - the
+  // succession role - and every existing case above describes a creator, so nothing pinned that the
+  // count reaches this one. Two gates have to agree for it to arrive: `findAccessible` must return
+  // the lake at all (pinned against a real Mongo in DataLakeModel.orgScopeAgreement.test.ts, which
+  // is where the bug was) and `canManageLake` must then rate the caller an editor, which is what
+  // admits the count. This covers the second half; `findAccessible` is mocked here, so it cannot
+  // and does not stand in for the first.
+  it('carries the count for an org admin who did not create the lake', async () => {
+    const orgLake = lake({ id: 'org-lake', slug: 'org-lake', createdByUserId: 'creator', organizationId: 'org-a' });
+    const db = {
+      dataLakes: { findAccessible: vi.fn().mockResolvedValue([orgLake]), find: vi.fn() },
+      dataLakeProposals: counts({ 'org-lake': 2 }),
+    };
+
+    // administeredOrgIds ONLY, with an empty membership set - exactly the principal #2005 describes
+    // (a team manager or appointed admin who sits on no read/write users[] ACL row).
+    const result = await listDataLakes(ctx({ userId: 'manager', administeredOrgIds: ['org-a'] }), { db });
+
+    expect(result.find(l => l.id === 'org-lake')?.canManage).toBe(true);
+    expect(result.find(l => l.id === 'org-lake')?.pendingProposalCount).toBe(2);
+  });
 });
 
 describe('listDataLakes - systemPrompt is returned to a lake EDITOR only', () => {

--- a/packages/database/src/models/ai/DataLakeModel.orgScopeAgreement.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.orgScopeAgreement.test.ts
@@ -25,9 +25,19 @@ import { setupMongoTest } from '../../__test__/utils';
  * is never an unlistable one - is pinned next to those predicates in
  * `OrganizationModel.membershipOrgIds.test.ts`. Keep the two in mind together: this file proves the
  * lake read path honors the membership set, that one proves the set matches what the switcher offers.
+ *
+ * #2005 is the second half of the same idea on the other authority: the read path must also honor
+ * the org-ADMIN set, because `canManageLake` grants manage (and so read) on it. Same seam, same
+ * failure mode - a principal the write/manage path authorizes cannot find what it authorized them
+ * for - so the cases live here rather than in a third file.
  */
 
-const orgLake = (slug: string, organizationId: string, createdByUserId: string): Omit<IDataLake, 'id'> =>
+const orgLake = (
+  slug: string,
+  organizationId: string,
+  createdByUserId: string,
+  extra: Partial<IDataLake> = {}
+): Omit<IDataLake, 'id'> =>
   ({
     slug,
     name: slug,
@@ -36,12 +46,17 @@ const orgLake = (slug: string, organizationId: string, createdByUserId: string):
     createdByUserId,
     status: 'active',
     organizationId,
+    ...extra,
   }) as Omit<IDataLake, 'id'>;
 
 /**
  * The manager list's AccessContext, built the way `toAccessContext` builds it: `organizationIds`
- * comes from the membership set and nothing else. Callers pass no selected-org pointer because the
- * production context has nowhere to put one - which is the fix being pinned.
+ * from the membership set, `administeredOrgIds` from the org-admin-rights set, and no selected-org
+ * pointer because the production context has nowhere to put one - which is the #1648 fix.
+ *
+ * Both sets come from the real repositories on purpose. Hardcoding `administeredOrgIds: []` here is
+ * what let #2005 sit uncovered: every case in this file described a principal whose admin set was
+ * empty anyway, so the missing org-admin arm never had a test that could see it.
  */
 const listContext = async (userId: string): Promise<AccessContext> => ({
   userId,
@@ -49,13 +64,13 @@ const listContext = async (userId: string): Promise<AccessContext> => ({
   userTags: [],
   organizationIds: await organizationRepository.findMembershipOrgIds(userId),
   entitlementKeys: [],
-  administeredOrgIds: [],
+  administeredOrgIds: await organizationRepository.findIdsWithAdminRights(userId),
 });
 
 const listableSlugs = async (userId: string) =>
   (await dataLakeRepository.findAccessible(await listContext(userId))).map(l => l.slug).sort();
 
-describe('data-lake org scope: switcher selection agrees with the manager list (#1648)', () => {
+describe('data-lake org scope: the manager list agrees with what the org grants (#1648, #2005)', () => {
   setupMongoTest();
 
   /** An org the switcher offers `member` (ACL arm), owned by someone else. */
@@ -90,5 +105,89 @@ describe('data-lake org scope: switcher selection agrees with the manager list (
     await dataLakeRepository.create(orgLake('a-lake', String(orgA._id), 'creator'));
 
     expect(await listableSlugs('stranger')).toEqual([]);
+  });
+
+  /**
+   * The org-ADMIN half of the same seam (#2005). `canManageLake` rung 4 admits an admin of the
+   * lake's own org, and `classifyLakeAccess` runs that rung BEFORE its org prerequisite, so such a
+   * principal could open, review and approve an org lake while `findAccessible` left it out of the
+   * only list that leads there. Manage implies read; these pin that the datastore mirror says so too.
+   *
+   * The admin set (`findIdsWithAdminRights`: billing owner OR managerId OR adminUserIds) is WIDER
+   * than the membership set above and stays a separate set - see the note on `orgMembershipFilter`
+   * for why folding these arms into membership instead would have changed a write privilege.
+   */
+  /** An org whose admin rights `admin` holds without any `users[]` ACL row conferring membership. */
+  const orgWithManager = (name: string, manager: string) =>
+    Organization.create({ name, userId: 'org-owner', managerId: manager, users: [], groups: [] });
+
+  it('lists an org lake for a team manager who sits on no users[] ACL row', async () => {
+    const orgA = await orgWithManager('org-a', 'manager');
+    await dataLakeRepository.create(orgLake('a-lake', String(orgA._id), 'creator'));
+
+    expect(await listableSlugs('manager')).toEqual(['a-lake']);
+  });
+
+  it('lists an org lake for an appointed admin whose ACL row carries no permissions', async () => {
+    // The appointment route (`POST /api/organizations/:id/admins`) requires the target to be in
+    // `users[]` but never inspects `permissions`, so this row is a state the product can really
+    // reach - and it confers admin rights while conferring no membership.
+    const orgA = await Organization.create({
+      name: 'org-a',
+      userId: 'org-owner',
+      users: [{ userId: 'appointee' }],
+      adminUserIds: ['appointee'],
+      groups: [],
+    });
+    await dataLakeRepository.create(orgLake('a-lake', String(orgA._id), 'creator'));
+
+    expect(await listableSlugs('appointee')).toEqual(['a-lake']);
+  });
+
+  it('lists a gated org lake for its org admin, whose rights outrank the gate', async () => {
+    // Load-bearing for the arm's SHAPE, not just its presence: the org-admin arm is unconstrained,
+    // like the owner arm. An implementation that ANDed the requirement onto it would pass every
+    // other case here and still hide this lake - which the gate opens, since canManageLake resolves
+    // before lakeMatchesAccess is ever consulted.
+    const orgA = await orgWithManager('org-a', 'manager');
+    await dataLakeRepository.create(
+      orgLake('a-lake', String(orgA._id), 'creator', { requiredUserTag: 'tag-the-manager-lacks' })
+    );
+
+    expect(await listableSlugs('manager')).toEqual(['a-lake']);
+  });
+
+  it('lists an archived org lake for its org admin, so restore/cleanup can reach it', async () => {
+    // The management views pass includePublic:false because restore/cleanup are owner/admin-only.
+    // An org admin is in that class, so the arm must survive there too.
+    const orgA = await orgWithManager('org-a', 'manager');
+    await dataLakeRepository.create(orgLake('a-lake', String(orgA._id), 'creator', { status: 'archived' }));
+
+    const archived = await dataLakeRepository.findAccessible(await listContext('manager'), {
+      statuses: ['archived'],
+      includePublic: false,
+    });
+    expect(archived.map(l => l.slug)).toEqual(['a-lake']);
+  });
+
+  it('does not turn admin rights into membership, so the account switcher is unaffected', async () => {
+    // The anti-regression for the fix NOT taken. Widening `orgMembershipFilter` would have listed
+    // the lake too, and also handed `manager` the org as a selectable write target via
+    // `resolveActiveOrg`. Membership must stay ACL-only while the lake still lists.
+    const orgA = await orgWithManager('org-a', 'manager');
+    await dataLakeRepository.create(orgLake('a-lake', String(orgA._id), 'creator'));
+
+    expect(await organizationRepository.findMembershipOrgIds('manager')).toEqual([]);
+    expect(await organizationRepository.findIdsWithAdminRights('manager')).toEqual([String(orgA._id)]);
+    expect(await listableSlugs('manager')).toEqual(['a-lake']);
+  });
+
+  it('still hides an org lake from an admin of a different org (the arm is scoped, not disabled)', async () => {
+    const orgA = await orgWithManager('org-a', 'manager');
+    const orgB = await orgWithManager('org-b', 'other-manager');
+    await dataLakeRepository.create(orgLake('a-lake', String(orgA._id), 'creator'));
+    await dataLakeRepository.create(orgLake('b-lake', String(orgB._id), 'creator'));
+
+    expect(await listableSlugs('manager')).toEqual(['a-lake']);
   });
 });

--- a/packages/database/src/models/ai/DataLakeModel.orgScopeAgreement.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.orgScopeAgreement.test.ts
@@ -129,9 +129,10 @@ describe('data-lake org scope: the manager list agrees with what the org grants 
   });
 
   it('lists an org lake for an appointed admin whose ACL row carries no permissions', async () => {
-    // The appointment route (`POST /api/organizations/:id/admins`) requires the target to be in
-    // `users[]` but never inspects `permissions`, so this row is a state the product can really
-    // reach - and it confers admin rights while conferring no membership.
+    // `PUT /api/organizations/:id/admins` now refuses to MINT this shape - it requires an ACL row
+    // that confers membership. The state is still reachable, which is why the case stays: rows
+    // appointed before that check existed persist, and the route grandfathers them on resend rather
+    // than revoking retroactively. So the datastore really does hold admin rights with no membership.
     const orgA = await Organization.create({
       name: 'org-a',
       userId: 'org-owner',

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -441,7 +441,7 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
 
   /**
    * Datastore-side accessibility filter mirroring the single access gate:
-   * owner OR (org-constraint AND requirement-constraint AND not-private). The org and
+   * owner OR org-admin OR (org-constraint AND requirement-constraint AND not-private). The org and
    * requirement arms are ANDed for non-owners, so a tag/entitlement-holder in a different
    * org never receives the lake. The requirement arm is the Mongo mirror of the in-memory
    * `lakeMatchesAccess` any-of (shared with findActiveByUserTagsAndEntitlements).
@@ -450,6 +450,14 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
    * blank). Such a lake is owner/admin-only - it is NOT world-readable. A non-owner reaches
    * a lake only when it grants them something: their org (org-scoped lake) or a gate they
    * hold. This is the Private-by-default rule; the owner still matches via the separate arm.
+   *
+   * The unconstrained arms (owner, org-admin, grant) are unconstrained because the gate this
+   * mirrors resolves MANAGE first (`classifyLakeAccess` -> `canManageLake`, before its own
+   * org prerequisite) and manage grants read - so ANDing the org/requirement constraints onto
+   * them would hide a lake the gate then opens. Keeping the mirror faithful is the whole
+   * contract of this method, and the failure is quiet when it breaks: a lake missing here is
+   * still reachable by direct id, so the caller keeps every right they had and simply loses
+   * the only surface that would have told them the lake exists (#2005).
    */
   async findAccessible(
     ctx: AccessContext,
@@ -499,6 +507,20 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
     // (dropped for management views via includePublic - see the note at the top of this method).
     const nonOwnerArms: Record<string, unknown>[] = [{ $and: [orgConstraint, requirement, notPrivate] }];
     if (includePublic) nonOwnerArms.unshift(publicArm);
+
+    // Org-admin arm (#2005): a lake in an org the caller holds ADMIN rights in, reachable by those
+    // rights alone - the analog of the owner arm, for the same reason (the gate admits them via
+    // canManageLake before it ever reaches the org prerequisite). Keyed off `administeredOrgIds`
+    // (billing owner OR managerId OR adminUserIds), deliberately a DIFFERENT set from the
+    // `organizationIds` membership the org arm above uses: membership also decides what the account
+    // switcher offers as a write target (see `orgMembershipFilter`), so widening membership to fix
+    // this would have handed a team manager the org as somewhere to write as. The two sets are meant
+    // to differ; what was wrong was that only one of them reached this query. Applies to the
+    // management views too (includePublic:false): restore/cleanup are owner/admin-only and an org
+    // admin is in that class - `redactLakesForActor` agrees, keying off the same `canManageLake`.
+    // Served by the existing { organizationId: 1, status: 1 } index.
+    const administeredOrgIds = ctx.administeredOrgIds ?? [];
+    if (administeredOrgIds.length > 0) nonOwnerArms.push({ organizationId: { $in: administeredOrgIds } });
 
     // Explicit-grant arm (#1668): a lake the caller holds an active access grant on is reachable by
     // that grant alone - the grant IS the authorization, so it needs none of the org/gate constraints

--- a/packages/database/src/models/infra/admin/OrganizationModel.membershipOrgIds.test.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.membershipOrgIds.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { orgAclRowConfersMembership } from '@bike4mind/common';
 import { Organization, organizationRepository } from './OrganizationModel';
 import { setupMongoTest } from '../../../__test__/utils';
 
@@ -98,5 +99,56 @@ describe('OrganizationRepository.search - users[] ACL membership arm', () => {
     const expected = [String(owned._id), String(viaAcl._id)].sort();
     expect((await searchByUser('u1')).sort()).toEqual(expected);
     expect((await organizationRepository.findMembershipOrgIds('u1')).sort()).toEqual(expected);
+  });
+});
+
+/**
+ * `orgAclRowConfersMembership` is the in-memory twin of `orgMembershipFilter`'s `$elemMatch`, used
+ * wherever the rule has to be answered without issuing the Mongo query: the admin appointment route
+ * and the picker that feeds it (#2005), and the access view's org-channel `holderCount`. Two
+ * expressions of one rule, so drift is the whole risk: this pins them equal per ROW SHAPE rather
+ * than testing the predicate against its own definition, which would pass happily while the filter
+ * said something else.
+ */
+describe('orgAclRowConfersMembership agrees with orgMembershipFilter, per row shape', () => {
+  setupMongoTest();
+
+  // 'write' and a missing `permissions` key cannot come from any app write path (writers hard-code
+  // ['read'], and the schema types the field as required), so those rows go in through the raw
+  // driver - the same reason the write-only search case above does. They are exactly the shapes the
+  // predicate is defensive about, so omitting them would skip the interesting half.
+  const insertRaw = async (name: string, row: Record<string, unknown>) => {
+    const result = await Organization.collection.insertOne({
+      name,
+      userId: 'someone-else',
+      users: [row],
+      groups: [],
+      isGlobalRead: false,
+      isGlobalWrite: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return String(result.insertedId);
+  };
+
+  const shapes: { label: string; permissions?: string[] }[] = [
+    { label: 'read', permissions: ['read'] },
+    { label: 'write (legacy/out-of-band only)', permissions: ['write'] },
+    { label: 'read plus unrelated verbs', permissions: ['share', 'read'] },
+    { label: 'share only', permissions: ['share'] },
+    { label: 'every non-membership verb', permissions: ['create', 'update', 'delete', 'share'] },
+    { label: 'empty permissions array', permissions: [] },
+    { label: 'permissions key absent entirely', permissions: undefined },
+  ];
+
+  it.each(shapes)('$label: the predicate matches what the datastore admits', async ({ permissions }) => {
+    const row: Record<string, unknown> = { userId: 'u1' };
+    if (permissions !== undefined) row.permissions = permissions;
+    const orgId = await insertRaw('shape-org', row);
+
+    const datastoreSaysMember = (await organizationRepository.findMembershipOrgIds('u1')).includes(orgId);
+    const predicateSaysMember = orgAclRowConfersMembership({ permissions });
+
+    expect(predicateSaysMember).toBe(datastoreSaysMember);
   });
 });

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -40,6 +40,13 @@ const MEMBER_PERMISSIONS = ORG_MEMBERSHIP_ACL_PERMISSIONS;
  *
  * Deliberately NO groups arm, unlike the shareable ACL (`findAccessibleById`) that the write-side
  * `resolveActiveOrg` validates against; see that function's note on the wider write predicate.
+ *
+ * Deliberately NO managerId/adminUserIds arms either, and #2005 is the reason to keep it that way:
+ * org-admin rights DO grant lake visibility, but they earn it through `AccessContext
+ * .administeredOrgIds` (`findIdsWithAdminRights` -> the org-admin arm of `findAccessible`), not by
+ * being folded in here. Widening this predicate would reach the switcher and therefore
+ * `resolveActiveOrg`, turning "may administer that org" into "may write as that org" - a privilege
+ * change, not a visibility fix. Admin rights and membership are meant to be different sets.
  */
 const orgMembershipFilter = (userId: string): Record<string, unknown> => ({
   $or: [{ userId }, { users: { $elemMatch: { userId, permissions: { $in: MEMBER_PERMISSIONS } } } }],


### PR DESCRIPTION
## Description

Two rules disagreed about whether org-admin rights imply data-lake visibility. `classifyLakeAccess` (the in-memory access gate) resolves `canManageLake` *before* it ever reaches its own org-membership prerequisite, so a team manager or an appointed org admin can already review/approve a lake's acquisition proposals through that gate. But `findAccessible`, the Mongo query that mirrors that gate for `GET /api/data-lakes`, had no org-admin arm - so the same lake stayed invisible in the manager UI. The principal kept every right they had (the lake was still reachable by direct id) and simply lost the only surface that would have told them the lake exists.

The fix adds the missing arm to the mirror rather than widening org membership itself: `administeredOrgIds` (from `findIdsWithAdminRights`: billing owner OR `managerId` OR `adminUserIds`) is deliberately a *different* set from `organizationIds` (membership), because membership also decides what the account switcher offers as a write target. Folding admin rights into membership would have turned "may administer this org" into "may write as this org" - a privilege change, not a visibility fix.

While fixing this, found a related write-time gap and folded it in: the admin-appointment route (`PUT /api/organizations/:id/admins`) accepted any `users[]` row by `userId` alone, so it could appoint an admin whose ACL row carried no read/write permission - minting a principal with admin rights over an org that was unselectable in their own account switcher. Both the route and the client picker that feeds it now share one predicate (`orgAclRowConfersMembership`), so they can't drift apart again.

That eligibility rule binds the appointments a call **adds**, not the roster's history. `PUT /admins` is a full replace, so every sitting admin is resent on every save; validating the whole set would let one row appointed before the check existed block every later edit of the roster until the operator de-appointed them - a stricter rule turning into a retroactive revocation. A resend of an existing appointment is grandfathered instead: it mints no new principal, and it is exactly the principal the read half of this PR deliberately serves. Roster membership is **not** waived - a grandfathered id must still hold a `users[]` row, so removal from the org still ejects them.

The same asymmetry governs the picker. Eligibility narrows the picker's **options** only; the selected chips resolve against the unfiltered roster, and the appointed ids are appended back into the options. Narrowing both would turn a display filter into a write: a sitting admin whose row confers no membership would stay in the selection while rendering no chip, and the next unrelated edit would rebuild the selection from the visible chips - so the full-replace save would silently revoke them.

## Changes

- `packages/database/.../DataLakeModel.ts`: `findAccessible` gains an org-admin arm (`organizationId: { $in: administeredOrgIds }`), served by the existing `{ organizationId: 1, status: 1 }` index. No new authority granted - `canManageLake` already admitted the same principal.
- `b4m-core/common/.../DataLakeTypes.ts`: updated `IDataLakeRepository.findAccessible` contract docstring to match.
- `packages/database/.../OrganizationModel.ts`: docstring note on `orgMembershipFilter` explaining why admin rights are deliberately kept out of the membership predicate.
- `b4m-core/common/src/constants/organization.ts`: new shared predicate `orgAclRowConfersMembership`, the in-memory twin of `orgMembershipFilter`'s `$elemMatch`.
- `apps/client/pages/api/organizations/[id]/admins.ts`: appointment eligibility now checks that predicate instead of bare `userId` presence, and binds only the ids a call adds - a resend of a sitting appointment is grandfathered while it still holds a `users[]` row. Error message names the real reason, and only the ids the operator can act on.
- `apps/client/app/components/organizations/OrganizationGroups.tsx`: the admins picker filters its **options** with the same predicate, so it never offers a save that would 400; the chips resolve against the unfiltered roster so a sitting admin is never invisibly dropped by a full-replace save.
- `b4m-core/services/.../assembleLakeAccessView.ts`: converted a third hand-rolled copy of the same rule (the org-channel `holderCount`) to the shared predicate.
- Tests: `DataLakeModel.orgScopeAgreement.test.ts` (6 new cases - team manager, permission-less appointed admin, gated lake, archived view, switcher anti-regression, cross-org scoping), `dataLakeService.test.ts` (org-admin pending-proposal count), new `admins.test.ts` (10 cases - whole-batch refusal since the route is a full replace, plus grandfathering a resend, still refusing a new permission-less appointee in the same batch, and not grandfathering an admin who is off the roster), `OrganizationModel.membershipOrgIds.test.ts` (`it.each` pinning the predicate equal to the datastore per row shape), `OrganizationGroups.test.tsx` (picker excludes a permission-less row from its options; a sitting permission-less admin still renders as a chip).

## Guide for Testers

This is a backend/data-visibility fix with one small UI surface (the admins picker). No new page or control to click through beyond the existing Data Lake Manager and Org Admins editor.

1. As an org's billing owner, go to your org's Admin panel -> Organization Groups tab (`app.staging.bike4mind.com` -> your org -> Groups).
2. In "Organization Admins", appoint a member who has an ACL row with no read/write permission (this requires a raw DB row today - not producible through any existing UI flow, since every in-app write path already stamps `['read']`). Confirm they do NOT appear in the picker's options list.
3. Now make that same permission-less member an admin by raw DB write (set `adminUserIds`). Reload the Groups tab and confirm they DO render as a chip in "Organization Admins" - then add a second, ordinary admin and save. The save must succeed and both admins must persist; the permission-less one must not silently disappear.
4. Remove the permission-less admin's chip explicitly and save. That should succeed too - de-appointment is allowed, it just has to be a deliberate act.
5. As a team manager (or an appointed org admin) for an org that owns a data lake, open the org's Data Lake Manager. Confirm the org's lakes are now listed, `canManage: true`, and any pending acquisition-proposal count/badge shows (e.g. "N to review").
6. Confirm a plain org member (no admin rights) still sees only the lakes their explicit grants/memberships allow - no widening for ordinary members.

### Regression Checks
- A user who is only an org member (not admin) should see no change in which lakes they can list.
- The account switcher must still NOT offer an org to a manager/admin who lacks membership - only admin rights over lakes changed, not write-target eligibility.
- Appointing a brand-new admin whose ACL row confers no membership must still be refused (the grandfather clause covers resends only, never a new appointment).

## Additional Information

Verified live on local self-host with the arm toggled on/off: baseline (arm disabled) returned only the built-in static lake and "Nothing here yet"; with the arm enabled, the same session returned 5 org lakes, `canManage: true`, `pendingProposalCount: 3`, and the manager chip "3 to review". Negative control (plain member, no admin rights) unaffected in both states.

## Developer Notes (Optional)

- `orgAclRowConfersMembership` is now the single definition of "does this ACL row confer org membership" and is meant to be reused by any future in-memory check of the same rule - see its docstring for the three layers it already unifies (persistence gate, engine holder-count, app-side eligibility checks).
- The route's grandfather clause is the general shape for a full-replace endpoint that gains a stricter admission rule: validate the delta, not the state, or the new rule revokes retroactively. It stays narrow on purpose - it waives the *permissions* requirement for an id already in `adminUserIds`, and nothing else.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no user-facing doc describes this internal visibility rule
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields - N/A
