### PR TITLE
fix(services): persist only changed fields in repository updates

### DIFF
--- a/apps/client/__tests__/api/stripe/webhook.test.ts
+++ b/apps/client/__tests__/api/stripe/webhook.test.ts
@@ -22,6 +22,7 @@ const mockFindByOrgStripeCustomerId = vi.fn();
 const mockFindById = vi.fn();
 const mockUserUpdate = vi.fn();
 const mockSubtractCredits = vi.fn();
+const mockAddCredits = vi.fn();
 const mockStampCreditLot = vi.fn();
 const mockClawbackCreditLotsByStripeRef = vi.fn();
 const mockUpdateTransactionStatus = vi.fn();
@@ -51,6 +52,7 @@ vi.mock('@bike4mind/database', () => ({
 
 vi.mock('@bike4mind/services', () => ({
   creditService: {
+    addCredits: (...args: unknown[]) => mockAddCredits(...args),
     subtractCredits: (...args: unknown[]) => mockSubtractCredits(...args),
     stampCreditLot: (...args: unknown[]) => mockStampCreditLot(...args),
     clawbackCreditLotsByStripeRef: (...args: unknown[]) => mockClawbackCreditLotsByStripeRef(...args),
@@ -198,6 +200,7 @@ describe('Stripe webhook — new fraud prevention handlers', () => {
     mockUpdateByStripeSubscriptionId.mockResolvedValue(undefined);
     mockUpdateTransactionStatus.mockResolvedValue(undefined);
     mockStampCreditLot.mockResolvedValue(undefined);
+    mockAddCredits.mockResolvedValue(undefined);
     mockClawbackCreditLotsByStripeRef.mockResolvedValue(undefined);
   });
 
@@ -218,21 +221,26 @@ describe('Stripe webhook — new fraud prevention handlers', () => {
       },
     };
 
-    it('grants credits and stamps a pack credit lot with the payment intent as stripeRef', async () => {
+    it('grants credits through the atomic credit ledger keyed on the payment intent', async () => {
       mockFindByStripeCustomerId.mockResolvedValue({ ...mockUser });
 
       await invokeWebhookWithEvent(packEvent);
 
-      expect(mockUserUpdate).toHaveBeenCalledWith(expect.objectContaining({ currentCredits: 600 }));
-      expect(mockStampCreditLot).toHaveBeenCalledWith(
+      // The purchase path now delegates to creditService.addCredits, which records the
+      // transaction, atomically increments the balance, and stamps the pack lot - keyed
+      // idempotently on stripePaymentIntentId. No whole-document balance overwrite.
+      expect(mockAddCredits).toHaveBeenCalledWith(
         expect.objectContaining({
+          type: 'purchase',
           ownerId: 'user123',
-          amount: 500,
-          grantType: 'purchase',
-          stripeRef: 'pi_pack',
+          credits: 500,
+          amount: 999,
+          stripePaymentIntentId: 'pi_pack',
+          packageId: 'pkg_1',
         }),
         expect.anything()
       );
+      expect(mockUserUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/client/__tests__/team-manager.test.ts
+++ b/apps/client/__tests__/team-manager.test.ts
@@ -218,7 +218,9 @@ describe('organizationService.update - Manager Permissions', () => {
       shareable: {
         findUpdateAccessById: vi.fn().mockResolvedValue(mockOrganization),
       },
-      update: vi.fn().mockImplementation(org => Promise.resolve(org)),
+      // Mirror findOneAndUpdate({ new: true }): the real repo returns the full merged
+      // document, not just the $set partial the service now passes.
+      update: vi.fn().mockImplementation(org => Promise.resolve({ ...mockOrganization, ...org })),
       findById: vi.fn().mockResolvedValue(mockOrganization),
     };
   });

--- a/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.test.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.test.tsx
@@ -49,7 +49,9 @@ describe('CreditAdjustmentModal — reason threading + audit trail', () => {
     fireEvent.click(screen.getByRole('button', { name: /Add Credits/i }));
 
     await waitFor(() => expect(onCreditAdjustment).toHaveBeenCalledTimes(1));
-    expect(onCreditAdjustment).toHaveBeenCalledWith('user-1', 100, 100, 'Compensation for outage');
+    // (userId, signed adjustment, note) - the stale currentCredits arg was removed; the
+    // server applies the signed delta atomically.
+    expect(onCreditAdjustment).toHaveBeenCalledWith('user-1', 100, 'Compensation for outage');
   });
 
   it('passes an undefined reason (not an empty string) when the note is blank on removal', async () => {
@@ -68,7 +70,7 @@ describe('CreditAdjustmentModal — reason threading + audit trail', () => {
     fireEvent.click(screen.getByRole('button', { name: /Remove Credits/i }));
 
     await waitFor(() => expect(onCreditAdjustment).toHaveBeenCalledTimes(1));
-    expect(onCreditAdjustment).toHaveBeenCalledWith('user-1', 100, -100, undefined);
+    expect(onCreditAdjustment).toHaveBeenCalledWith('user-1', -100, undefined);
   });
 
   it('renders the audit trail of recent adjustments', async () => {

--- a/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.tsx
@@ -26,7 +26,7 @@ interface CreditAdjustmentModalProps {
   open: boolean;
   onClose: () => void;
   selectedUser: AdminUserListItem | null;
-  onCreditAdjustment: (userId: string, currentCredits: number, adjustment: number, note?: string) => Promise<void>;
+  onCreditAdjustment: (userId: string, adjustment: number, note?: string) => Promise<void>;
 }
 
 export const CreditAdjustmentModal: React.FC<CreditAdjustmentModalProps> = ({
@@ -50,12 +50,7 @@ export const CreditAdjustmentModal: React.FC<CreditAdjustmentModalProps> = ({
   const handleCreditAdjustment = async (isAdd: boolean) => {
     if (selectedUser && creditAmount > 0) {
       const adjustment = isAdd ? creditAmount : -creditAmount;
-      await onCreditAdjustment(
-        selectedUser.id,
-        selectedUser.currentCredits || 0,
-        adjustment,
-        creditNote.trim() || undefined
-      );
+      await onCreditAdjustment(selectedUser.id, adjustment, creditNote.trim() || undefined);
       queryClient.invalidateQueries({ queryKey: userCreditAdjustmentsKey(selectedUser.id) });
       handleClose();
     }

--- a/apps/client/app/components/admin/CreditAnalysis/hooks/useUpdateUserCredits.ts
+++ b/apps/client/app/components/admin/CreditAnalysis/hooks/useUpdateUserCredits.ts
@@ -3,9 +3,11 @@ import { api } from '@client/app/contexts/ApiContext';
 
 export function useUpdateUserCredits() {
   return useMutation({
-    mutationFn: async ({ userId, credits, note }: { userId: string; credits: number; note?: string }) => {
+    mutationFn: async ({ userId, creditDelta, note }: { userId: string; creditDelta: number; note?: string }) => {
       const response = await api.put(`/api/users/${userId}/update`, {
-        currentCredits: credits,
+        // Signed delta, not an absolute balance: the server applies it atomically so
+        // spend between page load and this write is never refunded (see adminUpdateUser).
+        creditDelta,
         // Persisted on the audited CreditTransaction (server defaults a description
         // when omitted). Previously sent as `adminNote`, which the schema dropped.
         creditReason: note,

--- a/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.ts
+++ b/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.ts
@@ -50,12 +50,14 @@ export function useUserCreditsManager(onRefresh?: () => void) {
 
   const users = allUsers.data?.users ?? [];
 
-  const handleCreditAdjustment = async (userId: string, currentCredits: number, adjustment: number, note?: string) => {
-    const newCredits = Math.max(0, currentCredits + adjustment);
+  const handleCreditAdjustment = async (userId: string, adjustment: number, note?: string) => {
     try {
       await updateUserCreditsMutation.mutateAsync({
         userId,
-        credits: newCredits,
+        // Send the signed adjustment, not a client-computed absolute. The server
+        // applies it atomically against the live balance, so interim spend is not
+        // refunded and the balance never goes negative.
+        creditDelta: adjustment,
         // The admin's typed "Reason for adjustment" - persisted on the audit
         // record. Server supplies a default description when this is empty.
         note: note?.trim() || undefined,

--- a/apps/client/pages/api/admin/users/[userId]/grant-subscription.ts
+++ b/apps/client/pages/api/admin/users/[userId]/grant-subscription.ts
@@ -268,10 +268,11 @@ const handler = baseApi().post(
           }
         );
 
-        // Update organization seats if needed
+        // Update organization seats if needed. Targeted write: a whole-org snapshot
+        // here would $set the pre-grant currentCredits back over the atomic $inc
+        // addCredits just applied, erasing the credits granted above.
         if (targetOrganization.seats < seats) {
-          targetOrganization.seats = seats;
-          await organizationRepository.update(targetOrganization);
+          await organizationRepository.update({ id: targetOrganization.id, seats });
         }
 
         req.logger.info(`Admin ${req.user.id} granted team subscription to organization ${targetOrganization.id}`, {

--- a/apps/client/pages/api/quest-plans/[id]/index.ts
+++ b/apps/client/pages/api/quest-plans/[id]/index.ts
@@ -60,8 +60,10 @@ const handler = baseApi()
         return res.status(403).json({ error: 'Access denied' });
       }
 
+      // Read-triggered touch: persist only lastAccessedAt, never the whole snapshot,
+      // so a concurrent owner revocation or visibility change is not reverted.
       plan.lastAccessedAt = new Date();
-      await questMasterPlanRepository.update(plan);
+      await questMasterPlanRepository.update({ id: planId, lastAccessedAt: plan.lastAccessedAt });
 
       res.json(plan);
     } catch (error) {
@@ -126,7 +128,11 @@ const handler = baseApi()
         }
       }
 
-      if (goal !== undefined) plan.goal = goal;
+      // Persist only the fields this request changed, never a spread of the read
+      // snapshot - a whole-document write would revert any concurrent atomic write
+      // (e.g. a share change) that landed during this handler.
+      const changes: Partial<typeof plan> & { id: string } = { id: planId };
+      if (goal !== undefined) changes.goal = goal;
       if (state !== undefined) {
         const currentState = plan.state || 'active';
         if (!questMasterPlanRepository.isValidStateTransition(currentState, state)) {
@@ -134,16 +140,16 @@ const handler = baseApi()
             error: `Invalid state transition from '${currentState}' to '${state}'`,
           });
         }
-        plan.state = state;
+        changes.state = state;
       }
-      if (visibility !== undefined) plan.visibility = visibility;
-      if (tags !== undefined) plan.tags = tags;
-      if (priority !== undefined) plan.priority = priority;
-      if (sharedUserIds !== undefined) plan.sharedWith = sharedUserIds;
+      if (visibility !== undefined) changes.visibility = visibility;
+      if (tags !== undefined) changes.tags = tags;
+      if (priority !== undefined) changes.priority = priority;
+      if (sharedUserIds !== undefined) changes.sharedWith = sharedUserIds;
 
-      plan.lastAccessedAt = new Date();
+      changes.lastAccessedAt = new Date();
 
-      const updated = await questMasterPlanRepository.update(plan);
+      const updated = await questMasterPlanRepository.update(changes);
       res.json(updated);
     } catch (error) {
       console.error('Error updating quest plan:', error);
@@ -174,9 +180,8 @@ const handler = baseApi()
         return res.status(403).json({ error: 'Only owner can archive quest plan' });
       }
 
-      // Soft delete by archiving
-      plan.state = 'archived';
-      await questMasterPlanRepository.update(plan);
+      // Soft delete by archiving - targeted write so it cannot revert a concurrent change.
+      await questMasterPlanRepository.update({ id: planId, state: 'archived' });
 
       res.status(204).end();
     } catch (error) {

--- a/apps/client/pages/api/stripe/webhook.ts
+++ b/apps/client/pages/api/stripe/webhook.ts
@@ -98,8 +98,10 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
 
         // Records the CreditTransaction (idempotent on stripePaymentIntentId),
         // then atomically $inc's the balance and stamps the pack lot. Replaces a
-        // former read-modify-$set of the whole user doc, which both reverted any
-        // concurrent balance write and double-credited on Stripe's webhook retries.
+        // former read-modify-$set of the whole user doc, which reverted any concurrent
+        // balance write. (The unique stripePaymentIntentId index already blocked
+        // double-crediting on Stripe retries: createTransaction rethrew the E11000 before
+        // the increment. The $inc additionally makes the balance update itself atomic.)
         await creditService.addCredits(
           {
             type: 'purchase',

--- a/apps/client/pages/api/stripe/webhook.ts
+++ b/apps/client/pages/api/stripe/webhook.ts
@@ -96,37 +96,32 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
       } else {
         req.logger.info(`Adding ${intent.metadata.credits} credits to user ${user.id}`);
 
-        // Create credit transaction record
-        await creditTransactionRepository.createTransaction('purchase', {
-          ownerId: user.id,
-          ownerType: CreditHolderType.User,
-          amount: intent.amount,
-          credits: Number(intent.metadata.credits),
-          status: CreditPurchaseStatus.Completed,
-          stripePaymentIntentId: intent.id,
-          packageId: intent.metadata.packageId,
-          metadata: {
-            environment: intent.metadata.environment,
-            paymentMethod: intent.payment_method_types?.[0],
-          },
-        });
-
-        // Update user's credit balance
-        user.currentCredits += Number(intent.metadata.credits);
-        await userRepository.update(user);
-
-        // Bypasses addCredits (this path predates it), so stamp the pack lot
-        // inline here rather than through the central seam. Best-effort - see
-        // stampCreditLot.
-        await creditService.stampCreditLot(
+        // Records the CreditTransaction (idempotent on stripePaymentIntentId),
+        // then atomically $inc's the balance and stamps the pack lot. Replaces a
+        // former read-modify-$set of the whole user doc, which both reverted any
+        // concurrent balance write and double-credited on Stripe's webhook retries.
+        await creditService.addCredits(
           {
+            type: 'purchase',
             ownerId: user.id,
             ownerType: CreditHolderType.User,
-            amount: Number(intent.metadata.credits),
-            grantType: 'purchase',
-            stripeRef: intent.id,
+            amount: intent.amount,
+            credits: Number(intent.metadata.credits),
+            status: CreditPurchaseStatus.Completed,
+            stripePaymentIntentId: intent.id,
+            packageId: intent.metadata.packageId,
+            metadata: {
+              environment: intent.metadata.environment,
+              paymentMethod: intent.payment_method_types?.[0],
+            },
           },
-          { db: { creditLots: creditLotRepository } }
+          {
+            db: {
+              creditTransactions: creditTransactionRepository,
+              creditLots: creditLotRepository,
+            },
+            creditHolderMethods: userRepository,
+          }
         );
       }
       break;
@@ -220,8 +215,7 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
           break;
         }
 
-        user.stripeCustomerId = null;
-        await userRepository.update(user);
+        await userRepository.update({ id: user.id, stripeCustomerId: null });
         req.logger.info(`Removed Stripe customer ID from user ${user.id}`);
       } else {
         const organization = await organizationRepository.findByStripeCustomerId(customer.id);
@@ -230,8 +224,7 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
           break;
         }
 
-        organization.stripeCustomerId = null;
-        await organizationRepository.update(organization);
+        await organizationRepository.update({ id: organization.id, stripeCustomerId: null });
         req.logger.info(`Removed Stripe customer ID from organization ${organization.id}`);
       }
 
@@ -312,8 +305,7 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
       }
 
       if (user) {
-        user.disputePending = true;
-        await userRepository.update(user);
+        await userRepository.update({ id: user.id, disputePending: true });
 
         await postMessageToSlack(
           `🚨 *Stripe Dispute Created* — dispute ${dispute.id}\n*User:* ${user.name || user.email} (${user.id})\n*Amount:* $${(dispute.amount / 100).toFixed(2)} ${dispute.currency.toUpperCase()}\n*Reason:* ${dispute.reason}\nAccount flagged, credits clawback initiated.`
@@ -362,8 +354,7 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
       }
 
       if (user) {
-        user.disputePending = false;
-        await userRepository.update(user);
+        await userRepository.update({ id: user.id, disputePending: false });
 
         await postMessageToSlack(
           `✅ *Stripe Dispute Won* — dispute ${dispute.id}\n*User:* ${user.name || user.email} (${user.id})\n*Amount:* $${(dispute.amount / 100).toFixed(2)} ${dispute.currency.toUpperCase()}\nAccount dispute flag cleared.`

--- a/apps/client/server/events/sessionTagging.ts
+++ b/apps/client/server/events/sessionTagging.ts
@@ -122,7 +122,7 @@ export const handler = withEventContext(async (event, logger) => {
     logger.info(`No quests found for session ${sessionId} - marking as tagged with empty tags`);
     session.tags = [];
     session.taggedAt = new Date();
-    await sessionRepository.update(session);
+    await sessionRepository.update({ id: session.id, tags: session.tags, taggedAt: session.taggedAt });
     return;
   }
 
@@ -182,7 +182,10 @@ export const handler = withEventContext(async (event, logger) => {
     session.tags = parsedTags;
     session.taggedAt = new Date();
     logger.info(`Tags: ${JSON.stringify(session.tags)}`);
-    await sessionRepository.update(session);
+    // Persist ONLY the tag fields. The read-to-write window spans a full LLM
+    // completion; a whole-session write would revert any share revocation,
+    // visibility change or soft-delete the owner made during it.
+    await sessionRepository.update({ id: session.id, tags: session.tags, taggedAt: session.taggedAt });
   } else {
     // Log the failure but don't throw - mark as attempted
     logger.warn(`Failed to parse tags from LLM response for session ${sessionId}`);
@@ -191,6 +194,6 @@ export const handler = withEventContext(async (event, logger) => {
     // Mark as tagged with empty tags to prevent retry loops
     session.tags = [];
     session.taggedAt = new Date();
-    await sessionRepository.update(session);
+    await sessionRepository.update({ id: session.id, tags: session.tags, taggedAt: session.taggedAt });
   }
 });

--- a/b4m-core/services/src/fabFileService/get.ts
+++ b/b4m-core/services/src/fabFileService/get.ts
@@ -120,7 +120,10 @@ export const generateSignedUrl = async (fabFile: IFabFileDocument, { db, storage
   fabFile.fileUrl = fileUrl;
   fabFile.fileUrlExpireAt = fileUrlExpireAt;
 
-  await db.fabFiles.update(fabFile, { timestamps: false });
+  // Read-triggered cache refresh: persist ONLY the regenerated URL fields. A
+  // whole-document write here (this GET is reachable by a sharee) would revert an
+  // owner's concurrent revocation, soft-delete or visibility change.
+  await db.fabFiles.update({ id: fabFile.id, fileUrl, fileUrlExpireAt }, { timestamps: false });
 
   return fabFile;
 };

--- a/b4m-core/services/src/organizationService/update.test.ts
+++ b/b4m-core/services/src/organizationService/update.test.ts
@@ -64,30 +64,18 @@ describe('organizationService - update', () => {
       currentCredits: 2000,
     };
 
-    // Mock the current date for updatedAt
-    const mockDate = new Date('2023-02-01T00:00:00.000Z');
-    const originalDate = global.Date;
-    global.Date = vi.fn(function () {
-      return mockDate;
-    }) as any;
-    global.Date.now = originalDate.now;
+    await update(mockRegularUser as IUserDocument, updateParams, mockAdapters);
 
-    try {
-      await update(mockRegularUser as IUserDocument, updateParams, mockAdapters);
-
-      expect(mockAdapters.db.organizations.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          ...existingOrganization,
-          id: 'org1',
-          name: 'Updated Organization',
-          description: 'Updated description',
-          billingContact: 'updated@example.com',
-          updatedAt: mockDate,
-        })
-      );
-    } finally {
-      global.Date = originalDate;
-    }
+    // Targeted write: only the caller-editable fields that changed. currentCredits
+    // is admin-only, so a non-admin's value never reaches the write. Unchanged and
+    // non-editable fields (seats, users, updatedAt) are not round-tripped.
+    const persisted = mockAdapters.db.organizations.update.mock.calls[0][0];
+    expect(persisted).toEqual({
+      id: 'org1',
+      name: 'Updated Organization',
+      description: 'Updated description',
+      billingContact: 'updated@example.com',
+    });
   });
 
   it('should update only the provided fields and keep others unchanged', async () => {
@@ -104,15 +92,10 @@ describe('organizationService - update', () => {
       updatedAt: expect.any(Date),
     });
 
-    expect(mockAdapters.db.organizations.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'org1',
-        name: 'Updated Organization',
-        description: 'Original description', // Unchanged
-        billingContact: 'original@example.com', // Unchanged
-        currentCredits: 1000, // Unchanged
-      })
-    );
+    // Targeted write: only the changed field. Unchanged fields are left untouched in the
+    // DB rather than round-tripped (which is what stops a concurrent write being reverted).
+    const persisted = mockAdapters.db.organizations.update.mock.calls[0][0];
+    expect(persisted).toEqual({ id: 'org1', name: 'Updated Organization' });
   });
 
   it('should throw NotFoundError when organization is not found', async () => {
@@ -138,16 +121,12 @@ describe('organizationService - update', () => {
       mockAdapters
     );
 
-    expect(mockAdapters.db.organizations.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'org1',
-        name: 'Updated Organization',
-      })
-    );
-
     const updateCall = mockAdapters.db.organizations.update.mock.calls[0][0];
+    expect(updateCall).toEqual({ id: 'org1', name: 'Updated Organization' });
     expect(updateCall).not.toHaveProperty('extraParam');
-    expect(updateCall.seats).toBe(3); // Original value, not 10
+    // seats is not a caller-editable field, so it is never in the write - it stays 3 in the
+    // DB because a targeted write leaves it untouched, not because it was round-tripped.
+    expect(updateCall).not.toHaveProperty('seats');
   });
 
   it('should update currentCredits when provided by admin user', async () => {
@@ -178,12 +157,10 @@ describe('organizationService - update', () => {
 
     expect(result.currentCredits).toBe(1000); // Original value
 
-    expect(mockAdapters.db.organizations.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'org1',
-        currentCredits: 1000, // Original value, not 5000
-      })
-    );
+    // A non-admin's currentCredits never reaches the write at all (not round-tripped),
+    // so a concurrent credit change cannot be reverted by this PUT.
+    const persisted = mockAdapters.db.organizations.update.mock.calls[0][0];
+    expect(persisted).not.toHaveProperty('currentCredits');
   });
 
   // Regression: findUpdateAccessById returns a HYDRATED Mongoose doc (unlike
@@ -219,9 +196,12 @@ describe('organizationService - update', () => {
     expect(result.stripeCustomerId).toBe('cus_SECRET');
     expect(result.name).toBe('Acme2');
 
+    // The persisted write is a targeted partial built field-by-field, so hydrated
+    // internals cannot leak and non-editable fields (userId) are never round-tripped.
     const persisted = mockAdapters.db.organizations.update.mock.calls[0][0];
     expect('_doc' in persisted).toBe(false);
-    expect(persisted.userId).toBe('user1');
+    expect('$__' in persisted).toBe(false);
+    expect(persisted).toEqual({ id: 'org1', name: 'Acme2' });
   });
 
   it('sets a positive per-member cap when admin', async () => {
@@ -285,14 +265,15 @@ describe('organizationService - update', () => {
       updatedAt: expect.any(Date),
     });
 
-    expect(mockAdapters.db.organizations.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'org1',
-        name: 'Updated By Regular User',
-        description: 'Updated description by regular user',
-        billingContact: 'regular@example.com',
-        currentCredits: 1000, // Original value, not 5000
-      })
-    );
+    // The write carries only the caller-editable fields the non-admin changed;
+    // currentCredits is admin-only and never enters the write.
+    const persisted = mockAdapters.db.organizations.update.mock.calls[0][0];
+    expect(persisted).toEqual({
+      id: 'org1',
+      name: 'Updated By Regular User',
+      description: 'Updated description by regular user',
+      billingContact: 'regular@example.com',
+    });
+    expect(persisted).not.toHaveProperty('currentCredits');
   });
 });

--- a/b4m-core/services/src/organizationService/update.ts
+++ b/b4m-core/services/src/organizationService/update.ts
@@ -45,32 +45,32 @@ export const update = async (user: IUserDocument, params: UpdateParameters, adap
   const isManager = plain.managerId === user.id;
   const isOwner = plain.userId === user.id;
 
-  organization = {
-    ...plain,
-    name: rest.name ?? plain.name,
-    description: rest.description ?? plain.description,
-    // Only allow billing contact changes for owners and admins, not managers
-    billingContact:
-      isManager && !isOwner && !user.isAdmin ? plain.billingContact : (rest.billingContact ?? plain.billingContact),
-    // Managers can update systemPrompt intentionally - they customize org-wide AI
-    // behavior. Authorization is already checked via findUpdateAccessById.
-    systemPrompt: rest.systemPrompt ?? plain.systemPrompt,
-    updatedAt: new Date(),
-  };
+  // Persist ONLY the caller-editable fields this request changed, never a spread of
+  // the read snapshot. A whole-document write reverted concurrent credit, seat and
+  // membership writes; currentCredits/seats/users[]/userDetails[] are never round-tripped.
+  const update: Partial<typeof plain> & { id: string } = { id };
+  if (rest.name !== undefined) update.name = rest.name;
+  if (rest.description !== undefined) update.description = rest.description;
+  // Only allow billing contact changes for owners and admins, not managers.
+  if (rest.billingContact !== undefined && !(isManager && !isOwner && !user.isAdmin)) {
+    update.billingContact = rest.billingContact;
+  }
+  // Managers can update systemPrompt intentionally - they customize org-wide AI
+  // behavior. Authorization is already checked via findUpdateAccessById.
+  if (rest.systemPrompt !== undefined) update.systemPrompt = rest.systemPrompt;
 
   if (user.isAdmin && rest.currentCredits !== undefined) {
-    organization.currentCredits = rest.currentCredits;
+    update.currentCredits = rest.currentCredits;
   }
 
   // Only admins can set per-member credit caps. Coalesce a cleared cap to null, NOT undefined:
-  // the repo update is `updateOne({_id}, { $set: organization })` and BSON drops undefined, so
-  // `?? undefined` would leave the previous cap in place (a null PUT silently no-ops). null is
-  // persisted by $set and read as "no cap" by isMemberCreditCapExceeded.
+  // $set persists null (read as "no cap" by isMemberCreditCapExceeded), and BSON drops
+  // undefined, so `?? undefined` would leave the previous cap in place (a null PUT no-ops).
   if (user.isAdmin && rest.maxCreditsPerMember !== undefined) {
-    organization.maxCreditsPerMember = rest.maxCreditsPerMember ?? null;
+    update.maxCreditsPerMember = rest.maxCreditsPerMember ?? null;
   }
 
-  await adapters.db.organizations.update(organization);
+  const updated = await adapters.db.organizations.update(update);
 
-  return organization;
+  return updated ?? ({ ...plain, ...update } as typeof plain);
 };

--- a/b4m-core/services/src/sessionService/update.test.ts
+++ b/b4m-core/services/src/sessionService/update.test.ts
@@ -158,7 +158,11 @@ describe('updateSession - forceKnowledgeRetrieval passthrough', () => {
   it('leaves forceKnowledgeRetrieval untouched when the field is omitted', async () => {
     const { update, adapters } = makeAdapters({ forceKnowledgeRetrieval: true });
     await updateSession(user, { id: 'session-1', name: 'Renamed' }, adapters);
-    expect(update.mock.calls[0][0]).toMatchObject({ forceKnowledgeRetrieval: true, name: 'Renamed' });
+    // Omitted -> not written at all, so the stored value is left untouched (a targeted
+    // write, not a round-trip of the whole session).
+    const saved = update.mock.calls[0][0];
+    expect(saved.name).toBe('Renamed');
+    expect(saved).not.toHaveProperty('forceKnowledgeRetrieval');
   });
 
   it('ignores surface even if a caller passes it (allow-list strips it; sidebar visibility preserved)', async () => {
@@ -171,7 +175,9 @@ describe('updateSession - forceKnowledgeRetrieval passthrough', () => {
     );
     const saved = update.mock.calls[0][0];
     expect(saved.forceKnowledgeRetrieval).toBe(true);
-    expect(saved.surface).toBe('opti'); // unchanged - never overwritten by the update
+    // surface is stripped by the allow-list AND never round-tripped, so it is absent from
+    // the targeted write and the stored 'opti' is left untouched.
+    expect(saved).not.toHaveProperty('surface');
   });
 });
 
@@ -362,8 +368,9 @@ describe('updateSession - project propagation opt-out', () => {
       const { adapters } = makeAdapters();
       await updateSession(user, { id: 'session-1', name: 'renamed' }, adapters);
 
-      // The fixture session carries [], so this pins "unchanged", not "cleared".
-      expect(adapters.db.sessions.update.mock.calls[0][0].knowledgeIds).toEqual([]);
+      // Field absent -> not written at all, so the stored list is left untouched rather
+      // than round-tripped. A stronger "unchanged, not cleared" guarantee than before.
+      expect(adapters.db.sessions.update.mock.calls[0][0]).not.toHaveProperty('knowledgeIds');
     });
   });
 });
@@ -469,6 +476,8 @@ describe('updateSession - lake-scope derivation on attach', () => {
 
     await updateSession(user, { id: 'session-1', knowledgeIds: [LAKE_FILE_ID] } as never, adapters as never);
 
-    expect(update.mock.calls[0][0]).toMatchObject({ retrievalTags: ['datalake:chosen'] });
+    // Derivation is skipped, so retrievalTags is never in the targeted write - the existing
+    // scope is left untouched rather than overwritten (or round-tripped).
+    expect(update.mock.calls[0][0]).not.toHaveProperty('retrievalTags');
   });
 });

--- a/b4m-core/services/src/sessionService/update.ts
+++ b/b4m-core/services/src/sessionService/update.ts
@@ -84,7 +84,14 @@ export const updateSession = async (
     await addFilesToProjects(user, { session, fileIds: addedFileIds }, adapters);
   }
 
-  session.name = name || session.name;
+  // Persist ONLY the fields this request changed, as a plain partial keyed by id.
+  // findUpdateAccessById returns a hydrated mongoose doc, and passing it straight to
+  // db.sessions.update($set of the whole thing) reverted any owner share revocation,
+  // visibility change or soft-delete that landed during this handler's window (the read
+  // authorizes a sharee; a lake derivation and signed-URL pre-warm can run before the write).
+  const update: Partial<ISessionDocument> & { id: string } = { id };
+  if (name) update.name = name;
+
   // Re-derive the lake scope whenever a file is ATTACHED. Deriving only at CREATE left the most
   // ordinary way a user reaches a lake completely unscoped: attaching a lake file to an
   // already-open notebook goes through here, and an empty `retrievalTags` is not a narrow scope -
@@ -101,22 +108,22 @@ export const updateSession = async (
       logger: adapters.logger,
       resolveLakeAccess: adapters.resolveLakeAccess,
     });
-    if (derived.length > 0) session.retrievalTags = derived;
+    if (derived.length > 0) update.retrievalTags = derived;
   }
 
-  session.knowledgeIds = knowledgeIds || session.knowledgeIds;
-  session.artifactIds = artifactIds || session.artifactIds;
-  session.tags = tags || session.tags;
-  session.lastUsedModel = lastUsedModel || session.lastUsedModel;
+  if (knowledgeIds) update.knowledgeIds = knowledgeIds;
+  if (artifactIds) update.artifactIds = artifactIds;
+  if (tags) update.tags = tags;
+  if (lastUsedModel) update.lastUsedModel = lastUsedModel;
   // Explicit undefined check (not `|| session.x`) so toggling OFF (false) actually persists.
   if (forceKnowledgeRetrieval !== undefined) {
-    session.forceKnowledgeRetrieval = forceKnowledgeRetrieval;
+    update.forceKnowledgeRetrieval = forceKnowledgeRetrieval;
   }
-  session.lastUpdated = new Date();
+  update.lastUpdated = new Date();
 
-  await db.sessions.update(session);
+  const updated = await db.sessions.update(update);
 
-  return session;
+  return updated ?? session;
 };
 
 const addFilesToProjects = async (

--- a/b4m-core/services/src/userService/adminUpdate.test.ts
+++ b/b4m-core/services/src/userService/adminUpdate.test.ts
@@ -185,6 +185,58 @@ describe('adminUpdateUser — audited credit adjustments', () => {
   });
 });
 
+describe('adminUpdateUser - signed creditDelta path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes a positive creditDelta through a generic_add and stamps lastCreditsPurchasedAt', async () => {
+    const { adapters, createTransaction, incrementCredits, update } = makeAdapters(100);
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: 50, creditReason: 'Bonus' }, adapters);
+
+    const [type, data] = createTransaction.mock.calls[0];
+    expect(type).toBe('generic_add');
+    expect(data.credits).toBe(50);
+    expect(data.metadata).toMatchObject({ actorId: ADMIN_ID, previousBalance: 100, resultingBalance: 150 });
+    expect(incrementCredits).toHaveBeenCalledWith(TARGET_ID, 50, expect.anything());
+    // A grant stamps the purchase timestamp even though the UI sends only creditDelta.
+    expect(update.mock.calls[0][0].lastCreditsPurchasedAt).toBeInstanceOf(Date);
+  });
+
+  it('routes a negative creditDelta through a generic_deduct', async () => {
+    const { adapters, createTransaction, incrementCredits } = makeAdapters(100);
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: -30 }, adapters);
+
+    expect(createTransaction.mock.calls[0][0]).toBe('generic_deduct');
+    expect(incrementCredits).toHaveBeenCalledWith(TARGET_ID, -30);
+  });
+
+  it('does not invert a deduction when the balance is already negative', async () => {
+    const { adapters, createTransaction, incrementCredits } = makeAdapters(-100);
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: -50 }, adapters);
+
+    // The clamp must not floor at -previousBalance (+100): that would turn a 50-credit
+    // deduction into a +100 grant. The deduction applies verbatim on a negative balance.
+    expect(createTransaction.mock.calls[0][0]).toBe('generic_deduct');
+    expect(incrementCredits).toHaveBeenCalledWith(TARGET_ID, -50);
+    expect(createTransaction.mock.calls[0][1].metadata).toMatchObject({
+      previousBalance: -100,
+      resultingBalance: -150,
+    });
+  });
+
+  it('applies a creditDelta to the doc write when no creditTransactions adapter is wired', async () => {
+    const { adapters, incrementCredits, update } = makeAdapters(100, { withCreditTransactions: false });
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: 50 }, adapters);
+
+    // No ledger adapter: the delta must not be silently dropped - it lands on the doc write.
+    expect(incrementCredits).not.toHaveBeenCalled();
+    expect(update.mock.calls[0][0].currentCredits).toBe(150);
+  });
+});
+
 describe('adminUpdateUser - preferences merge', () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/b4m-core/services/src/userService/adminUpdate.ts
+++ b/b4m-core/services/src/userService/adminUpdate.ts
@@ -116,10 +116,6 @@ export async function adminUpdateUser(
   if (!user) {
     throw new Error('User not found');
   }
-  let lastCreditsPurchasedAt = user.lastCreditsPurchasedAt;
-  if ((params.currentCredits ?? 0) > 0 && params.currentCredits !== user.currentCredits) {
-    lastCreditsPurchasedAt = new Date();
-  }
 
   // Route a `currentCredits` change through the audited ledger when the adapter
   // is wired. The ledger runs before every write below, so a failure aborts with
@@ -131,16 +127,20 @@ export async function adminUpdateUser(
   const previousBalance = user.currentCredits ?? 0;
   const { moderationStatus, creditReason, creditDelta: signedDelta, ...baseParams } = params;
   // A signed `creditDelta` is applied verbatim (no interim-spend refund). Absolute
-  // `currentCredits` falls back to delta-from-fresh-balance.
+  // `currentCredits` falls back to delta-from-snapshot.
   const rawDelta =
     signedDelta !== undefined
       ? signedDelta
       : params.currentCredits !== undefined && params.currentCredits !== previousBalance
         ? params.currentCredits - previousBalance
         : 0;
-  // Never drive the balance below zero (mirrors the old client-side Math.max(0, ...)
-  // clamp, but against the fresh server balance instead of a stale snapshot).
-  const creditDelta = Math.max(rawDelta, -previousBalance);
+  // Floor a deduction so a non-negative balance is never driven below zero (mirrors the
+  // old client-side Math.max(0, ...) clamp). Only when the balance is non-negative: when
+  // it is already negative, `-previousBalance` is a positive floor that would invert a
+  // deduction into a credit, so apply the delta verbatim in that case.
+  const creditDelta = previousBalance >= 0 ? Math.max(rawDelta, -previousBalance) : rawDelta;
+  // Stamp a purchase timestamp only for a net grant; a deduction must not count as a purchase.
+  const lastCreditsPurchasedAt = creditDelta > 0 ? new Date() : user.lastCreditsPurchasedAt;
   const auditCreditChange = creditDelta !== 0 && !!db.creditTransactions;
 
   const builtParams = { ...baseParams, lastCreditsPurchasedAt };
@@ -152,6 +152,12 @@ export async function adminUpdateUser(
   const writeData = toUserUpdatePartial(builtUser, builtParams);
   if (auditCreditChange) {
     delete (writeData as { currentCredits?: number }).currentCredits;
+  } else if (signedDelta !== undefined && creditDelta !== 0) {
+    // Signed-delta path with no ledger adapter wired: apply the delta to the doc write
+    // directly (like the legacy absolute-`currentCredits` fallback) instead of dropping
+    // it silently. `currentCredits` is not in `baseParams` on this path, so nothing else
+    // would persist the change.
+    (writeData as { currentCredits?: number }).currentCredits = previousBalance + creditDelta;
   }
 
   // Audited credit adjustment: runs BEFORE any persistence (org membership, the
@@ -160,6 +166,9 @@ export async function adminUpdateUser(
   // generic_add / generic_deduct CreditTransaction.
   if (auditCreditChange && db.creditTransactions) {
     const note = creditReason?.trim() || undefined;
+    // Best-effort resulting balance predicted from the read snapshot. The atomic $inc
+    // inside addCredits/subtractCredits is the source of truth, so concurrent spend
+    // between the read and the increment can make this differ from the committed balance.
     const resultingBalance = previousBalance + creditDelta;
     const metadata: Record<string, unknown> = { actorId: userId, previousBalance, resultingBalance };
     if (note) {

--- a/b4m-core/services/src/userService/adminUpdate.ts
+++ b/b4m-core/services/src/userService/adminUpdate.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { updateUserSchema, applyBaseUserUpdates } from './update';
+import { updateUserSchema, applyBaseUserUpdates, toUserUpdatePartial } from './update';
 import {
   CreditHolderType,
   ICreditTransactionRepository,
@@ -45,6 +45,12 @@ export const adminUpdateUserSchema = updateUserSchema.extend({
   // CreditTransaction (description + metadata.note) instead. See `currentCredits`
   // routing in `adminUpdateUser`.
   creditReason: z.string().max(500).optional(),
+  // Signed credit adjustment (e.g. -50 / +100) from the admin credit-adjustment UI.
+  // Applied verbatim to the ledger so interim spend between the admin's page load and
+  // this write is never refunded (the failure mode of sending a frozen client snapshot
+  // as an absolute `currentCredits`). Not a user-doc field: stripped from the doc write
+  // and routed to addCredits/subtractCredits. Takes precedence over `currentCredits`.
+  creditDelta: z.number().optional(),
 });
 
 export type AdminUpdateUserParameters = z.infer<typeof adminUpdateUserSchema>;
@@ -54,7 +60,7 @@ export interface AdminUpdateUserAdapters {
     users: IUserRepository;
     organizations: {
       findById: (id: string) => Promise<IOrganizationDocument | null>;
-      update: (organization: IOrganizationDocument) => Promise<unknown>;
+      update: (organization: Partial<IOrganizationDocument> & { id: string }) => Promise<unknown>;
     };
     friendship: IFriendshipModelAdapter;
     /**
@@ -118,24 +124,35 @@ export async function adminUpdateUser(
   // Route a `currentCredits` change through the audited ledger when the adapter
   // is wired. The ledger runs before every write below, so a failure aborts with
   // nothing persisted; its atomic `$inc` is the sole owner of the balance.
+  //
+  // `moderationStatus`/`creditReason`/`creditDelta` are handled out-of-band (a dedicated
+  // repo call, the CreditTransaction record, and the ledger respectively) - pull them out
+  // so they never land as stray top-level fields on the user doc.
   const previousBalance = user.currentCredits ?? 0;
-  const creditDelta =
-    params.currentCredits !== undefined && params.currentCredits !== previousBalance
-      ? params.currentCredits - previousBalance
-      : 0;
+  const { moderationStatus, creditReason, creditDelta: signedDelta, ...baseParams } = params;
+  // A signed `creditDelta` is applied verbatim (no interim-spend refund). Absolute
+  // `currentCredits` falls back to delta-from-fresh-balance.
+  const rawDelta =
+    signedDelta !== undefined
+      ? signedDelta
+      : params.currentCredits !== undefined && params.currentCredits !== previousBalance
+        ? params.currentCredits - previousBalance
+        : 0;
+  // Never drive the balance below zero (mirrors the old client-side Math.max(0, ...)
+  // clamp, but against the fresh server balance instead of a stale snapshot).
+  const creditDelta = Math.max(rawDelta, -previousBalance);
   const auditCreditChange = creditDelta !== 0 && !!db.creditTransactions;
 
-  // `moderationStatus`/`creditReason` are handled out-of-band (a dedicated repo
-  // call and the credit ledger, respectively) - pull them out so they never land
-  // as stray top-level fields on the user doc.
-  const { moderationStatus, creditReason, ...baseParams } = params;
-  const builtUser = applyBaseUserUpdates(user, { ...baseParams, lastCreditsPurchasedAt });
-  // When auditing, omit `currentCredits` from the doc write so its `$set` cannot
-  // clobber the ledger `$inc`. `applyBaseUserUpdates` re-adds it via the `...user`
-  // spread, so it is dropped from the built doc here (not just `baseParams`). The
-  // legacy path keeps it and overwrites the balance directly.
-  const { currentCredits, ...auditedUser } = builtUser;
-  const updatedUser = auditCreditChange ? auditedUser : builtUser;
+  const builtParams = { ...baseParams, lastCreditsPurchasedAt };
+  const builtUser = applyBaseUserUpdates(user, builtParams);
+  // Persist ONLY the fields this request changed, never a spread of the read snapshot -
+  // that is what let an admin save round-trip (and revert) a concurrent tokenVersion bump
+  // or credit deduction. When auditing, drop `currentCredits` so its `$set` cannot clobber
+  // the ledger `$inc`; the legacy (no-ledger) path keeps it and overwrites the balance.
+  const writeData = toUserUpdatePartial(builtUser, builtParams);
+  if (auditCreditChange) {
+    delete (writeData as { currentCredits?: number }).currentCredits;
+  }
 
   // Audited credit adjustment: runs BEFORE any persistence (org membership, the
   // user-doc write, the moderation transition) so a ledger failure leaves nothing
@@ -143,7 +160,7 @@ export async function adminUpdateUser(
   // generic_add / generic_deduct CreditTransaction.
   if (auditCreditChange && db.creditTransactions) {
     const note = creditReason?.trim() || undefined;
-    const resultingBalance = params.currentCredits as number;
+    const resultingBalance = previousBalance + creditDelta;
     const metadata: Record<string, unknown> = { actorId: userId, previousBalance, resultingBalance };
     if (note) {
       metadata.note = note;
@@ -188,8 +205,8 @@ export async function adminUpdateUser(
         throw new Error('Organization not found');
       }
 
-      currentOrg.users = currentOrg.users.filter(userDetail => userDetail.userId !== user.id);
-      await db.organizations.update(currentOrg);
+      const remainingUsers = currentOrg.users.filter(userDetail => userDetail.userId !== user.id);
+      await db.organizations.update({ id: currentOrg.id, users: remainingUsers });
     }
 
     if (params.organizationId) {
@@ -200,12 +217,12 @@ export async function adminUpdateUser(
 
       await sendFriendRequestsToOrgMembers(userId, newOrg, db);
 
-      newOrg.users.push({ userId: user.id, permissions: [Permission.read] });
-      await db.organizations.update(newOrg);
+      const updatedUsers = [...newOrg.users, { userId: user.id, permissions: [Permission.read] }];
+      await db.organizations.update({ id: newOrg.id, users: updatedUsers });
     }
   }
 
-  await db.users.update(updatedUser);
+  await db.users.update(writeData);
 
   // Apply the moderation escalation transition last so it authoritatively sets
   // `moderation.status`, `throttledUntil`, and the `isModerated` mirror.

--- a/b4m-core/services/src/userService/update.test.ts
+++ b/b4m-core/services/src/userService/update.test.ts
@@ -470,8 +470,12 @@ describe('updateUser', () => {
     // The benign field is applied; the injected tags are stripped (untouched).
     expect(result.name).toBe('Renamed');
     expect(result.tags).toEqual(['Customer']);
+    // Targeted write: an unchanged field is not written at all. `tags` is left untouched
+    // in the DB rather than round-tripped, which is also what stops a concurrent admin
+    // tag change from being reverted by a self-service profile save.
     const persisted = mockUserRepository.update.mock.calls[0][0] as IUserDocument;
-    expect(persisted.tags).toEqual(['Customer']);
+    expect(persisted).not.toHaveProperty('tags');
+    expect(persisted.name).toBe('Renamed');
   });
 
   it('coerces an ISO-string contextTelemetryConsentedAt on write (telemetry level is not write-once)', async () => {

--- a/b4m-core/services/src/userService/update.ts
+++ b/b4m-core/services/src/userService/update.ts
@@ -109,6 +109,26 @@ export function applyBaseUserUpdates(user: IUserDocument, params: UpdateUserPara
 }
 
 /**
+ * Reduce a fully-built user document to the targeted write partial: the id, a fresh
+ * updatedAt, and ONLY the fields the request actually changed. Persisting this instead
+ * of the whole built document is what stops a profile or admin save from round-tripping
+ * (and thereby reverting a concurrent write to) currentCredits, tokenVersion, isBanned,
+ * tags and every other field the caller never sent. `params` supplies the changed-field
+ * keys; `built` supplies their post-merge values (hashed password, merged preferences).
+ */
+export function toUserUpdatePartial(
+  built: IUserDocument,
+  params: Record<string, unknown>
+): Partial<IUserDocument> & { id: string } {
+  const write: Record<string, unknown> = { id: built.id, updatedAt: built.updatedAt };
+  for (const key of Object.keys(params)) {
+    if (key === 'id') continue;
+    write[key] = (built as unknown as Record<string, unknown>)[key];
+  }
+  return write as Partial<IUserDocument> & { id: string };
+}
+
+/**
  * `preferences` is merged onto the stored object, not replaced, so a partial write cannot
  * silently drop keys the caller omitted. An explicit `null` still clears the whole object -
  * that is the only way to remove individual keys. `experimentalFeatures` is merged one level
@@ -138,6 +158,9 @@ export async function updateUser(userId: string, parameters: UpdateUserParameter
 
   const updatedUser = applyBaseUserUpdates(userPassword, params);
 
-  await db.users.update(updatedUser);
+  // Persist ONLY the fields this request changed. Writing the whole built document
+  // (a spread of the read snapshot) is what let a routine profile save revert a
+  // concurrent credit deduction, tokenVersion bump or admin tag/ban change.
+  await db.users.update(toUserUpdatePartial(updatedUser, params));
   return updatedUser;
 }

--- a/packages/database/src/models/auth/UserModel.repositoryUpdate.integration.test.ts
+++ b/packages/database/src/models/auth/UserModel.repositoryUpdate.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import mongoose from 'mongoose';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../__test__/createMongoServer';
+import { User, userRepository } from './UserModel';
+
+/**
+ * Real-MongoDB regression for the whole-document read-modify-write hazard in
+ * BaseRepository.update. `userRepository` inherits `BaseRepository.update` unchanged,
+ * so it exercises the exact primitive the call-site fixes rely on. currentCredits and
+ * tokenVersion stand in for the atomic security/credit writes (credit deductions, the
+ * session kill switch) that a concurrent whole-document $set was reverting.
+ */
+
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
+let server: Awaited<ReturnType<typeof createMongoServer>>;
+
+const seed = () =>
+  User.create({
+    username: 'racer',
+    name: 'Racer',
+    email: 'racer@example.com',
+    currentCredits: 100,
+    tokenVersion: 0,
+  });
+
+beforeAll(async () => {
+  server = await createMongoServer();
+  await mongoose.connect(server.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server.stop();
+});
+
+afterEach(async () => {
+  await User.deleteMany({});
+});
+
+describe('BaseRepository.update whole-document hazard (via userRepository)', () => {
+  it('a TARGETED partial write preserves a concurrent credit deduction (the fix)', async () => {
+    const u = await seed();
+    const id = String(u._id);
+
+    // A credit deduction lands in the read-to-write window.
+    await userRepository.incrementCredits(id, -30);
+
+    // The write persists ONLY the field the request changed.
+    await userRepository.update({ id, name: 'Renamed' });
+
+    const after = await User.findById(id);
+    expect(after!.currentCredits).toBe(70); // survived
+    expect(after!.name).toBe('Renamed');
+  });
+
+  it('a TARGETED partial write preserves a concurrent tokenVersion bump (session kill switch)', async () => {
+    const u = await seed();
+    const id = String(u._id);
+
+    await userRepository.incrementTokenVersion(id); // forced logout -> tokenVersion 1
+
+    await userRepository.update({ id, name: 'Renamed' });
+
+    const after = await User.findById(id);
+    expect(after!.tokenVersion).toBe(1); // kill switch survived
+    expect(after!.name).toBe('Renamed');
+  });
+
+  it('a WHOLE-DOCUMENT snapshot write reverts a concurrent credit deduction (the hazard removed by the fix)', async () => {
+    const u = await seed();
+    const id = String(u._id);
+
+    // A caller that read currentCredits=100 earlier still holds that stale value.
+    const stale = { id, name: 'Racer', currentCredits: 100 };
+    await userRepository.incrementCredits(id, -30); // concurrent deduction -> 70
+
+    await userRepository.update(stale); // $set of the whole stale snapshot
+
+    const after = await User.findById(id);
+    expect(after!.currentCredits).toBe(100); // reverted - this is exactly the bug the call sites now avoid
+  });
+
+  it('a HYDRATED whole-document write also reverts a concurrent write (hydration is not a safety net)', async () => {
+    const u = await seed();
+    const id = String(u._id);
+
+    // findUpdateAccessById (sessionService/update) returns a hydrated mongoose doc. Object-rest
+    // spreads its schema fields just like a plain toJSON() snapshot, so passing it straight to
+    // update() clobbers exactly the same way - the concurrent deduction is reverted. This is why
+    // sessionService/update builds a targeted partial instead of writing the hydrated session.
+    const hydrated = await User.findById(id); // snapshot, currentCredits=100
+    await userRepository.incrementCredits(id, -30); // concurrent deduction -> 70
+
+    await userRepository.update(hydrated as unknown as Parameters<typeof userRepository.update>[0]);
+
+    const after = await User.findById(id);
+    expect(after!.currentCredits).toBe(100); // reverted, identical to a plain snapshot
+  });
+});

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -16,7 +16,10 @@ export interface IOrganizationObject extends HydratedDocument<IOrganizationDocum
 
 interface IOrganizationModel extends Model<IOrganizationDocument, {}> {
   isNew: boolean;
-  update: (organization: IOrganizationDocument) => Promise<unknown>;
+  // Accepts a targeted partial (id + only the changed fields), not just a whole document -
+  // the static below just $sets whatever it is handed, and passing a partial is how callers
+  // avoid reverting a concurrent write to fields they did not touch.
+  update: (organization: Partial<IOrganizationDocument> & { id: string }) => Promise<unknown>;
   findShareAccessById: (userId: string, id: string) => Promise<IOrganizationDocument | null>;
 }
 
@@ -162,7 +165,7 @@ const OrganizationSchema = new Schema<IOrganizationDocument>(
 
         return result;
       },
-      update: function (organization: IOrganizationDocument) {
+      update: function (organization: Partial<IOrganizationDocument> & { id: string }) {
         return this.updateOne({ _id: organization.id }, { $set: organization });
       },
     },


### PR DESCRIPTION
## What

Several repository call sites read a whole document, did unrelated async work, then persisted the entire previously-read snapshot back through `BaseRepository.update` (a `$set` of every field). Because the write carried the whole snapshot, it could overwrite field-level changes that landed concurrently between the read and the write.

This change converts those sites to persist only the fields each request actually changed (targeted `$set`), and routes credit changes through the atomic credit ledger instead of a read-modify-write of the balance.

## Changes

- `userService.updateUser` / `adminUpdateUser`: build a targeted update partial (new `toUserUpdatePartial` helper) instead of writing the whole built user document; org membership add/remove writes carry only the members array.
- `organizationService.update` and `sessionService.update`: persist only the caller-editable fields the request changed.
- `fabFileService.get`: the signed-URL refresh persists only the two URL fields.
- Session tagging job: writes only the tag fields.
- Stripe webhook `payment_intent.succeeded`: use `creditService.addCredits` (which records the transaction, increments the balance atomically, and stamps the credit lot, keyed idempotently on the payment intent) instead of a read-modify-write of the balance; the customer-deleted and dispute handlers write only their single flag field.
- Quest-plan GET/PATCH/DELETE and the admin team-subscription seat bump: targeted single-field / changed-field writes.
- Admin credit-adjustment UI: sends a signed delta that the server applies atomically against the live balance, instead of a client-computed absolute.

## Tests

- New real-MongoDB test (`UserModel.repositoryUpdate.integration.test.ts`): a targeted partial write preserves a concurrent atomic increment (credits and tokenVersion), while a whole-document snapshot write reverts it.
- Existing service unit tests updated to assert the targeted-partial write shape.

## Notes

`BaseRepository.update` itself is unchanged: a repository-wide staleness guard was evaluated and set aside because a large number of legitimate callers pass a freshly-stamped `updatedAt` (which such a guard would reject) and four repositories override `update` (which such a guard would silently skip). The safe path is per-site targeted writes, done here for the affected set.
