### PR TITLE
fix(data-lakes): pick the taxonomy batch that needs attention for each lake's review chip

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -990,17 +990,35 @@ describe('DataLakeManagerPanel - background AI-tag suggestion status', () => {
     expect(screen.getByTestId('mock-taxonomy-review-panel')).toHaveAttribute('data-batch-id', 'b1');
   });
 
+  // A batch whose taxonomy phase is already resolved ('applied') but whose ingest is still
+  // running stays in the batches list, and the server's ingest-active finder puts it AHEAD of
+  // the sibling awaiting review. It used to take the lake's one chip slot and render nothing,
+  // so the review surface silently did not exist. Both consumer surfaces are asserted.
   it('prefers the taxonomy-attention batch when a lake has more than one active batch', async () => {
-    // An ingest-only batch (taxonomyStatus 'none') alongside the one actually awaiting review -
-    // the attention-worthy one must win, not whichever happens to come first in the list.
     useActiveDataLakeBatches.mockReturnValue({
-      data: [batch({ id: 'ingest-only', taxonomyStatus: 'none' }), batch({ id: 'b1', taxonomyStatus: 'ready' })],
+      data: [batch({ id: 'still-ingesting', taxonomyStatus: 'applied' }), batch({ id: 'b1', taxonomyStatus: 'ready' })],
     });
     const user = userEvent.setup();
     renderPanel();
 
     await user.click(screen.getByTestId('datalake-manager-taxonomy-review-mine'));
     expect(screen.getByTestId('mock-taxonomy-review-panel')).toHaveAttribute('data-batch-id', 'b1');
+
+    await user.click(screen.getByTestId('mock-taxonomy-review-close'));
+    await user.click(screen.getByTestId('datalake-manager-lake-mine'));
+    expect(screen.getByTestId('datalake-manager-taxonomy-review-chip-mine')).toBeInTheDocument();
+  });
+
+  // The nastier variant: an in-progress sibling DOES render, so the ready batch was masked
+  // behind a plausible-looking "AI tagging..." state rather than showing nothing.
+  it('does not let an in-progress sibling mask the batch awaiting review', async () => {
+    useActiveDataLakeBatches.mockReturnValue({
+      data: [batch({ id: 'analyzing', taxonomyStatus: 'analyzing' }), batch({ id: 'b1', taxonomyStatus: 'ready' })],
+    });
+    renderPanel();
+
+    expect(screen.getByTestId('datalake-manager-taxonomy-review-mine')).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-manager-taxonomy-progress-mine')).toBeNull();
   });
 });
 

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -1026,7 +1026,9 @@ describe('DataLakeManagerPanel - background AI-tag suggestion status', () => {
   });
 
   // The nastier variant: an in-progress sibling DOES render, so the ready batch was masked
-  // behind a plausible-looking "AI tagging..." state rather than showing nothing.
+  // behind a plausible-looking "AI tagging..." state rather than showing nothing. As in the
+  // test above, the sibling's id sorts before the winner's on purpose - rename it after 'b1'
+  // and a selector that ranked nothing would pass here on the id tie-break alone.
   it('does not let an in-progress sibling mask the batch awaiting review', async () => {
     useActiveDataLakeBatches.mockReturnValue({
       data: [batch({ id: 'analyzing', taxonomyStatus: 'analyzing' }), batch({ id: 'b1', taxonomyStatus: 'ready' })],

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import type { IDataLakeBatchSummary } from '@bike4mind/common';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import DataLakeManagerPanel from './DataLakeManagerPanel';
@@ -886,7 +887,10 @@ describe('DataLakeManagerPanel - canManageSettings gates the fallback-lake setti
  * that's actually reachable in the app.
  */
 describe('DataLakeManagerPanel - background AI-tag suggestion status', () => {
-  const batch = (overrides: Record<string, unknown> = {}) => ({
+  // Typed rather than Record<string, unknown>: a misspelt override there is an inert extra
+  // property that silently leaves the default in force. Note this is an editor-and-review guard
+  // only - apps/client/tsconfig.json excludes *.test.ts(x), so CI never typechecks this file.
+  const batch = (overrides: Partial<IDataLakeBatchSummary> = {}) => ({
     id: 'b1',
     dataLakeId: 'mine',
     taxonomyStatus: 'ready',
@@ -903,15 +907,18 @@ describe('DataLakeManagerPanel - background AI-tag suggestion status', () => {
     expect(screen.queryByTestId('datalake-manager-taxonomy-review-chip-mine')).toBeNull();
   });
 
-  it('shows the in-progress indicator in the sidebar and the right pane while queued/analyzing', async () => {
-    useActiveDataLakeBatches.mockReturnValue({ data: [batch({ taxonomyStatus: 'analyzing' })] });
-    const user = userEvent.setup();
-    renderPanel();
+  it.each(['queued', 'analyzing'] as const)(
+    'shows the in-progress indicator in the sidebar and the right pane while %s',
+    async status => {
+      useActiveDataLakeBatches.mockReturnValue({ data: [batch({ taxonomyStatus: status })] });
+      const user = userEvent.setup();
+      renderPanel();
 
-    expect(screen.getByTestId('datalake-manager-taxonomy-progress-mine')).toBeInTheDocument();
-    await user.click(screen.getByTestId('datalake-manager-lake-mine'));
-    expect(screen.getByTestId('datalake-manager-taxonomy-progress-chip-mine')).toHaveTextContent('AI tagging');
-  });
+      expect(screen.getByTestId('datalake-manager-taxonomy-progress-mine')).toBeInTheDocument();
+      await user.click(screen.getByTestId('datalake-manager-lake-mine'));
+      expect(screen.getByTestId('datalake-manager-taxonomy-progress-chip-mine')).toHaveTextContent('AI tagging');
+    }
+  );
 
   it('opens the review panel with the right batch and prefix from the sidebar indicator', async () => {
     useActiveDataLakeBatches.mockReturnValue({ data: [batch()] });
@@ -960,7 +967,7 @@ describe('DataLakeManagerPanel - background AI-tag suggestion status', () => {
     await user.click(screen.getByTestId('datalake-manager-taxonomy-review-mine'));
     expect(screen.getByTestId('mock-taxonomy-review-panel')).toBeInTheDocument();
 
-    // 'applied' isn't in the attention set, so the batch disappears from the list response.
+    // Once ingest also finishes, an applied batch is in neither server finder and leaves the list.
     useActiveDataLakeBatches.mockReturnValue({ data: [] });
     rerenderPanel(rerender);
 
@@ -988,15 +995,24 @@ describe('DataLakeManagerPanel - background AI-tag suggestion status', () => {
     expect(screen.getByTestId('datalake-manager-taxonomy-failed-mine')).toBeInTheDocument();
     await user.click(screen.getByTestId('datalake-manager-taxonomy-failed-mine'));
     expect(screen.getByTestId('mock-taxonomy-review-panel')).toHaveAttribute('data-batch-id', 'b1');
+
+    await user.click(screen.getByTestId('mock-taxonomy-review-close'));
+    await user.click(screen.getByTestId('datalake-manager-lake-mine'));
+    expect(screen.getByTestId('datalake-manager-taxonomy-failed-chip-mine')).toBeInTheDocument();
   });
 
   // A batch whose taxonomy phase is already resolved ('applied') but whose ingest is still
   // running stays in the batches list, and the server's ingest-active finder puts it AHEAD of
   // the sibling awaiting review. It used to take the lake's one chip slot and render nothing,
-  // so the review surface silently did not exist. Both consumer surfaces are asserted.
+  // so the review surface silently did not exist. Both consumer surfaces are asserted. The
+  // squatter's id sorts before the winner's on purpose, so a selector that ranked nothing and fell
+  // through to the id tie-break would answer 'a-still-ingesting' and fail here.
   it('prefers the taxonomy-attention batch when a lake has more than one active batch', async () => {
     useActiveDataLakeBatches.mockReturnValue({
-      data: [batch({ id: 'still-ingesting', taxonomyStatus: 'applied' }), batch({ id: 'b1', taxonomyStatus: 'ready' })],
+      data: [
+        batch({ id: 'a-still-ingesting', taxonomyStatus: 'applied' }),
+        batch({ id: 'b1', taxonomyStatus: 'ready' }),
+      ],
     });
     const user = userEvent.setup();
     renderPanel();

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -19,9 +19,9 @@ import { FallbackLakeSettingsModal } from './FallbackLakeSettingsModal';
 import type { EditableFallbackLake } from './FallbackLakeSettingsModal';
 import TaxonomyReviewPanel from './TaxonomyReviewPanel';
 import { DEFAULT_DATA_LAKE_GROUNDING_MODE } from '@bike4mind/common';
-import type { IDataLakeBatchSummary } from '@bike4mind/common';
 import type { ManagerLake } from './manager/shared';
 import { prefixSegments } from './manager/shared';
+import { selectTaxonomyBatchByLakeId } from './manager/taxonomySlot';
 import ManagerNav from './manager/ManagerNav';
 import { LakeInfoPanel, ManagerOverview } from './manager/LakeInfoPanel';
 
@@ -44,17 +44,7 @@ export default function DataLakeManagerPanel() {
     () => activeBatches?.find(b => b.id === reviewingBatchId) ?? null,
     [activeBatches, reviewingBatchId]
   );
-  // One pass over the batch list, not a per-lake filter/find on every row render. Only batches
-  // whose taxonomy phase actually needs attention are kept - a lake with none just misses the
-  // map entry, which every consumer already treats the same as "nothing to show."
-  const taxonomyBatchByLakeId = useMemo(() => {
-    const map = new Map<string, IDataLakeBatchSummary>();
-    for (const batch of activeBatches ?? []) {
-      if (!batch.taxonomyStatus || batch.taxonomyStatus === 'none') continue;
-      if (!map.has(batch.dataLakeId)) map.set(batch.dataLakeId, batch);
-    }
-    return map;
-  }, [activeBatches]);
+  const taxonomyBatchByLakeId = useMemo(() => selectTaxonomyBatchByLakeId(activeBatches), [activeBatches]);
   const openWizard = useDataLakeWizardStore(s => s.openWizard);
   // Store-driven so openManager('discover') deep-links land on the public catalog; the
   // sidebar footer's Discover button flips it the same way.

--- a/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
@@ -59,7 +59,7 @@ export function LakeInfoPanel({
   fileCount: number | undefined;
   /** Membership split by arm - meta-tagged vs prefix-only. See lakeArmCounts. */
   armCounts: { metaCount: number; prefixOnlyCount: number } | undefined;
-  /** This lake's attention-worthy taxonomy batch, if any (see taxonomyBatchByLakeId). */
+  /** This lake's attention-worthy taxonomy batch, if any (see manager/taxonomySlot.ts). */
   taxonomyBatch: IDataLakeBatchSummary | undefined;
   onOpenSettings: () => void;
   /** Opens the owner-facing access & membership view (#1672) - manager-only, like settings. */

--- a/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
@@ -463,7 +463,10 @@ export function LakeInfoPanel({
             </Tooltip>
           )}
           {/* Background AI-tag suggestion progress - an independent clock from ingest, so this
-              can appear well after the lake's files are already fully uploaded/searchable. */}
+              can appear well after the lake's files are already fully uploaded/searchable.
+              Adding or removing a taxonomyStatus gate here means revisiting SLOT_PRIORITY in
+              manager/taxonomySlot.ts, whose order is argued from which statuses these gates
+              render. */}
           {(taxonomyBatch?.taxonomyStatus === 'queued' || taxonomyBatch?.taxonomyStatus === 'analyzing') && (
             <Tooltip title="Usually ready in under a minute" size="sm">
               <Chip

--- a/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
@@ -462,11 +462,11 @@ export function LakeInfoPanel({
               </Chip>
             </Tooltip>
           )}
-          {/* Background AI-tag suggestion progress - an independent clock from ingest, so this
-              can appear well after the lake's files are already fully uploaded/searchable.
-              Adding or removing a taxonomyStatus gate here means revisiting SLOT_PRIORITY in
-              manager/taxonomySlot.ts, whose order is argued from which statuses these gates
-              render. */}
+          {/* Background AI-tag suggestion chips (progress, review, failed) - an independent
+              clock from ingest, so these can appear well after the lake's files are already
+              fully uploaded/searchable. Adding or removing a taxonomyStatus gate anywhere in
+              this block means revisiting SLOT_PRIORITY in manager/taxonomySlot.ts, whose
+              order is argued from which statuses these gates render. */}
           {(taxonomyBatch?.taxonomyStatus === 'queued' || taxonomyBatch?.taxonomyStatus === 'analyzing') && (
             <Tooltip title="Usually ready in under a minute" size="sm">
               <Chip

--- a/apps/client/app/components/DataLakeWizard/manager/ManagerNav.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/ManagerNav.tsx
@@ -436,10 +436,11 @@ export default function ManagerNav({
                                   />
                                 </Tooltip>
                               )}
-                              {/* Background AI-tag suggestion indicator - an independent clock
-                                  from ingest, so this can appear well after the lake's files
-                                  are already fully uploaded/searchable. Adding or removing a
-                                  taxonomyStatus gate here means revisiting SLOT_PRIORITY in
+                              {/* Background AI-tag suggestion gates (progress, review, failed) -
+                                  an independent clock from ingest, so these can appear well
+                                  after the lake's files are already fully uploaded/searchable.
+                                  Adding or removing a taxonomyStatus gate anywhere in this
+                                  block means revisiting SLOT_PRIORITY in
                                   manager/taxonomySlot.ts, whose order is argued from which
                                   statuses these gates render. */}
                               {(taxonomyBatch?.taxonomyStatus === 'queued' ||

--- a/apps/client/app/components/DataLakeWizard/manager/ManagerNav.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/ManagerNav.tsx
@@ -438,7 +438,10 @@ export default function ManagerNav({
                               )}
                               {/* Background AI-tag suggestion indicator - an independent clock
                                   from ingest, so this can appear well after the lake's files
-                                  are already fully uploaded/searchable. */}
+                                  are already fully uploaded/searchable. Adding or removing a
+                                  taxonomyStatus gate here means revisiting SLOT_PRIORITY in
+                                  manager/taxonomySlot.ts, whose order is argued from which
+                                  statuses these gates render. */}
                               {(taxonomyBatch?.taxonomyStatus === 'queued' ||
                                 taxonomyBatch?.taxonomyStatus === 'analyzing') && (
                                 <Tooltip title="Suggesting tags with AI - usually ready in under a minute" size="sm">

--- a/apps/client/app/components/DataLakeWizard/manager/ManagerNav.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/ManagerNav.tsx
@@ -74,7 +74,7 @@ interface ManagerNavProps {
   lakesLoading: boolean;
   /** Per-lake live file count, resolved by lake membership (see lakeCount). */
   lakeCount: (lake: ManagerLake) => number | undefined;
-  /** Lake id -> its attention-worthy taxonomy batch, if any (see taxonomyBatchByLakeId). */
+  /** Lake id -> its attention-worthy taxonomy batch, if any (see manager/taxonomySlot.ts). */
   taxonomyBatchByLakeId: Map<string, IDataLakeBatchSummary>;
   activeLake: ManagerLake | null;
   /** In-lake tag path, seeded with the lake's prefix segments (see selectLake). */

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { TAXONOMY_ATTENTION_STATUSES } from '@bike4mind/common';
 import type { IDataLakeBatchSummary } from '@bike4mind/common';
-import { SLOT_PRIORITY, selectTaxonomyBatchByLakeId } from './taxonomySlot';
+import { selectTaxonomyBatchByLakeId } from './taxonomySlot';
 
-/** Only the four fields the selector reads; the summary type is far wider than this. */
+/** Only the three fields the selector reads; the summary type is far wider than this. */
 const batch = (overrides: Partial<IDataLakeBatchSummary> & { id: string }) =>
   ({ dataLakeId: 'lake-a', ...overrides }) as IDataLakeBatchSummary;
 
@@ -11,12 +11,14 @@ const pick = (batches: IDataLakeBatchSummary[], lakeId = 'lake-a') =>
   selectTaxonomyBatchByLakeId(batches).get(lakeId)?.id;
 
 describe('selectTaxonomyBatchByLakeId', () => {
-  it('is a permutation of the server attention set - same members, no extras, no omissions', () => {
-    expect([...SLOT_PRIORITY].sort()).toEqual([...TAXONOMY_ATTENTION_STATUSES].sort());
-  });
-
   it('returns an empty map for an undefined list', () => {
     expect(selectTaxonomyBatchByLakeId(undefined).size).toBe(0);
+  });
+
+  // Eligibility, tested through the selector rather than by comparing SLOT_PRIORITY to the
+  // server constant: a new attention status that nobody ranks would silently lose its chip.
+  it.each(TAXONOMY_ATTENTION_STATUSES)('keeps a %s batch eligible for the slot', status => {
+    expect(selectTaxonomyBatchByLakeId([batch({ id: 'b1', taxonomyStatus: status })]).has('lake-a')).toBe(true);
   });
 
   it.each(['none', 'applied', 'dismissed'] as const)('skips a lake whose only batch is %s', status => {
@@ -35,37 +37,34 @@ describe('selectTaxonomyBatchByLakeId', () => {
     );
   });
 
-  it('prefers the ready batch over an analyzing one that arrived first', () => {
-    expect(pick([batch({ id: 'a1', taxonomyStatus: 'analyzing' }), batch({ id: 'b1', taxonomyStatus: 'ready' })])).toBe(
-      'b1'
-    );
+  // Every pair, both arrival orders. Each relation is argued in SLOT_PRIORITY's docblock from
+  // which consumer gate the status can render, so an unnoticed reshuffle is a real regression -
+  // e.g. 'analyzing' above 'failed' deletes the failed-review affordance. The 'w'/'l' ids are
+  // load-bearing: the id tie-break sorts ascending and would answer 'l', so a collapsed rank
+  // cannot pass by accident.
+  it.each([
+    ['ready', 'failed'],
+    ['ready', 'analyzing'],
+    ['ready', 'queued'],
+    ['ready', 'applying'],
+    ['failed', 'analyzing'],
+    ['failed', 'queued'],
+    ['failed', 'applying'],
+    ['analyzing', 'queued'],
+    ['analyzing', 'applying'],
+    ['queued', 'applying'],
+  ] as const)('prefers %s over %s regardless of arrival order', (winner, loser) => {
+    const w = batch({ id: 'w', taxonomyStatus: winner });
+    const l = batch({ id: 'l', taxonomyStatus: loser });
+    expect(pick([w, l])).toBe('w');
+    expect(pick([l, w])).toBe('w');
   });
 
-  // 'applying' matches no consumer gate, so it must not take the slot from a status that does.
-  it('prefers analyzing over applying', () => {
-    expect(
-      pick([batch({ id: 'ap', taxonomyStatus: 'applying' }), batch({ id: 'an', taxonomyStatus: 'analyzing' })])
-    ).toBe('an');
-  });
-
-  it('prefers ready over failed regardless of list order', () => {
-    const ready = batch({ id: 'b1', taxonomyStatus: 'ready' });
-    const failed = batch({ id: 'b0', taxonomyStatus: 'failed' });
-    expect(pick([failed, ready])).toBe('b1');
-    expect(pick([ready, failed])).toBe('b1');
-  });
-
-  // ISO strings, not Dates: that is what the list endpoint actually puts on the wire.
-  it('breaks a rank tie by updatedAt desc, stably across input order', () => {
-    const older = batch({ id: 'b1', taxonomyStatus: 'ready', updatedAt: '2026-01-01T00:00:00Z' as unknown as Date });
-    const newer = batch({ id: 'b2', taxonomyStatus: 'ready', updatedAt: '2026-02-01T00:00:00Z' as unknown as Date });
-    expect(pick([older, newer])).toBe('b2');
-    expect(pick([newer, older])).toBe('b2');
-  });
-
-  it('breaks an exact tie by id ascending, stably across input order', () => {
-    const a = batch({ id: 'aaa', taxonomyStatus: 'ready' });
-    const z = batch({ id: 'zzz', taxonomyStatus: 'ready' });
+  // Two ready siblings on one lake is legal; the winner must not depend on arrival order, and
+  // must not move when an unrelated ingest write touches the batch.
+  it('breaks a rank tie by id ascending, stably across input order', () => {
+    const a = batch({ id: 'aaa', taxonomyStatus: 'ready', updatedAt: new Date('2020-01-01') });
+    const z = batch({ id: 'zzz', taxonomyStatus: 'ready', updatedAt: new Date('2026-01-01') });
     expect(pick([z, a])).toBe('aaa');
     expect(pick([a, z])).toBe('aaa');
   });

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { TAXONOMY_ATTENTION_STATUSES } from '@bike4mind/common';
+import type { IDataLakeBatchSummary } from '@bike4mind/common';
+import { SLOT_PRIORITY, selectTaxonomyBatchByLakeId } from './taxonomySlot';
+
+/** Only the four fields the selector reads; the summary type is far wider than this. */
+const batch = (overrides: Partial<IDataLakeBatchSummary> & { id: string }) =>
+  ({ dataLakeId: 'lake-a', ...overrides }) as IDataLakeBatchSummary;
+
+const pick = (batches: IDataLakeBatchSummary[], lakeId = 'lake-a') =>
+  selectTaxonomyBatchByLakeId(batches).get(lakeId)?.id;
+
+describe('selectTaxonomyBatchByLakeId', () => {
+  it('is a permutation of the server attention set - same members, no extras, no omissions', () => {
+    expect([...SLOT_PRIORITY].sort()).toEqual([...TAXONOMY_ATTENTION_STATUSES].sort());
+  });
+
+  it('returns an empty map for an undefined list', () => {
+    expect(selectTaxonomyBatchByLakeId(undefined).size).toBe(0);
+  });
+
+  it.each(['none', 'applied', 'dismissed'] as const)('skips a lake whose only batch is %s', status => {
+    expect(selectTaxonomyBatchByLakeId([batch({ id: 'b1', taxonomyStatus: status })]).has('lake-a')).toBe(false);
+  });
+
+  it('skips a batch with no taxonomyStatus at all', () => {
+    expect(selectTaxonomyBatchByLakeId([batch({ id: 'b1' })]).has('lake-a')).toBe(false);
+  });
+
+  // The reported bug: an applied batch still ingesting arrives first from the server's
+  // ingest-active finder and used to squat the slot, hiding the review chip entirely.
+  it('prefers the ready batch over an applied one that arrived first', () => {
+    expect(pick([batch({ id: 'ap1', taxonomyStatus: 'applied' }), batch({ id: 'b1', taxonomyStatus: 'ready' })])).toBe(
+      'b1'
+    );
+  });
+
+  it('prefers the ready batch over an analyzing one that arrived first', () => {
+    expect(pick([batch({ id: 'a1', taxonomyStatus: 'analyzing' }), batch({ id: 'b1', taxonomyStatus: 'ready' })])).toBe(
+      'b1'
+    );
+  });
+
+  // 'applying' matches no consumer gate, so it must not take the slot from a status that does.
+  it('prefers analyzing over applying', () => {
+    expect(
+      pick([batch({ id: 'ap', taxonomyStatus: 'applying' }), batch({ id: 'an', taxonomyStatus: 'analyzing' })])
+    ).toBe('an');
+  });
+
+  it('prefers ready over failed regardless of list order', () => {
+    const ready = batch({ id: 'b1', taxonomyStatus: 'ready' });
+    const failed = batch({ id: 'b0', taxonomyStatus: 'failed' });
+    expect(pick([failed, ready])).toBe('b1');
+    expect(pick([ready, failed])).toBe('b1');
+  });
+
+  // ISO strings, not Dates: that is what the list endpoint actually puts on the wire.
+  it('breaks a rank tie by updatedAt desc, stably across input order', () => {
+    const older = batch({ id: 'b1', taxonomyStatus: 'ready', updatedAt: '2026-01-01T00:00:00Z' as unknown as Date });
+    const newer = batch({ id: 'b2', taxonomyStatus: 'ready', updatedAt: '2026-02-01T00:00:00Z' as unknown as Date });
+    expect(pick([older, newer])).toBe('b2');
+    expect(pick([newer, older])).toBe('b2');
+  });
+
+  it('breaks an exact tie by id ascending, stably across input order', () => {
+    const a = batch({ id: 'aaa', taxonomyStatus: 'ready' });
+    const z = batch({ id: 'zzz', taxonomyStatus: 'ready' });
+    expect(pick([z, a])).toBe('aaa');
+    expect(pick([a, z])).toBe('aaa');
+  });
+
+  it('keeps lakes independent', () => {
+    const map = selectTaxonomyBatchByLakeId([
+      batch({ id: 'a-ready', dataLakeId: 'lake-a', taxonomyStatus: 'ready' }),
+      batch({ id: 'b-failed', dataLakeId: 'lake-b', taxonomyStatus: 'failed' }),
+    ]);
+    expect(map.get('lake-a')?.id).toBe('a-ready');
+    expect(map.get('lake-b')?.id).toBe('b-failed');
+  });
+});

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
@@ -37,6 +37,14 @@ describe('selectTaxonomyBatchByLakeId', () => {
     );
   });
 
+  // Arrival order is only sorted for the taxonomy-attention half of the merged server list, so
+  // an ineligible batch can land after the winner. Skipping it must leave the slot alone.
+  it('ignores an applied batch that arrives after the ready one', () => {
+    expect(pick([batch({ id: 'b1', taxonomyStatus: 'ready' }), batch({ id: 'ap2', taxonomyStatus: 'applied' })])).toBe(
+      'b1'
+    );
+  });
+
   // Every pair, both arrival orders. Each relation is argued in SLOT_PRIORITY's docblock from
   // which consumer gate the status can render, so an unnoticed reshuffle is a real regression -
   // e.g. 'analyzing' above 'failed' deletes the failed-review affordance. The 'w'/'l' ids are
@@ -60,6 +68,16 @@ describe('selectTaxonomyBatchByLakeId', () => {
     expect(pick([l, w])).toBe('w');
   });
 
+  // Three-plus active batches on one lake is ordinary; every one has to be scanned, not just the
+  // ends of the list. Ids are picked so a rank that collapsed to the id tie-break answers a loser.
+  it('scans every batch when a lake has three active ones, in either arrival order', () => {
+    const ready = batch({ id: 'b-ready', taxonomyStatus: 'ready' });
+    const queued = batch({ id: 'a-queued', taxonomyStatus: 'queued' });
+    const applying = batch({ id: 'c-applying', taxonomyStatus: 'applying' });
+    expect(pick([ready, queued, applying])).toBe('b-ready');
+    expect(pick([queued, applying, ready])).toBe('b-ready');
+  });
+
   // Two ready siblings on one lake is legal; the winner must not depend on arrival order, and
   // must not move when an unrelated ingest write touches the batch.
   it('breaks a rank tie by id ascending, stably across input order', () => {
@@ -67,6 +85,15 @@ describe('selectTaxonomyBatchByLakeId', () => {
     const z = batch({ id: 'zzz', taxonomyStatus: 'ready', updatedAt: new Date('2026-01-01') });
     expect(pick([z, a])).toBe('aaa');
     expect(pick([a, z])).toBe('aaa');
+  });
+
+  // The server route dedupes by id, so this should not arrive - but `<` vs `<=` in outranks is a
+  // one-character edit, and last-wins on a tie is exactly the poll instability the id key prevents.
+  // Asserted by identity: two batches sharing an id are indistinguishable by id alone.
+  it('keeps the first of two batches sharing an id', () => {
+    const first = batch({ id: 'dup', taxonomyStatus: 'ready' });
+    const second = batch({ id: 'dup', taxonomyStatus: 'ready' });
+    expect(selectTaxonomyBatchByLakeId([first, second]).get('lake-a')).toBe(first);
   });
 
   it('keeps lakes independent', () => {

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
@@ -10,7 +10,7 @@ const batch = (overrides: Partial<IDataLakeBatchSummary> & { id: string }) =>
 const pick = (batches: IDataLakeBatchSummary[], lakeId = 'lake-a') =>
   selectTaxonomyBatchByLakeId(batches).get(lakeId)?.id;
 
-/** Every pair of attention statuses, higher-priority first. Kept whole by the count assertion below. */
+/** Every pair of attention statuses, higher-priority first. Row count asserted below against the server constant. */
 const ORDER_PAIRS = [
   ['ready', 'failed'],
   ['ready', 'analyzing'],

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.test.ts
@@ -10,6 +10,20 @@ const batch = (overrides: Partial<IDataLakeBatchSummary> & { id: string }) =>
 const pick = (batches: IDataLakeBatchSummary[], lakeId = 'lake-a') =>
   selectTaxonomyBatchByLakeId(batches).get(lakeId)?.id;
 
+/** Every pair of attention statuses, higher-priority first. Kept whole by the count assertion below. */
+const ORDER_PAIRS = [
+  ['ready', 'failed'],
+  ['ready', 'analyzing'],
+  ['ready', 'queued'],
+  ['ready', 'applying'],
+  ['failed', 'analyzing'],
+  ['failed', 'queued'],
+  ['failed', 'applying'],
+  ['analyzing', 'queued'],
+  ['analyzing', 'applying'],
+  ['queued', 'applying'],
+] as const;
+
 describe('selectTaxonomyBatchByLakeId', () => {
   it('returns an empty map for an undefined list', () => {
     expect(selectTaxonomyBatchByLakeId(undefined).size).toBe(0);
@@ -45,27 +59,24 @@ describe('selectTaxonomyBatchByLakeId', () => {
     );
   });
 
-  // Every pair, both arrival orders. Each relation is argued in SLOT_PRIORITY's docblock from
-  // which consumer gate the status can render, so an unnoticed reshuffle is a real regression -
-  // e.g. 'analyzing' above 'failed' deletes the failed-review affordance. The 'w'/'l' ids are
+  // Both arrival orders per pair. Each relation is argued in SLOT_PRIORITY's docblock from which
+  // consumer gate the status can render, so an unnoticed reshuffle is a real regression - e.g.
+  // 'analyzing' above 'failed' deletes the failed-review affordance. The 'w'/'l' ids are
   // load-bearing: the id tie-break sorts ascending and would answer 'l', so a collapsed rank
   // cannot pass by accident.
-  it.each([
-    ['ready', 'failed'],
-    ['ready', 'analyzing'],
-    ['ready', 'queued'],
-    ['ready', 'applying'],
-    ['failed', 'analyzing'],
-    ['failed', 'queued'],
-    ['failed', 'applying'],
-    ['analyzing', 'queued'],
-    ['analyzing', 'applying'],
-    ['queued', 'applying'],
-  ] as const)('prefers %s over %s regardless of arrival order', (winner, loser) => {
+  it.each(ORDER_PAIRS)('prefers %s over %s regardless of arrival order', (winner, loser) => {
     const w = batch({ id: 'w', taxonomyStatus: winner });
     const l = batch({ id: 'l', taxonomyStatus: loser });
     expect(pick([w, l])).toBe('w');
     expect(pick([l, w])).toBe('w');
+  });
+
+  // The eligibility table above grows off the server constant on its own; this hand-written one
+  // does not, so a sixth attention status would stay eligible with its rank unpinned. Only the
+  // count notices, and dropping a row also silently drops a test from the suite total.
+  it('covers every pair of attention statuses', () => {
+    const n = TAXONOMY_ATTENTION_STATUSES.length;
+    expect(ORDER_PAIRS).toHaveLength((n * (n - 1)) / 2);
   });
 
   // Three-plus active batches on one lake is ordinary; every one has to be scanned, not just the
@@ -79,12 +90,24 @@ describe('selectTaxonomyBatchByLakeId', () => {
   });
 
   // Two ready siblings on one lake is legal; the winner must not depend on arrival order, and
-  // must not move when an unrelated ingest write touches the batch.
+  // must not move when an unrelated ingest write touches the batch. updatedAt runs OPPOSITE to
+  // the id order on purpose: it is the key the module docblock rules out, and with the two keys
+  // agreeing this test cannot tell one from the other.
   it('breaks a rank tie by id ascending, stably across input order', () => {
-    const a = batch({ id: 'aaa', taxonomyStatus: 'ready', updatedAt: new Date('2020-01-01') });
-    const z = batch({ id: 'zzz', taxonomyStatus: 'ready', updatedAt: new Date('2026-01-01') });
+    const a = batch({ id: 'aaa', taxonomyStatus: 'ready', updatedAt: new Date('2026-01-01') });
+    const z = batch({ id: 'zzz', taxonomyStatus: 'ready', updatedAt: new Date('2020-01-01') });
     expect(pick([z, a])).toBe('aaa');
     expect(pick([a, z])).toBe('aaa');
+  });
+
+  // The poll-stability property the id key exists for: ingest bumps updatedAt per file on a clock
+  // independent of taxonomy, so a winner that tracked it would swap the review chip's batch out
+  // from under the user between 10s polls.
+  it('keeps the same tie winner when an ingest write bumps only updatedAt', () => {
+    const a = batch({ id: 'aaa', taxonomyStatus: 'ready', updatedAt: new Date('2020-01-01') });
+    const z = batch({ id: 'zzz', taxonomyStatus: 'ready', updatedAt: new Date('2020-01-02') });
+    expect(pick([a, z])).toBe('aaa');
+    expect(pick([{ ...a, updatedAt: new Date('2026-01-01') }, z])).toBe('aaa');
   });
 
   // The server route dedupes by id, so this should not arrive - but `<` vs `<=` in outranks is a

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
@@ -1,37 +1,32 @@
 import type { IDataLakeBatchSummary, TaxonomyStatus } from '@bike4mind/common';
 
 /**
- * Which taxonomy phase wins the one per-lake chip slot, most-actionable first. Only 'ready' and
- * 'failed' open the review panel, so they outrank every in-progress phase; 'analyzing'/'queued'
- * at least render the progress indicator; 'applying' renders in no consumer gate at all
- * (ManagerNav, LakeInfoPanel), so it ranks last rather than hiding a sibling that would show
- * something. Must stay a permutation of TAXONOMY_ATTENTION_STATUSES - taxonomySlot.test.ts
- * asserts it, and membership in this array is also what makes a batch eligible at all.
+ * Which taxonomy phase wins the one per-lake chip slot, most-actionable first, and - since
+ * eligibility is membership in this array - which phases can hold the slot at all. Only 'ready'
+ * and 'failed' open the review panel, so they outrank every in-progress phase;
+ * 'analyzing'/'queued' at least render the progress indicator; 'applying' renders in no consumer
+ * gate at all (ManagerNav, LakeInfoPanel), so it ranks last rather than hiding a sibling that
+ * would show something. Must stay a permutation of TAXONOMY_ATTENTION_STATUSES - taxonomySlot.test.ts
+ * asserts every pairwise relation here and that each attention status stays eligible.
  */
-export const SLOT_PRIORITY: TaxonomyStatus[] = ['ready', 'failed', 'analyzing', 'queued', 'applying'];
+const SLOT_PRIORITY: readonly TaxonomyStatus[] = ['ready', 'failed', 'analyzing', 'queued', 'applying'];
 
-/** -1 for any status outside SLOT_PRIORITY ('none', 'applied', 'dismissed', unset), which is
- *  also the "not eligible for the slot" signal. */
+/** -1 for any status outside SLOT_PRIORITY ('none', 'applied', 'dismissed', unset). */
 const rankOf = (batch: IDataLakeBatchSummary): number =>
   batch.taxonomyStatus ? SLOT_PRIORITY.indexOf(batch.taxonomyStatus) : -1;
 
-/** JSON hands back an ISO string here despite the `Date` on IDataLakeBatchSummary (the list
- *  query does no date revival), so go through Date() rather than calling .getTime() on the
- *  field. A missing/unparseable value collapses to 0 so the ordering stays total. */
-const updatedAtMs = (batch: IDataLakeBatchSummary): number => {
-  const ms = new Date(batch.updatedAt).getTime();
-  return Number.isNaN(ms) ? 0 : ms;
-};
-
-/** Deterministic total order, so the slot cannot swap between 10s polls and change the id the
- *  chip hands to onReviewTaxonomy mid-review. The ingest half of the batches list has no
- *  server-side sort, so arrival order is not a usable tie-break. */
+/**
+ * Total order: rank, then id ascending. Equal rank means an identical taxonomyStatus and so an
+ * identical rendered chip, leaving only "which id does the chip hand to onReviewTaxonomy" to
+ * settle - and it has to settle the same way on every 10s poll. Both keys are immutable, so the
+ * winner cannot change while the batches merely ingest. Deliberately NOT `updatedAt`: ingest
+ * bumps it per file (incrementCounters, DataLakeModel) on a clock independent of taxonomy, so
+ * two 'ready' siblings would trade the slot between polls. Id ascending is oldest-first among
+ * equals, ObjectIds being creation-ordered.
+ */
 const outranks = (candidate: IDataLakeBatchSummary, held: IDataLakeBatchSummary): boolean => {
   const byRank = rankOf(candidate) - rankOf(held);
-  if (byRank !== 0) return byRank < 0;
-  const byUpdated = updatedAtMs(held) - updatedAtMs(candidate);
-  if (byUpdated !== 0) return byUpdated < 0;
-  return candidate.id < held.id;
+  return byRank !== 0 ? byRank < 0 : candidate.id < held.id;
 };
 
 /**
@@ -42,6 +37,9 @@ const outranks = (candidate: IDataLakeBatchSummary, held: IDataLakeBatchSummary)
  * phase - still chunking, hence still in the list - ahead of a sibling awaiting review.
  * A lake with no eligible batch just misses the map entry, which every consumer already
  * treats the same as "nothing to show."
+ *
+ * Returns a prebuilt Map because the sidebar looks a lake up per row (ManagerNav): one pass
+ * over the batch list, not a filter/find on every row of every render.
  */
 export function selectTaxonomyBatchByLakeId(
   batches: readonly IDataLakeBatchSummary[] | undefined

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
@@ -6,9 +6,15 @@ import type { IDataLakeBatchSummary, TaxonomyStatus } from '@bike4mind/common';
  * and 'failed' open the review panel, so they outrank every in-progress phase;
  * 'analyzing'/'queued' at least render the progress indicator; 'applying' renders in no consumer
  * gate at all (ManagerNav, LakeInfoPanel), so it ranks last rather than hiding a sibling that
- * would show something. Must stay a permutation of TAXONOMY_ATTENTION_STATUSES - taxonomySlot.test.ts
- * asserts every pairwise relation here, that each attention status stays eligible, and that the
- * three phases outside that set stay out.
+ * would show something. Accepted consequence of one chip per lake: a 'failed' batch's error and
+ * its exits (re-analyze, dismiss) wait behind an unresolved 'ready' sibling - review is the more
+ * valuable affordance and a failure is non-destructive - and surface once that sibling is applied
+ * or dismissed and so leaves the attention set.
+ *
+ * Must stay a permutation of TAXONOMY_ATTENTION_STATUSES. taxonomySlot.test.ts pins the pairwise
+ * relations among today's five statuses, that every attention status stays eligible, and that the
+ * three TaxonomyStatus values outside the attention set stay out; those 5 + 3 exhaust the union
+ * today, so a sixth attention status needs its own rows in that pairwise table.
  */
 const SLOT_PRIORITY: readonly TaxonomyStatus[] = ['ready', 'failed', 'analyzing', 'queued', 'applying'];
 
@@ -22,8 +28,8 @@ const rankOf = (batch: IDataLakeBatchSummary): number =>
  * settle - and it has to settle the same way on every 10s poll. Neither key moves on an ingest
  * write, so the winner changes only when a taxonomy phase does. Deliberately NOT `updatedAt`: ingest
  * bumps it per file (incrementCounters, DataLakeModel) on a clock independent of taxonomy, so
- * two 'ready' siblings would trade the slot between polls. Id ascending is oldest-first among
- * equals, ObjectIds being creation-ordered.
+ * two 'ready' siblings would trade the slot between polls. Id ascending only has to be
+ * deterministic; it approximates oldest-first, an ObjectId's timestamp being whole-second.
  */
 const outranks = (candidate: IDataLakeBatchSummary, held: IDataLakeBatchSummary): boolean => {
   const byRank = rankOf(candidate) - rankOf(held);

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
@@ -1,0 +1,56 @@
+import type { IDataLakeBatchSummary, TaxonomyStatus } from '@bike4mind/common';
+
+/**
+ * Which taxonomy phase wins the one per-lake chip slot, most-actionable first. Only 'ready' and
+ * 'failed' open the review panel, so they outrank every in-progress phase; 'analyzing'/'queued'
+ * at least render the progress indicator; 'applying' renders in no consumer gate at all
+ * (ManagerNav, LakeInfoPanel), so it ranks last rather than hiding a sibling that would show
+ * something. Must stay a permutation of TAXONOMY_ATTENTION_STATUSES - taxonomySlot.test.ts
+ * asserts it, and membership in this array is also what makes a batch eligible at all.
+ */
+export const SLOT_PRIORITY: TaxonomyStatus[] = ['ready', 'failed', 'analyzing', 'queued', 'applying'];
+
+/** -1 for any status outside SLOT_PRIORITY ('none', 'applied', 'dismissed', unset), which is
+ *  also the "not eligible for the slot" signal. */
+const rankOf = (batch: IDataLakeBatchSummary): number =>
+  batch.taxonomyStatus ? SLOT_PRIORITY.indexOf(batch.taxonomyStatus) : -1;
+
+/** JSON hands back an ISO string here despite the `Date` on IDataLakeBatchSummary (the list
+ *  query does no date revival), so go through Date() rather than calling .getTime() on the
+ *  field. A missing/unparseable value collapses to 0 so the ordering stays total. */
+const updatedAtMs = (batch: IDataLakeBatchSummary): number => {
+  const ms = new Date(batch.updatedAt).getTime();
+  return Number.isNaN(ms) ? 0 : ms;
+};
+
+/** Deterministic total order, so the slot cannot swap between 10s polls and change the id the
+ *  chip hands to onReviewTaxonomy mid-review. The ingest half of the batches list has no
+ *  server-side sort, so arrival order is not a usable tie-break. */
+const outranks = (candidate: IDataLakeBatchSummary, held: IDataLakeBatchSummary): boolean => {
+  const byRank = rankOf(candidate) - rankOf(held);
+  if (byRank !== 0) return byRank < 0;
+  const byUpdated = updatedAtMs(held) - updatedAtMs(candidate);
+  if (byUpdated !== 0) return byUpdated < 0;
+  return candidate.id < held.id;
+};
+
+/**
+ * One batch per lake for the manager's taxonomy chip: the batch that most needs the user, not
+ * the first one the list happens to carry. The batches list interleaves two server finders
+ * (see pages/api/data-lakes/batches/index.ts) and every ingest-active batch precedes every
+ * taxonomy-attention one, so arrival order routinely puts a batch with a terminal taxonomy
+ * phase - still chunking, hence still in the list - ahead of a sibling awaiting review.
+ * A lake with no eligible batch just misses the map entry, which every consumer already
+ * treats the same as "nothing to show."
+ */
+export function selectTaxonomyBatchByLakeId(
+  batches: readonly IDataLakeBatchSummary[] | undefined
+): Map<string, IDataLakeBatchSummary> {
+  const map = new Map<string, IDataLakeBatchSummary>();
+  for (const batch of batches ?? []) {
+    if (rankOf(batch) < 0) continue;
+    const held = map.get(batch.dataLakeId);
+    if (!held || outranks(batch, held)) map.set(batch.dataLakeId, batch);
+  }
+  return map;
+}

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
@@ -7,7 +7,8 @@ import type { IDataLakeBatchSummary, TaxonomyStatus } from '@bike4mind/common';
  * 'analyzing'/'queued' at least render the progress indicator; 'applying' renders in no consumer
  * gate at all (ManagerNav, LakeInfoPanel), so it ranks last rather than hiding a sibling that
  * would show something. Must stay a permutation of TAXONOMY_ATTENTION_STATUSES - taxonomySlot.test.ts
- * asserts every pairwise relation here and that each attention status stays eligible.
+ * asserts every pairwise relation here, that each attention status stays eligible, and that the
+ * three phases outside that set stay out.
  */
 const SLOT_PRIORITY: readonly TaxonomyStatus[] = ['ready', 'failed', 'analyzing', 'queued', 'applying'];
 
@@ -18,8 +19,8 @@ const rankOf = (batch: IDataLakeBatchSummary): number =>
 /**
  * Total order: rank, then id ascending. Equal rank means an identical taxonomyStatus and so an
  * identical rendered chip, leaving only "which id does the chip hand to onReviewTaxonomy" to
- * settle - and it has to settle the same way on every 10s poll. Both keys are immutable, so the
- * winner cannot change while the batches merely ingest. Deliberately NOT `updatedAt`: ingest
+ * settle - and it has to settle the same way on every 10s poll. Neither key moves on an ingest
+ * write, so the winner changes only when a taxonomy phase does. Deliberately NOT `updatedAt`: ingest
  * bumps it per file (incrementCounters, DataLakeModel) on a clock independent of taxonomy, so
  * two 'ready' siblings would trade the slot between polls. Id ascending is oldest-first among
  * equals, ObjectIds being creation-ordered.

--- a/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
+++ b/apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts
@@ -14,7 +14,8 @@ import type { IDataLakeBatchSummary, TaxonomyStatus } from '@bike4mind/common';
  * Must stay a permutation of TAXONOMY_ATTENTION_STATUSES. taxonomySlot.test.ts pins the pairwise
  * relations among today's five statuses, that every attention status stays eligible, and that the
  * three TaxonomyStatus values outside the attention set stay out; those 5 + 3 exhaust the union
- * today, so a sixth attention status needs its own rows in that pairwise table.
+ * today, and a sixth attention status fails that file's pair-count assertion until it is given
+ * its own rows in the pairwise table.
  */
 const SLOT_PRIORITY: readonly TaxonomyStatus[] = ['ready', 'failed', 'analyzing', 'queued', 'applying'];
 


### PR DESCRIPTION
## Summary

A data lake can have more than one active batch at a time. The manager panel keeps exactly one "taxonomy batch" per lake in a client-side map, filled first-wins from a server-ordered list where ingest-active batches always precede taxonomy-attention ones. An `applied`-but-still-chunking batch could squat that slot ahead of a `ready` batch on the same lake, and since the only entry point to taxonomy review is a chip gated on `taxonomyStatus`, the review surface would silently not exist (or, for a `queued`/`analyzing` squatter, an in-progress chip would mask the ready one).

This fixes the per-lake selection to resolve to the batch that actually needs the user: attention-first, not arrival-first.

## What changed

- Added `apps/client/app/components/DataLakeWizard/manager/taxonomySlot.ts`: a pure selector that filters to `TAXONOMY_ATTENTION_STATUSES` (the server's own definition of "needs attention" - reused, not re-declared) and ranks the survivors `ready > failed > analyzing > queued > applying`, with `id` ascending as a stable tie-break.
- `DataLakeManagerPanel.tsx`'s `taxonomyBatchByLakeId` memo is now a one-line call into the selector; the old first-wins loop and its now-inaccurate comment are gone.
- Updated the misleading existing regression test (it pitted `'none'` against `'ready'`, which the old filter already handled) and added a new one covering the actual bug: an `applied` ingest-active batch ahead of a `ready` batch on the same lake, checked through both consumer surfaces (sidebar nav row and the lake info panel).
- Added a masking-specific test: an `analyzing` batch must not hide a `ready` sibling's chip.
- `taxonomySlot.test.ts`: exhaustive pairwise ordering coverage (`ORDER_PAIRS`, both arrival orders, ids chosen to defeat the id tie-break), a behavioural eligibility table over every `TaxonomyStatus` value, and a poll-stability case (an ingest write that only bumps `updatedAt` must not move the slot).

Server route, both DB finders, the list's spread order, `ManagerNav`, `LakeInfoPanel`, and `TaxonomyReviewPanel` are unchanged - this is a pure client-side derivation fix.

## Behavior change worth flagging

A lake whose only non-`none` batch is `applied` or `dismissed` previously got a map entry that rendered nothing (no gate matches those statuses); it now gets no entry at all. No consumer can observe the difference.

Among two batches tied on rank, the chip now opens the older batch (`id` ascending) rather than whichever arrived first in the list. Also unobservable in the rendered chip (equal rank means an identical chip), and deliberately chosen over a timestamp for poll stability.

## Known out-of-scope items (each merits its own ticket, not touched here)

- Client test files (`*.test.ts(x)`) are excluded from `apps/client`'s CI typecheck (`tsconfig.json`), so type-level test bugs need mutation testing rather than the compiler to catch.
- `DataLakeModel.ts`'s dismiss-taxonomy comment calling it "planned" is stale - it's shipped and reachable.
- `UploadStep.tsx` spells the ready/failed gate a third time with a stale status list; doesn't read the slot map.
- `DataLakeManagerPanel.test.tsx`'s "closes the panel once the batch drops out of the attention set" test models apply-completion as an empty batch list, which production contradicts (an applied-but-chunking batch stays in the list). Doesn't affect this fix - the open review panel reads the full batch list by id, not the per-lake map.
- A `failed` batch's error and dismiss/re-analyze actions are only reachable via its own chip; while a `ready` sibling holds the slot on the same lake, the failed one waits. This is an improvement over pre-fix behavior (which could hide both behind an `applied`/`dismissed` squatter), not a regression, but a second review entry point for that case is a legitimate product follow-up.

## How to test

- `pnpm --filter @bike4mind/client exec vitest run app/components/DataLakeWizard/manager/taxonomySlot.ts` and the full `app/components/DataLakeWizard` directory (`pnpm --filter @bike4mind/client exec vitest run app/components/DataLakeWizard`).
- `pnpm --filter @bike4mind/client typecheck` and `pnpm lint:check`.
- Manually: on a lake, start an upload (ingest-active) on one batch and get a second batch to `ready` taxonomy status; confirm the "Review AI tags" chip appears in both the sidebar and the lake info panel.