### PR TITLE
feat(data-lakes): gate corpus grounding mode, flag preauthorized lake usage, bind API keys to lakes

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
@@ -1128,6 +1128,7 @@ describe('DataLakeSettingsModal - Test this lake', () => {
     // lake-under-test's own `groundingMode` rides along, not some other value.
     expect(startChatWithLakesMock).toHaveBeenCalledWith({
       retrievalTags: ['datalake:test-lake', 'datalake:open-lake'],
+      preauthorizedLakeIds: [],
       groundingMode: 'retrieve',
     });
     // The scope dialog is a separate flow from the settings form - confirming it must not also

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
@@ -1124,11 +1124,11 @@ describe('DataLakeSettingsModal - Test this lake', () => {
 
     // Tags come back in the fetched-lakes list order, not selection order. The fixture tags are
     // deliberately unequal to the lake ids and carry the `datalake:` prefix, so this discriminates
-    // both an id-for-tag mixup and a dropped prefix. The exact-object match also pins that no
-    // `corpusGroundingMode` rides along: /api/sessions/create strips it off any request without a
-    // `dataLakeId`, so sending one would be a silent no-op.
+    // both an id-for-tag mixup and a dropped prefix. The exact-object match also pins that the
+    // lake-under-test's own `groundingMode` rides along, not some other value.
     expect(startChatWithLakesMock).toHaveBeenCalledWith({
       retrievalTags: ['datalake:test-lake', 'datalake:open-lake'],
+      groundingMode: 'retrieve',
     });
     // The scope dialog is a separate flow from the settings form - confirming it must not also
     // close the settings modal out from under the caller.

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.test.tsx
@@ -1151,4 +1151,25 @@ describe('DataLakeSettingsModal - Test this lake', () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Could not start a test chat for this lake'));
     expect(screen.getByTestId('test-lake-scope-dialog')).toBeInTheDocument();
   });
+
+  it("surfaces the route's own refusal rather than the generic fallback", async () => {
+    // An axios rejection, not a plain Error: the route's reason lives on response.data.error, and
+    // axios's `message` is only "Request failed with status code N" - a plain-Error mock cannot
+    // tell a working extraction from a broken one.
+    startChatWithLakesMock.mockRejectedValue({
+      message: 'Request failed with status code 403',
+      response: { data: { error: 'You do not manage data lake lake-1' } },
+    });
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <DataLakeSettingsModal lake={openLake} onClose={vi.fn()} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByTestId(`datalake-settings-test-btn-${openLake.id}`));
+    await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('You do not manage data lake lake-1'));
+  });
 });

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
@@ -302,13 +302,14 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
     );
   };
 
-  const handleConfirmTestScope = async (retrievalTags: string[]) => {
+  const handleConfirmTestScope = async (scope: { retrievalTags: string[]; preauthorizedLakeIds: string[] }) => {
     if (!lake) return;
     setStartingTestChat(true);
     try {
       await startChatWithLakes({
-        retrievalTags,
+        retrievalTags: scope.retrievalTags,
         groundingMode: lake.groundingMode ?? DEFAULT_DATA_LAKE_GROUNDING_MODE,
+        preauthorizedLakeIds: scope.preauthorizedLakeIds,
       });
       setTestScopeOpen(false);
     } catch {

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
@@ -306,7 +306,10 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
     if (!lake) return;
     setStartingTestChat(true);
     try {
-      await startChatWithLakes({ retrievalTags });
+      await startChatWithLakes({
+        retrievalTags,
+        groundingMode: lake.groundingMode ?? DEFAULT_DATA_LAKE_GROUNDING_MODE,
+      });
       setTestScopeOpen(false);
     } catch {
       toast.error('Could not start a test chat for this lake');
@@ -351,7 +354,7 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
             data-testid="datalake-systemprompt-input"
           />
           <FormHelperText data-testid="datalake-systemprompt-help">
-            {`Extra instructions added to answers on turns that actually pull content from this lake. They apply to you and to members of this lake's organization - not to users granted access by tag or entitlement - and never fire on turns that don't use the lake. Your organization's prompt stays authoritative on conflict, and only people who can manage this lake can read this text in the app.${
+            {`Extra instructions added to answers on turns that actually pull content from this lake. They apply to you, to members of this lake's organization, and to a manager testing it in a scoped session - not to users granted access by tag or entitlement - and never fire on turns that don't use the lake. Your organization's prompt stays authoritative on conflict, and only people who can manage this lake can read this text in the app.${
               // Count what SAVE will persist (trimmed), not the raw field contents.
               systemPrompt.trim() ? ` (${systemPrompt.trim().length} characters)` : ''
             }`}

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
@@ -313,9 +313,10 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
       });
       setTestScopeOpen(false);
     } catch (err) {
-      // The route's refusal (unmanaged lake, non-active lake, unbound API key) rides on
-      // response.data.error; axios's own `message` is just "Request failed with status code N",
-      // which renders those very different failures identical to whoever is testing the lake.
+      // The route's refusals (unmanaged lake, non-active lake, over the per-session cap) and any
+      // unexpected server exception both ride on response.data.error; axios's own `message` is just
+      // "Request failed with status code N", which renders those very different failures identical
+      // to whoever is testing the lake.
       const detail = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
       toast.error(detail || 'Could not start a test chat for this lake');
     } finally {

--- a/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx
@@ -312,8 +312,12 @@ export function DataLakeSettingsModal({ lake, onClose }: { lake: EditableLake | 
         preauthorizedLakeIds: scope.preauthorizedLakeIds,
       });
       setTestScopeOpen(false);
-    } catch {
-      toast.error('Could not start a test chat for this lake');
+    } catch (err) {
+      // The route's refusal (unmanaged lake, non-active lake, unbound API key) rides on
+      // response.data.error; axios's own `message` is just "Request failed with status code N",
+      // which renders those very different failures identical to whoever is testing the lake.
+      const detail = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      toast.error(detail || 'Could not start a test chat for this lake');
     } finally {
       setStartingTestChat(false);
     }

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.test.tsx
@@ -6,7 +6,7 @@ import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { TestLakeScopeDialog } from './TestLakeScopeDialog';
 
-type MockLake = { id: string; name: string; datalakeTag: string; isOwn?: boolean };
+type MockLake = { id: string; name: string; datalakeTag: string; isOwn?: boolean; canPreauthorize?: boolean };
 
 const useGetDataLakesMock = vi.fn<
   [],
@@ -22,8 +22,8 @@ const Wrapper = ({ children }: { children: ReactNode }) => (
 );
 
 const LAKES: MockLake[] = [
-  { id: 'lake-a', name: 'Alpha Lake', datalakeTag: 'datalake:alpha' },
-  { id: 'lake-b', name: 'Beta Lake', datalakeTag: 'datalake:beta', isOwn: false },
+  { id: 'lake-a', name: 'Alpha Lake', datalakeTag: 'datalake:alpha', canPreauthorize: true },
+  { id: 'lake-b', name: 'Beta Lake', datalakeTag: 'datalake:beta', isOwn: false, canPreauthorize: false },
 ];
 
 beforeEach(() => {
@@ -45,7 +45,50 @@ describe('TestLakeScopeDialog', () => {
     expect(screen.getByTestId('test-lake-scope-checkbox-lake-b').querySelector('input')).not.toBeChecked();
 
     await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
-    expect(onConfirm).toHaveBeenCalledWith(['datalake:alpha']);
+    expect(onConfirm).toHaveBeenCalledWith({
+      retrievalTags: ['datalake:alpha'],
+      preauthorizedLakeIds: ['lake-a'],
+    });
+  });
+
+  it('admits only the checked lakes the caller may pre-authorize, while scoping retrieval to all of them', async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={onConfirm} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByTestId('test-lake-scope-checkbox-lake-b').querySelector('input')!);
+    await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
+
+    // Both lakes narrow retrieval; only lake-a is admitted. Sending lake-b would 403 the whole
+    // request at /api/sessions/create, taking the working lake-a scoping down with it.
+    expect(onConfirm).toHaveBeenCalledWith({
+      retrievalTags: ['datalake:alpha', 'datalake:beta'],
+      preauthorizedLakeIds: ['lake-a'],
+    });
+  });
+
+  it('confirms with no admission when the caller may pre-authorize none of the checked lakes', async () => {
+    // The platform-admin-only maintainer: canManage would be true for these, canPreauthorize is not.
+    useGetDataLakesMock.mockReturnValue({
+      data: [{ id: 'lake-a', name: 'Alpha Lake', datalakeTag: 'datalake:alpha', canPreauthorize: false }],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <TestLakeScopeDialog anchorLakeId="lake-a" onClose={vi.fn()} onConfirm={onConfirm} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByTestId('test-lake-scope-confirm-btn'));
+    expect(onConfirm).toHaveBeenCalledWith({ retrievalTags: ['datalake:alpha'], preauthorizedLakeIds: [] });
   });
 
   it('marks a not-owned lake with the owner icon', () => {

--- a/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
+++ b/apps/client/app/components/DataLakeWizard/TestLakeScopeDialog.tsx
@@ -25,8 +25,11 @@ export interface TestLakeScopeDialogProps {
   /** The lake whose settings modal opened this dialog - checked by default. */
   anchorLakeId: string;
   onClose: () => void;
-  /** One `datalakeTag` per checked lake, the exact shape `retrievalTags` expects. */
-  onConfirm: (retrievalTags: string[]) => void;
+  /**
+   * `retrievalTags`: one `datalakeTag` per checked lake. `preauthorizedLakeIds`: the ids of the
+   * checked lakes this caller may ADMIT (see below) - a subset, frequently empty.
+   */
+  onConfirm: (scope: { retrievalTags: string[]; preauthorizedLakeIds: string[] }) => void;
   confirming?: boolean;
 }
 
@@ -66,6 +69,17 @@ export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirmi
   // error branch.
   const selectedTags = useMemo(
     () => (lakes ?? []).filter(l => selected.has(l.id)).map(l => l.datalakeTag),
+    [lakes, selected]
+  );
+
+  // The manage-but-not-member admission: without it a maintainer who is neither the lake's creator
+  // nor in its org tests the lake and gets an empty retrieval, which is the bug this dialog exists
+  // to expose. Filtered on `canPreauthorize`, NOT `canManage` - the latter includes the
+  // platform-admin rung, which /api/sessions/create refuses with a 403, so sending it would turn a
+  // degraded-but-working button into a hard failure. Ids the caller cannot admit are simply omitted;
+  // the route re-authorizes every id it does receive, so this filter is an affordance, not the gate.
+  const preauthorizedLakeIds = useMemo(
+    () => (lakes ?? []).filter(l => selected.has(l.id) && l.canPreauthorize).map(l => l.id),
     [lakes, selected]
   );
 
@@ -142,7 +156,7 @@ export function TestLakeScopeDialog({ anchorLakeId, onClose, onConfirm, confirmi
           <Button
             loading={confirming}
             disabled={selectedTags.length === 0 || isError}
-            onClick={() => onConfirm(selectedTags)}
+            onClick={() => onConfirm({ retrievalTags: selectedTags, preauthorizedLakeIds })}
             data-testid="test-lake-scope-confirm-btn"
           >
             Start test chat

--- a/apps/client/app/components/admin/Users/Details/AdminGenerateApiKeyModal.test.tsx
+++ b/apps/client/app/components/admin/Users/Details/AdminGenerateApiKeyModal.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import AdminGenerateApiKeyModal from './AdminGenerateApiKeyModal';
+
+const h = vi.hoisted(() => ({
+  lakes: [
+    { id: 'lakeA', name: 'Lake A' },
+    { id: 'lakeB', name: 'Lake B' },
+  ] as { id: string; name: string }[] | undefined,
+  lakesLoading: false,
+  lakesError: false,
+  refetchLakes: vi.fn(),
+  mutate: vi.fn(),
+}));
+
+vi.mock('@client/app/hooks/data/dataLakes', () => ({
+  useGetDataLakes: () => ({
+    data: h.lakes,
+    isLoading: h.lakesLoading,
+    isError: h.lakesError,
+    refetch: h.refetchLakes,
+  }),
+}));
+
+vi.mock('@client/app/hooks/data/userApiKeys', () => ({
+  useAdminGenerateApiKey: () => ({ mutate: h.mutate, isPending: false }),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const USER = { id: 'u1', username: 'target-user' } as never;
+
+const renderModal = () =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <AdminGenerateApiKeyModal open onClose={vi.fn()} user={USER} />
+    </CssVarsProvider>
+  );
+
+beforeEach(() => {
+  h.lakes = [
+    { id: 'lakeA', name: 'Lake A' },
+    { id: 'lakeB', name: 'Lake B' },
+  ];
+  h.lakesLoading = false;
+  h.lakesError = false;
+  h.refetchLakes.mockClear();
+  h.mutate.mockClear();
+});
+
+describe('AdminGenerateApiKeyModal - pre-authorized lakes', () => {
+  it('shows a loading state while lakes are fetching', () => {
+    h.lakesLoading = true;
+    renderModal();
+    expect(screen.getByTestId('admin-generate-key-lakes-loading')).toBeTruthy();
+  });
+
+  it('shows an error state with a retry when the lake fetch fails', () => {
+    h.lakesError = true;
+    renderModal();
+    expect(screen.getByTestId('admin-generate-key-lakes-error')).toBeTruthy();
+    fireEvent.click(screen.getByText('Retry'));
+    expect(h.refetchLakes).toHaveBeenCalled();
+  });
+
+  it('shows an empty state when there are no lakes', () => {
+    h.lakes = [];
+    renderModal();
+    expect(screen.getByText('No lakes yet')).toBeTruthy();
+  });
+
+  it('submits with no preauthorizedLakeIds when none are checked', () => {
+    renderModal();
+    fireEvent.change(screen.getByPlaceholderText(/Data Lake Upload/i), { target: { value: 'my key' } });
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    fireEvent.click(screen.getByText('Generate API Key'));
+
+    const call = h.mutate.mock.calls[0][0];
+    expect(call.data.preauthorizedLakeIds).toBeUndefined();
+  });
+
+  it('checking a lake includes its id, and unchecking removes it, in the submitted data', () => {
+    renderModal();
+    fireEvent.change(screen.getByPlaceholderText(/Data Lake Upload/i), { target: { value: 'my key' } });
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+
+    fireEvent.click(screen.getByTestId('admin-generate-key-lake-checkbox-lakeA').querySelector('input')!);
+    expect(screen.getByTestId('admin-generate-key-lakes-count').textContent).toContain('1 selected');
+
+    fireEvent.click(screen.getByTestId('admin-generate-key-lake-checkbox-lakeB').querySelector('input')!);
+    expect(screen.getByTestId('admin-generate-key-lakes-count').textContent).toContain('2 selected');
+
+    fireEvent.click(screen.getByText('Generate API Key'));
+    const call = h.mutate.mock.calls[0][0];
+    expect(call.data.preauthorizedLakeIds).toEqual(['lakeA', 'lakeB']);
+
+    fireEvent.click(screen.getByTestId('admin-generate-key-lake-checkbox-lakeA').querySelector('input')!);
+    expect(screen.getByTestId('admin-generate-key-lakes-count').textContent).toContain('1 selected');
+  });
+});

--- a/apps/client/app/components/admin/Users/Details/AdminGenerateApiKeyModal.tsx
+++ b/apps/client/app/components/admin/Users/Details/AdminGenerateApiKeyModal.tsx
@@ -1,5 +1,6 @@
 import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
-import { useAdminGenerateApiKey, CreateUserApiKeyRequest } from '@client/app/hooks/data/userApiKeys';
+import { useAdminGenerateApiKey, AdminCreateUserApiKeyRequest } from '@client/app/hooks/data/userApiKeys';
+import { useGetDataLakes } from '@client/app/hooks/data/dataLakes';
 import { useCopyToClipboard } from '@client/app/hooks/useCopyToClipboard';
 import { GENERIC_MODAL_API_KEY_SCOPES } from '@client/app/constants/apiKeyScopes';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -15,6 +16,7 @@ import {
   Modal,
   ModalDialog,
   Select,
+  Skeleton,
   Option,
   Stack,
   Typography,
@@ -35,7 +37,7 @@ const scopeOptions = GENERIC_MODAL_API_KEY_SCOPES;
 const scopeValues = scopeOptions.map(s => s.value);
 
 export default function AdminGenerateApiKeyModal({ open, onClose, user }: AdminGenerateApiKeyModalProps) {
-  const [formData, setFormData] = useState<CreateUserApiKeyRequest>({
+  const [formData, setFormData] = useState<AdminCreateUserApiKeyRequest>({
     name: '',
     scopes: [],
     rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
@@ -43,6 +45,8 @@ export default function AdminGenerateApiKeyModal({ open, onClose, user }: AdminG
   const [expirationDays, setExpirationDays] = useState<string>('never');
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const { handleCopyToClipboard, copied } = useCopyToClipboard({ showToast: true });
+  const { data: lakes, isLoading: lakesLoading, isError: lakesError, refetch: refetchLakes } = useGetDataLakes(open);
+  const preauthorizedLakeIds = formData.preauthorizedLakeIds ?? [];
 
   const generateMutation = useAdminGenerateApiKey({
     onSuccess: result => {
@@ -67,11 +71,21 @@ export default function AdminGenerateApiKeyModal({ open, onClose, user }: AdminG
   };
 
   const handleSubmit = () => {
-    const submitData: CreateUserApiKeyRequest = {
+    const submitData: AdminCreateUserApiKeyRequest = {
       ...formData,
       expiresAt: expirationDays === 'never' ? undefined : dayjs().add(parseInt(expirationDays), 'days').toDate(),
+      preauthorizedLakeIds: preauthorizedLakeIds.length > 0 ? preauthorizedLakeIds : undefined,
     };
     generateMutation.mutate({ userId: user.id, data: submitData });
+  };
+
+  const toggleLake = (lakeId: string) => {
+    setFormData({
+      ...formData,
+      preauthorizedLakeIds: preauthorizedLakeIds.includes(lakeId)
+        ? preauthorizedLakeIds.filter(id => id !== lakeId)
+        : [...preauthorizedLakeIds, lakeId],
+    });
   };
 
   const allScopesSelected = scopeOptions.every(s => formData.scopes.includes(s.value));
@@ -179,6 +193,59 @@ export default function AdminGenerateApiKeyModal({ open, onClose, user }: AdminG
                   </Typography>
                 </Box>
               ))}
+            </Box>
+          </FormControl>
+
+          <FormControl>
+            <FormLabel sx={{ mb: 0.5 }} data-testid="admin-generate-key-lakes-count">
+              Pre-authorized lakes ({preauthorizedLakeIds.length} selected)
+            </FormLabel>
+            <Typography level="body-xs" color="neutral" sx={{ mb: 1 }}>
+              Lets this key admit any of the checked lakes into a session it manages but is not a member of, on top of
+              the caller&apos;s ordinary access. Leave empty for a key with no such widening.
+            </Typography>
+            <Box
+              sx={{
+                maxHeight: '200px',
+                overflow: 'auto',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 'sm',
+                p: 1,
+              }}
+              data-testid="admin-generate-key-lakes-box"
+            >
+              {lakesLoading ? (
+                <Stack gap={1} data-testid="admin-generate-key-lakes-loading">
+                  {[0, 1].map(i => (
+                    <Skeleton key={i} variant="text" level="body-sm" />
+                  ))}
+                </Stack>
+              ) : lakesError ? (
+                <Stack gap={1} data-testid="admin-generate-key-lakes-error">
+                  <Typography level="body-sm" sx={{ color: 'danger.400' }}>
+                    Could not load lakes.
+                  </Typography>
+                  <Button size="sm" variant="outlined" color="neutral" onClick={() => refetchLakes()}>
+                    Retry
+                  </Button>
+                </Stack>
+              ) : (lakes?.length ?? 0) === 0 ? (
+                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                  No lakes yet
+                </Typography>
+              ) : (
+                lakes!.map(lake => (
+                  <Checkbox
+                    key={lake.id}
+                    size="sm"
+                    label={lake.name}
+                    checked={preauthorizedLakeIds.includes(lake.id)}
+                    onChange={() => toggleLake(lake.id)}
+                    data-testid={`admin-generate-key-lake-checkbox-${lake.id}`}
+                  />
+                ))
+              )}
             </Box>
           </FormControl>
 

--- a/apps/client/app/hooks/data/userApiKeys.ts
+++ b/apps/client/app/hooks/data/userApiKeys.ts
@@ -46,6 +46,15 @@ export interface CreateUserApiKeyRequest {
   branding?: IEmbedBranding;
 }
 
+/**
+ * Admin-only mint request: the self-service shape plus `preauthorizedLakeIds` (manage-but-not-member
+ * session admission, see pages/api/sessions/create.ts). Kept out of `CreateUserApiKeyRequest` so the
+ * self-service mint path can't accept this field even at the type level.
+ */
+export interface AdminCreateUserApiKeyRequest extends CreateUserApiKeyRequest {
+  preauthorizedLakeIds?: string[];
+}
+
 /** Configure an existing embed key - only the provided fields change. */
 export interface UpdateEmbedKeyRequest {
   keyId: string;
@@ -162,7 +171,7 @@ export function useUpdateEmbedKey({ onSuccess }: { onSuccess?: () => void } = {}
 export function useAdminGenerateApiKey({ onSuccess }: { onSuccess?: (result: CreateUserApiKeyResponse) => void } = {}) {
   const queryClient = useQueryClient();
 
-  return useMutation<CreateUserApiKeyResponse, Error, { userId: string; data: CreateUserApiKeyRequest }>({
+  return useMutation<CreateUserApiKeyResponse, Error, { userId: string; data: AdminCreateUserApiKeyRequest }>({
     mutationFn: async ({ userId, data }) => {
       const response = await api.post(`/api/admin/users/${userId}/generate-api-key`, data);
       return response.data;

--- a/apps/client/app/hooks/useStartChatWithLake.test.tsx
+++ b/apps/client/app/hooks/useStartChatWithLake.test.tsx
@@ -60,18 +60,19 @@ describe('useStartChatWithLake (single lake)', () => {
 });
 
 describe('useStartChatWithLakes (multi-lake subset)', () => {
-  it('sends retrievalTags and forceKnowledgeRetrieval only - no dataLakeId, no corpusGroundingMode', async () => {
+  it('sends retrievalTags, forceKnowledgeRetrieval, and the given groundingMode - no dataLakeId', async () => {
     apiPost.mockResolvedValue({ data: { id: 'session-2' } });
     const { result } = renderWithClient(() => useStartChatWithLakes());
 
     await act(async () => {
-      await result.current({ retrievalTags: ['datalake:a', 'datalake:b'] });
+      await result.current({ retrievalTags: ['datalake:a', 'datalake:b'], groundingMode: 'inline' });
     });
 
     expect(apiPost).toHaveBeenCalledWith('/api/sessions/create', {
       name: 'New Notebook',
       retrievalTags: ['datalake:a', 'datalake:b'],
       forceKnowledgeRetrieval: true,
+      corpusGroundingMode: 'inline',
     });
     expect(setCurrentSession).toHaveBeenCalledWith({ id: 'session-2' });
   });
@@ -82,7 +83,7 @@ describe('useStartChatWithLakes (multi-lake subset)', () => {
 
     await expect(
       act(async () => {
-        await result.current({ retrievalTags: ['datalake:a'] });
+        await result.current({ retrievalTags: ['datalake:a'], groundingMode: 'retrieve' });
       })
     ).rejects.toThrow('network down');
     expect(setCurrentSession).not.toHaveBeenCalled();

--- a/apps/client/app/hooks/useStartChatWithLake.test.tsx
+++ b/apps/client/app/hooks/useStartChatWithLake.test.tsx
@@ -77,6 +77,46 @@ describe('useStartChatWithLakes (multi-lake subset)', () => {
     expect(setCurrentSession).toHaveBeenCalledWith({ id: 'session-2' });
   });
 
+  it('sends preauthorizedLakeIds when the caller may admit some of the checked lakes', async () => {
+    apiPost.mockResolvedValue({ data: { id: 'session-3' } });
+    const { result } = renderWithClient(() => useStartChatWithLakes());
+
+    await act(async () => {
+      await result.current({
+        retrievalTags: ['datalake:a', 'datalake:b'],
+        groundingMode: 'retrieve',
+        preauthorizedLakeIds: ['lake-a'],
+      });
+    });
+
+    expect(apiPost).toHaveBeenCalledWith('/api/sessions/create', {
+      name: 'New Notebook',
+      retrievalTags: ['datalake:a', 'datalake:b'],
+      forceKnowledgeRetrieval: true,
+      corpusGroundingMode: 'retrieve',
+      preauthorizedLakeIds: ['lake-a'],
+    });
+  });
+
+  it('omits preauthorizedLakeIds entirely when the admission list is empty', async () => {
+    // An empty array must not appear in the body: the route treats a present-but-empty list as a
+    // request to admit nothing, and an ordinary test session's payload should be byte-identical to
+    // what it was before the admission existed.
+    apiPost.mockResolvedValue({ data: { id: 'session-4' } });
+    const { result } = renderWithClient(() => useStartChatWithLakes());
+
+    await act(async () => {
+      await result.current({ retrievalTags: ['datalake:a'], groundingMode: 'retrieve', preauthorizedLakeIds: [] });
+    });
+
+    expect(apiPost).toHaveBeenCalledWith('/api/sessions/create', {
+      name: 'New Notebook',
+      retrievalTags: ['datalake:a'],
+      forceKnowledgeRetrieval: true,
+      corpusGroundingMode: 'retrieve',
+    });
+  });
+
   it('propagates a request failure so the caller can surface its own error UX', async () => {
     apiPost.mockRejectedValue(new Error('network down'));
     const { result } = renderWithClient(() => useStartChatWithLakes());

--- a/apps/client/app/hooks/useStartChatWithLake.ts
+++ b/apps/client/app/hooks/useStartChatWithLake.ts
@@ -73,6 +73,13 @@ export default function useStartChatWithLake() {
  * lake-defaults merge for it to override. Callers pass the lake's own `groundingMode` (falling back
  * to `DEFAULT_DATA_LAKE_GROUNDING_MODE`, mirroring resolveLakeSessionDefaults) so the test session
  * actually exercises what the lake is configured to do, rather than the size-only deferral default.
+ *
+ * `preauthorizedLakeIds` is the manage-but-not-member admission: a maintainer who is neither the
+ * lake's creator nor a member of its org otherwise gets an empty retrieval here, which is precisely
+ * the state a test session exists to disprove. Callers pass only ids the list marked
+ * `canPreauthorize` - /api/sessions/create re-authorizes each one live and 403s on any it refuses,
+ * so an unfiltered list would fail the whole request rather than degrade. Omitted when empty so an
+ * ordinary test session's body is unchanged.
  */
 export function useStartChatWithLakes() {
   const { setCurrentSession, setCurrentSessionId } = useSessions();
@@ -81,13 +88,18 @@ export function useStartChatWithLakes() {
   const closeManager = useDataLakeWizardStore(s => s.closeManager);
 
   return useCallback(
-    async (params: { retrievalTags: string[]; groundingMode: DataLakeGroundingMode }): Promise<ISessionDocument> =>
+    async (params: {
+      retrievalTags: string[];
+      groundingMode: DataLakeGroundingMode;
+      preauthorizedLakeIds?: string[];
+    }): Promise<ISessionDocument> =>
       createAndOpenSession(
         {
           name: 'New Notebook',
           retrievalTags: params.retrievalTags,
           forceKnowledgeRetrieval: true,
           corpusGroundingMode: params.groundingMode,
+          ...(params.preauthorizedLakeIds?.length ? { preauthorizedLakeIds: params.preauthorizedLakeIds } : {}),
         },
         { queryClient, setCurrentSession, setCurrentSessionId, closeManager, navigate }
       ),

--- a/apps/client/app/hooks/useStartChatWithLake.ts
+++ b/apps/client/app/hooks/useStartChatWithLake.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
-import type { ISessionDocument } from '@bike4mind/common';
+import type { DataLakeGroundingMode, ISessionDocument } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
 import { useSessions } from '@client/app/contexts/SessionsContext';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
@@ -68,11 +68,11 @@ export default function useStartChatWithLake() {
  * for the single-lake `dataLakeId` path (sessionService/resolveLakeSessionDefaults.ts). Omitting
  * them would silently create an unscoped, non-retrieving session.
  *
- * `corpusGroundingMode` is deliberately NOT sent: /api/sessions/create strips any client-sent value
- * before the merge and only the `dataLakeId` arm re-supplies one, so a subset request cannot set it
- * at all. The test session inherits the size-only deferral default instead of the lake's configured
- * mode - invisible on the empty session created here, and only divergent once files are attached to
- * it. Carrying the mode through needs that server-side strip relaxed, not another client field.
+ * `corpusGroundingMode` IS sent: naming a lake subset by `retrievalTags` alone (no `dataLakeId`) is
+ * exactly the case /api/sessions/create trusts a client-sent mode for, since there is no later
+ * lake-defaults merge for it to override. Callers pass the lake's own `groundingMode` (falling back
+ * to `DEFAULT_DATA_LAKE_GROUNDING_MODE`, mirroring resolveLakeSessionDefaults) so the test session
+ * actually exercises what the lake is configured to do, rather than the size-only deferral default.
  */
 export function useStartChatWithLakes() {
   const { setCurrentSession, setCurrentSessionId } = useSessions();
@@ -81,12 +81,13 @@ export function useStartChatWithLakes() {
   const closeManager = useDataLakeWizardStore(s => s.closeManager);
 
   return useCallback(
-    async (params: { retrievalTags: string[] }): Promise<ISessionDocument> =>
+    async (params: { retrievalTags: string[]; groundingMode: DataLakeGroundingMode }): Promise<ISessionDocument> =>
       createAndOpenSession(
         {
           name: 'New Notebook',
           retrievalTags: params.retrievalTags,
           forceKnowledgeRetrieval: true,
+          corpusGroundingMode: params.groundingMode,
         },
         { queryClient, setCurrentSession, setCurrentSessionId, closeManager, navigate }
       ),

--- a/apps/client/global.d.ts
+++ b/apps/client/global.d.ts
@@ -17,6 +17,13 @@ declare global {
       billingOwnerType?: ApiKeyBillingOwnerType;
       /** Organization the key bills, present iff billingOwnerType is Organization. */
       organizationId?: string;
+      /**
+       * Lake ids this key is bound to for the manage-but-not-member session admission
+       * (`preauthorizedLakeIds` on a session). Admin-minted only. A request from this key that
+       * names a `preauthorizedLakeIds` id outside this set is refused at session-create, even when
+       * the underlying user could otherwise manage that lake.
+       */
+      preauthorizedLakeIds?: string[];
     }
 
     interface ApiKeyUsageInfo {

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
@@ -137,4 +137,25 @@ describe('POST /api/admin/users/:userId/generate-api-key - scope allowlist guard
     await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
     expect(mockCreateKey).not.toHaveBeenCalled();
   });
+
+  it('forwards preauthorizedLakeIds to the service', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: ['lake1', 'lake2'] });
+    await mockRefs.postHandler!(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      'target-user',
+      expect.objectContaining({ preauthorizedLakeIds: ['lake1', 'lake2'] }),
+      expect.anything()
+    );
+  });
+
+  it('omits preauthorizedLakeIds from the service call when not given', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] });
+    await mockRefs.postHandler!(req, res);
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      'target-user',
+      expect.objectContaining({ preauthorizedLakeIds: undefined }),
+      expect.anything()
+    );
+  });
 });

--- a/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
+++ b/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
@@ -30,6 +30,8 @@ interface CreateApiKeyBody {
     requestsPerMinute: number;
     requestsPerDay: number;
   };
+  /** Lake ids to bind this key to for the manage-but-not-member session admission. Admin-only. */
+  preauthorizedLakeIds?: string[];
 }
 
 /**
@@ -57,7 +59,7 @@ const handler = baseApi({ auth: true })
         throw new BadRequestError('User not found');
       }
 
-      const { name, scopes, expiresAt, rateLimit } = req.body as CreateApiKeyBody;
+      const { name, scopes, expiresAt, rateLimit, preauthorizedLakeIds } = req.body as CreateApiKeyBody;
 
       // Reject any scope outside the mintable allowlist, including admin:* and cc-bridge:connect.
       const requestedScopes = Array.isArray(scopes) ? scopes : [];
@@ -73,6 +75,7 @@ const handler = baseApi({ auth: true })
           scopes: scopes as Parameters<typeof userApiKeyService.createUserApiKey>[1]['scopes'],
           expiresAt: expiresAt ? new Date(expiresAt) : undefined,
           rateLimit,
+          preauthorizedLakeIds,
           metadata: {
             clientIP: req.ip,
             userAgent: req.headers['user-agent'],

--- a/apps/client/pages/api/data-lakes/index.ts
+++ b/apps/client/pages/api/data-lakes/index.ts
@@ -5,6 +5,7 @@ import {
   dataLakeRepository,
   dataLakeAccessGrantRepository,
   dataLakeProposalRepository,
+  organizationRepository,
   userRepository,
   adminSettingsRepository,
   fallbackLakeSettingsRepository,
@@ -39,6 +40,9 @@ const handler = baseApi()
       // the queue's only discovery surface - without it a reviewer has to open a lake's settings to
       // learn whether anything is waiting, which nobody does unprompted.
       dataLakeProposals: dataLakeProposalRepository,
+      // Org repo: resolves the org-admin rung of `canPreauthorize` for an admin caller, whose
+      // ctx.administeredOrgIds is deliberately zeroed. Without it that rung goes dark on this list.
+      organizations: organizationRepository,
     };
     // Admins see all data lakes; non-admins see only those they can access (owner/org/tag).
     const dataLakes = ctx.isAdmin

--- a/apps/client/pages/api/sessions/__tests__/create-grounding-gate.test.ts
+++ b/apps/client/pages/api/sessions/__tests__/create-grounding-gate.test.ts
@@ -95,6 +95,16 @@ describe('POST /api/sessions/create - corpusGroundingMode gate', () => {
     expect(h.assertLakeAccess).not.toHaveBeenCalled();
   });
 
+  it('strips a client-sent mode when retrievalTags is present but empty', async () => {
+    const { res } = makeRes();
+
+    await run(post({ name: 'N', retrievalTags: [], corpusGroundingMode: 'inline' }), res);
+
+    // An empty array names no lake, so it belongs on the ordinary-session branch rather than the
+    // tags-only exception that trusts the caller's mode.
+    expect('corpusGroundingMode' in paramsOf()).toBe(false);
+  });
+
   it('strips a client-sent mode when dataLakeId is set, even alongside retrievalTags, so the lake wins', async () => {
     h.assertLakeAccess.mockResolvedValue({ datalakeTag: 'datalake:acme', groundingMode: 'inline' });
     const { res } = makeRes();

--- a/apps/client/pages/api/sessions/__tests__/create-grounding-gate.test.ts
+++ b/apps/client/pages/api/sessions/__tests__/create-grounding-gate.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * corpusGroundingMode is resolved server-side and must never let a hand-built request pin a mode
+ * the server did not choose - except the one case where naming a lake BY TAGS (retrievalTags, no
+ * dataLakeId) is itself the caller's deliberate act of choosing what to test, and there is no later
+ * lake-defaults merge for a client value to override.
+ */
+const h = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  assertLakeAccess: vi.fn(),
+  toAccessContext: vi.fn(),
+  findByIdAndUpdate: vi.fn(),
+  logEvent: vi.fn(),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const routes: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign((req: { method?: string }, res: unknown) => routes[req.method ?? 'POST']?.(req, res), {
+      use: () => chain,
+      post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((routes.POST = fns[fns.length - 1]), chain),
+    });
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/asyncHandler', () => ({ asyncHandler: (fn: unknown) => fn }));
+vi.mock('@bike4mind/database', () => ({
+  dataLakeRepository: {},
+  dataLakeAccessGrantRepository: {
+    listByLake: vi.fn().mockResolvedValue([]),
+    listActiveByLakes: vi.fn().mockResolvedValue([]),
+    listByPrincipal: vi.fn().mockResolvedValue([]),
+    findGrant: vi.fn().mockResolvedValue(null),
+    upsertGrant: vi.fn().mockResolvedValue({}),
+    removeGrant: vi.fn().mockResolvedValue(true),
+    removeAllForLake: vi.fn().mockResolvedValue(0),
+  },
+  organizationRepository: { findIdsWithAdminRights: vi.fn().mockResolvedValue([]) },
+  projectRepository: {},
+  sessionRepository: {},
+  fabFileRepository: {},
+  fallbackLakeSettingsRepository: {},
+  userRepository: {},
+  activityRepository: {},
+  User: { findByIdAndUpdate: h.findByIdAndUpdate },
+}));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: h.logEvent }));
+vi.mock('@server/dataLakes/toAccessContext', () => ({ toAccessContext: h.toAccessContext }));
+vi.mock('@client/config/activities', () => ({ ActivityType: { NOTEBOOK_ADDED_TO_PROJECT: 'added' } }));
+vi.mock('@bike4mind/services', () => ({
+  sessionService: {
+    createSession: h.createSession,
+    resolveLakeSessionDefaults: (lake: { datalakeTag: string; groundingMode?: string }) => ({
+      retrievalTags: [lake.datalakeTag],
+      corpusGroundingMode: lake.groundingMode,
+    }),
+  },
+  dataLakeService: { assertLakeAccess: h.assertLakeAccess, resolveCanManageLake: vi.fn() },
+  projectService: { get: vi.fn() },
+}));
+
+import handler from '../create';
+
+const makeRes = () => {
+  const json = vi.fn();
+  return { res: { json, status: vi.fn(() => ({ json })) } as never, json };
+};
+const post = (body: Record<string, unknown>) => ({ method: 'POST', user: { id: 'u1' }, ability: {}, body }) as never;
+const run = (req: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(req, res);
+const paramsOf = () => h.createSession.mock.calls[0][1] as Record<string, unknown>;
+
+describe('POST /api/sessions/create - corpusGroundingMode gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.createSession.mockResolvedValue({ id: 's1', name: 'New Notebook', knowledgeIds: [], agentIds: [] });
+    h.findByIdAndUpdate.mockResolvedValue(undefined);
+    h.toAccessContext.mockResolvedValue({ userId: 'u1', isAdmin: false, userTags: [] });
+  });
+
+  it('strips a client-sent mode on an ordinary session (no retrievalTags, no dataLakeId)', async () => {
+    const { res } = makeRes();
+
+    await run(post({ name: 'N', corpusGroundingMode: 'inline' }), res);
+
+    expect('corpusGroundingMode' in paramsOf()).toBe(false);
+  });
+
+  it('keeps a client-sent mode when the session names a lake only by retrievalTags', async () => {
+    const { res } = makeRes();
+
+    await run(post({ name: 'N', retrievalTags: ['datalake:acme'], corpusGroundingMode: 'inline' }), res);
+
+    expect(paramsOf().corpusGroundingMode).toBe('inline');
+    expect(h.assertLakeAccess).not.toHaveBeenCalled();
+  });
+
+  it('strips a client-sent mode when dataLakeId is set, even alongside retrievalTags, so the lake wins', async () => {
+    h.assertLakeAccess.mockResolvedValue({ datalakeTag: 'datalake:acme', groundingMode: 'inline' });
+    const { res } = makeRes();
+
+    await run(
+      post({ name: 'N', dataLakeId: 'acme', retrievalTags: ['mock:tag'], corpusGroundingMode: 'retrieve' }),
+      res
+    );
+
+    // The lake's own mode, not the client-sent 'retrieve' - proves the client value never reached
+    // the merge rather than merely losing a tie against an identical lake default.
+    expect(paramsOf().corpusGroundingMode).toBe('inline');
+  });
+});

--- a/apps/client/pages/api/sessions/__tests__/create-preauthorized-lake.test.ts
+++ b/apps/client/pages/api/sessions/__tests__/create-preauthorized-lake.test.ts
@@ -183,3 +183,45 @@ describe('POST /api/sessions/create - preauthorizedLakeIds', () => {
     expect(h.sessionUpdate).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /api/sessions/create - preauthorizedLakeIds API key containment', () => {
+  const postAsApiKey = (body: Record<string, unknown>, apiKeyInfo: { preauthorizedLakeIds?: string[] }) =>
+    ({ method: 'POST', user: { id: 'u1' }, ability: {}, body, apiKeyInfo }) as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.createSession.mockResolvedValue({ id: 's1', name: 'New Notebook', knowledgeIds: [], agentIds: [] });
+    h.findByIdAndUpdate.mockResolvedValue(undefined);
+    h.findIdsWithAdminRights.mockResolvedValue([]);
+    h.findById.mockResolvedValue({ id: LAKE_ID, status: 'active', createdByUserId: 'other', organizationId: 'org1' });
+    h.sessionUpdate.mockResolvedValue({ preauthorizedLakeIds: [LAKE_ID] });
+    h.resolveCanManageLake.mockResolvedValue(true);
+  });
+
+  it('rejects a lake the API key is not bound to, even though the underlying user manages it', async () => {
+    const { res } = makeRes();
+
+    await expect(
+      run(postAsApiKey({ name: 'N', preauthorizedLakeIds: [LAKE_ID] }, { preauthorizedLakeIds: [MISSING_ID] }), res)
+    ).rejects.toThrow(`This API key is not bound to data lake ${LAKE_ID}`);
+    expect(h.resolveCanManageLake).not.toHaveBeenCalled();
+    expect(h.createSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a lake entirely when the key carries no preauthorizedLakeIds binding at all', async () => {
+    const { res } = makeRes();
+
+    await expect(run(postAsApiKey({ name: 'N', preauthorizedLakeIds: [LAKE_ID] }, {}), res)).rejects.toThrow(
+      `This API key is not bound to data lake ${LAKE_ID}`
+    );
+  });
+
+  it('admits a lake the API key is bound to, still subject to the manage check', async () => {
+    const { res } = makeRes();
+
+    await run(postAsApiKey({ name: 'N', preauthorizedLakeIds: [LAKE_ID] }, { preauthorizedLakeIds: [LAKE_ID] }), res);
+
+    expect(h.resolveCanManageLake).toHaveBeenCalled();
+    expect(h.sessionUpdate).toHaveBeenCalledWith({ id: 's1', preauthorizedLakeIds: [LAKE_ID] });
+  });
+});

--- a/apps/client/pages/api/sessions/__tests__/create-preauthorized-lake.test.ts
+++ b/apps/client/pages/api/sessions/__tests__/create-preauthorized-lake.test.ts
@@ -98,6 +98,19 @@ describe('POST /api/sessions/create - preauthorizedLakeIds', () => {
     expect(h.sessionUpdate).toHaveBeenCalledWith({ id: 's1', preauthorizedLakeIds: [LAKE_ID] });
   });
 
+  it('rejects a lake that resolves but is not active', async () => {
+    h.findById.mockResolvedValue({ id: LAKE_ID, status: 'draft', createdByUserId: 'other', organizationId: 'org1' });
+    h.resolveCanManageLake.mockResolvedValue(true);
+    const { res } = makeRes();
+
+    await expect(run(post({ name: 'N', preauthorizedLakeIds: [LAKE_ID] }), res)).rejects.toThrow(
+      `Data lake ${LAKE_ID} not found`
+    );
+    // The manage check runs after the status test and is mocked to PASS here, so the refusal can
+    // only have come from the status guard - not from a manage failure wearing the same message.
+    expect(h.resolveCanManageLake).not.toHaveBeenCalled();
+  });
+
   it('rejects the request when the caller does not manage the lake, rather than dropping the id', async () => {
     h.resolveCanManageLake.mockResolvedValue(false);
     const { res } = makeRes();

--- a/apps/client/pages/api/sessions/create.ts
+++ b/apps/client/pages/api/sessions/create.ts
@@ -42,12 +42,17 @@ const handler = baseApi().post(
     const body = req.body as CreateSessionBody;
     const { projectId } = body;
 
-    // corpusGroundingMode is resolved server-side from the lake (resolveLakeSessionDefaults), never
-    // client-supplied. Strip any value a hand-built body carries BEFORE the merge below, so it can
-    // neither override a lake editor's deliberate per-lake mode (body would otherwise win the spread)
-    // nor pin a mode on an ordinary non-lake session and switch off size-based deferral there. The
-    // lake arm re-sets it from the lake; a non-lake session is left with no mode (size-only behavior).
-    delete body.corpusGroundingMode;
+    // corpusGroundingMode is resolved server-side from the lake (resolveLakeSessionDefaults) whenever
+    // a lake is named, never client-supplied for one: strip it unconditionally when `dataLakeId` is
+    // set so a lake editor's deliberate per-lake mode always wins the merge below. The one caller
+    // trusted to set it directly is a session that names a lake ONLY by `retrievalTags` (no
+    // `dataLakeId`) - e.g. "test this lake" - where there is no later lake-defaults merge to be
+    // overridden and the mode is the caller's own choice of what to test. An ordinary non-lake
+    // session (neither field set) still has it stripped, leaving no mode (size-only behavior).
+    const namesALakeByTagsOnly = !body.dataLakeId && Array.isArray(body.retrievalTags) && body.retrievalTags.length > 0;
+    if (!namesALakeByTagsOnly) {
+      delete body.corpusGroundingMode;
+    }
 
     // Manage-but-not-member admission: a lake maintainer who is not a member of the lake's org (or
     // does not otherwise pass the ordinary tag/entitlement gate) can still test it, for exactly this
@@ -87,6 +92,14 @@ const handler = baseApi().post(
         // zod schema, so nothing upstream has checked the shape.
         if (!isValidObjectId(lakeId)) {
           throw new NotFoundError(`Data lake ${lakeId} not found`);
+        }
+        // A key that widens the caller's own manage rights would otherwise let a leaked API key
+        // reach every lake its minting user manages, not just the lakes the key was bound to at
+        // mint time. This is IN ADDITION to the canManageLake check below, never instead of it - the
+        // key binding narrows what the underlying user's authority may be used for, it never grants
+        // authority the user lacks.
+        if (req.apiKeyInfo && !req.apiKeyInfo.preauthorizedLakeIds?.includes(lakeId)) {
+          throw new ForbiddenError(`This API key is not bound to data lake ${lakeId}`);
         }
         const lake = await dataLakeRepository.findById(lakeId);
         if (!lake || lake.status !== 'active') {

--- a/apps/client/server/middlewares/apiKeyAuth.test.ts
+++ b/apps/client/server/middlewares/apiKeyAuth.test.ts
@@ -109,3 +109,40 @@ describe('apiKeyAuth scope gate', () => {
     expect((await run(undefined, makeReq())).passed).toBe(true);
   });
 });
+
+describe('apiKeyAuth preauthorizedLakeIds binding', () => {
+  const bindingOf = (req: Request) =>
+    (req as Request & { apiKeyInfo?: { preauthorizedLakeIds?: string[] } }).apiKeyInfo?.preauthorizedLakeIds;
+
+  const validation = (extra: Record<string, unknown> = {}) => ({
+    isValid: true,
+    keyId: 'key-1',
+    userId: 'user-1',
+    scopes: [ApiKeyScope.AI_CHAT],
+    rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
+    ...extra,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findByIdMock.mockResolvedValue({ id: 'user-1', isBanned: false });
+  });
+
+  it('copies the key binding from the validation onto req.apiKeyInfo', async () => {
+    validateUserApiKeyMock.mockResolvedValue(validation({ preauthorizedLakeIds: ['lake-a'] }));
+    const req = makeReq();
+
+    expect((await run(undefined, req)).passed).toBe(true);
+    // /api/sessions/create reads this to refuse any lake the key was not bound to at mint time.
+    // Dropping it here fails that containment OPEN for every bound key.
+    expect(bindingOf(req)).toEqual(['lake-a']);
+  });
+
+  it('leaves the binding undefined for a key that carries none', async () => {
+    validateUserApiKeyMock.mockResolvedValue(validation());
+    const req = makeReq();
+
+    expect((await run(undefined, req)).passed).toBe(true);
+    expect(bindingOf(req)).toBeUndefined();
+  });
+});

--- a/apps/client/server/middlewares/apiKeyAuth.ts
+++ b/apps/client/server/middlewares/apiKeyAuth.ts
@@ -131,6 +131,7 @@ export const apiKeyAuth = (requiredScopes?: ApiKeyScope[]) => {
         productId: validation.productId,
         billingOwnerType: validation.billingOwnerType,
         organizationId: validation.organizationId,
+        preauthorizedLakeIds: validation.preauthorizedLakeIds,
       };
 
       // Create CASL ability for the user

--- a/apps/client/types/api.ts
+++ b/apps/client/types/api.ts
@@ -59,8 +59,9 @@ export const CreateSessionRequestSchema = z.object({
   forceKnowledgeRetrieval: z.boolean().optional(),
   retrievalTags: z.array(z.string()).optional(),
   // Resolved from the lake by the create route (resolveLakeSessionDefaults) so the merged create
-  // params carry it through to core; declared here for the shared type only. NOT client-supplied:
-  // the route strips any client-sent value, so the lake stays authoritative for the grounding mode.
+  // params carry it through to core; declared here for the shared type only. The route strips a
+  // client-sent value whenever `dataLakeId` is set, leaving the lake authoritative; a session that
+  // names a lake by `retrievalTags` alone is the one case where the caller's own mode survives.
   corpusGroundingMode: z.enum(DATA_LAKE_GROUNDING_MODES).optional(),
   retrievalExcludeFilenameMarkers: z
     .array(z.string().trim().min(1).max(RETRIEVAL_EXCLUDE_MARKER_MAX_LENGTH))

--- a/b4m-core/common/src/constants/dataLakes.ts
+++ b/b4m-core/common/src/constants/dataLakes.ts
@@ -418,6 +418,24 @@ export interface ManageableDataLakeConfig extends DataLakeConfig {
    */
   isOwn: boolean;
   /**
+   * Whether the caller may name this lake in `preauthorizedLakeIds` at session create - i.e. the
+   * manage-but-not-member admission that lets a maintainer ground a scoped session on a lake the
+   * ordinary tag/entitlement gate would not give them.
+   *
+   * NOT the same predicate as `canManage`, and the difference is the point: this one is resolved
+   * with `isAdmin: false`, exactly as `pages/api/sessions/create.ts` and `filterStillManagedLakes`
+   * both resolve it. Platform-admin is deliberately not an admission rung there (the admission
+   * widens FILE retrieval, not just prompt injection - see unionPreauthorizedLakeAccess), so a
+   * platform admin who holds no other rung on the lake gets `canManage: true` and
+   * `canPreauthorize: false`. The UI must gate the admission on THIS field: gating on `canManage`
+   * would send ids the route rejects with a 403.
+   *
+   * REQUIRED for the same reason as `isOwn`: a projection that forgot it would silently send no
+   * admission and reintroduce the bug with a green typecheck. Built-in fallback lakes have no
+   * document (session-create resolves ids via `findById`), so `false`.
+   */
+  canPreauthorize: boolean;
+  /**
    * Display name (name || username, never email) of the lake's creator. Populated ONLY for lakes
    * the caller does NOT own, and ONLY when the list projection was given a user lookup (the
    * manager list route) - the content-scope resolver and Slack omit it and pay for no extra

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -433,6 +433,16 @@ export const RetrievalSummarySchema = z.object({
   injectedLakePromptIds: z.array(z.string()).optional(),
   /** mementoCount/mementoIds precedent: mirrors injectedLakePromptIds.length. */
   injectedLakePromptCount: z.number().optional(),
+  /**
+   * Which of this turn's injected lake prompt ids came from a session's pre-authorized (manage-
+   * but-not-member admission) set, rather than the caller's ordinary accessible lakes - see
+   * unionPreauthorizedLakeAccess and pages/api/sessions/create.ts. A subset of injectedLakePromptIds,
+   * never a superset. Lets a turn that actually used the widening be asserted directly, instead of
+   * inferred from the session's static `preauthorizedLakeIds` (which records what was ADMITTED, not
+   * what a given turn actually injected). Absent means no pre-authorized id was among this turn's
+   * injections - including every turn on a session with no pre-authorization at all.
+   */
+  preauthorizedLakeIdsUsed: z.array(z.string()).optional(),
 });
 
 /**

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -434,13 +434,15 @@ export const RetrievalSummarySchema = z.object({
   /** mementoCount/mementoIds precedent: mirrors injectedLakePromptIds.length. */
   injectedLakePromptCount: z.number().optional(),
   /**
-   * Which of this turn's injected lake prompt ids came from a session's pre-authorized (manage-
-   * but-not-member admission) set, rather than the caller's ordinary accessible lakes - see
-   * unionPreauthorizedLakeAccess and pages/api/sessions/create.ts. A subset of injectedLakePromptIds,
-   * never a superset. Lets a turn that actually used the widening be asserted directly, instead of
-   * inferred from the session's static `preauthorizedLakeIds` (which records what was ADMITTED, not
-   * what a given turn actually injected). Absent means no pre-authorized id was among this turn's
-   * injections - including every turn on a session with no pre-authorization at all.
+   * Which of this turn's injected lake prompt ids were BOTH in the session's pre-authorized (manage-
+   * but-not-member admission) set AND injected on this turn - see unionPreauthorizedLakeAccess and
+   * pages/api/sessions/create.ts. A subset of injectedLakePromptIds, never a superset. Narrows the
+   * session's static `preauthorizedLakeIds` (what was ADMITTED) to what a given turn actually used.
+   *
+   * MEMBERSHIP, NOT CAUSATION. An admitted lake the caller could already reach - its creator, or a
+   * member of its org - injects through the ordinary trust arm and is listed here all the same, so a
+   * non-empty value does not prove the admission is what made the injection possible. Absent means no
+   * admitted id was among this turn's injections, including every turn on a session with none.
    */
   preauthorizedLakeIdsUsed: z.array(z.string()).optional(),
 });

--- a/b4m-core/common/src/types/entities/UserApiKeyTypes.ts
+++ b/b4m-core/common/src/types/entities/UserApiKeyTypes.ts
@@ -168,6 +168,14 @@ export interface IUserApiKey {
   agentId?: string;
   /** https origin allow-list for an embed key (normalized, deduped, capped at EMBED_ORIGINS_MAX). */
   allowedOrigins?: string[];
+  /**
+   * Lake ids this key is bound to for the manage-but-not-member session admission (see
+   * `preauthorizedLakeIds` on the session, and its containment check at
+   * pages/api/sessions/create.ts). Admin-minted only; a key's presence in this list is not itself
+   * authority to admit a lake - the caller must still pass the live canManageLake check on every
+   * request, this only narrows which lakes that authority may be exercised for.
+   */
+  preauthorizedLakeIds?: string[];
   /** Optional white-label config for an embed key (see {@link IEmbedBranding}). */
   branding?: IEmbedBranding;
   /**

--- a/b4m-core/services/src/dataLakeService/listDataLakes.canPreauthorize.test.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.canPreauthorize.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AccessContext, IDataLakeDocument } from '@bike4mind/common';
+import { listDataLakes, listAllDataLakes } from './listDataLakes';
+
+const ctx = (overrides: Partial<AccessContext> = {}): AccessContext => ({
+  userId: 'someone',
+  isAdmin: false,
+  userTags: [],
+  organizationIds: [],
+  ...overrides,
+});
+
+const lake = (overrides: Partial<IDataLakeDocument> = {}): IDataLakeDocument =>
+  ({
+    id: 'lake1',
+    name: 'Lake',
+    slug: 'lake',
+    fileTagPrefix: 'lk:',
+    datalakeTag: 'datalake:lake',
+    createdByUserId: 'owner',
+    status: 'active',
+    ...overrides,
+  }) as IDataLakeDocument;
+
+const grantRepo = (rows: Record<string, unknown>[] = []) => ({
+  listActiveByLakes: vi.fn().mockResolvedValue(rows),
+  listByPrincipal: vi.fn().mockResolvedValue([]),
+});
+
+describe('listDataLakes / listAllDataLakes - canPreauthorize', () => {
+  it('is FALSE for a platform admin holding no other rung, while canManage stays true', async () => {
+    // The originally-reported shape: an admin-created lake with no organizationId, whose only manage
+    // rung is platform-admin. The affordance must go dark rather than send an id session-create 403s.
+    const theirs = lake({ id: 'theirs', slug: 'theirs', createdByUserId: 'someone-else' });
+    const db = {
+      dataLakes: { findAccessible: vi.fn(), find: vi.fn().mockResolvedValue([theirs]) },
+      dataLakeAccessGrants: grantRepo(),
+      organizations: { findIdsWithAdminRights: vi.fn().mockResolvedValue([]) },
+    };
+
+    const result = await listAllDataLakes(ctx({ userId: 'admin', isAdmin: true }), { db });
+
+    const row = result.find(l => l.id === 'theirs');
+    expect(row?.canManage).toBe(true);
+    expect(row?.canPreauthorize).toBe(false);
+  });
+
+  it('is TRUE for the lake creator', async () => {
+    const mine = lake({ id: 'mine', slug: 'mine', createdByUserId: 'me' });
+    const db = {
+      dataLakes: { findAccessible: vi.fn().mockResolvedValue([mine]), find: vi.fn() },
+      dataLakeAccessGrants: grantRepo(),
+    };
+
+    const result = await listDataLakes(ctx({ userId: 'me' }), { db });
+    expect(result.find(l => l.id === 'mine')?.canPreauthorize).toBe(true);
+  });
+
+  it('is TRUE for a platform admin who ALSO holds a curator grant - the no-code unblock', async () => {
+    const theirs = lake({ id: 'theirs', slug: 'theirs', createdByUserId: 'someone-else' });
+    const db = {
+      dataLakes: { findAccessible: vi.fn(), find: vi.fn().mockResolvedValue([theirs]) },
+      dataLakeAccessGrants: grantRepo([
+        { dataLakeId: 'theirs', principalType: 'user', principalId: 'admin', role: 'curator' },
+      ]),
+      organizations: { findIdsWithAdminRights: vi.fn().mockResolvedValue([]) },
+    };
+
+    const result = await listAllDataLakes(ctx({ userId: 'admin', isAdmin: true }), { db });
+    expect(result.find(l => l.id === 'theirs')?.canPreauthorize).toBe(true);
+  });
+
+  it('resolves the org-admin rung for an ADMIN caller, whose ctx.administeredOrgIds is zeroed', async () => {
+    // toAccessContext hands admins an empty administeredOrgIds, so reading it off ctx would report a
+    // false negative here. The list must re-resolve it, exactly as sessions/create does.
+    const orgLake = lake({
+      id: 'org-lake',
+      slug: 'org-lake',
+      createdByUserId: 'someone-else',
+      organizationId: 'org-1',
+    });
+    const db = {
+      dataLakes: { findAccessible: vi.fn(), find: vi.fn().mockResolvedValue([orgLake]) },
+      dataLakeAccessGrants: grantRepo(),
+      organizations: { findIdsWithAdminRights: vi.fn().mockResolvedValue(['org-1']) },
+    };
+
+    const result = await listAllDataLakes(ctx({ userId: 'admin', isAdmin: true, administeredOrgIds: [] }), { db });
+    expect(result.find(l => l.id === 'org-lake')?.canPreauthorize).toBe(true);
+  });
+
+  it('degrades that rung to false when no org repo is wired, rather than over-reporting it', async () => {
+    const orgLake = lake({
+      id: 'org-lake',
+      slug: 'org-lake',
+      createdByUserId: 'someone-else',
+      organizationId: 'org-1',
+    });
+    const db = {
+      dataLakes: { findAccessible: vi.fn(), find: vi.fn().mockResolvedValue([orgLake]) },
+      dataLakeAccessGrants: grantRepo(),
+    };
+
+    const result = await listAllDataLakes(ctx({ userId: 'admin', isAdmin: true }), { db });
+    expect(result.find(l => l.id === 'org-lake')?.canPreauthorize).toBe(false);
+  });
+
+  it('is FALSE for every built-in fallback lake, which session-create could only 404', async () => {
+    const db = { dataLakes: { findAccessible: vi.fn().mockResolvedValue([]), find: vi.fn() } };
+    const result = await listDataLakes(ctx({ userId: 'me', userTags: ['Opti'] }), { db });
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every(l => l.canPreauthorize === false)).toBe(true);
+  });
+});

--- a/b4m-core/services/src/dataLakeService/listDataLakes.canPreauthorize.test.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.canPreauthorize.test.ts
@@ -56,6 +56,21 @@ describe('listDataLakes / listAllDataLakes - canPreauthorize', () => {
     expect(result.find(l => l.id === 'mine')?.canPreauthorize).toBe(true);
   });
 
+  it('is FALSE for a DRAFT lake the caller created, while canManage stays true', async () => {
+    // session-create 404s any non-active lake, so the affordance must go dark until the lake's first
+    // upload lands - otherwise "test this lake" is offered on exactly the lake it cannot serve.
+    const mine = lake({ id: 'mine', slug: 'mine', createdByUserId: 'me', status: 'draft' });
+    const db = {
+      dataLakes: { findAccessible: vi.fn().mockResolvedValue([mine]), find: vi.fn() },
+      dataLakeAccessGrants: grantRepo(),
+    };
+
+    const result = await listDataLakes(ctx({ userId: 'me' }), { db });
+    const row = result.find(l => l.id === 'mine');
+    expect(row?.canManage).toBe(true);
+    expect(row?.canPreauthorize).toBe(false);
+  });
+
   it('is TRUE for a platform admin who ALSO holds a curator grant - the no-code unblock', async () => {
     const theirs = lake({ id: 'theirs', slug: 'theirs', createdByUserId: 'someone-else' });
     const db = {

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -228,8 +228,10 @@ const toManageableConfig = (
   ...toConfig(dl),
   canManage: manageable,
   // Deliberately NOT `manageable`: resolved without the platform-admin rung, mirroring the
-  // session-create route. See the field's doc comment for why the two must differ.
-  canPreauthorize,
+  // session-create route. See the field's doc comment for why the two must differ. The status test
+  // mirrors that route too - it 404s a non-active lake, so a draft offered here would advertise an
+  // admission the server is guaranteed to refuse.
+  canPreauthorize: canPreauthorize && dl.status === 'active',
   // A DB lake HAS a document, so rebuild and manage are the same decision - only a fallback
   // (built-in) lake needs the narrower `canRebuild`; see toFallbackConfig and the field's comment.
   canRebuild: manageable,

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -6,6 +6,7 @@ import type {
   IDataLakeRepository,
   IFallbackLakeSetting,
   IFallbackLakeSettingsRepository,
+  IOrganizationRepository,
   DataLakeConfig,
   ManageableDataLakeConfig,
 } from '@bike4mind/common';
@@ -19,6 +20,26 @@ type GrantLookup = Pick<IDataLakeAccessGrantRepository, 'listActiveByLakes' | 'l
 
 /** Settings slice for the read-time grant cutover flag - governs reader-grant inclusion in the list. */
 type SettingsLookup = Pick<IAdminSettingsRepository, 'getSettingsValue'>;
+
+/** Org-admin lookup for the `canPreauthorize` rung. Optional for the same reason as the grant repo. */
+type OrgAdminLookup = Pick<IOrganizationRepository, 'findIdsWithAdminRights'>;
+
+/**
+ * The org-admin set to resolve `canPreauthorize` against.
+ *
+ * `toAccessContext` ZEROES `administeredOrgIds` for an admin caller (org resolution is pure
+ * overhead for the ordinary read gates, which grant an admin outright), so reading it off `ctx`
+ * would report `canPreauthorize: false` for a platform admin whose real rung on the lake is
+ * org-admin - the same trap `pages/api/sessions/create.ts` documents and avoids by re-resolving.
+ * Re-resolve here too, and ONLY for an admin: a non-admin's `ctx` value is already correct.
+ *
+ * Degrades to `[]` when no org repo is wired, which under-reports that one rung rather than
+ * over-reporting it: the affordance goes dark, the route stays authoritative.
+ */
+const preauthorizeOrgIdsFor = async (ctx: AccessContext, organizations?: OrgAdminLookup): Promise<string[]> => {
+  if (!ctx.isAdmin) return ctx.administeredOrgIds ?? [];
+  return organizations ? organizations.findIdsWithAdminRights(ctx.userId) : [];
+};
 
 /**
  * The active grants for a set of lakes, grouped by lake id, so per-lake `canManage`/`isOwn` labels
@@ -54,6 +75,11 @@ type OwnerLookup = { id: string; name?: string; username?: string }[];
 interface ListDataLakesAdapters {
   db: {
     dataLakes: Pick<IDataLakeRepository, 'findAccessible' | 'find'>;
+    /**
+     * Optional org-admin lookup, needed only to resolve the org-admin rung of `canPreauthorize`
+     * for an ADMIN caller (see preauthorizeOrgIdsFor). Unwired callers lose that one rung.
+     */
+    organizations?: OrgAdminLookup;
     /**
      * Optional owner-name lookup. When present (the manager list route), the projection labels
      * lakes the caller does NOT own with the creator's display name, so a global admin (who sees
@@ -195,11 +221,15 @@ const toManageableConfig = (
   dl: IDataLakeDocument,
   manageable: boolean,
   isOwn: boolean,
+  canPreauthorize: boolean,
   ownerDisplayName?: string,
   pendingProposalCount?: number
 ): ManageableDataLakeConfig => ({
   ...toConfig(dl),
   canManage: manageable,
+  // Deliberately NOT `manageable`: resolved without the platform-admin rung, mirroring the
+  // session-create route. See the field's doc comment for why the two must differ.
+  canPreauthorize,
   // A DB lake HAS a document, so rebuild and manage are the same decision - only a fallback
   // (built-in) lake needs the narrower `canRebuild`; see toFallbackConfig and the field's comment.
   canRebuild: manageable,
@@ -277,6 +307,9 @@ const toFallbackConfig = (
   canManageSettings: ctx.isAdmin,
   // Built-in registry lakes have no creator, so they are never "yours" and carry no owner label.
   isOwn: false,
+  // A registry lake has no document, and session-create resolves every pre-authorized id through
+  // findById - so naming one could only ever 404. Never offer the affordance.
+  canPreauthorize: false,
   ...(ctx.isAdmin && overlay?.groundingMode ? { groundingMode: overlay.groundingMode } : {}),
   ...(ctx.isAdmin && overlay?.preferredSystemPromptId
     ? { preferredSystemPromptId: overlay.preferredSystemPromptId }
@@ -322,6 +355,17 @@ export const listDataLakes = async (
   // manage. `toManageableConfig` drops the count for the rest anyway, so narrowing the aggregate both
   // saves the discarded work and keeps a count the caller must not see out of this function entirely.
   const manageableById = new Map(dynamicLakes.map(dl => [dl.id, canManageLake(dl, ctx, grantsByLake.get(dl.id))]));
+  // The admission rung, resolved WITHOUT platform-admin - see canPreauthorize's doc comment. On this
+  // (non-admin) branch it can only ever equal canManage; it is computed separately anyway so the two
+  // branches share one rule and a future rung change cannot drift them apart.
+  const preauthorizeActor = {
+    userId: ctx.userId,
+    isAdmin: false,
+    administeredOrgIds: await preauthorizeOrgIdsFor(ctx, db.organizations),
+  };
+  const canPreauthorizeById = new Map(
+    dynamicLakes.map(dl => [dl.id, canManageLake(dl, preauthorizeActor, grantsByLake.get(dl.id))])
+  );
   const pendingCounts = await pendingCountsFor(
     dynamicLakes.filter(dl => manageableById.get(dl.id)),
     db.dataLakeProposals
@@ -331,6 +375,7 @@ export const listDataLakes = async (
       dl,
       manageableById.get(dl.id) ?? false,
       isEffectiveOwner(dl, ctx, grantsByLake.get(dl.id)),
+      canPreauthorizeById.get(dl.id) ?? false,
       ownerNames.get(dl.createdByUserId),
       pendingCounts[dl.id]
     )
@@ -374,6 +419,13 @@ export const listAllDataLakes = async (
   const ownerNames = await resolveOwnerNames(dynamicLakes, ctx.userId, db.users);
   const grantsByLake = await grantsByLakeIdFor(dynamicLakes, db.dataLakeAccessGrants);
   const pendingCounts = await pendingCountsFor(dynamicLakes, db.dataLakeProposals);
+  // This is the branch where canManage and canPreauthorize genuinely diverge: the admin manages every
+  // DB lake, but may only ADMIT the ones they hold a real rung on (owner/curator/org-admin/org-grant).
+  const preauthorizeActor = {
+    userId: ctx.userId,
+    isAdmin: false,
+    administeredOrgIds: await preauthorizeOrgIdsFor(ctx, db.organizations),
+  };
   // Admin manages every DB lake (canManage: true), but isOwn stays the true effective-owner test so
   // the "you" label still means ownership, not the admin's blanket manage power.
   const dynamicConfigs = dynamicLakes.map(dl =>
@@ -381,6 +433,7 @@ export const listAllDataLakes = async (
       dl,
       true,
       isEffectiveOwner(dl, ctx, grantsByLake.get(dl.id)),
+      canManageLake(dl, preauthorizeActor, grantsByLake.get(dl.id)),
       ownerNames.get(dl.createdByUserId),
       pendingCounts[dl.id]
     )

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -1752,6 +1752,40 @@ describe('KnowledgeRetrievalFeature scoped lake-prompt injection (#1108)', () =>
     expect(quest.promptMeta?.retrieval?.injectedLakePromptIds).toBeUndefined();
     expect(quest.promptMeta?.retrieval?.injectedLakePromptCount).toBeUndefined();
   });
+
+  it('records preauthorizedLakeIdsUsed when the injected lake came from the pre-authorized set', async () => {
+    const quest = makeQuest();
+    const feature = new KnowledgeRetrievalFeature(
+      makeCtx([lakeFile('fA', 'datalake:x')], [makeLake()]) as unknown as ConstructorParameters<
+        typeof KnowledgeRetrievalFeature
+      >[0],
+      undefined,
+      'named',
+      undefined,
+      ['lakeX']
+    );
+    await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'anything'
+    );
+    expect(quest.promptMeta?.retrieval?.preauthorizedLakeIdsUsed).toEqual(['lakeX']);
+  });
+
+  it('leaves preauthorizedLakeIdsUsed absent when the injected lake was not pre-authorized', async () => {
+    const quest = makeQuest();
+    const feature = new KnowledgeRetrievalFeature(
+      makeCtx([lakeFile('fA', 'datalake:x')], [makeLake()]) as unknown as ConstructorParameters<
+        typeof KnowledgeRetrievalFeature
+      >[0]
+    );
+    await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'anything'
+    );
+    expect(quest.promptMeta?.retrieval?.preauthorizedLakeIdsUsed).toBeUndefined();
+  });
 });
 
 /**

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -1609,7 +1609,10 @@ describe('KnowledgeRetrievalFeature scoped lake-prompt injection (#1108)', () =>
   const makeCtx = (
     files: Array<{ id: string; fileName: string; tags: Array<{ name: string }> }>,
     lakes?: Array<Record<string, unknown>>,
-    opts: { dataLakesThrows?: boolean } = {}
+    opts: {
+      dataLakesThrows?: boolean;
+      activeGrants?: Array<{ dataLakeId: string; principalType: string; principalId: string; role: string }>;
+    } = {}
   ) => {
     const chunksByFile = Object.fromEntries(
       files.map(f => [f.id, [{ id: `ch-${f.id}`, fabFileId: f.id, text: `content of ${f.fileName}`, vector: [1, 0] }]])
@@ -1628,7 +1631,20 @@ describe('KnowledgeRetrievalFeature scoped lake-prompt injection (#1108)', () =>
           findVectorsByFabFileIds: vi.fn((ids: string[]) => Promise.resolve(ids.flatMap(id => chunksByFile[id] ?? []))),
         },
         ...(lakes !== undefined || opts.dataLakesThrows
-          ? { dataLakes: { findActiveByUserTags: vi.fn(), findActiveByUserTagsAndEntitlements: findLakes } }
+          ? {
+              dataLakes: {
+                findActiveByUserTags: vi.fn(),
+                findActiveByUserTagsAndEntitlements: findLakes,
+                // getAccessibleDataLakePrompts' pre-authorized branch is guarded on findById, so an
+                // adapter without it skips the manage re-check and admits nothing at all.
+                findById: vi.fn((id: string) => Promise.resolve((lakes ?? []).find(l => String(l.id) === id) ?? null)),
+              },
+            }
+          : {}),
+        // Wiring the grant reader is what lets the re-check trust a rung other than the creator's -
+        // see filterStillManagedLakes, which blanks the creator when this is absent.
+        ...(opts.activeGrants
+          ? { dataLakeAccessGrants: { listActiveByLakes: vi.fn().mockResolvedValue(opts.activeGrants) } }
           : {}),
       },
       resolveEntitlementKeys: vi.fn().mockResolvedValue([]),
@@ -1753,7 +1769,12 @@ describe('KnowledgeRetrievalFeature scoped lake-prompt injection (#1108)', () =>
     expect(quest.promptMeta?.retrieval?.injectedLakePromptCount).toBeUndefined();
   });
 
-  it('records preauthorizedLakeIdsUsed when the injected lake came from the pre-authorized set', async () => {
+  // The field measures MEMBERSHIP in the admitted set, not causation: a lake the caller could
+  // already reach is listed too. This case is the sharpest form of that - no grant reader is wired,
+  // so the per-turn re-check blanks the creator rung and admits NOTHING, yet the id is still
+  // recorded because the creator arm injected the prompt on its own. A reader who treats a non-empty
+  // value as proof the admission did work would be wrong here.
+  it('records preauthorizedLakeIdsUsed for an admitted lake the caller could already reach anyway', async () => {
     const quest = makeQuest();
     const feature = new KnowledgeRetrievalFeature(
       makeCtx([lakeFile('fA', 'datalake:x')], [makeLake()]) as unknown as ConstructorParameters<
@@ -1770,6 +1791,52 @@ describe('KnowledgeRetrievalFeature scoped lake-prompt injection (#1108)', () =>
       'anything'
     );
     expect(quest.promptMeta?.retrieval?.preauthorizedLakeIdsUsed).toEqual(['lakeX']);
+  });
+
+  // The causation case the one above cannot show: the caller neither created the lake nor belongs
+  // to its org, so isTrustedForInjection is false and the ordinary arm injects nothing. Only the
+  // admission - re-derived here through a live curator grant - puts the prompt on the turn.
+  it('records preauthorizedLakeIdsUsed when ONLY the admission could have injected the prompt', async () => {
+    const quest = makeQuest();
+    const feature = new KnowledgeRetrievalFeature(
+      makeCtx([lakeFile('fA', 'datalake:x')], [makeLake({ createdByUserId: 'someone-else' })], {
+        activeGrants: [{ dataLakeId: 'lakeX', principalType: 'user', principalId: OWNER, role: 'curator' }],
+      }) as unknown as ConstructorParameters<typeof KnowledgeRetrievalFeature>[0],
+      undefined,
+      'named',
+      undefined,
+      ['lakeX']
+    );
+    await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'anything'
+    );
+    expect(quest.promptMeta?.retrieval?.preauthorizedLakeIdsUsed).toEqual(['lakeX']);
+    expect(quest.promptMeta?.retrieval?.injectedLakePromptIds).toEqual(['lakeX']);
+  });
+
+  // Same untrusted lake, same admission, but the curator grant is gone: the re-check refuses, the
+  // ordinary trust arm was never available, and nothing is injected. This is what pins the previous
+  // test to the admission rather than to some other arm firing incidentally.
+  it('injects nothing when the admitted lake is untrusted and the manage grant is gone', async () => {
+    const quest = makeQuest();
+    const feature = new KnowledgeRetrievalFeature(
+      makeCtx([lakeFile('fA', 'datalake:x')], [makeLake({ createdByUserId: 'someone-else' })], {
+        activeGrants: [],
+      }) as unknown as ConstructorParameters<typeof KnowledgeRetrievalFeature>[0],
+      undefined,
+      'named',
+      undefined,
+      ['lakeX']
+    );
+    await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'anything'
+    );
+    expect(quest.promptMeta?.retrieval?.preauthorizedLakeIdsUsed).toBeUndefined();
+    expect(quest.promptMeta?.retrieval?.injectedLakePromptIds).toEqual([]);
   });
 
   it('leaves preauthorizedLakeIdsUsed absent when the injected lake was not pre-authorized', async () => {

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -1827,6 +1827,8 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         { db, user, entitlementKeys, logger: this.logger },
         { restrictToDatalakeTags: datalakeTags, preauthorizedLakeIds: this.preauthorizedLakeIds }
       );
+      const preauthorizedSet = new Set(this.preauthorizedLakeIds);
+      const preauthorizedLakeIdsUsed = prompts.map(p => p.id).filter(id => preauthorizedSet.has(id));
       // Recorded whenever this injection site ran, even if nothing qualified (present-and-empty
       // is distinct from absent - see the field's own comment in promptMeta.ts).
       quest.promptMeta = quest.promptMeta ?? {};
@@ -1835,6 +1837,7 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         surfaces: [],
         dataLakeTags: [],
         injectedLakePromptIds: prompts.map(p => p.id),
+        ...(preauthorizedLakeIdsUsed.length ? { preauthorizedLakeIdsUsed } : {}),
       });
       const section = renderDataLakePromptSection(prompts);
       if (!section) return null;

--- a/b4m-core/services/src/llm/tools/base/resolveSessionLakeAccess.ts
+++ b/b4m-core/services/src/llm/tools/base/resolveSessionLakeAccess.ts
@@ -24,9 +24,9 @@ const NO_LAKES: ResolvedLakeAccessSet = {
 export async function resolveSessionLakeAccess(context: ToolContext): Promise<ResolvedLakeAccessSet> {
   if (context.suppressLakeArms) return NO_LAKES;
   const resolved = await getDynamicDataLakeAccess(context);
-  // `context.userId` is the session OWNER on any turn that carries preauthorizedLakeIds - the field
-  // is only populated after vetPreauthorizedLakeIds matches the session owner to the request's
-  // authenticated principal, and is left unset where there is no principal to vet against.
+  // `context.userId` is the session OWNER on any turn that carries preauthorizedLakeIds:
+  // vetPreauthorizedLakeIds blanks the field unless the session's own userId equals the acting
+  // user, and the identity-substituting worker paths never reach that call at all.
   const unioned = await unionPreauthorizedLakeAccess(
     resolved,
     context.sessionPreauthorizedLakeIds,

--- a/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.test.ts
@@ -101,4 +101,36 @@ describe('prependRetrievedLakePrompts', () => {
     });
     expect(result).toContain('Sales playbook.');
   });
+
+  it('records preauthorizedLakeIdsUsed for an injected id drawn from the pre-authorized set', async () => {
+    getAccessibleDataLakePromptsMock.mockResolvedValueOnce([
+      { id: 'managed', name: 'Managed Lake', systemPrompt: 'Sales playbook.' },
+      { id: 'ordinary', name: 'Ordinary Lake', systemPrompt: 'Ordinary.' },
+    ]);
+    const context = makeContext({ sessionPreauthorizedLakeIds: ['managed'] });
+    await prependRetrievedLakePrompts(context, 'result text', ['datalake:managed', 'datalake:ordinary'], new Set());
+
+    expect(context.statusUpdate).toHaveBeenCalledWith({
+      promptMeta: {
+        retrieval: {
+          attempted: true,
+          surfaces: [],
+          dataLakeTags: [],
+          injectedLakePromptIds: ['managed', 'ordinary'],
+          preauthorizedLakeIdsUsed: ['managed'],
+        },
+      },
+    });
+  });
+
+  it('omits preauthorizedLakeIdsUsed when no injected id came from the pre-authorized set', async () => {
+    getAccessibleDataLakePromptsMock.mockResolvedValueOnce([
+      { id: 'ordinary', name: 'Ordinary Lake', systemPrompt: 'Ordinary.' },
+    ]);
+    const context = makeContext();
+    await prependRetrievedLakePrompts(context, 'result text', ['datalake:ordinary'], new Set());
+
+    const call = (context.statusUpdate as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect('preauthorizedLakeIdsUsed' in call.promptMeta.retrieval).toBe(false);
+  });
 });

--- a/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.ts
+++ b/b4m-core/services/src/llm/tools/implementation/retrievedLakePrompts.ts
@@ -35,6 +35,8 @@ export async function prependRetrievedLakePrompts(
       restrictToDatalakeTags: fresh,
       preauthorizedLakeIds: context.sessionPreauthorizedLakeIds,
     });
+    const preauthorizedSet = new Set(context.sessionPreauthorizedLakeIds ?? []);
+    const preauthorizedLakeIdsUsed = prompts.map(p => p.id).filter(id => preauthorizedSet.has(id));
     // Recorded whenever this injection site ran, even if nothing qualified - see the field's own
     // comment in promptMeta.ts. Merges onto whatever the tool's own retrieval outcome write already
     // set (applyQuestStatusChanges / mergeRetrievalSummary), not a replacement. Its own try/catch:
@@ -49,6 +51,7 @@ export async function prependRetrievedLakePrompts(
             surfaces: [],
             dataLakeTags: [],
             injectedLakePromptIds: prompts.map(p => p.id),
+            ...(preauthorizedLakeIdsUsed.length ? { preauthorizedLakeIdsUsed } : {}),
           },
         },
       });

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
@@ -160,4 +160,24 @@ describe('mergeRetrievalSummary', () => {
       expect(merged?.injectedLakePromptCount).toBe(1);
     });
   });
+
+  describe('preauthorizedLakeIdsUsed', () => {
+    it('unions ids without duplicates, independent of injectedLakePromptIds', () => {
+      const merged = mergeRetrievalSummary(
+        base({ injectedLakePromptIds: ['lake1'], preauthorizedLakeIdsUsed: ['lake1'] }),
+        base({ injectedLakePromptIds: ['lake1', 'lake2'], preauthorizedLakeIdsUsed: ['lake1'] })
+      );
+      expect(merged?.preauthorizedLakeIdsUsed).toEqual(['lake1']);
+    });
+
+    it('stays absent when neither side used a pre-authorized lake', () => {
+      const merged = mergeRetrievalSummary(base(), base());
+      expect(merged && 'preauthorizedLakeIdsUsed' in merged).toBe(false);
+    });
+
+    it('survives a side that never asserted the field', () => {
+      const merged = mergeRetrievalSummary(base({ preauthorizedLakeIdsUsed: ['lake1'] }), base());
+      expect(merged?.preauthorizedLakeIdsUsed).toEqual(['lake1']);
+    });
+  });
 });

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
@@ -49,9 +49,9 @@ function outcomeSeverity(outcome: RetrievalSummary['outcome']): number {
  *   makes this first-writer-wins under the accumulator convention (`existing` is the earlier
  *   write), not last-writer-wins. Unlike the fields above it is NOT commutative when both sides
  *   carry a different reason.
- * - surfaces / dataLakeTags / injectedLakePromptIds: union, deduped. injectedLakePromptCount is
- *   derived from the merged ids, not merged independently, so a two-sided merge can never leave
- *   the two disagreeing.
+ * - surfaces / dataLakeTags / injectedLakePromptIds / preauthorizedLakeIdsUsed: union, deduped.
+ *   injectedLakePromptCount is derived from the merged injectedLakePromptIds, not merged
+ *   independently, so a two-sided merge can never leave the two disagreeing.
  *
  * The one-sided returns below are a verbatim passthrough, and both injection sites emit a PARTIAL
  * summary (ids with no count; `attempted` with no `outcome`) meant only as a merge delta. So a
@@ -74,6 +74,10 @@ export function mergeRetrievalSummary(
     existing.injectedLakePromptIds || incoming.injectedLakePromptIds
       ? [...new Set([...(existing.injectedLakePromptIds ?? []), ...(incoming.injectedLakePromptIds ?? [])])]
       : undefined;
+  const preauthorizedLakeIdsUsed =
+    existing.preauthorizedLakeIdsUsed || incoming.preauthorizedLakeIdsUsed
+      ? [...new Set([...(existing.preauthorizedLakeIdsUsed ?? []), ...(incoming.preauthorizedLakeIdsUsed ?? [])])]
+      : undefined;
 
   // Keys are spread in only when defined: the shape is absent-or-fully-present on the Mongoose
   // side, and an explicit `undefined` would persist as a set-but-empty path.
@@ -85,5 +89,6 @@ export function mergeRetrievalSummary(
     surfaces: [...new Set([...existing.surfaces, ...incoming.surfaces])],
     dataLakeTags: [...new Set([...existing.dataLakeTags, ...incoming.dataLakeTags])],
     ...(injectedLakePromptIds ? { injectedLakePromptIds, injectedLakePromptCount: injectedLakePromptIds.length } : {}),
+    ...(preauthorizedLakeIdsUsed ? { preauthorizedLakeIdsUsed } : {}),
   };
 }

--- a/b4m-core/services/src/sessionService/create.ts
+++ b/b4m-core/services/src/sessionService/create.ts
@@ -30,8 +30,10 @@ const createSessionParametersSchema = z.object({
   disableUserIntegrations: z.boolean().optional(),
   forceKnowledgeRetrieval: z.boolean().optional(),
   retrievalTags: z.array(z.string()).optional(),
-  // Resolved from the lake at the create route (resolveLakeSessionDefaults), NOT client-supplied:
-  // the route deletes any client-sent value before merging, so the lake is authoritative for it.
+  // Resolved from the lake at the create route (resolveLakeSessionDefaults) whenever `dataLakeId`
+  // is set: the route deletes the client-sent value there, so the lake is authoritative. A session
+  // that names a lake ONLY by `retrievalTags` keeps the caller's own mode, having no lake-defaults
+  // merge for it to override.
   // secureParameters strips unknown keys, so it MUST be declared here or the resolved grounding mode
   // is silently dropped and the completion path falls back to size-only behavior.
   corpusGroundingMode: z.enum(DATA_LAKE_GROUNDING_MODES).optional(),

--- a/b4m-core/services/src/sessionService/update.ts
+++ b/b4m-core/services/src/sessionService/update.ts
@@ -26,6 +26,21 @@ const updateSessionParamtersSchema = SessionUpdateRequestSchema.extend({
 
 type UpdateSessionParameters = z.infer<typeof updateSessionParamtersSchema>;
 
+/**
+ * Compile-time guard for the manage-but-not-member admission, mirroring the one in
+ * sessionService/create.ts. `preauthorizedLakeIds` must never become an `updateSession` input: it is
+ * set once at session-create after the route's own `canManageLake` check, and a session update must
+ * not be able to grant or alter it. Adding the key to `SessionUpdateRequestSchema` resolves the
+ * argument to `false` and fails the build.
+ *
+ * This lives here rather than as a `@ts-expect-error` in update.test.ts because tsconfig.json
+ * excludes test files, so an assertion in one is in no typecheck program and can never fail.
+ */
+type AssertTrue<T extends true> = T;
+export type UpdateSessionParametersOmitPreauthorizedLakeIds = AssertTrue<
+  'preauthorizedLakeIds' extends keyof UpdateSessionParameters ? false : true
+>;
+
 interface UpdateSessionAdapters {
   db: {
     sessions: ISessionRepository;

--- a/b4m-core/services/src/userApiKeyService/__tests__/validate.test.ts
+++ b/b4m-core/services/src/userApiKeyService/__tests__/validate.test.ts
@@ -161,6 +161,24 @@ describe('validateUserApiKey - embed context fields', () => {
     expect(result.branding).toEqual({ displayName: 'Acme', primaryColor: '#336699', hideBranding: true });
   });
 
+  it('carries preauthorizedLakeIds through the projection', async () => {
+    const { repo } = makeSyncedRepo();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapters = { db: { userApiKeys: repo as any } };
+
+    const { key } = await createUserApiKey(
+      'sys-1',
+      { ...mintParams, preauthorizedLakeIds: ['lake-a', 'lake-b'] },
+      { ...adapters, systemUserId: 'sys-1' }
+    );
+
+    const result = await validateUserApiKey(key, adapters);
+
+    // apiKeyAuth copies this onto req.apiKeyInfo and /api/sessions/create refuses every lake the
+    // key is not bound to, so dropping it here silently un-binds every key that has a binding.
+    expect(result.preauthorizedLakeIds).toEqual(['lake-a', 'lake-b']);
+  });
+
   it('leaves embed fields undefined for a non-embed key', async () => {
     const { repo } = makeSyncedRepo();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/b4m-core/services/src/userApiKeyService/create.test.ts
+++ b/b4m-core/services/src/userApiKeyService/create.test.ts
@@ -81,3 +81,37 @@ describe('userApiKeyService - createUserApiKey org billing', () => {
     expect(repo.create).not.toHaveBeenCalled();
   });
 });
+
+describe('userApiKeyService - createUserApiKey preauthorizedLakeIds', () => {
+  let repo: IUserApiKeyRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo = makeRepo();
+  });
+
+  it('persists preauthorizedLakeIds without any existence or manage check at mint time', async () => {
+    const result = await createUserApiKey(
+      'user1',
+      { ...baseParams, preauthorizedLakeIds: ['lake1', 'lake2'] },
+      { db: { userApiKeys: repo } }
+    );
+
+    expect(result.preauthorizedLakeIds).toEqual(['lake1', 'lake2']);
+    expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ preauthorizedLakeIds: ['lake1', 'lake2'] }));
+  });
+
+  it('leaves preauthorizedLakeIds undefined when not given', async () => {
+    const result = await createUserApiKey('user1', baseParams, { db: { userApiKeys: repo } });
+
+    expect(result.preauthorizedLakeIds).toBeUndefined();
+  });
+
+  it('rejects more than 25 pre-authorized lake ids', async () => {
+    const ids = Array.from({ length: 26 }, (_, i) => `lake${i}`);
+    await expect(
+      createUserApiKey('user1', { ...baseParams, preauthorizedLakeIds: ids }, { db: { userApiKeys: repo } })
+    ).rejects.toThrow();
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/userApiKeyService/create.ts
+++ b/b4m-core/services/src/userApiKeyService/create.ts
@@ -53,6 +53,12 @@ const createUserApiKeySchema = z.object({
   // by the route; the service only enforces the field-shape invariant below.
   billingOwnerType: z.enum(CreditHolderType).optional(),
   organizationId: z.string().optional(),
+  // Manage-but-not-member session admission (see pages/api/sessions/create.ts): the lakes this
+  // key may bind a session to. No existence/manage check at mint time - session-create
+  // independently re-verifies the ACTING user's live manage rights against the lake on every
+  // request, so a stale or made-up id here is inert, never a privilege. No new ApiKeyScope: the
+  // widening is bound to specific lake ids rather than gated by a scope.
+  preauthorizedLakeIds: z.array(z.string().min(1)).max(25).optional(),
 });
 
 export type CreateUserApiKeyParameters = z.infer<typeof createUserApiKeySchema>;
@@ -91,6 +97,7 @@ export interface CreateUserApiKeyResult {
   allowedOrigins?: string[];
   branding?: IEmbedBranding;
   spendCap?: number;
+  preauthorizedLakeIds?: string[];
   createdAt: Date;
 }
 
@@ -202,6 +209,7 @@ export const createUserApiKey = async (
     allowedOrigins: params.allowedOrigins,
     branding: params.branding,
     spendCap: params.spendCap,
+    preauthorizedLakeIds: params.preauthorizedLakeIds,
   });
 
   return {
@@ -222,6 +230,7 @@ export const createUserApiKey = async (
     allowedOrigins: apiKeyDocument.allowedOrigins,
     branding: apiKeyDocument.branding,
     spendCap: apiKeyDocument.spendCap,
+    preauthorizedLakeIds: apiKeyDocument.preauthorizedLakeIds,
     createdAt: apiKeyDocument.createdAt,
   };
 };

--- a/b4m-core/services/src/userApiKeyService/validate.ts
+++ b/b4m-core/services/src/userApiKeyService/validate.ts
@@ -34,6 +34,8 @@ export interface ValidationResult {
   agentId?: string;
   /** Origins an embed key may be used from (defense-in-depth); embed keys only. */
   allowedOrigins?: string[];
+  /** Lake ids this key is bound to for the manage-but-not-member session admission. */
+  preauthorizedLakeIds?: string[];
   /** White-label config for an embed key; consumed by the widget serve route. */
   branding?: IEmbedBranding;
   /** Spend ceiling in credits for an embed key. Present 0 = real cap; absent = uncapped. */
@@ -74,6 +76,7 @@ function finalizeApiKeyValidation(apiKey: IUserApiKeyDocument, db: ValidateUserA
     organizationId: apiKey.organizationId,
     agentId: apiKey.agentId,
     allowedOrigins: apiKey.allowedOrigins,
+    preauthorizedLakeIds: apiKey.preauthorizedLakeIds,
     branding: apiKey.branding,
     spendCap: apiKey.spendCap,
     currentSpend: apiKey.usage?.totalSpendCredits,

--- a/packages/database/src/models/auth/UserApiKeyModel.ts
+++ b/packages/database/src/models/auth/UserApiKeyModel.ts
@@ -219,6 +219,11 @@ const UserApiKeySchema = new mongoose.Schema<IUserApiKeyDocument, IUserApiKeyMod
     // `[]`/`{}` (which would otherwise echo in the API response for every key).
     agentId: { type: String },
     allowedOrigins: { type: [String], default: undefined },
+    // Lake ids this key is bound to for the manage-but-not-member session admission (see
+    // pages/api/sessions/create.ts's preauthorizedLakeIds containment check). Admin-minted only.
+    // No index: the only read is by the key's own id (already indexed), never a bulk lookup by
+    // lake. `default: undefined` so an ordinary key does not materialize an empty array.
+    preauthorizedLakeIds: { type: [String], default: undefined },
     branding: {
       type: new mongoose.Schema<IEmbedBranding>(
         {

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -66,6 +66,8 @@ const RetrievalSummarySchema = subSchema({
   // default: undefined for the same auto-vivification reason as dataLakeTags above.
   injectedLakePromptIds: { type: [String], required: false, default: undefined },
   injectedLakePromptCount: { type: Number, required: false },
+  // default: undefined for the same auto-vivification reason as injectedLakePromptIds above.
+  preauthorizedLakeIdsUsed: { type: [String], required: false, default: undefined },
 });
 
 // Partial-grounding-coverage detail. subSchema + default:undefined for the same reason as


### PR DESCRIPTION
## Description

#2421 landed the manage-but-not-member session admission: at session create a maintainer may name
lake ids they want that one session grounded on, each authorized live with `canManageLake`. It
shipped with three gaps it disclosed rather than hid, and a fourth this branch's review surfaced.
This closes all four, plus one compile guard extracted from a phase that was subsequently dropped.

1. **The lake's configured grounding mode never reached a test session.** `/api/sessions/create`
   stripped any client-sent `corpusGroundingMode` unconditionally, and only the `dataLakeId` arm
   re-supplied one. A session that names a lake subset by `retrievalTags` alone - which is exactly
   what "Test this lake" builds - therefore silently ran on the size-only deferral default instead of
   the mode the lake is configured with. #2416's round-2 review shipped dialog copy *disclosing* that
   divergence; this removes it.
2. **A turn that used the widening was indistinguishable from one that did not.** The session
   records what was *admitted*; nothing recorded what a given turn actually *injected* through the
   admission. That is the assertion the eval harness needs and the only reader that exists.
3. **The widening had no per-key containment.** `preauthorizedLakeIds` is accepted from any
   authenticated principal, an API key included, so a leaked key could reach every lake its minting
   user manages. Binding the key at mint time narrows which of the user's manage rights the key may
   exercise; it never grants authority the user lacks.
4. **The admission had no client sender.** `preauthorizedLakeIds` was reachable only from a
   hand-built request, so the maintainer who can set a lake's `systemPrompt` still had no way in the
   product to make it fire. "Test this lake" now requests admission for the checked lakes the caller
   may actually admit.

It also delivers the fourth acceptance criterion, which #2421 explicitly left unmet: the settings-modal
sentence naming who a lake's `systemPrompt` applies to, which #2421 is what made wrong by admitting
a third audience the sentence excludes.

With this the mechanism is complete and product-reachable: the maintainer's prompt fires and is
visible in `promptMeta`, the tool-retrieval path is confirmed (it injects, and now records),
regression tests exist in both directions, and the modal states which turns the prompt applies to.
One acceptance step is operational rather than code - see immediately below.

Closes #2405

**What "closes" means precisely, since the issue thread records an end-to-end acceptance test.** The
mechanism is complete and reachable from the product: a maintainer holding a real rung on a lake
(creator, curator/owner grant, or org-admin) can now click "Test this lake" and have that lake's
`systemPrompt` fire, with `promptMeta.retrieval.injectedLakePromptIds` and
`preauthorizedLakeIdsUsed` recording it. What is NOT a code change is the reported lake's own
unblock: its maintainer's only rung is platform-admin, which is deliberately not admissible (see
**Additional Information**), so that lake needs a **curator grant row** before the acceptance test
passes on it. The second clause of the issue title - no production lake is org-scoped - remains
unaddressed and, given the grant-row path, is no longer on the critical path for injection.

Plan: `~/Dev/planning/bike4mind/2405-lake-testing-for-maintainers.md`, milestone *"ONE PR closing
out Phase 3"*. This completes the code side of that plan; what remains is an operational
grant-row (or org-scoping) step that carries no code change (see **Additional Information**).

## Changes

**Grounding mode (scope item 3)**
- `/api/sessions/create` replaces the unconditional `delete body.corpusGroundingMode` with
  `namesALakeByTagsOnly` - a client-sent mode survives only when the body sets `retrievalTags` and
  no `dataLakeId`. With a `dataLakeId` the strip is unchanged, so a lake editor's per-lake mode still
  always wins the merge; an ordinary non-lake session is still left with no mode (size-only
  behavior). The existing two-reason comment is amended in place rather than removed.
- `useStartChatWithLakes` now takes `groundingMode` and sends it as `corpusGroundingMode`. Its
  docblock previously stated the field was deliberately not sent, with the reason; that paragraph is
  rewritten to state the new rule.
- `DataLakeSettingsModal` passes `lake.groundingMode ?? DEFAULT_DATA_LAKE_GROUNDING_MODE`, mirroring
  `resolveLakeSessionDefaults`'s own fallback, and its `systemPrompt` help text now names all three
  audiences ("to you, to members of this lake's organization, and to a manager testing it in a
  scoped session").

**`promptMeta` flag (scope item 4, `promptMeta` half only)**
- `RetrievalSummarySchema.preauthorizedLakeIdsUsed` plus its hand-maintained `QuestModel.ts` mirror
  (`default: undefined` on the array, per the parity test).
- Written at both injection sites - `KnowledgeRetrievalFeature` (`ChatCompletionFeatures.ts`) and
  `prependRetrievedLakePrompts` (`retrievedLakePrompts.ts`) - as the subset of the turn's
  `injectedLakePromptIds` whose ids came from the session's pre-authorized set. A subset, never a
  superset. Spread in only when non-empty, so absent means "no pre-authorized id was injected on
  this turn", which is also every turn on a session with no pre-authorization.
- `mergeRetrievalSummary` unions it, deduped, like `injectedLakePromptIds`.

**API-key lake binding (scope item 1, key half)**
- `IUserApiKey.preauthorizedLakeIds` + the `UserApiKeyModel` mirror (`default: undefined`, matching
  `allowedOrigins`), threaded model -> `userApiKeyService/create.ts` -> `validate.ts` ->
  `req.apiKeyInfo` exactly as `productId` already is, via `apps/client/global.d.ts`'s
  `Express.ApiKeyInfo`.
- Mint is admin-only by reusing the route that is already admin-gated:
  `pages/api/admin/users/[userId]/generate-api-key.ts` (gated on `req.user?.isAdmin`) accepts and
  forwards the field. **No new `ApiKeyScope`** - the widening is bound to specific lake ids rather
  than gated by a scope, so there is nothing for `ADMIN_ONLY_API_KEY_SCOPES` to key on. The
  self-service mint path cannot accept the field even at the type level: the client request type is
  a separate `AdminCreateUserApiKeyRequest extends CreateUserApiKeyRequest`.
- Capped at 25 ids. **No existence or manage check at mint time**, deliberately: session-create
  re-verifies the acting user's live manage rights against the lake on every request, so a stale or
  made-up id on a key is inert rather than a privilege.
- Enforcement at `/api/sessions/create`: an API-key-authenticated request naming a
  `preauthorizedLakeIds` id that the key is not bound to gets a 403, checked **before** and **in
  addition to** the `canManageLake` check, never instead of it. A cookie/JWT session is unaffected.
- Admin UI: a lake multi-select in `AdminGenerateApiKeyModal`, with loading, error+retry and
  empty states.

**Client sender for the admission (scope item 1, session half)**
- `ManageableDataLakeConfig.canPreauthorize` - a new REQUIRED boolean, resolved by both list
  projections with `isAdmin: false`, which is the same rung ladder `/api/sessions/create` and
  `filterStillManagedLakes` both apply. It is deliberately NOT `canManage`: that flag includes the
  platform-admin rung, and the route refuses it, so gating the UI on `canManage` would send ids the
  route 403s. Required rather than optional for the same reason `isOwn` is - a projection that
  forgot it would silently send no admission and reintroduce the bug with a green typecheck.
- `administeredOrgIds` is re-resolved for ADMIN callers via a new optional `organizations` adapter,
  because `toAccessContext` zeroes that field for admins as an optimization. Reading it off `ctx`
  would report `canPreauthorize: false` for an admin whose real rung is org-admin - the same trap
  `create.ts` documents and avoids. Unwired, that one rung degrades to `false`: under-reporting, so
  the affordance goes dark and the route stays authoritative.
- Fallback (registry) lakes are always `false` - they have no document, and session-create resolves
  every id through `findById`, so naming one could only ever 404.
- `TestLakeScopeDialog` filters the checked lakes on `canPreauthorize` and widens `onConfirm` to
  `{ retrievalTags, preauthorizedLakeIds }`. Retrieval still narrows to ALL checked lakes; only the
  admissible subset is admitted. `useStartChatWithLakes` omits the field entirely when empty, so an
  ordinary test session's payload is byte-identical to before.

**Update-side compile guard**
- `sessionService/update.ts` gains the `AssertTrue` guard mirroring `create.ts:61-71`, asserting
  `preauthorizedLakeIds` is not a key of `UpdateSessionParameters`. Today the update side is safe by
  omission only - `update.ts`'s fixed eight-field destructuring whitelist - with neither the compile
  guard nor the runtime test the create side got. If the field ever round-trips through
  `SessionUpdateRequestSchema`, **a rename becomes a self-grant**, and the ownership invariant cannot
  catch it because the self-granter is the owner. The guard lives in the source file, not as a
  `@ts-expect-error` in the test, because `tsconfig.json` excludes test files - an assertion in one
  is in no typecheck program and can never fail.

**Tests** - new/extended files for every item above: the grounding gate's matrix
(`__tests__/create-grounding-gate.test.ts`), the key-binding refusal
(`__tests__/create-preauthorized-lake.test.ts`), the mint path, the admin modal, both injection
sites, the merge, and the admin route.

## Guide for Testers

Environment: a preview or staging deploy (`app.pr<N>.preview.bike4mind.com`). You need a
platform-admin account. Parts C and D drive the session-level admission over the public API by hand:
the client sends it too (**Test this lake**, Part B), but a hand-built request is what lets you read
the per-turn `promptMeta` back and vary the admitted ids independently of what the UI would offer.

### A. The settings-modal copy names all three audiences

1. Sign in as a platform admin. Open **the data lake manager** and click a lake you can manage, then
   open its **Settings**.
2. Read the helper text directly under the **System prompt** field. Expected, verbatim: it contains
   `They apply to you, to members of this lake's organization, and to a manager testing it in a
   scoped session - not to users granted access by tag or entitlement`. It must NOT read
   `They apply to you and to members of this lake's organization - not to users granted access by
   tag or entitlement` (the pre-change sentence, which excluded the third audience).

### B. The lake's grounding mode reaches a "Test this lake" session

3. In the same lake's Settings, set **Grounding mode** to **Inline into the prompt** (any value other
   than the default **Retrieve (recommended)**) and click **Save**. Expected: a success toast.
4. Open your browser devtools **Network** tab and keep it open.
5. Click **Test this lake**, keep the default selection, and confirm. Expected: a new notebook named
   "New Notebook" opens.
6. In the Network tab, find the `POST /api/sessions/create` request from step 5 and read its
   **request payload**. Expected: it contains `"corpusGroundingMode": "inline"` alongside
   `retrievalTags` and `"forceKnowledgeRetrieval": true`. Before this change the client sent no such
   field.
7. Read the **response** of that same request. Expected: the returned session's
   `corpusGroundingMode` is `"inline"` - the server kept the client's value. Before this change the
   server stripped it and the field was absent, so the session silently ran on size-only deferral.
8. Set the lake's **Grounding mode** back to **Retrieve (recommended)**, save, and repeat steps 5-7.
   Expected: `"corpusGroundingMode": "retrieve"` in both payload and response.

### B2. "Test this lake" now requests the admission

8a. Sign in as a user who **created** the lake (not merely a platform admin). Open its Settings,
    click **Test this lake**, keep the default single-lake selection, confirm, and read the
    `POST /api/sessions/create` payload in the Network tab. Expected: it now carries
    `"preauthorizedLakeIds": ["<that lake id>"]`. Before this change the field was absent entirely.
8b. In the same dialog, additionally check a lake you can merely READ (someone else's public lake).
    Expected: `retrievalTags` carries BOTH lakes' tags, while `preauthorizedLakeIds` carries only the
    one you manage. The request must still return `200` - a lake you cannot admit is omitted, never
    sent and refused.
8c. Sign in as a **platform admin whose only rung on the lake is admin** (not its creator, not in its
    org, holding no grant row). Open Settings -> **Test this lake** and confirm. Expected: the
    payload carries **no** `preauthorizedLakeIds` field, and the request returns `200`. This is the
    deliberate behavior: the affordance goes dark rather than sending an id the route would 403.
8d. Grant that same admin an **owner or curator grant** on the lake via the lake's access panel, then
    repeat 8c. Expected: the payload now carries `"preauthorizedLakeIds": ["<lake id>"]` and the
    request returns `200`. This is the no-code unblock for the originally-reported lake.

### C. The API key is bound to its lakes

9. Go to **Admin -> Users**, open any user who manages at least two data lakes, and click
   **Generate API Key**.
10. Expected: a **Pre-authorized lakes** section is present, with the header
    `Pre-authorized lakes (0 selected)` and a scrollable checkbox list of lakes.
11. Check exactly **one** lake. Expected: the header updates to `Pre-authorized lakes (1 selected)`.
12. Give the key a name, tick the scopes **Write Notebooks**, **Read Notebooks** and **AI Chat**, and
    click **Generate API Key**. Copy the key - it is shown once. Call it `$KEY`.
13. Collect two lake ids: `$BOUND` (the lake you checked in step 11) and `$UNBOUND` (a different lake
    the same user also manages, which you did NOT check). A lake's id is the `id` field in the
    response of `GET /api/datalakes`, or in the lake manager's URL.
14. Run, with the **bound** id:

    ```bash
    curl -sS -o /dev/null -w '%{http_code}\n' -X POST \
      https://app.pr<N>.preview.bike4mind.com/api/sessions/create \
      -H 'Content-Type: application/json' -H "x-api-key: $KEY" \
      -d "{\"name\":\"bound lake\",\"preauthorizedLakeIds\":[\"$BOUND\"]}"
    ```

    Expected: `200`.
15. Run the identical command with `$UNBOUND` instead. Expected: **`403`**, and with `-i` the body
    contains `This API key is not bound to data lake <id>`. This is the containment: the key's
    underlying user *does* manage that lake, and the key still cannot admit it.
16. Generate a second key for the same user with **no** lakes checked, and repeat step 14 with it.
    Expected: **`403`** for any id - a key with no binding has no widening at all.
17. Confirm a browser session is unaffected: with your admin cookie session (not a key), the same
    `POST /api/sessions/create` body from step 14 with `$UNBOUND` still succeeds, because the key
    binding narrows keys only. Run it from the devtools console on the app origin:

    ```js
    await fetch('/api/sessions/create', {
      method: 'POST', headers: { 'Content-Type': 'application/json' },
      body: JSON.stringify({ name: 'cookie path', preauthorizedLakeIds: ['<UNBOUND>'] }),
    }).then(r => r.status)
    ```

    Expected: `200`.

### D. `promptMeta` records that a turn used the pre-authorization

18. Pick a lake the key's user **manages but is not a member of** (they are not its creator and not
    in its organization). Their rung on it must be creator-of-record, curator/owner **grant**, or
    org-admin - a user whose ONLY rung is platform-admin is deliberately not admissible, so give them
    a curator grant row on the lake first (see step 8d). Mint a key bound to exactly that lake, per steps 9-12. Set a distinctive
    **System prompt** on the lake, e.g. `Always begin your answer with the word BANANA.`, and save.
19. Create a session admitting it, and keep the returned `id` as `$SID`:

    ```bash
    curl -sS -X POST https://app.pr<N>.preview.bike4mind.com/api/sessions/create \
      -H 'Content-Type: application/json' -H "x-api-key: $KEY" \
      -d "{\"name\":\"preauth turn\",\"forceKnowledgeRetrieval\":true,\"preauthorizedLakeIds\":[\"$LAKE\"]}"
    ```

    Expected: `200` and a session object.
20. Send a turn on it whose answer needs that lake's content:

    ```bash
    curl -sS -X POST https://app.pr<N>.preview.bike4mind.com/api/chat \
      -H 'Content-Type: application/json' -H "x-api-key: $KEY" \
      -d "{\"sessionId\":\"$SID\",\"message\":\"What does this lake contain?\"}"
    ```

    Keep the returned quest id as `$QID`. Expected: `200`.
21. Poll the quest until it is finished, then read its metadata:

    ```bash
    curl -sS "https://app.pr<N>.preview.bike4mind.com/api/quests/$QID" -H "x-api-key: $KEY" \
      | python3 -c 'import json,sys; q=json.load(sys.stdin); print(json.dumps(q.get("promptMeta",{}).get("retrieval"), indent=2))'
    ```

    Expected, within ~30 seconds: `injectedLakePromptIds` contains `$LAKE`, **and**
    `preauthorizedLakeIdsUsed` contains `$LAKE`. The answer text should also begin with `BANANA`,
    confirming the lake's prompt actually fired.
22. Repeat steps 19-21 for a lake the same user **created themselves**, admitting it the same way.
    Expected: `injectedLakePromptIds` contains that lake's id and `preauthorizedLakeIdsUsed` contains
    it **as well**. The field records membership in the admitted set, not causation: the creator
    would have reached this lake without the admission, and it is still listed. To see the field
    absent, omit `preauthorizedLakeIds` from the create request instead.

### Regression Checks

23. Create an ordinary notebook from the app (**+ New**, no lake), attach a large file, and send a
    message. Expected: unchanged behavior; the session carries no `corpusGroundingMode`
    (`GET /api/sessions/<id>` shows the field absent) and retrieval still defers by size.
24. Open a lake and use the single-lake **Start chat** entry point (the `dataLakeId` path, not
    "Test this lake"). Expected: the session's `corpusGroundingMode` is the lake's configured mode,
    exactly as before this change - the server still strips any client value on this arm.
25. Hand-build a session-create request that sets BOTH `dataLakeId` and `corpusGroundingMode` to a
    value that disagrees with the lake's. Expected: the created session carries the **lake's** mode,
    not the request's - the strip is unchanged whenever `dataLakeId` is present.
26. Rename a session created in step 19 (`PUT /api/sessions/<id>` with a new `name`, or rename it in
    the UI). Expected: the rename succeeds, and `GET /api/sessions/<id>` still grounds on the same
    lake. A subsequent turn still reports the lake in `preauthorizedLakeIdsUsed`, and a rename
    carrying `preauthorizedLakeIds` in its body cannot alter the admission.
27. Sign in as a **non-admin** and open the self-service API-key screen in profile settings.
    Expected: **no** Pre-authorized lakes section.

### What NOT to test

- The org-scoping of any production lake. This PR does not perform it, it is not a code change, and
  the grant-row path above makes it unnecessary for injection specifically - see
  **Additional Information**.
- Admitting a lake whose only manage rung is platform-admin. That is refused by design; step 8c is
  the test for the refusal.
- Mid-session scope change (adding or removing pre-authorized lakes on an existing session). Not
  supported, by decision.
- The lake access audit view / CSV. Deliberately untouched - see below.

## Additional Information

**Deliberately not in this PR**, so review budget goes to the mechanism rather than scope
archaeology:

- **Scope item 4's lake-access-view half - DROPPED, not deferred.** An access-basis field on
  `LakeAccessEventModel` plus `assembleLakeAccessView.ts`, `lakeAccessViewCsv.ts` and
  `LakeAccessViewTypes.ts` with tests: about nine files including a Mongoose schema change, on a
  surface with no readers. The `promptMeta` flag in this PR already gives the only existing reader
  (the eval harness) what it needs to assert a turn used the widening. Recorded as a decision so it
  is not re-raised as missing coverage.
- **No api-contract entry for `/api/sessions/create` - considered and left.** That route parses no
  zod schema and is not a contract-backed public endpoint today; giving it one to document a single
  optional field is a separate migration, not part of this change.
- **Mid-session scope change - DROPPED,** and deliberately not filed as an issue. Nothing needs it:
  both eval harnesses create one session per run. What survived it is the `UpdateSessionParameters`
  compile guard above, which is the one real hazard it contained.
- **Unconditional manager trust at the injection gate is NOT adopted.** The issue's own "Proposed
  fix" was to admit managers to `isTrustedForInjection` for every turn. The mechanism here is
  narrower on purpose: explicit per-session opt-in, authorized at create and re-derived per turn, so
  a maintainer's ambient manage rights never silently widen grounding on a session that did not ask
  for it. If unconditional trust is later judged the right end state, this plumbing makes it a
  one-predicate change.
- **Platform-admin is still NOT an admission rung, and that is a deliberate reversal of the issue's
  own proposed fix.** The admission does not merely bypass prompt-injection trust: it widens FILE
  retrieval. `unionPreauthorizedLakeAccess` inserts the lake into the resolved access set, which is
  passed straight into the candidate-file query as `dataLakeTags` / `lakeMemberships` /
  `restrictToDataLake` (forced retrieval and the KB tools alike). Admitting `isAdmin` would therefore
  let any platform superuser ground an arbitrary turn on any lake's file contents by session-create
  request alone - a materially larger grant than the bug asks for, and one the admin panel does not
  already confer. `filterStillManagedLakes` hardcodes the same `isAdmin: false` and documents that
  the two gates must not drift, so changing only the route would also produce an admission that is
  granted at create and silently inert from turn 1.

  **The unblock for a platform-admin-only maintainer is a grant row, not a code path.**
  `resolveCanManageLake` is already wired with the grant repo at the session-create gate, so an
  owner or curator grant on the lake makes that maintainer admissible with no code change, no
  org-scoping, and no widening for anyone else. `listDataLakes.canPreauthorize.test.ts` pins this
  case directly. Such a maintainer now sees `canPreauthorize: false` and the button stops pretending
  - which is the honest state, not a regression.
- **The operational org-scoping step is not here and carries no code.** Writing an
  `organizationId` onto a lake is a live-data operation with a hard precondition (every user holding
  the lake's `requiredUserTag` must already be in the target org, or their access goes dark, because
  `DataLakeModel.ts:421` makes org a hard prerequisite rather than a flat OR with the tag). The
  read-only precondition queries are written out in the plan. This PR is what makes a non-member
  maintainer survive that write, and it does not depend on the write having happened.

**One incidental fix, not called for by the plan:** `isApiKeyAuth(req)` does not typecheck at
`create.ts`'s call site, because `asyncHandler`'s bare generic resolves the request to `unknown`
while `isApiKeyAuth` takes a full-default-generic `Request`. This is local to that call site (the
helper's other callers do not go through `asyncHandler`), so the route reads `req.apiKeyInfo`
directly instead of importing the helper. `asyncHandler` and `isApiKeyAuth` themselves are
unchanged - widening either is a larger change than this PR should carry.

**Known-environmental local failures, not from this diff:**
`apps/client/__tests__/premiumMigrationsWiring.test.ts` reads a gitignored generated file, and the
pre-push hook reports premium-overlay typecheck errors from packages that are not linked into
`node_modules` locally.

## Developer Notes

- **`promptMeta.preauthorizedLakeIdsUsed`** is the assertable per-turn record of the widening. The
  session's own `preauthorizedLakeIds` says what was *admitted*; this says which admitted lakes a
  given turn actually *injected*. Anything measuring lake grounding should read the turn field, not
  the session field - but read it as membership, not causation: an admitted lake the caller could
  already reach (creator, or org member) injects through the ordinary trust arm and is listed too.
- **The `AssertTrue` idiom now exists on both sides of the session service** (`create.ts` and
  `update.ts`). It is the pattern for "this field must never become an input to this service": it
  fails the build, not a test, which matters here because `tsconfig.json` excludes test files.
- **Key-scoped narrowing without a new scope.** `preauthorizedLakeIds` on a key is a *binding*, not
  a grant: it restricts which of the underlying user's existing manage rights the key may exercise,
  and is always checked alongside the live authorization rather than in place of it. That shape is
  reusable for any future capability where a key should be able to do less than its user, and it
  needs no `ApiKeyScope` and no `ADMIN_ONLY_API_KEY_SCOPES` entry.
- **`AdminCreateUserApiKeyRequest extends CreateUserApiKeyRequest`** is how an admin-only mint field
  stays off the self-service path at the type level rather than by a runtime check.
- **`canManage` and `canPreauthorize` are two different questions and must not be conflated.**
  "May I edit this lake?" includes platform-admin; "may I ground a session on it?" does not. Any new
  UI affordance for the admission gates on the latter. There are now three places that resolve the
  admission rung - the route, `filterStillManagedLakes`, and the list projections - and all three
  pass `isAdmin: false`; a rung change has to touch all three or they drift.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, `preauthorizedLakeIdsUsed` is internal lake ids on the existing `promptMeta.retrieval` object, no new classification category


