### PR TITLE
fix(data-lake): resolve foreign-org grant-held lakes by slug

### DIFF
--- a/apps/client/server/slack/dataLakeIngestAuthz.test.ts
+++ b/apps/client/server/slack/dataLakeIngestAuthz.test.ts
@@ -153,6 +153,9 @@ describe('authorizeLakeForWrite - both gates honour the org-admin rung', () => {
     dataLakes: {
       findById: vi.fn().mockResolvedValue(null),
       findBySlug: vi.fn().mockResolvedValue(lake),
+      // Never actually called here: findBySlug above always hits, and assertLakeAccess's #2425
+      // grant-fallback arm only runs on a miss. Present only so this mock satisfies the type.
+      findBySlugAmongIds: vi.fn().mockResolvedValue(null),
       // Gate 2 re-resolves the lake by meta-tag rather than by slug.
       findByDatalakeTag: vi.fn().mockResolvedValue(lake),
       find: vi.fn().mockResolvedValue([]),

--- a/apps/client/server/slack/dataLakeIngestAuthz.ts
+++ b/apps/client/server/slack/dataLakeIngestAuthz.ts
@@ -46,7 +46,7 @@ export interface LakeWriteRefusal {
 
 export interface LakeAuthzDeps {
   // `find` is required by the fallback tagger, the others by the write gate.
-  dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug' | 'findByDatalakeTag' | 'find'>;
+  dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug' | 'findBySlugAmongIds' | 'findByDatalakeTag' | 'find'>;
   /**
    * The lake's access grants, which `assertLakeWriteAccess` resolves so a CURATOR or a transferred
    * owner may ingest and not only the original creator. Declared on the shared prologue rather than

--- a/apps/client/server/slack/handleDataLakeCommand.test.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.test.ts
@@ -8,10 +8,13 @@ const { ingestSlackFilesIntoLake, ingestSlackLinkIntoLake, buildSlackAccessConte
   ingestSlackLinkIntoLake: vi.fn(),
   buildSlackAccessContext: vi.fn(),
 }));
-const { listDataLakes } = vi.hoisted(() => ({ listDataLakes: vi.fn() }));
+const { listDataLakes, grantedLakeIdsFor } = vi.hoisted(() => ({
+  listDataLakes: vi.fn(),
+  grantedLakeIdsFor: vi.fn(),
+}));
 
 vi.mock('@bike4mind/slack', () => ({ parseDataLakeCommand }));
-vi.mock('@bike4mind/services', () => ({ dataLakeService: { listDataLakes } }));
+vi.mock('@bike4mind/services', () => ({ dataLakeService: { listDataLakes, grantedLakeIdsFor } }));
 // Both ingest paths and the shared AccessContext builder are stubbed, so these tests exercise
 // dispatch and reply composition only. Each path's own behavior has its own test file.
 vi.mock('./dataLakeIngestAuthz', () => ({ buildSlackAccessContext }));
@@ -37,6 +40,7 @@ const baseParams = (overrides: Record<string, unknown> = {}) => ({
 beforeEach(() => {
   vi.clearAllMocks();
   buildSlackAccessContext.mockResolvedValue({ userId: 'u1', isAdmin: false, userTags: [], entitlementKeys: [] });
+  grantedLakeIdsFor.mockResolvedValue([]);
 });
 
 describe('handleDataLakeCommand', () => {
@@ -303,6 +307,46 @@ describe('handleDataLakeCommand', () => {
             );
           }
         }
+      });
+
+      it('resolves a foreign-org grant-held lake by slug, mirroring findBySlug (#2425)', async () => {
+        // A lake in an org the caller does not belong to still reaches `add` when the grants
+        // fallback resolves it - `list` must agree, or it omits exactly the lake `add` accepts.
+        listDataLakes.mockResolvedValue([
+          { id: 'lake-1', slug: 'granted', name: 'Granted Lake', canManage: true, organizationId: 'org-b' },
+        ]);
+        grantedLakeIdsFor.mockResolvedValue(['lake-1']);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toContain('granted');
+        expect(reply).toContain('Granted Lake');
+      });
+
+      it('still omits a foreign-org lake with NO grant, even though listDataLakes returned it', async () => {
+        listDataLakes.mockResolvedValue([
+          { id: 'lake-1', slug: 'ungranted', name: 'Ungranted Lake', canManage: true, organizationId: 'org-b' },
+        ]);
+        grantedLakeIdsFor.mockResolvedValue([]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toMatch(/cannot add to any data lakes/i);
+      });
+
+      it("prefers the caller's own-org lake over a same-slug foreign-org grant-held one", async () => {
+        // findBySlug never reaches its grant-fallback arm when an own-org match exists for the
+        // slug - the grant tier must lose the tie regardless of org-id string ordering.
+        listDataLakes.mockResolvedValue([
+          { id: 'lake-own', slug: 'notes', name: 'Own Org Notes', canManage: true, organizationId: 'org-a' },
+          { id: 'lake-foreign', slug: 'notes', name: 'Foreign Grant Notes', canManage: true, organizationId: 'org-z' },
+        ]);
+        grantedLakeIdsFor.mockResolvedValue(['lake-foreign']);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toContain('Own Org Notes');
+        expect(reply).not.toContain('Foreign Grant Notes');
       });
     });
   });

--- a/apps/client/server/slack/handleDataLakeCommand.test.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.test.ts
@@ -21,7 +21,13 @@ vi.mock('./dataLakeIngestAuthz', () => ({ buildSlackAccessContext }));
 vi.mock('./dataLakeFileIngest', () => ({ ingestSlackFilesIntoLake }));
 vi.mock('./dataLakeLinkIngest', () => ({ ingestSlackLinkIntoLake }));
 
-import { handleDataLakeCommand, runDataLakeSlackCommand, formatIngestOutcome } from './handleDataLakeCommand';
+import {
+  handleDataLakeCommand,
+  runDataLakeSlackCommand,
+  formatIngestOutcome,
+  slugTier,
+  type ListScope,
+} from './handleDataLakeCommand';
 
 const actor = { id: 'u1', isAdmin: false };
 const dataLakeAccessGrants = { listByLake: vi.fn(), listActiveByLakes: vi.fn(), listByPrincipal: vi.fn() };
@@ -263,40 +269,57 @@ describe('handleDataLakeCommand', () => {
 
       it('never prints a slug `add` cannot resolve (listed implies addable)', async () => {
         const catalog = [
-          { slug: 'personal', name: 'Personal', canManage: true },
-          { slug: 'ours', name: 'Ours', canManage: true, organizationId: 'org-a' },
-          { slug: 'theirs', name: 'Theirs', canManage: true, organizationId: 'org-b' },
-          { slug: 'open-lake', name: 'Open', canManage: true, organizationId: 'org-b', isPublic: true },
-          { slug: 'notes', name: 'Org-less Notes', canManage: true },
-          { slug: 'notes', name: 'Org Notes', canManage: true, organizationId: 'org-a' },
+          { id: 'personal', slug: 'personal', name: 'Personal', canManage: true },
+          { id: 'ours', slug: 'ours', name: 'Ours', canManage: true, organizationId: 'org-a' },
+          { id: 'theirs', slug: 'theirs', name: 'Theirs', canManage: true, organizationId: 'org-b' },
+          { id: 'open', slug: 'open-lake', name: 'Open', canManage: true, organizationId: 'org-b', isPublic: true },
+          { id: 'notes-orgless', slug: 'notes', name: 'Org-less Notes', canManage: true },
+          { id: 'notes-org', slug: 'notes', name: 'Org Notes', canManage: true, organizationId: 'org-a' },
           // Deliberately NOT uniformly writable: the winning lake for `shared` is unwritable, so
           // `add` refuses the slug and the guard must see the reply omit it rather than print the
           // writable org-less one. A catalog with canManage: true everywhere cannot catch that.
-          { slug: 'shared', name: 'Writable Org-less Shared', canManage: true },
-          { slug: 'shared', name: 'Read-only Org Shared', canManage: false, organizationId: 'org-a' },
+          { id: 'shared-orgless', slug: 'shared', name: 'Writable Org-less Shared', canManage: true },
+          {
+            id: 'shared-org',
+            slug: 'shared',
+            name: 'Read-only Org Shared',
+            canManage: false,
+            organizationId: 'org-a',
+          },
+          // A grant-held (tier 2) lake, present so this guard exercises all three tiers `slugTier`
+          // ranks - not just own-org/org-less - and would catch a future tier this reply omits.
+          { id: 'granted-lake', slug: 'granted-only', name: 'Granted Only', canManage: true, organizationId: 'org-z' },
         ];
         listDataLakes.mockResolvedValue(catalog);
+        grantedLakeIdsFor.mockResolvedValue(['granted-lake']);
 
-        // Mirrors DataLakeModel.findBySlug: an own-org match first (lowest org id), then the
-        // org-less fallback. If that rule changes, this guard is what catches the divergence.
-        const findBySlug = (slug: string) => {
-          const own = catalog
-            .filter(l => l.slug === slug && l.organizationId && adminCtx.organizationIds.includes(l.organizationId))
-            .sort((a, b) => String(a.organizationId).localeCompare(String(b.organizationId)));
-          return own[0] ?? catalog.find(l => l.slug === slug && !l.organizationId) ?? null;
+        // Mirrors `add` by calling the SAME production ranking function `list` itself uses
+        // (`slugTier`, exported from handleDataLakeCommand.ts) rather than a hand-rolled copy of
+        // the arm order - a hand-rolled copy is exactly what let the grant tier go uncovered here
+        // before #2425's review caught it.
+        const resolveBySlug = (slug: string, scope: ListScope, grantedLakeIds: ReadonlySet<string>) => {
+          let best: { lake: (typeof catalog)[number]; tier: 0 | 1 | 2 } | null = null;
+          for (const lake of catalog) {
+            if (lake.slug !== slug) continue;
+            const tier = slugTier(lake, scope, grantedLakeIds);
+            if (tier !== null && (!best || tier < best.tier)) best = { lake, tier };
+          }
+          return best?.lake ?? null;
         };
 
         // Both actors, because the write gate differs: an admin is granted outright on any
         // non-registry lake, so an admin-only run cannot see an unwritable winner at all.
         for (const isAdmin of [true, false]) {
-          buildSlackAccessContext.mockResolvedValue({ ...adminCtx, isAdmin });
+          const scope = { ...adminCtx, isAdmin };
+          buildSlackAccessContext.mockResolvedValue(scope);
 
           const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin } }));
 
           const slugs = printedSlugs(reply);
           expect(slugs.length, `no rows printed for isAdmin=${isAdmin}`).toBeGreaterThan(0);
+          const grantedLakeIds = new Set(['granted-lake']);
           for (const slug of slugs) {
-            const resolved = findBySlug(slug);
+            const resolved = resolveBySlug(slug, scope, grantedLakeIds);
             expect(resolved, `add to \`${slug}\` would be refused`).not.toBeNull();
             expect(reply).toContain(resolved!.name);
             // `add` gates the lake findBySlug returned, with no retry against a same-slug sibling,
@@ -347,6 +370,65 @@ describe('handleDataLakeCommand', () => {
 
         expect(reply).toContain('Own Org Notes');
         expect(reply).not.toContain('Foreign Grant Notes');
+      });
+
+      it('prefers a personal (org-less) lake over a same-slug foreign-org grant-held one', async () => {
+        // The other new tie this change introduces: org-less (tier 1) still beats grant-held
+        // (tier 2), so a caller's own personal lake wins the slug over a lake transferred to them
+        // from a foreign org - decided by tier alone here, not by name/id ordering.
+        listDataLakes.mockResolvedValue([
+          { id: 'lake-personal', slug: 'notes', name: 'Personal Notes', canManage: true },
+          { id: 'lake-foreign', slug: 'notes', name: 'Foreign Grant Notes', canManage: true, organizationId: 'org-z' },
+        ]);
+        grantedLakeIdsFor.mockResolvedValue(['lake-foreign']);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toContain('Personal Notes');
+        expect(reply).not.toContain('Foreign Grant Notes');
+      });
+
+      it('picks the lower lake id between two same-slug foreign-org grant-held lakes', async () => {
+        // Mirrors DataLakeModel.findBySlugAmongIds' `.sort({_id: 1})`: two grant-held lakes across
+        // two different non-member orgs sharing a slug must resolve to the same winner every time.
+        listDataLakes.mockResolvedValue([
+          { id: 'lake-b', slug: 'shared-grant', name: 'From Org B', canManage: true, organizationId: 'org-b' },
+          { id: 'lake-a', slug: 'shared-grant', name: 'From Org A', canManage: true, organizationId: 'org-a-foreign' },
+        ]);
+        grantedLakeIdsFor.mockResolvedValue(['lake-b', 'lake-a']);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toContain('From Org A');
+        expect(reply).not.toContain('From Org B');
+      });
+
+      it('resolves two same-slug org-less lakes deterministically (null vs empty-string organizationId)', async () => {
+        // #2425 review: null and '' are both stored as "org-less" but are distinct index keys, so
+        // two org-less lakes CAN share a slug - unlike own-org/grant-held, this had no tie-break at
+        // all before this fix. orgSortKey treats null/undefined (BSON Null) as sorting before any
+        // string, mirroring DataLakeModel's own `.sort({organizationId:1})` on this arm.
+        listDataLakes.mockResolvedValue([
+          { id: 'lake-empty', slug: 'orgless-tie', name: 'Empty String Org', canManage: true, organizationId: '' },
+          { id: 'lake-null', slug: 'orgless-tie', name: 'Null Org', canManage: true, organizationId: undefined },
+        ]);
+
+        const reply = await handleDataLakeCommand(baseParams({ actor: { id: 'u1', isAdmin: true } }));
+
+        expect(reply).toContain('Null Org');
+        expect(reply).not.toContain('Empty String Org');
+      });
+
+      it('slugTier ranks a foreign-org lake null (unaddressable) when no grant covers it', () => {
+        // Direct unit coverage of the exported ranker itself, not just through the Slack reply -
+        // the same function `list` and this guard both call, so nothing here can drift from it.
+        const scope: ListScope = { isAdmin: false, organizationIds: ['org-a'] };
+        const foreign = { id: 'x', slug: 'x', name: 'X', organizationId: 'org-z', canManage: true };
+
+        expect(slugTier(foreign, scope, new Set())).toBeNull();
+        expect(slugTier(foreign, scope, new Set(['x']))).toBe(2);
+        expect(slugTier({ ...foreign, organizationId: 'org-a' }, scope, new Set())).toBe(0);
+        expect(slugTier({ ...foreign, organizationId: undefined }, scope, new Set())).toBe(1);
       });
     });
   });

--- a/apps/client/server/slack/handleDataLakeCommand.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.ts
@@ -97,26 +97,43 @@ const isWritable = (lake: ListableLake, scope: ListScope): boolean =>
   lake.canManage || (scope.isAdmin && !STATIC_LAKE_IDS.has(lake.id));
 
 /**
- * Whether `@datalake add to <slug>` can RESOLVE this lake for this caller: an org-less lake, or one
- * scoped to an org the caller belongs to. Mirrors `findBySlug`'s own-org-then-org-less lookup
+ * Whether `@datalake add to <slug>` can RESOLVE this lake for this caller: an org-less lake, one
+ * scoped to an org the caller belongs to, or - last resort - a foreign-org lake the caller holds a
+ * real owner/curator grant on (#2425). Mirrors `findBySlug`'s three arms in order
  * (packages/database/src/models/ai/DataLakeModel.ts) and must stay in sync with it - a row that
  * fails there is a slug this reply promised and `add` then refuses as "No Data Lake found".
  */
-const isSlugAddressable = (lake: ListableLake, scope: ListScope): boolean => {
+const isSlugAddressable = (lake: ListableLake, scope: ListScope, grantedLakeIds: ReadonlySet<string>): boolean => {
   const orgId = lakeOrgId(lake);
-  return !orgId || (scope.organizationIds ?? []).includes(orgId);
+  return !orgId || (scope.organizationIds ?? []).includes(orgId) || grantedLakeIds.has(lake.id);
+};
+
+/** findBySlug's three arms, in the order it tries them - own-org, then org-less, then grant-held. */
+const slugPriorityTier = (lake: ListableLake, scope: ListScope, grantedLakeIds: ReadonlySet<string>): 0 | 1 | 2 => {
+  const orgId = lakeOrgId(lake);
+  if (orgId && (scope.organizationIds ?? []).includes(orgId)) return 0;
+  if (!orgId) return 1;
+  return 2; // foreign-org, addressable only via a grant
 };
 
 /**
- * Of two lakes sharing a slug, the one `findBySlug` would resolve: an org-scoped lake beats an
- * org-less one, and among org-scoped ones the lowest org id wins (the model sorts ascending).
+ * Of two lakes sharing a slug, the one `findBySlug` would resolve: own-org beats org-less beats
+ * grant-held, matching the arm order above. Within own-org the lowest org id wins, and within
+ * grant-held the lowest lake id wins (both mirror the model's own `.sort()` tie-breaks) - org-less
+ * needs no tie-break since at most one org-less lake can share a slug.
  */
-const preferredBySlug = (a: ListableLake, b: ListableLake): ListableLake => {
-  const aOrg = lakeOrgId(a);
-  const bOrg = lakeOrgId(b);
-  if (!aOrg) return bOrg ? b : a;
-  if (!bOrg) return a;
-  return bOrg < aOrg ? b : a;
+const preferredBySlug = (
+  a: ListableLake,
+  b: ListableLake,
+  scope: ListScope,
+  grantedLakeIds: ReadonlySet<string>
+): ListableLake => {
+  const tierA = slugPriorityTier(a, scope, grantedLakeIds);
+  const tierB = slugPriorityTier(b, scope, grantedLakeIds);
+  if (tierA !== tierB) return tierA < tierB ? a : b;
+  if (tierA === 0) return (lakeOrgId(b) as string) < (lakeOrgId(a) as string) ? b : a;
+  if (tierA === 2) return b.id < a.id ? b : a;
+  return a;
 };
 
 /**
@@ -125,11 +142,11 @@ const preferredBySlug = (a: ListableLake, b: ListableLake): ListableLake => {
  * target. Runs over every ADDRESSABLE lake, before the write gate, because `findBySlug` resolves by
  * org priority without consulting write access (see the note in `handleList`).
  */
-const dedupeBySlug = (lakes: ListableLake[]): ListableLake[] => {
+const dedupeBySlug = (lakes: ListableLake[], scope: ListScope, grantedLakeIds: ReadonlySet<string>): ListableLake[] => {
   const bySlug = new Map<string, ListableLake>();
   for (const lake of lakes) {
     const existing = bySlug.get(lake.slug);
-    bySlug.set(lake.slug, existing ? preferredBySlug(existing, lake) : lake);
+    bySlug.set(lake.slug, existing ? preferredBySlug(existing, lake, scope, grantedLakeIds) : lake);
   }
   return Array.from(bySlug.values());
 };
@@ -167,13 +184,24 @@ async function handleList(params: HandleDataLakeCommandParams): Promise<string> 
     // bound on today's system, not a rung this omission is meant to guard against.)
     { db: { dataLakes: params.deps.dataLakes, dataLakeAccessGrants: params.deps.dataLakeAccessGrants } }
   );
+  // The same last-resort grant lookup findBySlug's #2425 fallback arm runs, so a foreign-org
+  // owner/curator grant holder sees the lake here too - otherwise `list` would omit exactly the
+  // lake `add` now accepts (isSlugAddressable would filter it out before dedupe/write-gate ever run).
+  const grantedLakeIds = new Set(
+    await dataLakeService.grantedLakeIdsFor(
+      ctx.userId,
+      ctx.organizationIds ?? [],
+      params.deps.dataLakeAccessGrants,
+      false
+    )
+  );
   // Order matters, and it mirrors `add`: resolve the slug's winning lake FIRST, then apply the write
   // gate to that winner. `findBySlug` picks by org priority alone and never falls back when the lake
   // it picked turns out to be unwritable, so gating before the dedupe would hide a higher-priority
   // lake and print a slug `add` resolves elsewhere and refuses. `isWritable` also restores the
   // manage LABEL that suppressing isAdmin silenced in canManageLake; it only ever removes rows.
-  const addressable = lakes.filter(lake => isSlugAddressable(lake, ctx));
-  const writable = dedupeBySlug(addressable).filter(lake => isWritable(lake, ctx));
+  const addressable = lakes.filter(lake => isSlugAddressable(lake, ctx, grantedLakeIds));
+  const writable = dedupeBySlug(addressable, ctx, grantedLakeIds).filter(lake => isWritable(lake, ctx));
 
   if (writable.length === 0) {
     return 'You cannot add to any data lakes yet. You can add to lakes you created, or ask an admin.';

--- a/apps/client/server/slack/handleDataLakeCommand.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.ts
@@ -78,10 +78,10 @@ export async function handleDataLakeCommand(params: HandleDataLakeCommandParams)
 }
 
 /** The lake fields the `list` scoping rules and the rendered rows need. */
-type ListableLake = Pick<ManageableDataLakeConfig, 'id' | 'slug' | 'name' | 'organizationId' | 'canManage'>;
+export type ListableLake = Pick<ManageableDataLakeConfig, 'id' | 'slug' | 'name' | 'organizationId' | 'canManage'>;
 
 /** The caller facts both scoping rules key off. */
-type ListScope = Pick<AccessContext, 'isAdmin' | 'organizationIds'>;
+export type ListScope = Pick<AccessContext, 'isAdmin' | 'organizationIds'>;
 
 /** An org-scoped lake's org id, with a blank string read as org-less (both forms are stored). */
 const lakeOrgId = (lake: ListableLake): string | undefined => lake.organizationId?.trim() || undefined;
@@ -96,68 +96,68 @@ const lakeOrgId = (lake: ListableLake): string | undefined => lake.organizationI
 const isWritable = (lake: ListableLake, scope: ListScope): boolean =>
   lake.canManage || (scope.isAdmin && !STATIC_LAKE_IDS.has(lake.id));
 
-/**
- * Whether `@datalake add to <slug>` can RESOLVE this lake for this caller: an org-less lake, one
- * scoped to an org the caller belongs to, or - last resort - a foreign-org lake the caller holds a
- * real owner/curator grant on (#2425). Mirrors `findBySlug`'s three arms in order
- * (packages/database/src/models/ai/DataLakeModel.ts) and must stay in sync with it - a row that
- * fails there is a slug this reply promised and `add` then refuses as "No Data Lake found".
- */
-const isSlugAddressable = (lake: ListableLake, scope: ListScope, grantedLakeIds: ReadonlySet<string>): boolean => {
-  const orgId = lakeOrgId(lake);
-  return !orgId || (scope.organizationIds ?? []).includes(orgId) || grantedLakeIds.has(lake.id);
-};
+/** Tier 1 (org-less) ordering key: null/undefined (BSON Null) sorts before any string, mirroring
+ * DataLakeModel.findBySlug's `.sort({ organizationId: 1 })` on its own org-less arm. */
+const orgSortKey = (organizationId: string | null | undefined): readonly [0 | 1, string] =>
+  organizationId == null ? [0, ''] : [1, organizationId];
 
 /**
- * findBySlug's three arms, in the order it tries them - own-org, then org-less, then grant-held.
- * Only ever called on lakes `isSlugAddressable` already passed, so a foreign-org lake reaching
- * here is expected to be grant-held - asserted directly (rather than assumed by elimination) so a
- * future caller that skips that filter fails loudly instead of silently misranking an ungranted
- * lake as tier 2.
+ * findBySlug's three arms, in the order it tries them - own-org, then org-less, then grant-held
+ * (#2425) - as ONE total function rather than a boolean check plus a separately-derived rank:
+ * `null` means "not resolvable by this caller at all" and doubles as the addressability check
+ * (`slugTier(...) !== null`), so there is no separate predicate that can drift out of sync with
+ * the ranking, and no precondition to assert at runtime - a foreign-org lake with no grant simply
+ * ranks `null` instead of being assumed away by elimination. Must stay in sync with `findBySlug`
+ * (packages/database/src/models/ai/DataLakeModel.ts) - a row that fails there is a slug this reply
+ * promised and `add` then refuses as "No Data Lake found".
  */
-const slugPriorityTier = (lake: ListableLake, scope: ListScope, grantedLakeIds: ReadonlySet<string>): 0 | 1 | 2 => {
+export const slugTier = (
+  lake: ListableLake,
+  scope: ListScope,
+  grantedLakeIds: ReadonlySet<string>
+): 0 | 1 | 2 | null => {
   const orgId = lakeOrgId(lake);
   if (orgId && (scope.organizationIds ?? []).includes(orgId)) return 0;
   if (!orgId) return 1;
-  if (!grantedLakeIds.has(lake.id)) {
-    throw new Error(
-      `slugPriorityTier: foreign-org lake ${lake.id} has no grant - caller must filter via isSlugAddressable first`
-    );
-  }
-  return 2;
+  return grantedLakeIds.has(lake.id) ? 2 : null;
 };
+
+/** A lake paired with the (already non-null) tier it resolved to - computed once per lake, in the
+ * filter pass, and carried through dedupe rather than re-derived. */
+interface AddressableRow {
+  lake: ListableLake;
+  tier: 0 | 1 | 2;
+}
 
 /**
  * Of two lakes sharing a slug, the one `findBySlug` would resolve: own-org beats org-less beats
- * grant-held, matching the arm order above. Within own-org the lowest org id wins, and within
- * grant-held the lowest lake id wins (both mirror the model's own `.sort()` tie-breaks) - org-less
- * needs no tie-break since at most one org-less lake can share a slug.
+ * grant-held, matching the arm order above. Within own-org the lowest org id wins, within
+ * org-less the lower `orgSortKey` wins (see its doc comment - `null` and `''` are distinct index
+ * keys and CAN collide on one slug), and within grant-held the lowest lake id wins (all three
+ * mirror the model's own `.sort()` tie-breaks).
  */
-const preferredBySlug = (
-  a: ListableLake,
-  b: ListableLake,
-  scope: ListScope,
-  grantedLakeIds: ReadonlySet<string>
-): ListableLake => {
-  const tierA = slugPriorityTier(a, scope, grantedLakeIds);
-  const tierB = slugPriorityTier(b, scope, grantedLakeIds);
-  if (tierA !== tierB) return tierA < tierB ? a : b;
-  if (tierA === 0) return (lakeOrgId(b) as string) < (lakeOrgId(a) as string) ? b : a;
-  if (tierA === 2) return b.id < a.id ? b : a;
-  return a;
+const preferredRow = (a: AddressableRow, b: AddressableRow): AddressableRow => {
+  if (a.tier !== b.tier) return a.tier < b.tier ? a : b;
+  if (a.tier === 0) return (lakeOrgId(b.lake) as string) < (lakeOrgId(a.lake) as string) ? b : a;
+  if (a.tier === 1) {
+    const [aType, aOrg] = orgSortKey(a.lake.organizationId);
+    const [bType, bOrg] = orgSortKey(b.lake.organizationId);
+    return bType !== aType ? (bType < aType ? b : a) : bOrg < aOrg ? b : a;
+  }
+  return b.lake.id < a.lake.id ? b : a;
 };
 
 /**
  * One row per slug. A slug is unique per org, so a collision means two lakes the caller can reach
  * under one name - keep the one `add` would resolve, or the reply names a lake the command does not
- * target. Runs over every ADDRESSABLE lake, before the write gate, because `findBySlug` resolves by
+ * target. Runs over every ADDRESSABLE row, before the write gate, because `findBySlug` resolves by
  * org priority without consulting write access (see the note in `handleList`).
  */
-const dedupeBySlug = (lakes: ListableLake[], scope: ListScope, grantedLakeIds: ReadonlySet<string>): ListableLake[] => {
-  const bySlug = new Map<string, ListableLake>();
-  for (const lake of lakes) {
-    const existing = bySlug.get(lake.slug);
-    bySlug.set(lake.slug, existing ? preferredBySlug(existing, lake, scope, grantedLakeIds) : lake);
+const dedupeBySlug = (rows: AddressableRow[]): AddressableRow[] => {
+  const bySlug = new Map<string, AddressableRow>();
+  for (const row of rows) {
+    const existing = bySlug.get(row.lake.slug);
+    bySlug.set(row.lake.slug, existing ? preferredRow(existing, row) : row);
   }
   return Array.from(bySlug.values());
 };
@@ -185,7 +185,7 @@ async function handleList(params: HandleDataLakeCommandParams): Promise<string> 
   const ctx = await buildSlackAccessContext(params.actor, params.deps, { resolveEntitlementsForAdmin: true });
   // The same last-resort grant lookup findBySlug's #2425 fallback arm runs, so a foreign-org
   // owner/curator grant holder sees the lake here too - otherwise `list` would omit exactly the
-  // lake `add` now accepts (isSlugAddressable would filter it out before dedupe/write-gate ever run).
+  // lake `add` now accepts (slugTier would rank it null before dedupe/write-gate ever run).
   // Resolved ONCE and handed to listDataLakes below as its precomputed set, rather than each
   // independently running the identical listByPrincipal query - listDataLakes' own includeReaders
   // is always false here too, since we deliberately never thread a settings adapter (see below).
@@ -216,8 +216,14 @@ async function handleList(params: HandleDataLakeCommandParams): Promise<string> 
   // it picked turns out to be unwritable, so gating before the dedupe would hide a higher-priority
   // lake and print a slug `add` resolves elsewhere and refuses. `isWritable` also restores the
   // manage LABEL that suppressing isAdmin silenced in canManageLake; it only ever removes rows.
-  const addressable = lakes.filter(lake => isSlugAddressable(lake, ctx, grantedLakeIds));
-  const writable = dedupeBySlug(addressable, ctx, grantedLakeIds).filter(lake => isWritable(lake, ctx));
+  const addressable: AddressableRow[] = [];
+  for (const lake of lakes) {
+    const tier = slugTier(lake, ctx, grantedLakeIds);
+    if (tier !== null) addressable.push({ lake, tier });
+  }
+  const writable = dedupeBySlug(addressable)
+    .map(row => row.lake)
+    .filter(lake => isWritable(lake, ctx));
 
   if (writable.length === 0) {
     return 'You cannot add to any data lakes yet. You can add to lakes you created, or ask an admin.';

--- a/apps/client/server/slack/handleDataLakeCommand.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.ts
@@ -108,12 +108,23 @@ const isSlugAddressable = (lake: ListableLake, scope: ListScope, grantedLakeIds:
   return !orgId || (scope.organizationIds ?? []).includes(orgId) || grantedLakeIds.has(lake.id);
 };
 
-/** findBySlug's three arms, in the order it tries them - own-org, then org-less, then grant-held. */
+/**
+ * findBySlug's three arms, in the order it tries them - own-org, then org-less, then grant-held.
+ * Only ever called on lakes `isSlugAddressable` already passed, so a foreign-org lake reaching
+ * here is expected to be grant-held - asserted directly (rather than assumed by elimination) so a
+ * future caller that skips that filter fails loudly instead of silently misranking an ungranted
+ * lake as tier 2.
+ */
 const slugPriorityTier = (lake: ListableLake, scope: ListScope, grantedLakeIds: ReadonlySet<string>): 0 | 1 | 2 => {
   const orgId = lakeOrgId(lake);
   if (orgId && (scope.organizationIds ?? []).includes(orgId)) return 0;
   if (!orgId) return 1;
-  return 2; // foreign-org, addressable only via a grant
+  if (!grantedLakeIds.has(lake.id)) {
+    throw new Error(
+      `slugPriorityTier: foreign-org lake ${lake.id} has no grant - caller must filter via isSlugAddressable first`
+    );
+  }
+  return 2;
 };
 
 /**
@@ -172,28 +183,33 @@ async function handleList(params: HandleDataLakeCommandParams): Promise<string> 
   // through the non-admin arms, so without the keys an entitlement-gated lake in the admin's OWN
   // org would fail findAccessible's requirement constraint and vanish from a list `add` still takes.
   const ctx = await buildSlackAccessContext(params.actor, params.deps, { resolveEntitlementsForAdmin: true });
-  const lakes = await dataLakeService.listDataLakes(
-    { ...ctx, isAdmin: false },
-    // Grants make the reply agree with `add`, which already resolves them: without this repo
-    // `listDataLakes` degrades both of its grant reads to empty, so a curator-granted or
-    // transferred lake neither enters the row set nor earns a manage label, and `list` omits a lake
-    // `add` accepts. Deliberately NO `settings` adapter alongside it: that flag is what admits
-    // READER grants specifically, and a reader cannot write, so passing it would advertise lakes
-    // `add` then refuses - the #2022 failure in a new place. (An org-principal owner/curator grant
-    // - canManageLake's fifth rung - CAN write; nothing mints that principal type yet, so this is a
-    // bound on today's system, not a rung this omission is meant to guard against.)
-    { db: { dataLakes: params.deps.dataLakes, dataLakeAccessGrants: params.deps.dataLakeAccessGrants } }
-  );
   // The same last-resort grant lookup findBySlug's #2425 fallback arm runs, so a foreign-org
   // owner/curator grant holder sees the lake here too - otherwise `list` would omit exactly the
   // lake `add` now accepts (isSlugAddressable would filter it out before dedupe/write-gate ever run).
-  const grantedLakeIds = new Set(
-    await dataLakeService.grantedLakeIdsFor(
-      ctx.userId,
-      ctx.organizationIds ?? [],
-      params.deps.dataLakeAccessGrants,
-      false
-    )
+  // Resolved ONCE and handed to listDataLakes below as its precomputed set, rather than each
+  // independently running the identical listByPrincipal query - listDataLakes' own includeReaders
+  // is always false here too, since we deliberately never thread a settings adapter (see below).
+  const grantedLakeIdsArray = await dataLakeService.grantedLakeIdsFor(
+    ctx.userId,
+    ctx.organizationIds ?? [],
+    params.deps.dataLakeAccessGrants,
+    false
+  );
+  const grantedLakeIds = new Set(grantedLakeIdsArray);
+  const lakes = await dataLakeService.listDataLakes(
+    { ...ctx, isAdmin: false },
+    {
+      // Grants make the reply agree with `add`, which already resolves them: without this repo
+      // `listDataLakes` degrades both of its grant reads to empty, so a curator-granted or
+      // transferred lake neither enters the row set nor earns a manage label, and `list` omits a lake
+      // `add` accepts. Deliberately NO `settings` adapter alongside it: that flag is what admits
+      // READER grants specifically, and a reader cannot write, so passing it would advertise lakes
+      // `add` then refuses - the #2022 failure in a new place. (An org-principal owner/curator grant
+      // - canManageLake's fifth rung - CAN write; nothing mints that principal type yet, so this is a
+      // bound on today's system, not a rung this omission is meant to guard against.)
+      db: { dataLakes: params.deps.dataLakes, dataLakeAccessGrants: params.deps.dataLakeAccessGrants },
+      grantedLakeIds: grantedLakeIdsArray,
+    }
   );
   // Order matters, and it mirrors `add`: resolve the slug's winning lake FIRST, then apply the write
   // gate to that winner. `findBySlug` picks by org priority alone and never falls back when the lake

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -364,18 +364,19 @@ export interface IDataLakeRepository extends IBaseRepository<IDataLakeDocument> 
    * caller's membership set to disambiguate: a lake in one of the caller's own orgs is
    * preferred, falling back to an org-less lake with that slug. Without a set, only
    * org-less lakes match.
-   *
-   * `resolveGrantedLakeIds` is a last-resort, lazily-invoked fallback (#2425): when the own-org
-   * and org-less arms both miss, and it is supplied, the ids it resolves to are tried as a third
-   * `{slug, _id: {$in: ...}}` arm - so a real owner/curator grant on a lake in a non-member org
-   * still resolves by slug. Lazy so callers that omit it (and the existing own-org/org-less hit
-   * path) never pay for the extra grants lookup.
    */
-  findBySlug(
-    slug: string,
-    organizationIds?: string[],
-    resolveGrantedLakeIds?: () => Promise<string[]>
-  ): Promise<IDataLakeDocument | null>;
+  findBySlug(slug: string, organizationIds?: string[]): Promise<IDataLakeDocument | null>;
+  /**
+   * Resolve a lake by slug, restricted to a specific candidate id set (#2425). The caller's
+   * last-resort arm: when `findBySlug`'s own-org/org-less lookup misses, a real owner/curator
+   * grant on a lake in a non-member org is still legitimate access, so the caller (typically
+   * `assertLakeAccess`, via `grantedLakeIdsFor`) resolves the grant-held id set itself and tries
+   * it here - keeping the decision of WHEN to pay for that extra grants lookup in the service
+   * layer, not hidden inside this repository method. Sorted by `_id` so two candidates sharing a
+   * slug (e.g. two independent `transferLakeOwnership` calls into different non-member orgs)
+   * resolve to the same winner every time.
+   */
+  findBySlugAmongIds(slug: string, ids: string[]): Promise<IDataLakeDocument | null>;
   /** Resolve a lake by its globally-unique join meta-tag (`datalake:<slug>` / `datalake:<org>:<slug>`). */
   findByDatalakeTag(datalakeTag: string): Promise<IDataLakeDocument | null>;
   /**

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -364,8 +364,18 @@ export interface IDataLakeRepository extends IBaseRepository<IDataLakeDocument> 
    * caller's membership set to disambiguate: a lake in one of the caller's own orgs is
    * preferred, falling back to an org-less lake with that slug. Without a set, only
    * org-less lakes match.
+   *
+   * `resolveGrantedLakeIds` is a last-resort, lazily-invoked fallback (#2425): when the own-org
+   * and org-less arms both miss, and it is supplied, the ids it resolves to are tried as a third
+   * `{slug, _id: {$in: ...}}` arm - so a real owner/curator grant on a lake in a non-member org
+   * still resolves by slug. Lazy so callers that omit it (and the existing own-org/org-less hit
+   * path) never pay for the extra grants lookup.
    */
-  findBySlug(slug: string, organizationIds?: string[]): Promise<IDataLakeDocument | null>;
+  findBySlug(
+    slug: string,
+    organizationIds?: string[],
+    resolveGrantedLakeIds?: () => Promise<string[]>
+  ): Promise<IDataLakeDocument | null>;
   /** Resolve a lake by its globally-unique join meta-tag (`datalake:<slug>` / `datalake:<org>:<slug>`). */
   findByDatalakeTag(datalakeTag: string): Promise<IDataLakeDocument | null>;
   /**

--- a/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
+++ b/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
@@ -19,12 +19,12 @@ import {
 
 interface AssertLakeAccessAdapters {
   db: {
-    dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
+    dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug' | 'findBySlugAmongIds'>;
     // Optional: when wired, a transferred/delegated owner or curator reaches the lake through the
     // single read gate too (canAccessLake delegates to the grant-aware canManageLake). Absent ->
     // read access falls back to createdByUserId + org/tag/public, the pre-grant behavior.
     // `listByPrincipal` (#2425) additionally lets a foreign-org owner/curator grant holder
-    // resolve the lake BY SLUG in the first place - see the findBySlug call below.
+    // resolve the lake BY SLUG in the first place - see the findBySlugAmongIds call below.
     dataLakeAccessGrants?: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
     // Optional: the read-time grant cutover flag (#1673). When wired, a persisted READER grant
     // resolves into an ephemeral membership view at the gate; the flag governs whether that
@@ -164,6 +164,25 @@ async function resolveFallbackLake(
 }
 
 /**
+ * The #2425 last-resort arm: only called on a `findBySlug` miss, and only when a grants repo is
+ * wired. Owner/curator only (`includeReaders: false`) - a foreign-org grant resolves the lake
+ * here, but `canManageLake` in the caller still gates what the grant actually admits the caller
+ * to do with it. Extracted so the miss-only laziness is visible at the call site (an `??` on two
+ * awaited calls) rather than hidden inside a thunk passed into the repository method.
+ */
+const resolveGrantHeldLakeBySlug = async (
+  slug: string,
+  ctx: AccessContext,
+  dataLakeAccessGrants: AssertLakeAccessAdapters['db']['dataLakeAccessGrants'],
+  dataLakes: Pick<IDataLakeRepository, 'findBySlugAmongIds'>
+): Promise<IDataLakeDocument | null> => {
+  if (!dataLakeAccessGrants) return null;
+  const grantedLakeIds = await grantedLakeIdsFor(ctx.userId, ctx.organizationIds ?? [], dataLakeAccessGrants, false);
+  if (grantedLakeIds.length === 0) return null;
+  return dataLakes.findBySlugAmongIds(slug, grantedLakeIds);
+};
+
+/**
  * The single access gate. Resolves a lake by id (then slug) from the DB, falling back
  * to the hardcoded DATA_LAKES configs (which have no backing document but are listed
  * by listDataLakes, so they must be openable). A DB lake always takes precedence - a
@@ -174,10 +193,12 @@ async function resolveFallbackLake(
  *
  * Slug resolution (#2425): findBySlug's own-org/org-less arms miss a lake in an org the
  * caller isn't a member of, even when they hold a real owner/curator grant on it (e.g. a
- * cross-org transferLakeOwnership). When `dataLakeAccessGrants` is wired, a lazy
- * grantedLakeIdsFor lookup is threaded through as findBySlug's last-resort fallback arm, so
- * a foreign-org grant holder can still reach the lake by slug - canManageLake below still
- * gates what they're actually allowed to do with it.
+ * cross-org transferLakeOwnership). On that miss, and only when `dataLakeAccessGrants` is
+ * wired, this resolves the grant-held id set itself (owner/curator only, includeReaders=false)
+ * and retries via `findBySlugAmongIds` - so a foreign-org grant holder can still reach the lake
+ * by slug, and canManageLake below still gates what they're actually allowed to do with it. The
+ * extra grants query only ever runs on a miss, matching the prior lazy-thunk design, but the
+ * decision now lives here rather than inside the repository method.
  */
 export const assertLakeAccess = async (
   lakeIdOrSlug: string,
@@ -186,16 +207,8 @@ export const assertLakeAccess = async (
 ): Promise<IDataLakeDocument> => {
   const lake =
     (await db.dataLakes.findById(lakeIdOrSlug).catch(() => null)) ??
-    (await db.dataLakes.findBySlug(
-      lakeIdOrSlug,
-      ctx.organizationIds,
-      // Lazy (#2425): only invoked by findBySlug on an own-org/org-less miss. Owner/curator only
-      // (includeReaders=false) - a foreign-org grant resolves the lake here, but canManageLake
-      // below still gates what the grant actually admits the caller to do with it.
-      db.dataLakeAccessGrants
-        ? () => grantedLakeIdsFor(ctx.userId, ctx.organizationIds, db.dataLakeAccessGrants, false)
-        : undefined
-    ));
+    (await db.dataLakes.findBySlug(lakeIdOrSlug, ctx.organizationIds)) ??
+    (await resolveGrantHeldLakeBySlug(lakeIdOrSlug, ctx, db.dataLakeAccessGrants, db.dataLakes));
   if (lake) {
     // A persisted lake may carry grants; a fallback lake never does. Fetch only when the repo is
     // wired, so callers that have not threaded it keep the createdByUserId + org/tag/public behavior.

--- a/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
+++ b/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
@@ -10,7 +10,12 @@ import { DATA_LAKES, lakeMatchesAccess, normalizeEntitlementKey } from '@bike4mi
 import { BadRequestError, NotFoundError, normalizeId } from '@bike4mind/utils';
 import type { LakeGrant } from './manageRule';
 import { classifyLakeAccess } from './classifyLakeAccess';
-import { resolveEnforceReadGrants, resolveLakeReadAccess, type LakeAccessLogger } from './resolveLakeReadAccess';
+import {
+  grantedLakeIdsFor,
+  resolveEnforceReadGrants,
+  resolveLakeReadAccess,
+  type LakeAccessLogger,
+} from './resolveLakeReadAccess';
 
 interface AssertLakeAccessAdapters {
   db: {
@@ -18,7 +23,9 @@ interface AssertLakeAccessAdapters {
     // Optional: when wired, a transferred/delegated owner or curator reaches the lake through the
     // single read gate too (canAccessLake delegates to the grant-aware canManageLake). Absent ->
     // read access falls back to createdByUserId + org/tag/public, the pre-grant behavior.
-    dataLakeAccessGrants?: Pick<IDataLakeAccessGrantRepository, 'listByLake'>;
+    // `listByPrincipal` (#2425) additionally lets a foreign-org owner/curator grant holder
+    // resolve the lake BY SLUG in the first place - see the findBySlug call below.
+    dataLakeAccessGrants?: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
     // Optional: the read-time grant cutover flag (#1673). When wired, a persisted READER grant
     // resolves into an ephemeral membership view at the gate; the flag governs whether that
     // resolution is ENFORCED or merely reported (report-only). Absent -> report-only (legacy), so
@@ -164,6 +171,13 @@ async function resolveFallbackLake(
  * final (no fallback retry). Denies with a NOT-FOUND-style error so a user who can't
  * see a lake can't confirm it exists. Every single-lake read and every batch/file
  * operation calls this first. Returns the lake on grant.
+ *
+ * Slug resolution (#2425): findBySlug's own-org/org-less arms miss a lake in an org the
+ * caller isn't a member of, even when they hold a real owner/curator grant on it (e.g. a
+ * cross-org transferLakeOwnership). When `dataLakeAccessGrants` is wired, a lazy
+ * grantedLakeIdsFor lookup is threaded through as findBySlug's last-resort fallback arm, so
+ * a foreign-org grant holder can still reach the lake by slug - canManageLake below still
+ * gates what they're actually allowed to do with it.
  */
 export const assertLakeAccess = async (
   lakeIdOrSlug: string,
@@ -172,7 +186,16 @@ export const assertLakeAccess = async (
 ): Promise<IDataLakeDocument> => {
   const lake =
     (await db.dataLakes.findById(lakeIdOrSlug).catch(() => null)) ??
-    (await db.dataLakes.findBySlug(lakeIdOrSlug, ctx.organizationIds));
+    (await db.dataLakes.findBySlug(
+      lakeIdOrSlug,
+      ctx.organizationIds,
+      // Lazy (#2425): only invoked by findBySlug on an own-org/org-less miss. Owner/curator only
+      // (includeReaders=false) - a foreign-org grant resolves the lake here, but canManageLake
+      // below still gates what the grant actually admits the caller to do with it.
+      db.dataLakeAccessGrants
+        ? () => grantedLakeIdsFor(ctx.userId, ctx.organizationIds, db.dataLakeAccessGrants, false)
+        : undefined
+    ));
   if (lake) {
     // A persisted lake may carry grants; a fallback lake never does. Fetch only when the repo is
     // wired, so callers that have not threaded it keep the createdByUserId + org/tag/public behavior.

--- a/b4m-core/services/src/dataLakeService/authorizeLakeWrite.ts
+++ b/b4m-core/services/src/dataLakeService/authorizeLakeWrite.ts
@@ -36,7 +36,7 @@ export const assertLakeWriteAccess = async (
     db,
   }: {
     db: {
-      dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
+      dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug' | 'findBySlugAmongIds'>;
       // 'listByPrincipal' (#2425) flows straight through to assertLakeAccess's own adapter type
       // below, which uses it to resolve a foreign-org owner/curator grant by slug.
       dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
@@ -78,7 +78,7 @@ export const assertLakeRebuildAccess = async (
     db,
   }: {
     db: {
-      dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
+      dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug' | 'findBySlugAmongIds'>;
       // 'listByPrincipal' (#2425) flows straight through to assertLakeAccess's own adapter type
       // below, which uses it to resolve a foreign-org owner/curator grant by slug.
       dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
@@ -115,7 +115,7 @@ export const assertFallbackLakeSettingsWriteAccess = async (
     logger,
   }: {
     db: {
-      dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
+      dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug' | 'findBySlugAmongIds'>;
       // 'listByPrincipal' (#2425) flows straight through to assertLakeAccess's own adapter type
       // below, which uses it to resolve a foreign-org owner/curator grant by slug.
       dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;

--- a/b4m-core/services/src/dataLakeService/authorizeLakeWrite.ts
+++ b/b4m-core/services/src/dataLakeService/authorizeLakeWrite.ts
@@ -37,7 +37,9 @@ export const assertLakeWriteAccess = async (
   }: {
     db: {
       dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
-      dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake'>;
+      // 'listByPrincipal' (#2425) flows straight through to assertLakeAccess's own adapter type
+      // below, which uses it to resolve a foreign-org owner/curator grant by slug.
+      dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
     };
   }
 ): Promise<IDataLakeDocument> => {
@@ -77,7 +79,9 @@ export const assertLakeRebuildAccess = async (
   }: {
     db: {
       dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
-      dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake'>;
+      // 'listByPrincipal' (#2425) flows straight through to assertLakeAccess's own adapter type
+      // below, which uses it to resolve a foreign-org owner/curator grant by slug.
+      dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
     };
   }
 ): Promise<IDataLakeDocument> => {
@@ -112,7 +116,9 @@ export const assertFallbackLakeSettingsWriteAccess = async (
   }: {
     db: {
       dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
-      dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake'>;
+      // 'listByPrincipal' (#2425) flows straight through to assertLakeAccess's own adapter type
+      // below, which uses it to resolve a foreign-org owner/curator grant by slug.
+      dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
       /**
        * Declared, and non-optional, so the overlay merge cannot be lost by a caller that builds
        * exactly this type. It previously worked only by structural typing - the one route passes a

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -346,6 +346,90 @@ describe('assertLakeAccess — hardcoded fallback lakes (no backing document)', 
   });
 });
 
+/**
+ * #2425: a lake scoped to an org the caller does not belong to is invisible to findBySlug's own-org
+ * and org-less arms. A real owner/curator grant on it (a cross-org transferLakeOwnership) is still
+ * legitimate access - canManageLake already admits it once the lake resolves - so assertLakeAccess
+ * must thread a grant-resolution fallback into findBySlug. `findBySlug` itself is mocked here (its
+ * real org-vs-grant arm logic is proved against a real Mongo in DataLakeModel.test.ts); this suite
+ * pins that assertLakeAccess actually SUPPLIES the thunk, and only when a grant repo is wired.
+ */
+describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => {
+  const theirs = lake({
+    id: 'foreign-granted',
+    slug: 'foreign-granted',
+    createdByUserId: 'other',
+    organizationId: 'orgA',
+  });
+
+  // Mirrors DataLakeModel.findBySlug's real shape: own-org/org-less miss, then a last-resort check
+  // against whatever ids the supplied thunk resolves to.
+  const findBySlugFake = () =>
+    vi
+      .fn()
+      .mockImplementation(
+        async (_slug: string, organizationIds?: string[], resolveGrantedLakeIds?: () => Promise<string[]>) => {
+          if (organizationIds?.includes('orgA')) return theirs;
+          if (!resolveGrantedLakeIds) return null;
+          const grantedIds = await resolveGrantedLakeIds();
+          return grantedIds.includes(theirs.id) ? theirs : null;
+        }
+      );
+
+  const grantRepo = (role: 'owner' | 'curator') => ({
+    listByPrincipal: vi.fn().mockResolvedValue([{ dataLakeId: theirs.id, role }]),
+    listByLake: vi
+      .fn()
+      .mockResolvedValue([{ dataLakeId: theirs.id, principalType: 'user', principalId: 'grantee', role }]),
+  });
+
+  it('resolves the lake for a foreign-org owner-grant holder', async () => {
+    const db = {
+      dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug: findBySlugFake() },
+      dataLakeAccessGrants: grantRepo('owner'),
+    };
+
+    await expect(
+      assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgB'] }), { db })
+    ).resolves.toBe(theirs);
+  });
+
+  it('resolves the lake for a foreign-org curator-grant holder', async () => {
+    const db = {
+      dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug: findBySlugFake() },
+      dataLakeAccessGrants: grantRepo('curator'),
+    };
+
+    await expect(
+      assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgB'] }), { db })
+    ).resolves.toBe(theirs);
+  });
+
+  it('still denies (not-found-style) a foreign-org caller with NO grant - no enumeration widening', async () => {
+    const db = {
+      dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug: findBySlugFake() },
+      dataLakeAccessGrants: {
+        listByPrincipal: vi.fn().mockResolvedValue([]),
+        listByLake: vi.fn().mockResolvedValue([]),
+      },
+    };
+
+    await expect(
+      assertLakeAccess('foreign-granted', ctx({ userId: 'stranger', organizationIds: ['orgB'] }), { db })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('never threads a grant thunk when no grant repo is wired - back-compat for callers that have not', async () => {
+    const findBySlug = findBySlugFake();
+    const db = { dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug } };
+
+    await expect(
+      assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgB'] }), { db })
+    ).rejects.toThrow(/not found/i);
+    expect(findBySlug).toHaveBeenCalledWith('foreign-granted', ['orgB'], undefined);
+  });
+});
+
 describe('assertLakeWritable / isFallbackLake — fallback lakes are read-only', () => {
   it('identifies a fallback lake by config id and refuses the write with a clear read-only error', () => {
     expect(isFallbackLake({ id: 'opti-knowledge' })).toBe(true);

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -627,6 +627,30 @@ describe('listDataLakes - grant-reachable lakes (#2034)', () => {
   });
 });
 
+describe('listDataLakes - precomputed grantedLakeIds (#2425 P3)', () => {
+  const dbFor = () => ({ dataLakes: { findAccessible: vi.fn().mockResolvedValue([]), find: vi.fn() } });
+
+  it('reuses a precomputed grantedLakeIds set instead of re-resolving it', async () => {
+    const db = dbFor();
+    const grantedLakeIds = ['granted-1'];
+
+    await listDataLakes(ctx({ userId: 'me' }), { db, grantedLakeIds });
+
+    expect(db.dataLakes.findAccessible).toHaveBeenCalledWith(expect.anything(), {
+      statuses: ['draft', 'active'],
+      grantedLakeIds,
+    });
+  });
+
+  it('throws when a precomputed set and a settings adapter are supplied together', async () => {
+    const db = { ...dbFor(), settings: { getSettingsValue: vi.fn() } };
+
+    await expect(listDataLakes(ctx({ userId: 'me' }), { db, grantedLakeIds: ['granted-1'] })).rejects.toThrow(
+      /grantedLakeIds and db.settings cannot both be supplied/
+    );
+  });
+});
+
 // systemPrompt is EDITOR-ONLY: it steers every answer drawn from the lake, but only the lake's
 // creator or an admin may read the wording. The list endpoint is where the editor UI gets the
 // value to seed its form, and it is also the endpoint that surfaces strangers' public lakes.

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -274,7 +274,9 @@ describe('canAccessLake - lake org id shape parity with the casting collection q
 describe('assertLakeAccess — not-found-style denial', () => {
   it('throws a not-found-style error for a denied non-member (does not disclose existence)', async () => {
     const l = lake({ organizationId: 'orgA', requiredUserTag: 'Opti' });
-    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(l), findBySlug: vi.fn() } };
+    const db = {
+      dataLakes: { findById: vi.fn().mockResolvedValue(l), findBySlug: vi.fn(), findBySlugAmongIds: vi.fn() },
+    };
     await expect(
       assertLakeAccess('lake1', ctx({ organizationIds: ['orgB'], userTags: ['opti'] }), { db })
     ).rejects.toThrow(/not found/i);
@@ -282,17 +284,22 @@ describe('assertLakeAccess — not-found-style denial', () => {
 
   it('returns the lake on grant', async () => {
     const l = lake();
-    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(l), findBySlug: vi.fn() } };
+    const db = {
+      dataLakes: { findById: vi.fn().mockResolvedValue(l), findBySlug: vi.fn(), findBySlugAmongIds: vi.fn() },
+    };
     await expect(assertLakeAccess('lake1', ctx({ userId: 'owner' }), { db })).resolves.toBe(l);
   });
 });
 
 describe('assertLakeAccess — hardcoded fallback lakes (no backing document)', () => {
-  // The DB knows nothing: both lookups miss, as they do for the seeded opti-knowledge lake.
+  // The DB knows nothing: both lookups miss, as they do for the seeded opti-knowledge lake. No
+  // dataLakeAccessGrants wired, so the #2425 grant-fallback arm never calls findBySlugAmongIds -
+  // it's mocked only to satisfy the adapter type.
   const emptyDb = () => ({
     dataLakes: {
       findById: vi.fn().mockRejectedValue(new Error('bad id')),
       findBySlug: vi.fn().mockResolvedValue(null),
+      findBySlugAmongIds: vi.fn().mockResolvedValue(null),
     },
   });
 
@@ -327,6 +334,7 @@ describe('assertLakeAccess — hardcoded fallback lakes (no backing document)', 
       dataLakes: {
         findById: vi.fn().mockRejectedValue(new Error('bad id')),
         findBySlug: vi.fn().mockResolvedValue(dbLake),
+        findBySlugAmongIds: vi.fn().mockResolvedValue(null),
       },
     };
     await expect(assertLakeAccess('opti-knowledge', ctx({ userId: 'owner' }), { db })).resolves.toBe(dbLake);
@@ -338,6 +346,7 @@ describe('assertLakeAccess — hardcoded fallback lakes (no backing document)', 
       dataLakes: {
         findById: vi.fn().mockRejectedValue(new Error('bad id')),
         findBySlug: vi.fn().mockResolvedValue(dbLake),
+        findBySlugAmongIds: vi.fn().mockResolvedValue(null),
       },
     };
     await expect(
@@ -349,10 +358,11 @@ describe('assertLakeAccess — hardcoded fallback lakes (no backing document)', 
 /**
  * #2425: a lake scoped to an org the caller does not belong to is invisible to findBySlug's own-org
  * and org-less arms. A real owner/curator grant on it (a cross-org transferLakeOwnership) is still
- * legitimate access - canManageLake already admits it once the lake resolves - so assertLakeAccess
- * must thread a grant-resolution fallback into findBySlug. `findBySlug` itself is mocked here (its
- * real org-vs-grant arm logic is proved against a real Mongo in DataLakeModel.test.ts); this suite
- * pins that assertLakeAccess actually SUPPLIES the thunk, and only when a grant repo is wired.
+ * legitimate access - canManageLake already admits it once the lake resolves - so on a findBySlug
+ * miss, assertLakeAccess resolves the grant-held id set itself and retries via
+ * `findBySlugAmongIds`, a separate repository method (its own real query logic is proved against a
+ * real Mongo in DataLakeModel.test.ts). This suite pins that assertLakeAccess only calls it on a
+ * miss, and only when a grant repo is wired.
  */
 describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => {
   const theirs = lake({
@@ -362,19 +372,12 @@ describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => 
     organizationId: 'orgA',
   });
 
-  // Mirrors DataLakeModel.findBySlug's real shape: own-org/org-less miss, then a last-resort check
-  // against whatever ids the supplied thunk resolves to.
-  const findBySlugFake = () =>
-    vi
-      .fn()
-      .mockImplementation(
-        async (_slug: string, organizationIds?: string[], resolveGrantedLakeIds?: () => Promise<string[]>) => {
-          if (organizationIds?.includes('orgA')) return theirs;
-          if (!resolveGrantedLakeIds) return null;
-          const grantedIds = await resolveGrantedLakeIds();
-          return grantedIds.includes(theirs.id) ? theirs : null;
-        }
-      );
+  // `findBySlug` mocks the own-org/org-less arms directly (real shape, real signature - no thunk
+  // param): a miss for anyone not in orgA. `findBySlugAmongIds` is the separate #2425 last-resort
+  // method `assertLakeAccess` calls itself on that miss, mirroring DataLakeModel's own split.
+  const findBySlugMiss = () => vi.fn().mockResolvedValue(null);
+  const findBySlugAmongIdsFake = () =>
+    vi.fn().mockImplementation(async (_slug: string, ids: string[]) => (ids.includes(theirs.id) ? theirs : null));
 
   const grantRepo = (role: 'owner' | 'curator') => ({
     listByPrincipal: vi.fn().mockResolvedValue([{ dataLakeId: theirs.id, role }]),
@@ -385,7 +388,11 @@ describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => 
 
   it('resolves the lake for a foreign-org owner-grant holder', async () => {
     const db = {
-      dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug: findBySlugFake() },
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: findBySlugMiss(),
+        findBySlugAmongIds: findBySlugAmongIdsFake(),
+      },
       dataLakeAccessGrants: grantRepo('owner'),
     };
 
@@ -396,7 +403,11 @@ describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => 
 
   it('resolves the lake for a foreign-org curator-grant holder', async () => {
     const db = {
-      dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug: findBySlugFake() },
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: findBySlugMiss(),
+        findBySlugAmongIds: findBySlugAmongIdsFake(),
+      },
       dataLakeAccessGrants: grantRepo('curator'),
     };
 
@@ -407,7 +418,11 @@ describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => 
 
   it('still denies (not-found-style) a foreign-org caller with NO grant - no enumeration widening', async () => {
     const db = {
-      dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug: findBySlugFake() },
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: findBySlugMiss(),
+        findBySlugAmongIds: findBySlugAmongIdsFake(),
+      },
       dataLakeAccessGrants: {
         listByPrincipal: vi.fn().mockResolvedValue([]),
         listByLake: vi.fn().mockResolvedValue([]),
@@ -419,14 +434,39 @@ describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => 
     ).rejects.toThrow(/not found/i);
   });
 
-  it('never threads a grant thunk when no grant repo is wired - back-compat for callers that have not', async () => {
-    const findBySlug = findBySlugFake();
-    const db = { dataLakes: { findById: vi.fn().mockRejectedValue(new Error('bad id')), findBySlug } };
+  it('never calls findBySlugAmongIds when no grant repo is wired - back-compat for callers that have not', async () => {
+    const findBySlugAmongIds = findBySlugAmongIdsFake();
+    const db = {
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: findBySlugMiss(),
+        findBySlugAmongIds,
+      },
+    };
 
     await expect(
       assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgB'] }), { db })
     ).rejects.toThrow(/not found/i);
-    expect(findBySlug).toHaveBeenCalledWith('foreign-granted', ['orgB'], undefined);
+    expect(findBySlugAmongIds).not.toHaveBeenCalled();
+  });
+
+  it('never calls findBySlugAmongIds when findBySlug already resolved the lake (laziness)', async () => {
+    // The extra grants query must only run on a MISS - if it ran unconditionally, the common
+    // own-org/org-less hit path would pay for a listByPrincipal call it never needed.
+    const findBySlugAmongIds = findBySlugAmongIdsFake();
+    const db = {
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: vi.fn().mockResolvedValue(theirs),
+        findBySlugAmongIds,
+      },
+      dataLakeAccessGrants: grantRepo('owner'),
+    };
+
+    await expect(
+      assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgA'] }), { db })
+    ).resolves.toBe(theirs);
+    expect(findBySlugAmongIds).not.toHaveBeenCalled();
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -126,7 +126,8 @@ interface ListDataLakesAdapters {
    * Optional pre-resolved grant-id set (#2425 P3): skips this function's own `grantedLakeIdsFor`
    * call when the caller already ran the identical query. Only safe to pass when the caller never
    * threads `db.settings` above, so `resolveEnforceReadGrants` (and thus the `includeReaders` this
-   * function would otherwise resolve to) is always `false` - `handleList`
+   * function would otherwise resolve to) is always `false` - enforced below with a thrown error if
+   * both are supplied together, rather than left as a caller-observed precondition only. `handleList`
    * (apps/client/server/slack/handleDataLakeCommand.ts) is the one caller today, and it satisfies
    * that precondition by construction. Absent -> recomputes exactly as before.
    */
@@ -351,6 +352,16 @@ export const listDataLakes = async (
   { db, grantedLakeIds: precomputedGrantedLakeIds }: ListDataLakesAdapters
 ): Promise<ManageableDataLakeConfig[]> => {
   const includeReaders = await resolveEnforceReadGrants(db.settings);
+  // The precomputed set is only valid under includeReaders=false (see the field's doc comment) -
+  // a caller that also threads `settings` could get includeReaders=true here, silently mismatching
+  // what the precomputed set was actually resolved with. Guarded rather than assumed, so that
+  // combination fails loudly instead of quietly dropping reader/org grants.
+  if (precomputedGrantedLakeIds && db.settings) {
+    throw new Error(
+      'listDataLakes: grantedLakeIds and db.settings cannot both be supplied - the precomputed set ' +
+        'is only valid when includeReaders is forced false (no settings adapter)'
+    );
+  }
   const grantedLakeIds =
     precomputedGrantedLakeIds ??
     (await grantedLakeIdsFor(ctx.userId, ctx.organizationIds ?? [], db.dataLakeAccessGrants, includeReaders));

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -122,14 +122,26 @@ interface ListDataLakesAdapters {
    * set" - see resolveFallbackSettings for why silence there is not harmless.
    */
   logger?: LakeAccessLogger;
+}
+
+/**
+ * `listDataLakes`-only options (#2425 P3 review): kept OUT of `ListDataLakesAdapters` on purpose,
+ * even though it is a sibling of `db`/`logger` there, because that type is shared with
+ * `listAllDataLakes`/`listArchivedDataLakes`/`listDeletedDataLakes` and none of them honor this
+ * field - two of them even run their own `grantedLakeIdsFor` call, so a field that looked
+ * type-valid there but was silently dropped would be worse than not having the option at all.
+ * Scoping it to a type only `listDataLakes` accepts keeps the field's type-checked surface equal
+ * to its actual support.
+ */
+interface ListDataLakesOptions extends ListDataLakesAdapters {
   /**
-   * Optional pre-resolved grant-id set (#2425 P3): skips this function's own `grantedLakeIdsFor`
-   * call when the caller already ran the identical query. Only safe to pass when the caller never
-   * threads `db.settings` above, so `resolveEnforceReadGrants` (and thus the `includeReaders` this
-   * function would otherwise resolve to) is always `false` - enforced below with a thrown error if
-   * both are supplied together, rather than left as a caller-observed precondition only. `handleList`
-   * (apps/client/server/slack/handleDataLakeCommand.ts) is the one caller today, and it satisfies
-   * that precondition by construction. Absent -> recomputes exactly as before.
+   * Optional pre-resolved grant-id set: skips this function's own `grantedLakeIdsFor` call when
+   * the caller already ran the identical query. Only safe to pass when the caller never threads
+   * `db.settings` above, so `resolveEnforceReadGrants` (and thus the `includeReaders` this
+   * function would otherwise resolve to) is always `false` - enforced below with a thrown error
+   * if both are supplied together, rather than left as a caller-observed precondition only.
+   * `handleList` (apps/client/server/slack/handleDataLakeCommand.ts) is the one caller today, and
+   * it satisfies that precondition by construction. Absent -> recomputes exactly as before.
    */
   grantedLakeIds?: string[];
 }
@@ -349,19 +361,20 @@ const toFallbackConfig = (
  */
 export const listDataLakes = async (
   ctx: AccessContext,
-  { db, grantedLakeIds: precomputedGrantedLakeIds }: ListDataLakesAdapters
+  { db, grantedLakeIds: precomputedGrantedLakeIds }: ListDataLakesOptions
 ): Promise<ManageableDataLakeConfig[]> => {
-  const includeReaders = await resolveEnforceReadGrants(db.settings);
   // The precomputed set is only valid under includeReaders=false (see the field's doc comment) -
-  // a caller that also threads `settings` could get includeReaders=true here, silently mismatching
-  // what the precomputed set was actually resolved with. Guarded rather than assumed, so that
-  // combination fails loudly instead of quietly dropping reader/org grants.
+  // a caller that also threads `settings` could get includeReaders=true below, silently
+  // mismatching what the precomputed set was actually resolved with. Guarded rather than
+  // assumed, so that combination fails loudly instead of quietly dropping reader/org grants.
+  // Checked BEFORE the settings read below, so an invalid combination costs nothing.
   if (precomputedGrantedLakeIds && db.settings) {
     throw new Error(
       'listDataLakes: grantedLakeIds and db.settings cannot both be supplied - the precomputed set ' +
         'is only valid when includeReaders is forced false (no settings adapter)'
     );
   }
+  const includeReaders = await resolveEnforceReadGrants(db.settings);
   const grantedLakeIds =
     precomputedGrantedLakeIds ??
     (await grantedLakeIdsFor(ctx.userId, ctx.organizationIds ?? [], db.dataLakeAccessGrants, includeReaders));

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -122,6 +122,15 @@ interface ListDataLakesAdapters {
    * set" - see resolveFallbackSettings for why silence there is not harmless.
    */
   logger?: LakeAccessLogger;
+  /**
+   * Optional pre-resolved grant-id set (#2425 P3): skips this function's own `grantedLakeIdsFor`
+   * call when the caller already ran the identical query. Only safe to pass when the caller never
+   * threads `db.settings` above, so `resolveEnforceReadGrants` (and thus the `includeReaders` this
+   * function would otherwise resolve to) is always `false` - `handleList`
+   * (apps/client/server/slack/handleDataLakeCommand.ts) is the one caller today, and it satisfies
+   * that precondition by construction. Absent -> recomputes exactly as before.
+   */
+  grantedLakeIds?: string[];
 }
 
 const toConfig = (dl: IDataLakeDocument): DataLakeConfig => toDataLakeConfig(dl);
@@ -339,15 +348,12 @@ const toFallbackConfig = (
  */
 export const listDataLakes = async (
   ctx: AccessContext,
-  { db }: ListDataLakesAdapters
+  { db, grantedLakeIds: precomputedGrantedLakeIds }: ListDataLakesAdapters
 ): Promise<ManageableDataLakeConfig[]> => {
   const includeReaders = await resolveEnforceReadGrants(db.settings);
-  const grantedLakeIds = await grantedLakeIdsFor(
-    ctx.userId,
-    ctx.organizationIds ?? [],
-    db.dataLakeAccessGrants,
-    includeReaders
-  );
+  const grantedLakeIds =
+    precomputedGrantedLakeIds ??
+    (await grantedLakeIdsFor(ctx.userId, ctx.organizationIds ?? [], db.dataLakeAccessGrants, includeReaders));
   let dynamicLakes: IDataLakeDocument[] = [];
   try {
     dynamicLakes = await db.dataLakes.findAccessible(ctx, { statuses: ['draft', 'active'], grantedLakeIds });

--- a/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.test.ts
+++ b/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.test.ts
@@ -24,11 +24,14 @@ const lake = (overrides: Partial<IDataLakeDocument> = {}): IDataLakeDocument =>
     ...overrides,
   }) as IDataLakeDocument;
 
-// The DB knows nothing: both lookups miss, as they do for the seeded opti-knowledge lake.
+// The DB knows nothing: both lookups miss, as they do for the seeded opti-knowledge lake. No
+// dataLakeAccessGrants wired, so the #2425 grant-fallback arm never calls findBySlugAmongIds -
+// it's mocked only to satisfy the adapter type.
 const fallbackDb = () => ({
   dataLakes: {
     findById: vi.fn().mockRejectedValue(new Error('bad id')),
     findBySlug: vi.fn().mockResolvedValue(null),
+    findBySlugAmongIds: vi.fn().mockResolvedValue(null),
   },
 });
 
@@ -87,6 +90,7 @@ describe('resolveFallbackLake (via assertLakeAccess) - merges the fallback overl
       dataLakes: {
         findById: vi.fn().mockRejectedValue(new Error('bad id')),
         findBySlug: vi.fn().mockResolvedValue(dbLake),
+        findBySlugAmongIds: vi.fn().mockResolvedValue(null),
       },
       fallbackLakeSettings: { findByLakeId },
     };
@@ -112,7 +116,9 @@ describe('assertFallbackLakeSettingsWriteAccess', () => {
 
   it('refuses a DB (persisted) lake outright - it has its own settings editor', async () => {
     const l = lake({ createdByUserId: 'owner' });
-    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(l), findBySlug: vi.fn() } };
+    const db = {
+      dataLakes: { findById: vi.fn().mockResolvedValue(l), findBySlug: vi.fn(), findBySlugAmongIds: vi.fn() },
+    };
     await expect(assertFallbackLakeSettingsWriteAccess('lake1', ctx({ isAdmin: true }), { db })).rejects.toThrow(
       /its own settings editor/i
     );

--- a/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.ts
+++ b/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.ts
@@ -18,7 +18,7 @@ type UpdateFallbackLakeSettingsParams = z.infer<typeof UpdateFallbackLakeSetting
 
 interface UpdateFallbackLakeSettingsAdapters {
   db: {
-    dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
+    dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug' | 'findBySlugAmongIds'>;
     // 'listByPrincipal' (#2425) flows through to assertFallbackLakeSettingsWriteAccess's own
     // adapter type, which uses it to resolve a foreign-org owner/curator grant by slug.
     dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;

--- a/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.ts
+++ b/b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.ts
@@ -19,7 +19,9 @@ type UpdateFallbackLakeSettingsParams = z.infer<typeof UpdateFallbackLakeSetting
 interface UpdateFallbackLakeSettingsAdapters {
   db: {
     dataLakes: Pick<IDataLakeRepository, 'findById' | 'findBySlug'>;
-    dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake'>;
+    // 'listByPrincipal' (#2425) flows through to assertFallbackLakeSettingsWriteAccess's own
+    // adapter type, which uses it to resolve a foreign-org owner/curator grant by slug.
+    dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'listByPrincipal'>;
     /**
      * `findByLakeId` is REQUIRED here, unlike everywhere else this repo is consumed, and it is the
      * audit that makes it so: the `before` side of the config diff below is read from the overlay

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -706,6 +706,56 @@ describe('DataLakeRepository.findBySlug', () => {
     const resolved = await dataLakeRepository.findBySlug('shared-slug', ['org-b', 'org-a']);
     expect(resolved?.organizationId).toBe('org-a');
   });
+
+  // #2425: a lake scoped to an org the caller does NOT belong to is invisible to the own-org and
+  // org-less arms above. A real owner/curator grant on it (e.g. after a cross-org
+  // transferLakeOwnership) is still legitimate access, so a third, last-resort arm tries the
+  // caller's granted lake ids - fed in lazily, exactly as `assertLakeAccess` wires it.
+  it('resolves a foreign-org lake by slug when the caller has a granted lake id (#2425)', async () => {
+    const created = await dataLakeRepository.create(
+      baseLake({ slug: 'foreign-org-lake', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
+    );
+
+    // Caller belongs only to org-b, so neither the own-org nor org-less arm can match; the grant
+    // is what makes the lake reachable.
+    const resolved = await dataLakeRepository.findBySlug('foreign-org-lake', ['org-b'], async () => [created.id]);
+
+    expect(resolved?.id).toBe(created.id);
+  });
+
+  it('returns null for a foreign-org lake when the caller holds no grant on it - no enumeration widening', async () => {
+    await dataLakeRepository.create(
+      baseLake({ slug: 'foreign-org-lake-2', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
+    );
+
+    const resolved = await dataLakeRepository.findBySlug('foreign-org-lake-2', ['org-b'], async () => []);
+
+    expect(resolved).toBeNull();
+  });
+
+  it('never invokes resolveGrantedLakeIds when the own-org arm already resolves the lake', async () => {
+    await dataLakeRepository.create(
+      baseLake({ slug: 'own-org-lake', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
+    );
+    const resolveGrantedLakeIds = async (): Promise<string[]> => {
+      throw new Error('resolveGrantedLakeIds should not be called on an own-org hit');
+    };
+
+    const resolved = await dataLakeRepository.findBySlug('own-org-lake', ['org-a'], resolveGrantedLakeIds);
+
+    expect(resolved?.organizationId).toBe('org-a');
+  });
+
+  it('never invokes resolveGrantedLakeIds when the org-less arm already resolves the lake', async () => {
+    await dataLakeRepository.create(baseLake({ slug: 'orgless-lake', createdByUserId: 'someone' }));
+    const resolveGrantedLakeIds = async (): Promise<string[]> => {
+      throw new Error('resolveGrantedLakeIds should not be called on an org-less hit');
+    };
+
+    const resolved = await dataLakeRepository.findBySlug('orgless-lake', ['org-a'], resolveGrantedLakeIds);
+
+    expect(resolved?.slug).toBe('orgless-lake');
+  });
 });
 
 describe('DataLakeRepository - fileTagPrefix is unique per creator (DB backstop)', () => {

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -707,54 +707,78 @@ describe('DataLakeRepository.findBySlug', () => {
     expect(resolved?.organizationId).toBe('org-a');
   });
 
-  // #2425: a lake scoped to an org the caller does NOT belong to is invisible to the own-org and
-  // org-less arms above. A real owner/curator grant on it (e.g. after a cross-org
-  // transferLakeOwnership) is still legitimate access, so a third, last-resort arm tries the
-  // caller's granted lake ids - fed in lazily, exactly as `assertLakeAccess` wires it.
-  it('resolves a foreign-org lake by slug when the caller has a granted lake id (#2425)', async () => {
+  // #2425 review: null and '' are both stored as "org-less" but are distinct index keys, so two
+  // org-less lakes CAN share a slug - this had no tie-break at all before this fix.
+  it('resolves org-less lakes deterministically when organizationId is null vs empty string', async () => {
+    await dataLakeRepository.create(baseLake({ slug: 'orgless-tie', organizationId: '', createdByUserId: 'someone' }));
+    await dataLakeRepository.create(baseLake({ slug: 'orgless-tie', createdByUserId: 'someone-else' }));
+
+    const resolved = await dataLakeRepository.findBySlug('orgless-tie');
+
+    // Both are legitimately org-less; the assertion is determinism (same winner every call),
+    // not which one - repeat to catch a naive unsorted `$in` returning either at random.
+    for (let i = 0; i < 3; i++) {
+      expect((await dataLakeRepository.findBySlug('orgless-tie'))?.createdByUserId).toBe(resolved?.createdByUserId);
+    }
+  });
+});
+
+describe('DataLakeRepository.findBySlugAmongIds', () => {
+  setupMongoTest();
+
+  // #2425: a lake scoped to an org the caller does NOT belong to is invisible to `findBySlug`'s
+  // own-org and org-less arms. A real owner/curator grant on it (e.g. after a cross-org
+  // transferLakeOwnership) is still legitimate access, so `assertLakeAccess` resolves the
+  // caller's granted lake ids itself and retries here, with this method taking the id set as an
+  // already-resolved argument rather than a thunk (#2425 review - keeps the "when to pay for the
+  // extra grants query" decision in the service layer, not hidden inside this repository method).
+  it('resolves a foreign-org lake by slug when the given id set includes it', async () => {
     const created = await dataLakeRepository.create(
       baseLake({ slug: 'foreign-org-lake', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
     );
 
-    // Caller belongs only to org-b, so neither the own-org nor org-less arm can match; the grant
-    // is what makes the lake reachable.
-    const resolved = await dataLakeRepository.findBySlug('foreign-org-lake', ['org-b'], async () => [created.id]);
+    const resolved = await dataLakeRepository.findBySlugAmongIds('foreign-org-lake', [created.id]);
 
     expect(resolved?.id).toBe(created.id);
   });
 
-  it('returns null for a foreign-org lake when the caller holds no grant on it - no enumeration widening', async () => {
+  it('returns null when the given id set is empty - no enumeration widening', async () => {
     await dataLakeRepository.create(
       baseLake({ slug: 'foreign-org-lake-2', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
     );
 
-    const resolved = await dataLakeRepository.findBySlug('foreign-org-lake-2', ['org-b'], async () => []);
+    const resolved = await dataLakeRepository.findBySlugAmongIds('foreign-org-lake-2', []);
 
     expect(resolved).toBeNull();
   });
 
-  it('never invokes resolveGrantedLakeIds when the own-org arm already resolves the lake', async () => {
+  it('returns null when no id in the given set matches the slug - no enumeration widening', async () => {
     await dataLakeRepository.create(
-      baseLake({ slug: 'own-org-lake', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
+      baseLake({ slug: 'foreign-org-lake-3', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
     );
-    const resolveGrantedLakeIds = async (): Promise<string[]> => {
-      throw new Error('resolveGrantedLakeIds should not be called on an own-org hit');
-    };
 
-    const resolved = await dataLakeRepository.findBySlug('own-org-lake', ['org-a'], resolveGrantedLakeIds);
+    const resolved = await dataLakeRepository.findBySlugAmongIds('foreign-org-lake-3', [
+      new mongoose.Types.ObjectId().toString(),
+    ]);
 
-    expect(resolved?.organizationId).toBe('org-a');
+    expect(resolved).toBeNull();
   });
 
-  it('never invokes resolveGrantedLakeIds when the org-less arm already resolves the lake', async () => {
-    await dataLakeRepository.create(baseLake({ slug: 'orgless-lake', createdByUserId: 'someone' }));
-    const resolveGrantedLakeIds = async (): Promise<string[]> => {
-      throw new Error('resolveGrantedLakeIds should not be called on an org-less hit');
-    };
+  it('resolves the lowest lake id when two granted lakes across different orgs share a slug', async () => {
+    // Mirrors the own-org arm's N5 test above: input order deliberately reversed from the
+    // expected winner so a naive "first in ids" bug (rather than the sort) would fail.
+    const second = await dataLakeRepository.create(
+      baseLake({ slug: 'shared-grant-slug', organizationId: 'org-b', createdByUserId: 'org-b-owner' })
+    );
+    const first = await dataLakeRepository.create(
+      baseLake({ slug: 'shared-grant-slug', organizationId: 'org-a', createdByUserId: 'org-a-owner' })
+    );
+    const [lower, higher] = [first.id, second.id].sort();
 
-    const resolved = await dataLakeRepository.findBySlug('orgless-lake', ['org-a'], resolveGrantedLakeIds);
+    const resolved = await dataLakeRepository.findBySlugAmongIds('shared-grant-slug', [second.id, first.id]);
 
-    expect(resolved?.slug).toBe('orgless-lake');
+    expect(resolved?.id).toBe(lower);
+    expect(resolved?.id).not.toBe(higher);
   });
 });
 

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -329,7 +329,11 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
     return super.find(filter, { ...options, ...LIST_PROJECTION_FIELDS });
   }
 
-  async findBySlug(slug: string, organizationIds?: string[]): Promise<IDataLakeDocument | null> {
+  async findBySlug(
+    slug: string,
+    organizationIds?: string[],
+    resolveGrantedLakeIds?: () => Promise<string[]>
+  ): Promise<IDataLakeDocument | null> {
     // Slug is unique per (organizationId, slug). Prefer a lake in one of the caller's own
     // orgs, then fall back to an org-less lake with the same slug. Sorted so two own-org
     // matches resolve deterministically rather than by document order.
@@ -340,7 +344,23 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
       if (own) return own.toJSON() as IDataLakeDocument;
     }
     const orgless = await this.dataLakeModel.findOne({ slug, organizationId: { $in: [null, ''] } });
-    return (orgless?.toJSON() as IDataLakeDocument) ?? null;
+    if (orgless) return orgless.toJSON() as IDataLakeDocument;
+    // Last resort, and lazy on purpose (#2425): a lake in an org the caller is not a member of
+    // is invisible to both arms above, but a real owner/curator grant on it is still legitimate
+    // access - canManageLake already admits it once the lake resolves. Only invoked on a miss so
+    // the extra grants query never runs on the common own-org/org-less hit path.
+    if (resolveGrantedLakeIds) {
+      const grantedLakeIds = await resolveGrantedLakeIds();
+      if (grantedLakeIds.length > 0) {
+        // Sorted for the same reason as the own-org arm above: two granted lakes can share a slug
+        // across two different non-member orgs (e.g. two independent transferLakeOwnership calls),
+        // and an unsorted `$in` match has no ordering guarantee - without a tie-break, which lake
+        // wins would be nondeterministic rather than merely unspecified-but-stable.
+        const granted = await this.dataLakeModel.findOne({ slug, _id: { $in: grantedLakeIds } }).sort({ _id: 1 });
+        if (granted) return granted.toJSON() as IDataLakeDocument;
+      }
+    }
+    return null;
   }
 
   async findByDatalakeTag(datalakeTag: string): Promise<IDataLakeDocument | null> {

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -329,11 +329,7 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
     return super.find(filter, { ...options, ...LIST_PROJECTION_FIELDS });
   }
 
-  async findBySlug(
-    slug: string,
-    organizationIds?: string[],
-    resolveGrantedLakeIds?: () => Promise<string[]>
-  ): Promise<IDataLakeDocument | null> {
+  async findBySlug(slug: string, organizationIds?: string[]): Promise<IDataLakeDocument | null> {
     // Slug is unique per (organizationId, slug). Prefer a lake in one of the caller's own
     // orgs, then fall back to an org-less lake with the same slug. Sorted so two own-org
     // matches resolve deterministically rather than by document order.
@@ -343,24 +339,31 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
         .sort({ organizationId: 1 });
       if (own) return own.toJSON() as IDataLakeDocument;
     }
-    const orgless = await this.dataLakeModel.findOne({ slug, organizationId: { $in: [null, ''] } });
-    if (orgless) return orgless.toJSON() as IDataLakeDocument;
-    // Last resort, and lazy on purpose (#2425): a lake in an org the caller is not a member of
-    // is invisible to both arms above, but a real owner/curator grant on it is still legitimate
-    // access - canManageLake already admits it once the lake resolves. Only invoked on a miss so
-    // the extra grants query never runs on the common own-org/org-less hit path.
-    if (resolveGrantedLakeIds) {
-      const grantedLakeIds = await resolveGrantedLakeIds();
-      if (grantedLakeIds.length > 0) {
-        // Sorted for the same reason as the own-org arm above: two granted lakes can share a slug
-        // across two different non-member orgs (e.g. two independent transferLakeOwnership calls),
-        // and an unsorted `$in` match has no ordering guarantee - without a tie-break, which lake
-        // wins would be nondeterministic rather than merely unspecified-but-stable.
-        const granted = await this.dataLakeModel.findOne({ slug, _id: { $in: grantedLakeIds } }).sort({ _id: 1 });
-        if (granted) return granted.toJSON() as IDataLakeDocument;
-      }
-    }
-    return null;
+    // Sorted too (#2425 review): `organizationId: null` and `organizationId: ''` are both stored
+    // as "org-less" but are distinct index keys, so two org-less lakes CAN share a slug. Without
+    // this, which one wins would depend on document order rather than being merely unspecified.
+    const orgless = await this.dataLakeModel
+      .findOne({ slug, organizationId: { $in: [null, ''] } })
+      .sort({ organizationId: 1 });
+    return (orgless?.toJSON() as IDataLakeDocument) ?? null;
+  }
+
+  /**
+   * Last-resort slug resolution (#2425): a lake in an org the caller is not a member of is
+   * invisible to `findBySlug`, but a real owner/curator grant on it is still legitimate access -
+   * canManageLake already admits it once the lake resolves. The caller (`assertLakeAccess`)
+   * decides whether it is worth resolving the grant-held id set at all, so this method takes the
+   * ALREADY-resolved candidates rather than a thunk - keeping the "when to pay for the extra
+   * grants query" decision in the service layer instead of hidden inside the data layer.
+   */
+  async findBySlugAmongIds(slug: string, ids: string[]): Promise<IDataLakeDocument | null> {
+    if (ids.length === 0) return null;
+    // Sorted for the same reason as the own-org arm above: two granted lakes can share a slug
+    // across two different non-member orgs (e.g. two independent transferLakeOwnership calls),
+    // and an unsorted `$in` match has no ordering guarantee - without a tie-break, which lake
+    // wins would be nondeterministic rather than merely unspecified-but-stable.
+    const granted = await this.dataLakeModel.findOne({ slug, _id: { $in: ids } }).sort({ _id: 1 });
+    return (granted?.toJSON() as IDataLakeDocument) ?? null;
   }
 
   async findByDatalakeTag(datalakeTag: string): Promise<IDataLakeDocument | null> {


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="1512" height="801" alt="01-fixture-lake-created" src="https://github.com/user-attachments/assets/38146be8-5d49-40b1-9e53-26653d1ce08c" />

**Fixture: `QA Foreign Grant Lake` created (slug `qa-foreign-grant-lake`)**

<img width="1512" height="801" alt="02-fixture-transfer-ownership" src="https://github.com/user-attachments/assets/e5aeb0a4-6a3f-4055-a086-9a7c32bab1d3" />

**Fixture: ownership transferred to a member of a different org - this is the foreign-org grant**

<img width="424" height="376" alt="03-slack-datalake-add" src="https://github.com/user-attachments/assets/5cc17f31-07bd-4234-8338-1718d32a599c" />

**Main assertion: `@datalake add to qa-foreign-grant-lake` succeeds for the foreign-org grant holder**

<img width="421" height="296" alt="04-slack-datalake-list" src="https://github.com/user-attachments/assets/2ae1426d-1b5c-41d8-a1a1-598f7c172a7e" />

**Main assertion: `@datalake list` now shows the foreign-org grant-held lake**

<img width="424" height="356" alt="05-slack-regression-no-access" src="https://github.com/user-attachments/assets/f5aa7fcc-b01e-4ec0-bcf0-e7fa0c2f345f" />

**Regression check: an account with no grant on the lake is still refused - no over-widening**

## Description

`findBySlug` resolved a lake by slug against only the caller's own-org lakes or org-less lakes -
never a lake scoped to an org the caller is not a member of. Authorization (`canManageLake`) does
not care which org a grant's lake belongs to - an owner or curator grant admits the holder
regardless of org - but the lake must resolve before authorization ever runs, so a foreign-org
grant was unreachable by slug no matter how legitimate the grant. `@datalake add` in Slack, and
any other `assertLakeAccess` caller that receives a slug rather than an id, inherited this: a
cross-org `transferLakeOwnership` left the new owner holding a real grant on a lake they could
never open by the only identifier Slack shows them.

The repository gains a second lookup, `findBySlugAmongIds(slug, ids)`: a plain query restricted to
a specific candidate id set. `assertLakeAccess` calls it only on a `findBySlug` miss, and only
when a `dataLakeAccessGrants` repo is wired - it resolves the caller's granted lake ids itself
(via the existing `grantedLakeIdsFor` helper, already used by `listDataLakes`), scoped to
owner/curator grants only (`includeReaders: false` - a reader grant does not get slug-resolution
by design, matching the issue's acceptance criteria), then retries with that set. The extra grants
query only ever runs on a miss, and only when the caller has threaded the grants repo, so a caller
that has not keeps exact prior behavior.

(An earlier version of this fix threaded a lazy thunk into `findBySlug` itself, so the repository
method decided when to run the fallback query. Human review flagged that as a layering leak - the
repo method depended on a service-owned query it could not be reasoned about from its own
signature - so it was reworked into the current shape: two plain repository methods, with the
service layer deciding when to call the second one. Same laziness, cleaner boundary - see
Additional Information.)

`@datalake add` inherits the fix for free (it calls `assertLakeAccess`), but `@datalake list` does
not call `assertLakeAccess`/`findBySlug` at all - `handleDataLakeCommand.ts` inlines its own copy
of the org-resolution rule to decide what a caller can resolve by slug, and that copy had not been
updated with the grant arm, so `list` omitted exactly the lake `add` now accepted. That copy (two
separate functions, `isSlugAddressable` and `slugPriorityTier`) is now one exported `slugTier`
function admitting the grant-held tier too, ranked below own-org and org-less to match
`findBySlug`'s arm order - including a now-corrected org-less tie-break found in review (see
Additional Information).

Closes #2425

## Changes

- `b4m-core/common/src/types/entities/DataLakeTypes.ts`
  - `IDataLakeRepository.findBySlug` (:368) is back to its plain two-parameter signature (no
    thunk).
  - New `findBySlugAmongIds(slug, ids)` (:379): resolve a lake restricted to a specific candidate
    id set - the #2425 last-resort method, called by the service layer rather than by `findBySlug`
    itself.
- `packages/database/src/models/ai/DataLakeModel.ts`
  - `findBySlug` (:332) is back to its plain two-arm shape; its org-less arm now sorts
    (`.sort({organizationId: 1})`) so two org-less lakes sharing a slug (`organizationId: null` vs
    `''` - distinct index keys, both read as org-less) resolve deterministically, a gap found in
    review.
  - New `findBySlugAmongIds` (:359): the `{slug, _id: {$in: ids}}` query, sorted
    (`.sort({_id: 1})`) for the same determinism reason as the removed thunk arm had.
- `b4m-core/services/src/dataLakeService/assertLakeAccess.ts`
  - New `resolveGrantHeldLakeBySlug` helper (:173-183): resolves the caller's granted lake ids via
    `grantedLakeIdsFor` and calls `findBySlugAmongIds`, only when `dataLakeAccessGrants` is wired.
  - `assertLakeAccess`'s resolution chain (:205-211) now reads `findById ?? findBySlug ??
    resolveGrantHeldLakeBySlug` - the miss-only laziness is visible at the call site instead of
    hidden inside a thunk.
  - `AssertLakeAccessAdapters.db.dataLakes` Pick (:22) widens to add `'findBySlugAmongIds'`; its
    `dataLakeAccessGrants` Pick still widens to add `'listByPrincipal'`, as before.
- `b4m-core/services/src/dataLakeService/authorizeLakeWrite.ts`
  - The same `dataLakes` Pick widens on all three sibling functions (`assertLakeWriteAccess` :39,
    `assertLakeRebuildAccess` :81, `assertFallbackLakeSettingsWriteAccess` :118), whose `db` object
    flows straight into `assertLakeAccess`.
- `b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.ts`
  - Same widening on `UpdateFallbackLakeSettingsAdapters.db.dataLakes` (:21).
- `apps/client/server/slack/dataLakeIngestAuthz.ts`
  - Same widening on `LakeAuthzDeps.dataLakes` (:49) - the Slack ingest paths' own adapter type,
    which also flows into `assertLakeAccess` via `assertLakeWriteAccess`.
- `b4m-core/services/src/dataLakeService/listDataLakes.ts`
  - New `ListDataLakesOptions` type (:136), extending `ListDataLakesAdapters` with an optional
    `grantedLakeIds` field - kept OUT of the shared adapters type (used by 3 other exported
    functions that never honored it, a gap review found) so only `listDataLakes` accepts it.
  - `listDataLakes` (:362-380) now validates the `grantedLakeIds` + `db.settings` combination
    BEFORE its settings read (moved up per a review nit), and reuses the precomputed set when
    supplied.
- `apps/client/server/slack/handleDataLakeCommand.ts`
  - `isSlugAddressable` and `slugPriorityTier` merged into one exported `slugTier` (:114) returning
    `0 | 1 | 2 | null` - `null` doubles as "not addressable", removing the separate boolean check
    and the runtime-asserted precondition the two-function split needed.
  - New `orgSortKey` (:101) and rewritten `preferredRow`/`dedupeBySlug` (:135, :152) add the
    missing org-less tie-break and operate on a `{lake, tier}` row computed once per lake, rather
    than re-deriving the tier during dedupe.
  - `handleList` (:177-235) computes each lake's tier once and filters/dedupes via that row shape.
- `apps/client/server/slack/handleDataLakeCommand.test.ts`
  - The "listed implies addable" guard now imports and calls the real `slugTier` instead of
    reimplementing the arm order - the old copy didn't cover the grant tier, a gap review found.
  - 4 new cases: org-less-vs-grant-held tie (org-less wins), grant-vs-grant tie (lower id wins),
    org-less-vs-org-less tie (null vs `''` determinism), and a direct unit test of `slugTier`.
- `b4m-core/services/src/dataLakeService/dataLakeService.test.ts`
  - The `assertLakeAccess - foreign-org grant resolves by slug (#2425)` block is rewritten off the
    old thunk-simulating `findBySlugFake` (itself a third hand-rolled copy of the arm order, per
    review) to mock `findBySlug`/`findBySlugAmongIds` directly, matching the new shape. Added a
    laziness case: `findBySlugAmongIds` is never called when `findBySlug` already resolved the
    lake.
- `packages/database/src/models/ai/DataLakeModel.test.ts`
  - New `DataLakeRepository.findBySlugAmongIds` describe block: resolves a granted lake; returns
    `null` on an empty or non-matching id set; a lowest-id tie-break test (mirrors the existing
    own-org N5 test). `findBySlug`'s own block gains an org-less-tie determinism test.
- `b4m-core/services/src/dataLakeService/updateFallbackLakeSettings.test.ts` and
  `apps/client/server/slack/dataLakeIngestAuthz.test.ts`
  - `findBySlugAmongIds` mocks added to each file's `dataLakes` fixtures, to satisfy the widened
    adapter type - never actually called in these tests (no grants repo wired, or `findBySlug`
    always hits).

## Tests

Automated tests in this diff: 4 new cases in `DataLakeModel.test.ts` (real Mongo, via
`setupMongoTest`) plus 3 more added during review response (`findBySlugAmongIds`'s own describe
block, plus an org-less-tie case); 5 cases in `dataLakeService.test.ts` (mocked adapters,
rewritten during review response, +1 net new laziness case); and 7 cases in
`handleDataLakeCommand.test.ts` (mocked adapters, 3 original + 4 added during review response) -
19 test cases total tied to #2425. Commands run, with the output seen:

- `pnpm --filter @bike4mind/database exec vitest run src/models/ai/DataLakeModel.test.ts
  src/models/ai/DataLakeModel.idOrSlugResolution.test.ts` - 2 files, 229 tests passing.
- `pnpm --filter @bike4mind/services exec vitest run src/dataLakeService` - 71 files, 1673 tests
  passing.
- `pnpm --filter @bike4mind/client exec vitest run --project node server/slack` - 5 files, 108
  tests passing (includes `handleDataLakeCommand.test.ts` and `dataLakeIngestAuthz.test.ts`).
- `pnpm --filter @bike4mind/client exec vitest run --project node pages/api/data-lakes` - 36
  files, 361 tests passing - checks the wider adapter-type blast radius (`LakeAuthzDeps` and the
  4 sibling Picks) didn't break any data-lake API route.
- `pnpm --filter @bike4mind/common build`, `pnpm --filter @bike4mind/database build`,
  `pnpm --filter @bike4mind/services build` - rebuilt so downstream typechecks see the interface
  change. `pnpm --filter @bike4mind/database typecheck`, `pnpm --filter @bike4mind/services
  typecheck` - no errors on either package. `apps/client`: `pnpm --filter @bike4mind/client
  typecheck` (its own memory-flagged script; a bare `tsc --noEmit` OOMs on this app regardless of
  this diff) - no errors beyond 2 pre-existing, unrelated ones in `app/utils/clearClientCaches.ts`
  (missing premium-overlay codegen module, not present in a non-premium dev checkout - untouched
  by this diff, confirmed via `git status`/`git log` on that file).
- `eslint` on all 13 changed files - 0 errors (pre-existing, unrelated `any` warnings only, in the
  same large `dataLakeService.test.ts` sections as before).
- ASCII/control-byte guard scripts (`check-no-control-bytes.sh`, `check-no-smart-punctuation.sh`,
  `--changed main`) - clean on both.

Reverting `DataLakeModel.ts`'s `findBySlugAmongIds` addition alone (production file only, test
file kept) fails 3 of its 4 new `findBySlugAmongIds` tests. Reverting `assertLakeAccess.ts`'s
`resolveGrantHeldLakeBySlug` wiring (plus its 4 sibling adapter-type widenings) alone fails the
`assertLakeAccess - foreign-org grant resolves by slug` owner/curator cases. Reverting
`handleDataLakeCommand.ts`'s production changes alone (test file kept) fails the grant-tier and
tie-break cases in `handleDataLakeCommand.test.ts`, reproducing the same "You cannot add to any
data lakes yet" message the live Slack verification hit before the original fix. All three
confirmed this session by temporarily reverting each file to its pre-fix content and re-running.
The org-less tie-break sort (both the model's and the handler's) could not be proven to fail on
revert by a real-Mongo test - see Additional Information for why, same as the `_id`-sort caveat
below it.

## Guide for Testers

No UI changed in this PR - it is a data-lake resolution/authorization fix reachable through
`@datalake add`/`@datalake list` in Slack, the `IDataLakeRepository.findBySlug` API surface
directly, or any HTTP route that resolves a lake by slug (see the last step below, added during
review - roughly 24 `assertLakeAccess` call sites wire a grants repo and inherit slug-side grant
resolution, `GET /api/data-lakes/[id]` and `compute-sync-delta.ts` among them). **Steps 1-5 were
run manually against the PR preview environment; see the Optional Screenshot/Video section above
for evidence. Step 6 was added during review and has not been separately re-verified live in this
session - it is a script for a tester to run, not a past-tense finding.**

**Preconditions**

1. `EnableDataLakes` is ON for the environment.
2. Two accounts in different organizations: ORG_A_OWNER (a member of Org A only) and
   ORG_B_MEMBER (a member of Org B only, NOT Org A). Neither account should belong to both orgs.
   Org A and Org B must both exist and each be able to hold a data lake.
3. ORG_B_MEMBER's Slack identity is linked to their B4M account (Profile Settings -> Slack
   Integration). Without this, `@datalake` replies "your Slack account isn't linked yet" instead
   of either the pass or fail case below, and the assertion has not actually run.

**Building the fixture**

1. As ORG_A_OWNER, `Sidebar -> Data Lakes -> Create data lake`, name it `QA Foreign Grant Lake`,
   both gates blank. Note the derived slug (e.g. `qa-foreign-grant-lake`) and the lake's id.
2. As ORG_A_OWNER, transfer ownership of that lake to ORG_B_MEMBER: `Manage lakes ->
   QA Foreign Grant Lake -> Access -> Transfer ownership`, select ORG_B_MEMBER as the new owner,
   confirm. Expected: the transfer succeeds; ORG_B_MEMBER now holds an owner grant on a lake
   scoped to Org A, an org they do not belong to.

**The assertion (Slack, as ORG_B_MEMBER)**

3. Post `@datalake add to <slug>` (the slug from step 1) with a small `.txt` attached. Expected:
   `Added 1 file to QA Foreign Grant Lake`. Fail: `No Data Lake <slug> found.` - this is exactly
   the bug this PR fixes.
4. Post `@datalake list`. Expected: `QA Foreign Grant Lake` (and its slug) appears among
   ORG_B_MEMBER's rows. Fail: "You cannot add to any data lakes yet" with no mention of the lake.

**Regression check**

5. As a THIRD account with no grant on the lake and not a member of Org A, post
   `@datalake add to <slug>` (the same slug). Expected: `No Data Lake <slug> found.` - a caller
   with no grant must still be refused; the fix must not widen who can reach the lake.

**Non-Slack surface (added during review)**

6. As ORG_B_MEMBER, `GET /api/data-lakes/<slug from step 1>` (authenticated as ORG_B_MEMBER).
   Expected: 200 with the lake's details - the same grant resolves here as it does for `add`,
   since this route calls `assertLakeAccess` with the same slug. Fail: a not-found-style error.

### What NOT to test

- No component, style, or route changed - there is nothing to inspect visually beyond the Slack
  reply text captured in the attached screenshots.
- Do not treat the green test suite, typecheck, or lint run above as evidence for steps 3-6 on
  their own; those verify the code path in isolation, not the deployed Slack/HTTP surface - the
  attached screenshots are the evidence for the Slack steps specifically.

## Additional Information

Known limitations, named rather than papered over:

- `grantedLakeIdsFor` (used by both `assertLakeAccess`'s fallback and the Slack `list` fix)
  resolves owner/curator grants only (`includeReaders: false`), matching the issue's acceptance
  criteria. A reader-only grant on a foreign-org lake still does not resolve by slug or appear in
  `list`; that is unchanged by this PR and was not in scope.
- `findById`'s existing behavior (no org filter at all) is untouched - it already admitted a
  foreign-org grant holder correctly (see #2035); the gap closed here was reaching the lake by
  slug, since Slack has no id entry point.
- If a caller holds owner/curator grants on two lakes that happen to share a slug across two
  different non-member orgs, `findBySlugAmongIds`' `.sort({_id: 1})` makes resolution
  deterministic (same lake wins every time), but this specific tie-break could not be proven by a
  failing/passing real-Mongo test in this session: `_id`-indexed `$in` queries already return in
  ascending key order by default in this MongoDB setup, so a test asserting the sorted winner
  passes identically whether or not the `.sort()` call is present. The same caveat applies to the
  new `.sort({organizationId: 1})` on `findBySlug`'s org-less arm (added in review response for
  the null-vs-`''` tie). Both sorts are kept as documented, contract-correct hardening rather than
  left to chance.
- **Design evolution from human review**: the original version of this fix threaded a lazy
  `resolveGrantedLakeIds` thunk into `findBySlug` itself, so the repository method decided when to
  pay for the extra grants query. Human review (onoya) pushed back on that as a layering leak - a
  repository method with a hidden dependency on a service-owned query, not reasoned-about from its
  own signature, and costly in the test suite (`dataLakeService.test.ts` had to reimplement all of
  `findBySlug`'s arms in a fake just to assert the thunk was supplied). The fix was reworked to the
  current two-method shape (`findBySlug` / `findBySlugAmongIds`), with `assertLakeAccess` deciding
  when to call the second one - identical laziness, no hidden repo-to-service dependency. The same
  review also caught: a false "at most one org-less lake per slug" claim in a doc comment (fixed
  with the sort above), two missing tie-break test cases (grant-vs-grant, org-less-vs-grant-held -
  now covered), the `grantedLakeIds` field living on a shared type 3 other exported functions
  silently ignored (moved to a `listDataLakes`-only type), and two small nits (validate-before-await
  in `listDataLakes`, an `?? []` consistency fix in `assertLakeAccess`) - all addressed in the
  commits following the review.
- **Semver** (raised by review, resolved by Chael): the `dataLakeAccessGrants` Pick widening from
  `'listByLake'` to `'listByLake' | 'listByPrincipal'` sits on a required field of several exported
  `@bike4mind/services` functions - technically a breaking type change for any caller that doesn't
  already satisfy it. Zero consumers outside `apps/client` were found across all `b4m-*` repos, and
  these are internal dependency-injection adapter shapes, not a documented public API contract, so
  this ships as a normal patch rather than a breaking-change bump.
- The manual verification fixture (steps in Guide for Testers) required creating 2 test
  organizations and manually working around a "pending invite" state (an org invite must be
  accepted by the invitee before an ownership transfer can target them) - both are pre-existing
  environment/product behaviors unrelated to this fix, not new gaps it introduces.

## Developer Notes (Optional)

- **Reusable pattern**: a lazy last-resort lookup, callable from the service layer only after a
  cheap primary lookup misses (`findBySlug` then, on a miss, `findBySlugAmongIds`), lets an
  expensive fallback stay off the common hot path without hiding a service-owned dependency inside
  the repository method that offers the cheap path. The rejected alternative - a thunk parameter
  threaded into the cheap method - achieves the same laziness but couples the repository to the
  service layer's own query; prefer two plain methods and let the caller sequence them.
- **A single total function beats a boolean check plus a separately-derived rank**: `slugTier`
  returns `0 | 1 | 2 | null` rather than pairing a `isAddressable` predicate with a
  `priorityTier` function - there is exactly one place the three arms are enumerated, so a new
  arm cannot make the two fall out of sync, and an invalid input (a foreign-org lake with no
  grant) has a real value (`null`) to return instead of a precondition to assert or violate.
- Any local reimplementation of an access/resolution rule that documents itself as "must stay in
  sync with X" is a drift risk by construction - a change to X has no compiler-enforced link back
  to the copy. This PR reduced the count from four hand-synced copies of the arm order (the model,
  the Slack handler's two functions, and two separate test fakes) to two irreducible ones (the
  model's real query arms, and the handler's `slugTier` - now exported and used directly by its own
  test guard, so at least that one copy cannot silently drift from what it claims to mirror).

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
