### PR TITLE
chore(data-lake): follow up on kb-search-token-budget review nits

### DIFF
--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3357,7 +3357,9 @@ export const settingsMap = {
       "setting's own value is then unused there, though it still governs the keyword-search " +
       'fallback, and the count served if token pricing itself fails). Does NOT raise the ' +
       "tool's hard ceiling of 10 passages per call - a model that reads max_results up to 10 " +
-      "from its own tool schema won't ask for more than that regardless of this setting.",
+      "from its own tool schema won't ask for more than that regardless of this setting. " +
+      'A change is not instantaneous: the settings cache is per-instance, so it applies immediately ' +
+      'on the instance that served the change and within ~5 min (one cache TTL) everywhere else.',
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 5,
@@ -3388,7 +3390,9 @@ export const settingsMap = {
       'chunked smaller no longer silently returns less material for the same setting. 0 (default) ' +
       'disables it: search_knowledge_base then serves exactly kbSearchDefaultResults passages, ' +
       'unchanged from before this setting existed. The FIRST matching passage is always returned ' +
-      'even if it alone exceeds the budget - a search that found something never returns nothing.',
+      'even if it alone exceeds the budget - a search that found something never returns nothing. ' +
+      'A change is not instantaneous: the settings cache is per-instance, so it applies immediately ' +
+      'on the instance that served the change and within ~5 min (one cache TTL) everywhere else.',
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 6,
@@ -3408,7 +3412,9 @@ export const settingsMap = {
       'Cosine similarity is not comparable across embedding models: a floor tuned for one model can ' +
       'filter out an entire alternate model, when a lake mixes embedding models, more aggressively ' +
       "than intended. Start low and raise gradually while watching the tool's own retrieval-" +
-      'skipped notices.',
+      'skipped notices. A change is not instantaneous: the settings cache is per-instance, so it ' +
+      'applies immediately on the instance that served the change and within ~5 min (one cache TTL) ' +
+      'everywhere else.',
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 7,

--- a/b4m-core/services/src/dataLakeService/resolveSearchBudgets.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveSearchBudgets.test.ts
@@ -137,11 +137,28 @@ describe('resolveSearchBudgets - scoped path', () => {
 
   it('falls back to the platform path if scoped resolution throws', async () => {
     const logger = loggerStub();
-    const db = makeDb({ dataLakeSearchMaxFiles: '3000' }, [], { throwOverrides: true });
+    // Every kb* field is set to a NON-default platform value: the degrade must carry the platform
+    // read, and a coded default would be indistinguishable from carrying it if these matched.
+    const db = makeDb(
+      {
+        dataLakeSearchMaxFiles: '3000',
+        kbSearchDefaultResults: '7',
+        kbSearchResultTokenBudget: '4000',
+        kbSearchMinRelevancePct: '25',
+      },
+      [],
+      { throwOverrides: true }
+    );
     const budgets = await resolveSearchBudgets(db, logger, scope);
     expect(budgets.maxFiles).toBe(3000);
     // The fallback must carry the serve budget too, or the scoped path degrades into an unclipped one.
     expect(budgets.maxChunkChars).toBe(DEFAULT_SERVE_CHARS);
+    // Same for the #1955 kb* fields - a degrade that silently reverted the floor or the token budget
+    // to its coded default would widen retrieval on an outage, which no caller could tell from a
+    // deliberate config change.
+    expect(budgets.kbDefaultResults).toBe(7);
+    expect(budgets.kbResultTokenBudget).toBe(4000);
+    expect(budgets.kbMinRelevance).toBeCloseTo(0.25);
   });
 
   it('carries the same derived serve budget as the platform path', async () => {

--- a/b4m-core/services/src/dataLakeService/resolveSearchBudgets.ts
+++ b/b4m-core/services/src/dataLakeService/resolveSearchBudgets.ts
@@ -48,9 +48,14 @@ export type ResolvedSearchBudgets = SemanticSearchBudgets & {
  * a matched chunk to SERVE, and (#1955) how many passages and how relevant they must be for
  * `search_knowledge_base` specifically.
  *
- * Shared by every entrypoint (the search route, the chat KB tool, forced retrieval) so one
- * surface cannot end up scanning further than another. Uses the CACHED settings accessor, so
- * this costs no round-trip on a warm cache.
+ * Shared by every entrypoint (the search route, the chat KB tool, forced retrieval) so no surface
+ * derives its budget by hand. That guarantees one DERIVATION, not one number: the KB tool resolves
+ * through the scoped path below while the search route (data-lakes/semantic-search) still resolves
+ * platform-only, so once an org/owner override is written the two surfaces legitimately scan to
+ * different depths for the same caller. Widening the guarantee back to one number means giving the
+ * remaining platform-only callers a scope, not narrowing this resolver.
+ *
+ * Uses the CACHED settings accessor, so this costs no round-trip on a warm cache.
  *
  * The serve budget is DERIVED from the chunk-size policy (`DefaultChunkSize`, the same row the
  * chunker reads as its passage target) rather than being a lever of its own. Two independently-set

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
@@ -2777,6 +2777,35 @@ describe('search_knowledge_base max_results clamp (#1757)', () => {
       expect(out).toContain('Tell the user the knowledge base may be returning partial results');
     });
 
+    it('does not blame the floor when nothing was compared - an unembedded lake is not a filtered one', async () => {
+      // Zero results is equally true of a corpus that was never vectorized, so attributing it to the
+      // threshold points the model (and the operator reading the log) at a knob that never ran.
+      semanticDataLakeSearchMock.mockResolvedValue({
+        results: [],
+        totalChunksSearched: 0,
+        filesInScope: 3,
+        chunksScored: 0,
+        scan: { ...scan, chunksScanned: 0, annHits: 0 },
+      });
+      const out = await runWith({}, contextWithKbSettings({ kbSearchMinRelevancePct: '50' }));
+      expect(out).not.toContain('a configured relevance threshold filtered out every candidate passage');
+      expect(clampLogger.log).not.toHaveBeenCalledWith(expect.stringContaining('relevance floor'));
+    });
+
+    it('still blames the floor on an ANN-served lake, which legitimately scores zero chunks', async () => {
+      // The guard must be `comparedNoPassages`, not `chunksScored > 0`: an Atlas/OpenSearch lake
+      // answers entirely from ANN hits and reports chunksScored 0 even when the floor did the work.
+      semanticDataLakeSearchMock.mockResolvedValue({
+        results: [],
+        totalChunksSearched: 0,
+        filesInScope: 3,
+        chunksScored: 0,
+        scan: { ...scan, chunksScanned: 0, annFilesQueried: 3, annHits: 12, annModelsQueried: 1 },
+      });
+      const out = await runWith({}, contextWithKbSettings({ kbSearchMinRelevancePct: '50' }));
+      expect(out).toContain('a configured relevance threshold filtered out every candidate passage');
+    });
+
     it('an org-rung override on kbSearchMinRelevancePct reaches minScore end-to-end', async () => {
       semanticDataLakeSearchMock.mockResolvedValue({ results: hits(3), totalChunksSearched: 3, filesInScope: 3, scan });
       const context = contextWithKbSettings(

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
@@ -186,6 +186,22 @@ function formatSkipNotice(skipNotice?: SkipNotice | null): string {
 }
 
 /**
+ * Did a configured relevance floor empty an otherwise-populated result set - as opposed to there
+ * having been nothing to filter?
+ *
+ * `comparedNoPassages` is what makes the claim honest: an unembedded lake, or a tag filter that
+ * matched no files, also returns zero results, and blaming the floor there sends the model (and the
+ * sweep in packages/scripts/retrieval) chasing a threshold that never ran. Deliberately NOT
+ * `chunksScored > 0` - a healthy all-ANN lake legitimately scores zero chunks (see
+ * `comparedNoPassages` in semanticDataLakeSearch), which that check would misread as unindexed.
+ *
+ * Shared by both semantic arms so the attribution rule cannot drift between them.
+ */
+function floorEmptiedResultSet(search: SemanticDataLakeSearchResult, kbMinRelevance: number): boolean {
+  return kbMinRelevance > 0 && search.results.length === 0 && !comparedNoPassages(search);
+}
+
+/**
  * Compose the one notice channel that survives the fall-through to keyword search.
  *
  * The relevance-floor reason leads and is COMPOSED with (not replaced by) the search limitations:
@@ -576,7 +592,7 @@ async function trySemanticKbSearch(
     // relevance floor that emptied an otherwise-thin-but-nonempty result set has to fold into
     // `skipNotice` here, not just a server log, or the model reads a bare metadata listing as
     // "the knowledge base has nothing on this topic".
-    const floorEmptiedResults = budgets.kbMinRelevance > 0 && search.results.length === 0;
+    const floorEmptiedResults = floorEmptiedResultSet(search, budgets.kbMinRelevance);
     const skipNotice = buildSkipNotice(search, floorEmptiedResults);
     if (search.results.length === 0) {
       if (floorEmptiedResults) {
@@ -711,7 +727,7 @@ async function tryScopedSemanticKbSearch(
     await recordAllEmbeddingUsage(context, query, embeddingModel, provider, search.alternateModelsEmbedded ?? []);
 
     // See the matching branch in trySemanticKbSearch above for why this folds into skipNotice.
-    const scopedFloorEmptiedResults = budgets.kbMinRelevance > 0 && search.results.length === 0;
+    const scopedFloorEmptiedResults = floorEmptiedResultSet(search, budgets.kbMinRelevance);
     const skipNotice = buildSkipNotice(search, scopedFloorEmptiedResults);
     if (search.results.length === 0) {
       if (scopedFloorEmptiedResults) {

--- a/b4m-core/services/src/settings/resolveScopedSetting.ts
+++ b/b4m-core/services/src/settings/resolveScopedSetting.ts
@@ -364,6 +364,15 @@ export function scopeForFileOwner(file: { userId: string; organizationId?: strin
  * the caller's own and shared files), so there is no single lake for a narrower rung to key on.
  * Owner derivation matches `scopeForLake`/`scopeForFileOwner`: an org member resolves at
  * `owner:<orgId>`, otherwise at `owner:<userId>`.
+ *
+ * CAVEAT for a second consumer: unlike its two siblings, this one cannot derive the org from the
+ * resource - there is no resource - so it keys on `caller.organizationId`, which callers feed from
+ * `user.organizationId`: the SELECTED-org display pointer, not proof of membership. The #1674
+ * invariant is that org resolution comes from membership, and this is the one derivation that does
+ * not satisfy it. Tolerable for a read-only BUDGET (worst case a member of two orgs reads the
+ * other's ceiling for one search), and NOT tolerable for anything that grants access, hides data or
+ * spends money. A consumer in that class must resolve membership first and pass the result here,
+ * not reach for this function as-is.
  */
 export function scopeForCaller(caller: { userId: string; organizationId?: string | null }): SettingScope {
   const orgId = caller.organizationId || undefined;

--- a/packages/scripts/retrieval/auditEvent.ts
+++ b/packages/scripts/retrieval/auditEvent.ts
@@ -22,10 +22,15 @@ export type AuditEventShape = Pick<RecordLakeAccessEventInput, 'fileIds' | 'scor
 /**
  * The tool's own notice when a nonzero relevance floor rejected every candidate passage.
  *
- * COUPLED BY TEXT to `knowledgeBaseSearch/index.ts` (both semantic arms build this literal when
- * `budgets.kbMinRelevance > 0 && search.results.length === 0`), because the tool exposes no
- * structural signal for it: the floor-emptied turn and a turn where the semantic arm was never
- * available reach the same keyword-arm status write, and `warnings` is the only field that differs.
+ * COUPLED BY TEXT to `knowledgeBaseSearch/index.ts` (both semantic arms build this literal when its
+ * `floorEmptiedResultSet` says so), because the tool exposes no structural signal for it: the
+ * floor-emptied turn and a turn where the semantic arm was never available reach the same
+ * keyword-arm status write, and `warnings` is the only field that differs.
+ *
+ * That predicate requires the floor to have had something to reject. A corpus that compared nothing
+ * returns zero results too, and it must NOT land in this bucket: with files in scope it is already
+ * `not_indexed` and never reaches the check below, but an empty scope (a tag filter matching no
+ * files) keeps `outcome: 'ok'` and would otherwise score as a floor rejection here.
  *
  * Drift is safe, not silent. If the wording changes, a floor-emptied turn stops matching, reads as
  * `keyword-fallback`, and ABORTS the sweep with an error - it can never quietly score a wrong row.


### PR DESCRIPTION
## Description

Closes #2122

Follow-up on the five non-blocking nits from #2009's ([#1955](https://github.com/Bike4Mind/bike4mind/issues/1955)) review, tracked in #2122. All five behavior changes are inert at today's defaults (both new knobs - `kbSearchMinRelevancePct` and `kbSearchResultTokenBudget` - ship off), so this carries no runtime risk today.

One correction to the issue's own text: item 1 proposed guarding on `search.chunksScored > 0`. That's the wrong check - a healthy all-ANN-served lake legitimately scores zero chunks (already documented at `index.test.ts` around the `not_indexed` outcome tests), so that guard would misclassify every Atlas/OpenSearch deployment as unindexed. Used the existing, tested `comparedNoPassages()` seam instead.

## Changes

- **Relevance-floor attribution** (`knowledgeBaseSearch/index.ts`): both semantic arms now only blame the relevance floor for an empty result set when `!comparedNoPassages(search)` - an unembedded lake, or a tag filter matching no files, also returns zero and must not be reported as "filtered". Extracted the shared `floorEmptiedResultSet()` helper so the two arms (and the retrieval-sweep script's text-matching, see below) can't drift apart on the predicate.
- **`scopeForCaller`** (`resolveScopedSetting.ts`): documented that it keys the org rung on `caller.organizationId` (the selected-org display pointer), which conflicts with the #1674 invariant that org resolution comes from membership. Fine for a read-only budget lever; called out as unsafe for a future access/spend-granting consumer to reuse as-is.
- **`resolveSearchBudgets` docblock**: corrected the stale claim that "one surface cannot end up scanning further than another" - that stopped being true once the KB tool started resolving budgets through the scoped path while other callers (e.g. the search route) still resolve platform-only. Restated the actual guarantee: one shared derivation, not one shared number.
- **kb\* setting descriptions** (`settings.ts`): added the standard "~5 min (one cache TTL)" clause to all three, matching neighboring settings.
- **Degrade-path test** (`resolveSearchBudgets.test.ts`): the scoped-to-platform fallback test now pins all three kb\* fields (not just `maxFiles`/`maxChunkChars`) to non-default values, so a silent revert-to-coded-default on outage would actually fail the test.

Also updated `packages/scripts/retrieval/auditEvent.ts`'s docblock, which restated the relevance-floor predicate by hand as its text-coupling contract with the tool - left unfixed it would have documented a condition the code no longer uses.

## Guide for Testers

Backend/internal-only change - no user-facing behavior differs at today's config (both kb* knobs default to off).

### What NOT to test
- No UI surface changed. `kbSearchDefaultResults`, `kbSearchResultTokenBudget`, and `kbSearchMinRelevancePct` admin-settings descriptions changed (more explanatory text only, same fields/values) - visual diff on the admin settings page not required.
- No behavior change to verify manually: `search_knowledge_base`'s relevance-floor notice only fires when `kbSearchMinRelevancePct > 0`, which nothing sets today.

### Regression Checks
1. `pnpm --filter @bike4mind/services test src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts src/dataLakeService/resolveSearchBudgets.test.ts` - expect all green (includes two new tests pinning the corrected floor-attribution guard).
2. `pnpm --filter @bike4mind/scripts test retrieval/` - expect all green (retrieval-sweep suite, covers the `auditEvent.ts` docblock's matching contract).
3. `pnpm turbo:typecheck && pnpm lint:check` - expect clean.

## Additional Information

Two things intentionally left out of scope, noted for a future follow-up rather than silently expanded into here:
- The three scan-budget settings (`dataLakeSearchMaxFiles`, `dataLakeSearchMaxChunks`, `DefaultChunkSize`) also lack the cache-TTL clause - pre-existing gap, not something #2122 or the original review flagged.
- `tryScopedSemanticKbSearch` (the file-scoped semantic arm) has no test coverage of the relevance-floor notice at all, only of `minScore` passthrough. Narrowed the risk via the shared helper, didn't add scoped-arm coverage.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a - no user-facing doc)
- [x] My changes generate no new warnings

