### PR TITLE
chore(preview): throwaway preview stand

### DIFF
--- a/apps/client/.preview-cachebust
+++ b/apps/client/.preview-cachebust
@@ -1,0 +1,1 @@
+preview stand cachebust 2026-09-08T00:00:00Z


### PR DESCRIPTION
Throwaway draft PR used only to boot a preview stack for manual verification. Not for merge; will be closed and the branch deleted once the stand is torn down.