### PR TITLE
fix(data-lakes): classify a Drive rate limit as retryable so a throttled sync stops dropping files

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -41,11 +41,6 @@ const useGetDeletedDataLakes = vi.fn(() => ({ data: undefined as unknown[] | und
 const useLakeDriveConnection = vi.fn(() => ({ data: null as unknown, isError: false, isLoading: false }));
 vi.mock('@client/app/hooks/data/googleDrive', () => ({
   useLakeDriveConnection: () => useLakeDriveConnection(),
-  DRIVE_STATUS_BADGE: {
-    connected: { label: 'Connected', color: 'success' },
-    needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
-    credential_error: { label: 'Credential error', color: 'danger' },
-  },
 }));
 vi.mock('@client/app/hooks/data/dataLakes', () => {
   const mutation = () => ({ mutate: vi.fn(), isPending: false });

--- a/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.test.tsx
@@ -11,11 +11,6 @@ import type { ManagerLake } from './shared';
 // rather than needing a QueryClientProvider.
 vi.mock('@client/app/hooks/data/googleDrive', () => ({
   useLakeDriveConnection: () => ({ data: null, isError: false, isLoading: false }),
-  DRIVE_STATUS_BADGE: {
-    connected: { label: 'Connected', color: 'success' },
-    needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
-    credential_error: { label: 'Credential error', color: 'danger' },
-  },
 }));
 
 // "Start chat" pulls in SessionsContext/react-router/react-query transitively - irrelevant to this

--- a/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.test.tsx
@@ -18,12 +18,6 @@ vi.mock('@client/app/hooks/data/googleDrive', () => ({
   useLakeDriveConnection: () => ({ data: h.connection.current, isLoading: false, isError: h.isError.current }),
   useConnectDriveFolderToLake: () => ({ mutate: h.connectMutate, isPending: false }),
   useDisconnectLakeDrive: () => ({ mutate: h.disconnectMutate, isPending: false }),
-  // Real map, not a stub: the status wording is the thing under test in the connected case.
-  DRIVE_STATUS_BADGE: {
-    connected: { label: 'Connected', color: 'success' },
-    needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
-    credential_error: { label: 'Credential error', color: 'danger' },
-  },
 }));
 vi.mock('react-google-drive-picker', () => ({ default: () => [h.openPicker] }));
 vi.mock('@client/app/contexts/ApiContext', () => ({ api: { get: vi.fn(), post: vi.fn() } }));
@@ -72,6 +66,29 @@ describe('DriveConnectAction', () => {
     expect(screen.getByTestId('drive-connection-status')).toHaveTextContent('Docs');
     expect(screen.getByTestId('drive-resync-btn')).toBeInTheDocument();
     expect(screen.getByTestId('drive-disconnect-btn')).toBeInTheDocument();
+  });
+
+  it('reports a healthy connection as Connected and shows no error line', () => {
+    h.connection.current = connected();
+    wrap(<DriveConnectAction lake={{ id: 'lake1' }} />);
+    expect(screen.getByTestId('drive-connection-status')).toHaveTextContent('Connected');
+    expect(screen.queryByTestId('drive-connection-last-error')).toBeNull();
+  });
+
+  it('does NOT report a sync that stopped short as Connected (#2394)', () => {
+    // releaseSyncClaim heals the status back to 'connected' whatever happened and records WHY on
+    // lastError, so this pair is a sync that left files out of the lake. The old code showed a green
+    // "Connected" chip here and rendered lastError only for status === 'credential_error', which is
+    // exactly the "every dashboard says the sync worked" failure.
+    h.connection.current = connected({
+      lastError: 'Google Drive is rate-limiting this sync, and it stopped after 20 continuation runs.',
+    });
+    wrap(<DriveConnectAction lake={{ id: 'lake1' }} />);
+
+    const status = screen.getByTestId('drive-connection-status');
+    expect(status).toHaveTextContent('Stopped short');
+    expect(status).not.toHaveTextContent('Connected');
+    expect(screen.getByTestId('drive-connection-last-error')).toHaveTextContent('rate-limiting');
   });
 
   it('requires a confirm step before disconnecting, so a single click is not destructive', () => {

--- a/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/DriveConnectAction.tsx
@@ -8,8 +8,8 @@ import {
   useLakeDriveConnection,
   useConnectDriveFolderToLake,
   useDisconnectLakeDrive,
-  DRIVE_STATUS_BADGE,
 } from '@client/app/hooks/data/googleDrive';
+import { describeDriveConnection } from '@client/app/hooks/data/driveConnectionDisplay';
 import { useDriveFolderPicker } from '@client/app/hooks/data/useDriveFolderPicker';
 
 /** The specific server `error` message off an axios failure, if the response carried one. */
@@ -72,15 +72,17 @@ export default function DriveConnectAction({ lake }: { lake: { id: string } }) {
   }
 
   if (connection) {
-    const badge = DRIVE_STATUS_BADGE[connection.status];
+    // Not DRIVE_STATUS_BADGE directly: a 'connected' connection carrying a lastError is a sync that
+    // stopped short with files missing, and only describeDriveConnection reads it that way.
+    const { label, color } = describeDriveConnection(connection);
     return (
       <Stack direction="row" gap={1} alignItems="center" flexWrap="wrap" data-testid="drive-connection-status">
         <CloudIcon color="primary" />
         <Typography level="body-sm">
           <strong>{connection.folderName || connection.driveFolderId}</strong>
         </Typography>
-        <Chip size="sm" variant="soft" color={badge.color}>
-          {badge.label}
+        <Chip size="sm" variant="soft" color={color}>
+          {label}
         </Chip>
         <Button
           data-testid="drive-resync-btn"
@@ -138,9 +140,12 @@ export default function DriveConnectAction({ lake }: { lake: { id: string } }) {
             Disconnect
           </Button>
         )}
-        {connection.status === 'credential_error' && connection.lastError && (
+        {connection.lastError && (
           <Box sx={{ flexBasis: '100%' }}>
-            <Typography level="body-xs" color="danger">
+            {/* Shown for ANY status that recorded one, not just credential_error: a sync that stopped
+                short heals the status back to 'connected', so gating on the error statuses hid the
+                one message saying files are missing from the lake (#2394). */}
+            <Typography level="body-xs" color={color} data-testid="drive-connection-last-error">
               {connection.lastError}
             </Typography>
           </Box>

--- a/apps/client/app/components/datalake/LakeDriveStatusChip.tsx
+++ b/apps/client/app/components/datalake/LakeDriveStatusChip.tsx
@@ -1,6 +1,7 @@
 import { Chip, Tooltip } from '@mui/joy';
 import CloudIcon from '@mui/icons-material/Cloud';
-import { DRIVE_STATUS_BADGE, useLakeDriveConnection } from '@client/app/hooks/data/googleDrive';
+import { useLakeDriveConnection } from '@client/app/hooks/data/googleDrive';
+import { describeDriveConnection } from '@client/app/hooks/data/driveConnectionDisplay';
 
 /**
  * Read-only "this lake has a Drive folder attached" marker, for the surfaces a user reaches when
@@ -26,24 +27,17 @@ export default function LakeDriveStatusChip({
   const { data: connection } = useLakeDriveConnection(lakeId, !!organizationId);
   if (!connection) return null;
 
-  const badge = DRIVE_STATUS_BADGE[connection.status];
+  // Wording and severity both come from describeDriveConnection - notably it does NOT read a
+  // 'connected' connection carrying a lastError as a healthy sync (see its doc).
+  const { title, color } = describeDriveConnection(connection);
   const folder = connection.folderName || connection.driveFolderId;
 
   return (
-    <Tooltip
-      size="sm"
-      title={
-        connection.status === 'connected'
-          ? `Syncing the Google Drive folder "${folder}"`
-          : `Google Drive folder "${folder}": ${badge.label.toLowerCase()}${
-              connection.lastError ? ` - ${connection.lastError}` : ''
-            }`
-      }
-    >
+    <Tooltip size="sm" title={title}>
       <Chip
         size="sm"
         variant="soft"
-        color={badge.color}
+        color={color}
         startDecorator={<CloudIcon sx={{ fontSize: 12 }} />}
         sx={{ fontSize: '11px', maxWidth: 220 }}
         data-testid={`datalake-drive-status-chip-${lakeId}`}

--- a/apps/client/app/hooks/data/driveConnectionDisplay.test.ts
+++ b/apps/client/app/hooks/data/driveConnectionDisplay.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { describeDriveConnection } from './driveConnectionDisplay';
+
+const conn = (over: Partial<Parameters<typeof describeDriveConnection>[0]> = {}) => ({
+  status: 'connected' as const,
+  lastError: null,
+  folderName: 'Handbook',
+  driveFolderId: 'FOLDER',
+  ...over,
+});
+
+describe('describeDriveConnection', () => {
+  it('reads a clean connected sync as healthy', () => {
+    expect(describeDriveConnection(conn())).toEqual({
+      label: 'Connected',
+      title: 'Syncing the Google Drive folder "Handbook"',
+      color: 'success',
+    });
+  });
+
+  // The silently-incomplete-lake case (#2394): releaseSyncClaim stamps the status back to
+  // 'connected' whatever happened, so lastError is the ONLY thing separating a finished sync from
+  // one that stopped short with files missing. Reporting that green is the bug.
+  it('does NOT read a connected connection carrying a lastError as healthy', () => {
+    const { label, title, color } = describeDriveConnection(
+      conn({ lastError: 'Google Drive is rate-limiting this sync, and it stopped after 20 continuation runs.' })
+    );
+    expect(color).toBe('warning');
+    expect(label).toBe('Stopped short');
+    expect(title).toContain('last sync stopped short');
+    expect(title).toContain('rate-limiting');
+    expect(title).not.toContain('Syncing the Google Drive folder');
+  });
+
+  it('keeps the badge wording and severity for a genuinely broken connection', () => {
+    expect(describeDriveConnection(conn({ status: 'credential_error', lastError: 'invalid_grant' }))).toEqual({
+      label: 'Credential error',
+      title: 'Google Drive folder "Handbook": credential error - invalid_grant',
+      color: 'danger',
+    });
+  });
+
+  it('falls back to the folder id when Drive gave us no folder name', () => {
+    expect(describeDriveConnection(conn({ folderName: null })).title).toContain('"FOLDER"');
+  });
+});

--- a/apps/client/app/hooks/data/driveConnectionDisplay.test.ts
+++ b/apps/client/app/hooks/data/driveConnectionDisplay.test.ts
@@ -40,6 +40,30 @@ describe('describeDriveConnection', () => {
     });
   });
 
+  // 'syncing' is a real stored status the hand-listed client union used to omit, so the badge lookup
+  // came back undefined and both Drive surfaces threw `Cannot read properties of undefined` for the
+  // whole duration of a sync. The union is derived from the DB enum now, which is what stops it.
+  it('describes an in-flight sync instead of throwing on it', () => {
+    const { label, title, color } = describeDriveConnection(conn({ status: 'syncing' }));
+    expect(label).toBe('Syncing');
+    expect(title).toBe('Sync in progress for the Google Drive folder "Handbook"');
+    expect(color).toBe('success');
+  });
+
+  it('does not dress an in-flight sync as stopped-short using the PREVIOUS run error', () => {
+    const { label, title } = describeDriveConnection(conn({ status: 'syncing', lastError: 'a previous failure' }));
+    expect(label).toBe('Syncing');
+    expect(title).not.toContain('stopped short');
+  });
+
+  it('never throws on a status no longer in the badge table', () => {
+    // The endpoint hands back the raw stored status with no validation, so this is the boundary the
+    // fallback exists for - a crash here takes out the whole lake panel.
+    const rogue = conn({ status: 'a_status_from_the_future' as never });
+    expect(() => describeDriveConnection(rogue)).not.toThrow();
+    expect(describeDriveConnection(rogue).color).toBe('warning');
+  });
+
   it('falls back to the folder id when Drive gave us no folder name', () => {
     expect(describeDriveConnection(conn({ folderName: null })).title).toContain('"FOLDER"');
   });

--- a/apps/client/app/hooks/data/driveConnectionDisplay.ts
+++ b/apps/client/app/hooks/data/driveConnectionDisplay.ts
@@ -1,0 +1,63 @@
+/**
+ * How a Drive connection READS to a user: label, tooltip line, severity.
+ *
+ * Deliberately free of hook/API imports so every surface can call it directly and no test suite has
+ * to stub it - three hand-copied wording tables is exactly the drift this consolidates.
+ */
+
+export type DriveConnectionStatus = 'connected' | 'needs_reconnect' | 'credential_error';
+
+export type DriveConnectionSeverity = 'success' | 'warning' | 'danger';
+
+/**
+ * Wording + severity per raw status. Every surface that renders a Drive connection (the wizard's
+ * connect action, the lake detail chip) reads the SAME table - hand-synced copies would drift the
+ * moment a status is added.
+ */
+export const DRIVE_STATUS_BADGE: Record<DriveConnectionStatus, { label: string; color: DriveConnectionSeverity }> = {
+  connected: { label: 'Connected', color: 'success' },
+  needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
+  credential_error: { label: 'Credential error', color: 'danger' },
+};
+
+/** The subset of a connection this wording is derived from. */
+export type DescribableDriveConnection = {
+  status: DriveConnectionStatus;
+  lastError: string | null;
+  folderName: string | null;
+  driveFolderId: string;
+};
+
+/**
+ * The subtlety is `connected` WITH a `lastError`. Releasing a sync claim always stamps the status
+ * back to 'connected' and records why the run stopped short on `lastError`
+ * (OrgGoogleDriveConnectionModel.releaseSyncClaim), so that pair means the last sync did NOT finish -
+ * files are missing from the lake. Reporting it as a plain green "Connected" is the silently-
+ * incomplete lake this exists to stop (#2394), and `lastError` is the only account of it that
+ * reaches a user at all.
+ */
+export function describeDriveConnection(connection: DescribableDriveConnection): {
+  label: string;
+  title: string;
+  color: DriveConnectionSeverity;
+} {
+  const folder = connection.folderName || connection.driveFolderId;
+  const badge = DRIVE_STATUS_BADGE[connection.status];
+
+  if (connection.status === 'connected') {
+    return connection.lastError
+      ? {
+          label: 'Stopped short',
+          title: `Google Drive folder "${folder}": last sync stopped short - ${connection.lastError}`,
+          color: 'warning',
+        }
+      : { label: badge.label, title: `Syncing the Google Drive folder "${folder}"`, color: badge.color };
+  }
+
+  const detail = connection.lastError ? ` - ${connection.lastError}` : '';
+  return {
+    label: badge.label,
+    title: `Google Drive folder "${folder}": ${badge.label.toLowerCase()}${detail}`,
+    color: badge.color,
+  };
+}

--- a/apps/client/app/hooks/data/driveConnectionDisplay.ts
+++ b/apps/client/app/hooks/data/driveConnectionDisplay.ts
@@ -5,7 +5,16 @@
  * to stub it - three hand-copied wording tables is exactly the drift this consolidates.
  */
 
-export type DriveConnectionStatus = 'connected' | 'needs_reconnect' | 'credential_error';
+import type { GoogleDriveConnectionStatus } from '@bike4mind/common';
+
+/**
+ * Derived from the stored enum rather than re-listed. The drive-connection endpoint returns
+ * `c.status` verbatim with no contract validation, so a status this module does not know about
+ * reaches the badge lookup as `undefined` and every surface below throws a render-time TypeError.
+ * 'syncing' is exactly how that bit: it is a real stored status for the whole duration of a sync,
+ * was missing from the hand-listed union, and crashed both Drive surfaces while a sync ran.
+ */
+export type DriveConnectionStatus = GoogleDriveConnectionStatus;
 
 export type DriveConnectionSeverity = 'success' | 'warning' | 'danger';
 
@@ -16,9 +25,13 @@ export type DriveConnectionSeverity = 'success' | 'warning' | 'danger';
  */
 export const DRIVE_STATUS_BADGE: Record<DriveConnectionStatus, { label: string; color: DriveConnectionSeverity }> = {
   connected: { label: 'Connected', color: 'success' },
+  syncing: { label: 'Syncing', color: 'success' },
   needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
   credential_error: { label: 'Credential error', color: 'danger' },
 };
+
+/** Last resort if an unvalidated status still slips past the derived union (see DriveConnectionStatus). */
+const UNKNOWN_STATUS_BADGE = { label: 'Unknown', color: 'warning' } as const;
 
 /** The subset of a connection this wording is derived from. */
 export type DescribableDriveConnection = {
@@ -42,7 +55,17 @@ export function describeDriveConnection(connection: DescribableDriveConnection):
   color: DriveConnectionSeverity;
 } {
   const folder = connection.folderName || connection.driveFolderId;
-  const badge = DRIVE_STATUS_BADGE[connection.status];
+  const badge = DRIVE_STATUS_BADGE[connection.status] ?? UNKNOWN_STATUS_BADGE;
+
+  // A run is in flight, so any lastError belongs to the PREVIOUS one - reporting this as a sync that
+  // stopped short would be wrong. DriveConnectAction still renders the old message on its own line.
+  if (connection.status === 'syncing') {
+    return {
+      label: badge.label,
+      title: `Sync in progress for the Google Drive folder "${folder}"`,
+      color: badge.color,
+    };
+  }
 
   if (connection.status === 'connected') {
     return connection.lastError

--- a/apps/client/app/hooks/data/googleDrive.ts
+++ b/apps/client/app/hooks/data/googleDrive.ts
@@ -1,30 +1,17 @@
 import { api } from '@client/app/contexts/ApiContext';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { DriveConnectionStatus } from '@client/app/hooks/data/driveConnectionDisplay';
 
 /** Safe, credential-free view returned by GET /api/data-lakes/:id/drive-connection. */
 export type LakeDriveConnection = {
   id: string;
   driveFolderId: string;
   folderName: string | null;
-  status: 'connected' | 'needs_reconnect' | 'credential_error';
+  status: DriveConnectionStatus;
   enabled: boolean;
   lastError: string | null;
   lastUsedAt: string | null;
   connectedAt: string | null;
-};
-
-/**
- * User-facing label + severity per connection status. Lives beside the type so every surface that
- * renders a Drive connection (the wizard's connect action, the lake detail panel, the page header)
- * reads the SAME wording - three hand-synced copies would drift the moment a status is added.
- */
-export const DRIVE_STATUS_BADGE: Record<
-  LakeDriveConnection['status'],
-  { label: string; color: 'success' | 'warning' | 'danger' }
-> = {
-  connected: { label: 'Connected', color: 'success' },
-  needs_reconnect: { label: 'Needs reconnect', color: 'warning' },
-  credential_error: { label: 'Credential error', color: 'danger' },
 };
 
 const lakeDriveConnectionKey = (dataLakeId?: string) => ['lake-drive-connection', dataLakeId];

--- a/apps/client/pages/api/data-lakes/batches/index.ts
+++ b/apps/client/pages/api/data-lakes/batches/index.ts
@@ -115,6 +115,7 @@ const handler = baseApi()
       failedFiles: 0,
       processingFailedFiles: 0,
       skippedFiles: 0,
+      deferredFiles: 0,
       uploadedSizeBytes: 0,
       files: [],
       appliedTags: data.appliedTags || [],

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -19,6 +19,39 @@ export function isFolder(file: DriveFile): boolean {
   return file.mimeType === FOLDER_MIME_TYPE;
 }
 
+// The `errors[].reason` values Drive uses for a throttle. A 403 carries these as often as a 429
+// does, and the reason is the ONLY thing separating such a 403 from a genuine permission denial.
+const DRIVE_RATE_LIMIT_REASONS = new Set(['userRateLimitExceeded', 'rateLimitExceeded', 'quotaExceeded']);
+
+/**
+ * Is this error Drive telling us to slow down, rather than a permanent failure?
+ *
+ * Read structurally off the GaxiosError (status plus `errors[].reason`, at both the shapes
+ * googleapis surfaces them) rather than by matching the message, which carries no stable marker.
+ * Callers MUST treat a true here as retryable: a throttle misread as permanent drops the file and
+ * still reports the run a success (#2394).
+ */
+export function isDriveRateLimitError(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) return false;
+  const err = e as Record<string, unknown>;
+  const response = err.response as Record<string, unknown> | undefined;
+  const data = response?.data as { error?: { errors?: unknown } } | undefined;
+
+  for (const raw of [err.code, err.status, response?.status]) {
+    if ((typeof raw === 'string' ? Number(raw) : raw) === 429) return true;
+  }
+
+  for (const list of [err.errors, data?.error?.errors]) {
+    if (!Array.isArray(list)) continue;
+    for (const detail of list) {
+      const reason = (detail as { reason?: unknown } | null)?.reason;
+      if (typeof reason === 'string' && DRIVE_RATE_LIMIT_REASONS.has(reason)) return true;
+    }
+  }
+
+  return false;
+}
+
 // Drive file/folder ids are URL-safe tokens ([A-Za-z0-9_-]); the alias 'root' also matches. The
 // length bound (real ids are ~33-44 chars) stops ~1MB of legal characters being interpolated into
 // the `q` string and sent outbound. Validate before interpolating so a crafted id can't break out.

--- a/apps/client/server/integrations/google/drive/driveContent.test.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { drive_v3 } from 'googleapis';
 import { SupportedFabFileMimeTypes } from '@bike4mind/common';
 import { walkFolder, fetchDriveFileContent } from './driveContent';
-import { FOLDER_MIME_TYPE } from './driveClient';
+import { FOLDER_MIME_TYPE, isDriveRateLimitError } from './driveClient';
 
 const folder = (id: string, name: string) => ({ id, name, mimeType: FOLDER_MIME_TYPE });
 const file = (id: string, name: string, mimeType: string) => ({ id, name, mimeType });
@@ -104,5 +104,76 @@ describe('fetchDriveFileContent', () => {
 
     const res = await fetchDriveFileContent(drive, file('big', 'Huge', 'application/vnd.google-apps.document'));
     expect(res).toMatchObject({ ok: false, reason: 'export_too_large' });
+  });
+
+  // The whole point of the separate reason: `error` is permanent to the caller, so a throttle
+  // landing there drops the file from the lake and still finalizes the batch clean.
+  it('reports rate_limited (not error) when Drive throttles a native download', async () => {
+    const getFn = vi.fn(async () => {
+      throw Object.assign(new Error('Rate Limit Exceeded'), {
+        code: 429,
+        response: { status: 429, data: { error: { errors: [{ reason: 'userRateLimitExceeded' }] } } },
+      });
+    });
+    const drive = { files: { export: vi.fn(), get: getFn } } as unknown as drive_v3.Drive;
+
+    const res = await fetchDriveFileContent(drive, file('n', 'notes.txt', 'text/plain'));
+    expect(res).toMatchObject({ ok: false, reason: 'rate_limited' });
+  });
+
+  it('reports rate_limited for a 403 whose reason is a quota, not a permission denial', async () => {
+    const exportFn = vi.fn(async () => {
+      throw Object.assign(new Error('The user has exceeded their rate limit.'), {
+        code: 403,
+        response: { status: 403, data: { error: { errors: [{ reason: 'rateLimitExceeded' }] } } },
+      });
+    });
+    const drive = { files: { export: exportFn, get: vi.fn() } } as unknown as drive_v3.Drive;
+
+    const res = await fetchDriveFileContent(drive, file('d', 'Doc', 'application/vnd.google-apps.document'));
+    expect(res).toMatchObject({ ok: false, reason: 'rate_limited' });
+  });
+
+  it('still reports a permanent error for a non-throttle failure', async () => {
+    const getFn = vi.fn(async () => {
+      throw Object.assign(new Error('File not found'), { code: 404, response: { status: 404 } });
+    });
+    const drive = { files: { export: vi.fn(), get: getFn } } as unknown as drive_v3.Drive;
+
+    const res = await fetchDriveFileContent(drive, file('n', 'notes.txt', 'text/plain'));
+    expect(res).toMatchObject({ ok: false, reason: 'error' });
+  });
+});
+
+describe('isDriveRateLimitError', () => {
+  it.each([
+    ['a numeric 429 code', { code: 429 }],
+    ['a string 429 code (googleapis stringifies it in places)', { code: '429' }],
+    ['a 429 only on the response', { response: { status: 429 } }],
+    ['a 403 carrying userRateLimitExceeded', { code: 403, errors: [{ reason: 'userRateLimitExceeded' }] }],
+    [
+      'a nested quotaExceeded reason',
+      { code: 403, response: { data: { error: { errors: [{ reason: 'quotaExceeded' }] } } } },
+    ],
+  ])('detects %s', (_label, shape) => {
+    expect(isDriveRateLimitError(Object.assign(new Error('throttled'), shape))).toBe(true);
+  });
+
+  it.each([
+    [
+      'a permission denial, which shares the 403 but not the reason',
+      { code: 403, errors: [{ reason: 'insufficientFilePermissions' }] },
+    ],
+    ['an oversized export', { code: 403, errors: [{ reason: 'exportSizeLimitExceeded' }] }],
+    ['a not-found', { code: 404 }],
+    ['a DNS failure whose code is a non-numeric string', { code: 'ENOTFOUND' }],
+    ['a plain error', {}],
+  ])('does not treat %s as a rate limit', (_label, shape) => {
+    expect(isDriveRateLimitError(Object.assign(new Error('nope'), shape))).toBe(false);
+  });
+
+  it('is safe on non-object rejections', () => {
+    expect(isDriveRateLimitError(undefined)).toBe(false);
+    expect(isDriveRateLimitError('429')).toBe(false);
   });
 });

--- a/apps/client/server/integrations/google/drive/driveContent.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.ts
@@ -1,7 +1,7 @@
 import type { drive_v3 } from 'googleapis';
 import { SupportedFabFileMimeTypes } from '@bike4mind/common';
 import { resolveSupportedMimeType } from '@bike4mind/utils';
-import { listFolderChildren, isFolder, type DriveFile } from './driveClient';
+import { listFolderChildren, isFolder, isDriveRateLimitError, type DriveFile } from './driveClient';
 
 const GOOGLE_DOC = 'application/vnd.google-apps.document';
 const GOOGLE_SHEET = 'application/vnd.google-apps.spreadsheet';
@@ -47,9 +47,14 @@ export async function walkFolder(drive: drive_v3.Drive, rootFolderId: string): P
   return files;
 }
 
+/**
+ * `rate_limited` is the one RETRYABLE failure: Drive throttled us, so the file is fine and the
+ * caller must defer it rather than record it skipped. `unsupported`, `export_too_large` and
+ * `error` are all permanent for this file's current content.
+ */
 export type FetchedContent =
   | { ok: true; bytes: Buffer; mimeType: string }
-  | { ok: false; reason: 'unsupported' | 'export_too_large' | 'error'; detail?: string };
+  | { ok: false; reason: 'unsupported' | 'export_too_large' | 'error' | 'rate_limited'; detail?: string };
 
 /**
  * Fetch one Drive file's bytes for ingest:
@@ -57,8 +62,9 @@ export type FetchedContent =
  *   google-apps types (Forms, Drawings, ...) aren't ingestible and are reported `unsupported`.
  * - Native files -> `files.get?alt=media`, gated by `resolveSupportedMimeType`.
  *
- * Returns a discriminated result so the caller skips-and-counts rather than crashing the whole
- * walk on one bad file (an oversized Editors export, an unsupported type, a transient error).
+ * Returns a discriminated result so the caller skips-and-counts rather than crashing the whole walk
+ * on one bad file (an oversized Editors export, an unsupported type). A throttle is reported as its
+ * own `rate_limited` reason - see FetchedContent for why the caller must not conflate the two.
  */
 export async function fetchDriveFileContent(drive: drive_v3.Drive, file: DriveFile): Promise<FetchedContent> {
   try {
@@ -86,6 +92,11 @@ export async function fetchDriveFileContent(drive: drive_v3.Drive, file: DriveFi
     // Drive's ~10MB export hard cap surfaces as exportSizeLimitExceeded - skip, don't fail the run.
     if (/exportSizeLimitExceeded/i.test(detail)) {
       return { ok: false, reason: 'export_too_large', detail };
+    }
+    // Transient, and reported apart from `error` because the caller treats `error` as a permanent
+    // per-file skip - which for a throttle silently drops the file from the lake (#2394).
+    if (isDriveRateLimitError(e)) {
+      return { ok: false, reason: 'rate_limited', detail };
     }
     return { ok: false, reason: 'error', detail };
   }

--- a/apps/client/server/queueHandlers/dataLakeBatchProgress.test.ts
+++ b/apps/client/server/queueHandlers/dataLakeBatchProgress.test.ts
@@ -49,6 +49,8 @@ import {
   finalizeBatchIfComplete,
   enqueueTaxonomyAnalysisIfWanted,
   deferFailureIfRetryable,
+  isBatchComplete,
+  completedBatchStatus,
 } from './dataLakeBatchProgress';
 
 // `warn` as well as `error`, matching what the real callers pass (the Lambda logger): the audit
@@ -122,6 +124,49 @@ describe('finalizeBatchIfComplete - batch-completion metric parity', () => {
     await finalizeBatchIfComplete(batch({ vectorizedFiles: 1 }), logger as never);
     expect(h.markTerminalIfActive).not.toHaveBeenCalled();
     expect(h.recordBatchCompletion).not.toHaveBeenCalled();
+  });
+
+  // A Drive continuation chain that stopped short re-plans totalFiles down to what it produced, so it
+  // DOES cross the threshold - by construction, since the shortfall was subtracted from the total. The
+  // only thing separating it from a clean run is deferredFiles, so if the outcome ignores that field a
+  // 3-of-500 sync settles as a green 'completed' and no surface anywhere says files are missing (#2394).
+  it('settles a chain that wrote files off unfinished as completed_with_errors, not completed', async () => {
+    const short = batch({ totalFiles: 3, vectorizedFiles: 3, deferredFiles: 497 });
+    h.markTerminalIfActive.mockResolvedValue(short);
+
+    await finalizeBatchIfComplete(short, logger as never);
+
+    expect(h.markTerminalIfActive).toHaveBeenCalledWith('b1', 'completed_with_errors');
+    expect(h.recordBatchCompletion).toHaveBeenCalledWith('completed_with_errors');
+  });
+
+  // The degenerate chain: nothing produced, so the re-plan lands on 0 and the threshold is met at 0.
+  it('settles a chain that ingested nothing as completed_with_errors rather than an empty success', async () => {
+    const nothing = batch({ totalFiles: 0, vectorizedFiles: 0, deferredFiles: 2 });
+    h.markTerminalIfActive.mockResolvedValue(nothing);
+
+    await finalizeBatchIfComplete(nothing, logger as never);
+
+    expect(h.markTerminalIfActive).toHaveBeenCalledWith('b1', 'completed_with_errors');
+  });
+
+  // deferredFiles must stay OUT of the completion threshold. A deferred candidate mints no manifest
+  // entry and no counter, so no later event can ever satisfy a gate that counted it - the batch would
+  // sit in 'processing' until the stuck-batch reconciler force-failed it, which is a worse outcome than
+  // the one this field exists to report. The threshold decides WHETHER it is done; the outcome decides
+  // whether it went well.
+  it('does not let a deferred count hold a batch open past its completion threshold', async () => {
+    const short = batch({ totalFiles: 3, vectorizedFiles: 3, deferredFiles: 497 }) as unknown as never;
+    expect(isBatchComplete(short)).toBe(true);
+    expect(completedBatchStatus(short)).toBe('completed_with_errors');
+  });
+
+  // The six websocket progress payloads report the outcome through this helper, so the client cannot
+  // be told 'completed' about a batch the database settled as 'completed_with_errors'.
+  it('reports no status at all while a batch is still short of its threshold', () => {
+    expect(completedBatchStatus(batch({ vectorizedFiles: 1 }))).toBeUndefined();
+    expect(completedBatchStatus(null)).toBeUndefined();
+    expect(completedBatchStatus(batch())).toBe('completed');
   });
 
   it('does not record when another handler already finalized (guard lost)', async () => {

--- a/apps/client/server/queueHandlers/dataLakeBatchProgress.ts
+++ b/apps/client/server/queueHandlers/dataLakeBatchProgress.ts
@@ -81,7 +81,7 @@ export async function finalizeBatchIfComplete(
   if (!batch) return;
   if (batch.vectorizedFiles + batch.failedFiles + batch.skippedFiles < batch.totalFiles) return;
 
-  const outcome = batch.failedFiles > 0 ? 'completed_with_errors' : 'completed';
+  const outcome = resolveBatchOutcome(batch);
   const finalized = await dataLakeBatchRepository.markTerminalIfActive(batch.id, outcome);
   if (!finalized) return; // another handler finalized first — don't double-recompute.
 
@@ -119,6 +119,33 @@ export async function finalizeBatchIfComplete(
 /** True once a batch has reached its completion threshold. */
 export function isBatchComplete(batch: IDataLakeBatchDocument | null): boolean {
   return !!batch && batch.vectorizedFiles + batch.failedFiles + batch.skippedFiles >= batch.totalFiles;
+}
+
+/**
+ * Which terminal status a finished batch settles as. The single source of truth for that decision:
+ * the persisted transition above and the six `data_lake_batch_progress` websocket payloads that
+ * report it (objectCreated, fabFileChunk x3, fabFileVectorize x2) each open-coded this expression,
+ * so the record and the client's view of the same batch could disagree.
+ *
+ * `deferredFiles` counts candidates a multi-run Drive chain planned and then wrote off unfinished, so
+ * a batch carrying any is NOT a clean success even when nothing failed - the files are missing from
+ * the lake. It is deliberately absent from `isBatchComplete`'s threshold: a deferred candidate mints
+ * no manifest entry and no counter, so gating completion on it would strand every stopped-short batch
+ * in `processing` until the reconciler force-failed it. The threshold decides WHETHER a batch is
+ * done; this decides whether it went well (#2394).
+ */
+export function resolveBatchOutcome(batch: IDataLakeBatchDocument): 'completed' | 'completed_with_errors' {
+  return batch.failedFiles > 0 || (batch.deferredFiles ?? 0) > 0 ? 'completed_with_errors' : 'completed';
+}
+
+/**
+ * The terminal status to REPORT for a batch, or `undefined` while it has not finished - the shape the
+ * websocket progress payloads want, so they stay in lockstep with what was actually persisted.
+ */
+export function completedBatchStatus(
+  batch: IDataLakeBatchDocument | null
+): 'completed' | 'completed_with_errors' | undefined {
+  return batch && isBatchComplete(batch) ? resolveBatchOutcome(batch) : undefined;
 }
 
 /**

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -828,7 +828,8 @@ describe('driveLakeIngest consumer', () => {
 
       await run({ connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1 });
 
-      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 2);
+      // Narrowed to what the chain produced, with the 7 planned-but-unfinished recorded alongside it.
+      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 2, 7);
     });
 
     it('starts a fresh batch when the batch it was told to resume has already been settled', async () => {
@@ -867,7 +868,7 @@ describe('driveLakeIngest consumer', () => {
 
       expect(h.sendToQueue).not.toHaveBeenCalled();
       // Settled rather than stranded, the claim released, and the operator told why it stopped short.
-      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 1);
+      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 1, 2);
       expect(h.releaseSyncClaim).toHaveBeenCalledWith(
         'conn1',
         'token-claim',
@@ -931,6 +932,31 @@ describe('driveLakeIngest consumer', () => {
       const [, , lastError] = h.releaseSyncClaim.mock.calls[0];
       expect(lastError).toContain('rate-limiting');
       expect(lastError).not.toContain('subfolders');
+    });
+
+    it('records the write-off when a chain ends having ingested nothing at all', async () => {
+      // The degenerate chain: throttled before the first file on the last slice, nothing produced.
+      // Settling re-plans totalFiles DOWN to what the chain produced so the finalize gate is reachable
+      // at all - which on its own turns "0 of 2 ingested" into an indistinguishable "0 of 0", i.e. a
+      // clean success over an empty folder. The shortfall has to ride on that same update.
+      h.walkFolder.mockResolvedValue(walkOf('d1', 'd2'));
+      h.fetchDriveFileContent.mockResolvedValue({ ok: false, reason: 'rate_limited', detail: '429' });
+      h.batchFindById.mockResolvedValue({
+        id: 'batch1',
+        dataLakeId: 'lake1',
+        status: 'processing',
+        totalFiles: 2,
+        skippedFiles: 0,
+        files: [],
+        vectorizedFiles: 0,
+        failedFiles: 0,
+      });
+
+      await run({ connectionId: 'conn1', resumeBatchId: 'batch1', slice: MAX_INGEST_SLICES - 1 });
+
+      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 0, 2);
+      // Nothing was permanently skipped, which is what keeps the files re-walkable by the next poll.
+      expect(h.recordSkippedDriveFile).not.toHaveBeenCalled();
     });
 
     it('tolerates a release that loses its CAS when the claim was taken away mid-slice', async () => {
@@ -1111,7 +1137,8 @@ describe('driveLakeIngest consumer', () => {
       await run({ connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'tok0' });
 
       // Correct: 1 non-skipped manifest entry + 1 skippedFiles = 2, not files.length(2) + skippedFiles(1) = 3.
-      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 2);
+      // The deferred count is derived from the SAME produced figure, so the double-count guard covers both.
+      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 2, 3);
     });
 
     it('settles an adopted batch when a later slice pushes the folder over the candidate cap', async () => {
@@ -1136,8 +1163,9 @@ describe('driveLakeIngest consumer', () => {
       await run({ connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'tok0' });
 
       // Re-planned to what the chain actually produced (1 manifest entry) and nudged toward finalize,
-      // instead of being left open with no owner once the cap refusal returns.
-      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 1);
+      // instead of being left open with no owner once the cap refusal returns. The 4 candidates the
+      // refusal wrote off are recorded rather than vanishing into the narrowed total.
+      expect(h.setTotalFilesIfActive).toHaveBeenCalledWith('batch1', 1, 4);
       expect(h.finalizeBatchIfComplete).toHaveBeenCalled();
       expect(h.batchCreate).not.toHaveBeenCalled();
       expect(h.createFabFile).not.toHaveBeenCalled();

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -875,6 +875,64 @@ describe('driveLakeIngest consumer', () => {
       );
     });
 
+    it('defers the rest of the slice on a Drive rate limit instead of silently short-changing the batch', async () => {
+      // The bug this exists for: a 429 used to come back as reason 'error', which the loop recorded
+      // as a PERMANENT skip. recordSkippedDriveFile is idempotent per chain, so the file was
+      // subtracted from every later walk - gone from the lake for good - while `skippedFiles` carried
+      // the batch over the finalize gate and the whole sync reported success.
+      h.walkFolder.mockResolvedValue(walkOf('d1', 'd2', 'd3'));
+      h.fetchDriveFileContent
+        .mockResolvedValueOnce(okBytes())
+        .mockResolvedValueOnce({ ok: false, reason: 'rate_limited', detail: 'Rate Limit Exceeded' });
+
+      await run({ connectionId: 'conn1' });
+
+      // The throttled file keeps its candidacy: no skip recorded, so the continuation's walk still
+      // sees it. d3 is never even attempted - the quota is exhausted, not this one file.
+      expect(h.recordSkippedDriveFile).not.toHaveBeenCalled();
+      expect(h.fetchDriveFileContent).toHaveBeenCalledTimes(2);
+      expect(h.upload).toHaveBeenCalledTimes(1);
+
+      // And the batch is handed on rather than settled, so nothing can report this run complete.
+      expect(h.finalizeBatchIfComplete).not.toHaveBeenCalled();
+      expect(h.setTotalFilesIfActive).not.toHaveBeenCalled();
+      expect(h.releaseSyncClaim).not.toHaveBeenCalled();
+      expect(h.sendToQueue).toHaveBeenCalledWith(
+        'ingest-queue-url',
+        { connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'token-renew' },
+        expect.any(Number)
+      );
+      // Unlike the deadline yield, a throttled slice delays its continuation - coming straight back
+      // would hit the same exhausted quota.
+      expect(h.sendToQueue.mock.calls[0][2]).toBeGreaterThanOrEqual(60);
+    });
+
+    it('tells the operator the sync was rate-limited when a throttled chain hits the ceiling', async () => {
+      // lastError is the only account of a chain that stopped short that reaches a user (the lake's
+      // Drive chip surfaces it - describeDriveConnection), and the large-folder advice ("split into
+      // subfolders") is both wrong and unactionable for a quota problem.
+      h.walkFolder.mockResolvedValue(walkOf('d1', 'd2'));
+      h.fetchDriveFileContent.mockResolvedValue({ ok: false, reason: 'rate_limited', detail: '429' });
+      h.batchFindById.mockResolvedValue({
+        id: 'batch1',
+        dataLakeId: 'lake1',
+        status: 'processing',
+        totalFiles: 2,
+        skippedFiles: 0,
+        files: [],
+        vectorizedFiles: 0,
+        failedFiles: 0,
+      });
+
+      await run({ connectionId: 'conn1', resumeBatchId: 'batch1', slice: MAX_INGEST_SLICES - 1 });
+
+      expect(h.sendToQueue).not.toHaveBeenCalled();
+      expect(h.recordSkippedDriveFile).not.toHaveBeenCalled();
+      const [, , lastError] = h.releaseSyncClaim.mock.calls[0];
+      expect(lastError).toContain('rate-limiting');
+      expect(lastError).not.toContain('subfolders');
+    });
+
     it('tolerates a release that loses its CAS when the claim was taken away mid-slice', async () => {
       // Someone else owns the connection now (a stale-claim reclaim). The release still RUNS - it is a
       // compare-and-set on this run's token, so it misses the new owner's document and heals nothing,

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -75,6 +75,15 @@ const MAX_INGEST_FILE_BYTES = 50 * 1024 * 1024;
 // duplicate the tail, so this buffer is the thing that actually keeps a large folder converging.
 const INGEST_DEADLINE_BUFFER_MS = 90_000;
 
+// Wait before the continuation slice when Drive throttled this one. The jitter is what makes it
+// shedding rather than a reschedule: several connections poll on the same tick against ONE Drive
+// project quota, so a fixed delay would just re-collide them at the new time. Per-call retry inside
+// each Drive call site is separate hardening (#2395); this is the amount the deferral itself needs.
+const INGEST_RATE_LIMIT_DELAY_SECONDS = 60;
+const INGEST_RATE_LIMIT_JITTER_SECONDS = 30;
+const rateLimitBackoffSeconds = () =>
+  INGEST_RATE_LIMIT_DELAY_SECONDS + Math.floor(Math.random() * INGEST_RATE_LIMIT_JITTER_SECONDS);
+
 // Wall-clock budget when the caller cannot supply the Lambda's real remaining time (tests, the
 // self-host worker, any non-Lambda host). Keeps the guard active by default rather than silently
 // absent. Mirrors extractLakeMemory's DEFAULT_RUN_BUDGET_MS, against the same 10-minute ceiling.
@@ -205,14 +214,22 @@ export function hasDriveFileChanged(
  * vectorizedFiles never increments and the batch never crosses its finalize threshold. Hence the
  * per-file `appendFiles` AHEAD of `storage.upload`, not a single append after the loop.
  *
- * totalFiles is seeded with the candidate count (adds + re-ingests); a skip (oversized / unsupported
- * / transient fetch error) is folded into `skippedFiles` as it happens, so `vectorized + failed +
- * skipped` still reaches totalFiles exactly (finalizeBatchIfComplete's gate) without the ingestable
- * count being known up front. Removals happen outside the batch (immediate lake-membership pulls).
+ * totalFiles is seeded with the candidate count (adds + re-ingests); a PERMANENT skip (oversized,
+ * unsupported, a fetch that failed for this file's own sake) is folded into `skippedFiles` as it
+ * happens, so `vectorized + failed + skipped` still reaches totalFiles exactly
+ * (finalizeBatchIfComplete's gate) without the ingestable count being known up front. Removals happen
+ * outside the batch (immediate lake-membership pulls).
+ *
+ * A Drive RATE LIMIT is deliberately not one of those. recordSkippedDriveFile is idempotent per chain,
+ * so a skip is subtracted from every later slice's walk - recording a throttle as one drops the file
+ * from the lake for good while the batch still finalizes clean, which is a silently incomplete lake
+ * behind a green dashboard (#2394). It takes the deferral path below instead.
  *
  * A folder too large for one invocation ingests across SEVERAL, as a chain of slices. The loop yields
- * on the Lambda deadline (INGEST_DEADLINE_BUFFER_MS) rather than being killed, then re-enqueues itself
- * carrying the batch it was filling. Three things make that converge where a plain SQS retry did not:
+ * on the Lambda deadline (INGEST_DEADLINE_BUFFER_MS) rather than being killed - or on a Drive rate
+ * limit, which additionally delays the continuation so the next slice is not hammering the same
+ * exhausted quota - then re-enqueues itself carrying the batch it was filling. Three things make
+ * that converge where a plain SQS retry did not:
  *
  *   - The next slice ADOPTS the batch instead of creating one, and subtracts the Drive ids that batch
  *     has already UPLOADED or permanently skipped a FabFile for (findDriveFileIdsByBatchId,
@@ -900,6 +917,9 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       //    upload. Only one file's bytes are ever live, and the manifest entry precedes the upload so
       //    the objectCreated/chunk/vectorize claims the upload fires can find it (see header).
       let deferred = 0;
+      // Set when Drive throttled this slice, which changes both the continuation's delay and the
+      // message the operator sees if the chain runs out of slices still throttled.
+      let rateLimited = false;
       for (const [index, file] of candidates.entries()) {
         // Yield rather than get killed, checked BEFORE starting a file so the run never dies between
         // creating a FabFile and uploading its bytes - including before the FIRST file: a slice whose
@@ -922,6 +942,23 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
 
         const result = await fetchDriveFileContent(drive, file);
         if (!result.ok) {
+          // A throttle is transient, so it must never become a permanent skip (see header). Yield the
+          // whole remainder rather than just this file: the next candidates would hit the same
+          // exhausted quota, and deferred candidates are re-walked by the continuation, so they stay
+          // in play and the batch cannot finalize as a clean success without them.
+          if (result.reason === 'rate_limited') {
+            rateLimited = true;
+            deferred = candidates.length - index;
+            logger.warn('[driveLakeIngest] Drive rate-limited a content fetch; deferring the rest of the slice', {
+              connectionId,
+              batchId: batch.id,
+              driveFileId: file.id,
+              slice,
+              deferred,
+              detail: result.detail,
+            });
+            break;
+          }
           await skip(file.id, result.reason);
           continue;
         }
@@ -1002,13 +1039,14 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         uploaded,
         skipped,
         deferred,
+        rateLimited,
         retired,
       });
 
-      // 7) Out of time with files left: hand the claim and the batch to another slice rather than
-      //    finishing here. The claim is renewed (never released) so the connection stays 'syncing' and
-      //    no poll can start a competing walk in the gap, and the batch stays open so the next slice
-      //    appends to it instead of starting a second one.
+      // 7) Files left over (out of time, or Drive throttling us): hand the claim and the batch to
+      //    another slice rather than finishing here. The claim is renewed (never released) so the
+      //    connection stays 'syncing' and no poll can start a competing walk in the gap, and the batch
+      //    stays open so the next slice appends to it instead of starting a second one.
       if (deferred > 0 && slice + 1 < MAX_INGEST_SLICES) {
         const renewedToken = await orgGoogleDriveConnectionRepository.renewSyncClaim(
           connectionId,
@@ -1021,20 +1059,29 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
           // holds, and releasing on a superseded token is a silent no-op that would strand the
           // connection at 'syncing' with no continuation ever enqueued.
           ingestClaimToken = renewedToken;
-          await sendToQueue(Resource.driveLakeIngestQueue.url, {
-            connectionId,
-            resumeBatchId: batch.id,
-            slice: slice + 1,
-            claimToken: renewedToken,
-          });
+          // Spread rather than passing `undefined`: the deadline yield wants SQS's own immediate
+          // delivery, and only a throttled slice asks for a delay.
+          const backoff: [number] | [] = rateLimited ? [rateLimitBackoffSeconds()] : [];
+          await sendToQueue(
+            Resource.driveLakeIngestQueue.url,
+            {
+              connectionId,
+              resumeBatchId: batch.id,
+              slice: slice + 1,
+              claimToken: renewedToken,
+            },
+            ...backoff
+          );
           // Handed off: the continuation owns the claim from here, so a later throw (the `finally`
           // below) must NOT release it out from under that slice.
           ingestClaimToken = undefined;
-          logger.info('[driveLakeIngest] out of time; enqueued continuation slice', {
+          logger.info('[driveLakeIngest] enqueued continuation slice', {
             connectionId,
             batchId: batch.id,
             slice: slice + 1,
             deferred,
+            rateLimited,
+            delaySeconds: backoff[0],
           });
           // Deliberately NOT releasing the claim, and NOT finalizing: the chain owns both until it ends.
           return;
@@ -1063,6 +1110,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
           batchId: batch.id,
           slice,
           deferred,
+          rateLimited,
           maxSlices: MAX_INGEST_SLICES,
         });
       }
@@ -1075,11 +1123,15 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       if (adoptedBatch || deferred > 0) await settleChainedBatch(batch.id);
       else await finalizeBatchIfComplete(await dataLakeBatchRepository.findById(batch.id), logger);
 
-      await releaseClaim(
-        deferred > 0
-          ? `Sync stopped after ${MAX_INGEST_SLICES} continuation runs with ${deferred} files left. The next scheduled poll continues from here; split very large folders into subfolders to converge faster.`
-          : null
-      );
+      // The one operator-visible account of a chain that stopped short, so it has to name the actual
+      // cause: "split the folder up" is wrong (and unactionable) advice for a quota problem.
+      const stoppedShort =
+        deferred === 0
+          ? null
+          : rateLimited
+            ? `Google Drive is rate-limiting this sync, and it stopped after ${MAX_INGEST_SLICES} continuation runs with ${deferred} files still to ingest. Those files are NOT in the lake yet. The next scheduled poll retries them; if it keeps happening, sync fewer folders on the same schedule.`
+            : `Sync stopped after ${MAX_INGEST_SLICES} continuation runs with ${deferred} files left. The next scheduled poll continues from here; split very large folders into subfolders to converge faster.`;
+      await releaseClaim(stoppedShort);
     } finally {
       await flushReclaimedStorage();
 

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -248,7 +248,10 @@ export function hasDriveFileChanged(
  *     interval is its queue wait, not its run length.
  *   - `totalFiles` is re-planned as the chain goes (raised when a later walk finds more, set exactly
  *     when the chain ends), so the finalize gate is still reached exactly and the batch never settles
- *     mid-chain or strands in `processing` afterwards.
+ *     mid-chain or strands in `processing` afterwards. That final set is a NARROWING, so the same
+ *     settle records the shortfall it just wrote off as `deferredFiles` - otherwise a chain that
+ *     ingested 3 of 500 files finalizes as a clean 3-of-3, and the only account of the other 497 is a
+ *     connection field the next sync overwrites (#2394).
  *
  * A throw part-way through a CONTINUATION slice is rethrown for SQS retry as before, and that retry
  * redelivers the same message - resumeBatchId included - so it adopts the batch and resumes instead of
@@ -305,10 +308,19 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       // handler's own skip() (drive-side: oversized/unsupported/fetch-failed) mints no manifest entry
       // at all, so those are the only skippedFiles that need adding back in.
       const produced = (current.files?.filter(f => f.status !== 'skipped').length ?? 0) + (current.skippedFiles ?? 0);
+      // What the chain PLANNED minus what it produced is exactly the work it gave up on, and it is
+      // derivable here at every exit - including the ones that cannot know a count (a continuation whose
+      // connection or lake was deleted mid-chain settles a batch it never got to walk). Recording it is
+      // what keeps the re-plan below honest: dropping totalFiles to `produced` is what lets the finalize
+      // gate be reached at all, but on its own it rewrites a chain that ingested 3 of 500 files into a
+      // clean 3-of-3 success, and in the degenerate case (throttled before the first file on every
+      // slice) into an empty folder. `max` because a mid-chain walk that finds MORE files raises the
+      // plan, never lowers it, so produced can never legitimately exceed it.
+      const deferredFiles = Math.max(0, current.totalFiles - produced);
       const settled =
         produced === current.totalFiles
           ? current
-          : await dataLakeBatchRepository.setTotalFilesIfActive(batchId, produced);
+          : await dataLakeBatchRepository.setTotalFilesIfActive(batchId, produced, deferredFiles);
       await finalizeBatchIfComplete(settled ?? current, logger);
     };
 
@@ -878,6 +890,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
           failedFiles: 0,
           processingFailedFiles: 0,
           skippedFiles: 0,
+          deferredFiles: 0,
           uploadedSizeBytes: 0,
           files: [],
           appliedTags: [],

--- a/apps/client/server/queueHandlers/fabFileChunk.test.ts
+++ b/apps/client/server/queueHandlers/fabFileChunk.test.ts
@@ -53,7 +53,7 @@ const h = vi.hoisted(() => {
     getSettingsValue: vi.fn(),
     sendToClient: vi.fn(async () => undefined),
     finalizeBatchIfComplete: vi.fn(),
-    isBatchComplete: vi.fn(),
+    completedBatchStatus: vi.fn(),
     deferFailureIfRetryable: vi.fn(),
     fabFileUpdateOne: vi.fn(() => ({ catch: vi.fn() })),
     userFindById: vi.fn(async () => ({ id: 'u1' })),
@@ -134,7 +134,7 @@ vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => h.sendTo
 vi.mock('@server/websocket/utils', () => ({ sendToClient: (...a: unknown[]) => h.sendToClient(...a) }));
 vi.mock('@server/queueHandlers/dataLakeBatchProgress', () => ({
   finalizeBatchIfComplete: (...a: unknown[]) => h.finalizeBatchIfComplete(...a),
-  isBatchComplete: (...a: unknown[]) => h.isBatchComplete(...a),
+  completedBatchStatus: (...a: unknown[]) => h.completedBatchStatus(...a),
   deferFailureIfRetryable: (...a: unknown[]) => h.deferFailureIfRetryable(...a),
 }));
 vi.mock('@bike4mind/common', async () => {
@@ -197,7 +197,7 @@ describe('fabFileChunk handler - chunk-failure surfacing', () => {
       vectorizedFiles: 0,
       totalFiles: 3,
     });
-    h.isBatchComplete.mockReturnValue(false);
+    h.completedBatchStatus.mockReturnValue(undefined);
     h.chunkFabfile.mockRejectedValue(new Error(CHUNK_ERR));
   });
 
@@ -273,7 +273,7 @@ describe('fabFileChunk handler - retry gating (#1412)', () => {
       vectorizedFiles: 0,
       totalFiles: 3,
     });
-    h.isBatchComplete.mockReturnValue(false);
+    h.completedBatchStatus.mockReturnValue(undefined);
     h.chunkFabfile.mockRejectedValue(new Error(CHUNK_ERR));
   });
 
@@ -883,7 +883,7 @@ describe('fabFileChunk handler - a failed vectorize enqueue must not strand the 
     h.incrementCounter.mockResolvedValue({ chunkedFiles: 1, failedFiles: 0, totalFiles: 1 });
     h.markFailedIfNotAlready.mockResolvedValue(true);
     h.incrementCounters.mockResolvedValue({ failedFiles: 1, processingFailedFiles: 1, totalFiles: 3 });
-    h.isBatchComplete.mockReturnValue(false);
+    h.completedBatchStatus.mockReturnValue(undefined);
     h.deferFailureIfRetryable.mockResolvedValue(false);
     h.findVectorlessChunkIds.mockResolvedValue([]);
     h.sendToQueue.mockResolvedValue(undefined);
@@ -1160,7 +1160,7 @@ describe('fabFileChunk handler - pre-flight failures are accounted', () => {
       vectorizedFiles: 0,
       totalFiles: 3,
     });
-    h.isBatchComplete.mockReturnValue(false);
+    h.completedBatchStatus.mockReturnValue(undefined);
   });
 
   it('marks the file errored (terminal for the rescue sweep) when the user is gone, and re-throws', async () => {

--- a/apps/client/server/queueHandlers/fabFileChunk.ts
+++ b/apps/client/server/queueHandlers/fabFileChunk.ts
@@ -20,7 +20,7 @@ import { sendToQueue } from '@server/utils/sqs';
 import { dispatchWithLogger, MARK_PAUSED_MAX_ATTEMPTS, MARK_PAUSED_RETRY_DELAY_MS } from '@server/queueHandlers/utils';
 import {
   finalizeBatchIfComplete,
-  isBatchComplete,
+  completedBatchStatus,
   deferFailureIfRetryable,
 } from '@server/queueHandlers/dataLakeBatchProgress';
 import { FAB_FILE_CHUNK_MAX_RECEIVE_COUNT } from '@server/queueHandlers/sqsDelivery';
@@ -172,7 +172,7 @@ async function accountFileFailure(params: {
       batchId,
       failedFiles: batch?.failedFiles ?? 1,
       processingFailedFiles: batch?.processingFailedFiles ?? 1,
-      status: isBatchComplete(batch) ? (batch!.failedFiles > 0 ? 'completed_with_errors' : 'completed') : undefined,
+      status: completedBatchStatus(batch),
     });
   } catch (innerErr) {
     logger.error(`Error reporting batch ${action.toLowerCase()} failure: ${innerErr}`);
@@ -280,7 +280,7 @@ async function revertStrandBatchAccounting(params: {
       failedFiles: batch.failedFiles,
       processingFailedFiles: batch.processingFailedFiles,
       vectorizedFiles: batch.vectorizedFiles,
-      status: isBatchComplete(batch) ? (batch.failedFiles > 0 ? 'completed_with_errors' : 'completed') : undefined,
+      status: completedBatchStatus(batch),
     });
   } catch (err) {
     logger.error(`Error reverting the vectorize-enqueue failure accounting for ${fabFileId}: ${err}`);
@@ -768,11 +768,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
               action: 'data_lake_batch_progress',
               batchId: fabFile.batchId,
               vectorizedFiles: batch?.vectorizedFiles ?? 1,
-              status: isBatchComplete(batch)
-                ? batch!.failedFiles > 0
-                  ? 'completed_with_errors'
-                  : 'completed'
-                : undefined,
+              status: completedBatchStatus(batch),
             });
           }
         } catch (error) {

--- a/apps/client/server/queueHandlers/fabFileVectorize.test.ts
+++ b/apps/client/server/queueHandlers/fabFileVectorize.test.ts
@@ -105,7 +105,7 @@ vi.mock('@bike4mind/services', () => ({
 }));
 vi.mock('@server/queueHandlers/dataLakeBatchProgress', () => ({
   finalizeBatchIfComplete: vi.fn(),
-  isBatchComplete: vi.fn(),
+  completedBatchStatus: vi.fn(),
   deferFailureIfRetryable: (...a: unknown[]) => h.deferFailureIfRetryable(...a),
 }));
 vi.mock('@server/websocket/utils', () => ({ sendToClient: vi.fn(async () => undefined) }));

--- a/apps/client/server/queueHandlers/fabFileVectorize.ts
+++ b/apps/client/server/queueHandlers/fabFileVectorize.ts
@@ -37,7 +37,7 @@ import {
 import { getEmbeddingModelCost } from '@bike4mind/common';
 import {
   finalizeBatchIfComplete,
-  isBatchComplete,
+  completedBatchStatus,
   deferFailureIfRetryable,
 } from '@server/queueHandlers/dataLakeBatchProgress';
 import { FAB_FILE_VECTORIZE_MAX_RECEIVE_COUNT } from '@server/queueHandlers/sqsDelivery';
@@ -526,12 +526,11 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
             const batch = await dataLakeBatchRepository.incrementCounter(fabFile.batchId, 'vectorizedFiles');
             await finalizeBatchIfComplete(batch, logger);
 
-            const isComplete = isBatchComplete(batch);
             await sendToClient(userId, Resource.websocket.managementEndpoint, {
               action: 'data_lake_batch_progress',
               batchId: fabFile.batchId,
               vectorizedFiles: batch?.vectorizedFiles ?? 1,
-              status: isComplete ? (batch!.failedFiles > 0 ? 'completed_with_errors' : 'completed') : undefined,
+              status: completedBatchStatus(batch),
             });
           }
         } catch (error) {
@@ -614,13 +613,12 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         }
         await finalizeBatchIfComplete(batch, logger);
 
-        const isComplete = isBatchComplete(batch);
         await sendToClient(userId, Resource.websocket.managementEndpoint, {
           action: 'data_lake_batch_progress',
           batchId: existingFabFile.batchId,
           failedFiles: batch?.failedFiles ?? 1,
           processingFailedFiles: batch?.processingFailedFiles ?? 1,
-          status: isComplete ? (batch!.failedFiles > 0 ? 'completed_with_errors' : 'completed') : undefined,
+          status: completedBatchStatus(batch),
         });
       } catch (innerErr) {
         logger.error(`Error reporting batch failure: ${innerErr}`);

--- a/apps/client/server/s3/objectCreated.test.ts
+++ b/apps/client/server/s3/objectCreated.test.ts
@@ -14,7 +14,7 @@ const h = vi.hoisted(() => ({
   sendToQueue: vi.fn(),
   recomputeUploaded: vi.fn(),
   finalizeBatchIfComplete: vi.fn(),
-  isBatchComplete: vi.fn(),
+  completedBatchStatus: vi.fn(),
 }));
 
 // withContext just threads a logger; the handler body is the subject.
@@ -50,7 +50,7 @@ vi.mock('@server/dataLakes/recomputeStatsForUploadedFile', () => ({
 }));
 vi.mock('@server/queueHandlers/dataLakeBatchProgress', () => ({
   finalizeBatchIfComplete: h.finalizeBatchIfComplete,
-  isBatchComplete: h.isBatchComplete,
+  completedBatchStatus: h.completedBatchStatus,
 }));
 vi.mock('sst', () => ({
   Resource: { websocket: { managementEndpoint: 'wss://test' }, fabFileChunkQueue: { url: 'http://sqs/chunk' } },
@@ -111,7 +111,8 @@ describe('objectCreated - data lake stats (#1342)', () => {
     const file = metadata({ batchId: 'b1' });
     h.findOne.mockResolvedValue(file);
     h.incrementCounter.mockResolvedValue({ id: 'b1', skippedFiles: 1, failedFiles: 0 });
-    h.isBatchComplete.mockReturnValue(true);
+    // The batch crosses its threshold on this skip, so the payload reports a terminal status.
+    h.completedBatchStatus.mockReturnValue('completed');
 
     await run();
 

--- a/apps/client/server/s3/objectCreated.ts
+++ b/apps/client/server/s3/objectCreated.ts
@@ -15,7 +15,7 @@ import { RekognitionImageModerationService } from '@bike4mind/utils/imageModerat
 import { getFilesStorage } from '@server/utils/storage';
 import { moderateUploadedFile } from '@server/s3/moderateUploadedFile';
 import { recomputeStatsForUploadedFile } from '@server/dataLakes/recomputeStatsForUploadedFile';
-import { finalizeBatchIfComplete, isBatchComplete } from '@server/queueHandlers/dataLakeBatchProgress';
+import { completedBatchStatus, finalizeBatchIfComplete } from '@server/queueHandlers/dataLakeBatchProgress';
 import { sendToQueue } from '@server/utils/sqs';
 import { sendToClient } from '@server/websocket/utils';
 import { Resource } from 'sst';
@@ -250,11 +250,7 @@ export const func = withContext(async (event, context, logger) => {
             action: 'data_lake_batch_progress',
             batchId: metadata.batchId,
             skippedFiles: batch?.skippedFiles ?? 1,
-            status: isBatchComplete(batch)
-              ? batch!.failedFiles > 0
-                ? 'completed_with_errors'
-                : 'completed'
-              : undefined,
+            status: completedBatchStatus(batch),
           });
         }
       } catch (error) {

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -655,6 +655,19 @@ export interface IDataLakeBatch {
   processingFailedFiles: number;
   skippedFiles: number;
   /**
+   * Candidates a multi-run Drive chain PLANNED to ingest and then wrote off unfinished - the chain hit
+   * its slice ceiling, was throttled, lost its claim, or had its connection/lake deleted mid-flight.
+   * Deliberately NOT part of the `vectorized + failed + skipped >= totalFiles` finalize gate: a
+   * deferred candidate mints no manifest entry and no counter, so folding it into that sum would strand
+   * every stopped-short batch in `processing` until the reconciler force-failed it. It is the record
+   * that a `completed` batch is nonetheless SHORT - without it, settling re-plans totalFiles down to
+   * what the chain produced and a 3-of-500 run finalizes as a clean 3-of-3 (#2394).
+   *
+   * Optional because every batch written before this field existed genuinely lacks it; read it as
+   * `?? 0`. Not a `BatchCounterField` either - it is set once when a chain ends, not $inc'd per file.
+   */
+  deferredFiles?: number;
+  /**
    * Drive-ingest-only: driveFileIds skip() has already counted into `skippedFiles` for THIS batch.
    * A skip mints no FabFile, so it is invisible to the ordinary alreadyIngested subtraction
    * (findDriveFileIdsByBatchId) - without recording it here, a chain re-diffing the same
@@ -840,8 +853,17 @@ export interface IDataLakeBatchRepository extends IBaseRepository<IDataLakeBatch
    * the expected total is only known progressively - it is raised whenever a later slice re-walks a
    * folder that grew, and set exactly when the chain ends, which is what lets the finalize gate
    * (`vectorized + failed + skipped === totalFiles`) still be reached exactly.
+   *
+   * That end-of-chain set is a NARROWING, and `deferredFiles` is how it stays honest: pass the
+   * shortfall being written off so the same update records it, rather than leaving a short chain
+   * indistinguishable from one that ingested everything it planned (see the field's doc). Omit it on
+   * the mid-chain RAISE, which writes nothing off and must not claim otherwise.
    */
-  setTotalFilesIfActive(batchId: string, totalFiles: number): Promise<IDataLakeBatchDocument | null>;
+  setTotalFilesIfActive(
+    batchId: string,
+    totalFiles: number,
+    deferredFiles?: number
+  ): Promise<IDataLakeBatchDocument | null>;
   /**
    * Bump `updatedAt` on a still-non-terminal batch, without touching status or counters. Used
    * by the chunk/vectorize handlers on a non-final SQS delivery attempt, so a batch that is

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -1028,6 +1028,56 @@ describe('DataLakeBatchRepository.updateIfActive - guarded multi-field transitio
   });
 });
 
+describe('DataLakeBatchRepository.setTotalFilesIfActive - re-plan plus the write-off (#2394)', () => {
+  setupMongoTest();
+
+  const activeBatch = () =>
+    dataLakeBatchRepository.create({ dataLakeId: 'lake1', userId: 'u1', totalFiles: 500 } as never);
+
+  // The field has to exist in BOTH the entity type and the Mongoose schema or the $set is dropped on
+  // write with no error, leaving the narrowed total behind and nothing recording what it wrote off.
+  // Asserting on a re-read, not the returned doc, is the point: only the re-read proves it persisted.
+  it('persists the deferred count alongside the narrowed total', async () => {
+    const batch = await activeBatch();
+
+    const settled = await dataLakeBatchRepository.setTotalFilesIfActive(batch.id, 3, 497);
+    expect(settled?.totalFiles).toBe(3);
+
+    const fresh = await dataLakeBatchRepository.findById(batch.id);
+    expect(fresh?.totalFiles).toBe(3);
+    expect(fresh?.deferredFiles).toBe(497);
+  });
+
+  // The mid-chain RAISE omits the argument, and must not stamp a zero over a count a settle wrote (or,
+  // symmetrically, claim a write-off it did not make).
+  it('leaves the deferred count untouched when the caller omits it', async () => {
+    const batch = await activeBatch();
+    await dataLakeBatchRepository.setTotalFilesIfActive(batch.id, 3, 497);
+
+    await dataLakeBatchRepository.setTotalFilesIfActive(batch.id, 600);
+
+    const fresh = await dataLakeBatchRepository.findById(batch.id);
+    expect(fresh?.totalFiles).toBe(600);
+    expect(fresh?.deferredFiles).toBe(497);
+  });
+
+  it('defaults the deferred count to zero on a batch no chain ever wrote off', async () => {
+    const batch = await activeBatch();
+    expect((await dataLakeBatchRepository.findById(batch.id))?.deferredFiles).toBe(0);
+  });
+
+  it('is a no-op on a terminal batch, so a settled batch cannot be re-planned', async () => {
+    const batch = await activeBatch();
+    await dataLakeBatchRepository.markTerminalIfActive(batch.id, 'completed');
+
+    const settled = await dataLakeBatchRepository.setTotalFilesIfActive(batch.id, 3, 497);
+    expect(settled).toBeNull();
+    const fresh = await dataLakeBatchRepository.findById(batch.id);
+    expect(fresh?.totalFiles).toBe(500);
+    expect(fresh?.deferredFiles).toBe(0);
+  });
+});
+
 describe('DataLakeBatchRepository.claimFileStatus - from-set gating', () => {
   setupMongoTest();
 

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -902,6 +902,11 @@ const DataLakeBatchSchema = new mongoose.Schema(
     // accounting; upload-complete.ts's browser-reported failures never touch it.
     processingFailedFiles: { type: Number, default: 0 },
     skippedFiles: { type: Number, default: 0 },
+    // Drive-ingest-only: candidates a continuation chain planned and then wrote off unfinished, so a
+    // `completed` batch that is SHORT can be told apart from one that ingested all it planned. Kept out
+    // of the finalize gate's sum on purpose - see IDataLakeBatch.deferredFiles for why folding it in
+    // would strand every stopped-short batch in `processing`.
+    deferredFiles: { type: Number, default: 0 },
     // Drive-ingest-only: the driveFileIds skip() has already counted into skippedFiles, so a later
     // slice of the same chain can subtract them (see IDataLakeBatch.skippedDriveFileIds) instead of
     // re-fetching and re-skipping (and re-incrementing) the same permanently-unsupported file.
@@ -1285,9 +1290,20 @@ class DataLakeBatchRepository extends BaseRepository<IDataLakeBatchDocument> imp
    * may have grown, so `totalFiles` has to be raised before the chain can overrun it (finalizing the
    * batch mid-chain) and set exactly once the chain ends. Guarded like every other write here, so it
    * cannot re-plan a batch someone already settled.
+   *
+   * `deferredFiles` rides along on the end-of-chain call because that set is a NARROWING: recording the
+   * shortfall in the SAME update is what stops a short chain from finalizing as a clean success. Left
+   * untouched when omitted, so the mid-chain raise cannot zero a count a later settle will write.
    */
-  async setTotalFilesIfActive(batchId: string, totalFiles: number): Promise<IDataLakeBatchDocument | null> {
-    return this.guardedActiveUpdate(batchId, { totalFiles });
+  async setTotalFilesIfActive(
+    batchId: string,
+    totalFiles: number,
+    deferredFiles?: number
+  ): Promise<IDataLakeBatchDocument | null> {
+    return this.guardedActiveUpdate(batchId, {
+      totalFiles,
+      ...(deferredFiles !== undefined && { deferredFiles }),
+    });
   }
 
   async touchIfActive(batchId: string): Promise<void> {


### PR DESCRIPTION
# Pull Request

Closes #2394

## Description

A transient Google Drive rate limit silently removed documents from a lake and reported the batch as a success.

`fetchDriveFileContent` classified exactly one error (`exportSizeLimitExceeded`) and lumped everything else into `reason: 'error'`. The ingest loop treats `'error'` as a **permanent** per-file outcome: it calls `skip()`, which records the id via `recordSkippedDriveFile`. Because that record is idempotent per chain, the file was then subtracted from **every later slice's walk** (`driveLakeIngest.ts:506-512`) - gone from the lake for good - while the `skippedFiles` increment carried the batch over `finalizeBatchIfComplete`'s gate. Nothing distinguished "Drive told us to slow down" from "this file cannot be ingested."

The result is a lake that is quietly incomplete while every surface says the sync worked. For a grounded chat session that reads as the model not knowing something it should.

Two surfaces made the reporting half worse than the data-loss half. `releaseSyncClaim` always stamps the connection status back to `connected` and records *why* a run stopped short on `lastError` - but `LakeDriveStatusChip` discarded the message on the `connected` branch, and `DriveConnectAction` gated it on `status === 'credential_error'`. So the one recorded account of a short sync reached nobody, and the model's own comment calling `lastError` "the operator-visible half" was not true of that path.

## Changes

**Classification**
- `driveClient.ts` - new `isDriveRateLimitError(e: unknown)`. Reads the throttle structurally off the GaxiosError: a 429 at `code` / `status` / `response.status`, or an `errors[].reason` of `userRateLimitExceeded` / `rateLimitExceeded` / `quotaExceeded`, checked at both shapes googleapis surfaces them. Not message-matching - the message carries no stable marker. Lives here rather than in `driveContent.ts` because the remaining Drive call sites need the same predicate (see Additional Information).
- `driveContent.ts` - `FetchedContent` gains a fourth reason, `rate_limited`, documented as the one **retryable** arm. The `exportSizeLimitExceeded` check still runs first, so that classification is unchanged.

**Plumbing through the batch**
- `driveLakeIngest.ts` - a `rate_limited` result no longer calls `skip()`. It sets `deferred` and breaks, routing the file into the existing continuation-slice path, so the file keeps its candidacy and the batch cannot finalize without it. Yielding the whole remainder rather than just that one file is deliberate: the next candidates hit the same exhausted quota, and shedding load is the point.
- A throttled continuation is enqueued with a delay - 60s plus up to 30s jitter, because several connections poll on the same tick against a single Drive project quota, so a fixed delay would just re-collide them. The deadline yield keeps SQS's immediate delivery.
- At the slice ceiling the recorded `lastError` now names the quota. The existing text advised splitting the folder into subfolders, which is both wrong and unactionable for a rate limit.

**Batch honesty - a stopped-short chain no longer settles as a clean success**
- `settleChainedBatch` re-plans `totalFiles` down to what the chain actually produced, which is what makes the finalize gate reachable at all - but on its own it rewrites a chain that ingested 3 of 500 files into a clean 3-of-3, and a chain throttled before its first file into an empty folder. It now records the shortfall it just wrote off as a new `deferredFiles` on the same update, derived as `plan - produced`. Deriving it beats threading a count through the eight exits that settle a batch: several of them (a connection or lake deleted mid-chain) genuinely cannot know a count, and the document already holds both numbers.
- `deferredFiles` is deliberately **absent** from the `vectorized + failed + skipped >= totalFiles` completion threshold. A deferred candidate mints no manifest entry and no counter, so no later event could ever satisfy a gate that counted it - the batch would sit in `processing` until the stuck-batch reconciler force-failed it, which is worse than the reporting gap. The threshold decides *whether* a batch is done; the outcome decides *whether it went well*.
- That outcome now comes from one `resolveBatchOutcome()`: a batch carrying any `deferredFiles` settles `completed_with_errors`, not `completed`. That reuses the status vocabulary the pipeline already has, so no consumer needs a new state.
- The same decision was open-coded inline at **six** `data_lake_batch_progress` websocket payloads (`objectCreated`, `fabFileChunk` x3, `fabFileVectorize` x2), each sitting right after the one real DB write in `finalizeBatchIfComplete`. Fixing only the write would have left the database saying `completed_with_errors` while the client was told `completed`; for a Drive batch that is the *likely* order, since vectorize usually crosses the threshold after the slice has already returned. All seven sites now go through one decision - the payloads via a `completedBatchStatus(batch)` helper, which also drops five `batch!` non-null assertions.

**Making the incompleteness visible**
- New `app/hooks/data/driveConnectionDisplay.ts` - a pure module holding `DRIVE_STATUS_BADGE` plus `describeDriveConnection()`, returning `{ label, title, color }`. A `connected` connection carrying a `lastError` now reads **"Stopped short"** in `warning`, not green **"Connected"**.
- `LakeDriveStatusChip.tsx` and `DriveConnectAction.tsx` both read from it, so the two surfaces cannot drift. The `lastError` line in `DriveConnectAction` renders for any status carrying one, not just `credential_error`.
- The module deliberately has no hook or API imports. Three existing suites hand-copied `DRIVE_STATUS_BADGE` into their `vi.mock` factories; because nothing mocks the new module, they keep working, and their duplicated tables are deleted.

**A latent crash found while consolidating the above, and fixed**
- `DRIVE_STATUS_BADGE` was keyed by a hand-listed union of three statuses, but the stored enum (`GoogleDriveConnectionStatus`) has **four** - it includes `syncing` - and `toSafeConnection` returns `c.status` verbatim with no contract validation. So for the entire duration of a sync, the badge lookup was `undefined` and both Drive surfaces threw `TypeError: Cannot read properties of undefined (reading 'label')`. This pre-dates this PR (`main` has the identical unguarded lookup) but the consolidation is what surfaced it, and this module is now the single place to fix it.
- The union is now **derived** from `GoogleDriveConnectionStatus` rather than re-listed, so a status added to the enum is a compile error here instead of a render-time crash. `syncing` gets its own label, and reports the run in flight rather than dressing the previous run's `lastError` as a stopped-short sync. A fallback badge covers an unvalidated status slipping past the type entirely.

**Tests**
- `driveContent.test.ts` - a 429 native download and a 403-carrying-`rateLimitExceeded` export both classify as `rate_limited`; a 404 still classifies as `error`. Plus a table for `isDriveRateLimitError` covering both positive shapes and the negatives that share a status but not a reason (`insufficientFilePermissions`, `exportSizeLimitExceeded`), a non-numeric `code`, and non-object rejections.
- `driveLakeIngest.test.ts` - a 429 on one file records **no** skip, does not finalize the batch, does not release the claim, and enqueues a delayed continuation; a throttled chain hitting the slice ceiling records a reason naming the rate limit and not the folder-split advice.
- `driveConnectionDisplay.test.ts` + `DriveConnectAction.test.tsx` - `connected` + `lastError` is not reported as healthy on either surface; `syncing` is described rather than thrown on; an unrecognised status does not throw.
- `driveLakeIngest.test.ts` also pins the write-off on every settle path, including the degenerate chain that ingested nothing (`setTotalFilesIfActive('batch1', 0, 2)` - the total narrowed to 0 *and* the 2 written-off files recorded on the same update), and the four pre-existing settle assertions now assert the shortfall alongside the re-planned total.
- `dataLakeBatchProgress.test.ts` - a chain that wrote files off settles `completed_with_errors` (both the 3-of-500 and the ingested-nothing shapes); `deferredFiles` does **not** hold a batch open past its threshold; `completedBatchStatus` reports nothing while a batch is short, so the client cannot be told `completed` about a batch settled otherwise.
- `DataLakeModel.test.ts` - the counter actually persists. Asserted on a **re-read**, not the returned document: a field present in the entity type but missing from the Mongoose schema is dropped on write with no error, and only a re-read catches that. Plus: the mid-chain raise (which omits the argument) leaves an existing count alone, the field defaults to 0, and the write is still a no-op on a terminal batch.

## Verified live

### The rendered surface (local self-host)

Run on a local self-host stack (`next dev` against the Docker Mongo/SQS/MinIO/Mailpit infra), logged in as an org owner, cycling a real Drive connection document through three states and reading the rendered result each time:

| Connection state | Rendered | Verdict |
| --- | --- | --- |
| `credential_error` + message | "Credential error", `colorDanger`, message shown | unchanged (regression) |
| `connected` + `lastError` | **"Stopped short"**, `colorWarning`, message shown; chip tooltip `...: last sync stopped short - ...` | the fix, verified |
| `connected`, `lastError: null` | "Connected", `colorSuccess`, error element absent from the DOM | unchanged (regression) |

The `syncing` crash was confirmed the same way before fixing it - a probe against `describeDriveConnection` threw `TypeError: Cannot read properties of undefined (reading 'label')`.

### The batch record (preview pr2479)

The unit tests MOCK `completedBatchStatus`, so nothing in the suite exercises the seven refactored call sites for real. Three ordinary browser uploads through the wizard on the preview, which do:

| Run | Config | totalFiles | vectorized | failed | skipped | `deferredFiles` | `status` | Finalize latency |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | default | 4 | 0 | 4 | 0 | **0** | `completed_with_errors` | 12m23s (SQS redelivery) |
| 2 | default | 3 | 0 | 3 | 0 | **0** | `completed_with_errors` | 12m23s (SQS redelivery) |
| 3 | `enableAutoChunk` off | 3 | 0 | 0 | 3 | **0** | **`completed`** | **10.8s (inline)** |

- `resolveBatchOutcome` is exercised on **both** branches, and the persisted status agreed with the wizard's view in every run.
- **`deferredFiles` persists and reads back** on every batch, `0` throughout - correct, since it is only ever set when a multi-run Drive chain ends short.
- **It is correctly excluded from the finalize threshold.** Run 3 settled inline in 10.8s (`startedAt` 13:26:11.821Z -> `completedAt` 13:26:22.610Z) through the skip path's own `finalizeBatchIfComplete`, and never appeared in the active-batch list at all despite polling every 2s from ~1s after Start Upload. That is what the field's doc promises: a batch is not held open waiting on a counter no later event can satisfy. Against 12m23s on the redelivery path, the difference is not marginal.
- **The `objectCreated` skip payload site** was reached in run 3 (`skippedFiles: 3`, `chunkCount: 0` on all three files, no chunk/skip mix). It is unreachable on the default config, so run 3 is the only cover for it.
- Progress bars advanced through uploaded and chunked to a terminal card in ~17s in runs 1-2, with zero new console errors during the upload runs.

**Not verified live:**

- **The 429 itself.** Inducing one needs a real Drive project quota exhausted mid-ingest, which cannot be arranged on demand. The classification boundary and the defer-instead-of-skip behaviour rest on the unit tests, each of which was confirmed to fail on `origin/main`.
- **A batch carrying `deferredFiles > 0`.** Reaching it needs a real Drive continuation chain to end short, and there is no API path to force the state (the batch PUT accepts only `status`/`failedFiles`/`failedFileNames`/`completedAt`). Covered by `dataLakeBatchProgress.test.ts` and a mongodb-memory-server persistence test in `DataLakeModel.test.ts`, not by a live run.
- **The clean `completed` branch on the normal chunk+vectorize path.** pr2479 has no embedding credential - its ChatCompletion task definition carries `SST_RESOURCE_OPENAI_API_KEY` set to the literal `"not-configured"`, so the vectorize queue leased its messages and never acked them, with an empty DLQ and nothing logged. Run 3 reaches `'completed'` by the skip path instead, which is the same `resolveBatchOutcome` branch and the same persisted write.
- **Raw `data_lake_batch_progress` frames.** The live counter advance is indirect evidence the frames carry the right `status`; a websocket interceptor was attached too late to quote the field directly.

Two pre-existing defects turned up during verification, neither from this PR and both filed/flagged separately: a personal lake's Add-files view (#2507) fires a guaranteed-404 `drive-connection` request (`SourceSelectionStep.tsx:312` renders `DriveConnectAction` ungated, where the sibling `SelectedLakeHeader.tsx:93` gates it), and with `enableAutoChunk` off the wizard's terminal card claims "chunking and vectorizing in progress" on a batch that is already `completed`.

## Guide for Testers

The 429 cannot be induced on demand, so this guide verifies what **is** reachable: the reporting that used to hide a short sync, and the classification boundary. See "What NOT to test".

### Prerequisites (read this first - some of it is not a repo change)

**AdminSettings**
- `EnableDataLakes` must be **on**. It gates every data-lake API route, including the Drive connect/status/disconnect ones.
- `EnableDataLakeDrivePoll` (child of the above, **off by default**) is only needed to test the *scheduled* poll. The manual connect/re-sync path does not need it.
- Gotcha: the ingest queue handler itself has **no** flag check. Once a message is enqueued it runs regardless, so turning the flag off mid-test will not stop an in-flight chain.

**Google OAuth - the most likely blocker**
- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are **per-stage** SST secrets that default to `not-configured`; they do **not** inherit into a new stage. Confirm with `sst secret list --stage <stage>`, or check the admin **System Health** page, which reports both as missing when unset.
- The redirect URI is `${APP_URL}/google-drive/callback`, so it differs per stage and **must be registered as an authorized redirect URI on the Google Cloud OAuth client**. That is a Google Cloud Console change, not something this repo can do - it is the prerequisite most likely to be missed when standing up a fresh stage.
- **No separate Google API / developer key is needed** - the picker is called with `developerKey: ''` and authenticates on the OAuth access token alone.
- Symptom when any of the above is missing: the Connect button toasts *"Google Drive is unavailable right now. Please try again."* rather than erroring visibly, because `serverConfig` sanitizes an unset client id to `''`.
- The requested scope is `drive.readonly` **only**, so testing cannot modify or delete anything in the source Drive folder.
- Each tester links **their own** Google account (this is user OAuth, not a service account), and Google's consent screen is forced every time so a refresh token is always issued.

**Account and lake shape**
- The lake must be **org-scoped**. A personal lake is rejected server-side, not merely hidden - `POST /api/data-lakes/drive-sync` returns 400 and the status route returns 404.
- The tester must be a **platform admin, or the org's owner or manager**. Anyone else gets a **404, not a 403** - deliberately indistinguishable from "no such org" - so a permission problem will look like a missing lake. Worth knowing before filing that as a bug.
- A Google Drive folder with a handful of supported files (PDF/DOCX/TXT, or Google Docs/Sheets/Slides).

**Database access**
- Parts A and C need **direct Mongo write access** to `orggoogledriveconnections` and `datalakebatches`. No API route or admin screen can set a connection's `lastError` or a batch's counters, and no seed script exists for either. This is unavoidable for this fix: the states being verified are ones a *transient Drive throttle* leaves behind, and that cannot be induced on demand.

**Where to test**
- **Staging** can exercise everything, including the scheduled poll.
- A **PR preview stage cannot test the scheduled poll at all** - the poll cron is deployed only on `production`/`dev` stages (`infra/cron.ts:781`), so on a preview it does not exist regardless of the flag. The manual re-sync path and the ingest queue are available on every stage.
- Both trigger paths are the **same endpoint**: `POST /api/data-lakes/drive-sync` handles the initial connect and a re-sync of an existing folder. There is no separate re-sync route.

### Part A - a short sync is no longer reported as healthy

Needs an org-scoped data lake with a Google Drive folder connected. Two surfaces render this, and they are different components - check both:
- **the chip + error line** (`DriveConnectAction`) - in the chat's **Data Lakes** grounding panel, and in the lake wizard's source step
- **the status chip + tooltip only** (`LakeDriveStatusChip`) - in the Data Lake Manager modal, via **Files -> Upload Files -> Data Lakes**

1. Log in as an **org owner or manager** (the drive-connection endpoint is owner/manager gated).
2. Open the chat's **Data Lakes** panel and select an org lake that has a Google Drive folder connected. Expected: the folder row shows a green **Connected** chip and no error text beneath it.
3. Now put the connection into the state a stopped-short sync leaves behind - `connected`, with `lastError` set - which is exactly what `releaseSyncClaim` does. In Mongo:
   ```js
   db.orggoogledriveconnections.updateOne(
     { driveFolderId: '<the folder id shown in the UI>' },
     { $set: { status: 'connected', lastError: 'Google Drive is rate-limiting this sync, and it stopped after 20 continuation runs with 12 files still to ingest.' } }
   )
   ```
4. Reload and reopen the panel from step 2. Expected: the chip reads **Stopped short** in amber/warning, **not** green "Connected", and the message from step 3 is rendered beneath it in the same warning colour.
5. Open the Data Lake Manager (**Files -> Upload Files -> Data Lakes**) and hover that lake's Drive status chip. Expected tooltip: `Google Drive folder "<name>": last sync stopped short - <the message>`.
6. Set `status: 'syncing'` on the same document and reload. Expected: a **Syncing** chip, and **no crash** - before this PR both surfaces threw and the panel failed to render.
7. Restore: `$set: { status: 'connected', lastError: null }`. Expected: back to a green **Connected** chip with no error line.

### Part B - the classification boundary

8. No UI for this; it is asserted directly.
   ```
   pnpm --filter @bike4mind/client test --project node server/integrations/google/drive/driveContent.test.ts
   ```
   Expected: all pass, including `reports rate_limited (not error) when Drive throttles a native download` and `reports rate_limited for a 403 whose reason is a quota, not a permission denial`.
9. ```
   pnpm --filter @bike4mind/client test --project node server/queueHandlers/driveLakeIngest.test.ts
   ```
   Expected: all pass, including `defers the rest of the slice on a Drive rate limit instead of silently short-changing the batch`.

### Part C - a stopped-short batch reads as stopped short

This is the batch *record*, so it is checked in Mongo rather than in the UI - no surface renders a Drive sync batch's counters today (the wizard's progress UI is the browser-upload flow, and `skippedFiles` is already invisible there; the human-facing account of a short sync is the connection chip from Part A).

9a. Take an org lake with a Drive connection and a batch document from a completed Drive sync. Confirm a **normal** completed sync has `deferredFiles: 0` and `status: 'completed'`.
9b. Simulate a stopped-short chain directly on the batch: `db.datalakebatches.updateOne({_id: <id>}, {$set: {status: 'processing', totalFiles: 5, vectorizedFiles: 2, deferredFiles: 3}})`, then let any pipeline event finalize it (or call the finalize path). Expected: it settles **`completed_with_errors`**, not `completed`, and `deferredFiles` survives as 3. That is the whole point - the record says "finished, but short".
9c. Confirm it does **not** hang. A batch with `deferredFiles > 0` must still reach a terminal state; if it sits in `processing` waiting for the deferred files to be counted, the deferred count has leaked into the completion threshold and that is a bug.

### Regression Checks

10. **A normal Drive sync still completes.** Connect an org lake to a small Drive folder (3-5 supported files) and trigger a sync with **Re-sync**. Expected: files appear in the lake, the batch reaches a terminal state, and the chip stays green **Connected** with no error line.
11. **A genuinely unsupported file still skips permanently.** Put a `.exe` or a Google Form in the folder and re-sync. Expected: it is skipped and counted (it does not block or defer the batch), the other files ingest, and the sync completes green. This is the path that must NOT have been turned into a deferral.
12. **An oversized Editors export still skips.** A Google Doc over Drive's ~10MB export cap must still classify `export_too_large`, not `rate_limited` - the `exportSizeLimitExceeded` check runs first by design.
13. **A credential error still reads as danger.** Set `status: 'credential_error', lastError: 'invalid_grant'`. Expected: red/danger **Credential error** chip with `invalid_grant` beneath it - unchanged from before this PR.
14. **A browser-upload batch is unaffected.** Upload files to a lake through the Data Lake wizard as normal. Expected: the progress indicator advances and the batch settles exactly as before - `completed` when everything vectorized, `completed_with_errors` when a file failed. Seven call sites that decide that status were refactored onto one decision, so this is the path that would show a regression.
15. **A large folder still slices.** A folder big enough to need more than one invocation must still chain and converge. The continuation for a *deadline* yield must be enqueued with **no** delay (only a throttled one is delayed).

### What NOT to test

- **Do not try to induce a real Drive 429.** It requires exhausting a Drive project quota mid-ingest and cannot be triggered on demand; that path is covered by the unit tests in Part B, which drive the classified result directly.
- **Do not test rate-limit retry at `listFolderChildren` or `getFolderAccess`.** Those call sites are untouched here - see Additional Information.
- No AdminSettings, feature flag, infra, or schema changes in this PR; nothing to hydrate or migrate.

## Additional Information

**This is half of the rate-limit story, by design.** #2395 covers the missing per-call retry with backoff at every Drive call site, and it is still open and unshipped: `listFolderChildren` has no try/catch at all (a 429 throws to SQS retry and then DLQ), and `getFolderAccess` wraps everything in a blanket catch that returns `exists: false`, so a throttle there is still indistinguishable from "the user lost access to the folder". This PR deliberately does not touch either - it fixes the one path that **loses data** rather than merely failing. `isDriveRateLimitError` is exported and placed in `driveClient.ts` so #2395 can reuse it at those sites rather than growing a second detector.

**Acceptance criterion (c) is now fully met, having started out half-met.** The first pass left `skippedFiles` as purely permanent skips but recorded nothing about deferred work, so a chain that hit `MAX_INGEST_SLICES` still finalized as a clean `completed` with `totalFiles` rewritten down to what it produced - `totalFiles: 0` in the degenerate case. That was the **pre-existing** chain-ceiling contract rather than a regression (`main`'s deadline-yield path reaches the identical outcome), and it was going to be filed separately. It is fixed here instead: see "Batch honesty" above. The fix also covers the deadline-yield path, so a folder that merely ran out of invocations is now reported honestly too - a strictly wider fix than #2394 asked for, on the same seam.

**Where a throttle can still cost you a slice.** A sustained rate limit will burn continuation slices (one per throttled attempt, up to `MAX_INGEST_SLICES`) before the chain gives up with the new operator-visible reason. That is bounded and self-announcing, and it matches the existing deadline-ceiling contract rather than inventing a second one - but it is not the same thing as real per-call backoff, which is #2395.

**A note on `quotaExceeded`.** Drive uses that reason for both a daily-limit throttle and a storage-quota failure. We only ever read and export here (never upload to Drive), so on this path it is always the throttle form, and retrying is correct.

**One inaccuracy in the issue text**, for the record: its fenced snippet shows `reason: 'tooLarge'`, but the real union member is `export_too_large`. The snippet is explicitly elided and the issue's "Where" section is accurate, so this is a transcription artifact, not spec drift.

## Developer Notes

- **`isDriveRateLimitError` is a reusable seam.** Any Drive call site can now ask "is this retryable?" without re-deriving the GaxiosError shape. #2395 is its intended second consumer.
- **`FetchedContent` now distinguishes transient from permanent.** Future per-file outcomes should extend that axis rather than adding another opaque `reason` string, since the caller's skip-vs-defer decision keys on it.
- **`describeDriveConnection` is the single place Drive connection wording and severity are decided.** `DRIVE_STATUS_BADGE` is no longer read directly by any component. Adding a status, or another "healthy status but something went wrong" state, is a one-file change that both surfaces pick up - and being pure, it is assertable without rendering a Joy `Tooltip`.
- **Derive a display union from the stored enum, don't re-list it.** The `syncing` crash existed because a client-side union drifted from `GoogleDriveConnectionStatus` while the endpoint passed the raw value through. `export type DriveConnectionStatus = GoogleDriveConnectionStatus` turns that class of drift into a compile error. Worth copying wherever a UI keys a lookup table off a stored enum, and a reminder that an unvalidated DTO boundary is where these land.
- **A narrowing write must record what it narrowed away.** `settleChainedBatch` dropping `totalFiles` to `produced` is legitimate and necessary, but it destroys the only evidence of the difference. The general shape: when you rewrite a planned total down to an actual, the shortfall is information, and the honest place to put it is the same atomic update - not a log line, and not a connection field the next run overwrites.
- **A duplicated decision is a divergence waiting to happen.** The terminal-outcome expression existed in seven places; six were websocket payloads whose whole job is telling the client what the seventh just persisted. Nothing typechecked the agreement. If you find yourself adding a term to one copy of a rule, that is the signal to collapse the copies first - the divergence here would have shown up as a client saying `completed` about a batch the database called `completed_with_errors`, which is exactly the class of bug this issue is about.
- **A full-module `vi.mock` factory silently omits new exports, and nothing typechecks it.** Collapsing the six payload sites onto `completedBatchStatus` broke three suites that mock `dataLakeBatchProgress` wholesale and listed only the exports the code used *before*. The mocked module returned `undefined` for the new name, so the call threw and the payload was never sent - one suite failed on a missing field, another on `sendToClient` never being called at all, and a third passed while latently broken because its assertions happened to miss the path. Worth knowing when adding an export that existing code starts calling: grep the mock factories, not just the call sites. The three factories now stub `completedBatchStatus` and drop `isBatchComplete`, which no production file imports any more (it is internal to the helper plus its own test).
- **The threshold and the verdict are different questions.** `deferredFiles` belongs in "did it go well" and must stay out of "is it done". Conflating them would have traded a reporting gap for batches stranded in `processing` - a strictly worse failure, and a tempting one, because folding the new counter into the existing sum looks like the consistent move.
- **The pattern for making a hook-module constant testable:** the wording moved into a module with no react-query/API imports, so component suites that mock the hook module do not have to stub it, and drift between mock and real wording becomes impossible.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no settings added
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - **not done, flagging deliberately.** `docs-site/docs/features/data-lakes.md` exists and has an FAQ, but it does not mention Google Drive or syncing at all, so the whole Drive-as-lake surface is undocumented rather than this change being undocumented. A "my Drive sync says it stopped short / files are missing from my lake" FAQ entry is the natural home for the user-visible half of this fix; I left it out rather than document a feature inside a bug fix, but happy to add it here if preferred.
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a

