### PR TITLE
fix(data-lakes): scope rebuild passages to a registry lake's prefix arm

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/rechunk.ts
+++ b/apps/client/pages/api/data-lakes/[id]/rechunk.ts
@@ -120,6 +120,11 @@ const handler = baseApi()
       // allSettled, not all: one failed send must not fail the whole wave. A file whose send didn't
       // land is left in the reset state (chunked:false, chunkCount:0), which is exactly what the
       // rescue sweep selects on, so it self-heals on the next pass rather than needing an undo.
+      // The cost of routing recovery that way, since the reset above covers the whole wave before
+      // any send: such a file stays unsearchable until REBUILD_PENDING_STALE_MS (2h) has elapsed
+      // AND the next daily 05:00 UTC reconcile runs. On a registry lake its owner may never have
+      // joined the lake, so nobody is watching for it. Resetting each file immediately before its
+      // own send would close the window.
       //
       // NO `chunkSize` on purpose, unlike /converge which sends `policy.requiredTarget`. This door
       // restores RETRIEVABILITY and is deliberately policy-independent: it has to work on a lake with

--- a/b4m-core/services/src/dataLakeService/computeLakeHealth.ts
+++ b/b4m-core/services/src/dataLakeService/computeLakeHealth.ts
@@ -16,8 +16,7 @@ import {
   type LakeMembershipReport,
 } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
-import { lakeMembershipScope, registryMembershipScope } from './lakeMembershipScope';
-import { isFallbackLake } from './assertLakeAccess';
+import { resolveLakeMembershipScope } from './lakeMembershipScope';
 import { resolveScopedSetting, scopeForLake } from '../settings/resolveScopedSetting';
 
 /**
@@ -113,9 +112,8 @@ export async function computeLakeHealth(
   // ONE scope for both reads and for the disclosure. A registry lake has no backing document, so its
   // `createdByUserId` is `''` (assertLakeAccess) and an `owned` scope would fail closed to
   // meta-tag-only - silently dropping the very arm those lakes are mostly made of, while the
-  // disclosure still named a prefix. Branch here exactly as the sibling read paths do (see
-  // GET /api/data-lakes/:id/articles), and never re-derive the disclosure from the lake document.
-  const scope = isFallbackLake(lake) ? registryMembershipScope(lake) : lakeMembershipScope(lake);
+  // disclosure still named a prefix. Never re-derive the disclosure from the lake document.
+  const scope = resolveLakeMembershipScope(lake);
 
   // Defense in depth: `datalakeTag` is `required: true` on the lake, but an absent one would serialize
   // to `null` in the membership `$match` and degrade the query to "files with no tags" across every

--- a/b4m-core/services/src/dataLakeService/convergeLakePolicy.test.ts
+++ b/b4m-core/services/src/dataLakeService/convergeLakePolicy.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DATA_LAKES, effectiveTagPrefixArm } from '@bike4mind/common';
+import { lakeMembershipScope, registryMembershipScope } from './lakeMembershipScope';
 import {
   DEFAULT_CONVERGENCE_WAVE,
   planLakeConvergenceRun,
@@ -242,6 +244,62 @@ describe('planLakeConvergenceRun', () => {
     expect(wave).toHaveLength(20);
     expect(adapters.db.dataLakes.findByDatalakeTag).toHaveBeenCalledTimes(1);
     expect(adapters.db.dataLakes.find).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The owner-less synthetic document `assertLakeAccess` hands back for a hardcoded DATA_LAKES
+   * lake. A real registry id, so `isFallbackLake` decides by its own config-id rule rather than a
+   * flag; `requiredPassageTokenTarget` is inherited from the base fixture, which is what an overlay
+   * entry carrying one looks like by the time it reaches this function.
+   */
+  const registryConfig = DATA_LAKES.find(dl => dl.id === 'opti-knowledge')!;
+  const registryLake: ConvergenceLake = {
+    ...lake,
+    id: registryConfig.id,
+    datalakeTag: registryConfig.datalakeTag,
+    fileTagPrefix: registryConfig.fileTagPrefix,
+    createdByUserId: '',
+  };
+
+  // The invariant the `policyInherited` gate carries for registry lakes, which no test pinned: with
+  // no declared target they turn back here, so the creator-less scope below is never even built.
+  it('refuses a registry lake on the inherited default without reading a member', async () => {
+    const adapters = makeAdapters([member('a', 2100)]);
+
+    const { report, wave } = await planLakeConvergenceRun(
+      { ...registryLake, requiredPassageTokenTarget: undefined },
+      adapters
+    );
+
+    expect(report.refusal).toBe('policyInherited');
+    expect(wave).toEqual([]);
+    expect(adapters.db.fabFiles.findLakeConvergenceMembers).not.toHaveBeenCalled();
+  });
+
+  // ...and what happens when it does NOT turn back. `PREMIUM_DATA_LAKES` is an unvalidated
+  // `as DataLakeConfig[]` cast that `resolveFallbackLake` spreads verbatim, so an overlay lake
+  // declaring a target reaches the member read - where an `owned` scope would fail closed to
+  // meta-tag-only and silently skip the prefix-tagged members the lake is mostly made of.
+  it('scopes an explicit-policy registry lake through the registry arm, keeping the prefix arm live', async () => {
+    const adapters = makeAdapters([]);
+
+    await planLakeConvergenceRun(registryLake, adapters);
+
+    const [scope] = adapters.db.fabFiles.findLakeConvergenceMembers.mock.calls[0];
+    expect(scope).toEqual(registryMembershipScope(registryLake));
+    expect(effectiveTagPrefixArm(scope)).toBe(registryConfig.fileTagPrefix);
+    expect(effectiveTagPrefixArm(lakeMembershipScope(registryLake))).toBeNull();
+  });
+
+  it('keeps a persisted lake on the creator-anchored scope, so the two kinds are not collapsed', async () => {
+    const adapters = makeAdapters([]);
+
+    await planLakeConvergenceRun(lake, adapters);
+
+    expect(adapters.db.fabFiles.findLakeConvergenceMembers).toHaveBeenCalledWith(
+      lakeMembershipScope(lake),
+      expect.any(Number)
+    );
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/convergeLakePolicy.ts
+++ b/b4m-core/services/src/dataLakeService/convergeLakePolicy.ts
@@ -369,6 +369,12 @@ export async function planLakeConvergenceRun(
     return { report: emptyReport(null), wave: [] };
   }
 
+  // `lakeMembershipScope`, not `resolveLakeMembershipScope`: the `policyInherited` gate above is what
+  // keeps that safe. A registry lake's synthetic document carries no `requiredPassageTokenTarget`
+  // (DataLakeConfig has no such field), so it returns there and never reaches this line - which is
+  // the only reason an `owned` scope over a creator-less lake cannot silently drop the prefix arm
+  // here the way it did on the rebuild door. Move that gate below this read and this needs the
+  // resolving builder.
   const rows = await db.fabFiles.findLakeConvergenceMembers(lakeMembershipScope(lake), MEMBER_SCAN_LIMIT);
   const scanTruncated = rows.length > MEMBER_SCAN_LIMIT;
   const members = scanTruncated ? rows.slice(0, MEMBER_SCAN_LIMIT) : rows;

--- a/b4m-core/services/src/dataLakeService/convergeLakePolicy.ts
+++ b/b4m-core/services/src/dataLakeService/convergeLakePolicy.ts
@@ -17,7 +17,7 @@ import {
 import { effectiveChunkTokenLimit } from '@bike4mind/fab-pipeline';
 import { Logger } from '@bike4mind/observability';
 import { buildLakeRequirements, findMemberLakesForFile } from './chunkPolicyConflict';
-import { lakeMembershipScope } from './lakeMembershipScope';
+import { resolveLakeMembershipScope } from './lakeMembershipScope';
 import { resolveScopedSetting, scopeForLake } from '../settings/resolveScopedSetting';
 
 /**
@@ -369,13 +369,13 @@ export async function planLakeConvergenceRun(
     return { report: emptyReport(null), wave: [] };
   }
 
-  // `lakeMembershipScope`, not `resolveLakeMembershipScope`: the `policyInherited` gate above is what
-  // keeps that safe. A registry lake's synthetic document carries no `requiredPassageTokenTarget`
-  // (DataLakeConfig has no such field), so it returns there and never reaches this line - which is
-  // the only reason an `owned` scope over a creator-less lake cannot silently drop the prefix arm
-  // here the way it did on the rebuild door. Move that gate below this read and this needs the
-  // resolving builder.
-  const rows = await db.fabFiles.findLakeConvergenceMembers(lakeMembershipScope(lake), MEMBER_SCAN_LIMIT);
+  // Resolving builder, not `lakeMembershipScope`: a registry lake can reach this line. The
+  // `policyInherited` gate above only turns it back when the lake declares no target, and
+  // `PREMIUM_DATA_LAKES` is an unvalidated `as DataLakeConfig[]` cast that `resolveFallbackLake`
+  // spreads verbatim, so an overlay entry carrying `requiredPassageTokenTarget` arrives here as a
+  // creator-less `owned` scope - which fails closed to meta-tag-only and drops the prefix arm the
+  // lake is mostly made of, the same defect this door's sibling had.
+  const rows = await db.fabFiles.findLakeConvergenceMembers(resolveLakeMembershipScope(lake), MEMBER_SCAN_LIMIT);
   const scanTruncated = rows.length > MEMBER_SCAN_LIMIT;
   const members = scanTruncated ? rows.slice(0, MEMBER_SCAN_LIMIT) : rows;
   if (scanTruncated) {

--- a/b4m-core/services/src/dataLakeService/lakeMembershipScope.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembershipScope.ts
@@ -1,4 +1,5 @@
 import type { DataLakeConfig, DataLakeMembershipScope, IDataLakeDocument } from '@bike4mind/common';
+import { isFallbackLake } from './assertLakeAccess';
 
 /** The lake fields the membership scope is derived from - always the persisted document. */
 type ScopeSourceLake = Pick<IDataLakeDocument, 'datalakeTag' | 'fileTagPrefix' | 'createdByUserId'>;
@@ -32,3 +33,22 @@ export const registryMembershipScope = (
   datalakeTag: config.datalakeTag,
   fileTagPrefix: config.fileTagPrefix,
 });
+
+/**
+ * The scope for a lake as the ACCESS GATE handed it back, whichever kind that turned out to be.
+ * Use this on any path `assertLakeAccess` / `assertLakeRebuildAccess` can reach, because those
+ * resolve a DATA_LAKES lake to a synthetic document with `createdByUserId: ''` - and an `owned`
+ * scope over a creator-less lake fails closed to meta-tag-only (`effectiveTagPrefixArm`), silently
+ * dropping the prefix arm a registry lake is mostly made of.
+ *
+ * Every path behind `assertLakeWritable` refuses a fallback lake outright, so those can keep
+ * calling `lakeMembershipScope` directly; this exists so a path that CAN see a registry lake never
+ * open-codes the branch again and gets it wrong on the third try.
+ *
+ * Two copies remain open-coded on purpose, in `GET /api/data-lakes/:id` and
+ * `GET /api/data-lakes/:id/articles`: their tests assert the branch shape at the route, so folding
+ * them in is a test-touching change of its own. Keep them in step with this.
+ */
+export const resolveLakeMembershipScope = (
+  lake: ScopeSourceLake & Pick<IDataLakeDocument, 'id'>
+): DataLakeMembershipScope => (isFallbackLake(lake) ? registryMembershipScope(lake) : lakeMembershipScope(lake));

--- a/b4m-core/services/src/dataLakeService/rebuildLakePassages.test.ts
+++ b/b4m-core/services/src/dataLakeService/rebuildLakePassages.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
-import { OVERSIZED_PASSAGE_TOKEN_THRESHOLD } from '@bike4mind/common';
+import { DATA_LAKES, OVERSIZED_PASSAGE_TOKEN_THRESHOLD, effectiveTagPrefixArm } from '@bike4mind/common';
 import { detectUnderChunkedFiles, countFailedLakeFiles } from './rebuildLakePassages';
+import { lakeMembershipScope, registryMembershipScope } from './lakeMembershipScope';
 
-const lake = { datalakeTag: 'datalake:acme', fileTagPrefix: 'acme:', createdByUserId: 'owner-1' };
+const lake = {
+  id: '507f1f77bcf86cd799439011',
+  datalakeTag: 'datalake:acme',
+  fileTagPrefix: 'acme:',
+  createdByUserId: 'owner-1',
+};
 
 const makeDeps = (
   files: { id: string; userId: string }[],
@@ -114,5 +120,58 @@ describe('countFailedLakeFiles', () => {
       fileTagPrefix: 'acme:',
       creatorUserId: 'owner-1',
     });
+  });
+});
+
+/**
+ * The lake shape `assertLakeAccess` hands back for a hardcoded DATA_LAKES lake: the config spread
+ * over an owner-less synthetic document. A real registry id, so `isFallbackLake` decides by its own
+ * config-id rule rather than a flag.
+ */
+const REGISTRY_LAKE = { ...DATA_LAKES.find(dl => dl.id === 'opti-knowledge')!, createdByUserId: '' };
+
+/**
+ * `assertLakeRebuildAccess` is the ONE file-level gate that admits a fallback lake, so this door is
+ * the only one whose lake can be creator-less. Scoping it `owned` anyway dropped the prefix arm
+ * (`effectiveTagPrefixArm` returns null with no creator to anchor to), and a registry lake is mostly
+ * prefix-tagged members - so the rebuild reported itself finished having never looked at them.
+ *
+ * Asserted against the real builders, never a hand-written literal: an independently written second
+ * copy of the scope is exactly the drift being guarded against (registryScopeParity.test.ts records
+ * why at length).
+ */
+describe('registry-lake membership scope', () => {
+  it('scopes both detectUnderChunkedFiles reads through registryMembershipScope', async () => {
+    const deps = makeDeps([], []);
+    await detectUnderChunkedFiles(REGISTRY_LAKE, deps);
+    const expected = registryMembershipScope(REGISTRY_LAKE);
+    expect(deps.db.fabFiles.findChunkedFilesByScope).toHaveBeenCalledWith(expected);
+    expect(deps.db.fabFiles.findConvergencePausedFilesByScope).toHaveBeenCalledWith(expected);
+  });
+
+  it('scopes countFailedLakeFiles through registryMembershipScope', async () => {
+    const countFailedFilesByScope = vi.fn().mockResolvedValue(0);
+    await countFailedLakeFiles(REGISTRY_LAKE, { db: { fabFiles: { countFailedFilesByScope } } });
+    expect(countFailedFilesByScope).toHaveBeenCalledWith(registryMembershipScope(REGISTRY_LAKE));
+  });
+
+  it('keeps a persisted lake on the creator-anchored scope, so the two kinds are not collapsed', async () => {
+    const deps = makeDeps([], []);
+    await detectUnderChunkedFiles(lake, deps);
+    expect(deps.db.fabFiles.findChunkedFilesByScope).toHaveBeenCalledWith(lakeMembershipScope(lake));
+    expect(deps.db.fabFiles.findConvergencePausedFilesByScope).toHaveBeenCalledWith(lakeMembershipScope(lake));
+  });
+
+  // The scope's SHAPE can look fine while the arm it resolves to is gone - which is the whole bug:
+  // `{ kind: 'owned', creatorUserId: '' }` is well formed and matches meta-tag-only. So pin the
+  // decision the membership predicate actually makes. `effectiveTagPrefixArm` is what
+  // `buildDataLakeMembershipFilter` delegates that call to, and it lives in @bike4mind/common, so
+  // this pins the predicate without reaching across into the database package.
+  it('resolves to a LIVE prefix arm, where the owned scope over the same lake drops it', async () => {
+    const deps = makeDeps([], []);
+    await detectUnderChunkedFiles(REGISTRY_LAKE, deps);
+    const scope = deps.db.fabFiles.findChunkedFilesByScope.mock.calls[0][0];
+    expect(effectiveTagPrefixArm(scope)).toBe(REGISTRY_LAKE.fileTagPrefix);
+    expect(effectiveTagPrefixArm(lakeMembershipScope(REGISTRY_LAKE))).toBeNull();
   });
 });

--- a/b4m-core/services/src/dataLakeService/rebuildLakePassages.test.ts
+++ b/b4m-core/services/src/dataLakeService/rebuildLakePassages.test.ts
@@ -132,9 +132,8 @@ const REGISTRY_LAKE = { ...DATA_LAKES.find(dl => dl.id === 'opti-knowledge')!, c
 
 /**
  * `assertLakeRebuildAccess` is the ONE file-level gate that admits a fallback lake, so this door is
- * the only one whose lake can be creator-less. Scoping it `owned` anyway dropped the prefix arm
- * (`effectiveTagPrefixArm` returns null with no creator to anchor to), and a registry lake is mostly
- * prefix-tagged members - so the rebuild reported itself finished having never looked at them.
+ * the only one whose lake can be creator-less - see `resolveLakeMembershipScope` for why an `owned`
+ * scope over such a lake silently drops the prefix arm the lake is mostly made of.
  *
  * Asserted against the real builders, never a hand-written literal: an independently written second
  * copy of the scope is exactly the drift being guarded against (registryScopeParity.test.ts records

--- a/b4m-core/services/src/dataLakeService/rebuildLakePassages.ts
+++ b/b4m-core/services/src/dataLakeService/rebuildLakePassages.ts
@@ -1,6 +1,6 @@
 import type { IDataLakeDocument, IFabFileRepository, IFabFileChunkRepository } from '@bike4mind/common';
 import { OVERSIZED_PASSAGE_TOKEN_THRESHOLD } from '@bike4mind/common';
-import { lakeMembershipScope } from './lakeMembershipScope';
+import { resolveLakeMembershipScope } from './lakeMembershipScope';
 
 /** Default files re-chunked per "Rebuild passages" call. Small so a single wave never bursts the
  *  embedding provider's tokens-per-minute; the caller repeats waves until the count reaches zero. */
@@ -8,7 +8,10 @@ export const DEFAULT_REBUILD_WAVE = 50;
 /** Hard cap on one wave, so a hand-crafted request can't fan out an unbounded embedding burst. */
 export const MAX_REBUILD_WAVE = 200;
 
-type ScopeSourceLake = Pick<IDataLakeDocument, 'datalakeTag' | 'fileTagPrefix' | 'createdByUserId'>;
+/** `id` is required, not optional: this door admits registry lakes (assertLakeRebuildAccess is the
+ *  one file-level gate that does), and it is what `resolveLakeMembershipScope` tells them apart by.
+ *  An id-less lake would fail closed to meta-tag-only instead of failing to compile. */
+type ScopeSourceLake = Pick<IDataLakeDocument, 'id' | 'datalakeTag' | 'fileTagPrefix' | 'createdByUserId'>;
 
 export type UnderChunkedFile = { fabFileId: string; userId: string };
 
@@ -46,7 +49,7 @@ export const detectUnderChunkedFiles = async (
   { db }: DetectDeps,
   tokenThreshold: number = OVERSIZED_PASSAGE_TOKEN_THRESHOLD
 ): Promise<UnderChunkedFile[]> => {
-  const scope = lakeMembershipScope(lake);
+  const scope = resolveLakeMembershipScope(lake);
   const [files, stranded] = await Promise.all([
     db.fabFiles.findChunkedFilesByScope(scope),
     db.fabFiles.findConvergencePausedFilesByScope(scope),
@@ -86,4 +89,4 @@ export const detectUnderChunkedFiles = async (
 export const countFailedLakeFiles = async (
   lake: ScopeSourceLake,
   { db }: { db: { fabFiles: Pick<IFabFileRepository, 'countFailedFilesByScope'> } }
-): Promise<number> => db.fabFiles.countFailedFilesByScope(lakeMembershipScope(lake));
+): Promise<number> => db.fabFiles.countFailedFilesByScope(resolveLakeMembershipScope(lake));

--- a/b4m-core/services/src/dataLakeService/resolveIngestSpendScope.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveIngestSpendScope.test.ts
@@ -73,6 +73,38 @@ describe('resolveIngestSpendScope', () => {
     expect(scope).toEqual({});
   });
 
+  it('meters a prefix-only static-registry member, which carries neither a batchId nor a meta-tag', async () => {
+    // The population Rebuild Passages newly selects: a registry lake's prefix arm is most of the
+    // lake, and those files carry no `datalake:*` tag at all. Matching the meta-tag alone left them
+    // resolving to null - no throughput window, no period budget and no ledger row - so widening
+    // the rebuild scope without this would have put most of the wave outside the gate.
+    const db = deps();
+    const scope = await resolveIngestSpendScope(
+      { id: 'f1', userId: 'user1', tags: [{ name: 'opti:pumps' }] },
+      db as never
+    );
+    expect(scope).toEqual({});
+    expect(scope).not.toBeNull();
+  });
+
+  it('reads the prefix arm off the registry, so a non-member with a namespaced tag is still not lake work', async () => {
+    const db = deps();
+    const scope = await resolveIngestSpendScope(
+      { id: 'f1', userId: 'user1', tags: [{ name: 'personal:pumps' }] },
+      db as never
+    );
+    expect(scope).toBeNull();
+  });
+
+  it('prefers the DB-backed lake over a registry prefix match, keeping the run and lake meters', async () => {
+    const db = deps({ lakes: [lake('lake1', { fileTagPrefix: 'opti:' })] });
+    const scope = await resolveIngestSpendScope(
+      { id: 'f1', userId: 'user1', tags: [{ name: 'opti:pumps' }] },
+      db as never
+    );
+    expect(scope).toEqual({ dataLakeId: 'lake1' });
+  });
+
   it('prefers the DB-backed lake when a file carries both a static and a real lake tag', async () => {
     const db = deps({ byTag: lake('lake1') });
     const scope = await resolveIngestSpendScope(

--- a/b4m-core/services/src/dataLakeService/resolveIngestSpendScope.ts
+++ b/b4m-core/services/src/dataLakeService/resolveIngestSpendScope.ts
@@ -1,4 +1,5 @@
 import type { IDataLakeBatchRepository, IDataLakeRepository } from '@bike4mind/common';
+import { DATA_LAKES, matchesTagPrefixArm } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
 import { findMemberLakesForFile, type ChunkPolicyFile } from './chunkPolicyConflict';
 import { extractDataLakeMetaTags, isStaticRegistryDatalakeTag } from './authorizeLakeWrite';
@@ -35,11 +36,13 @@ export interface IngestSpendScope {
  * why findMemberLakesForFile drops their meta-tags - a filter that exists there so a documentless
  * lake cannot be asked to declare a chunk policy, and which would silently read as "not lake work"
  * here. But Rebuild Passages does run over them (assertLakeRebuildAccess is deliberately the one
- * file-level lake write that needs no lake document), and their members are stamped with the
- * meta-tag and no batchId, so this is precisely the bulk-door-over-tagged-population case the
- * throughput cap exists for. Returning an empty scope puts those calls under the platform-wide
- * throughput and period windows while leaving the run and lake meters alone - correct rather than
- * merely convenient, since neither has anywhere to write for a lake that does not exist.
+ * file-level lake write that needs no lake document), and their members carry no batchId, so this
+ * is precisely the bulk-door-over-tagged-population case the throughput cap exists for. BOTH of
+ * their membership arms count: the `datalake:<slug>` meta-tag and a tag under the registry
+ * `fileTagPrefix` - the latter is most of such a lake, and no batch or meta-tag signal reaches it.
+ * Returning an empty scope puts those calls under the platform-wide throughput and period windows
+ * while leaving the run and lake meters alone - correct rather than merely convenient, since
+ * neither has anywhere to write for a lake that does not exist.
  *
  * Deliberately does NOT catch a failed lakes read. An unreadable membership is UNKNOWN, and
  * treating unknown as "not lake work" would route the call around the throughput cap and every
@@ -65,13 +68,20 @@ export async function resolveIngestSpendScope(
 
   const memberLakes = await findMemberLakesForFile(file, db.dataLakes);
   if (memberLakes.length === 0) {
-    // No DB-backed lake. Before calling this "not lake work", check the one membership signal
+    // No DB-backed lake. Before calling this "not lake work", check the membership signals
     // findMemberLakesForFile is built to discard (see the doc comment above).
     const tagNames = (file.tags ?? []).map(t => t?.name);
-    const staticTags = extractDataLakeMetaTags(tagNames).filter(isStaticRegistryDatalakeTag);
-    if (staticTags.length > 0) {
+    const staticTag = extractDataLakeMetaTags(tagNames).filter(isStaticRegistryDatalakeTag)[0];
+    // The prefix arm, matched against the COMPILE-TIME registry so this costs no lakes read and the
+    // zero-reads property above survives. No ownership conjunct, mirroring `registryMembershipScope`
+    // - a registry prefix is config rather than a user-chosen tag, so there is no creator to anchor
+    // to. Reaching this arm is what keeps the rebuild door's members metered now that it selects
+    // them (`resolveLakeMembershipScope`); meta-tag-only here left most of the wave unmetered.
+    const prefixArmLake = DATA_LAKES.find(config => matchesTagPrefixArm(tagNames, config.fileTagPrefix));
+    if (staticTag || prefixArmLake) {
       logger?.log?.(
-        `[spendGate] file ${file.id} is a static-registry lake member (${staticTags[0]}); metering platform windows only`
+        `[spendGate] file ${file.id} is a static-registry lake member ` +
+          `(${staticTag ?? prefixArmLake?.fileTagPrefix}); metering platform windows only`
       );
       return {};
     }


### PR DESCRIPTION
# Pull Request

## Description

Closes #2377.

"Rebuild passages" resolved a lake's membership through `lakeMembershipScope` with no fallback branch. `assertLakeRebuildAccess` is the one file-level gate that admits a hardcoded `DATA_LAKES` lake, and `assertLakeAccess` resolves those to a synthetic document with `createdByUserId: ''` (owner-less on purpose - there is no document to own). `effectiveTagPrefixArm` correctly returns `null` for a creator-less `owned` scope, so `buildDataLakeMembershipFilter` returned the bare meta arm and both reads saw only `datalake:<slug>`-meta-tagged members.

Every prefix-tagged (`opti:*`) member was therefore invisible to the repair: never counted, never reset, never re-enqueued. The badge read as though the rebuild had finished, and when the counts were zero the UI hid its own button - the same "hid itself on precisely the lake that needed it" failure the stranded-member arm was added to fix.

This is the third instance of the same defect. The sibling read paths (`computeLakeHealth`, `GET /api/data-lakes/:id`, `GET /api/data-lakes/:id/articles`) already branch correctly; the service layer never did. So the fix is the unified helper the issue asks for rather than a third open-coded ternary.

## Changes

- `lakeMembershipScope.ts`: new `resolveLakeMembershipScope(lake)` - `isFallbackLake(lake) ? registryMembershipScope(lake) : lakeMembershipScope(lake)`, sitting next to the two builders it picks between.
- `rebuildLakePassages.ts`: `detectUnderChunkedFiles` and `countFailedLakeFiles` both use it. `ScopeSourceLake` gains a **required** `id` - deliberately required, so an id-less lake breaks the build instead of silently failing closed to meta-tag-only.
- `computeLakeHealth.ts`: pure extraction - its existing ternary now calls the helper. No behavior change, no test assertion changes.
- `convergeLakePolicy.ts`: comment only. It has the same unconditional call and is wrong-but-unreachable - a registry lake's synthetic document carries no `requiredPassageTokenTarget`, so `planLakeConvergence` returns `policyInherited` before that line. Noted in place so the next reader neither "fixes" it blind nor moves the gate that keeps it safe.
- `rebuildLakePassages.test.ts`: regression coverage (below). The existing `countFailedLakeFiles` assertion is unchanged; its fixture just gains an `id`.

`GET /api/data-lakes/:id` and `.../articles` keep their open-coded branch: their tests assert the branch shape at the route, so folding those in is a separate test-touching change. The helper's doc comment cross-references them so the copies stay in step.

## Behavior change worth calling out

This **widens** what the rebuild POST touches on a registry lake. Prefix-only members will now be reset (`resetChunkStateByIds` deletes their passages) and re-enqueued for embedding. That is the intended repair, but it is real spend on a population that has been invisible, and on `opti-knowledge` that population is most of the lake. The existing wave cap bounds each call (`DEFAULT_REBUILD_WAVE` 50, `MAX_REBUILD_WAVE` 200) and the convergence kill switch is still checked before the reset, so the exposure is per-click, not a single burst.

No DB-lake behavior changes: `isFallbackLake` is false for every persisted lake, so those get the byte-for-byte identical scope they got before.

## Tests

Four new cases in `b4m-core/services/src/dataLakeService/rebuildLakePassages.test.ts`, asserted against the **real** `registryMembershipScope` / `lakeMembershipScope` functions rather than hand-written literals - an independently written second copy of the scope is the exact drift being guarded against (`registryScopeParity.test.ts` records why at length).

1. `detectUnderChunkedFiles` passes `registryMembershipScope(lake)` to both `findChunkedFilesByScope` and `findConvergencePausedFilesByScope`.
2. `countFailedLakeFiles` passes it to `countFailedFilesByScope`.
3. A persisted lake still gets `lakeMembershipScope(lake)`, so the two kinds are not collapsed.
4. The scope the service actually passed resolves to a LIVE prefix arm - `effectiveTagPrefixArm(captured)` is `'opti:'`, where the old owned scope over the same lake returns `null`. This pins the predicate decision, not just the scope shape, since `{ kind: 'owned', creatorUserId: '' }` is perfectly well formed and still matches meta-tag-only. `effectiveTagPrefixArm` is what `buildDataLakeMembershipFilter` delegates that call to and it lives in `@bike4mind/common`, so this stays inside the package.

Verified 3 of the 4 fail on the pre-fix source and all pass after.

## Guide for Testers

Backend-only; the surface is the "Rebuild passages" control on a built-in (registry) data lake. Requires platform-admin rights - `assertLakeRebuildAccess` gates the POST on `ctx.isAdmin` for a fallback lake.

1. Sign in to `app.staging.bike4mind.com` as a **platform admin**.
2. Navigate: Sidebar -> Data Lakes -> **Optimization Knowledge Base** (`opti-knowledge`).
3. Open the lake's management view and find the **Rebuild passages** control.
4. **Expected:** the under-chunked / failed counts now include members tagged only `opti:*` (no `datalake:opti-knowledge` meta-tag). Before this change these counts read 0 on that lake and the button hid itself. The number will be substantially larger than it was - that is the fix, not a regression.
5. Click **Rebuild passages** once.
6. **Expected:** the response reports `detected` / `enqueued` / `remaining`, with `enqueued` capped at 50 (the default wave). A prefix-only member is among those enqueued.
7. Wait for the wave to finish, then reload.
8. **Expected:** `remaining` has dropped by roughly the wave size. Repeat clicks continue to drain it.
9. Turn the convergence kill switch **on** and click **Rebuild passages** again.
10. **Expected:** the response comes back with `outcome: 'paused'` and `enqueued: 0`, and no passages are deleted. Turn the switch back off.

### Regression Checks

11. Repeat steps 2-8 on any **user-created** (non-built-in) data lake.
12. **Expected:** counts and rebuild behavior are exactly as before this change - a persisted lake's scope is untouched.
13. Open lake **Health** on both a built-in and a user-created lake.
14. **Expected:** unchanged. `computeLakeHealth` was refactored to call the shared helper but its branch is identical; its tests pass with no assertion changes.
15. Open **Converge** on a built-in lake.
16. **Expected:** unchanged - it still reports `policyInherited` and plans nothing. Only a comment was added to that file.

### What NOT to test

No UI, styling, routing, or schema changes. No new admin settings, no migrations, no telemetry fields. Nothing outside the data-lake rebuild/health read paths is touched.

## Additional Information

Verified locally: `pnpm turbo:typecheck`, `pnpm lint:check`, and the full `@bike4mind/services` (6094), `@bike4mind/client` (12054), `@bike4mind/database` (2384), `@bike4mind/scripts` (652) and `@bike4mind/utils` (888) suites all green. `pnpm turbo:test` in one shot oversubscribes this 11-core host and drops workers with EPIPE; each package passes run individually.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry changes
