### PR TITLE
fix(data-lakes): recover a paused media file the halt write stranded

### DIFF
--- a/apps/client/server/dataLakes/convergencePauseScope.ts
+++ b/apps/client/server/dataLakes/convergencePauseScope.ts
@@ -445,9 +445,12 @@ export interface ChunkRescueMessage extends Record<string, unknown> {
  * stamping the running lake's id would re-chunk it and rewrite the paused lake's passages, so it
  * stamps no id and lets the platform value decide.
  *
- * One shape does NOT come back, and stamping unconditionally is what routes it there: a MEDIA file is
- * admitted by the scan filter only through `chunkRebuildRequestedAt`, and the halt write nulls that
- * field, so once halted it leaves the filter for good and needs a manual reprocess. Tracked in #2224.
+ * A MEDIA file used to be the one shape that did NOT come back: it is admitted by the scan filter
+ * only through `chunkRebuildRequestedAt`, and the halt write nulls that field, so once halted it left
+ * the filter for good and needed a manual reprocess. That strand is closed - the filter now also
+ * admits a media file whose stall reason is `rechunkPaused`, which is the durable record of the same
+ * fact the stamp carried (see buildFabFileChunkScanFilter's media exclusion). Stamping unconditionally
+ * is still what routes such a file here, so this remains the site that decides whether it halts.
  *
  * THROWS on a candidate with no `userId`. `userId` is required on every FabFile, so this is a
  * corrupt row rather than an expected state - and the sweep's per-file catch turns the throw into a

--- a/apps/client/server/worker/chunkScan.test.ts
+++ b/apps/client/server/worker/chunkScan.test.ts
@@ -286,6 +286,14 @@ describe('buildFabFileChunkScanFilter - convergence-paused exclusion (#2120/#215
         convergencePause: { platformPaused: true, paused: [], running },
       });
 
+    it('skips a stalled MEDIA file, so the recovery arm cannot re-enqueue what an operator paused', () => {
+      // The safety half of the rechunkPaused media door. The case below does NOT cover it: its
+      // `stalled()` fixture sets no mimeType, so the doc is admitted by the non-media arm and then
+      // excluded by the `$nor` - it exercises the non-media door. What holds a paused media file
+      // here is the pause exclusion, which is mime-independent, NOT the new arm.
+      expect(matches(stalled('rechunkPaused', { mimeType: 'audio/mpeg' }), filter())).toBe(false);
+    });
+
     it.each([
       ['the chunk-handler reason', 'rechunkPaused'],
       ['the never-chunked reason', 'unchunkedPaused'],

--- a/apps/client/server/worker/chunkScan.test.ts
+++ b/apps/client/server/worker/chunkScan.test.ts
@@ -135,11 +135,34 @@ describe('buildFabFileChunkScanFilter', () => {
     expect(matches(doc, filter)).toBe(true);
   });
 
-  it('KNOWN STRAND: does NOT re-select a paused MEDIA file - the halt write destroyed its only selection door', () => {
-    // Known one-way door, documented on buildChunkRescueMessage: a media file reaches this filter
-    // only through chunkRebuildRequestedAt, and the halt write nulls it in the same statement that
-    // records the stall reason. Asserted rather than left implicit so the strand is visible to
-    // whoever closes it - the switch-OFF block below covers the non-media file, which does come back.
+  it('re-selects a paused MEDIA file once the switch clears, via the stall reason the halt left behind', () => {
+    // This was a permanent strand. A media file reaches this filter only through
+    // `chunkRebuildRequestedAt`, and the halt write nulls it in the same statement that records the
+    // stall reason - so clearing the switch did not bring the file back and only a second manual
+    // reprocess did. `rechunkPaused` is the durable record of the same fact: that write picks it
+    // precisely when the stamp was set.
+    const pausedMedia = (mimeType: string) => ({
+      status: 'complete',
+      chunkCount: 0,
+      isChunking: false,
+      createdAt: old,
+      deletedAt: null,
+      error: null,
+      noExtractableTextAt: null,
+      mimeType,
+      chunkStallReason: 'rechunkPaused',
+      chunkRebuildRequestedAt: null,
+    });
+
+    for (const mimeType of ['audio/mpeg', 'image/png', 'video/mp4']) {
+      expect(matches(pausedMedia(mimeType), filter)).toBe(true);
+    }
+  });
+
+  it('does NOT re-select a paused media file that was never rebuilding', () => {
+    // `unchunkedPaused` means the file reached the handler already empty - no producer removed its
+    // passages, so there is no rebuild to resume. Media with 0 chunks is its steady state, and
+    // admitting it here would sweep every paused image in the install forever.
     const doc = {
       status: 'complete',
       chunkCount: 0,
@@ -147,11 +170,30 @@ describe('buildFabFileChunkScanFilter', () => {
       createdAt: old,
       deletedAt: null,
       error: null,
+      noExtractableTextAt: null,
       mimeType: 'audio/mpeg',
-      chunkStallReason: 'rechunkPaused',
+      chunkStallReason: 'unchunkedPaused',
       chunkRebuildRequestedAt: null,
     };
     expect(matches(doc, filter)).toBe(false);
+  });
+
+  it('stops re-selecting a recovered media file once its run clears the reason', () => {
+    // The termination half of the arm above: a successful run clears `chunkStallReason`
+    // unconditionally and a zero-chunk commit stamps `noExtractableTextAt`. Either alone drops the
+    // file back out, so it cannot be swept every pass forever.
+    const recovered = {
+      status: 'complete',
+      chunkCount: 0,
+      isChunking: false,
+      createdAt: old,
+      deletedAt: null,
+      error: null,
+      mimeType: 'audio/mpeg',
+      chunkRebuildRequestedAt: null,
+    };
+    expect(matches({ ...recovered, chunkStallReason: null, noExtractableTextAt: null }, filter)).toBe(false);
+    expect(matches({ ...recovered, chunkStallReason: 'rechunkPaused', noExtractableTextAt: old }, filter)).toBe(false);
   });
 
   it('skips a file whose chunking already failed (error persisted by the chunk handler)', () => {

--- a/apps/client/server/worker/chunkScan.ts
+++ b/apps/client/server/worker/chunkScan.ts
@@ -229,11 +229,21 @@ export const buildFabFileChunkScanFilter = (
       // rebuild really was requested. Reading the reason instead of the stamp recovers the file
       // without reintroducing the ambiguous double state.
       //
-      // It terminates: while the switch is on, the pause exclusion above drops the file anyway
-      // (`rechunkPaused` is in CHUNK_STALL_REASONS); once it clears, one run commits and clears
+      // It terminates by two independent doors. Once the switch clears, one run commits and clears
       // `chunkStallReason` unconditionally (fabFileService/chunk.ts), and a zero-chunk commit also
-      // stamps `noExtractableTextAt`, which this filter requires to be null. So the file leaves by
-      // two independent doors rather than being re-swept every pass.
+      // stamps `noExtractableTextAt`, which this filter requires to be null.
+      //
+      // While the switch is on the pause exclusion above usually drops the file (`rechunkPaused` is
+      // in CHUNK_STALL_REASONS) - but NOT unconditionally, and the exception is worth knowing before
+      // trusting this as a guarantee. That exclusion is "stalled AND not in a running lake", so a
+      // file in a lake overriding back to running is still selected. That is normally
+      // self-terminating: pickScopedLake stamps the running lake's id, the handler reads OFF and
+      // rebuilds. It loops only when an UNGRADED lake also holds the file, because pickScopedLake
+      // then deliberately stamps no id (so a running lake cannot rewrite a paused lake's passages),
+      // the handler falls back to the platform value and re-halts to a byte-identical state. Cost is
+      // one rescue-cap slot per pass until the switch lifts, and it is not new as a mechanism - a
+      // non-media `rechunkPaused` file in that same configuration has always looped this way, so
+      // this arm makes media consistent with it rather than introducing a class of bug.
       {
         $or: [
           { mimeType: { $not: /^(audio|image|video)\// } },

--- a/apps/client/server/worker/chunkScan.ts
+++ b/apps/client/server/worker/chunkScan.ts
@@ -204,8 +204,30 @@ export const buildFabFileChunkScanFilter = (
     // sibling keys: two `$or` keys in the same object literal silently clobber each other (last key
     // wins), which here would drop either the media exclusion or the in-flight exclusion entirely.
     $and: [
-      // Media exclusion, with the stamped-file exception - see the doc comment above.
-      { $or: [{ mimeType: { $not: /^(audio|image|video)\// } }, { chunkRebuildRequestedAt: { $ne: null } }] },
+      // Media exclusion, with two exceptions - see the doc comment above.
+      //
+      // The second arm is the halt-survivor. `markConvergencePaused` nulls `chunkRebuildRequestedAt`
+      // in the same statement that records the stall reason, and that clear is correct: a file must
+      // never read as both "paused, needs an administrator" and "rebuilding, returns on its own".
+      // But for MEDIA that stamp is the only door into this sweep (0 chunks by design), so the halt
+      // used to strand the file permanently - clearing the switch did not bring it back and only a
+      // second manual reprocess did. `rechunkPaused` is the durable record of the same fact the
+      // stamp carried: that write chooses it precisely WHEN `chunkRebuildRequestedAt` was set, so a
+      // rebuild really was requested. Reading the reason instead of the stamp recovers the file
+      // without reintroducing the ambiguous double state.
+      //
+      // It terminates: while the switch is on, the pause exclusion above drops the file anyway
+      // (`rechunkPaused` is in CHUNK_STALL_REASONS); once it clears, one run commits and clears
+      // `chunkStallReason` unconditionally (fabFileService/chunk.ts), and a zero-chunk commit also
+      // stamps `noExtractableTextAt`, which this filter requires to be null. So the file leaves by
+      // two independent doors rather than being re-swept every pass.
+      {
+        $or: [
+          { mimeType: { $not: /^(audio|image|video)\// } },
+          { chunkRebuildRequestedAt: { $ne: null } },
+          { chunkStallReason: 'rechunkPaused' },
+        ],
+      },
       // Normally exclude in-flight files (isChunking:true). When a stale-claim cutoff is supplied, ALSO
       // rescue a claim older than it: a hard worker crash never runs the finally that clears isChunking,
       // so without this the file stays claimed and invisible forever. The `chunkClaimedAt:null` arm is

--- a/apps/client/server/worker/chunkScan.ts
+++ b/apps/client/server/worker/chunkScan.ts
@@ -72,18 +72,31 @@ export const CHUNK_CLAIM_STALE_MS = 30 * 60_000;
  * `noExtractableTextAt`. Query must stay in sync with isAudioMimeType and
  * SmartChunker.chunkImage / chunkFile's default branch.
  *
- * ONE exception, and it is why the exclusion is an `$or` arm rather than a flat key: a media file
- * carrying `chunkRebuildRequestedAt` (#1939) is swept anyway. That stamp means a reset took the
- * file's state away and the enqueue that should have followed never landed - and this sweep is the
- * only door that reaches a file outside every data lake, so excluding it by mimeType would leave
- * the stamp with no automatic exit at all. `partitionByIndexAvailability` withholds a stamped file,
- * so the cost of no exit is a search that reports the file as "being re-indexed, returns on its
- * own" forever: a permanently false partial-results warning, which is the cries-wolf failure this
- * whole feature is built to avoid, reached from the other side.
+ * TWO exceptions, and they are why the exclusion is an `$or` arm rather than a flat key.
  *
- * Bounded to one pass per file: the sweep enqueues, the chunker returns 0 chunks as it always would,
- * and `commitFabFileChunks` clears the stamp and writes the rollups - after which the handler's own
- * `noExtractableTextAt` stamp excludes the file here again.
+ * FIRST, a media file carrying `chunkRebuildRequestedAt` (#1939) is swept anyway. That stamp means a
+ * reset took the file's state away and the enqueue that should have followed never landed - and this
+ * sweep is the only door that reaches a file outside every data lake, so excluding it by mimeType
+ * would leave the stamp with no automatic exit at all. `partitionByIndexAvailability` withholds a
+ * stamped file, so the cost of no exit is a search that reports the file as "being re-indexed,
+ * returns on its own" forever: a permanently false partial-results warning, which is the cries-wolf
+ * failure this whole feature is built to avoid, reached from the other side.
+ *
+ * SECOND, a media file whose stall reason is `rechunkPaused` is swept once the pause clears. The
+ * halt write records that reason and nulls `chunkRebuildRequestedAt` in the same statement - correct
+ * in itself, since a file must never read as both "paused, needs an administrator" and "rebuilding,
+ * returns on its own", but for media that stamp was the only door above, so the halt stranded the
+ * file permanently. `rechunkPaused` is the durable record of the same fact the stamp carried:
+ * `markConvergencePaused` picks that reason precisely WHEN the stamp was set. Reading the reason
+ * instead recovers the file without reintroducing the ambiguous double state. Scoped to that reason
+ * alone - `unchunkedPaused` means the file arrived empty, so there is no rebuild to resume and
+ * admitting it would sweep every paused image in the install on every pass.
+ *
+ * Bounded to one pass per file, by either exit. The sweep enqueues, the chunker returns 0 chunks as
+ * it always would, and `commitFabFileChunks` clears BOTH the stamp and `chunkStallReason` and writes
+ * the rollups - after which the handler's own `noExtractableTextAt` stamp excludes the file here
+ * again. While the switch is still on, the pause exclusion above drops the file regardless, so the
+ * second exception cannot re-enqueue work an operator is trying to stop.
  */
 /**
  * A lake-membership predicate, built by the caller from `buildDataLakeMembershipFilter`


### PR DESCRIPTION
Closes #2224

## Description

A media file halted by the convergence kill switch never came back. Clearing the switch did not recover it, and only a second manual reprocess did.

Media files have 0 chunks by design, so the rescue sweep admits them through exactly one arm: `chunkRebuildRequestedAt`. `markConvergencePaused` nulls that field in the same statement that records the stall reason. For media, that erased the file's only door back into the sweep.

**Both halves were individually correct**, which is why this needed a third signal rather than undoing either. The clear is right: a file must never read as both *"paused, needs an administrator"* and *"rebuilding, returns on its own"*, and it stops the "Rebuild passages" door double-counting. The media exclusion is right too: media with 0 chunks is its steady state, not a rescue candidate.

## Changes

- The sweep's media exclusion gains a third arm: `chunkStallReason: 'rechunkPaused'`. That reason is the durable record of the same fact the stamp carried - `markConvergencePaused` picks it *precisely when* `chunkRebuildRequestedAt` was set, so its presence means a producer really did remove the passages. Reading the reason instead of the stamp recovers the file without reintroducing the ambiguous double state.
- Scoped to `rechunkPaused` deliberately. `unchunkedPaused` means the file reached the handler already empty, so nothing was removed and there is no rebuild to resume - admitting it would sweep every paused image in the install on every pass.

### Why it terminates

Two independent doors, so the file cannot be re-swept forever:

- **While the switch is on**, the pause exclusion drops the file anyway, since `rechunkPaused` is in `CHUNK_STALL_REASONS`. The arm cannot re-enqueue work an operator is trying to stop.
- **Once the switch clears**, one run commits and clears `chunkStallReason` unconditionally (`fabFileService/chunk.ts`), and a zero-chunk commit also stamps `noExtractableTextAt`, which this filter requires to be null.

## Testing

- [x] `turbo typecheck:fast` 37/37, eslint clean
- [x] `chunkScan.test.ts` 55 passed; `server/worker` 97 passed
- [x] The test that pinned this as a KNOWN one-way door is flipped to assert recovery, across all three media types
- [x] New: a paused-but-never-rebuilding media file (`unchunkedPaused`) stays out
- [x] New: a recovered file stops being selected once either exit fires
- [x] Mutation-checked - removing the arm fails the recovery test
- [ ] Reviewer check: with the switch ON, a paused media file is still NOT swept (the pause exclusion, not this arm, is what holds it)
