### PR TITLE
chore(infra): alarm on a sustained taxonomy tag-apply skip rate

### DIFF
--- a/infra/alarms.ts
+++ b/infra/alarms.ts
@@ -1072,6 +1072,53 @@ if (isMonitoredStage) {
     },
   });
 
+  /**
+   * Alarm: taxonomy tag-apply skips
+   *
+   * Counts files whose optimistic-concurrency check LOST during a taxonomy apply - tags the user
+   * asked for that were never written. A single skip is benign and expected under load (two writers
+   * touched one file's tags), which is why this alarms on a SUSTAINED rate rather than on any skip
+   * at all: three consecutive hours with a non-zero sum. The expected steady state is zero, so a
+   * burst inside one hour stays quiet and a persistent contention problem does not.
+   *
+   * `Sum` over `Maximum` because the metric is deliberately dimensionless (matching the
+   * low-cardinality convention in applyTaxonomySuggestions) and its value is the per-call skip
+   * count - so the aggregate rate is the signal, and there is no per-lake breakdown to take a max
+   * over. Threshold is a starting point to tune once there is a baseline.
+   *
+   * This became worth watching when #2274 shipped PUT /api/data-lakes/:id/files/:fabFileId/tags, a
+   * second door mutating tags under the same `fileTagPrefix` a taxonomy apply merges into and
+   * documented as "last-writer-partially-wins, deliberately" - so the contention this counts is now
+   * reachable by ordinary use rather than by an unusual overlap. Until now nothing watched it, and
+   * the only other trace was a logger.warn nothing alarms on.
+   *
+   * Metric emitted by: server/utils/cloudwatch.ts -> recordTaxonomyTagsApplySkipped, wired from
+   * pages/api/data-lakes/batches/[batchId]/apply-taxonomy.ts.
+   * Namespace: Lumina5/DataLakeBatch / TaxonomyTagsApplySkipped
+   */
+  new aws.cloudwatch.MetricAlarm('dataLakeTaxonomyTagsApplySkippedSustained', {
+    name: `${$app.name}-${$app.stage}-data-lake-taxonomy-tags-apply-skipped-sustained`,
+    alarmDescription:
+      'Taxonomy tag applies have been losing their concurrency check for three hours running - tags users asked for are not being written',
+    comparisonOperator: 'GreaterThanThreshold',
+    // Three periods with the default all-must-breach rule, so this needs three CONSECUTIVE
+    // breaching hours. Left implicit rather than spelling out datapointsToAlarm, which no other
+    // alarm in this file sets.
+    evaluationPeriods: 3,
+    metricName: 'TaxonomyTagsApplySkipped',
+    namespace: 'Lumina5/DataLakeBatch',
+    period: 3600, // 1 hour
+    statistic: 'Sum',
+    threshold: 0,
+    // No emission means no applies ran, which is not a problem. Steady state is zero either way.
+    treatMissingData: 'notBreaching',
+    alarmActions: [dataLakeStuckBatchesAlarm!.arn],
+    tags: {
+      Application: 'DataLakeBatch',
+      Severity: 'Low',
+    },
+  });
+
   // dlqAlarmTopic is a conditional export from infra/dlqAlarms.ts, gated by that file's OWN copy
   // of the MONITORED_STAGES + ENABLE_MONITORING expression. The two agree today, but asserting
   // `dlqAlarmTopic!` across a file boundary on a value another module owns means a future


### PR DESCRIPTION
Closes #2320

## Description

`TaxonomyTagsApplySkipped` was emitted and nothing watched it. Confirmed: `git grep "TaxonomyTagsApplySkipped" -- infra/` returned nothing.

The metric counts files whose optimistic-concurrency check lost during a taxonomy apply - tags a user asked for that were never written. The source comment in `applyTaxonomySuggestions` calls it *"the aggregate rate an alarm could eventually watch"*. That was aspirational: a sustained rate sat in CloudWatch with nobody looking, and the only other trace was a `logger.warn` nothing alarms on.

## Changes

One `MetricAlarm` alongside the existing data-lake stuck-batch alarm in `infra/alarms.ts`, reusing the `DataLakeStuckBatchesAlarm` topic rather than adding a second data-lake destination.

**Fires on three consecutive hours with a non-zero sum**, not on any skip. A single skip is benign and expected under load - two writers touched one file's tags - so a burst inside one hour stays quiet while a persistent contention problem does not.

Design notes:

- **`Sum`, not `Maximum`** - the metric is deliberately dimensionless (matching the low-cardinality convention in that service) and its value is the per-call skip count, so the aggregate rate is the signal and there is no per-lake breakdown to take a max over.
- **`treatMissingData: 'notBreaching'`** - no emission means no applies ran, which is not a problem. Steady state is zero either way.
- **`datapointsToAlarm` left implicit** - the default is all-N-must-breach, which is exactly the intent, and no other alarm in this file sets it.
- **Threshold 0 is a starting point**, to tune once there is a baseline, as the issue suggests.
- **Severity `Low`** - this is a "look into it" signal, not a page.

## Why now

Two things made this worth watching:

- **#2217** made the metric trustworthy for the first time. No-op merges are now filtered out before the write, so the count isolates genuine CAS losses instead of also counting writes that changed nothing.
- **#2274** shipped `PUT /api/data-lakes/:id/files/:fabFileId/tags`, a second door mutating tags under the same `fileTagPrefix` a taxonomy apply merges into, documented as *"last-writer-partially-wins, deliberately"*. So the contention this counts is now reachable by ordinary use rather than by an unusual overlap.

## Testing

- [x] `pnpm run typecheck:infra` clean
- [x] `turbo typecheck:fast` 37/37, eslint clean
- [x] Metric name and namespace verified against the emitter (`cloudwatch.ts` `TAXONOMY_TAGS_APPLY_SKIPPED` / `Lumina5/DataLakeBatch`)
- [ ] Reviewer check: threshold and window are a first guess with no production baseline - worth a second opinion on whether 3h is the right sustain
- [ ] Deploy-plan check that the alarm appears only on monitored stages (it sits inside the existing `isMonitoredStage` block)
