### PR TITLE
feat(data-lakes): execute a membership repair plan

### DIFF
--- a/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.test.ts
+++ b/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ removeFileFromDataLake: vi.fn() }));
+vi.mock('./removeFileFromDataLake', () => ({ removeFileFromDataLake: h.removeFileFromDataLake }));
+
+import { executeLakeMembershipRepair } from './executeLakeMembershipRepair';
+import {
+  groupIdentity,
+  planMembershipRepair,
+  type DuplicateGroup,
+  type MembershipDecisionRecord,
+} from '@bike4mind/common';
+
+const AT: Record<string, string> = {
+  new: '2026-03-01T00:00:00Z',
+  mid: '2026-02-01T00:00:00Z',
+  old: '2026-01-01T00:00:00Z',
+};
+const HEX = 'a3f1c0de5b2740198e6c';
+
+const member = (fabFileId: string, serverTextHash: string | null = null) => ({
+  fabFileId,
+  serverTextHash,
+  fileSize: 100,
+  createdAt: new Date(AT[fabFileId] ?? '2026-01-01T00:00:00Z'),
+  arm: 'meta-tag' as const,
+});
+
+const group = (fileName: string, bucket: DuplicateGroup['bucket'], members = [member('new'), member('old')]) => ({
+  fileName,
+  bucket,
+  members,
+  memberCount: members.length,
+});
+
+const actor = { userId: 'u1', isAdmin: false } as never;
+const adapters = { db: {}, logger: { warn: vi.fn() } } as never;
+
+const run = (
+  groups: DuplicateGroup[],
+  decisions: Parameters<typeof executeLakeMembershipRepair>[3] = [],
+  prior: MembershipDecisionRecord[] = []
+) => executeLakeMembershipRepair(actor, 'lake-1', planMembershipRepair(groups, prior), decisions, adapters);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.removeFileFromDataLake.mockResolvedValue({ success: true, fileCount: 1, totalSizeBytes: 1 });
+});
+
+describe('executeLakeMembershipRepair', () => {
+  it('removes membership ONLY - never the file, its chunks, or another lake', async () => {
+    // The property that makes this operation recoverable, and the issue asks for it asserted rather
+    // than assumed. `removeFileFromDataLake` pulls this lake's tags off the FabFile and nothing else,
+    // so the whole guarantee reduces to: that is the only mutation this executor performs.
+    await run([group('p.pdf', 'proven-identical', [member('new', HEX), member('old', HEX)])]);
+
+    expect(h.removeFileFromDataLake).toHaveBeenCalledTimes(1);
+    expect(h.removeFileFromDataLake).toHaveBeenCalledWith(actor, 'lake-1', 'old', adapters);
+  });
+
+  it('executes bucket A only when no decisions are supplied', async () => {
+    // #2245's headline behaviour, and it holds as a property of the PLAN rather than a rule this
+    // executor remembers: a `decide` group carries an empty `removeFabFileIds` by construction.
+    const plan = [
+      group('proven.pdf', 'proven-identical', [member('new', HEX), member('old', HEX)]),
+      group('differs.pdf', 'differing'),
+      group('unknown.pdf', 'unverified'),
+    ];
+
+    const outcome = await run(plan);
+
+    expect(outcome.removedFabFileIds).toEqual(['old']);
+    expect(outcome.groupsActedOn).toEqual([{ fileName: 'proven.pdf', removedFabFileIds: ['old'] }]);
+  });
+
+  it('keeps the newest of a collapsible group', async () => {
+    const outcome = await run([
+      group('p.pdf', 'proven-identical', [member('new', HEX), member('mid', HEX), member('old', HEX)]),
+    ]);
+
+    expect(outcome.removedFabFileIds).toEqual(['mid', 'old']);
+    expect(h.removeFileFromDataLake).not.toHaveBeenCalledWith(actor, 'lake-1', 'new', adapters);
+  });
+
+  it('carries out a keep-newest decision on a group the plan only asked about', async () => {
+    const outcome = await run(
+      [group('d.pdf', 'differing', [member('new'), member('mid'), member('old')])],
+      [{ fileName: 'd.pdf', decision: 'keep-newest' }]
+    );
+
+    expect(outcome.removedFabFileIds).toEqual(['mid', 'old']);
+  });
+
+  it('carries out keep-specific, and removes nothing for keep-both', async () => {
+    const both = group('b.pdf', 'differing');
+    const specific = group('s.pdf', 'differing', [member('new'), member('old')]);
+
+    const outcome = await run(
+      [both, specific],
+      [
+        { fileName: 'b.pdf', decision: 'keep-both' },
+        { fileName: 's.pdf', decision: 'keep-specific', keptFabFileId: 'old' },
+      ]
+    );
+
+    expect(outcome.removedFabFileIds).toEqual(['new']);
+  });
+
+  it('removes nothing for a keep-specific naming a member no longer in the group', async () => {
+    // The read-time posture `membersRemovedByDecision` already takes: a stale decision must not fall
+    // back to a default the owner did not choose - the fallback would delete the copy they kept.
+    const outcome = await run(
+      [group('s.pdf', 'differing')],
+      [{ fileName: 's.pdf', decision: 'keep-specific', keptFabFileId: 'gone' }]
+    );
+
+    expect(outcome.removedFabFileIds).toEqual([]);
+    expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
+  });
+
+  it('ignores a decision for a group the plan already settled', async () => {
+    // A settled group carries a prior decision that suppressed it. Its `outstandingRemovalFabFileIds`
+    // says work was never carried out; acting on that here would let a tombstone remove membership
+    // with no owner in the loop.
+    const g = group('kept.pdf', 'differing', [member('new'), member('old')]);
+    const settledBy: MembershipDecisionRecord = {
+      dataLakeId: 'lake-1',
+      fileName: 'kept.pdf',
+      decision: 'keep-newest',
+      groupIdentity: '',
+      decidedByUserId: 'u1',
+      decidedAt: new Date('2026-02-15T00:00:00Z'),
+    };
+    const plan = planMembershipRepair([g], [{ ...settledBy, groupIdentity: groupIdentity(g) }]);
+    expect(plan.settled).toHaveLength(1);
+
+    const outcome = await executeLakeMembershipRepair(
+      actor,
+      'lake-1',
+      plan,
+      [{ fileName: 'kept.pdf', decision: 'keep-newest' }],
+      adapters
+    );
+
+    expect(outcome.removedFabFileIds).toEqual([]);
+    expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
+  });
+
+  it('one failed removal costs only itself, and is reported', async () => {
+    // A repair that abandons the rest of the plan on one failure leaves the lake in a state neither
+    // the owner nor the next plan can reason about. Half-applied and re-runnable is recoverable.
+    h.removeFileFromDataLake.mockImplementation(async (_a: unknown, _l: unknown, id: string) => {
+      if (id === 'mid') throw new Error('write conflict');
+      return { success: true, fileCount: 1, totalSizeBytes: 1 };
+    });
+
+    const outcome = await run([
+      group('p.pdf', 'proven-identical', [member('new', HEX), member('mid', HEX), member('old', HEX)]),
+    ]);
+
+    expect(outcome.removedFabFileIds).toEqual(['old']);
+    expect(outcome.failures).toEqual([{ fabFileId: 'mid', fileName: 'p.pdf', error: 'write conflict' }]);
+    // Two attempts, not three: the group keeps its newest member. `old` went out AFTER `mid` threw,
+    // which is the isolation this asserts.
+    expect(h.removeFileFromDataLake).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes sequentially, because every removal recomputes the lake stats', async () => {
+    // Concurrent removals would race each other's recompute and persist a count from a partial view.
+    const order: string[] = [];
+    let inFlight = 0;
+    h.removeFileFromDataLake.mockImplementation(async (_a: unknown, _l: unknown, id: string) => {
+      expect(inFlight).toBe(0);
+      inFlight += 1;
+      await new Promise(resolve => setTimeout(resolve, 1));
+      inFlight -= 1;
+      order.push(id);
+      return { success: true, fileCount: 1, totalSizeBytes: 1 };
+    });
+
+    await run([group('p.pdf', 'proven-identical', [member('new', HEX), member('mid', HEX), member('old', HEX)])]);
+
+    expect(order).toEqual(['mid', 'old']);
+  });
+
+  it('does nothing at all on an empty plan', async () => {
+    const outcome = await run([]);
+
+    expect(outcome).toEqual({ removedFabFileIds: [], groupsActedOn: [], failures: [] });
+    expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.test.ts
+++ b/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.test.ts
@@ -23,6 +23,7 @@ const member = (fabFileId: string, serverTextHash: string | null = null) => ({
   serverTextHash,
   fileSize: 100,
   createdAt: new Date(AT[fabFileId] ?? '2026-01-01T00:00:00Z'),
+  userId: 'u1',
   arm: 'meta-tag' as const,
 });
 
@@ -118,6 +119,43 @@ describe('executeLakeMembershipRepair', () => {
     expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
   });
 
+  it('withholds a ruling whose group moved since the owner reviewed it', async () => {
+    // The sharp case for keep-newest, which is positional: the owner rules on [mid, old] electing to
+    // keep `mid`, a newer copy lands before the POST, and applying the ruling to [new, mid, old]
+    // removes `mid` - the copy they kept - and leaves the one they never saw.
+    const reviewed = group('d.pdf', 'differing', [member('mid'), member('old')]);
+    const moved = group('d.pdf', 'differing', [member('new'), member('mid'), member('old')]);
+
+    const outcome = await run(
+      [moved],
+      [{ fileName: 'd.pdf', decision: 'keep-newest', groupIdentity: groupIdentity(reviewed) }]
+    );
+
+    expect(outcome.removedFabFileIds).toEqual([]);
+    expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
+    expect(outcome.staleDecisions).toEqual([
+      {
+        fileName: 'd.pdf',
+        reviewedGroupIdentity: groupIdentity(reviewed),
+        currentGroupIdentity: groupIdentity(moved),
+      },
+    ]);
+  });
+
+  it('applies a ruling whose group identity still matches, and one that carries none at all', async () => {
+    // The other side of the gate: it withholds on mismatch, not on presence. A caller with no
+    // identity to offer is unchanged, which is what keeps the field optional.
+    const g = group('d.pdf', 'differing', [member('new'), member('old')]);
+
+    const matched = await run([g], [{ fileName: 'd.pdf', decision: 'keep-newest', groupIdentity: groupIdentity(g) }]);
+    expect(matched.removedFabFileIds).toEqual(['old']);
+    expect(matched.staleDecisions).toEqual([]);
+
+    const unqualified = await run([g], [{ fileName: 'd.pdf', decision: 'keep-newest' }]);
+    expect(unqualified.removedFabFileIds).toEqual(['old']);
+    expect(unqualified.staleDecisions).toEqual([]);
+  });
+
   it('ignores a decision for a group the plan already settled', async () => {
     // A settled group carries a prior decision that suppressed it. Its `outstandingRemovalFabFileIds`
     // says work was never carried out; acting on that here would let a tombstone remove membership
@@ -127,6 +165,7 @@ describe('executeLakeMembershipRepair', () => {
       dataLakeId: 'lake-1',
       fileName: 'kept.pdf',
       decision: 'keep-newest',
+      keptFabFileId: null,
       groupIdentity: '',
       decidedByUserId: 'u1',
       decidedAt: new Date('2026-02-15T00:00:00Z'),
@@ -186,7 +225,7 @@ describe('executeLakeMembershipRepair', () => {
   it('does nothing at all on an empty plan', async () => {
     const outcome = await run([]);
 
-    expect(outcome).toEqual({ removedFabFileIds: [], groupsActedOn: [], failures: [] });
+    expect(outcome).toEqual({ removedFabFileIds: [], groupsActedOn: [], failures: [], staleDecisions: [] });
     expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.ts
+++ b/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.ts
@@ -1,0 +1,118 @@
+import { membersRemovedByDecision, type MembershipRepairPlan, type PlannedRepairGroup } from '@bike4mind/common';
+import { removeFileFromDataLake, type RemoveFileFromDataLakeAdapters } from './removeFileFromDataLake';
+import type { MembershipActor } from './lakeMembership';
+
+/**
+ * Executing a membership repair plan (#2245).
+ *
+ * `planMembershipRepair` decides what to propose; this carries it out. Split the way `converge`
+ * splits `planLakeConvergenceRun` from its execution, and for the same reason: every rule about
+ * whether to touch a customer's membership is readable and testable in the pure module, and this
+ * one only has to be right about HOW.
+ *
+ * Removal is membership only - `removeFileFromDataLake` pulls the lake's tags off the FabFile. The
+ * file, its chunks, and its membership of any other lake are untouched, which is what makes the
+ * operation recoverable and is asserted rather than assumed (see the tests).
+ *
+ * NOT gated here. Like `recordMembershipDecision`, the manage gate and the convergence kill switch
+ * live on the route - the same arrangement `converge` uses, where the service plans and the handler
+ * decides whether it may run. A caller reaching this without those is unauthorized and nothing here
+ * will say so.
+ */
+
+/** What the caller asked to happen beyond the plan's automatic arm, keyed by file name. */
+export interface MembershipRepairDecisionInput {
+  fileName: string;
+  decision: Parameters<typeof membersRemovedByDecision>[1];
+  keptFabFileId?: string | null;
+}
+
+export interface MembershipRepairOutcome {
+  /** Members whose lake membership was removed, in the order they were removed. */
+  removedFabFileIds: string[];
+  /** Groups acted on, so a surface can report per-file rather than only a total. */
+  groupsActedOn: { fileName: string; removedFabFileIds: string[] }[];
+  /**
+   * Removals attempted that threw, with the reason. One member failing must not abandon the rest -
+   * a half-applied repair the owner can re-run is recoverable; an abandoned one silently is not.
+   */
+  failures: { fabFileId: string; fileName: string; error: string }[];
+}
+
+/**
+ * Which members a group loses in this run.
+ *
+ * The plan's own `removeFabFileIds` is the ONLY source for the automatic arm - it is empty on every
+ * `decide` group by construction (see `planMembershipRepair`), so an executor that read it for every
+ * group in the plan would still be correct. A supplied decision is what turns a `decide` group into
+ * removals, and it is resolved against the group as the PLAN saw it, not re-derived: the plan is the
+ * thing the owner reviewed.
+ */
+function removalsForGroup(group: PlannedRepairGroup, byFileName: Map<string, MembershipRepairDecisionInput>): string[] {
+  if (group.action === 'collapse') return group.removeFabFileIds;
+  const decision = byFileName.get(group.fileName);
+  if (!decision) return [];
+  return membersRemovedByDecision(group, decision.decision, decision.keptFabFileId);
+}
+
+/**
+ * Execute a repair plan: the automatic arm always, plus whatever the owner decided.
+ *
+ * With no decisions supplied this removes bucket A only and leaves B and C untouched - not by a rule
+ * this function remembers, but because the plan's `decide` groups carry an empty `removeFabFileIds`
+ * and no decision resolves to anything. That is the property `planMembershipRepair` exists to make
+ * true, and this executor is the caller it was made true for.
+ *
+ * `settled` groups are never acted on. They carry a prior decision that already suppressed them, and
+ * their `outstandingRemovalFabFileIds` is a SIGNAL about work never carried out, not an instruction -
+ * acting on it here would let a stale tombstone remove membership with no owner in the loop.
+ */
+export async function executeLakeMembershipRepair(
+  actor: MembershipActor,
+  dataLakeId: string,
+  plan: MembershipRepairPlan,
+  decisions: MembershipRepairDecisionInput[],
+  adapters: RemoveFileFromDataLakeAdapters
+): Promise<MembershipRepairOutcome> {
+  const { logger } = adapters;
+  const byFileName = new Map(decisions.map(d => [d.fileName, d]));
+
+  const removedFabFileIds: string[] = [];
+  const groupsActedOn: MembershipRepairOutcome['groupsActedOn'] = [];
+  const failures: MembershipRepairOutcome['failures'] = [];
+
+  // Sequential, not a fan-out: every removal recomputes the lake's stats and can activate a draft
+  // lake, so concurrent removals would race each other's recompute and persist a count from a
+  // partial view. The wave is bounded by the plan's own caps, so there is nothing to gain.
+  for (const group of [...plan.collapsible, ...plan.needsDecision]) {
+    const removals = removalsForGroup(group, byFileName);
+    if (removals.length === 0) continue;
+
+    const removedHere: string[] = [];
+    for (const fabFileId of removals) {
+      try {
+        await removeFileFromDataLake(actor, dataLakeId, fabFileId, adapters);
+        removedHere.push(fabFileId);
+        removedFabFileIds.push(fabFileId);
+      } catch (err) {
+        // Per-member catch: a repair that abandons the rest of the plan on one failure leaves the
+        // lake in a state neither the owner nor the next plan can reason about. Recorded and
+        // reported instead, so a re-run finishes the job and the caller can say what did not happen.
+        failures.push({
+          fabFileId,
+          fileName: group.fileName,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        logger?.warn?.(
+          `[membershipRepair] lake ${dataLakeId}: removing ${fabFileId} from '${group.fileName}' failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+
+    if (removedHere.length > 0) groupsActedOn.push({ fileName: group.fileName, removedFabFileIds: removedHere });
+  }
+
+  return { removedFabFileIds, groupsActedOn, failures };
+}

--- a/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.ts
+++ b/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.ts
@@ -1,4 +1,9 @@
-import { membersRemovedByDecision, type MembershipRepairPlan, type PlannedRepairGroup } from '@bike4mind/common';
+import {
+  membersRemovedByDecision,
+  type MembershipRepairPlan,
+  type PlannedRepairGroup,
+  type RepairDecision,
+} from '@bike4mind/common';
 import { removeFileFromDataLake, type RemoveFileFromDataLakeAdapters } from './removeFileFromDataLake';
 import type { MembershipActor } from './lakeMembership';
 
@@ -10,21 +15,42 @@ import type { MembershipActor } from './lakeMembership';
  * whether to touch a customer's membership is readable and testable in the pure module, and this
  * one only has to be right about HOW.
  *
- * Removal is membership only - `removeFileFromDataLake` pulls the lake's tags off the FabFile. The
- * file, its chunks, and its membership of any other lake are untouched, which is what makes the
- * operation recoverable and is asserted rather than assumed (see the tests).
+ * Removal is membership only - `removeFileFromDataLake` pulls the lake's tags off the FabFile; the
+ * file and its chunks survive, which is what makes the operation recoverable. Two qualifications
+ * that door spells out and this one inherits in bulk: a second lake sharing this lake's
+ * fileTagPrefix loses the shared tag, and outright loses a member it held by prefix alone; and each
+ * removal also mints a 30-minute restore row and recomputes stats, which can activate a draft lake.
+ * The membership-only property is pinned at `removeFileFromLake`'s single `pullTagsByFabFileId`, not
+ * by the tests here - they mock the callee, so what they assert is delegation.
  *
- * NOT gated here. Like `recordMembershipDecision`, the manage gate and the convergence kill switch
- * live on the route - the same arrangement `converge` uses, where the service plans and the handler
- * decides whether it may run. A caller reaching this without those is unauthorized and nothing here
- * will say so.
+ * NOT gated here, the same split `converge` uses: the service plans and the handler decides whether
+ * it may run. In practice this is not an ungated door - every removal reaches `removeFileFromLake`'s
+ * `resolveCanManageLake`, so an unauthorized caller is refused on the first member and every one
+ * after - but a route leaning on that gets N failure entries instead of one refusal.
+ *
+ * Two controls a route must supply that do NOT exist yet, stated because the natural assumption is
+ * that they do. The convergence kill switch cannot halt this: `isConvergenceHalted` returns early
+ * unless the work is convergence-origin and resolves a pause flag over queued embedding work, and a
+ * repair enqueues nothing. And nothing caps the wave - the planner truncates nothing, and
+ * `maxGroups`/`maxGroupMembers` are optional payload caps on the health report, not safety caps on a
+ * repair. Compare `converge`, which carries a hard `MAX_CONVERGENCE_WAVE`.
  */
 
 /** What the caller asked to happen beyond the plan's automatic arm, keyed by file name. */
 export interface MembershipRepairDecisionInput {
   fileName: string;
-  decision: Parameters<typeof membersRemovedByDecision>[1];
+  decision: RepairDecision;
   keptFabFileId?: string | null;
+  /**
+   * `groupIdentity` of the group the owner actually reviewed, so a ruling cannot land on a group
+   * that moved underneath it. Optional for a caller with none to offer, but the exposure is real
+   * rather than theoretical: a decision whose identity still matches settles its group, and settled
+   * groups are never acted on here - so the groups a live decision CAN reach are the ones with no
+   * prior ruling plus exactly the ones whose membership changed since review. `keep-newest` is
+   * positional, so on those a copy that arrived after review silently becomes the survivor and the
+   * copy the owner elected to keep is the one removed.
+   */
+  groupIdentity?: string;
 }
 
 export interface MembershipRepairOutcome {
@@ -37,6 +63,12 @@ export interface MembershipRepairOutcome {
    * a half-applied repair the owner can re-run is recoverable; an abandoned one silently is not.
    */
   failures: { fabFileId: string; fileName: string; error: string }[];
+  /**
+   * Decisions withheld because the group moved since it was reviewed. Reported, not dropped: the
+   * owner has to be re-asked, and a silent skip is indistinguishable from a repair that found
+   * nothing to do.
+   */
+  staleDecisions: { fileName: string; reviewedGroupIdentity: string; currentGroupIdentity: string }[];
 }
 
 /**
@@ -45,14 +77,32 @@ export interface MembershipRepairOutcome {
  * The plan's own `removeFabFileIds` is the ONLY source for the automatic arm - it is empty on every
  * `decide` group by construction (see `planMembershipRepair`), so an executor that read it for every
  * group in the plan would still be correct. A supplied decision is what turns a `decide` group into
- * removals, and it is resolved against the group as the PLAN saw it, not re-derived: the plan is the
- * thing the owner reviewed.
+ * removals, and it is resolved against the group as the PLAN saw it, not re-derived.
+ *
+ * That the plan is the thing the owner reviewed is a PRECONDITION, and the route cannot honour it:
+ * nothing persists a `MembershipRepairPlan`, so a POST has to re-plan and hands over a plan computed
+ * at request time. `groupIdentity` on the decision is what carries the reviewed group across that
+ * gap; a mismatch withholds the ruling rather than applying it to a group the owner never saw. The
+ * automatic arm is unaffected - a `collapse` group's removals come from the plan, never a decision.
  */
-function removalsForGroup(group: PlannedRepairGroup, byFileName: Map<string, MembershipRepairDecisionInput>): string[] {
-  if (group.action === 'collapse') return group.removeFabFileIds;
+function removalsForGroup(
+  group: PlannedRepairGroup,
+  byFileName: Map<string, MembershipRepairDecisionInput>
+): { removals: string[]; stale?: MembershipRepairOutcome['staleDecisions'][number] } {
+  if (group.action === 'collapse') return { removals: group.removeFabFileIds };
   const decision = byFileName.get(group.fileName);
-  if (!decision) return [];
-  return membersRemovedByDecision(group, decision.decision, decision.keptFabFileId);
+  if (!decision) return { removals: [] };
+  if (decision.groupIdentity && decision.groupIdentity !== group.groupIdentity) {
+    return {
+      removals: [],
+      stale: {
+        fileName: group.fileName,
+        reviewedGroupIdentity: decision.groupIdentity,
+        currentGroupIdentity: group.groupIdentity,
+      },
+    };
+  }
+  return { removals: membersRemovedByDecision(group, decision.decision, decision.keptFabFileId) };
 }
 
 /**
@@ -80,12 +130,15 @@ export async function executeLakeMembershipRepair(
   const removedFabFileIds: string[] = [];
   const groupsActedOn: MembershipRepairOutcome['groupsActedOn'] = [];
   const failures: MembershipRepairOutcome['failures'] = [];
+  const staleDecisions: MembershipRepairOutcome['staleDecisions'] = [];
 
   // Sequential, not a fan-out: every removal recomputes the lake's stats and can activate a draft
   // lake, so concurrent removals would race each other's recompute and persist a count from a
-  // partial view. The wave is bounded by the plan's own caps, so there is nothing to gain.
+  // partial view. Nothing bounds the wave here - the plan carries no cap - so a large plan is slow
+  // by construction, and the route is where that has to be capped.
   for (const group of [...plan.collapsible, ...plan.needsDecision]) {
-    const removals = removalsForGroup(group, byFileName);
+    const { removals, stale } = removalsForGroup(group, byFileName);
+    if (stale) staleDecisions.push(stale);
     if (removals.length === 0) continue;
 
     const removedHere: string[] = [];
@@ -103,16 +156,14 @@ export async function executeLakeMembershipRepair(
           fileName: group.fileName,
           error: err instanceof Error ? err.message : String(err),
         });
-        logger?.warn?.(
-          `[membershipRepair] lake ${dataLakeId}: removing ${fabFileId} from '${group.fileName}' failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
+        // Ids as fields and a static message, matching the sibling: a duplicate group is keyed by a
+        // customer-uploaded file name, which is often identifying and does not belong in log text.
+        logger?.warn?.('[dataLakes] membership repair could not remove a member', { dataLakeId, fabFileId, err });
       }
     }
 
     if (removedHere.length > 0) groupsActedOn.push({ fileName: group.fileName, removedFabFileIds: removedHere });
   }
 
-  return { removedFabFileIds, groupsActedOn, failures };
+  return { removedFabFileIds, groupsActedOn, failures, staleDecisions };
 }

--- a/b4m-core/services/src/dataLakeService/index.ts
+++ b/b4m-core/services/src/dataLakeService/index.ts
@@ -49,6 +49,7 @@ export * from './chunkPolicyConflict';
 export * from './admissionContract';
 export * from './lakeAdmissionGate';
 export * from './recordMembershipDecision';
+export * from './executeLakeMembershipRepair';
 export * from './removeFileFromDataLake';
 export * from './addFileToDataLake';
 export * from './setDataLakeFileTags';

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -12,7 +12,7 @@ import type { LakeConfigAuditAdapters } from './recordLakeConfigChange';
 /** How long a removal's restore record stays live - see `lakeMembershipRemovals` below. */
 const REMOVAL_RECORD_TTL_MS = 30 * 60 * 1000;
 
-interface RemoveFileFromDataLakeAdapters extends LakeConfigAuditAdapters {
+export interface RemoveFileFromDataLakeAdapters extends LakeConfigAuditAdapters {
   // Matches the three sibling recompute callers (see archiveDataLake). The audit repos are declared
   // rather than merely spread at the route because the type is the only place the requirement is
   // visible at all: TS skips excess-property checks on SPREAD properties, so `...lakeConfigAuditDb`


### PR DESCRIPTION
Part of #2245 - the **executor only**. Same increment shape as #2279 (the planner only) and #2284 (persistence only), both merged.

## Description

`planMembershipRepair` decides what to propose and the decision store remembers what an owner ruled. This carries a plan out.

Split the way `converge` splits `planLakeConvergenceRun` from its execution - and **gated the same way: not here.** In that stack the manage gate and the convergence kill switch live on the route, and `recordMembershipDecision` already takes the same arrangement. The docblock says so explicitly rather than leaving a reader to infer it, because a caller reaching this without those gates is unauthorized and nothing here will say so.

## Changes

`executeLakeMembershipRepair(actor, dataLakeId, plan, decisions, adapters)` returns what it removed, per group, plus any failures.

**Removal is membership only.** `removeFileFromDataLake` pulls this lake's tags off the FabFile and nothing else, so the file, its chunks, and its membership of any other lake survive. That is the property making the operation recoverable, and #2245 asks for it asserted rather than assumed - the test asserts it as the executor's *only* mutation, rather than by listing what it does not touch.

**"POST with no decisions executes bucket A only" holds without this function remembering it.** A `decide` group carries an empty `removeFabFileIds` by construction, so reading the plan's own field for every group is already correct. A supplied decision is the only thing that turns such a group into removals, and it resolves against the group as the *plan* saw it rather than re-deriving - the plan is what the owner reviewed.

**Settled groups are never acted on**, even with a decision supplied for that file name. Their `outstandingRemovalFabFileIds` is a signal that recorded work was never carried out, not an instruction; acting on it would let a tombstone remove membership with no owner in the loop.

Two operational choices, both commented at the code:

- **Sequential, not a fan-out.** Every removal recomputes the lake's stats and can activate a draft lake, so concurrent removals would race each other's recompute and persist a count from a partial view. The wave is bounded by the plan's own caps, so fanning out buys nothing.
- **Per-member catch.** A repair that abandons the rest of the plan on one failure leaves the lake in a state neither the owner nor the next plan can reason about. Half-applied and re-runnable is recoverable, and the failures come back so a caller can say what did not happen.

`RemoveFileFromDataLakeAdapters` is exported so the two share one adapter shape instead of the executor restating it.

## Testing

- [x] `turbo typecheck:fast` 37/37, eslint clean
- [x] `dataLakeService` 1676 passed (10 new)
- [x] Mutation-checked - acting on settled groups, dropping the per-member catch, and fanning out concurrently each fail a test
- [ ] Reviewer check: the "membership only" assertion is the one I would most like a second opinion on - it holds because `removeFileFromDataLake` is the sole mutation, so it is only as strong as that remaining true

## Not in this change

The contract-first `GET`/`POST` endpoint with its `requiredScopes` and OpenAPI entry, and the UI. Those are the remaining #2245 acceptance criteria and want their own review - the endpoint would be the first data-lake API contract.
