### PR TITLE
feat(settings): a write surface for scoped setting overrides

### DIFF
--- a/apps/client/app/components/admin/AdminSettingInputField.test.tsx
+++ b/apps/client/app/components/admin/AdminSettingInputField.test.tsx
@@ -7,8 +7,14 @@ import { SENSITIVE_SETTING_MASK, settingsMap } from '@bike4mind/common';
 const mutate = vi.fn();
 // Read at render time, so a test can put the mutation into its rejected state.
 let updateError: unknown;
+// A factory mock replaces the whole module, so every hook the component tree imports from it has
+// to be listed here - ScopedSettingOverrides (rendered for any setting declaring `scope`) reaches
+// the three scoped-override hooks, and a missing one fails this file at import time.
 vi.mock('@client/app/hooks/data/settings', () => ({
   useUpdateSettings: () => ({ mutate, isPending: false, error: updateError }),
+  useScopedSettingOverrides: () => ({ data: [] }),
+  useSetScopedSettingOverride: () => ({ mutate: vi.fn(), isPending: false, error: undefined }),
+  useClearScopedSettingOverride: () => ({ mutate: vi.fn(), isPending: false, error: undefined }),
 }));
 
 import AdminSettingInputField from './AdminSettingInputField';

--- a/apps/client/app/components/admin/AdminSettingInputField.tsx
+++ b/apps/client/app/components/admin/AdminSettingInputField.tsx
@@ -27,6 +27,8 @@ import {
   Box,
 } from '@mui/joy';
 import { useState } from 'react';
+import ScopedSettingOverrides from './ScopedSettingOverrides';
+import { rangeMessage } from './settingFieldHelpers';
 
 interface SubSetting {
   setting: (typeof settingsMap)[keyof typeof settingsMap];
@@ -51,47 +53,40 @@ const SubSettingToggle = ({ setting, defaultValue }: SubSetting) => {
   const isDirty = value !== resolvedDefault;
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 0.75 }}>
-      <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography level="title-md" sx={{ fontSize: '13px' }}>
-          {setting.name}
-        </Typography>
-        <Typography level="body-xs" sx={{ color: 'text.secondary', mt: 0.25 }}>
-          {setting.description}
-        </Typography>
+    <Box sx={{ py: 0.75 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography level="title-md" sx={{ fontSize: '13px' }}>
+            {setting.name}
+          </Typography>
+          <Typography level="body-xs" sx={{ color: 'text.secondary', mt: 0.25 }}>
+            {setting.description}
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
+          <Switch checked={value} onChange={e => setValue(e.target.checked)} />
+          {isDirty && (
+            <Tooltip title="Save" placement="top">
+              <Button
+                color="success"
+                size="sm"
+                loading={updateSettings.isPending}
+                onClick={() => updateSettings.mutate({ key: setting.key, value })}
+              >
+                <SaveIcon sx={{ fontSize: '16px' }} />
+              </Button>
+            </Tooltip>
+          )}
+        </Box>
       </Box>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
-        <Switch checked={value} onChange={e => setValue(e.target.checked)} />
-        {isDirty && (
-          <Tooltip title="Save" placement="top">
-            <Button
-              color="success"
-              size="sm"
-              loading={updateSettings.isPending}
-              onClick={() => updateSettings.mutate({ key: setting.key, value })}
-            >
-              <SaveIcon sx={{ fontSize: '16px' }} />
-            </Button>
-          </Tooltip>
-        )}
-      </Box>
+
+      {/* A scope-capable setting can be an inline child rather than a card of its own (a boolean
+          whose dependsOn points into its own group - see AdminSettingsTab.renderSettingGroup), so
+          the override section has to render here as well or two of the nine scope-capable settings
+          would have no write surface at all. */}
+      {setting.scope && <ScopedSettingOverrides setting={setting} />}
     </Box>
   );
-};
-
-/**
- * Why the server would refuse this number, in the words the field shows. The setting's own
- * schema carries the same bounds (makeNumberSetting in @bike4mind/common), and the update
- * route parses with it directly, so an out-of-range value comes back as an untranslated
- * ZodError: without this the admin sees Save do nothing and is told nothing.
- */
-const rangeMessage = (value: number, min?: number, max?: number): string | undefined => {
-  const inRange = (min === undefined || value >= min) && (max === undefined || value <= max);
-  if (!Number.isNaN(value) && inRange) return undefined;
-  if (min !== undefined && max !== undefined) return `Enter a number between ${min} and ${max}.`;
-  if (min !== undefined) return `Enter a number of ${min} or more.`;
-  if (max !== undefined) return `Enter a number of ${max} or less.`;
-  return 'Enter a number.';
 };
 
 const AdminSettingInputField = ({
@@ -298,6 +293,14 @@ const AdminSettingInputField = ({
                 />
               ))}
             </Stack>
+          </>
+        )}
+
+        {/* Only a setting that opts into scoping gets a write surface for the narrower rungs. */}
+        {setting.scope && (
+          <>
+            <Divider sx={{ my: 1 }} />
+            <ScopedSettingOverrides setting={setting} />
           </>
         )}
       </Card>

--- a/apps/client/app/components/admin/AdminSettingsTab.tsx
+++ b/apps/client/app/components/admin/AdminSettingsTab.tsx
@@ -26,6 +26,7 @@ import {
 import React, { useCallback, useMemo, useState } from 'react';
 import AdminSettingInputField from './AdminSettingInputField';
 import { AdminOperationsModelSetting } from './AdminOperationsModelSetting';
+import { ScopedOverridesByScope } from './ScopedOverridesByScope';
 
 import AdminLogoUpload from './AdminLogoUpload';
 import { McpServerName } from '@bike4mind/common';
@@ -559,6 +560,11 @@ const AdminSettingsTab: React.FC = () => {
 
         {/* Operations Model component for the AI category */}
         {category === 'AI' && <AdminOperationsModelSetting />}
+
+        {/* The by-scope read of the override overlay. Category-scoped rather than group-scoped:
+            seven of the nine scope-capable settings are AI, and the panel lists all nine wherever
+            it renders. */}
+        {category === 'AI' && <ScopedOverridesByScope />}
 
         {/* Logo Upload for the Branding category - shown when there's no
             search or the search matches the logoSettings definition */}

--- a/apps/client/app/components/admin/ScopedOverridesByScope.test.tsx
+++ b/apps/client/app/components/admin/ScopedOverridesByScope.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { settingsMap, type IAdminSettings, type IScopedSetting } from '@bike4mind/common';
+
+const clearMutate = vi.fn();
+// Read at render time so a test can stage the inventory and the platform values.
+let overrides: IScopedSetting[] = [];
+let platformSettings: IAdminSettings[] = [];
+
+vi.mock('@client/app/hooks/data/settings', () => ({
+  useScopedSettingOverrides: () => ({ data: overrides }),
+  useSettingsFromServer: () => ({ data: platformSettings }),
+  useClearScopedSettingOverride: () => ({ mutate: clearMutate, isPending: false, error: undefined }),
+}));
+
+import { ScopedOverridesByScope } from './ScopedOverridesByScope';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const renderPanel = () =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <ScopedOverridesByScope />
+    </CssVarsProvider>
+  );
+
+const scopeCapableKeys = Object.values(settingsMap)
+  .filter(s => s.scope)
+  .map(s => s.key);
+
+const enterAddress = (id: string) =>
+  fireEvent.change(screen.getByTestId('scoped-overrides-by-scope-id-input'), { target: { value: id } });
+
+describe('ScopedOverridesByScope', () => {
+  beforeEach(() => {
+    overrides = [];
+    platformSettings = [];
+    vi.clearAllMocks();
+  });
+
+  it('asks for a scope id before reporting anything', () => {
+    renderPanel();
+    expect(screen.getByTestId('scoped-overrides-by-scope-prompt')).toBeInTheDocument();
+    expect(screen.queryByTestId(`scoped-overrides-by-scope-row-${scopeCapableKeys[0]}`)).not.toBeInTheDocument();
+  });
+
+  it('lists every scope-capable setting for the address, and only those', () => {
+    renderPanel();
+    enterAddress('org-1');
+
+    // Nine today; asserted against the derived set so a setting opting into scoping later is
+    // covered without editing this test.
+    expect(scopeCapableKeys.length).toBeGreaterThan(0);
+    for (const key of scopeCapableKeys) {
+      expect(screen.getByTestId(`scoped-overrides-by-scope-row-${key}`)).toBeInTheDocument();
+    }
+    // A platform-only setting is not part of this view.
+    expect(screen.queryByTestId('scoped-overrides-by-scope-row-DefaultAPIModel')).not.toBeInTheDocument();
+  });
+
+  it('splits the list into overridden here, no override at this rung, and not settable here', () => {
+    overrides = [
+      {
+        settingName: 'kbSearchDefaultResults',
+        scopeLevel: 'organization',
+        scopeId: 'org-1',
+        settingValue: '7',
+      } as IScopedSetting,
+      // Same setting, a different address - must not be read as this scope's override.
+      {
+        settingName: 'kbSearchMinRelevancePct',
+        scopeLevel: 'organization',
+        scopeId: 'org-2',
+        settingValue: '40',
+      } as IScopedSetting,
+    ];
+    platformSettings = [{ settingName: 'kbSearchMinRelevancePct', settingValue: '10' } as IAdminSettings];
+    renderPanel();
+    enterAddress('org-1');
+
+    expect(screen.getByTestId('scoped-overrides-by-scope-row-kbSearchDefaultResults')).toHaveTextContent(
+      'overridden here: 7'
+    );
+    expect(screen.getByTestId('scoped-overrides-by-scope-row-kbSearchMinRelevancePct')).toHaveTextContent(
+      'no override at this rung (platform: 10)'
+    );
+    // No stored platform row: the setting's own default is the platform value.
+    expect(screen.getByTestId('scoped-overrides-by-scope-row-dataLakeSearchMaxFiles')).toHaveTextContent(
+      `no override at this rung (platform: ${String(settingsMap.dataLakeSearchMaxFiles.defaultValue)})`
+    );
+  });
+
+  // DefaultChunkSize is settableAt organization/owner only, so at the lake rung an override can
+  // never exist there - saying "no override" would read as if one could be set.
+  it('names a rung the setting cannot be set at, rather than calling it un-overridden', () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId('scoped-overrides-by-scope-level-select'));
+    fireEvent.click(screen.getByTestId('scoped-overrides-by-scope-level-option-lake'));
+    enterAddress('lake-1');
+
+    expect(screen.getByTestId('scoped-overrides-by-scope-row-DefaultChunkSize')).toHaveTextContent(
+      'not settable at this rung'
+    );
+    expect(screen.getByTestId('scoped-overrides-by-scope-row-PauseLakeConvergence')).toHaveTextContent(
+      'no override at this rung'
+    );
+  });
+
+  it('clears the override at the address it is listed under', () => {
+    overrides = [
+      {
+        settingName: 'PauseLakeConvergence',
+        scopeLevel: 'lake',
+        scopeId: 'lake-1',
+        settingValue: 'true',
+      } as IScopedSetting,
+    ];
+    renderPanel();
+    fireEvent.click(screen.getByTestId('scoped-overrides-by-scope-level-select'));
+    fireEvent.click(screen.getByTestId('scoped-overrides-by-scope-level-option-lake'));
+    enterAddress('lake-1');
+
+    // Only the overridden row offers a Clear.
+    expect(screen.queryByTestId('scoped-overrides-by-scope-clear-btn-DefaultChunkSize')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('scoped-overrides-by-scope-clear-btn-PauseLakeConvergence'));
+    expect(clearMutate).toHaveBeenCalledWith({
+      settingName: 'PauseLakeConvergence',
+      scopeLevel: 'lake',
+      scopeId: 'lake-1',
+    });
+  });
+
+  it('discloses the propagation delay', () => {
+    renderPanel();
+    expect(screen.getByTestId('scoped-overrides-by-scope')).toHaveTextContent(
+      'within ~5 min (one cache TTL) everywhere else'
+    );
+  });
+});

--- a/apps/client/app/components/admin/ScopedOverridesByScope.tsx
+++ b/apps/client/app/components/admin/ScopedOverridesByScope.tsx
@@ -1,0 +1,147 @@
+import { settingsMap, SettingScopeLevel } from '@bike4mind/common';
+import {
+  useClearScopedSettingOverride,
+  useScopedSettingOverrides,
+  useSettingsFromServer,
+} from '@client/app/hooks/data/settings';
+import { getErrorMessage } from '@client/app/utils/error';
+import TuneIcon from '@mui/icons-material/Tune';
+import { Alert, Box, Button, Card, FormControl, FormLabel, Input, Option, Select, Stack, Typography } from '@mui/joy';
+import { useMemo, useState } from 'react';
+import { displayValue, LEVEL_LABELS, OVERRIDE_STALENESS_NOTE, type OverrideLevel } from './ScopedSettingOverrides';
+
+const ALL_LEVELS: OverrideLevel[] = [SettingScopeLevel.Organization, SettingScopeLevel.Owner, SettingScopeLevel.Lake];
+
+/**
+ * The inverse view of the per-setting sections: given one scope address, which scope-capable
+ * settings carry an override THERE and which do not.
+ *
+ * Deliberately reports what is set AT the named rung, not the value a consumer would resolve. A
+ * consumer builds the whole scope chain (for a lake, `scopeForLake` pulls in its org and owner
+ * rungs), so a lake with no lake-rung row can still be overridden at its org - which is why the
+ * no-override case is worded as "no override at this rung" and the platform value is labelled as
+ * the platform value rather than as the effective one. A true effective-value read needs a resolve
+ * endpoint and is not part of this view.
+ */
+export function ScopedOverridesByScope() {
+  const { data: allOverrides } = useScopedSettingOverrides();
+  const { data: platformSettings } = useSettingsFromServer();
+  const clearOverride = useClearScopedSettingOverride();
+
+  const [level, setLevel] = useState<OverrideLevel>(SettingScopeLevel.Organization);
+  const [scopeId, setScopeId] = useState('');
+
+  // `scope` is an opt-in field on every setting, so the scope-capable set is derived rather than
+  // listed - a setting that opts in later appears here with no change needed.
+  const scopeCapableSettings = useMemo(
+    () =>
+      Object.values(settingsMap)
+        .filter(s => s.scope)
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    []
+  );
+
+  const address = scopeId.trim();
+  const clearError = clearOverride.error ? getErrorMessage(clearOverride.error) : undefined;
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2 }} data-testid="scoped-overrides-by-scope">
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <TuneIcon />
+        <Typography level="title-lg">Overrides by scope</Typography>
+      </Stack>
+      <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+        What one organization, owner or lake has set for itself. {OVERRIDE_STALENESS_NOTE}
+      </Typography>
+
+      <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1, flexWrap: 'wrap' }}>
+        <FormControl size="sm">
+          <FormLabel>Scope</FormLabel>
+          <Select
+            value={level}
+            onChange={(_e, next) => next && setLevel(next)}
+            slotProps={{ button: { 'data-testid': 'scoped-overrides-by-scope-level-select' } }}
+            sx={{ minWidth: 140 }}
+          >
+            {ALL_LEVELS.map(option => (
+              <Option key={option} value={option} data-testid={`scoped-overrides-by-scope-level-option-${option}`}>
+                {LEVEL_LABELS[option]}
+              </Option>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="sm">
+          <FormLabel>Scope id</FormLabel>
+          <Input
+            slotProps={{ input: { 'data-testid': 'scoped-overrides-by-scope-id-input' } }}
+            value={scopeId}
+            onChange={e => setScopeId(e.target.value)}
+            placeholder="id"
+            sx={{ minWidth: 240 }}
+          />
+        </FormControl>
+      </Box>
+
+      {clearError && (
+        <Alert color="danger" variant="soft" data-testid="scoped-overrides-by-scope-error">
+          {clearError}
+        </Alert>
+      )}
+
+      {!address ? (
+        <Typography level="body-sm" sx={{ color: 'text.secondary' }} data-testid="scoped-overrides-by-scope-prompt">
+          Enter a scope id to see what it overrides.
+        </Typography>
+      ) : (
+        <Stack spacing={0.5}>
+          {scopeCapableSettings.map(setting => {
+            const override = (allOverrides ?? []).find(
+              row => row.settingName === setting.key && row.scopeLevel === level && row.scopeId === address
+            );
+            const isSettableHere = setting.scope?.settableAt.includes(level) === true;
+            const platformValue =
+              platformSettings?.find(stored => stored.settingName === setting.key)?.settingValue ??
+              setting.defaultValue;
+
+            return (
+              <Box
+                key={setting.key}
+                data-testid={`scoped-overrides-by-scope-row-${setting.key}`}
+                sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}
+              >
+                <Typography level="body-sm" sx={{ flex: 1, minWidth: 0 }}>
+                  <strong>{setting.name}</strong>
+                  {' - '}
+                  {override
+                    ? `overridden here: ${displayValue(setting, override.settingValue)}`
+                    : isSettableHere
+                      ? `no override at this rung (platform: ${displayValue(setting, String(platformValue))})`
+                      : 'not settable at this rung'}
+                </Typography>
+                {override && (
+                  <Button
+                    data-testid={`scoped-overrides-by-scope-clear-btn-${setting.key}`}
+                    size="sm"
+                    variant="soft"
+                    color="danger"
+                    loading={clearOverride.isPending}
+                    onClick={() =>
+                      clearOverride.mutate({
+                        settingName: override.settingName,
+                        scopeLevel: override.scopeLevel,
+                        scopeId: override.scopeId,
+                      })
+                    }
+                  >
+                    Clear
+                  </Button>
+                )}
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
+    </Card>
+  );
+}

--- a/apps/client/app/components/admin/ScopedSettingOverrides.test.tsx
+++ b/apps/client/app/components/admin/ScopedSettingOverrides.test.tsx
@@ -6,12 +6,14 @@ import { settingsMap, type IScopedSetting } from '@bike4mind/common';
 
 const setMutate = vi.fn();
 const clearMutate = vi.fn();
-// Read at render time so a test can stage the inventory the section renders from.
+// Read at render time so a test can stage the inventory the section renders from, or put a
+// mutation into its rejected state.
 let overrides: IScopedSetting[] = [];
+let setError: unknown;
 
 vi.mock('@client/app/hooks/data/settings', () => ({
   useScopedSettingOverrides: () => ({ data: overrides }),
-  useSetScopedSettingOverride: () => ({ mutate: setMutate, isPending: false, error: undefined }),
+  useSetScopedSettingOverride: () => ({ mutate: setMutate, isPending: false, error: setError }),
   useClearScopedSettingOverride: () => ({ mutate: clearMutate, isPending: false, error: undefined }),
 }));
 
@@ -50,6 +52,7 @@ const chooseOption = (selectTestId: string, optionTestId: string) => {
 describe('ScopedSettingOverrides level options', () => {
   beforeEach(() => {
     overrides = [];
+    setError = undefined;
     vi.clearAllMocks();
   });
 
@@ -76,6 +79,7 @@ describe('ScopedSettingOverrides level options', () => {
 describe('ScopedSettingOverrides owner type', () => {
   beforeEach(() => {
     overrides = [];
+    setError = undefined;
     vi.clearAllMocks();
   });
 
@@ -128,6 +132,7 @@ describe('ScopedSettingOverrides owner type', () => {
 describe('ScopedSettingOverrides number values', () => {
   beforeEach(() => {
     overrides = [];
+    setError = undefined;
     vi.clearAllMocks();
   });
 
@@ -191,6 +196,7 @@ describe('ScopedSettingOverrides number values', () => {
 describe('ScopedSettingOverrides existing rows', () => {
   beforeEach(() => {
     overrides = [];
+    setError = undefined;
     vi.clearAllMocks();
   });
 
@@ -226,6 +232,17 @@ describe('ScopedSettingOverrides existing rows', () => {
     expect(screen.getByTestId('scoped-override-PauseLakeConvergence-empty')).toBeInTheDocument();
     expect(screen.getByTestId('scoped-override-PauseLakeConvergence-helper')).toHaveTextContent(
       'within ~5 min (one cache TTL) everywhere else'
+    );
+  });
+
+  // A refused write is otherwise silent - the button just stops spinning. The server's message is
+  // the only thing that names which rule was broken (the route preserves the service's wording).
+  it('surfaces a refused write', () => {
+    setError = new Error("[scopedSettings] 'PauseLakeConvergence' is not settable at scope level 'owner'");
+    renderSection(settingsMap.PauseLakeConvergence);
+
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-error')).toHaveTextContent(
+      'is not settable at scope level'
     );
   });
 });

--- a/apps/client/app/components/admin/ScopedSettingOverrides.test.tsx
+++ b/apps/client/app/components/admin/ScopedSettingOverrides.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { settingsMap, type IScopedSetting } from '@bike4mind/common';
+
+const setMutate = vi.fn();
+const clearMutate = vi.fn();
+// Read at render time so a test can stage the inventory the section renders from.
+let overrides: IScopedSetting[] = [];
+
+vi.mock('@client/app/hooks/data/settings', () => ({
+  useScopedSettingOverrides: () => ({ data: overrides }),
+  useSetScopedSettingOverride: () => ({ mutate: setMutate, isPending: false, error: undefined }),
+  useClearScopedSettingOverride: () => ({ mutate: clearMutate, isPending: false, error: undefined }),
+}));
+
+import ScopedSettingOverrides from './ScopedSettingOverrides';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+// PauseLakeConvergence is boolean and settable at all three rungs; kbSearchDefaultResults is a
+// bounded number settable at organization/owner only. Between them they cover every branch of the
+// value control and of the level options.
+const renderSection = (setting: (typeof settingsMap)[keyof typeof settingsMap]) =>
+  render(
+    <TestWrapper>
+      <ScopedSettingOverrides setting={setting} />
+    </TestWrapper>
+  );
+
+const row = (over: Partial<IScopedSetting>): IScopedSetting =>
+  ({
+    settingName: 'PauseLakeConvergence',
+    scopeLevel: 'lake',
+    scopeId: 'lake-1',
+    settingValue: 'true',
+    ...over,
+  }) as IScopedSetting;
+
+/** Open a Joy Select and pick one of its options by testid. */
+const chooseOption = (selectTestId: string, optionTestId: string) => {
+  fireEvent.click(screen.getByTestId(selectTestId));
+  fireEvent.click(screen.getByTestId(optionTestId));
+};
+
+describe('ScopedSettingOverrides level options', () => {
+  beforeEach(() => {
+    overrides = [];
+    vi.clearAllMocks();
+  });
+
+  it('offers exactly the rungs the setting is settableAt', () => {
+    renderSection(settingsMap.PauseLakeConvergence);
+    fireEvent.click(screen.getByTestId('scoped-override-PauseLakeConvergence-level-select'));
+
+    expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual(['Organization', 'Owner', 'Lake']);
+  });
+
+  it('omits the lake rung for a setting that is not settable there', () => {
+    renderSection(settingsMap.kbSearchDefaultResults);
+    fireEvent.click(screen.getByTestId('scoped-override-kbSearchDefaultResults-level-select'));
+
+    expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual(['Organization', 'Owner']);
+  });
+
+  it('renders nothing for a setting that does not opt into scoping', () => {
+    renderSection(settingsMap.DefaultAPIModel);
+    expect(screen.queryByTestId('scoped-override-DefaultAPIModel-header')).not.toBeInTheDocument();
+  });
+});
+
+describe('ScopedSettingOverrides owner type', () => {
+  beforeEach(() => {
+    overrides = [];
+    vi.clearAllMocks();
+  });
+
+  it('asks for an owner type only at the owner rung, and sends it only there', () => {
+    renderSection(settingsMap.PauseLakeConvergence);
+    // Lake is not the initial selection, so the absence below is not vacuous.
+    expect(screen.queryByTestId('scoped-override-PauseLakeConvergence-owner-type-select')).not.toBeInTheDocument();
+
+    chooseOption(
+      'scoped-override-PauseLakeConvergence-level-select',
+      'scoped-override-PauseLakeConvergence-level-option-owner'
+    );
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-owner-type-select')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('scoped-override-PauseLakeConvergence-scope-id-input'), {
+      target: { value: 'user-1' },
+    });
+    fireEvent.click(screen.getByTestId('scoped-override-PauseLakeConvergence-value-switch'));
+    fireEvent.click(screen.getByTestId('scoped-override-PauseLakeConvergence-set-btn'));
+
+    expect(setMutate).toHaveBeenCalledWith({
+      settingName: 'PauseLakeConvergence',
+      scopeLevel: 'owner',
+      scopeId: 'user-1',
+      ownerType: 'User',
+      value: true,
+    });
+  });
+
+  it('leaves ownerType off a lake-rung write - the service refuses it anywhere but owner', () => {
+    renderSection(settingsMap.PauseLakeConvergence);
+    chooseOption(
+      'scoped-override-PauseLakeConvergence-level-select',
+      'scoped-override-PauseLakeConvergence-level-option-lake'
+    );
+    fireEvent.change(screen.getByTestId('scoped-override-PauseLakeConvergence-scope-id-input'), {
+      target: { value: 'lake-9' },
+    });
+    fireEvent.click(screen.getByTestId('scoped-override-PauseLakeConvergence-set-btn'));
+
+    expect(setMutate).toHaveBeenCalledWith({
+      settingName: 'PauseLakeConvergence',
+      scopeLevel: 'lake',
+      scopeId: 'lake-9',
+      value: false,
+    });
+  });
+});
+
+describe('ScopedSettingOverrides number values', () => {
+  beforeEach(() => {
+    overrides = [];
+    vi.clearAllMocks();
+  });
+
+  it('sends a number, not a string, once the field holds a value in range', () => {
+    renderSection(settingsMap.kbSearchDefaultResults);
+    fireEvent.change(screen.getByTestId('scoped-override-kbSearchDefaultResults-scope-id-input'), {
+      target: { value: 'org-1' },
+    });
+    fireEvent.change(screen.getByTestId('scoped-override-kbSearchDefaultResults-value-input'), {
+      target: { value: '7' },
+    });
+    fireEvent.click(screen.getByTestId('scoped-override-kbSearchDefaultResults-set-btn'));
+
+    expect(setMutate).toHaveBeenCalledWith({
+      settingName: 'kbSearchDefaultResults',
+      scopeLevel: 'organization',
+      scopeId: 'org-1',
+      value: 7,
+    });
+  });
+
+  it('blocks Set on an out-of-range number and says why', () => {
+    renderSection(settingsMap.kbSearchDefaultResults);
+    fireEvent.change(screen.getByTestId('scoped-override-kbSearchDefaultResults-scope-id-input'), {
+      target: { value: 'org-1' },
+    });
+    fireEvent.change(screen.getByTestId('scoped-override-kbSearchDefaultResults-value-input'), {
+      target: { value: '500' },
+    });
+
+    expect(screen.getByTestId('scoped-override-kbSearchDefaultResults-set-btn')).toBeDisabled();
+    expect(screen.getByTestId('scoped-override-kbSearchDefaultResults-helper')).toHaveTextContent(
+      'Enter a number between 1 and 10.'
+    );
+
+    fireEvent.click(screen.getByTestId('scoped-override-kbSearchDefaultResults-set-btn'));
+    expect(setMutate).not.toHaveBeenCalled();
+  });
+
+  // Number('') is 0, which kbSearchResultTokenBudget (min: 0) would accept as a real zero.
+  it('blocks Set while the number field is empty', () => {
+    renderSection(settingsMap.kbSearchResultTokenBudget);
+    fireEvent.change(screen.getByTestId('scoped-override-kbSearchResultTokenBudget-scope-id-input'), {
+      target: { value: 'org-1' },
+    });
+
+    expect(screen.getByTestId('scoped-override-kbSearchResultTokenBudget-set-btn')).toBeDisabled();
+  });
+
+  it('blocks Set until a scope id is entered', () => {
+    renderSection(settingsMap.PauseLakeConvergence);
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-set-btn')).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('scoped-override-PauseLakeConvergence-scope-id-input'), {
+      target: { value: '  ' },
+    });
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-set-btn')).toBeDisabled();
+  });
+});
+
+describe('ScopedSettingOverrides existing rows', () => {
+  beforeEach(() => {
+    overrides = [];
+    vi.clearAllMocks();
+  });
+
+  it('lists only this setting overrides, with the stored value and a working Clear', () => {
+    overrides = [
+      row({ scopeLevel: 'lake', scopeId: 'lake-1', settingValue: 'true' }),
+      row({ scopeLevel: 'owner', scopeId: 'user-2', ownerType: 'User', settingValue: 'false' }),
+      row({ settingName: 'kbSearchDefaultResults', scopeLevel: 'organization', scopeId: 'org-3', settingValue: '7' }),
+    ];
+    renderSection(settingsMap.PauseLakeConvergence);
+
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-header')).toHaveTextContent('Scoped overrides (2)');
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-row-lake-lake-1')).toHaveTextContent(
+      'Lake lake-1 = On'
+    );
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-row-owner-user-2')).toHaveTextContent(
+      'Owner user-2 (User) = Off'
+    );
+    // The kbSearchDefaultResults row belongs to another setting section.
+    expect(screen.queryByTestId('scoped-override-PauseLakeConvergence-row-organization-org-3')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('scoped-override-PauseLakeConvergence-clear-btn-lake-lake-1'));
+    expect(clearMutate).toHaveBeenCalledWith({
+      settingName: 'PauseLakeConvergence',
+      scopeLevel: 'lake',
+      scopeId: 'lake-1',
+    });
+  });
+
+  it('says so when nothing is overridden, and discloses the propagation delay', () => {
+    renderSection(settingsMap.PauseLakeConvergence);
+
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('scoped-override-PauseLakeConvergence-helper')).toHaveTextContent(
+      'within ~5 min (one cache TTL) everywhere else'
+    );
+  });
+});

--- a/apps/client/app/components/admin/ScopedSettingOverrides.tsx
+++ b/apps/client/app/components/admin/ScopedSettingOverrides.tsx
@@ -1,0 +1,262 @@
+import { CreditHolderType, SettingOwnerType, SettingScopeLevel, settingsMap } from '@bike4mind/common';
+import {
+  useClearScopedSettingOverride,
+  useScopedSettingOverrides,
+  useSetScopedSettingOverride,
+} from '@client/app/hooks/data/settings';
+import { getErrorMessage } from '@client/app/utils/error';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Option,
+  Select,
+  Stack,
+  Switch,
+  Typography,
+} from '@mui/joy';
+import { useState } from 'react';
+import { rangeMessage } from './settingFieldHelpers';
+
+export type AdminSetting = (typeof settingsMap)[keyof typeof settingsMap];
+
+/** The override altitudes. `platform` is the base value and is written by PUT /api/settings/update. */
+export type OverrideLevel = Exclude<SettingScopeLevel, SettingScopeLevel.Platform>;
+
+export const LEVEL_LABELS: Record<OverrideLevel, string> = {
+  [SettingScopeLevel.Organization]: 'Organization',
+  [SettingScopeLevel.Owner]: 'Owner',
+  [SettingScopeLevel.Lake]: 'Lake',
+};
+
+/**
+ * The propagation bound an operator will otherwise read as a broken lever. Wording follows
+ * EnforceLakeAdmission's own description, which is where it is already documented.
+ */
+export const OVERRIDE_STALENESS_NOTE =
+  'A change applies immediately on the instance that served it and within ~5 min (one cache TTL) everywhere else.';
+
+/** Booleans are stored as 'true'/'false'; show the operator the switch position, not the string. */
+const displayValue = (setting: AdminSetting, storedValue: string): string =>
+  setting.type === 'boolean' ? (storedValue === 'true' ? 'On' : 'Off') : storedValue;
+
+/**
+ * The org/owner/lake overrides of ONE setting, with the controls to add, change and clear them.
+ * Rendered only for a setting that declares `scope`, so a platform-only setting's card is untouched.
+ *
+ * Scope ids are entered raw - there is no org/user/lake picker in this pass.
+ */
+const ScopedSettingOverrides = ({ setting }: { setting: AdminSetting }) => {
+  const settableAt = setting.scope?.settableAt;
+  const { data: allOverrides } = useScopedSettingOverrides();
+  const setOverride = useSetScopedSettingOverride();
+  const clearOverride = useClearScopedSettingOverride();
+
+  const [level, setLevel] = useState<OverrideLevel>(settableAt?.[0] ?? SettingScopeLevel.Organization);
+  const [scopeId, setScopeId] = useState('');
+  const [ownerType, setOwnerType] = useState<SettingOwnerType>(CreditHolderType.User);
+  const [value, setValue] = useState<string | boolean>(setting.type === 'boolean' ? false : '');
+
+  if (!settableAt) return null;
+
+  const rows = (allOverrides ?? []).filter(row => row.settingName === setting.key);
+
+  // Only number settings declare bounds, and only some of those, so they are read through the
+  // type discriminant rather than off the union - same as the platform field above.
+  const bounds: { min?: number; max?: number } = setting.type === 'number' ? setting : {};
+  const valueError =
+    setting.type !== 'number'
+      ? undefined
+      : // Number('') is 0, which a `min: 0` setting would accept as a genuine zero, so an emptied
+        // field is refused here rather than silently stored.
+        String(value).trim() === ''
+        ? 'Enter a number.'
+        : rangeMessage(Number(value), bounds.min, bounds.max);
+
+  const canSet = Boolean(scopeId.trim()) && !valueError;
+  // A rejected write is otherwise silent: the button just stops spinning.
+  const writeError = setOverride.error ? getErrorMessage(setOverride.error) : undefined;
+  const clearError = clearOverride.error ? getErrorMessage(clearOverride.error) : undefined;
+
+  const handleSet = () => {
+    if (!canSet) return;
+    setOverride.mutate({
+      settingName: setting.key,
+      scopeLevel: level,
+      scopeId: scopeId.trim(),
+      // ownerType is attribution, required at the owner rung and refused at every other one.
+      ...(level === SettingScopeLevel.Owner ? { ownerType } : {}),
+      value: setting.type === 'boolean' ? Boolean(value) : setting.type === 'number' ? Number(value) : String(value),
+    });
+  };
+
+  return (
+    <Stack spacing={1} sx={{ mt: 1 }}>
+      <Typography level="title-sm" data-testid={`scoped-override-${setting.key}-header`}>
+        Scoped overrides ({rows.length})
+      </Typography>
+
+      {rows.length === 0 ? (
+        <Typography
+          level="body-xs"
+          sx={{ color: 'text.secondary' }}
+          data-testid={`scoped-override-${setting.key}-empty`}
+        >
+          No overrides - every scope uses the platform value above.
+        </Typography>
+      ) : (
+        <Stack spacing={0.5}>
+          {rows.map(row => (
+            <Box
+              key={`${row.scopeLevel}-${row.scopeId}`}
+              data-testid={`scoped-override-${setting.key}-row-${row.scopeLevel}-${row.scopeId}`}
+              sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}
+            >
+              <Typography level="body-sm" sx={{ flex: 1, minWidth: 0 }}>
+                <strong>{LEVEL_LABELS[row.scopeLevel]}</strong> {row.scopeId}
+                {row.ownerType ? ` (${row.ownerType})` : ''} = {displayValue(setting, row.settingValue)}
+              </Typography>
+              <Button
+                data-testid={`scoped-override-${setting.key}-clear-btn-${row.scopeLevel}-${row.scopeId}`}
+                size="sm"
+                variant="soft"
+                color="danger"
+                loading={clearOverride.isPending}
+                onClick={() =>
+                  clearOverride.mutate({
+                    settingName: row.settingName,
+                    scopeLevel: row.scopeLevel,
+                    scopeId: row.scopeId,
+                  })
+                }
+              >
+                Clear
+              </Button>
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1, flexWrap: 'wrap' }}>
+        <FormControl size="sm">
+          <FormLabel>Scope</FormLabel>
+          <Select
+            value={level}
+            onChange={(_e, next) => next && setLevel(next)}
+            slotProps={{ button: { 'data-testid': `scoped-override-${setting.key}-level-select` } }}
+            sx={{ minWidth: 140 }}
+          >
+            {settableAt.map(option => (
+              <Option key={option} value={option} data-testid={`scoped-override-${setting.key}-level-option-${option}`}>
+                {LEVEL_LABELS[option]}
+              </Option>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="sm">
+          <FormLabel>Scope id</FormLabel>
+          <Input
+            slotProps={{ input: { 'data-testid': `scoped-override-${setting.key}-scope-id-input` } }}
+            value={scopeId}
+            onChange={e => setScopeId(e.target.value)}
+            placeholder="id"
+            sx={{ minWidth: 200 }}
+          />
+        </FormControl>
+
+        {level === SettingScopeLevel.Owner && (
+          <FormControl size="sm">
+            <FormLabel>Owner type</FormLabel>
+            <Select
+              value={ownerType}
+              onChange={(_e, next) => next && setOwnerType(next)}
+              slotProps={{ button: { 'data-testid': `scoped-override-${setting.key}-owner-type-select` } }}
+              sx={{ minWidth: 140 }}
+            >
+              {[CreditHolderType.User, CreditHolderType.Organization].map(option => (
+                <Option
+                  key={option}
+                  value={option}
+                  data-testid={`scoped-override-${setting.key}-owner-type-option-${option}`}
+                >
+                  {option}
+                </Option>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+
+        <FormControl size="sm" error={Boolean(valueError)}>
+          <FormLabel>Value</FormLabel>
+          {setting.type === 'boolean' ? (
+            <Switch
+              sx={{ alignSelf: 'center', py: 1 }}
+              slotProps={{ input: { 'data-testid': `scoped-override-${setting.key}-value-switch` } }}
+              checked={value === true}
+              onChange={e => setValue(e.target.checked)}
+            />
+          ) : setting.type === 'number' ? (
+            <Input
+              slotProps={{
+                input: {
+                  'data-testid': `scoped-override-${setting.key}-value-input`,
+                  min: bounds.min,
+                  max: bounds.max,
+                },
+              }}
+              type="number"
+              value={String(value)}
+              onChange={e => setValue(e.target.value)}
+              sx={{ minWidth: 140 }}
+            />
+          ) : setting.type === 'string' && setting.options ? (
+            <Select
+              value={String(value) || null}
+              onChange={(_e, next) => setValue(next ?? '')}
+              slotProps={{ button: { 'data-testid': `scoped-override-${setting.key}-value-select` } }}
+              sx={{ minWidth: 200 }}
+            >
+              {Array.from(new Set(setting.options)).map(option => (
+                <Option
+                  key={option}
+                  value={option}
+                  data-testid={`scoped-override-${setting.key}-value-option-${option}`}
+                >
+                  {option}
+                </Option>
+              ))}
+            </Select>
+          ) : (
+            <Input
+              slotProps={{ input: { 'data-testid': `scoped-override-${setting.key}-value-input` } }}
+              value={String(value)}
+              onChange={e => setValue(e.target.value)}
+              sx={{ minWidth: 200 }}
+            />
+          )}
+        </FormControl>
+
+        <Button
+          data-testid={`scoped-override-${setting.key}-set-btn`}
+          size="sm"
+          color="primary"
+          loading={setOverride.isPending}
+          disabled={!canSet}
+          onClick={handleSet}
+        >
+          Set
+        </Button>
+      </Box>
+
+      <FormHelperText data-testid={`scoped-override-${setting.key}-helper`}>
+        {valueError ?? writeError ?? clearError ?? `Overrides this setting for one scope. ${OVERRIDE_STALENESS_NOTE}`}
+      </FormHelperText>
+    </Stack>
+  );
+};
+
+export default ScopedSettingOverrides;

--- a/apps/client/app/components/admin/ScopedSettingOverrides.tsx
+++ b/apps/client/app/components/admin/ScopedSettingOverrides.tsx
@@ -6,6 +6,7 @@ import {
 } from '@client/app/hooks/data/settings';
 import { getErrorMessage } from '@client/app/utils/error';
 import {
+  Alert,
   Box,
   Button,
   FormControl,
@@ -40,7 +41,7 @@ export const OVERRIDE_STALENESS_NOTE =
   'A change applies immediately on the instance that served it and within ~5 min (one cache TTL) everywhere else.';
 
 /** Booleans are stored as 'true'/'false'; show the operator the switch position, not the string. */
-const displayValue = (setting: AdminSetting, storedValue: string): string =>
+export const displayValue = (setting: AdminSetting, storedValue: string): string =>
   setting.type === 'boolean' ? (storedValue === 'true' ? 'On' : 'Off') : storedValue;
 
 /**
@@ -65,7 +66,8 @@ const ScopedSettingOverrides = ({ setting }: { setting: AdminSetting }) => {
   const rows = (allOverrides ?? []).filter(row => row.settingName === setting.key);
 
   // Only number settings declare bounds, and only some of those, so they are read through the
-  // type discriminant rather than off the union - same as the platform field above.
+  // type discriminant rather than off the union - same as the platform field in
+  // AdminSettingInputField.
   const bounds: { min?: number; max?: number } = setting.type === 'number' ? setting : {};
   const valueError =
     setting.type !== 'number'
@@ -253,8 +255,14 @@ const ScopedSettingOverrides = ({ setting }: { setting: AdminSetting }) => {
       </Box>
 
       <FormHelperText data-testid={`scoped-override-${setting.key}-helper`}>
-        {valueError ?? writeError ?? clearError ?? `Overrides this setting for one scope. ${OVERRIDE_STALENESS_NOTE}`}
+        {valueError ?? `Overrides this setting for one scope. ${OVERRIDE_STALENESS_NOTE}`}
       </FormHelperText>
+
+      {(writeError ?? clearError) && (
+        <Alert color="danger" variant="soft" data-testid={`scoped-override-${setting.key}-error`}>
+          {writeError ?? clearError}
+        </Alert>
+      )}
     </Stack>
   );
 };

--- a/apps/client/app/components/admin/settingFieldHelpers.ts
+++ b/apps/client/app/components/admin/settingFieldHelpers.ts
@@ -1,0 +1,17 @@
+/**
+ * Why the server would refuse this number, in the words the field shows. The setting's own
+ * schema carries the same bounds (makeNumberSetting in @bike4mind/common), and the update
+ * route parses with it directly, so an out-of-range value comes back as an untranslated
+ * ZodError: without this the admin sees Save do nothing and is told nothing.
+ *
+ * Shared by the platform-value field (AdminSettingInputField) and the scoped-override add row
+ * (ScopedSettingOverrides), which have the same bounds and must not describe them differently.
+ */
+export const rangeMessage = (value: number, min?: number, max?: number): string | undefined => {
+  const inRange = (min === undefined || value >= min) && (max === undefined || value <= max);
+  if (!Number.isNaN(value) && inRange) return undefined;
+  if (min !== undefined && max !== undefined) return `Enter a number between ${min} and ${max}.`;
+  if (min !== undefined) return `Enter a number of ${min} or more.`;
+  if (max !== undefined) return `Enter a number of ${max} or less.`;
+  return 'Enter a number.';
+};

--- a/apps/client/app/hooks/data/queryKeys.ts
+++ b/apps/client/app/hooks/data/queryKeys.ts
@@ -24,3 +24,10 @@ export const ADMIN_SETTINGS_ARRAY_QUERY_KEY = ['adminsettings'] as const;
  * Must be invalidated when logo settings are updated
  */
 export const BRANDING_SETTINGS_QUERY_KEY = ['brandingSettings'] as const;
+
+/**
+ * Query key for the scoped setting override inventory (admin only)
+ * Used by useScopedSettingOverrides() - returns IScopedSetting[]
+ * Must be invalidated when an override is set or cleared
+ */
+export const SCOPED_SETTING_OVERRIDES_QUERY_KEY = ['scopedSettingOverrides'] as const;

--- a/apps/client/app/hooks/data/settings.ts
+++ b/apps/client/app/hooks/data/settings.ts
@@ -1,6 +1,7 @@
 import { api } from '@client/app/contexts/ApiContext';
 import {
   IAdminSettings,
+  IScopedSetting,
   LogoSettings,
   ServerStatusEnum,
   SettingKey,
@@ -12,7 +13,13 @@ import { useMemo } from 'react';
 import { z } from 'zod';
 import type { ServerConfig } from '@pages/api/settings/serverConfig';
 import type { ServerConfigPublic } from '@pages/api/settings/serverConfigPublic';
-import { ADMIN_SETTINGS_QUERY_KEY, ADMIN_SETTINGS_ARRAY_QUERY_KEY, BRANDING_SETTINGS_QUERY_KEY } from './queryKeys';
+import type { ScopedOverrideDeleteQuery, ScopedOverridePutBody } from '@pages/api/admin/scoped-settings';
+import {
+  ADMIN_SETTINGS_QUERY_KEY,
+  ADMIN_SETTINGS_ARRAY_QUERY_KEY,
+  BRANDING_SETTINGS_QUERY_KEY,
+  SCOPED_SETTING_OVERRIDES_QUERY_KEY,
+} from './queryKeys';
 import { useAccessToken, useIsFullyAuthenticated } from '@client/app/hooks/useAccessToken';
 
 export function useUpdateSettings() {
@@ -100,6 +107,55 @@ export function useSettingsFromServer() {
     refetchOnReconnect: true,
     refetchOnWindowFocus: true,
     enabled: hasAccessToken,
+  });
+}
+
+/**
+ * Every live org/owner/lake override row, at any rung, for every setting - the whole (small by
+ * design) overlay collection in one read. The admin UI slices it two ways: per setting ("which
+ * rungs override this") and per scope address ("what is overridden here"), so both views share one
+ * query rather than one request each.
+ */
+export function useScopedSettingOverrides() {
+  // Admin-only endpoint behind auth; gate on a token the way useSettingsFromServer does so an
+  // unauthenticated mount does not fire a guaranteed 401.
+  const hasAccessToken = useAccessToken(s => !!s.accessToken);
+  return useQuery({
+    queryKey: SCOPED_SETTING_OVERRIDES_QUERY_KEY,
+    queryFn: async () => {
+      const response = await api.get<IScopedSetting[]>('/api/admin/scoped-settings');
+      return response.data;
+    },
+    enabled: hasAccessToken,
+  });
+}
+
+/** Set or change the override at one (rung, setting) address. Writing to an address that already
+ * has a row is an upsert, so this is both "add" and "change". */
+export function useSetScopedSettingOverride() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: ScopedOverridePutBody) => {
+      const { data } = await api.put('/api/admin/scoped-settings', body);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SCOPED_SETTING_OVERRIDES_QUERY_KEY });
+    },
+  });
+}
+
+export function useClearScopedSettingOverride() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // The address travels as query params, not a body - see the route.
+    mutationFn: async (params: ScopedOverrideDeleteQuery) => {
+      const { data } = await api.delete('/api/admin/scoped-settings', { params });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SCOPED_SETTING_OVERRIDES_QUERY_KEY });
+    },
   });
 }
 

--- a/apps/client/pages/api/admin/scoped-settings/__tests__/index.e2e.test.ts
+++ b/apps/client/pages/api/admin/scoped-settings/__tests__/index.e2e.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import {
+  createMongoServer,
+  MONGO_TEST_TIMEOUT_MS,
+} from '../../../../../../../packages/database/src/__test__/createMongoServer';
+import { adminSettingsRepository, scopedSettingsRepository } from '@bike4mind/database/infra';
+import { isConvergenceHalted } from '@server/queueHandlers/convergenceKillSwitch';
+
+/**
+ * Agreement test for the scoped-override write surface, driving the REAL write service, repository,
+ * model and unique index against createMongoServer. The unit test beside this one mocks the service,
+ * so it can pin auth, validation and delegation but not what the overlay actually does; only this
+ * test proves the two things an operator depends on:
+ *
+ * 1. The route's own round trip - create, change in place (no duplicate row), clear, and set again
+ *    at a cleared address (the tombstone-reinsert case the partial unique index exists for).
+ * 2. That the lever fires: a lake-rung override written through the route changes what the REAL
+ *    consumer (`isConvergenceHalted`, the background-convergence kill switch) decides, and clearing
+ *    it hands the lake back to the platform value. A write surface whose writes no consumer honors
+ *    is the failure this whole scoped-settings epic exists to prevent, and it is invisible to any
+ *    test that stops at the repository.
+ *
+ * Only two seams are stubbed, neither under test: `baseApi` (auth middleware) and the lake lookup.
+ */
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
+        put: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.PUT = fns[fns.length - 1]), chain),
+        delete: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.DELETE = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+import handler from '../index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND hooks.
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
+let mongoServer: MongoMemoryServer;
+
+// A lake the kill switch can resolve: an org-less lake, so scopeForLake puts the owner rung on the
+// creating user. The id must be a real ObjectId hex - the kill switch skips the lookup for a static
+// registry lake's slug id and falls through to the platform value.
+const LAKE_ID = new mongoose.Types.ObjectId().toHexString();
+const LAKE = { id: LAKE_ID, createdByUserId: 'user-1', organizationId: null };
+
+const KILL_SWITCH_DEPS = {
+  adminSettings: adminSettingsRepository,
+  scopedSettings: scopedSettingsRepository,
+  dataLakes: { findById: async () => LAKE },
+} as unknown as Parameters<typeof isConvergenceHalted>[1];
+
+const call = (
+  method: 'GET' | 'PUT' | 'DELETE',
+  opts: { body?: unknown; query?: Record<string, string>; isAdmin?: boolean } = {}
+) => {
+  const { req, res } = createMocks({ method, body: opts.body, query: opts.query });
+  (req as Record<string, unknown>).user = { id: 'admin-1', isAdmin: opts.isAdmin ?? true };
+  (req as Record<string, unknown>).logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+};
+
+/** The route throws; `errorHandler` is middleware this file does not mount, so read the status off the throw. */
+const statusOf = async (promise: Promise<unknown>): Promise<number> => {
+  try {
+    await promise;
+    return 200;
+  } catch (err) {
+    return (err as { statusCode?: number; status?: number }).statusCode ?? (err as { status?: number }).status ?? 500;
+  }
+};
+
+const messageOf = async (promise: Promise<unknown>): Promise<string> => {
+  try {
+    await promise;
+    return '';
+  } catch (err) {
+    return (err as Error).message;
+  }
+};
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+});
+
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+describe('PUT/DELETE /api/admin/scoped-settings (real service, repository and Mongo)', () => {
+  it('creates a row, changes it in place, clears it, and sets it again at the cleared address', async () => {
+    const address = { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: LAKE_ID };
+
+    await call('PUT', { body: { ...address, value: true } }).promise;
+    let rows = await scopedSettingsRepository.find({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ settingName: 'PauseLakeConvergence', scopeLevel: 'lake', settingValue: 'true' });
+
+    // Same address again: an upsert, so the row changes rather than a second one appearing.
+    await call('PUT', { body: { ...address, value: false } }).promise;
+    rows = await scopedSettingsRepository.find({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0].settingValue).toBe('false');
+
+    await call('DELETE', { query: address }).promise;
+    expect(await scopedSettingsRepository.find({})).toHaveLength(0);
+
+    // The tombstone-reinsert case: without the index's partialFilterExpression this throws E11000.
+    await call('PUT', { body: { ...address, value: true } }).promise;
+    rows = await scopedSettingsRepository.find({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0].settingValue).toBe('true');
+  });
+
+  it('GET returns the live rows and refuses a non-admin', async () => {
+    await call('PUT', {
+      body: { settingName: 'dataLakeSearchMaxFiles', scopeLevel: 'organization', scopeId: 'org-1', value: 42 },
+    }).promise;
+
+    const { res, promise } = call('GET');
+    await promise;
+    const body = res._getJSONData() as Array<{ settingName: string; settingValue: string }>;
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ settingName: 'dataLakeSearchMaxFiles', settingValue: '42' });
+
+    expect(await statusOf(call('GET', { isAdmin: false }).promise)).toBe(403);
+  });
+
+  it('answers 400 (never 500) for every rejection the real write service raises', async () => {
+    const base = { scopeLevel: 'lake', scopeId: LAKE_ID };
+
+    // Platform-only setting: the service's settableAt gate, reached with a real settingsMap.
+    expect(
+      await statusOf(call('PUT', { body: { ...base, settingName: 'DefaultChunkSize', value: 900 } }).promise)
+    ).toBe(400);
+    // Out of range for the setting's own schema.
+    expect(
+      await statusOf(
+        call('PUT', {
+          body: { settingName: 'kbSearchMinRelevancePct', scopeLevel: 'organization', scopeId: 'o1', value: 500 },
+        }).promise
+      )
+    ).toBe(400);
+    // The ownerType biconditional, both directions.
+    expect(
+      await statusOf(
+        call('PUT', {
+          body: { settingName: 'PauseLakeConvergence', scopeLevel: 'owner', scopeId: 'u1', value: true },
+        }).promise
+      )
+    ).toBe(400);
+    expect(
+      await statusOf(
+        call('PUT', { body: { ...base, settingName: 'PauseLakeConvergence', value: true, ownerType: 'User' } }).promise
+      )
+    ).toBe(400);
+
+    // Nothing above reached the database.
+    expect(await scopedSettingsRepository.find({})).toHaveLength(0);
+  });
+
+  it('keeps the write service wording in the 400 an operator reads', async () => {
+    const message = await messageOf(
+      call('PUT', { body: { settingName: 'DefaultChunkSize', scopeLevel: 'lake', scopeId: LAKE_ID, value: 900 } })
+        .promise
+    );
+    expect(message).toContain('not settable at scope level');
+  });
+});
+
+describe('the lake-rung override an operator writes changes what the convergence kill switch decides', () => {
+  it('halts background convergence for the lake while the override is set, and resumes once it is cleared', async () => {
+    const message = { origin: 'convergence' as const, lakeId: LAKE_ID };
+    const address = { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: LAKE_ID };
+
+    // Platform value is OFF (the setting's default, no AdminSettings row), so the lake runs.
+    expect(await isConvergenceHalted(message, KILL_SWITCH_DEPS)).toBe(false);
+
+    await call('PUT', { body: { ...address, value: true } }).promise;
+    // Read-your-writes: writeScopedOverride invalidated this scope's cache entry.
+    expect(await isConvergenceHalted(message, KILL_SWITCH_DEPS)).toBe(true);
+
+    await call('DELETE', { query: address }).promise;
+    expect(await isConvergenceHalted(message, KILL_SWITCH_DEPS)).toBe(false);
+  });
+
+  it('pauses only the addressed lake, leaving every other lake running', async () => {
+    const otherLakeId = new mongoose.Types.ObjectId().toHexString();
+    await call('PUT', {
+      body: { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: LAKE_ID, value: true },
+    }).promise;
+
+    expect(await isConvergenceHalted({ origin: 'convergence', lakeId: LAKE_ID }, KILL_SWITCH_DEPS)).toBe(true);
+    expect(
+      await isConvergenceHalted({ origin: 'convergence', lakeId: otherLakeId }, {
+        ...KILL_SWITCH_DEPS,
+        dataLakes: { findById: async () => ({ ...LAKE, id: otherLakeId }) },
+      } as unknown as Parameters<typeof isConvergenceHalted>[1])
+    ).toBe(false);
+  });
+
+  it('leaves real-time user work running even while the lake is paused', async () => {
+    await call('PUT', {
+      body: { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: LAKE_ID, value: true },
+    }).promise;
+
+    expect(await isConvergenceHalted({ origin: 'user', lakeId: LAKE_ID }, KILL_SWITCH_DEPS)).toBe(false);
+  });
+});

--- a/apps/client/pages/api/admin/scoped-settings/__tests__/index.test.ts
+++ b/apps/client/pages/api/admin/scoped-settings/__tests__/index.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Keep @bike4mind/common real: the settingsMap, SettingKeySchema and HTTP error classes under test
+// are the actual ones. Mock only the infra + service + middleware seams.
+const find = vi.fn();
+const writeScopedOverride = vi.fn();
+const clearScopedOverride = vi.fn();
+
+vi.mock('@bike4mind/database/infra', () => ({
+  scopedSettingsRepository: { find: (...args: unknown[]) => find(...args) },
+}));
+vi.mock('@bike4mind/services', () => ({
+  scopedSettingsService: {
+    writeScopedOverride: (...args: unknown[]) => writeScopedOverride(...args),
+    clearScopedOverride: (...args: unknown[]) => clearScopedOverride(...args),
+  },
+}));
+// The route builds itself at import time via .get().put().delete(), so the chain captures each
+// handler on itself under a `__<method>` key; the default export IS the chain, which is how a test
+// gets hold of one method's handler. Assigning into a registry declared in this file would run
+// before that declaration (the route is imported before the test body executes).
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: Record<string, unknown> = {};
+  for (const method of ['get', 'put', 'delete']) {
+    chain[method] = (routeHandler: unknown) => {
+      chain[`__${method}`] = routeHandler;
+      return chain;
+    };
+  }
+  return { baseApi: () => chain };
+});
+
+import handler from '../index';
+
+type RouteHandler = (req: unknown, res: unknown) => Promise<unknown>;
+
+const routes = handler as unknown as Record<string, RouteHandler>;
+
+const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+/** Invoke one method's handler and return whatever it passed to res.json. */
+const invoke = async (
+  method: 'get' | 'put' | 'delete',
+  req: { body?: unknown; query?: unknown; isAdmin?: boolean } = {}
+) => {
+  const json = vi.fn((x: unknown) => x);
+  const { isAdmin = true, ...rest } = req;
+  await routes[`__${method}`]({ user: { isAdmin }, logger, ...rest }, { json });
+  return json.mock.calls[0]?.[0];
+};
+
+const expectStatus = (method: 'get' | 'put' | 'delete', req: Parameters<typeof invoke>[1], statusCode: number) =>
+  expect(invoke(method, req)).rejects.toMatchObject({ statusCode });
+
+const lakePause = {
+  settingName: 'PauseLakeConvergence',
+  scopeLevel: 'lake',
+  scopeId: 'lake-1',
+  value: true,
+};
+
+describe('admin/scoped-settings authorization', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('refuses a non-admin on every method', async () => {
+    await expectStatus('get', { isAdmin: false }, 403);
+    await expectStatus('put', { isAdmin: false, body: lakePause }, 403);
+    await expectStatus(
+      'delete',
+      { isAdmin: false, query: { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: 'lake-1' } },
+      403
+    );
+    expect(writeScopedOverride).not.toHaveBeenCalled();
+    expect(clearScopedOverride).not.toHaveBeenCalled();
+    expect(find).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin/scoped-settings request validation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects the platform rung - the platform value has its own writer', async () => {
+    await expectStatus('put', { body: { ...lakePause, scopeLevel: 'platform' } }, 400);
+    expect(writeScopedOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown setting name', async () => {
+    await expectStatus('put', { body: { ...lakePause, settingName: 'NotASetting' } }, 400);
+    expect(writeScopedOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty scopeId', async () => {
+    await expectStatus('put', { body: { ...lakePause, scopeId: '' } }, 400);
+    expect(writeScopedOverride).not.toHaveBeenCalled();
+  });
+
+  // A missing value is the one that would otherwise reach the database: the setting schemas end in
+  // `.prefault(...)`, so the write service's own safeParse(undefined) succeeds.
+  it('rejects a missing value before it can reach the write service', async () => {
+    await expectStatus(
+      'put',
+      { body: { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: 'l1' } },
+      400
+    );
+    expect(writeScopedOverride).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an object', { nested: true }],
+    ['an array', [1, 2]],
+    ['null', null],
+    // JSON has no Infinity literal, but 1e999 parses to one, and String(Infinity) would be stored.
+    ['a non-finite number', Number.POSITIVE_INFINITY],
+  ])('rejects %s as a value', async (_label, value) => {
+    await expectStatus('put', { body: { ...lakePause, value } }, 400);
+    expect(writeScopedOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects a DELETE with an incomplete address', async () => {
+    await expectStatus('delete', { query: { settingName: 'PauseLakeConvergence', scopeLevel: 'lake' } }, 400);
+    expect(clearScopedOverride).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The write service owns these rules; what is under test here is only that its plain-Error
+ * rejections come back as a readable 400 rather than the 500 `errorHandler` gives a plain Error -
+ * a 500 also logs at `error` level and trips the LiveOps CloudWatch filter, so an admin typing an
+ * out-of-range number would page someone.
+ */
+describe('admin/scoped-settings service rejection translation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    [
+      'a platform-only setting',
+      { settingName: 'DefaultAPIModel', scopeLevel: 'organization', scopeId: 'org-1', value: 'gpt-4o' },
+      "[scopedSettings] 'DefaultAPIModel' is not settable at scope level 'organization'",
+    ],
+    [
+      'a sensitive setting',
+      { settingName: 'anthropicDemoKey', scopeLevel: 'organization', scopeId: 'org-1', value: 'sk-test' },
+      "[scopedSettings] 'anthropicDemoKey' is sensitive and cannot be scoped",
+    ],
+    [
+      'an out-of-range number',
+      { settingName: 'kbSearchMinRelevancePct', scopeLevel: 'organization', scopeId: 'org-1', value: 500 },
+      "[scopedSettings] value for 'kbSearchMinRelevancePct' failed validation: 500",
+    ],
+    [
+      'an owner rung with no ownerType',
+      { settingName: 'kbSearchDefaultResults', scopeLevel: 'owner', scopeId: 'user-1', value: 5 },
+      "[scopedSettings] ownerType is required when writing an owner-scoped override for 'kbSearchDefaultResults'",
+    ],
+    [
+      'a non-owner rung carrying an ownerType',
+      { ...lakePause, ownerType: 'User' },
+      "[scopedSettings] ownerType is only meaningful at the owner scope, not 'lake'",
+    ],
+  ])('answers 400 with the service message for %s', async (_label, body, message) => {
+    writeScopedOverride.mockRejectedValue(new Error(message));
+    await expectStatus('put', { body }, 400);
+    await expect(invoke('put', { body })).rejects.toThrow(message);
+  });
+
+  it('leaves a failure that is not a write-service rejection as a server error', async () => {
+    const driverFailure = Object.assign(new Error('connection timed out'), { name: 'MongoServerError' });
+    writeScopedOverride.mockRejectedValue(driverFailure);
+
+    await expect(invoke('put', { body: lakePause })).rejects.toBe(driverFailure);
+  });
+});
+
+describe('admin/scoped-settings writes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    ['a boolean', true, 'true'],
+    ['a boolean off', false, 'false'],
+    ['a number', 42, '42'],
+  ])('stringifies %s on the way to the write service', async (_label, value, settingValue) => {
+    writeScopedOverride.mockResolvedValue(undefined);
+
+    const response = await invoke('put', { body: { ...lakePause, value } });
+
+    // The overlay stores this string verbatim and the resolver re-parses it, so the stored
+    // representation is the contract the round trip depends on.
+    expect(writeScopedOverride).toHaveBeenCalledWith(
+      'PauseLakeConvergence',
+      { scopeLevel: 'lake', scopeId: 'lake-1', ownerType: undefined },
+      settingValue,
+      { scopedSettings: expect.anything() },
+      { logger }
+    );
+    expect(response).toMatchObject({
+      settingName: 'PauseLakeConvergence',
+      scopeLevel: 'lake',
+      scopeId: 'lake-1',
+      settingValue,
+    });
+  });
+
+  it('carries ownerType through on an owner-rung write', async () => {
+    writeScopedOverride.mockResolvedValue(undefined);
+
+    await invoke('put', {
+      body: {
+        settingName: 'kbSearchDefaultResults',
+        scopeLevel: 'owner',
+        scopeId: 'org-7',
+        ownerType: 'Organization',
+        value: 5,
+      },
+    });
+
+    expect(writeScopedOverride).toHaveBeenCalledWith(
+      'kbSearchDefaultResults',
+      { scopeLevel: 'owner', scopeId: 'org-7', ownerType: 'Organization' },
+      '5',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('clears the override at the address given in the query', async () => {
+    clearScopedOverride.mockResolvedValue(undefined);
+
+    const response = await invoke('delete', {
+      query: { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: 'lake-1' },
+    });
+
+    expect(clearScopedOverride).toHaveBeenCalledWith(
+      'PauseLakeConvergence',
+      { scopeLevel: 'lake', scopeId: 'lake-1' },
+      { scopedSettings: expect.anything() },
+      { logger }
+    );
+    expect(response).toEqual({ cleared: true });
+  });
+});
+
+describe('admin/scoped-settings inventory', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns every live override row', async () => {
+    const rows = [
+      { settingName: 'PauseLakeConvergence', scopeLevel: 'lake', scopeId: 'lake-1', settingValue: 'true' },
+      { settingName: 'kbSearchDefaultResults', scopeLevel: 'owner', scopeId: 'user-1', settingValue: '7' },
+    ];
+    find.mockResolvedValue(rows);
+
+    expect(await invoke('get')).toBe(rows);
+    expect(find).toHaveBeenCalledWith({});
+  });
+});

--- a/apps/client/pages/api/admin/scoped-settings/__tests__/index.test.ts
+++ b/apps/client/pages/api/admin/scoped-settings/__tests__/index.test.ts
@@ -95,8 +95,6 @@ describe('admin/scoped-settings request validation', () => {
     expect(writeScopedOverride).not.toHaveBeenCalled();
   });
 
-  // A missing value is the one that would otherwise reach the database: the setting schemas end in
-  // `.prefault(...)`, so the write service's own safeParse(undefined) succeeds.
   it('rejects a missing value before it can reach the write service', async () => {
     await expectStatus(
       'put',
@@ -114,6 +112,17 @@ describe('admin/scoped-settings request validation', () => {
     ['a non-finite number', Number.POSITIVE_INFINITY],
   ])('rejects %s as a value', async (_label, value) => {
     await expectStatus('put', { body: { ...lakePause, value } }, 400);
+    expect(writeScopedOverride).not.toHaveBeenCalled();
+  });
+
+  // Blank is not empty to a number setting: z.coerce.number('') is 0, in range for the two
+  // `min: 0` settings, so without the route guard the overlay stores "" and resolves it as 0.
+  it.each([
+    ['empty', ''],
+    ['whitespace', '   '],
+  ])('rejects a %s string value', async (_label, value) => {
+    const body = { settingName: 'kbSearchMinRelevancePct', scopeLevel: 'organization', scopeId: 'org-1', value };
+    await expectStatus('put', { body }, 400);
     expect(writeScopedOverride).not.toHaveBeenCalled();
   });
 

--- a/apps/client/pages/api/admin/scoped-settings/__tests__/index.test.ts
+++ b/apps/client/pages/api/admin/scoped-settings/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ApiKeyScope } from '@bike4mind/common';
 
 // Keep @bike4mind/common real: the settingsMap, SettingKeySchema and HTTP error classes under test
 // are the actual ones. Mock only the infra + service + middleware seams.
@@ -28,7 +29,12 @@ vi.mock('@server/middlewares/baseApi', () => {
       return chain;
     };
   }
-  return { baseApi: () => chain };
+  return {
+    baseApi: (config?: unknown) => {
+      chain.__config = config;
+      return chain;
+    },
+  };
 });
 
 import handler from '../index';
@@ -74,6 +80,12 @@ describe('admin/scoped-settings authorization', () => {
     expect(writeScopedOverride).not.toHaveBeenCalled();
     expect(clearScopedOverride).not.toHaveBeenCalled();
     expect(find).not.toHaveBeenCalled();
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    // Pins the whole config object, not just requiredScopes - a sibling `auth: false` would skip
+    // baseApi's entire api-key chain and disable this gate while leaving requiredScopes untouched.
+    expect((handler as unknown as { __config?: unknown }).__config).toEqual({ requiredScopes: [ApiKeyScope.ADMIN] });
   });
 });
 

--- a/apps/client/pages/api/admin/scoped-settings/index.ts
+++ b/apps/client/pages/api/admin/scoped-settings/index.ts
@@ -1,0 +1,135 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { fromZodError } from 'zod-validation-error';
+import { CreditHolderType, SettingKeySchema, SettingScopeLevel } from '@bike4mind/common';
+import { scopedSettingsRepository } from '@bike4mind/database/infra';
+import { scopedSettingsService } from '@bike4mind/services';
+import { baseApi } from '@server/middlewares/baseApi';
+import { BadRequestError, ensureAdmin } from '@server/utils/errors';
+
+/**
+ * Admin write surface for the scoped-settings overlay - the org/owner/lake OVERRIDES read by
+ * `resolveScopedSetting`. Platform values keep their own writer (`PUT /api/settings/update`) and are
+ * untouched here, which is why `platform` is not a level this route accepts.
+ *
+ * Admin-only at EVERY rung, including `lake`: these are operational and cost levers, so the operator
+ * is the platform operator rather than a lake manager.
+ *
+ * Session/admin route, not a public API-key endpoint, so it carries no api-contract definition.
+ */
+
+// The override altitudes only. Rejecting `platform` structurally (rather than with a hand-written
+// check) is what keeps this route from ever looking like a second writer of the platform value.
+const ScopeLevelSchema = z.enum([SettingScopeLevel.Organization, SettingScopeLevel.Owner, SettingScopeLevel.Lake]);
+
+const ScopeAddressSchema = z.object({
+  settingName: SettingKeySchema,
+  scopeLevel: ScopeLevelSchema,
+  scopeId: z.string().min(1),
+});
+
+const PutBodySchema = ScopeAddressSchema.extend({
+  ownerType: z.enum([CreditHolderType.User, CreditHolderType.Organization]).optional(),
+  /**
+   * Required, and scalar only. Both guards are load-bearing rather than defensive:
+   * `makeNumberSetting`/`makeBooleanSetting` schemas end in `.prefault(...)`, so the write service's
+   * `safeParse(undefined)` SUCCEEDS and a missing value would sail past its validation to die on the
+   * Mongoose `required: true` as a 500. zod's `number` refuses NaN/Infinity, so `1e999` is rejected
+   * here instead of being stored as the string "Infinity".
+   */
+  value: z.union([z.boolean(), z.number(), z.string()]),
+});
+
+export type ScopedOverridePutBody = z.infer<typeof PutBodySchema>;
+export type ScopedOverrideDeleteQuery = z.infer<typeof ScopeAddressSchema>;
+
+/**
+ * Every rejection on this route answers 400. A raw ZodError would instead reach `errorHandler` as a
+ * 422 (see its `isZodError` branch), leaving the admin UI two statuses to message off for the same
+ * class of mistake.
+ */
+const parseOrBadRequest = <T>(schema: z.ZodType<T>, input: unknown): T => {
+  const parsed = schema.safeParse(input);
+  if (!parsed.success) throw new BadRequestError(fromZodError(parsed.error).message);
+  return parsed.data;
+};
+
+/**
+ * How `writeScopedOverride` marks its own rejections (not settable at this level, sensitive, failed
+ * validation, either ownerType violation). MUST STAY IN SYNC with the message prefix in
+ * `b4m-core/services/src/settings/writeScopedOverride.ts`.
+ */
+const SERVICE_REJECTION_PREFIX = '[scopedSettings]';
+
+/**
+ * The write service signals a rejection by throwing a plain `Error`, and `errorHandler` maps a plain
+ * `Error` to 500 AND logs it at `error` level - which is what the LiveOps CloudWatch filter keys on.
+ * An admin typing 500 into a `max: 100` field must not page anyone, so the service's rejections come
+ * back as a 400 with its own wording intact. Anything else (a driver or connection failure) is a
+ * real server error and is rethrown untouched.
+ */
+const runWrite = async (write: () => Promise<void>): Promise<void> => {
+  try {
+    await write();
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(SERVICE_REJECTION_PREFIX)) {
+      throw new BadRequestError(error.message);
+    }
+    throw error;
+  }
+};
+
+const handler = baseApi()
+  .get(async (req: Request, res: Response) => {
+    ensureAdmin(req.user?.isAdmin);
+    // The whole collection in one read. It is small by design - a row exists only where an operator
+    // actually set an override - and both questions the admin UI asks ("which rungs override setting
+    // X" and "what is overridden at scope Y") are answered from the same inventory. The soft-delete
+    // pre-hook excludes tombstones.
+    return res.json(await scopedSettingsRepository.find({}));
+  })
+  .put(async (req: Request, res: Response) => {
+    ensureAdmin(req.user?.isAdmin);
+    const { settingName, scopeLevel, scopeId, ownerType, value } = parseOrBadRequest(PutBodySchema, req.body);
+
+    // The overlay stores the raw string and the resolver re-parses it through the setting's own
+    // schema (pickOverride), so String() is the exact round trip for all three scalar types.
+    const settingValue = typeof value === 'string' ? value : String(value);
+
+    await runWrite(() =>
+      scopedSettingsService.writeScopedOverride(
+        settingName,
+        { scopeLevel, scopeId, ownerType },
+        settingValue,
+        { scopedSettings: scopedSettingsRepository },
+        { logger: req.logger }
+      )
+    );
+
+    return res.json({ settingName, scopeLevel, scopeId, ownerType, settingValue });
+  })
+  .delete(async (req: Request, res: Response) => {
+    ensureAdmin(req.user?.isAdmin);
+    // Address comes from the query, not a body: a DELETE body is awkward to send through axios and
+    // next-connect.
+    const { settingName, scopeLevel, scopeId } = parseOrBadRequest(ScopeAddressSchema, req.query);
+
+    await runWrite(() =>
+      scopedSettingsService.clearScopedOverride(
+        settingName,
+        { scopeLevel, scopeId },
+        { scopedSettings: scopedSettingsRepository },
+        { logger: req.logger }
+      )
+    );
+
+    return res.json({ cleared: true });
+  });
+
+export default handler;
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};

--- a/apps/client/pages/api/admin/scoped-settings/index.ts
+++ b/apps/client/pages/api/admin/scoped-settings/index.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import { fromZodError } from 'zod-validation-error';
-import { CreditHolderType, SettingKeySchema, SettingScopeLevel } from '@bike4mind/common';
+import { ApiKeyScope, CreditHolderType, SettingKeySchema, SettingScopeLevel } from '@bike4mind/common';
 import { scopedSettingsRepository } from '@bike4mind/database/infra';
 import { scopedSettingsService } from '@bike4mind/services';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -16,6 +16,8 @@ import { BadRequestError, ensureAdmin } from '@server/utils/errors';
  * is the platform operator rather than a lake manager.
  *
  * Session/admin route, not a public API-key endpoint, so it carries no api-contract definition.
+ * requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key before req.user
+ * exists, so `ensureAdmin` still has to run per method for the session path.
  */
 
 // The override altitudes only. Rejecting `platform` structurally (rather than with a hand-written
@@ -85,7 +87,7 @@ const runWrite = async (write: () => Promise<void>): Promise<void> => {
   }
 };
 
-const handler = baseApi()
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] })
   .get(async (req: Request, res: Response) => {
     ensureAdmin(req.user?.isAdmin);
     // The whole collection in one read. It is small by design - a row exists only where an operator

--- a/apps/client/pages/api/admin/scoped-settings/index.ts
+++ b/apps/client/pages/api/admin/scoped-settings/index.ts
@@ -31,14 +31,20 @@ const ScopeAddressSchema = z.object({
 const PutBodySchema = ScopeAddressSchema.extend({
   ownerType: z.enum([CreditHolderType.User, CreditHolderType.Organization]).optional(),
   /**
-   * Required, and scalar only. Both guards are load-bearing rather than defensive:
-   * `makeNumberSetting`/`makeBooleanSetting` schemas end in `.prefault(...)`, so the write service's
-   * `safeParse(undefined)` SUCCEEDS and a missing value would sail past its validation to die on the
-   * Mongoose `required: true` as a 500. zod's `number` refuses NaN/Infinity, so `1e999` is rejected
-   * here instead of being stored as the string "Infinity".
+   * Required, and scalar only. The overlay stores whatever string this becomes, so the door has to
+   * refuse the values that stringify into something the setting's own schema would then wave
+   * through: an absent value becomes the literal "undefined", and `1e999` (JSON has no Infinity
+   * literal, but it parses to one) becomes "Infinity", which passes any setting with no `max`.
    */
   value: z.union([z.boolean(), z.number(), z.string()]),
-});
+})
+  // A number setting's schema is `z.coerce.number()`, so a blank string is a genuine 0 to it - and
+  // 0 is in range for the two `min: 0` settings. Without this the overlay would store "" at that
+  // address: a row that reads as nothing in the admin UI while resolving to 0 for every consumer.
+  .refine(({ value }) => typeof value !== 'string' || value.trim().length > 0, {
+    path: ['value'],
+    message: 'value must not be blank',
+  });
 
 export type ScopedOverridePutBody = z.infer<typeof PutBodySchema>;
 export type ScopedOverrideDeleteQuery = z.infer<typeof ScopeAddressSchema>;


### PR DESCRIPTION
# Pull Request

Closes #2198

## Description

The scoped-settings **read** half has been complete and load-bearing for a while: `resolveScopedSetting` is wired into ~15 consumers (queue handlers, chunk rescue sweep, lake health, search budgets, chunk policy), and `writeScopedOverride` / `clearScopedOverride` in `b4m-core/services/src/settings/writeScopedOverride.ts` are fully implemented and tested. The **write** half had no caller - every grep hit was the definition or a re-export. The only way to set an org / owner / lake override was to hand-write a `ScopedSetting` document in the database.

Several settings even advertise the per-scope behaviour in their operator-facing copy (`PauseLakeConvergence`: "a per-lake (or per-org / per-owner) override pauses a subset while the rest keep running"), which was unactionable.

This PR adds the missing door: one admin route plus two admin-UI components, so a platform admin can set, change and clear an override of any of the nine scope-capable settings from the admin Settings tab, and can ask "for this scope address, what is overridden and what is not". Nothing in the read path or the write service changes.

Two decisions worth stating up front:

- **Surface: admin Settings tab only.** One generic surface that can address any rung by id, sitting next to the platform value. No change to the lake manager's settings modal.
- **Authorization: platform admin only.** Every rung, including lake, requires `req.user.isAdmin`. These are operational and cost levers, so the operator is the platform operator. A non-admin lake manager sees nothing and can write nothing.

## Changes

**New: `apps/client/pages/api/admin/scoped-settings/index.ts`** - `baseApi()` with an explicit `ensureAdmin` per method (same posture as `PUT /api/settings/update`; the neighbouring `admin/modals/variants.ts` is the shape precedent). Not a public API-key endpoint, so no `api-contract` contract.

- `GET` returns every live override row (`scopedSettingsRepository.find({})`; the soft-delete pre-hook excludes tombstones). The collection is small by design - one row per `(rung, setting)` an operator actually set - so one whole-collection read serves both axes the UI needs.
- `PUT { settingName, scopeLevel, scopeId, ownerType?, value }` stringifies the value and delegates to `writeScopedOverride`. `'true'`/`'false'` for booleans, `String(n)` for numbers: that is exactly the representation the overlay stores and the resolver re-parses, so the round trip is lossless.
- `DELETE ?settingName=&scopeLevel=&scopeId=` delegates to `clearScopedOverride` (query rather than body, because DELETE bodies are awkward through axios/next-connect).
- Zod schemas live at the top of the file and the inferred request types are exported for the client hooks to `import type` (precedent: `ServerConfig` from `@pages/api/settings/serverConfig`). `scopeLevel` is an enum of organization / owner / lake, so `platform` is rejected structurally - this route must never look like a second writer for the platform value.
- **Every rejection is a 400 with a readable message, never a 500.** `writeScopedOverride` throws plain `Error`s for its five rejections, and `errorHandler` maps a plain `Error` to 500 *and logs it at `error` level*, which is what the LiveOps CloudWatch filter keys on. An admin typing `500` into a `max: 100` field must not page anyone. The catch is keyed on the service's `[scopedSettings]` message prefix rather than on "any plain Error", so a driver or connection failure still surfaces as a genuine 500; a test pins that half too.
- The `value` guard is load-bearing beyond tidiness: `z.coerce.number('')` is a genuine `0`, so a blank value would have passed the two `min: 0` settings' schemas and stored an empty `settingValue` - a row that reads as nothing in the UI while resolving to `0` for every consumer.

**New UI**

- `ScopedSettingOverrides.tsx` - rendered only when `setting.scope` is present, so every non-scoped setting card is byte-for-byte unchanged. Lists this setting's live overrides (rung, scope id, `ownerType`, value, Clear) plus an add/change row whose level options are exactly that setting's `settableAt`, an `ownerType` select shown only at the owner rung, and a value control matching the setting's type with client-side range validation.
- `ScopedOverridesByScope.tsx` - given a level and a scope id, lists every scope-capable setting in one of three states: `overridden here: <value>`, `no override at this rung (platform: <value>)`, or `not settable at this rung`. Mounted once in the AI category, alongside the existing `AdminOperationsModelSetting` panel.
- Both disclose the propagation bound rather than hiding it: "A change applies immediately on the instance that served it and within ~5 min (one cache TTL) everywhere else."

**Mounted from both renderers in `AdminSettingInputField.tsx`, which is load-bearing.** `AdminSettingsTab.renderSettingGroup` reclassifies a `boolean` setting whose `dependsOn` points at another setting in the same group as an *inline child*, rendered by the compact `SubSettingToggle` row rather than as a `<Card>`. `PauseLakeConvergence` and `EnforceLakeAdmission` are both in that bucket - so gating the section on the card alone would have left `PauseLakeConvergence`, the setting the issue's whole journey is about, with no write surface. The alternative (excluding scope-capable settings from inline classification) would have moved two settings out of the `EnableDataLakes` card into their own, a visible layout regression for no gain.

**Also edited:** `queryKeys.ts` (one new key), `hooks/data/settings.ts` (one query + two invalidating mutations), `AdminSettingsTab.tsx` (one line mounting the by-scope panel), and `AdminSettingInputField.test.tsx` (its `vi.mock` factory replaces the whole settings-hooks module, so the new named imports had to be added to it or the file would fail at import time). `rangeMessage` moved from `AdminSettingInputField.tsx` into a new `settingFieldHelpers.ts` so both consumers share one copy without an import cycle.

**Deliberately unchanged:** `writeScopedOverride`, `clearScopedOverride`, `resolveScopedSetting*`, `ScopedSettingTypes.ts`, `ScopedSettingModel.ts`, every setting's `scope` metadata, and the repository (no new methods - `find({})`, `upsertOverride` and `clearOverride` already cover every read and write here).

**Known limits, all deliberate:** no org/user/lake pickers (raw ids this pass), no actor attribution on override rows, no shared-cache invalidation broadcast, and the by-scope view reports "set at this rung / not set", not the value a consumer would actually resolve - an honest effective-value view needs the full `SettingScope` a consumer builds (for a lake that pulls in its org and owner rungs) and is the natural home for a follow-up `.../resolve` endpoint.

## Guide for Testers

The whole flow was walked end to end locally against a real database and a real browser; these are the same steps.

**Setup**

1. Log in to `app.staging.bike4mind.com` as a **platform admin**.
2. Open the sidebar, expand **General Ops**, click **Admin Settings**, then select the **All Tabs** view.
3. Search or scroll to **Enable Data Lakes** and confirm it is **ON**. If it is off, turn it on and save. Three of the nine scope-capable settings declare `dependsOn: 'EnableDataLakes'`, and the admin tab renders no card at all for a dependent setting while its parent is off - so their sections are invisible until this is on. That is pre-existing admin-tab gating, not something this PR changes.

**The per-setting override section (AC4)**

4. Find the **Pause Lake Convergence** row (it appears as an inline row inside the **Enable Data Lakes** card, not as its own card). Expected: a **Scoped overrides (0)** section beneath the switch, with a level select, a scope-id input and a **Set** button.
5. Open the level select. Expected: exactly three options - `organization`, `owner`, `lake`.
6. Find **Default Chunk Size** (its own card) and open its level select. Expected: exactly two options - `organization`, `owner`. It is not settable at the lake rung.
7. Pick any setting that is **not** scope-capable (e.g. **Default API Model**). Expected: no **Scoped overrides** section at all.
8. Back on **Pause Lake Convergence**: choose level `lake`, type a real data lake id into the scope-id input, set the value switch to **On**, click **Set**. Expected: a row appears reading `Lake <id> = On` with a **Clear** button, and the header count becomes **Scoped overrides (1)**.
9. Set the same address again with the value **Off**. Expected: still **one** row, now reading `= Off` - an upsert, not a duplicate.
10. Select level `owner`. Expected: an **ownerType** select appears (`User` | `Organization`). Select `organization` or `lake` again. Expected: it disappears.
11. Find **KB Search Min Relevance Pct** (range 0-100), type `500` into the value input. Expected: **Set** is blocked with a bounds message; no request is sent.
12. Click **Clear** on the row from step 9. Expected: the row disappears and the count returns to **(0)**.

**The by-scope view (AC5)**

13. Scroll to the **AI** category and find the by-scope panel (alongside the operations-model panel).
14. Choose level `lake` and paste the same lake id used in step 8. Expected: all **nine** scope-capable settings are listed.
15. Re-create the `PauseLakeConvergence` lake override (step 8), then re-check the panel. Expected: `Pause Lake Convergence` shows **overridden here: On** with a **Clear**; other lake-settable settings show **no override at this rung (platform: <value>)**; **Default Chunk Size** shows **not settable at this rung**.
16. Confirm the propagation note is visible: "A change applies immediately on the instance that served it and within ~5 min (one cache TTL) everywhere else."

**Authorization (AC1)**

17. Log in as a **non-admin** user and navigate to the admin Settings tab. Expected: not reachable. Hitting `GET`, `PUT` and `DELETE` on `/api/admin/scoped-settings` directly (e.g. via `curl` with that user's session) should each return **403**.

**Rejections all answer 4xx, never 5xx (AC3)**

18. As an admin, `PUT /api/admin/scoped-settings` with each of the following. Expected in every case: **400** with a readable message, and nothing written.
19. `{ settingName: 'PauseLakeConvergence', scopeLevel: 'platform', scopeId: 'x', value: true }` - the platform rung has its own writer.
20. `{ settingName: 'DefaultAPIModel', scopeLevel: 'lake', scopeId: 'x', value: 'gpt-4' }` - not scope-capable. Expected message: `[scopedSettings] 'DefaultAPIModel' is not settable at scope level 'lake'`.
21. `{ settingName: 'DefaultChunkSize', scopeLevel: 'owner', scopeId: 'x', value: 500 }` with **no** `ownerType` - and separately with `scopeLevel: 'lake'` **plus** an `ownerType`. Both violate the `ownerType` biconditional.
22. `{ settingName: 'kbSearchMinRelevancePct', scopeLevel: 'organization', scopeId: 'x', value: 500 }` - out of range.
23. The same body with `value` **missing**, then `value: ''`, then `value: { a: 1 }`, then `value: 1e999`. All four rejected at the route.
24. An unknown `settingName`, and an empty `scopeId`.

**The operator journey (AC6)**

25. Confirm the **platform** value of `PauseLakeConvergence` is **OFF**.
26. Pick a data lake that has pending background convergence work (files stranded with `chunkStallReason: 'unchunkedPaused'` and no vectors). `GET /api/data-lakes/<id>/rechunk` should report a non-zero `underChunkedCount`.
27. `POST /api/data-lakes/<id>/rechunk`. Expected: the work is picked up - the response `outcome` is **not** `paused`.
28. Through the admin UI (step 8), set a **lake**-rung `PauseLakeConvergence` override to **On** for that lake.
29. `POST /api/data-lakes/<id>/rechunk` again. Expected: `outcome: 'paused'`, `enqueued: 0`, and a non-zero `detected` - the lake's background convergence work stops being picked up.
30. Repeat step 29 against a **different** lake with the same kind of stranded work. Expected: it keeps running. The override pauses a subset, not everything.
31. **Clear** the override in the admin UI, then `POST /api/data-lakes/<id>/rechunk` once more. Expected: no longer refused, with a non-zero `detected` proving the pause gate was re-evaluated against a non-empty wave. Work resumes.

**Regression Checks**

32. Every setting that is **not** scope-capable renders exactly as before - no new section, no layout shift.
33. Editing and saving a **platform** value still works (`PUT /api/settings/update`), and the settings tab still loads all categories (`GET /api/settings/fetch`).
34. `Pause Lake Convergence` and `Enforce Lake Admission` are still inline rows inside the `Enable Data Lakes` card - they were **not** promoted to their own cards.
35. Data lake features that read scoped settings (lake search, chunking, convergence) behave unchanged when no override exists.

**What NOT to test**

- The lake manager's own settings modal (`DataLakeSettingsModal`) is untouched by this PR, as is `/api/data-lakes/[id]/settings`, which writes a different overlay entirely.
- Cross-instance propagation timing. The up-to-one-cache-TTL bound is inherited from the existing `ScopedSettingsCache` and disclosed in the UI, not changed here.
- Scope-id ergonomics: raw ids are the intended scope of this pass, so "the id field should be a picker" is a known follow-up, not a bug.

## Additional Information

**Verification**

- `pnpm --filter @bike4mind/client typecheck` and `pnpm lint:check` - clean. `pnpm turbo:typecheck` - 40/40 tasks pass.
- `pnpm --filter @bike4mind/client test` - 1118 files / 12096 tests pass. `apps/client` is the only package this diff touches.
- New tests: 22 route unit tests, 7 route integration tests against a real mongod, 12 `ScopedSettingOverrides` tests, 6 `ScopedOverridesByScope` tests.
- Every acceptance criterion was walked locally in a running app (self-host mode, dedicated local mongod), including the criterion-6 journey above: real lake, real stranded convergence work, override set through the new route pauses pickup, a second lake keeps running, clearing it resumes. The one gap: no SQS in that environment, so `enqueued` is `0` even in the un-paused runs - the discriminator throughout is `outcome`, which is `'paused'` only when the kill switch fires, so "stops / resumes" is observed exactly and is not an artifact of the missing queue.
- `pnpm turbo:test` as a single command does not go green on the machine this was built on, for a pre-existing reason unrelated to this diff: `@bike4mind/scripts`' real-mongod migration suites time out under concurrent index builds (the contention `apps/client/vitest.config.mts` documents). Run one package at a time, or rely on CI's sharded matrix, which is built for exactly this. Nothing in this diff touches `packages/scripts` or `packages/database`.

**Two honest notes for review**

- The **sensitive-setting** rejection path is unreachable from this route by construction: no sensitive setting declares `scope`, so `writeScopedOverride`'s `settableAt` gate always fires first. Still a 400 with a readable message, and `settings.scopeMetadata.test.ts` is what keeps sensitive settings unscopable.
- `DefaultChunkSize`'s `clamp` runs at resolve time only, so an operator can store a value the resolver then clamps down; the row shown and the value in effect can differ. Display-only, and adding clamping to the write path would mean changing the write service.

## Developer Notes

- **New extension point:** any setting that declares `scope` metadata automatically gets a working write surface in the admin tab - both as a card and as an inline sub-setting row. Adding `settableAt` to a tenth setting needs no UI work.
- **`settingFieldHelpers.ts`** is the shared home for setting-field presentation helpers (`rangeMessage`, `displayValue`), extracted so `AdminSettingInputField` and the new components share one copy of the bounds message without an import cycle.
- **Route-level pattern worth reusing:** a session/admin route that delegates to a core service whose contract is plain `Error` throws should translate those into `BadRequestError` keyed on the service's own message prefix, not on the error class. Keying on the class would relabel infrastructure failures as client errors; keying on the prefix keeps 5xx meaning 5xx and keeps operator mistakes out of the LiveOps `error`-level alarm.
- **The `SubSettingToggle` mount point** is the thing to remember if you add another per-setting panel: `AdminSettingsTab.renderSettingGroup` silently routes some settings away from the `<Card>` renderer, so a panel mounted only in the card is invisible for them.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings are introduced; this is a write surface for existing `scope` metadata
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry fields changed
