### PR TITLE
fix(services): correct admin credit clamp sign and delta persistence

### DIFF
--- a/apps/client/pages/api/stripe/webhook.ts
+++ b/apps/client/pages/api/stripe/webhook.ts
@@ -98,8 +98,10 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
 
         // Records the CreditTransaction (idempotent on stripePaymentIntentId),
         // then atomically $inc's the balance and stamps the pack lot. Replaces a
-        // former read-modify-$set of the whole user doc, which both reverted any
-        // concurrent balance write and double-credited on Stripe's webhook retries.
+        // former read-modify-$set of the whole user doc, which reverted any concurrent
+        // balance write. (The unique stripePaymentIntentId index already blocked
+        // double-crediting on Stripe retries: createTransaction rethrew the E11000 before
+        // the increment. The $inc additionally makes the balance update itself atomic.)
         await creditService.addCredits(
           {
             type: 'purchase',

--- a/b4m-core/services/src/userService/adminUpdate.test.ts
+++ b/b4m-core/services/src/userService/adminUpdate.test.ts
@@ -185,6 +185,58 @@ describe('adminUpdateUser — audited credit adjustments', () => {
   });
 });
 
+describe('adminUpdateUser - signed creditDelta path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes a positive creditDelta through a generic_add and stamps lastCreditsPurchasedAt', async () => {
+    const { adapters, createTransaction, incrementCredits, update } = makeAdapters(100);
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: 50, creditReason: 'Bonus' }, adapters);
+
+    const [type, data] = createTransaction.mock.calls[0];
+    expect(type).toBe('generic_add');
+    expect(data.credits).toBe(50);
+    expect(data.metadata).toMatchObject({ actorId: ADMIN_ID, previousBalance: 100, resultingBalance: 150 });
+    expect(incrementCredits).toHaveBeenCalledWith(TARGET_ID, 50, expect.anything());
+    // A grant stamps the purchase timestamp even though the UI sends only creditDelta.
+    expect(update.mock.calls[0][0].lastCreditsPurchasedAt).toBeInstanceOf(Date);
+  });
+
+  it('routes a negative creditDelta through a generic_deduct', async () => {
+    const { adapters, createTransaction, incrementCredits } = makeAdapters(100);
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: -30 }, adapters);
+
+    expect(createTransaction.mock.calls[0][0]).toBe('generic_deduct');
+    expect(incrementCredits).toHaveBeenCalledWith(TARGET_ID, -30);
+  });
+
+  it('does not invert a deduction when the balance is already negative', async () => {
+    const { adapters, createTransaction, incrementCredits } = makeAdapters(-100);
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: -50 }, adapters);
+
+    // The clamp must not floor at -previousBalance (+100): that would turn a 50-credit
+    // deduction into a +100 grant. The deduction applies verbatim on a negative balance.
+    expect(createTransaction.mock.calls[0][0]).toBe('generic_deduct');
+    expect(incrementCredits).toHaveBeenCalledWith(TARGET_ID, -50);
+    expect(createTransaction.mock.calls[0][1].metadata).toMatchObject({
+      previousBalance: -100,
+      resultingBalance: -150,
+    });
+  });
+
+  it('applies a creditDelta to the doc write when no creditTransactions adapter is wired', async () => {
+    const { adapters, incrementCredits, update } = makeAdapters(100, { withCreditTransactions: false });
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, creditDelta: 50 }, adapters);
+
+    // No ledger adapter: the delta must not be silently dropped - it lands on the doc write.
+    expect(incrementCredits).not.toHaveBeenCalled();
+    expect(update.mock.calls[0][0].currentCredits).toBe(150);
+  });
+});
+
 describe('adminUpdateUser - preferences merge', () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/b4m-core/services/src/userService/adminUpdate.ts
+++ b/b4m-core/services/src/userService/adminUpdate.ts
@@ -116,10 +116,6 @@ export async function adminUpdateUser(
   if (!user) {
     throw new Error('User not found');
   }
-  let lastCreditsPurchasedAt = user.lastCreditsPurchasedAt;
-  if ((params.currentCredits ?? 0) > 0 && params.currentCredits !== user.currentCredits) {
-    lastCreditsPurchasedAt = new Date();
-  }
 
   // Route a `currentCredits` change through the audited ledger when the adapter
   // is wired. The ledger runs before every write below, so a failure aborts with
@@ -131,16 +127,20 @@ export async function adminUpdateUser(
   const previousBalance = user.currentCredits ?? 0;
   const { moderationStatus, creditReason, creditDelta: signedDelta, ...baseParams } = params;
   // A signed `creditDelta` is applied verbatim (no interim-spend refund). Absolute
-  // `currentCredits` falls back to delta-from-fresh-balance.
+  // `currentCredits` falls back to delta-from-snapshot.
   const rawDelta =
     signedDelta !== undefined
       ? signedDelta
       : params.currentCredits !== undefined && params.currentCredits !== previousBalance
         ? params.currentCredits - previousBalance
         : 0;
-  // Never drive the balance below zero (mirrors the old client-side Math.max(0, ...)
-  // clamp, but against the fresh server balance instead of a stale snapshot).
-  const creditDelta = Math.max(rawDelta, -previousBalance);
+  // Floor a deduction so a non-negative balance is never driven below zero (mirrors the
+  // old client-side Math.max(0, ...) clamp). Only when the balance is non-negative: when
+  // it is already negative, `-previousBalance` is a positive floor that would invert a
+  // deduction into a credit, so apply the delta verbatim in that case.
+  const creditDelta = previousBalance >= 0 ? Math.max(rawDelta, -previousBalance) : rawDelta;
+  // Stamp a purchase timestamp only for a net grant; a deduction must not count as a purchase.
+  const lastCreditsPurchasedAt = creditDelta > 0 ? new Date() : user.lastCreditsPurchasedAt;
   const auditCreditChange = creditDelta !== 0 && !!db.creditTransactions;
 
   const builtParams = { ...baseParams, lastCreditsPurchasedAt };
@@ -152,6 +152,12 @@ export async function adminUpdateUser(
   const writeData = toUserUpdatePartial(builtUser, builtParams);
   if (auditCreditChange) {
     delete (writeData as { currentCredits?: number }).currentCredits;
+  } else if (signedDelta !== undefined && creditDelta !== 0) {
+    // Signed-delta path with no ledger adapter wired: apply the delta to the doc write
+    // directly (like the legacy absolute-`currentCredits` fallback) instead of dropping
+    // it silently. `currentCredits` is not in `baseParams` on this path, so nothing else
+    // would persist the change.
+    (writeData as { currentCredits?: number }).currentCredits = previousBalance + creditDelta;
   }
 
   // Audited credit adjustment: runs BEFORE any persistence (org membership, the
@@ -160,6 +166,9 @@ export async function adminUpdateUser(
   // generic_add / generic_deduct CreditTransaction.
   if (auditCreditChange && db.creditTransactions) {
     const note = creditReason?.trim() || undefined;
+    // Best-effort resulting balance predicted from the read snapshot. The atomic $inc
+    // inside addCredits/subtractCredits is the source of truth, so concurrent spend
+    // between the read and the increment can make this differ from the committed balance.
     const resultingBalance = previousBalance + creditDelta;
     const metadata: Record<string, unknown> = { actorId: userId, previousBalance, resultingBalance };
     if (note) {


### PR DESCRIPTION
Addresses the review feedback on #2455. Stacked on `fix/targeted-repository-updates` so the diff is just these fixes.

## What was wrong

The admin credit-adjustment path routes through the atomic credit ledger and added a signed `creditDelta` input, but the `creditDelta` route (the only one the Credit Analysis admin UI sends) had three defects and two comments were inaccurate.

- **Clamp inverted a deduction on an already-negative balance.** `Math.max(rawDelta, -previousBalance)` only floors correctly when the balance is non-negative. When the balance is already negative, `-previousBalance` is a positive floor: balance `-100`, admin deducts `50` -> `rawDelta = -50`, floor `+100`, result `+100` -- a 50-credit deduction became a 100-credit grant.
- **Signed `creditDelta` was silently dropped with no ledger adapter.** With no `creditTransactions` adapter wired, `auditCreditChange` is false and `currentCredits` is not in params, so nothing persisted the change. (Latent today -- the sole production caller always wires the adapter -- but a real defensive gap.)
- **`lastCreditsPurchasedAt` was never stamped on the `creditDelta` path.** It was set only for an absolute `currentCredits` increase (and, as a latent bug, for any decrease to a positive target). The UI sends only `creditDelta`, so admin grants never stamped it.

## The fix

- Clamp floors at zero only when the balance is non-negative; on a negative balance the delta applies verbatim, so a deduction is never inverted into a credit.
- No-adapter `creditDelta` path falls back to applying the delta to the doc write (same shape as the legacy absolute-`currentCredits` fallback) instead of dropping it.
- `lastCreditsPurchasedAt` is stamped on a net positive grant regardless of which input drove it, and no longer on a deduction.
- Corrected the clamp comment (`previousBalance` is a read snapshot, not the fresh server balance) and the `resultingBalance` metadata comment (best-effort predicted from the snapshot; the atomic `$inc` is the source of truth).
- Corrected the webhook comment: the unique `stripePaymentIntentId` index already blocked double-crediting on Stripe retries (`createTransaction` rethrew the E11000 before the increment); the `$inc` only adds atomicity over the former read-modify-`$set`.

## Tests

`adminUpdate.test.ts` gains four `creditDelta`-path cases: positive delta -> `generic_add` + `lastCreditsPurchasedAt` stamp; negative delta -> `generic_deduct`; negative delta on a negative balance is not inverted; and `creditDelta` with no `creditTransactions` adapter lands on the doc write. Three of these fail on the pre-fix source and pass after.

## Verification

`pnpm --filter @bike4mind/services test` (6094 passing), `pnpm --filter @bike4mind/services typecheck`, `pnpm --filter @bike4mind/client typecheck`, and `pnpm lint:check` all green.