### PR TITLE
docs(data-lakes): correct the vectorize kill-switch comment's no-auto-resume premise

### DIFF
--- a/apps/client/server/queueHandlers/fabFileVectorize.ts
+++ b/apps/client/server/queueHandlers/fabFileVectorize.ts
@@ -117,9 +117,12 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
   // fanned out before it flipped. Placed AFTER the already-vectorized guard above so a completed
   // file is never touched, and before the embedding work (user work short-circuits in
   // isConvergenceHalted before any settings read). Unlike a chunk message, a dropped vectorize
-  // message does NOT auto-resume - fabFileChunk is its only producer and it early-returns on an
-  // already-chunked file - so flag the file so the abandoned, chunked-but-unvectorized state is
-  // enumerable and reprocessable (POST /api/files/reprocess re-drives it and clears the note).
+  // message does NOT auto-resume - not because a chunk message could not resume it (any redelivery
+  // for an already-chunked file does, via resumeVectorizeEnqueue in fabFileChunk) but because
+  // nothing produces one: the only automatic producer is the stranded sweep, and it selects on
+  // vectorizeEnqueueFailedAt (buildStrandedVectorizeScanFilter), which this branch never stamps.
+  // So flag the file, to keep the abandoned, chunked-but-unvectorized state enumerable and
+  // reprocessable (POST /api/files/reprocess re-drives it and clears the note).
   if (
     await isConvergenceHalted(
       { origin: payload.origin, lakeId: payload.lakeId },


### PR DESCRIPTION
## Summary
The kill-switch branch in `fabFileVectorize.ts` explained why a dropped vectorize message does not auto-resume by citing that `fabFileChunk` early-returns on an already-chunked file. That premise no longer holds: `fabFileChunk` now calls `resumeVectorizeEnqueue` and re-sends the fan-out for any chunk still lacking a vector.

The conclusion (no auto-resume) is still correct, just for a different reason: this branch stamps `chunkStallReason: 'vectorizePaused'` but never `vectorizeEnqueueFailedAt`, so `buildStrandedVectorizeScanFilter` cannot enumerate the file and nothing produces the chunk message that would resume it.

This PR updates the comment to state the true reason so the invariant survives the next reader.

## Test plan
- [x] `pnpm lint:check`
- [x] `pnpm --filter @bike4mind/client typecheck`
- [x] `vitest --project node server/queueHandlers/fabFileVectorize` (43/43 pass)
- [x] `scripts/check-no-smart-punctuation.sh`, `scripts/check-no-control-bytes.sh`