### PR TITLE
refactor(data-lakes): bound the stranded-vectorize rescue sends in both drivers

### DIFF
--- a/apps/client/server/cron/dataLakeBatchReconcile.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const h = vi.hoisted(() => ({
+  queueResourceThrows: false,
   findStuck: vi.fn(),
   reconcile: vi.fn(),
   findStuckTaxonomy: vi.fn(),
@@ -61,7 +62,15 @@ vi.mock('@bike4mind/observability', () => {
 });
 vi.mock('@server/utils/config', () => ({ Config: { MONGODB_URI: 'mongodb://localhost:27017/%STAGE%', STAGE: 'dev' } }));
 vi.mock('sst', () => ({
-  Resource: { App: { stage: 'dev' }, fabFileChunkQueue: { url: 'http://sqs/fabFileChunkQueue' } },
+  Resource: {
+    App: { stage: 'dev' },
+    // A getter, so a test can fault the RESOURCE READ itself - the thing that used to be swallowed
+    // once per candidate. Defaults to the working url.
+    get fabFileChunkQueue() {
+      if (h.queueResourceThrows) throw new Error('Resource "fabFileChunkQueue" is not linked');
+      return { url: 'http://sqs/fabFileChunkQueue' };
+    },
+  },
 }));
 vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => h.sendToQueue(...a) }));
 vi.mock('@server/worker/chunkRescueSweep', () => ({
@@ -88,6 +97,7 @@ const TIMEOUT = 180 * 60 * 1000;
 
 describe('dataLakeBatchReconcile cron handler', () => {
   beforeEach(() => {
+    h.queueResourceThrows = false;
     vi.clearAllMocks();
     h.recordRun.mockResolvedValue(undefined);
     h.recordForced.mockResolvedValue(undefined);
@@ -100,6 +110,10 @@ describe('dataLakeBatchReconcile cron handler', () => {
     // that makes sendToQueue reject leaks that into every test after it in file order.
     h.getSettingsValue.mockResolvedValue(false);
     h.sendToQueue.mockResolvedValue(undefined);
+    // Same reason as sendToQueue above, and the same leak: a test that makes the un-chunked sweep
+    // reject otherwise leaves that rejection in place for every test after it in file order, which
+    // shows up as a stray 'un-chunked rescue sweep failed' line in an unrelated test's log assertions.
+    h.runSweep.mockResolvedValue({ enqueued: 0, failed: 0 });
     h.fabFileFind.mockReturnValue({
       select: () => ({ limit: () => ({ lean: async () => [] }) }),
     });
@@ -241,6 +255,30 @@ describe('dataLakeBatchReconcile cron handler', () => {
       h.findStuck.mockResolvedValue([]);
       h.reconcile.mockResolvedValue([]);
       routeFind([]);
+    });
+
+    it('lets an unlinked queue fail the sweep ONCE rather than per candidate', async () => {
+      // The resource read used to sit inside the per-file `try`, so a config fault was caught once per
+      // candidate and `sent` stayed 0 - a hard misconfiguration arriving as a run of ordinary-looking
+      // send failures. Hoisted above the fan-out, it escapes the sweep instead. MUST STAY IN SYNC with
+      // the self-host twin's identical case in chunkRescueSweep.test.ts.
+      h.queueResourceThrows = true;
+      routeFind([
+        { _id: 'ff1', userId: 'u1' },
+        { _id: 'ff2', userId: 'u2' },
+        { _id: 'ff3', userId: 'u3' },
+      ]);
+
+      const res = await handler();
+
+      // ONE aggregate line from the sweep's own `.catch`, not one per candidate. That is the whole
+      // point: three identical per-file lines made a config fault look like ordinary send failures.
+      expect(h.loggerError).toHaveBeenCalledTimes(1);
+      expect(h.loggerError).toHaveBeenCalledWith(expect.stringContaining('stranded-vectorize rescue sweep failed'));
+      expect(h.sendToQueue).not.toHaveBeenCalled();
+      // The run still heartbeats and reports, so the rest of the cron is unaffected.
+      expect(JSON.parse(res.body).rescuedVectorizeFiles).toBe(0);
+      expect(h.recordRun).toHaveBeenCalled();
     });
 
     it('re-enqueues files whose vectorize hand-off was stranded, regardless of auto-chunk', async () => {

--- a/apps/client/server/cron/dataLakeBatchReconcile.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.test.ts
@@ -282,6 +282,39 @@ describe('dataLakeBatchReconcile cron handler', () => {
       expect(JSON.parse(res.body).rescuedVectorizeFiles).toBe(2);
     });
 
+    it('attempts every candidate across concurrency waves, not just the first wave', async () => {
+      // The fan-out runs in fixed-size waves; an off-by-one in the slice window would silently drop
+      // the tail of a full run, which is indistinguishable from "the backlog was small" in the log.
+      routeFind(Array.from({ length: 25 }, (_, i) => ({ _id: `ff${i}`, userId: `u${i}` })));
+
+      const res = await handler();
+
+      expect(h.sendToQueue).toHaveBeenCalledTimes(25);
+      expect(JSON.parse(res.body).rescuedVectorizeFiles).toBe(25);
+    });
+
+    it('never has more than ENQUEUE_CONCURRENCY sends in flight', async () => {
+      // This is the LAST of three sweeps in one 10-minute Lambda, so a sequential run against a
+      // degraded queue is what cuts the tail off - and the bound must stay pinned as a number,
+      // since a sequential loop (peak 1) and an unbounded Promise.all (peak 25) both keep every
+      // other assertion here green. Each send holds open across a macrotask so the overlap is
+      // observable at all; an immediately-resolving stub reports a peak of 1 either way.
+      routeFind(Array.from({ length: 25 }, (_, i) => ({ _id: `ff${i}`, userId: `u${i}` })));
+      let inFlight = 0;
+      let peak = 0;
+      h.sendToQueue.mockImplementation(async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        inFlight -= 1;
+      });
+
+      const res = await handler();
+
+      expect(peak).toBe(10);
+      expect(JSON.parse(res.body).rescuedVectorizeFiles).toBe(25);
+    });
+
     it('sends a stranded file UNSTAMPED, so the kill switch cannot route it into the rebuild door', async () => {
       // The inverse of the un-chunked sweep's rule (#2309), and the asymmetry is the point. These
       // files are already chunked, and the handler's halt branch sits above the already-chunked

--- a/apps/client/server/cron/dataLakeBatchReconcile.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.ts
@@ -45,6 +45,16 @@ const MAX_PER_RUN = 500;
 const CHUNK_RESCUE_MAX_PER_RUN = 500;
 
 /**
+ * How many stranded-vectorize sends are in flight at once, matching the bound the un-chunked sweep
+ * and driveLakeResyncPoll already use. sendToQueue builds a fresh SQSClient per call
+ * (server/utils/sqs.ts), so its retry token bucket never throttles down across the loop and every
+ * failed send pays its full attempt budget with no back-off. Run one-at-a-time against a degraded
+ * queue, CHUNK_RESCUE_MAX_PER_RUN of those is a wall-clock cost this handler cannot absorb - it is
+ * the LAST of three sweeps in one 10-minute Lambda, so the tail is what gets cut off.
+ */
+const ENQUEUE_CONCURRENCY = 10;
+
+/**
  * Hosted counterpart of the same second pass in the self-host worker's fabFileChunkScan: files
  * whose chunks were committed but whose vectorize hand-off failed. Re-enqueueing a chunk message
  * resumes only the fan-out (see buildStrandedVectorizeScanFilter and fabFileChunk.ts) - it never
@@ -59,13 +69,16 @@ async function rescueStrandedVectorizeFiles(): Promise<number> {
     .limit(CHUNK_RESCUE_MAX_PER_RUN)
     .lean();
 
-  // Per-send catch, not a bare sequential loop: one throttled or unroutable send must cost only
-  // itself, not abandon every candidate behind it (the same lesson driveLakeResyncPoll learned). A
-  // recovery sweep is the worst place for that, since it runs precisely when the queue is under the
-  // stress that makes a transient send failure likely. Returns the SENT count so a partially-failing
-  // tick is distinguishable from a clean one in the log.
+  // Bounded-concurrency fan-out with a PER-FILE catch: one throttled or unroutable send must cost
+  // only itself, not abandon every candidate behind it (the same lesson driveLakeResyncPoll
+  // learned). A recovery sweep is the worst place for that, since it runs precisely when the queue
+  // is under the stress that makes a transient send failure likely - which is also why the sends
+  // are bounded rather than sequential, see ENQUEUE_CONCURRENCY. Returns the SENT count so a
+  // partially-failing run is distinguishable from a clean one in the log.
+  // Read the queue URL once: an unlinked-resource fault is one config error, not a log per file.
+  const queueUrl = Resource.fabFileChunkQueue.url;
   let sent = 0;
-  for (const file of candidates) {
+  const sendOne = async (file: (typeof candidates)[number]) => {
     try {
       // Deliberately UNSTAMPED, unlike the un-chunked sweep above (#2309): these files are already
       // chunked, and the handler's halt branch (fabFileChunk.ts, isConvergenceHalted) runs ABOVE the
@@ -78,7 +91,7 @@ async function rescueStrandedVectorizeFiles(): Promise<number> {
       // no chunks to damage; this filter has no paused-file exclusion, which is what would make the
       // re-fire unbounded rather than one-shot. Finishing an already-committed hand-off is not the
       // background work the kill switch exists to stop.
-      await sendToQueue(Resource.fabFileChunkQueue.url, {
+      await sendToQueue(queueUrl, {
         fabFileId: String(file._id),
         userId: String(file.userId),
       });
@@ -86,6 +99,9 @@ async function rescueStrandedVectorizeFiles(): Promise<number> {
     } catch (err) {
       logger.error(`[DataLakeBatchReconcile] stranded-vectorize rescue send failed for ${file._id}: ${err}`);
     }
+  };
+  for (let i = 0; i < candidates.length; i += ENQUEUE_CONCURRENCY) {
+    await Promise.all(candidates.slice(i, i + ENQUEUE_CONCURRENCY).map(file => sendOne(file)));
   }
   return sent;
 }

--- a/apps/client/server/worker/chunkRescueSweep.test.ts
+++ b/apps/client/server/worker/chunkRescueSweep.test.ts
@@ -20,6 +20,9 @@ const h = vi.hoisted(() => ({
   buildStrandedFilter: vi.fn((cutoff: Date, _staleClaimBefore: Date) => ({
     vectorizeEnqueueFailedAt: { $lt: cutoff },
   })),
+  // A getter, so a test can make the RESOURCE READ itself fault - which is the thing that used to be
+  // swallowed once per candidate. Defaults to the working url.
+  queueResourceThrows: false,
 }));
 
 vi.mock('@bike4mind/database', () => ({
@@ -67,7 +70,14 @@ vi.mock('@bike4mind/services', () => ({
       }),
   },
 }));
-vi.mock('sst', () => ({ Resource: { fabFileChunkQueue: { url: 'http://elasticmq/fabFileChunkQueue' } } }));
+vi.mock('sst', () => ({
+  Resource: {
+    get fabFileChunkQueue() {
+      if (h.queueResourceThrows) throw new Error('Resource "fabFileChunkQueue" is not linked');
+      return { url: 'http://elasticmq/fabFileChunkQueue' };
+    },
+  },
+}));
 vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => h.sendToQueue(...a) }));
 // Only the filters are stubbed; buildChunkRescueMessage stays real so the payload shape this
 // sweep sends is asserted against the shared producer, not a local copy of it. Spreading the actual
@@ -274,8 +284,29 @@ describe('runStrandedVectorizeRescue (self-host stranded-vectorize pass)', () =>
 
   beforeEach(() => {
     vi.clearAllMocks();
+    h.queueResourceThrows = false;
     h.sendToQueue.mockResolvedValue(undefined);
     withCandidates([]);
+  });
+
+  it('lets an unlinked queue fail the pass ONCE rather than per candidate', async () => {
+    // The resource read used to sit inside the per-file `try`, so a config fault was caught once per
+    // candidate: up to CHUNK_SCAN_BATCH identical error lines a minute on the 60s tick, `sent` stuck
+    // at 0, and the summary log gated on `sent > 0` so nothing aggregate fired. A hard misconfiguration
+    // was indistinguishable from ordinary SQS throttling. Hoisted above the fan-out, it escapes to the
+    // driver's catch.
+    h.queueResourceThrows = true;
+    withCandidates([
+      { _id: 'ff1', userId: 'u1' },
+      { _id: 'ff2', userId: 'u2' },
+      { _id: 'ff3', userId: 'u3' },
+    ]);
+
+    await expect(runRescue()).rejects.toThrow(/not linked/);
+
+    // Not once per file, which is the whole point.
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(h.sendToQueue).not.toHaveBeenCalled();
   });
 
   it('runs regardless of auto-chunk', async () => {

--- a/apps/client/server/worker/chunkRescueSweep.test.ts
+++ b/apps/client/server/worker/chunkRescueSweep.test.ts
@@ -87,6 +87,22 @@ const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 const SELF_HOST_LIMIT = 50;
 const runSweep = (limit = SELF_HOST_LIMIT) => runChunkRescueSweep({ limit, logger: logger as never });
 
+/**
+ * Makes each send hold open across a macrotask so overlapping ones are actually observable: an
+ * immediately-resolving stub would report a peak of 1 even for an unbounded fan-out.
+ */
+const trackSendConcurrency = () => {
+  let inFlight = 0;
+  let peak = 0;
+  h.sendToQueue.mockImplementation(async () => {
+    inFlight += 1;
+    peak = Math.max(peak, inFlight);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    inFlight -= 1;
+  });
+  return () => peak;
+};
+
 const limitSpy = vi.fn();
 const withCandidates = (candidates: Candidate[]) => {
   h.fabFileFind.mockReturnValue({
@@ -239,6 +255,18 @@ describe('runChunkRescueSweep (self-host chunk rescue)', () => {
 
     expect(h.sendToQueue).toHaveBeenCalledTimes(25);
   });
+
+  it('never has more than ENQUEUE_CONCURRENCY sends in flight', async () => {
+    // The bound is what keeps the per-file catch affordable (see the ENQUEUE_CONCURRENCY docblock),
+    // so it is worth pinning as a number: a sequential loop peaks at 1 and an unbounded
+    // Promise.all over the whole pass peaks at 25, and both leave every other assertion green.
+    withCandidates(Array.from({ length: 25 }, (_, i) => ({ _id: `ff${i}`, userId: `u${i}` })));
+    const peak = trackSendConcurrency();
+
+    await expect(runSweep()).resolves.toEqual({ enqueued: 25, failed: 0 });
+
+    expect(peak()).toBe(10);
+  });
 });
 
 describe('runStrandedVectorizeRescue (self-host stranded-vectorize pass)', () => {
@@ -321,6 +349,28 @@ describe('runStrandedVectorizeRescue (self-host stranded-vectorize pass)', () =>
 
     expect(logger.info).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('attempts every candidate across concurrency waves, not just the first wave', async () => {
+    // The fan-out runs in fixed-size waves; an off-by-one in the slice window would silently drop
+    // the tail of a full pass, which is indistinguishable from "the backlog was small" in the logs.
+    withCandidates(Array.from({ length: 25 }, (_, i) => ({ _id: `ff${i}`, userId: `u${i}` })));
+
+    await expect(runRescue()).resolves.toBe(25);
+
+    expect(h.sendToQueue).toHaveBeenCalledTimes(25);
+  });
+
+  it('never has more than ENQUEUE_CONCURRENCY sends in flight', async () => {
+    // This pass shares the 60s non-reentrant tick with runChunkRescueSweep, so its sends are
+    // bounded for the same reason that sweep's are - and must stay bounded, since a sequential loop
+    // (peak 1) or an unbounded Promise.all (peak 25) both keep every other assertion here green.
+    withCandidates(Array.from({ length: 25 }, (_, i) => ({ _id: `ff${i}`, userId: `u${i}` })));
+    const peak = trackSendConcurrency();
+
+    await expect(runRescue()).resolves.toBe(25);
+
+    expect(peak()).toBe(10);
   });
 });
 

--- a/apps/client/server/worker/chunkRescueSweep.ts
+++ b/apps/client/server/worker/chunkRescueSweep.ts
@@ -41,7 +41,8 @@ import {
 } from '@server/dataLakes/convergencePauseScope';
 
 /**
- * How many rescue sends are in flight at once, matching driveLakeResyncPoll's sweep.
+ * How many rescue sends are in flight at once, matching driveLakeResyncPoll's sweep. Governs BOTH
+ * passes below, which share one tick.
  * The bound is what makes the per-file catch below safe: sendToQueue builds a fresh SQSClient per
  * call (server/utils/sqs.ts), so its retry token bucket never throttles down across the loop and
  * every failed send pays its full attempt budget with no back-off. Run one-at-a-time against a
@@ -175,13 +176,14 @@ export async function runStrandedVectorizeRescue(runLogger: Logger): Promise<num
   // Per-send catch so one throttled or unroutable send costs only itself: this is the last pass of
   // a scheduled task, so an escaping rejection would abandon every candidate behind it AND fail the
   // whole tick.
-  // Sequential, unlike the ENQUEUE_CONCURRENCY fan-out above - that bound does NOT apply here. It
-  // stays sequential to match the hosted twin, so bounding it is a change that belongs in both
-  // rather than a self-host-only edit. Worth knowing if that is ever revisited: this pass shares
-  // the 60s non-reentrant tick with runChunkRescueSweep, so the worst case the ENQUEUE_CONCURRENCY
-  // docblock describes is both passes' CHUNK_SCAN_BATCH inside one tick's budget.
+  // Same bounded fan-out as runChunkRescueSweep above, and for the reason its ENQUEUE_CONCURRENCY
+  // docblock gives: this pass shares the 60s non-reentrant tick with that sweep, so one tick has to
+  // absorb BOTH passes' CHUNK_SCAN_BATCH of sends. Run one-at-a-time against a degraded queue,
+  // where every failure pays its full attempt budget, that overruns the tick and costs the next one.
+  // Read the queue URL once: an unlinked-resource fault is one config error, not a log per file.
+  const queueUrl = Resource.fabFileChunkQueue.url;
   let sent = 0;
-  for (const file of candidates) {
+  const sendOne = async (file: (typeof candidates)[number]) => {
     try {
       // Deliberately UNSTAMPED, unlike the un-chunked sweep above (#2309): these files are already
       // chunked, and the handler's halt branch (fabFileChunk.ts, isConvergenceHalted) runs ABOVE the
@@ -190,7 +192,7 @@ export async function runStrandedVectorizeRescue(runLogger: Logger): Promise<num
       // and then throwing - so the resume never runs and this sweep re-sends the file every tick
       // until each message burns its retry ladder into the DLQ. Must stay in sync with the hosted
       // twin's identical reasoning in dataLakeBatchReconcile.ts.
-      await sendToQueue(Resource.fabFileChunkQueue.url, {
+      await sendToQueue(queueUrl, {
         fabFileId: String(file._id),
         userId: String(file.userId),
       });
@@ -198,6 +200,9 @@ export async function runStrandedVectorizeRescue(runLogger: Logger): Promise<num
     } catch (err) {
       runLogger.error(`[fabFileChunkScan] stranded-vectorize re-enqueue failed for ${file._id}: ${err}`);
     }
+  };
+  for (let i = 0; i < candidates.length; i += ENQUEUE_CONCURRENCY) {
+    await Promise.all(candidates.slice(i, i + ENQUEUE_CONCURRENCY).map(file => sendOne(file)));
   }
   if (sent > 0) {
     runLogger.info(`[fabFileChunkScan] re-enqueued ${sent} file(s) with a stranded vectorize hand-off`);


### PR DESCRIPTION
## Summary

Follow-up to #2263 (which extracted `runStrandedVectorizeRescue` on self-host). This is step 2 for #2189: bound the fan-out of both stranded-vectorize rescue drivers so a degraded queue can't let a pass outlast its own time budget.

- Both stranded-vectorize passes previously sent one file at a time with no bound on concurrency or wall-clock time. `sendToQueue` builds a fresh SQS client per call, so retries never throttle down across a loop, and a degraded queue - exactly when a recovery sweep matters - lets a full pass blow its budget: a 60s non-reentrant scheduled tick on self-host, or the tail of the last of three sweeps in one 10-minute Lambda on hosted.
- `apps/client/server/worker/chunkRescueSweep.ts`: `runStrandedVectorizeRescue` now uses the same fixed-wave `ENQUEUE_CONCURRENCY` (10) fan-out as `runChunkRescueSweep`, keeping the per-file catch and sent-count return. Queue URL is read once per pass instead of per file.
- `apps/client/server/cron/dataLakeBatchReconcile.ts`: `rescueStrandedVectorizeFiles` gets the same wave loop behind its own local `ENQUEUE_CONCURRENCY = 10` const (matching the in-repo idiom of `driveLakeResyncPoll.ts` and `runChunkRescueSweep`, each of which declares its own rather than sharing an import). Queue URL hoisted out of the loop.
- Removed a stale self-host docblock claiming the pass "stays sequential to match the hosted twin"; the ordering rationale (why the hosted pass being last matters) now lives on the hosted constant's docblock instead.

Send payloads, selection filters, per-file catch semantics, return types, and log lines are all unchanged in both files.

## Test plan

- [x] New tests pin the bound as a number in both drivers plus the un-chunked sweep (`never has more than ENQUEUE_CONCURRENCY sends in flight`), each holding sends open across a macrotask to make overlap observable
- [x] Mutation-verified both directions: `ENQUEUE_CONCURRENCY = 1000` and `= 1` both fail the new assertions while leaving every other assertion green
- [x] `vitest run --project node server/worker server/cron` - 12 files, 152 tests, green
- [x] `CLIENT_TEST_LANE=integration vitest run server/worker/chunkRescueSweep.e2e.test.ts server/cron/dataLakeBatchReconcile.e2e.test.ts` - 6 tests, green
- [x] `pnpm turbo:typecheck` - clean
- [x] `pnpm lint:check` - clean
- [x] ASCII guards (`check-no-smart-punctuation.sh`, `check-no-control-bytes.sh`) - clean