### PR TITLE
fix(data-lakes): surface the server's refusal text on lake mutations

### DIFF
--- a/apps/client/app/hooks/data/dataLakes.test.ts
+++ b/apps/client/app/hooks/data/dataLakes.test.ts
@@ -74,6 +74,9 @@ import {
   useRetryLakeLifecycle,
   useTransferLakeOwnership,
   usePurgeDataLakeDocument,
+  useCreateDataLake,
+  useReanalyzeTaxonomy,
+  useDismissTaxonomy,
 } from './dataLakes';
 
 const PAGE_SIZE = 24;
@@ -1422,5 +1425,139 @@ describe('the needs-attention list and its retry', () => {
     });
 
     expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['data-lakes', 'transitional']));
+  });
+});
+
+/**
+ * Every data-lake mutation that refuses for a reason the user can act on must show that reason.
+ *
+ * The bug (#2466): these handlers toasted `error.message`, which on an axios rejection is the
+ * generic "Request failed with status code 400" - the server's sentence sits at
+ * `response.data.error` and was thrown away. So "Tag prefix X overlaps an existing data lake -
+ * choose a different prefix" and "try again" both reached the user as the same status line.
+ *
+ * Driven through the real hooks rather than by unit-testing `serverRefusalMessage` directly: the
+ * helper was already correct and already present in this file: the defect was in which handlers
+ * called it, which only a test that mounts the hook can observe.
+ */
+describe('server refusal text reaches the toast', () => {
+  const mountHook = <T>(hook: () => T): { result: { current: T } } => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+    return renderHook(hook, { wrapper });
+  };
+
+  // One entry per door, each with the kind of refusal that door actually sends. `invoke` carries
+  // the hook's own mutate signature - they differ (an id, an object, a tag array, nothing).
+  const doors: {
+    name: string;
+    refusal: string;
+    status?: number;
+    mount: () => { result: { current: { mutateAsync: (arg: never) => Promise<unknown> } } };
+    arg: unknown;
+  }[] = [
+    {
+      name: 'useApplyTaxonomySuggestions',
+      refusal: "Could not verify this lake's tag prefix does not overlap another lake right now - try again",
+      mount: () => mountHook(() => useApplyTaxonomySuggestions('b1')) as never,
+      arg: [],
+    },
+    {
+      name: 'useCreateDataLake',
+      refusal: 'Tag prefix "acme:" overlaps an existing data lake - choose a different prefix.',
+      mount: () => mountHook(() => useCreateDataLake()) as never,
+      arg: { name: 'Acme', fileTagPrefix: 'acme:' },
+    },
+    {
+      name: 'useSetLakeVisibility',
+      refusal: 'Only the lake\u2019s owner can change how it is shared.',
+      mount: () => mountHook(() => useSetLakeVisibility()) as never,
+      arg: { id: 'lake1', visibility: 'public' },
+    },
+    {
+      name: 'useArchiveDataLake',
+      refusal: "Cannot archive a data lake in 'deleting' status",
+      mount: () => mountHook(() => useArchiveDataLake()) as never,
+      arg: 'lake1',
+    },
+    {
+      name: 'useCleanupDataLake',
+      refusal: 'Data lake must be soft-deleted before cleanup',
+      mount: () => mountHook(() => useCleanupDataLake()) as never,
+      arg: 'lake1',
+    },
+    {
+      name: 'useRetryLakeLifecycle',
+      refusal: 'This data lake is already being permanently deleted',
+      mount: () => mountHook(() => useRetryLakeLifecycle()) as never,
+      arg: { id: 'lake1', action: 'delete' },
+    },
+    {
+      name: 'useReanalyzeTaxonomy',
+      refusal: 'This batch is not in a state that can be re-analyzed right now',
+      mount: () => mountHook(() => useReanalyzeTaxonomy('b1')) as never,
+      arg: undefined,
+    },
+    {
+      name: 'useDismissTaxonomy',
+      refusal: 'Tag suggestions are not in a dismissible state for this batch',
+      mount: () => mountHook(() => useDismissTaxonomy('b1')) as never,
+      arg: undefined,
+    },
+    {
+      name: 'useRechunkDataLake',
+      refusal: 'This data lake is built into the platform and is read-only',
+      mount: () => mountHook(() => useRechunkDataLake('lake1')) as never,
+      arg: undefined,
+    },
+  ];
+
+  it.each(doors)('$name toasts the server sentence, not the status line', async ({ refusal, mount, arg }) => {
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+    apiPost.mockReset();
+    apiPost.mockRejectedValueOnce(axiosRefusal(400, refusal));
+
+    const { result } = mount();
+    await act(async () => {
+      await result.current.mutateAsync(arg as never).catch(() => {});
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(refusal);
+  });
+
+  // The anti-cheat for the table above: `serverRefusalMessage` returns undefined when the body
+  // carries no `error` key, and the handler must then fall back rather than toast "undefined".
+  it('falls back to the generic copy when the server sent no reason', async () => {
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+    apiPost.mockReset();
+    apiPost.mockRejectedValueOnce(
+      Object.assign(new Error('Request failed with status code 500'), {
+        isAxiosError: true,
+        response: { status: 500, data: {} },
+      })
+    );
+
+    const { result } = mountHook(() => useApplyTaxonomySuggestions('b1'));
+    await act(async () => {
+      await result.current.mutateAsync([]).catch(() => {});
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Request failed with status code 500');
+  });
+
+  // A non-axios throw (a bug in the mutationFn itself) must not be swallowed into the fallback -
+  // its own message is the only diagnostic there is.
+  it('keeps a non-axios error message', async () => {
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+    apiPost.mockReset();
+    apiPost.mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = mountHook(() => useApplyTaxonomySuggestions('b1'));
+    await act(async () => {
+      await result.current.mutateAsync([]).catch(() => {});
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('boom');
   });
 });

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -43,6 +43,26 @@ import { invalidateGearsStatusWhileLocked } from '@client/app/hooks/useGearsStat
 import { dataLakeKeys } from '@client/app/hooks/data/dataLakeKeys';
 
 /**
+ * The server's own refusal text, if it sent one. The body key is `error`, per
+ * server/middlewares/errorHandler.ts - every data-lake surface that shows a refusal to a human
+ * reads it through here so none of them can drift back onto `message` and silently show only
+ * their fallback.
+ *
+ * Why this matters on every mutation below: axios rejects with `.message` set to the generic
+ * "Request failed with status code 400", so a handler that toasts `error.message` discards the
+ * one sentence that tells the user what to do about it. These doors refuse for reasons the user
+ * can act on - "choose a different prefix", "Make it private first", "try again" - and a status
+ * code is the single least useful thing to show instead.
+ *
+ * Declared here rather than beside its first caller so all of them can read it without a
+ * forward reference.
+ */
+function serverRefusalMessage(error: unknown): string | undefined {
+  if (!isAxiosError(error)) return undefined;
+  return (error.response?.data as { error?: string } | undefined)?.error || undefined;
+}
+
+/**
  * True for a 4xx, which on the manage-gated lake reads (spend, proposals) means "you may see this
  * lake but not this surface". Callers hide the surface on it rather than painting an error, so it
  * must not widen to 5xx - a server fault is a real error and should read as one.
@@ -257,11 +277,9 @@ export function useTransferLakeOwnership() {
       toast.success('Data lake ownership transferred');
     },
     onError: (error: Error) => {
-      // Surface the server's own refusal text. This endpoint's rejections are the actionable kind
-      // ("name another member", "must belong to the organization that owns this data lake"), and
-      // axios would otherwise replace them with "Request failed with status code 400". The body key
-      // is `error`, per the API error handler (server/middlewares/errorHandler.ts).
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      // This endpoint's rejections are the actionable kind ("name another member", "must belong to
+      // the organization that owns this data lake").
+      const refusal = serverRefusalMessage(error);
       toast.error(refusal || error.message || 'Failed to transfer ownership');
     },
   });
@@ -344,7 +362,7 @@ export function useCreateDataLake(options?: { onSuccess?: (data: DataLakeConfig)
       options?.onSuccess?.(data);
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to create data lake');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to create data lake');
     },
   });
 }
@@ -375,7 +393,7 @@ export function useUpdateDataLake() {
       toast.success('Data lake updated');
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to update data lake');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to update data lake');
     },
   });
 }
@@ -398,7 +416,7 @@ export function useUpdateFallbackLakeSettings() {
       toast.success('Data lake settings updated');
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to update data lake settings');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to update data lake settings');
     },
   });
 }
@@ -441,7 +459,7 @@ export function useSetLakeVisibility() {
       toast.success(VISIBILITY_TOAST[visibility]);
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to change visibility');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to change visibility');
     },
   });
 }
@@ -516,7 +534,7 @@ function useLifecycleMutation(action: LifecycleAction, successMessage: string, e
       toast.success(successMessage);
     },
     onError: (error: Error) => {
-      toast.error(error.message || errorMessage);
+      toast.error(serverRefusalMessage(error) || error.message || errorMessage);
     },
   });
 }
@@ -616,7 +634,7 @@ export function useCleanupDataLake() {
       toast.success('Data lake permanently purged');
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to clean up data lake');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to clean up data lake');
     },
   });
 }
@@ -655,7 +673,7 @@ export function useRetryLakeLifecycle() {
       toast.success('Retrying the data lake operation');
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to retry the data lake operation');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to retry the data lake operation');
     },
   });
 }
@@ -788,7 +806,7 @@ export function useApplyTaxonomySuggestions(batchId: string) {
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.tagCountsRoot });
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to apply tag suggestions');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to apply tag suggestions');
     },
   });
 }
@@ -807,7 +825,7 @@ export function useReanalyzeTaxonomy(batchId: string) {
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.activeBatches });
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to re-analyze tags');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to re-analyze tags');
     },
   });
 }
@@ -828,7 +846,7 @@ export function useDismissTaxonomy(batchId: string) {
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.activeBatches });
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to dismiss tag suggestions');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to dismiss tag suggestions');
     },
   });
 }
@@ -887,7 +905,7 @@ export function useReprocessFabFile(dataLakeId: string | null) {
       }
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to re-process file');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to re-process file');
     },
   });
 }
@@ -982,13 +1000,11 @@ export function useAddFileToDataLake() {
       if (toastId !== undefined) toast.success('File restored to data lake.', { id: toastId });
     },
     onError: (error: Error, { toastId }) => {
-      // Surface the server's own refusal text, not axios' `"Request failed with status code N"`.
       // Every actionable rejection on this door lands here - "You do not have permission to add
       // files to this data lake", "Data lake not found", the built-in-lake refusal - and this is
       // the toast the non-owner confirmation copy calls their only way back, so a status string is
-      // the one message that cannot help them. Body key is `error` (server/middlewares/
-      // errorHandler.ts); same extraction as useTransferLakeOwnership above.
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      // the one message that cannot help them.
+      const refusal = serverRefusalMessage(error);
       const message = refusal || error.message || 'Failed to restore the file to the data lake';
       toast.error(message, toastId !== undefined ? { id: toastId } : undefined);
     },
@@ -1077,10 +1093,9 @@ export function useRecordMembershipDecision() {
       );
     },
     onError: (error: Error) => {
-      // Surface the server's own refusal text: "You do not have permission to resolve duplicates in
-      // this data lake" and "That file name no longer has duplicate members in this data lake" are
-      // both actionable, and a status string is the one message that cannot help.
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      // "You do not have permission to resolve duplicates in this data lake" and "That file name no
+      // longer has duplicate members in this data lake" are both actionable.
+      const refusal = serverRefusalMessage(error);
       toast.error(refusal || error.message || 'Failed to record the decision');
     },
   });
@@ -1136,7 +1151,7 @@ export function useRemoveFileFromDataLake(dataLakeId: string | null) {
       // dialog, so leaving this one bare would give Undo the server's reason and Remove a status
       // code. `Only the creator can remove files from this data lake` is exactly the text a
       // curator needs here.
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      const refusal = serverRefusalMessage(error);
       toast.error(refusal || error.message || 'Failed to remove file from data lake');
     },
   });
@@ -1196,7 +1211,7 @@ export function usePurgeDataLakeDocument(dataLakeId: string | null) {
       // failure is exactly the case where "Request failed with status code 500" is the one message
       // that cannot tell the owner whether their document is half destroyed. Body key is `error`
       // (server/middlewares/errorHandler.ts).
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      const refusal = serverRefusalMessage(error);
       toast.error(refusal || error.message || 'Failed to permanently delete this file');
     },
   });
@@ -1316,7 +1331,7 @@ export function useRechunkDataLake(dataLakeId: string | null) {
       }
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to start rebuild');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to start rebuild');
     },
   });
 }
@@ -1378,7 +1393,7 @@ export function useBuildLakeMemory(dataLakeId: string | null) {
       }
     },
     onError: (error: Error) => {
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      const refusal = serverRefusalMessage(error);
       if (refusal) {
         toast.error(refusal);
         return;
@@ -1412,7 +1427,7 @@ export function usePurgeLakeMemory(dataLakeId: string | null) {
       }
     },
     onError: (error: Error) => {
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      const refusal = serverRefusalMessage(error);
       toast.error(refusal || error.message || "Failed to erase this lake's memory profile");
     },
   });
@@ -1557,7 +1572,7 @@ export function useConvergeDataLake(dataLakeId: string | null) {
       }
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Failed to start convergence');
+      toast.error(serverRefusalMessage(error) || error.message || 'Failed to start convergence');
     },
   });
 }
@@ -1610,7 +1625,7 @@ export function useAddFilesToLake() {
       );
     },
     onError: (error: Error) => {
-      const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;
+      const refusal = serverRefusalMessage(error);
       if (refusal) {
         toast.error(refusal);
         return;
@@ -1878,17 +1893,6 @@ export function useDataLakeProposals(
  */
 export function reviewProposalFailureMessage(error: unknown): string {
   return serverRefusalMessage(error) || 'Could not record that decision. Try again shortly.';
-}
-
-/**
- * The server's own refusal text, if it sent one. The body key is `error`, per
- * server/middlewares/errorHandler.ts - every data-lake surface that shows a refusal to a human
- * reads it through here so none of them can drift back onto `message` and silently show only
- * their fallback.
- */
-function serverRefusalMessage(error: unknown): string | undefined {
-  if (!isAxiosError(error)) return undefined;
-  return (error.response?.data as { error?: string } | undefined)?.error || undefined;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Fixes #2466.

Every refusal from the taxonomy **Apply Tags** button reached the user as `Request failed with status code 400`. The handler toasted `error.message`, which on an axios rejection is the generic status line - the server's own sentence sits at `response.data.error` (per `server/middlewares/errorHandler.ts`), and the API interceptor bottoms out at a bare `Promise.reject`, so nothing on that path unwrapped it.

The sharpest case is the unverifiable-overlap refusal from #2435, which ends in "try again" precisely because the batch deliberately stays in `ready` and the same apply can simply be re-run. The user was never told, so a recoverable failure looked identical to a permanent one.

The issue's third acceptance bullet asked for an audit of the sibling mutations in this file. It found the same gap on **twelve more**, every one of which refuses for reasons the user can act on.

## Changes

**The bug**: 13 mutation handlers now read the server's refusal through the file's existing `serverRefusalMessage` helper, falling back to the previous generic copy when the server sent no reason.

| Hook | A refusal it was swallowing |
|---|---|
| `useApplyTaxonomySuggestions` | `...try again` (the ticket) |
| `useCreateDataLake` | `Tag prefix "x:" overlaps an existing data lake - choose a different prefix.` |
| `useUpdateDataLake` | `A public data lake cannot have an access tag... Make it private first` |
| `useUpdateFallbackLakeSettings` | `"x" is not a valid preferred system prompt` |
| `useSetLakeVisibility` | `Only the lake's owner can change how it is shared.` |
| `useLifecycleMutation` | `Cannot archive a data lake in 'deleting' status` |
| `useCleanupDataLake` | `Data lake must be soft-deleted before cleanup` |
| `useRetryLakeLifecycle` | `This data lake is already being permanently deleted` |
| `useReanalyzeTaxonomy` | `This batch is not in a state that can be re-analyzed right now` |
| `useDismissTaxonomy` | `Tag suggestions are not in a dismissible state for this batch` |
| `useReprocessFabFile` | `FabFile is currently being chunked` |
| `useRechunkDataLake` | `This data lake is built into the platform and is read-only` |
| `useConvergeDataLake` | same, via the shared `assertLakeAccess` gate |

`useLifecycleMutation` is the shared factory behind archive / unarchive / restore / permanent-delete, so that one line covers four more buttons.

**Consolidation** (no behavior change): `serverRefusalMessage` moves to the top of the file so 21 call sites read it without a forward reference, and the **eight** handlers that already did the extraction inline are folded onto it. That duplicated idiom was the reason the helper's own doc comment - *"every data-lake surface that shows a refusal to a human reads it through here so none of them can drift back onto `message`"* - was not actually true. It is now.

**Left alone deliberately**: `useBuildLakeMemory` and `useAddFilesToLake` keep their `if (refusal) { ...; return; }` shape - they extract first and branch, so their trailing `error.message` fallback is correct, not a miss. Queries (as opposed to mutations) are untouched; `isPermissionRejection` already handles the ones that hide a surface on 4xx.

## Guide for Testers

**Read this first.** The client deliberately mirrors most of these server guardrails, so the happy path cannot reach them: the Public radio is disabled whenever the lake has an access gate (`DataLakeSettingsModal.tsx:561`), the wizard refuses a colliding tag prefix before Start Upload (`DataLakeWizardModal.tsx:88-91`), and Clean up only fires from the deleted-lakes list. Those mirrors are correct and stay.

What that means for testing: these toasts appear exactly when a mirror was **wrong** - a stale cache, a concurrent edit in another tab, a permission revoked mid-session, or a transient server fault. So the test is to make the app submit a request the server will refuse, and watch what the toast says.

A direct `curl`/`fetch` against the endpoint does **not** test this change. The fix is in the client's `onError` handler; an API call bypasses React entirely and raises no toast. It would verify the server, which was never broken.

### Primary check - deterministic, one lake

1. Open the **PR preview environment for this PR** and sign in. Its URL is in the internal deploys channel, per the deployer bot comment on this PR.
2. Navigate to Sidebar -> Data Lakes and create a lake named `Toast Check`, accepting the derived tag prefix.
3. Open its settings, set a **required entitlement** to `qa-gate`, and save. Expected: saves cleanly, and the Visibility section now shows `Public` greyed out with the copy *"This lake has an access gate, so it can't be made public."* That disabled control is the client mirror working correctly.
4. Open devtools (F12) -> Console and run this, which re-enables only that one control and clicks it in the same statement (React would otherwise re-disable it on the next render):
   ```js
   const el = document.querySelector('[data-testid="datalake-settings-visibility-public"]');
   const radio = el.tagName === 'INPUT' ? el : el.querySelector('input');
   radio.disabled = false; radio.click();
   ```
   Expected: the "Make this data lake public?" confirmation dialog opens.
5. Confirm with **Make public**. Expected: the toast reads
   `A data lake with an access tag or required entitlement can't be made public. Remove the gate first, or share it through the entitlement instead.`
   **Before this PR it read** `Request failed with status code 400`. That difference is the entire fix.
   
   <img width="1508" height="756" alt="image" src="https://github.com/user-attachments/assets/a250f788-d34d-411e-b13a-3f8e6d5fbe73" />

6. Confirm nothing else changed: the lake is still private and still gated, and the settings modal stays open.

### Secondary check - a real two-tab race, no devtools

This one covers `useApplyTaxonomySuggestions`, the hook the ticket is actually about. Buttons disable themselves while a mutation is in flight (`loading={applyMutation.isPending}`), so a single tab cannot double-submit - but a second tab has its own mutation state and its own 10-second-stale copy of the batch list.

7. Create a second lake and upload a folder with two or three subfolders. Let the AI taxonomy step run until the review panel offers **Apply Tags**.
8. With that review panel open, duplicate the tab (Ctrl/Cmd-click the tab -> Duplicate, or open the same URL in a second tab) and get the same review panel open in both.
9. In **tab A**, click **Apply Tags**. Expected: it succeeds and the panel closes.
10. Switch to **tab B** and click **Apply Tags** there, within about 10 seconds. Expected: the toast reads `Tag suggestions are not ready to apply for this batch` - not `Request failed with status code 400`.
    
    <img width="1508" height="756" alt="image" src="https://github.com/user-attachments/assets/953628b9-3efa-443e-a21d-b3b67fa7a0c3" />
    
    - The 10 seconds is the active-batch poll (`ACTIVE_BATCHES_POLL_MS`). Tab B's copy of the batch is stale until then, which is what leaves its button enabled. Switching tabs does not shorten the window - that query sets `refetchOnWindowFocus: false`.
    - If you miss the window, tab B's panel will have closed on its own. That is correct behavior, not a failure; redo steps 7-10 and click sooner.

### Regression Checks

11. Rename a lake and save. Expected: the usual success toast, unchanged.
12. Apply tags on a healthy batch. Expected: succeeds and reports the file count, unchanged.
13. Archive a lake from the manager. Expected: the usual success toast, unchanged.

### What NOT to test

- Anything via `curl` or the devtools Network tab. See above - the server was already correct; this PR changes only whether the client displays what it sent.
- Which sentence the server chooses. Not touched here.
- The Apply Tags **prefix** refusals from #2435 specifically. They need a lake whose `fileTagPrefix` predates the create-time collision check, which no current create path can produce. Steps 7-10 exercise the same handler through a refusal you can actually reach.
- Double-clicking any single button to force a race. Every one of these buttons disables itself while its mutation is in flight, so the second click never fires. The second tab in steps 8-10 is what gets around that.

## Additional Information

Independent of #2435 - different package, no shared files, and it fixes a defect that is fully present on `main` today. #2435 only made the gap more visible by giving one of these doors better copy.

**On why this is worth fixing given the client mirrors these rules.** Writing the tester guide surfaced that the client guards most of these doors: it disables the control, or mirrors the server's validation, or disables the button while a mutation is in flight. That is a fair challenge to the whole PR, so here is the case, strongest first.

**Rate limits cannot be mirrored, and three of these thirteen endpoints have one.** `apply-taxonomy` caps at 60/hour, `reanalyze-taxonomy` at 50/day, and `converge` carries one too. The limiter refuses with `Rate limit exceeded. Try again in N seconds.` (`server/middlewares/rateLimit.ts`), which reaches the body as `{ error: ... }` like every other refusal. No client guard can mirror a server-side counter - the button is enabled, an ordinary user clicks it, and before this PR they saw `Request failed with status code 429`. The retry delay is the only actionable fact in that message and it was the part being discarded. No race, no stale cache, no devtools: just a normal click on an enabled button. The apply-taxonomy cap is a static 60 with no admin exemption, so it applies to everyone.

**Transient faults cannot be mirrored either.** The `try again` overlap refusal from #2435 fires when a Mongo read fails mid-request. Nothing client-side can predict it, and "try again" is precisely the instruction the user needs and was not getting.

**The guards are best-effort, and the races are real.** Steps 7-10 of the tester guide reproduce one end to end: buttons disable while in flight, but a second tab has its own mutation state and a batch list that is stale for up to 10 seconds (`ACTIVE_BATCHES_POLL_MS`, with `refetchOnWindowFocus: false`, so switching tabs does not heal it).

**What the guards genuinely do cover**, and where this PR's copy will rarely surface: the predictable single-user, single-tab cases - Public-with-a-gate, a colliding prefix at create, cleanup on a lake that is not soft-deleted. Those mirrors are correct and this PR does not change them. The value here is concentrated in the cases above, which are lower-frequency but are exactly the ones where the user has no way to guess what happened.

Beyond the toasts, this also makes the helper's own doc comment true again and deletes eight copies of a duplicated idiom.

Every one of these toasts fires precisely when the client's optimistic mirror was wrong or could not exist:

- a **stale cache** (the lake list backing the mirror was read before someone else changed the lake),
- a **concurrent edit** (another tab, another user, or a background job moved the lake or batch mid-request),
- a **revoked permission** (a grant removed after the page loaded),
- a **transient fault** with no mirror possible at all (the `try again` overlap refusal from #2435, which is a Mongo blip by definition),
- and **races the client cannot pre-check**, like double-clicking Re-analyze.

Those are the moments a user is most confused and least able to guess what happened, and they were the exact moments we replaced the explanation with a status code.

## Developer Notes (Optional)

- **Reusable pattern**: `serverRefusalMessage(error)` is now the single extraction point for this file. Any new data-lake mutation should call it rather than toasting `error.message`; the helper's doc comment explains why in one place instead of being restated per site.
- **Architecture note**: the helper is deliberately *not* pushed into the axios interceptor. Some data-lake queries treat a 4xx as "hide this surface" rather than "show an error" (`isPermissionRejection`), so unwrapping globally would change how those read. Extraction stays at the point of display.
- **Test pattern**: the new suite is table-driven over the real hooks rather than a unit test of the helper. The helper was already correct and already in the file - the defect was in *which handlers called it*, which only a test that mounts the hook can observe. Two anti-cheat cases pin the fallbacks (no `error` key in the body; a non-axios throw).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (n/a)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have made corresponding changes to the documentation (n/a)
- [ ] If adding/modifying telemetry fields (n/a)
