### PR TITLE
fix(client): hold menu rows on their hover ground on press, and share the menuitem recipe

### DIFF
--- a/apps/client/app/components/datalake/DataLakeLakePicker.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeLakePicker.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { menuItemClasses } from '@mui/joy/MenuItem';
 import { getThemeConfig } from '@client/app/utils/themes';
 import DataLakeLakePicker from './DataLakeLakePicker';
 import type { ManageableDataLakeConfig } from '@bike4mind/common';
@@ -176,6 +177,36 @@ describe('DataLakeLakePicker', () => {
 
     // A bare total under a single visible row reads as a stale count.
     expect(screen.getByTestId('datalake-lake-picker-lake-count')).toHaveTextContent('1 of 8 lakes');
+  });
+
+  // menuItemListSx reaches these rows through a `[role="menuitem"]` selector and marks the
+  // selected one off `.Mui-selected`, so both are load-bearing: a Joy change to either would
+  // silently drop the picker's rows back to Joy's neutral defaults.
+  it('renders its rows as menuitems, the hook the shared row recipe styles them through', () => {
+    renderPicker({
+      lakes: [lake({ id: 'a', name: 'Research Corpus' }), lake({ id: 'b', name: 'Design Docs' })],
+      selectedLakeId: 'a',
+    });
+    openMenu();
+
+    const selected = screen.getByTestId('datalake-lake-picker-lake-a');
+    expect(selected).toHaveAttribute('role', 'menuitem');
+    expect(selected).toHaveClass(menuItemClasses.selected);
+    expect(screen.getByTestId('datalake-lake-picker-lake-b')).not.toHaveClass(menuItemClasses.selected);
+  });
+
+  it('leaves the menu chrome off the row recipe, so only real rows pick up the row states', () => {
+    const lakes = Array.from({ length: 8 }, (_, i) => lake({ id: `l${i}`, name: `Lake ${i}` }));
+    renderPicker({ lakes });
+    openMenu();
+
+    // Joy gives a ListItem inside a Menu role="none"; the filter box and the count chip ride on
+    // those, so the [role="menuitem"] rule never reaches them.
+    const chrome = [
+      screen.getByTestId('datalake-lake-picker-search').closest('li'),
+      screen.getByTestId('datalake-lake-picker-lake-count').closest('li'),
+    ];
+    chrome.forEach(el => expect(el).not.toHaveAttribute('role', 'menuitem'));
   });
 
   it('lets the trigger label inherit the button color, which the themed body-sm default does not', () => {

--- a/apps/client/app/components/datalake/DataLakeLakePicker.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeLakePicker.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
-import { menuItemClasses } from '@mui/joy/MenuItem';
+import menuItemClasses from '@mui/joy/MenuItem/menuItemClasses';
 import { getThemeConfig } from '@client/app/utils/themes';
 import DataLakeLakePicker from './DataLakeLakePicker';
 import type { ManageableDataLakeConfig } from '@bike4mind/common';
@@ -206,7 +206,7 @@ describe('DataLakeLakePicker', () => {
       screen.getByTestId('datalake-lake-picker-search').closest('li'),
       screen.getByTestId('datalake-lake-picker-lake-count').closest('li'),
     ];
-    chrome.forEach(el => expect(el).not.toHaveAttribute('role', 'menuitem'));
+    chrome.forEach(el => expect(el).toHaveAttribute('role', 'none'));
   });
 
   it('lets the trigger label inherit the button color, which the themed body-sm default does not', () => {

--- a/apps/client/app/components/datalake/DataLakeLakePicker.tsx
+++ b/apps/client/app/components/datalake/DataLakeLakePicker.tsx
@@ -24,7 +24,7 @@ import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SearchIcon from '@mui/icons-material/Search';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
-import { menuListSx, menuSurfaceSx } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
+import { menuItemListSx, menuSurfaceSx } from '@client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx';
 import { useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
 import { lakeVisibilityLabelShort } from '@client/app/components/datalake/lakeVisibility';
 import type { ManageableDataLakeConfig } from '@bike4mind/common';
@@ -165,7 +165,7 @@ export default function DataLakeLakePicker({
           sx={theme => ({
             ...menuSurfaceSx(theme),
             // 2px, matching the row action menu: this list is dense and can run long.
-            ...menuListSx({ gap: '2px' }),
+            ...menuItemListSx(theme, { gap: '2px' }),
             minWidth: 236,
             maxWidth: 300,
             maxHeight: 360,

--- a/apps/client/app/components/datalake/rowActionsMenu.tsx
+++ b/apps/client/app/components/datalake/rowActionsMenu.tsx
@@ -35,9 +35,8 @@ const TRIGGER_SX = {
 const MENU_ICON_FRAME_SX = { ...MENU_ROW_ICON_SX, width: 20, height: 20 } as const;
 
 /**
- * One item in a row's action menu, styled like the profile menu's rows. Joy MenuItem needs
- * --variant-plainHoverBg pointed at the hover colour too, or its own variant rule wins over the
- * shared recipe's `&:hover`.
+ * One item in a row's action menu, styled like the profile menu's rows, which now carry the Joy
+ * hover and press variables themselves - so this only has to state where it DIVERGES from them.
  */
 export function RowMenuItem({
   testId,
@@ -64,9 +63,6 @@ export function RowMenuItem({
         // Take the destructive colour from Joy's danger plain variant, exactly as the sidebar's
         // session Delete item does - the shared recipe's hardcoded danger[500] is a different red.
         ...(danger && { color: itemTheme.palette.danger.plainColor, '--Icon-color': 'currentColor' }),
-        '--variant-plainHoverBg': danger
-          ? itemTheme.palette.danger.plainHoverBg
-          : itemTheme.palette.notebooklist.hoverBg,
         // Tighter than the profile menu's 40px/10px: this menu hangs off a row in a narrow rail.
         // Both of these override a direct declaration in the shared recipe, so they must be set
         // here as declarations too - the Joy vars below alone would lose to it.

--- a/apps/client/app/components/datalake/rowActionsMenu.tsx
+++ b/apps/client/app/components/datalake/rowActionsMenu.tsx
@@ -35,8 +35,9 @@ const TRIGGER_SX = {
 const MENU_ICON_FRAME_SX = { ...MENU_ROW_ICON_SX, width: 20, height: 20 } as const;
 
 /**
- * One item in a row's action menu, styled like the profile menu's rows, which now carry the Joy
- * hover and press variables themselves - so this only has to state where it DIVERGES from them.
+ * One item in a row's action menu, styled like the profile menu's rows. Stays on menuRowSx per
+ * item rather than the menu-wide menuItemListSx: the destructive row wants its own ground, and a
+ * list-scoped `[role="menuitem"]` rule would outrank anything set here.
  */
 export function RowMenuItem({
   testId,

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { menuListSx, menuSurfaceSx, selectListboxSx } from './menuSurfaceSx';
+import { menuListSx, menuRowSx, menuSurfaceSx, selectListboxSx } from './menuSurfaceSx';
 
 const theme = extendTheme({ ...getThemeConfig() });
 
@@ -63,5 +63,29 @@ describe('selectListboxSx', () => {
   it('styles option rows only, so it is inert on a Joy Menu (rows are role="menuitem")', () => {
     const roleSelectors = Object.keys(selectListboxSx(theme)).filter(key => key.includes('role='));
     expect(roleSelectors).toEqual(['& [role="option"]']);
+  });
+});
+
+describe('menuRowSx', () => {
+  // Joy's ListItemButton carries an unconditional `&:active` painted from --variant-plainActiveBg.
+  // Unset, it falls through to neutral.plainActiveBg, which this theme tints brand blue, so a
+  // Joy-backed row flashes blue under the finger.
+  it('pins the press ground rather than letting Joy fall through to the brand tint', () => {
+    expect(menuRowSx(theme)['--variant-plainActiveBg']).toBe(theme.palette.notebooklist.hoverBg);
+    expect(menuRowSx(theme)['--variant-plainActiveBg']).not.toBe(theme.palette.neutral.plainActiveBg);
+  });
+
+  it('keeps press on the hover ground rather than introducing a third colour', () => {
+    expect(menuRowSx(theme)['--variant-plainActiveBg']).toBe(menuRowSx(theme)['&:hover'].backgroundColor);
+    expect(menuRowSx(theme, true)['--variant-plainActiveBg']).toBe(menuRowSx(theme, true)['&:hover'].backgroundColor);
+  });
+
+  // The recipe sets the variables itself, so a Joy MenuItem consumer does not have to restate
+  // them - that restatement is what let the destructive row and the plain rows drift.
+  it('carries the danger ground on the declaration and both variables alike', () => {
+    const dangerRow = menuRowSx(theme, true);
+    expect(dangerRow['--variant-plainHoverBg']).toBe(theme.palette.danger.plainHoverBg);
+    expect(dangerRow['--variant-plainActiveBg']).toBe(theme.palette.danger.plainHoverBg);
+    expect(dangerRow['&:hover'].backgroundColor).toBe(theme.palette.danger.plainHoverBg);
   });
 });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { extendTheme } from '@mui/joy/styles';
-import { menuItemClasses } from '@mui/joy/MenuItem';
+import menuItemClasses from '@mui/joy/MenuItem/menuItemClasses';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { menuItemListSx, menuListSx, menuRowSx, menuSurfaceSx, selectListboxSx } from './menuSurfaceSx';
 
@@ -81,12 +81,31 @@ describe('menuItemListSx', () => {
   });
 
   // Joy paints .Mui-selected from the plainActive variant too, so the selected ground has to be a
-  // plain declaration - through the variable it would collapse onto the hover ground.
+  // declaration - through the variable it would collapse onto the hover ground.
   it('marks the selected row by its own ground, not by the press variable', () => {
     expect(rowSx[`&.${menuItemClasses.selected}`]).toMatchObject({
       backgroundColor: theme.palette.notebooklist.focusedBackground,
     });
-    expect(theme.palette.notebooklist.focusedBackground).not.toBe(rowSx['--variant-plainActiveBg']);
+  });
+
+  // The ground alone is NOT enough: dark mode gives hoverBg and focusedBackground the same value,
+  // so a hovered sibling paints the selected row's exact colour and only the weight still marks
+  // it. Asserted per scheme because `theme.palette` resolves to the light one, where the two
+  // tokens happen to differ - which is how a light-only assertion hid this.
+  describe.each(['light', 'dark'] as const)('in the %s scheme', scheme => {
+    const palette = theme.colorSchemes[scheme].palette;
+    const schemeRowSx = menuItemListSx({ ...theme, palette } as typeof theme)['& [role="menuitem"]'];
+    const selected = schemeRowSx[`&.${menuItemClasses.selected}`];
+
+    it('keeps the selected row distinguishable from a hovered sibling', () => {
+      const groundAlone = selected.backgroundColor !== schemeRowSx['--variant-plainHoverBg'];
+      expect(groundAlone || selected.fontWeight === 600).toBe(true);
+    });
+
+    it('routes hover and press at the menu ground for that scheme', () => {
+      expect(schemeRowSx['--variant-plainHoverBg']).toBe(palette.notebooklist.hoverBg);
+      expect(schemeRowSx['--variant-plainActiveBg']).toBe(palette.notebooklist.hoverBg);
+    });
   });
 
   // The two-line lake picker rows are the reason this exists rather than menuRowSx: a fixed
@@ -107,10 +126,17 @@ describe('menuRowSx', () => {
   // Joy's ListItemButton carries an unconditional `&:active` painted from --variant-plainActiveBg.
   // Unset, it falls through to neutral.plainActiveBg, which this theme tints brand blue, so a
   // Joy-backed row flashes blue under the finger.
-  it('pins the press ground rather than letting Joy fall through to the brand tint', () => {
-    expect(menuRowSx(theme)['--variant-plainActiveBg']).toBe(theme.palette.notebooklist.hoverBg);
-    expect(menuRowSx(theme)['--variant-plainActiveBg']).not.toBe(theme.palette.neutral.plainActiveBg);
-  });
+  // Both schemes: neutral.plainActiveBg is brand[100] in light and brand[700] in dark, and the
+  // fall-through was visible in both.
+  it.each(['light', 'dark'] as const)(
+    'pins the press ground rather than letting Joy fall through to the %s brand tint',
+    scheme => {
+      const palette = theme.colorSchemes[scheme].palette;
+      const row = menuRowSx({ ...theme, palette } as typeof theme);
+      expect(row['--variant-plainActiveBg']).toBe(palette.notebooklist.hoverBg);
+      expect(row['--variant-plainActiveBg']).not.toBe(palette.neutral.plainActiveBg);
+    }
+  );
 
   it('keeps press on the hover ground rather than introducing a third colour', () => {
     expect(menuRowSx(theme)['--variant-plainActiveBg']).toBe(menuRowSx(theme)['&:hover'].backgroundColor);
@@ -119,11 +145,10 @@ describe('menuRowSx', () => {
 
   // The recipe sets the variables itself, so a Joy MenuItem consumer does not have to restate
   // them - that restatement is what let the destructive row and the plain rows drift.
-  it('carries the danger ground on the declaration and both variables alike', () => {
+  it('carries the danger ground on both variables, not just the hover declaration', () => {
     const dangerRow = menuRowSx(theme, true);
     expect(dangerRow['--variant-plainHoverBg']).toBe(theme.palette.danger.plainHoverBg);
     expect(dangerRow['--variant-plainActiveBg']).toBe(theme.palette.danger.plainHoverBg);
-    expect(dangerRow['&:hover'].backgroundColor).toBe(theme.palette.danger.plainHoverBg);
   });
 
   // Both halves of the menuitem recipe sit on the same ground, so a plain row marks a press the

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { extendTheme } from '@mui/joy/styles';
+import { menuItemClasses } from '@mui/joy/MenuItem';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { menuListSx, menuRowSx, menuSurfaceSx, selectListboxSx } from './menuSurfaceSx';
+import { menuItemListSx, menuListSx, menuRowSx, menuSurfaceSx, selectListboxSx } from './menuSurfaceSx';
 
 const theme = extendTheme({ ...getThemeConfig() });
 
@@ -66,6 +67,42 @@ describe('selectListboxSx', () => {
   });
 });
 
+describe('menuItemListSx', () => {
+  const rowSx = menuItemListSx(theme)['& [role="menuitem"]'];
+
+  it('keeps the list tokens it layers on', () => {
+    expect(menuItemListSx(theme)['--List-gap']).toBe('4px');
+    expect(menuItemListSx(theme, { gap: '2px' })['--List-gap']).toBe('2px');
+  });
+
+  it('routes hover and press through the variables Joy actually paints from', () => {
+    expect(rowSx['--variant-plainHoverBg']).toBe(theme.palette.notebooklist.hoverBg);
+    expect(rowSx['--variant-plainActiveBg']).toBe(theme.palette.notebooklist.hoverBg);
+  });
+
+  // Joy paints .Mui-selected from the plainActive variant too, so the selected ground has to be a
+  // plain declaration - through the variable it would collapse onto the hover ground.
+  it('marks the selected row by its own ground, not by the press variable', () => {
+    expect(rowSx[`&.${menuItemClasses.selected}`]).toMatchObject({
+      backgroundColor: theme.palette.notebooklist.focusedBackground,
+    });
+    expect(theme.palette.notebooklist.focusedBackground).not.toBe(rowSx['--variant-plainActiveBg']);
+  });
+
+  // The two-line lake picker rows are the reason this exists rather than menuRowSx: a fixed
+  // height, padding or gap here would crop them.
+  it('sets no row geometry, so a two-line row with a decorator and a count still fits', () => {
+    expect(Object.keys(rowSx)).not.toContain('height');
+    expect(Object.keys(rowSx)).not.toContain('px');
+    expect(Object.keys(rowSx)).not.toContain('gap');
+  });
+
+  it('styles menuitem rows only, so it is inert on a Select listbox (rows are role="option")', () => {
+    const roleSelectors = Object.keys(menuItemListSx(theme)).filter(key => key.includes('role='));
+    expect(roleSelectors).toEqual(['& [role="menuitem"]']);
+  });
+});
+
 describe('menuRowSx', () => {
   // Joy's ListItemButton carries an unconditional `&:active` painted from --variant-plainActiveBg.
   // Unset, it falls through to neutral.plainActiveBg, which this theme tints brand blue, so a
@@ -87,5 +124,13 @@ describe('menuRowSx', () => {
     expect(dangerRow['--variant-plainHoverBg']).toBe(theme.palette.danger.plainHoverBg);
     expect(dangerRow['--variant-plainActiveBg']).toBe(theme.palette.danger.plainHoverBg);
     expect(dangerRow['&:hover'].backgroundColor).toBe(theme.palette.danger.plainHoverBg);
+  });
+
+  // Both halves of the menuitem recipe sit on the same ground, so a plain row marks a press the
+  // same way whichever one styles it.
+  it('agrees with menuItemListSx on the press ground', () => {
+    expect(menuRowSx(theme)['--variant-plainActiveBg']).toBe(
+      menuItemListSx(theme)['& [role="menuitem"]']['--variant-plainActiveBg']
+    );
   });
 });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
@@ -96,25 +96,36 @@ export const selectListboxSx = (theme: Theme, opts?: { gap?: string }) => ({
 
 /**
  * A single icon + label row inside a menuSurfaceSx panel. `danger` tints a destructive row.
- * Joy sets its own hover background from `--variant-plainHoverBg`, so consumers built on Joy
- * MenuItem must ALSO point that variable at the hover colour or Joy's rule wins.
+ *
+ * One ground covers hover and press, declared three ways because the consumers are not all the
+ * same kind of element. The `&:hover` declaration is what the profile menu's plain Boxes use;
+ * the two variables are what Joy reads on a MenuItem, whose own rules outrank that declaration.
+ * --variant-plainActiveBg in particular has to be set: Joy's ListItemButton carries an
+ * unconditional `&:active` painted from it, and left unset it falls through to
+ * neutral.plainActiveBg, which this theme tints brand blue (themePrimitives.ts) - so the row
+ * would flash blue under the finger instead of staying on its hover ground.
  */
-export const menuRowSx = (theme: Theme, danger = false) => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '12px',
-  px: '10px',
-  height: '40px',
-  borderRadius: '8px',
-  cursor: 'pointer',
-  color: danger ? theme.palette.danger[500] : theme.palette.sidenav?.navItemText,
-  // Joy icons - and the Credits Bike4MindIcon, which fills with var(--Icon-color) - read
-  // --Icon-color, not `color`. Tint them brand light-blue @50% (text.tertiary).
-  '--Icon-color': danger ? theme.palette.danger[500] : theme.palette.text.tertiary,
-  transition: 'background 0.15s',
-  '&:hover': { backgroundColor: theme.palette.notebooklist.hoverBg },
-  '&:focus-visible': { outline: `2px solid ${theme.palette.primary[500]}`, outlineOffset: '-2px' },
-});
+export const menuRowSx = (theme: Theme, danger = false) => {
+  const ground = danger ? theme.palette.danger.plainHoverBg : theme.palette.notebooklist.hoverBg;
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+    px: '10px',
+    height: '40px',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    color: danger ? theme.palette.danger[500] : theme.palette.sidenav?.navItemText,
+    // Joy icons - and the Credits Bike4MindIcon, which fills with var(--Icon-color) - read
+    // --Icon-color, not `color`. Tint them brand light-blue @50% (text.tertiary).
+    '--Icon-color': danger ? theme.palette.danger[500] : theme.palette.text.tertiary,
+    transition: 'background 0.15s',
+    '&:hover': { backgroundColor: ground },
+    '--variant-plainHoverBg': ground,
+    '--variant-plainActiveBg': ground,
+    '&:focus-visible': { outline: `2px solid ${theme.palette.primary[500]}`, outlineOffset: '-2px' },
+  };
+};
 
 /** Fixed box the row's icon sits in, so labels align regardless of glyph width. */
 export const MENU_ROW_ICON_SX = {

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
@@ -1,5 +1,5 @@
 import type { Theme } from '@mui/joy/styles';
-import { menuItemClasses } from '@mui/joy/MenuItem';
+import menuItemClasses from '@mui/joy/MenuItem/menuItemClasses';
 import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 
 /**
@@ -106,13 +106,19 @@ export const selectListboxSx = (theme: Theme, opts?: { gap?: string }) => ({
  *
  * Hover and press go through Joy's variables because Joy's own ListItemButton rules outrank a
  * bare `&:hover` here. The selected row cannot: Joy paints `.Mui-selected` from the plainActive
- * variant as well, so pointing that variable at the hover ground alone would erase the selected
- * marker. It is a plain declaration, which outweighs Joy's variant rule on specificity.
+ * variant as well, so pointing that variable at the hover ground would erase the selected marker.
+ * It is a declaration instead, and it lands because the descendant selector - not the fact that it
+ * is a declaration - outranks Joy's own rule on the row's class.
  *
- * A per-item sx CANNOT override what this sets - `.menu [role="menuitem"]` outranks the row's
- * own class - so a menu with per-row grounds (rowActionsMenu's destructive row) stays on
- * menuRowSx per item instead. Joy gives a ListItem inside a Menu role="none", so a menu's
- * non-row content (the lake picker's filter box, skeletons and count chip) is untouched.
+ * That same descendant selector means a per-item sx will NOT override what this sets short of
+ * escalating its own specificity (`&&`, `!important`), so a menu with per-row grounds
+ * (rowActionsMenu's destructive row) stays on menuRowSx per item instead. Joy gives a ListItem
+ * inside a Menu role="none", so a menu's non-row content (the lake picker's filter box, skeletons
+ * and count chip) is untouched.
+ *
+ * These are custom properties: they inherit into the row's whole subtree, so a plain-variant Joy
+ * child dropped into a row (an IconButton, a Chip) would pick the row's ground up as its own.
+ * rowActionsMenu.tsx zeroes both variables on its trigger for exactly that reason.
  */
 export const menuItemListSx = (theme: Theme, opts?: { gap?: string }) => ({
   ...menuListSx(opts),
@@ -120,10 +126,15 @@ export const menuItemListSx = (theme: Theme, opts?: { gap?: string }) => ({
     transition: 'background 0.15s',
     '--variant-plainHoverBg': theme.palette.notebooklist.hoverBg,
     '--variant-plainActiveBg': theme.palette.notebooklist.hoverBg,
-    // The ground is the whole marker here. selectListboxSx can add a bold weight because a Select
-    // Option's label is bare text; these rows label themselves with a Joy Typography, whose own
-    // fontWeight declaration beats anything inherited from the row.
-    [`&.${menuItemClasses.selected}`]: { backgroundColor: theme.palette.notebooklist.focusedBackground },
+    // The weight is load-bearing, not decoration: in dark mode notebooklist.hoverBg and
+    // focusedBackground are the SAME value, so a hovered sibling paints the selected row's exact
+    // ground and the ground alone stops marking anything. Joy's `body-sm` level declares no
+    // fontWeight, so this inherits into a row's label Typography; `body-xs` declares one, which is
+    // why a secondary line and a trailing count stay unbolded.
+    [`&.${menuItemClasses.selected}`]: {
+      backgroundColor: theme.palette.notebooklist.focusedBackground,
+      fontWeight: 600,
+    },
     '&:focus-visible': {
       outline: `2px solid ${theme.palette.primary[500]}`,
       outlineOffset: '-2px',

--- a/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts
@@ -1,4 +1,5 @@
 import type { Theme } from '@mui/joy/styles';
+import { menuItemClasses } from '@mui/joy/MenuItem';
 import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 
 /**
@@ -15,7 +16,7 @@ const MENU_INSET = '8px';
  * panel and the Data Lake menus use 8px, the More flyout 12px.
  *
  * Anything on this ground that renders as a Joy List - a Menu, a Select listbox - wants
- * menuListSx too, and a Select's listbox wants selectListboxSx.
+ * menuListSx too, and its rows want selectListboxSx (a Select) or menuItemListSx (a Menu).
  */
 export const menuSurfaceSx = (theme: Theme, radius = '8px') => ({
   backgroundColor: theme.palette.background.surface,
@@ -65,7 +66,8 @@ export const menuListSx = ({ gap = '4px' }: { gap?: string } = {}) => ({
  * declaration that outweighs Joy's `:active` on specificity.
  *
  * Scoped to [role="option"], so spreading it on a Joy Menu is inert - Menu rows are
- * role="menuitem" and take menuRowSx per item, which owns the danger variant too.
+ * role="menuitem" and take menuItemListSx, or menuRowSx per item where a row wants the fixed
+ * icon + label geometry (and the danger variant) too.
  *
  * Not every Select in the app belongs here: the model-filter, file-browser and upload dropdowns
  * (Session/ModelSelection, Files/Browser/MobileSearchFilter, Files/Browser/UploadActionsSelect)
@@ -87,6 +89,41 @@ export const selectListboxSx = (theme: Theme, opts?: { gap?: string }) => ({
       // than a different colour. (Nothing repaints on press - plainActive carries no `color`.)
       color: 'inherit',
     },
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary[500]}`,
+      outlineOffset: '-2px',
+    },
+  },
+});
+
+/**
+ * The [role="menuitem"] mirror of selectListboxSx: a Joy Menu's rows on a menuSurfaceSx ground.
+ * selectListboxSx is inert on these - Menu rows are menuitem, not option - which is how menus
+ * sitting on the same ground ended up marking their rows differently.
+ *
+ * Sets no geometry on purpose, so it tolerates rows that are not menuRowSx's single 40px
+ * icon + label line: the lake picker's are two-line, with a decorator and a trailing count.
+ *
+ * Hover and press go through Joy's variables because Joy's own ListItemButton rules outrank a
+ * bare `&:hover` here. The selected row cannot: Joy paints `.Mui-selected` from the plainActive
+ * variant as well, so pointing that variable at the hover ground alone would erase the selected
+ * marker. It is a plain declaration, which outweighs Joy's variant rule on specificity.
+ *
+ * A per-item sx CANNOT override what this sets - `.menu [role="menuitem"]` outranks the row's
+ * own class - so a menu with per-row grounds (rowActionsMenu's destructive row) stays on
+ * menuRowSx per item instead. Joy gives a ListItem inside a Menu role="none", so a menu's
+ * non-row content (the lake picker's filter box, skeletons and count chip) is untouched.
+ */
+export const menuItemListSx = (theme: Theme, opts?: { gap?: string }) => ({
+  ...menuListSx(opts),
+  '& [role="menuitem"]': {
+    transition: 'background 0.15s',
+    '--variant-plainHoverBg': theme.palette.notebooklist.hoverBg,
+    '--variant-plainActiveBg': theme.palette.notebooklist.hoverBg,
+    // The ground is the whole marker here. selectListboxSx can add a bold weight because a Select
+    // Option's label is bare text; these rows label themselves with a Joy Typography, whose own
+    // fontWeight declaration beats anything inherited from the row.
+    [`&.${menuItemClasses.selected}`]: { backgroundColor: theme.palette.notebooklist.focusedBackground },
     '&:focus-visible': {
       outline: `2px solid ${theme.palette.primary[500]}`,
       outlineOffset: '-2px',


### PR DESCRIPTION
# Pull Request

## Description

Closes #2477

**Now based on `main`.** This opened stacked on `refactor/select-listbox-recipe` (#2445), which has since merged as `44529f5d8`; the branch is rebased onto `main` and the base retargeted, so the diff here is the three commits and five files that belong to this issue alone. The replay was clean - `main`'s copies of all five touched files were byte-identical to the old base, and the resulting diff is byte-identical to the pre-rebase one. Context for the stacking, since the commit history no longer shows it: #2477 was found while reviewing #2445 and depends on its artifacts, and `selectListboxSx`, `menuListSx` and `menuSurfaceSx.test.ts` did not exist on `main` until #2445 landed.

#2445 consolidated the `[role="option"]` half of the floating-menu recipe and fixed the press state there. The `role="menuitem"` rows sitting on the same ground still had both gaps this closes.

**1. Menu rows flashed the brand tint while pressed.** `menuRowSx` set `&:hover` but never `--variant-plainActiveBg`. Joy's `ListItemButton` carries an unconditional `'&:active': theme.variants.plainActive[color]` (`ListItemButton/ListItemButton.js` in `@mui/joy@5.0.0-beta.52`), so with the variable unset it fell through to `neutral.plainActiveBg` - which this theme overrides to `brand[700]` (dark) / `brand[100]` (light) in `app/utils/themes/themePrimitives.ts:185,292`. Both Data Lake menus went visibly blue under the finger instead of staying on their hover ground. Measured on the pr2445 preview in dark mode: row actions menu `rgba(42, 64, 87, 0.976)`, lake picker `rgb(42, 65, 89)`, both `neutral.plainActiveBg`.

**2. The lake picker's rows did not share the row recipe at all.** They are `role="menuitem"`, so `selectListboxSx` is inert on them by design, and they kept Joy's neutral defaults rather than the app's `notebooklist` tokens (measured hover: `rgb(23, 26, 28)`). They cannot take `menuRowSx` as-is - that helper assumes a single 40px line with one icon and a label, and these rows are two-line with a decorator and a trailing count. #2445's "What NOT to test" named the missing sibling; this adds it.

## Changes

`apps/client/app/components/layouts/Notebook/Sidenav/menuSurfaceSx.ts`:

- `menuRowSx` now computes one `ground` (`danger ? danger.plainHoverBg : notebooklist.hoverBg`) and emits it three ways: the `&:hover` declaration, which is what the profile menu's plain `Box` rows use, plus `--variant-plainHoverBg` and `--variant-plainActiveBg`, which are what Joy's own `ListItemButton` rules read on a `MenuItem` and which outrank that declaration. Hover and press are the same ground by construction rather than by two literals agreeing.
- `menuItemListSx(theme, opts)` (new) - the `[role="menuitem"]` mirror of `selectListboxSx`: `menuListSx` plus the row hover / press / selected / focus states, scoped to `& [role="menuitem"]` exactly the way `selectListboxSx` is scoped to `[role="option"]`, so it is inert on a Select listbox. It sets **no geometry** on purpose (no height, padding or gap), which is what lets it cover two-line rows with a decorator and a count.

Call sites:

- `datalake/DataLakeLakePicker.tsx` - `menuListSx({ gap: '2px' })` becomes `menuItemListSx(theme, { gap: '2px' })`. Its rows now take the app's `notebooklist` hover / press grounds, the app's `primary[500]` focus ring, and a `notebooklist.focusedBackground` + bold marker on the selected row, matching how the chat panel's Select marks its selected option.
- `datalake/rowActionsMenu.tsx` - **drops** its per-item `--variant-plainHoverBg` instead of gaining a matching `--variant-plainActiveBg`. This is a deliberate deviation from the issue's second scope bullet: `menuRowSx(itemTheme, danger)` is spread first in that item's `sx` and now emits both variables with the identical danger branch, so restating either there would be provably dead code. The file deliberately stays on per-item `menuRowSx` rather than adopting `menuItemListSx`, because a list-scoped `.menu [role="menuitem"]` rule is (0,3,0) and outranks a row's own emotion class (0,1,0), so the destructive row could not override the shared ground. Documented in a docblock in both files.

Tests:

- `menuSurfaceSx.test.ts` (+2 describe blocks, 14 cases). `menuRowSx`: pins the press ground per colour scheme and proves it is *not* that scheme's `neutral.plainActiveBg`, proves press equals the hover ground in both the plain and the danger branch, and pins the danger branch on both variables. `menuItemListSx`: mirrors the existing `selectListboxSx` block (list tokens, hover + press variables, the selected ground, menuitem-only scoping), adds a "sets no row geometry" guard and a cross-check that both halves of the recipe agree on the press ground, and runs its colour assertions under `describe.each(['light', 'dark'])`.
- `DataLakeLakePicker.test.tsx` (+2 cases), DOM-level, because the two structural facts the recipe rests on are Joy implementation details: that picker rows really are `role="menuitem"` and the selected one really carries `menuItemClasses.selected`, and that the menu's non-row chrome (filter box, count chip) is `role="none"` rather than a row. A Joy upgrade changing either would silently drop the picker's rows back to Joy's neutral defaults; these fail loudly instead.

**Three visible side effects a reviewer should expect.** All three are intended, and none are named in the issue text:

1. **Profile menu "Return to safety" row** (`ProfileMenu.tsx:578`, the admin impersonation exit) now hovers on `danger.plainHoverBg` instead of the neutral `notebooklist.hoverBg`. Folding hover and press onto one danger-aware ground is what removes the drift; leaving `&:hover` neutral while the variables are danger-branched would leave `menuRowSx` self-contradictory two lines apart. It also aligns that row with the Data Lake Delete row, which already hovered red. Easy to back out if unwanted - make `&:hover` unconditionally `notebooklist.hoverBg`.
2. **The lake picker's selected row** - including the default "All data lakes" row, which is selected whenever no lake is scoped - moves from Joy's `neutral.plainActiveBg` brand tint to `notebooklist.focusedBackground` plus a bold label. In dark mode the weight does most of the work, because `notebooklist.dark.hoverBg` and `notebooklist.dark.focusedBackground` are the same value; that is the same trade the chat panel's Select already makes.
3. **The lake picker's rows pick up the app's `primary[500]` focus ring** in place of Joy's default, same as the Select's options.

## Guide for Testers

Preconditions: sign in with the `EnableDataLakes` feature flag on. Sections 1 and 2 need a Data Lake with at least one file in it; section 3 needs an **admin** account only if you want to check the impersonation row. Run the whole guide once in **dark mode** and once in **light mode** - the hover and selected grounds differ between them, and section 2 step 8 is dark-mode-specific.

**1. Data Lake row actions menu** - the press fix.

1. Go to `app.staging.bike4mind.com` and sign in.
2. Open any notebook session from the sidebar.
3. In the session header, turn on the **Data Lakes** toggle. Expected: a Data Lake tree panel appears alongside the chat.
4. In that tree, hover a file row and click its **"..."** button. Expected: the action menu opens on a bordered, softly shadowed panel with 8px corners and tight 2px gaps between rows.
5. Hover a non-destructive row (for example **Move** or **Rename**). Expected: a subtle grey-blue hover ground with 8px rounded corners.
6. **Press and hold** the mouse on that row without releasing, for about two seconds. Expected: the ground stays that same hover colour. **It must NOT flash blue.** A blue/brand fill under the finger is the bug this PR fixes - on `main` it appears immediately on mouse-down.
7. Hover the destructive row (**Remove** / **Delete**). Expected: a red-tinted hover ground with red label ink.
8. **Press and hold** the destructive row. Expected: the ground stays that same red - it must not flash blue, and it must not turn neutral grey either.
9. Release the mouse outside the menu, or press `Escape`, to dismiss without firing the action.

**2. Data Lake lake picker** - the press fix plus the new shared recipe. Every colour in this section changes relative to `main`.

10. In the same Data Lake tree panel, click the lake picker button at the top (it shows the current lake's name, or "All data lakes"). Expected: a menu opens with 8px corners on the same bordered, shadowed panel, with a search box at the top and one row per lake.
11. Hover a lake row. Expected: **the app's own grey-blue menu hover ground**, the same colour the row actions menu in section 1 uses and the same one the chat panel's Layout dropdown uses. On `main` this is a different, flatter near-black (`rgb(23, 26, 28)`) - a colour change here is the intended fix, not a regression.
12. **Press and hold** a lake row. Expected: the ground stays on that hover colour. It must not flash blue.
13. Note which row is selected (it is "All data lakes" unless a specific lake is already scoped). Expected: **the selected row's label is bold.**
14. In **light** mode: the selected row's ground also reads a step stronger than a hover. In **dark** mode: the selected ground is deliberately the *same* colour as a hover ground, so **the bold weight is the only tell** - a dark-mode selected row that looks identical to a hovered one is correct. What must NOT happen in either mode is the selected row showing a blue/brand fill, which is what `main` does.
15. Confirm the bold weight lands on the **lake name only**. Expected: the smaller visibility sub-label under the name and the trailing file count stay at normal weight.
16. Hover the selected row. Expected: no repaint - Joy scopes hover to non-selected rows, and the Select's options behave the same way. Not a regression.
17. Close the menu, reopen it, and press `ArrowDown` two or three times. Expected: the keyboard-highlighted row shows the same hover ground as the mouse hover, and the focus outline is a 2px blue-primary ring drawn just inside the row's rounded edge.
18. Click a lake row. Expected: the menu closes, the tree filters to that lake, and the picker button now shows that lake's name. Reopen the menu: that row is now the bold selected one.
19. Type into the picker's search box. Expected: the box itself is unchanged - no hover ground, no bold, no focus ring from this PR - and the rows filter as you type. Same for the trailing file-count chip and the "No matches" message: they are menu chrome, not rows, and must stay unstyled by the row recipe.

**3. Profile menu** - one intended colour change, everything else identical to `main`.

20. Click the profile/avatar row at the **bottom of the sidebar**. Expected: the panel opens above it with 8px corners.
21. Hover each ordinary row (Settings, Help, More, and so on). Expected: the same grey-blue hover ground as on `main`, unchanged.
22. **Press and hold** any of those rows. Expected: the ground stays on the hover colour, no blue flash. (These rows are plain `Box`es, so `main` already behaved here; this confirms nothing regressed.)
23. Admin only, and only if you can reach it: impersonate another user, then open the profile menu and hover **"Return to safety"**. Expected: **a red-tinted hover ground.** On `main` that row hovers neutral grey. This is the one intended colour change in the profile menu - it matches the Data Lake Delete row, which already hovered red.

### Regression Checks

- Every row action in the Data Lake row actions menu still fires (Move, Rename, Remove / Delete), and the menu still opens *above* the Data Lake manager modal rather than behind it.
- The lake picker still filters the tree, and its search box, Create and Discover rows all still work.
- The lake picker's row geometry is unchanged from `main`: two-line rows, the leading visibility decorator, the trailing count, the 2px gap between rows, and 8px row corners. This PR sets no geometry - only colours, weight and the focus ring.
- No menu changed its outer padding: the gap between a menu's border and its first row is still 8px.
- The chat panel's Layout dropdown (`Sidebar -> Admin`, then the **Layout** control in the floating AI Chat window's header) is untouched by this PR and should behave exactly as it does on `main`: hover ground, no blue press flash, bold selected row. That surface was fixed by #2445, which is now merged.
- The Data Lake tree's own row hover is untouched.

### What NOT to test

- The model selection dropdown, the file-browser search filters, upload actions, and the research config panel. Those six listboxes sit on a different surface and are tracked separately in #2460 - untouched here, as in #2445.
- Anything about **corner radius or scrollbars** in these menus. Those changed in #2445, which is already merged into `main`, so they are identical on both sides of this diff. This PR sets no geometry at all; if a radius or scrollbar looks off, it is #2445's and wants its own issue.
- The red **ink** contrast on the destructive rows. The row actions menu re-declares `color: danger.plainColor` (7.50:1 on the new ground), but the profile menu's "Return to safety" uses `danger[500]`, which measures 2.74:1 in dark on the new ground versus 2.51:1 on the old neutral one. Dark slightly improves and light stays above 4.5:1, so this PR is not a contrast regression - but that dark pairing does fail WCAG AA for body text and did so before this change too. Pre-existing and worth its own ticket; deliberately not widened into this one.

## Additional Information

**The issue's own Verification step has NOT been run yet** - it asks for press-and-hold on a preview in both themes, reading the computed background off the row. Everything here is reasoned from the Joy `5.0.0-beta.52` source and pinned by unit and DOM assertions; the browser confirmation is what a preview deploy on this PR is for, which is why it opens as a draft.

Verified locally against the rebased tree: `pnpm turbo:typecheck` 40/40 successful, `pnpm lint:check` clean, and the two touched projects on their own (`datalake/` + `Sidenav/`) 50 files / 718 tests passed - more than the 44 files / 573 measured before the rebase, because `main` has since added tests in those directories. The full `@bike4mind/client` suite passed at 1079 files / 11597 tests before the self-review amendments; the re-run after them had one unrelated file (`__tests__/server-config-public.test.ts`) time out in its `beforeEach` alongside `Failed to start forks worker` errors from this machine oversubscribing its cores - that file passes 4/4 in isolation. Repo-wide `pnpm turbo:test` is 36/39 with `@bike4mind/scripts` failing on `MongoMemoryServer` timeouts in its migration integration tests, reproducibly and locally only; this diff touches five files, all under `apps/client/app/components/`, and `packages/scripts` has no dependency on `@bike4mind/client`. CI is authoritative over both.

A self-review pass over this diff found and fixed two dark-mode-only defects, both in the last commit. (1) Once the selected lake row's marker was a ground alone, it stopped being a marker in dark mode: `notebooklist.dark.hoverBg` and `notebooklist.dark.focusedBackground` are the same value (`rgba(42, 44, 56, 0.7)`, `themes/components/notebooklist.ts:9-10`), so hovering any sibling painted the selected row's exact colour. `fontWeight: 600` is back, and it is load-bearing rather than decoration. (2) The comment used to justify dropping that weight was factually wrong: Joy's `body-md` and `body-sm` levels declare no `fontWeight` but `body-xs` does, so a weight on the row *does* reach a lake name (`body-sm`) and does *not* reach the visibility sub-label or the count (`body-xs`) - which is exactly the wanted result. The test that should have caught the first defect was itself wrong (`expect(focusedBackground).not.toBe(plainActiveBg)` holds only in the light scheme, which is what `extendTheme(...).palette` resolves to); it is now per-scheme `describe.each` coverage asserting the property that actually matters, that a selected row differs from a hovered sibling by ground OR by weight, and it was confirmed to fail in dark with the `fontWeight` removed.

Known and accepted: the "do not combine `menuItemListSx` with per-item `menuRowSx`" invariant lives only in prose in two docblocks, unenforced. And `rowActionsMenu.tsx` still has no test file, so its destructive row's hover ground now rests entirely on `menuRowSx`'s own tests.

## Developer Notes (Optional)

- **New extension point**: `menuItemListSx(theme, { gap })` from `layouts/Notebook/Sidenav/menuSurfaceSx.ts`. A Joy `Menu` on the app's floating-menu ground is now three spreads - `menuSurfaceSx` for the ground, `menuItemListSx` for the list and its rows, plus the menu's own geometry - with no per-row helper needed.
- **The recipe now has two symmetrical halves**, picked by row role, not by taste: `selectListboxSx` for `[role="option"]` (a Select listbox), `menuItemListSx` for `[role="menuitem"]` (a `Menu`). Each is inert on the other's surface, so spreading the wrong one is a no-op rather than a subtle mismatch. `menuRowSx` remains the per-row escape hatch for a menu whose rows need individually different grounds.
- **Architecture decision - why list-scoped rather than a per-row helper.** The lake picker has five separate `MenuItem` call sites in one `Menu`; a per-row helper would have to be threaded through all five. Joy also gives a `ListItem` inside a `Menu` `role="none"`, so a list-level `[role="menuitem"]` selector reaches exactly the rows and skips the filter box, skeletons, error block and count chip for free. The cost is specificity: (0,3,0) beats a row's own emotion class, so a menu with per-row grounds must stay on `menuRowSx`. Both halves of that trade are in the docblock.
- **Gotcha now captured in a docblock**: Joy's `ListItemButton` has an *unconditional* `&:active` painted from `--variant-plainActiveBg`, and this theme tints `neutral.plainActiveBg` brand blue. Any new Joy row that sets a hover ground must set the press variable too, or it flashes blue on mouse-down. `menuRowSx` derives both from one value so they cannot drift again.
- **Gotcha**: these are custom properties, so they inherit into a row's whole subtree - a plain-variant Joy child dropped into a row (an `IconButton`, a `Chip`) picks up the row's ground as its own. `rowActionsMenu.tsx` zeroes both variables on its trigger for exactly that reason.
- **Gotcha**: the selected row's ground cannot go through a variable. Joy paints `.Mui-selected` from the `plainActive` variant as well, so pointing that variable at the hover ground erases the selected marker. It is a declaration, and it lands on the strength of the descendant selector.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - N/A, no telemetry changes
