### PR TITLE
fix(oauth): harden device-code lookup, auth-code consumption, and user-code entropy

### DIFF
--- a/apps/client/pages/api/oauth/device/initiate.ts
+++ b/apps/client/pages/api/oauth/device/initiate.ts
@@ -1,7 +1,7 @@
-import { deviceAuthorizationRepository } from '@bike4mind/database';
+import { deviceAuthorizationRepository, digestDeviceCode } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
-import { generateDeviceCode, generateUserCode, hashDeviceCode } from '@server/utils/oauth/deviceAuthHelpers';
+import { generateDeviceCode, generateUserCode } from '@server/utils/oauth/deviceAuthHelpers';
 import { z } from 'zod';
 
 const InitiateRequestSchema = z.object({
@@ -21,10 +21,8 @@ const handler = baseApi({ auth: false })
     const deviceCode = generateDeviceCode();
     const userCode = generateUserCode();
 
-    const hashedDeviceCode = await hashDeviceCode(deviceCode);
-
     await deviceAuthorizationRepository.create({
-      deviceCode: hashedDeviceCode,
+      deviceCode: digestDeviceCode(deviceCode),
       userCode,
       status: 'pending',
       userId: null,

--- a/apps/client/pages/api/oauth/token.ts
+++ b/apps/client/pages/api/oauth/token.ts
@@ -49,7 +49,9 @@ const handler = baseApi({ auth: false })
           .json({ error: 'unauthorized_client', error_description: 'Invalid client credentials or redirect_uri' });
       }
 
-      const authCode = await oauthAuthorizationCodeRepository.findValidCode(code);
+      // Atomically claim the code so a leaked code can't be redeemed twice by
+      // concurrent requests. Any subsequent failure leaves it consumed (single-use).
+      const authCode = await oauthAuthorizationCodeRepository.consumeValidCode(code);
       if (!authCode) {
         return res
           .status(400)
@@ -71,9 +73,6 @@ const handler = baseApi({ auth: false })
             .json({ error: 'invalid_grant', error_description: 'code_verifier does not match code_challenge' });
         }
       }
-
-      // prevent replay
-      await oauthAuthorizationCodeRepository.markUsed(authCode.id);
 
       const user = await userRepository.findById(authCode.userId);
       if (!user) {

--- a/apps/client/server/utils/oauth/deviceAuthHelpers.test.ts
+++ b/apps/client/server/utils/oauth/deviceAuthHelpers.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateUserCode } from './deviceAuthHelpers';
+
+describe('generateUserCode', () => {
+  it('matches the XXXX-XXXX format over the confusion-free charset', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(generateUserCode()).toMatch(
+        /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{4}-[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{4}$/
+      );
+    }
+  });
+
+  it('uses a CSPRNG, never the predictable Math.random', () => {
+    const spy = vi.spyOn(Math, 'random');
+    generateUserCode();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/apps/client/server/utils/oauth/deviceAuthHelpers.ts
+++ b/apps/client/server/utils/oauth/deviceAuthHelpers.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto';
-import bcrypt from 'bcryptjs';
 
 /**
  * Generate 8-character user code (base32, no confusing characters)
@@ -12,7 +11,8 @@ export function generateUserCode(): string {
 
   for (let i = 0; i < 8; i++) {
     if (i === 4) code += '-'; // Add separator
-    code += charset[Math.floor(Math.random() * charset.length)];
+    // crypto.randomInt is a CSPRNG; Math.random is predictable and must never mint a credential.
+    code += charset[crypto.randomInt(charset.length)];
   }
 
   return code;
@@ -23,11 +23,4 @@ export function generateUserCode(): string {
  */
 export function generateDeviceCode(): string {
   return crypto.randomBytes(64).toString('hex');
-}
-
-/**
- * Hash device code for secure storage
- */
-export async function hashDeviceCode(deviceCode: string): Promise<string> {
-  return bcrypt.hash(deviceCode, 10);
 }

--- a/packages/database/src/models/auth/DeviceAuthorizationModel.test.ts
+++ b/packages/database/src/models/auth/DeviceAuthorizationModel.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { deviceAuthorizationRepository, digestDeviceCode } from './DeviceAuthorizationModel';
+import { setupMongoTest } from '../../__test__/utils';
+
+setupMongoTest();
+
+const base = (o: Record<string, unknown> = {}) =>
+  ({
+    deviceCode: digestDeviceCode('dc-default'),
+    userCode: 'AAAA-2345',
+    status: 'pending',
+    userId: null,
+    expiresAt: new Date(Date.now() + 600_000),
+    approvedAt: null,
+    lastPolledAt: null,
+    ipAddress: '127.0.0.1',
+    userAgent: 'test',
+    pollCount: 0,
+    verificationAttempts: 0,
+    ...o,
+  }) as never;
+
+describe('DeviceAuthorizationModel repository', () => {
+  it('digestDeviceCode is deterministic and never the raw code', () => {
+    expect(digestDeviceCode('raw')).toBe(digestDeviceCode('raw'));
+    expect(digestDeviceCode('raw')).not.toBe('raw');
+  });
+
+  it('findByDeviceCode resolves the raw code via its stored digest', async () => {
+    await deviceAuthorizationRepository.create(base({ userCode: 'AAAA-2345', deviceCode: digestDeviceCode('raw-1') }));
+    await deviceAuthorizationRepository.create(base({ userCode: 'BBBB-2345', deviceCode: digestDeviceCode('raw-2') }));
+    expect((await deviceAuthorizationRepository.findByDeviceCode('raw-2'))?.userCode).toBe('BBBB-2345');
+  });
+
+  it('returns null for an unknown or expired code', async () => {
+    await deviceAuthorizationRepository.create(
+      base({ userCode: 'CCCC-2345', deviceCode: digestDeviceCode('raw-live') })
+    );
+    await deviceAuthorizationRepository.create(
+      base({ userCode: 'DDDD-2345', deviceCode: digestDeviceCode('raw-dead'), expiresAt: new Date(Date.now() - 1000) })
+    );
+    expect(await deviceAuthorizationRepository.findByDeviceCode('nope')).toBeFalsy();
+    expect(await deviceAuthorizationRepository.findByDeviceCode('raw-dead')).toBeFalsy();
+  });
+});

--- a/packages/database/src/models/auth/DeviceAuthorizationModel.ts
+++ b/packages/database/src/models/auth/DeviceAuthorizationModel.ts
@@ -1,10 +1,21 @@
 import { IMongoDocument, IBaseRepository } from '@bike4mind/common';
 import mongoose, { Schema, model, Model } from 'mongoose';
-import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
 import BaseRepository from '@bike4mind/db-core';
 
+/**
+ * Deterministic digest for the device code lookup key. The raw device code is
+ * 64 bytes of CSPRNG output, so a plain SHA-256 is not brute-forceable and needs
+ * no salt - unlike a low-entropy secret. Being deterministic, it can be indexed,
+ * so a poll is an O(1) indexed lookup rather than a per-document bcrypt compare
+ * (an unauthenticated CPU-DoS vector). Store this; never store the raw code.
+ */
+export function digestDeviceCode(deviceCode: string): string {
+  return crypto.createHash('sha256').update(deviceCode).digest('hex');
+}
+
 export interface IDeviceAuthorizationDocument extends IMongoDocument {
-  deviceCode: string; // Hashed with bcrypt
+  deviceCode: string; // SHA-256 digest of the raw device code (see digestDeviceCode)
   userCode: string; // Plain text: "WXYZ-1234"
   status: 'pending' | 'approved' | 'denied' | 'expired' | 'consumed';
   userId: string | null;
@@ -51,6 +62,7 @@ const DeviceAuthorizationSchema = new Schema<IDeviceAuthorizationDocument>(
 // Indexes
 DeviceAuthorizationSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 }); // TTL index
 DeviceAuthorizationSchema.index({ status: 1, expiresAt: 1 });
+DeviceAuthorizationSchema.index({ deviceCode: 1 }); // O(1) token-poll lookup
 
 export type IDeviceAuthorizationModel = Model<IDeviceAuthorizationDocument>;
 
@@ -88,21 +100,12 @@ class DeviceAuthorizationRepository
   }
 
   async findByDeviceCode(deviceCode: string): Promise<IDeviceAuthorizationDocument | null> {
-    // Get all pending/approved/denied authorizations that haven't expired
-    const pending = await this.find({
+    // O(1) indexed lookup by deterministic digest - no per-document bcrypt scan.
+    return this.findOne({
+      deviceCode: digestDeviceCode(deviceCode),
       status: { $in: ['pending', 'approved', 'denied'] },
       expiresAt: { $gt: new Date() },
     });
-
-    // Compare device code with each hashed device code
-    for (const auth of pending) {
-      const isMatch = await bcrypt.compare(deviceCode, auth.deviceCode);
-      if (isMatch) {
-        return auth;
-      }
-    }
-
-    return null;
   }
 
   async findPendingAndUnexpired(): Promise<IDeviceAuthorizationDocument[]> {

--- a/packages/database/src/models/auth/OAuthAuthorizationCodeModel.test.ts
+++ b/packages/database/src/models/auth/OAuthAuthorizationCodeModel.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { oauthAuthorizationCodeRepository } from './OAuthAuthorizationCodeModel';
+import { setupMongoTest } from '../../__test__/utils';
+
+setupMongoTest();
+
+const base = (o: Record<string, unknown> = {}) =>
+  ({
+    code: 'code-default',
+    clientId: 'client-1',
+    userId: 'user-1',
+    redirectUri: 'https://app.example/cb',
+    scopes: ['openid'],
+    expiresAt: new Date(Date.now() + 600_000),
+    used: false,
+    ...o,
+  }) as never;
+
+describe('OAuthAuthorizationCodeModel repository', () => {
+  it('consumeValidCode returns the code once, then null (single-use)', async () => {
+    await oauthAuthorizationCodeRepository.create(base({ code: 'once' }));
+    expect((await oauthAuthorizationCodeRepository.consumeValidCode('once'))?.clientId).toBe('client-1');
+    expect(await oauthAuthorizationCodeRepository.consumeValidCode('once')).toBeFalsy();
+  });
+
+  it('rejects an expired or unknown code', async () => {
+    await oauthAuthorizationCodeRepository.create(base({ code: 'stale', expiresAt: new Date(Date.now() - 1000) }));
+    expect(await oauthAuthorizationCodeRepository.consumeValidCode('stale')).toBeFalsy();
+    expect(await oauthAuthorizationCodeRepository.consumeValidCode('ghost')).toBeFalsy();
+  });
+
+  it('redeems a code at most once under concurrent requests (atomic)', async () => {
+    await oauthAuthorizationCodeRepository.create(base({ code: 'race' }));
+    const results = await Promise.all([
+      oauthAuthorizationCodeRepository.consumeValidCode('race'),
+      oauthAuthorizationCodeRepository.consumeValidCode('race'),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+});

--- a/packages/database/src/models/auth/OAuthAuthorizationCodeModel.ts
+++ b/packages/database/src/models/auth/OAuthAuthorizationCodeModel.ts
@@ -17,8 +17,7 @@ export interface IOAuthAuthorizationCodeDocument extends IMongoDocument {
 }
 
 export interface IOAuthAuthorizationCodeRepository extends IBaseRepository<IOAuthAuthorizationCodeDocument> {
-  findValidCode(code: string): Promise<IOAuthAuthorizationCodeDocument | null>;
-  markUsed(id: string): Promise<void>;
+  consumeValidCode(code: string): Promise<IOAuthAuthorizationCodeDocument | null>;
 }
 
 type IOAuthAuthorizationCodeModel = Model<IOAuthAuthorizationCodeDocument>;
@@ -51,12 +50,16 @@ class OAuthAuthorizationCodeRepository
     super(m);
   }
 
-  findValidCode(code: string) {
-    return this.model.findOne({ code, used: false, expiresAt: { $gt: new Date() } }).exec();
-  }
-
-  async markUsed(id: string): Promise<void> {
-    await this.model.updateOne({ _id: id }, { $set: { used: true } });
+  /**
+   * Atomically claim an unused, unexpired code: flip `used` false->true and return
+   * the matched document, or null if it was already used/expired/unknown. Single
+   * DB round-trip so two concurrent token requests can't both redeem one code
+   * (the find-then-mark split had a race that let a leaked code be spent twice).
+   */
+  consumeValidCode(code: string) {
+    return this.model
+      .findOneAndUpdate({ code, used: false, expiresAt: { $gt: new Date() } }, { $set: { used: true } })
+      .exec();
   }
 }
 


### PR DESCRIPTION
## Description

Three self-contained hardening changes to the OAuth provider endpoints. Rationale and verification detail are tracked privately.

## Changes

- OAuth device user codes are now generated with a CSPRNG (`crypto.randomInt`) instead of `Math.random`.
- Device-code polling resolves the stored code via an indexed SHA-256 digest (`digestDeviceCode`) instead of loading every live authorization and `bcrypt.compare`-ing each one. Device codes are 64 bytes of CSPRNG output, so a deterministic digest is not brute-forceable and can be indexed, turning the poll into an O(1) lookup. Adds a `{ deviceCode: 1 }` index; no backfill needed (device codes have a 10-minute TTL).
- Authorization-code consumption is now atomic (`findOneAndUpdate` on `used: false`), so a code cannot be redeemed twice by concurrent requests. Replaces the previous find-then-mark split.

## Guide for Testers

These are OAuth provider/protocol endpoints with no first-party UI, so there is no click-through QA path - verification is backend-level. The flows are self-contained (B4M is the provider; the client is the CLI or a locally registered test client), so no external identity provider or callback-URI setup is involved and they can run against an on-demand PR preview. Substitute the preview host for `<host>`.

Device login (CLI) - hands-on, no setup (the device client id is built in):

1. Point the CLI at `<host>` and start `/login`. It prints a user code and a verification URL.
2. In a browser signed in to `<host>`, open the verification URL and approve.
3. Expected: the CLI completes, issues a session, and shows which account the login bound to.

### What NOT to test

- Device `user_code` entropy and the O(1) digest lookup are not observable by hand - covered by unit tests.
- Authorization-code single-use: covered by `OAuthAuthorizationCodeModel.test.ts` (including the concurrent double-redeem case, the property this change adds). Exercising it end-to-end needs a registered client and a signed-in Bearer, i.e. a maintainer/dev step, so the detailed reproduction is recorded on the private security tracker.

## Tests

- New unit tests: `deviceAuthHelpers.test.ts` (CSPRNG), `DeviceAuthorizationModel.test.ts` (digest lookup), `OAuthAuthorizationCodeModel.test.ts` (single-use, including concurrent redemption).
- `pnpm --filter @bike4mind/database typecheck` and client typecheck pass; the full `@bike4mind/database` suite (124 files, 1542 tests) passes with no regressions.

## Security Testing (for security-labeled PRs only)

- [ ] Verified on a PR preview with the steps above (output attached as a PR comment) -- pending preview env
- [x] Deterministic properties covered by unit tests (entropy source, indexed digest lookup, concurrent single-use)
- [x] Verified the changed files against `origin/main`; detailed reproduction/verification recorded on the private security tracker

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) -- n/a, backend-only
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) -- n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- n/a
