### PR TITLE
fix(services): scope image-tool FabFile lookups to the requesting user

### DIFF
--- a/apps/client/pages/api/agents/index.ts
+++ b/apps/client/pages/api/agents/index.ts
@@ -27,8 +27,11 @@ interface IAgentWithSystemPrompt extends IAgent {
   systemPrompt?: string;
 }
 
-// Helper function to refresh avatar URLs for agents
-const refreshAgentAvatarUrls = async (agents: IAgent[]): Promise<IAgent[]> => {
+// Helper function to refresh avatar URLs for agents. `viewerId` is the requesting user:
+// the signed-URL write-back below mutates the FabFile record, so it is gated to the file's
+// owner - a viewer of a *shared* agent still gets a freshly minted display URL but never
+// rewrites another user's FabFile record.
+const refreshAgentAvatarUrls = async (agents: IAgent[], viewerId: string): Promise<IAgent[]> => {
   const refreshedAgents = await Promise.all(
     agents.map(async agent => {
       // Skip if no portrait URL
@@ -63,13 +66,16 @@ const refreshAgentAvatarUrls = async (agents: IAgent[]): Promise<IAgent[]> => {
             const newSignedUrl = await getFilesStorage().getSignedUrl(fabFile.filePath);
 
             if (newSignedUrl) {
-              // Update the FabFile with the new URL and expiration
-              const newExpireAt = new Date(now.getTime() + 3600 * 1000);
-              await fabFileRepository.update({
-                ...fabFile,
-                fileUrl: newSignedUrl,
-                fileUrlExpireAt: newExpireAt,
-              });
+              // Persist the fresh URL only on the owner's own record - a shared-agent viewer
+              // must not mutate a FabFile owned by someone else.
+              if (fabFile.userId === viewerId) {
+                const newExpireAt = new Date(now.getTime() + 3600 * 1000);
+                await fabFileRepository.update({
+                  ...fabFile,
+                  fileUrl: newSignedUrl,
+                  fileUrlExpireAt: newExpireAt,
+                });
+              }
 
               // Return the agent with the new URL
               return {
@@ -122,7 +128,7 @@ const handler = baseApi()
     const data: IAgent[] = result.data;
 
     // Refresh avatar URLs for all agents BEFORE returning response
-    const agentsWithRefreshedAvatars = await refreshAgentAvatarUrls(data);
+    const agentsWithRefreshedAvatars = await refreshAgentAvatarUrls(data, req.user!.id);
 
     res.json({
       ...result,

--- a/apps/client/pages/api/agents/index.ts
+++ b/apps/client/pages/api/agents/index.ts
@@ -1,7 +1,7 @@
 // packages/client/pages/api/agents/index.ts
 import { Request } from 'express';
 import { baseApi } from '@client/server/middlewares/baseApi';
-import { agentRepository, userRepository, withTransaction, fabFileRepository } from '@bike4mind/database';
+import { agentRepository, userRepository, withTransaction } from '@bike4mind/database';
 import {
   IAgent,
   IAgentCapabilities,
@@ -9,10 +9,9 @@ import {
   supportedChatModels,
   supportedImageModels,
   UserLevelType,
-  isImageServeable,
 } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
-import { getFilesStorage } from '@server/utils/storage';
+import { refreshAgentAvatarUrls } from '@server/utils/refreshAgentAvatarUrls';
 import {
   validateToolList,
   validateMaxIterations,
@@ -26,87 +25,6 @@ import {
 interface IAgentWithSystemPrompt extends IAgent {
   systemPrompt?: string;
 }
-
-// Helper function to refresh avatar URLs for agents. `viewerId` is the requesting user:
-// the signed-URL write-back below mutates the FabFile record, so it is gated to the file's
-// owner - a viewer of a *shared* agent still gets a freshly minted display URL but never
-// rewrites another user's FabFile record.
-const refreshAgentAvatarUrls = async (agents: IAgent[], viewerId: string): Promise<IAgent[]> => {
-  const refreshedAgents = await Promise.all(
-    agents.map(async agent => {
-      // Skip if no portrait URL
-      if (!agent.visual?.portraitUrl) {
-        return agent;
-      }
-
-      try {
-        // Extract the filename from the S3 URL
-        // URLs look like: https://bucket.s3.region.amazonaws.com/filename.ext?params
-        const url = new URL(agent.visual.portraitUrl);
-        const pathname = url.pathname; // This gives us "/filename.ext"
-        const filename = pathname.substring(1); // Remove the leading "/"
-
-        if (!filename || !filename.includes('.')) {
-          return agent;
-        }
-
-        // The filePath in the database should be just the filename (without fab-files/ prefix)
-        const filePath = filename;
-
-        // Find the corresponding FabFile to get proper signed URL
-        const fabFile = await fabFileRepository.findOne({ filePath });
-        // Don't re-mint a signed URL for a held/blocked avatar image.
-        if (fabFile && fabFile.filePath && isImageServeable(fabFile)) {
-          // Check if the current URL is expired (older than 50 minutes)
-          const now = new Date();
-          const isExpired = !fabFile.fileUrlExpireAt || fabFile.fileUrlExpireAt <= now;
-
-          if (isExpired) {
-            // Generate a new signed URL
-            const newSignedUrl = await getFilesStorage().getSignedUrl(fabFile.filePath);
-
-            if (newSignedUrl) {
-              // Persist the fresh URL only on the owner's own record - a shared-agent viewer
-              // must not mutate a FabFile owned by someone else.
-              if (fabFile.userId === viewerId) {
-                const newExpireAt = new Date(now.getTime() + 3600 * 1000);
-                await fabFileRepository.update({
-                  ...fabFile,
-                  fileUrl: newSignedUrl,
-                  fileUrlExpireAt: newExpireAt,
-                });
-              }
-
-              // Return the agent with the new URL
-              return {
-                ...agent,
-                visual: {
-                  ...agent.visual,
-                  portraitUrl: newSignedUrl,
-                },
-              };
-            }
-          } else {
-            // URL is still valid, use the existing one
-            return {
-              ...agent,
-              visual: {
-                ...agent.visual,
-                portraitUrl: fabFile.fileUrl || agent.visual.portraitUrl,
-              },
-            };
-          }
-        }
-      } catch (error) {
-        console.error(`Error refreshing avatar URL for agent ${agent.name}:`, error);
-      }
-
-      return agent;
-    })
-  );
-
-  return refreshedAgents;
-};
 
 const handler = baseApi()
   .get<Request<{}, {}, {}, Record<string, string>>>(async (req, res) => {

--- a/apps/client/pages/api/sessions/[id]/agents.ts
+++ b/apps/client/pages/api/sessions/[id]/agents.ts
@@ -1,84 +1,9 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
-import { sessionRepository, agentRepository, fabFileRepository } from '@bike4mind/database';
+import { sessionRepository, agentRepository } from '@bike4mind/database';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
-import { getFilesStorage } from '@server/utils/storage';
-import { IAgent, IAgentDocument, redactSessionForClient, isImageServeable } from '@bike4mind/common';
-
-// `viewerId` is the requesting user: the signed-URL write-back below mutates the FabFile
-// record, so it is gated to the file's owner - a viewer of a *shared* agent still gets a
-// freshly minted display URL but never rewrites another user's FabFile record.
-const refreshAgentAvatarUrls = async (agents: IAgent[], viewerId: string): Promise<IAgent[]> => {
-  const refreshedAgents = await Promise.all(
-    agents.map(async agent => {
-      if (!agent.visual?.portraitUrl) {
-        return agent;
-      }
-
-      try {
-        // S3 URLs look like: https://bucket.s3.region.amazonaws.com/filename.ext?params
-        const url = new URL(agent.visual.portraitUrl);
-        const pathname = url.pathname;
-        const filename = pathname.substring(1);
-
-        if (!filename || !filename.includes('.')) {
-          return agent;
-        }
-
-        // The filePath in the database is just the filename, without the fab-files/ prefix
-        const filePath = filename;
-
-        const fabFile = await fabFileRepository.findOne({ filePath });
-        // Don't re-mint a signed URL for a held/blocked avatar image
-        if (fabFile && fabFile.filePath && isImageServeable(fabFile)) {
-          // Check if the current URL is expired (older than 50 minutes)
-          const now = new Date();
-          const isExpired = !fabFile.fileUrlExpireAt || fabFile.fileUrlExpireAt <= now;
-
-          if (isExpired) {
-            const newSignedUrl = await getFilesStorage().getSignedUrl(fabFile.filePath);
-
-            if (newSignedUrl) {
-              // Persist the fresh URL only on the owner's own record - a shared-agent viewer
-              // must not mutate a FabFile owned by someone else.
-              if (fabFile.userId === viewerId) {
-                const newExpireAt = new Date(now.getTime() + 3600 * 1000);
-                await fabFileRepository.update({
-                  ...fabFile,
-                  fileUrl: newSignedUrl,
-                  fileUrlExpireAt: newExpireAt,
-                });
-              }
-
-              return {
-                ...agent,
-                visual: {
-                  ...agent.visual,
-                  portraitUrl: newSignedUrl,
-                },
-              };
-            }
-          } else {
-            // URL is still valid, use the existing one
-            return {
-              ...agent,
-              visual: {
-                ...agent.visual,
-                portraitUrl: fabFile.fileUrl || agent.visual.portraitUrl,
-              },
-            };
-          }
-        }
-      } catch (error) {
-        console.error(`Error refreshing avatar URL for agent ${agent.name}:`, error);
-      }
-
-      return agent;
-    })
-  );
-
-  return refreshedAgents;
-};
+import { refreshAgentAvatarUrls } from '@server/utils/refreshAgentAvatarUrls';
+import { IAgentDocument, redactSessionForClient } from '@bike4mind/common';
 
 const handler = baseApi()
   .get(

--- a/apps/client/pages/api/sessions/[id]/agents.ts
+++ b/apps/client/pages/api/sessions/[id]/agents.ts
@@ -5,7 +5,10 @@ import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 import { getFilesStorage } from '@server/utils/storage';
 import { IAgent, IAgentDocument, redactSessionForClient, isImageServeable } from '@bike4mind/common';
 
-const refreshAgentAvatarUrls = async (agents: IAgent[]): Promise<IAgent[]> => {
+// `viewerId` is the requesting user: the signed-URL write-back below mutates the FabFile
+// record, so it is gated to the file's owner - a viewer of a *shared* agent still gets a
+// freshly minted display URL but never rewrites another user's FabFile record.
+const refreshAgentAvatarUrls = async (agents: IAgent[], viewerId: string): Promise<IAgent[]> => {
   const refreshedAgents = await Promise.all(
     agents.map(async agent => {
       if (!agent.visual?.portraitUrl) {
@@ -36,12 +39,16 @@ const refreshAgentAvatarUrls = async (agents: IAgent[]): Promise<IAgent[]> => {
             const newSignedUrl = await getFilesStorage().getSignedUrl(fabFile.filePath);
 
             if (newSignedUrl) {
-              const newExpireAt = new Date(now.getTime() + 3600 * 1000);
-              await fabFileRepository.update({
-                ...fabFile,
-                fileUrl: newSignedUrl,
-                fileUrlExpireAt: newExpireAt,
-              });
+              // Persist the fresh URL only on the owner's own record - a shared-agent viewer
+              // must not mutate a FabFile owned by someone else.
+              if (fabFile.userId === viewerId) {
+                const newExpireAt = new Date(now.getTime() + 3600 * 1000);
+                await fabFileRepository.update({
+                  ...fabFile,
+                  fileUrl: newSignedUrl,
+                  fileUrlExpireAt: newExpireAt,
+                });
+              }
 
               return {
                 ...agent,
@@ -88,7 +95,7 @@ const handler = baseApi()
       // Filter out any null/undefined results (deleted agents)
       const validAgents = agents.filter((agent): agent is IAgentDocument => agent != null);
 
-      const agentsWithRefreshedAvatars = await refreshAgentAvatarUrls(validAgents);
+      const agentsWithRefreshedAvatars = await refreshAgentAvatarUrls(validAgents, req.user!.id);
 
       res.json({ agents: agentsWithRefreshedAvatars });
     })

--- a/apps/client/server/queueHandlers/imageGeneration.ts
+++ b/apps/client/server/queueHandlers/imageGeneration.ts
@@ -22,6 +22,8 @@ import { getFilesStorage, getGeneratedImageStorage } from '@server/utils/storage
 import imageLogger from '@client/app/utils/imageLogger';
 import { getSourceQueueUrl } from '@server/utils/dlqRegistry';
 import { SessionEvents } from '@server/utils/eventBus';
+import { createAttachmentLakeAccess } from '@server/queueHandlers/agentExecutor.attachmentLakeAccess';
+import type { IUserDocument } from '@bike4mind/common';
 import { Resource } from 'sst';
 
 let _imageGeneration: ImageGenerationService | undefined;
@@ -43,6 +45,9 @@ export const getImageGeneration = (): ImageGenerationService => {
       },
       imageProcessorLambdaName: Resource.ImageProcessor.name,
       imageModerationService: new RekognitionImageModerationService(Logger.globalInstance),
+      // Owner-wide lake arms for the input-image lookup, parity with the chat/agent attachment
+      // doors - a lake-only image the workbench admitted must still resolve as an image-gen input.
+      resolveLakeAccess: (user: IUserDocument, logger: Logger) => createAttachmentLakeAccess(user, logger)(),
       startImageGenerationProcess: async body => {
         const queueUrl = getSourceQueueUrl('imageGenerationQueue');
         imageLogger.log('Queueing image generation', {

--- a/apps/client/server/utils/refreshAgentAvatarUrls.test.ts
+++ b/apps/client/server/utils/refreshAgentAvatarUrls.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IAgent } from '@bike4mind/common';
+
+// Hoisted so the vi.mock factories below can reference them (vi.mock is hoisted above imports).
+const h = vi.hoisted(() => ({
+  findOne: vi.fn(),
+  update: vi.fn().mockResolvedValue(undefined),
+  getSignedUrl: vi.fn().mockResolvedValue('https://signed.example/new.png'),
+}));
+
+vi.mock('@bike4mind/database', () => ({ fabFileRepository: { findOne: h.findOne, update: h.update } }));
+vi.mock('@server/utils/storage', () => ({ getFilesStorage: () => ({ getSignedUrl: h.getSignedUrl }) }));
+// Keep the rest of common (IAgent, etc.); only force the serveability gate true so the test
+// exercises the owner gate, not isImageServeable's internals.
+vi.mock('@bike4mind/common', async importOriginal => {
+  const actual = await importOriginal<typeof import('@bike4mind/common')>();
+  return { ...actual, isImageServeable: () => true };
+});
+
+const { refreshAgentAvatarUrls } = await import('./refreshAgentAvatarUrls');
+
+// A shared agent whose portrait's signed URL has expired, so the refresh path reaches the
+// owner-gated write-back. portraitUrl's pathname ("/abc.png") is what maps to the FabFile.
+const makeAgent = (): IAgent =>
+  ({ name: 'A', visual: { portraitUrl: 'https://bucket.s3.amazonaws.com/abc.png?sig=1' } }) as unknown as IAgent;
+
+const expiredOwnedBy = (userId: string) => ({
+  filePath: 'abc.png',
+  userId,
+  fileUrlExpireAt: new Date(Date.now() - 60 * 60 * 1000), // expired
+  fileUrl: 'https://old.example/abc.png',
+  mimeType: 'image/png',
+  moderationStatus: 'clean',
+});
+
+describe('refreshAgentAvatarUrls owner gate', () => {
+  beforeEach(() => {
+    h.findOne.mockReset().mockResolvedValue(expiredOwnedBy('owner'));
+    h.update.mockReset().mockResolvedValue(undefined);
+    h.getSignedUrl.mockReset().mockResolvedValue('https://signed.example/new.png');
+  });
+
+  it('a shared-agent viewer (non-owner) gets a fresh display URL but never rewrites the record', async () => {
+    const [agent] = await refreshAgentAvatarUrls([makeAgent()], 'viewer'); // viewer !== owner
+    // Display URL is minted for the viewer...
+    expect(agent.visual?.portraitUrl).toBe('https://signed.example/new.png');
+    // ...but the owner's FabFile is NOT mutated by a non-owner.
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it('the owner both gets the fresh URL and persists it back onto their own record', async () => {
+    const [agent] = await refreshAgentAvatarUrls([makeAgent()], 'owner'); // owner === owner
+    expect(agent.visual?.portraitUrl).toBe('https://signed.example/new.png');
+    expect(h.update).toHaveBeenCalledTimes(1);
+    expect(h.update).toHaveBeenCalledWith(
+      expect.objectContaining({ fileUrl: 'https://signed.example/new.png', userId: 'owner' })
+    );
+  });
+});

--- a/apps/client/server/utils/refreshAgentAvatarUrls.ts
+++ b/apps/client/server/utils/refreshAgentAvatarUrls.ts
@@ -1,0 +1,90 @@
+import { fabFileRepository } from '@bike4mind/database';
+import { IAgent, isImageServeable } from '@bike4mind/common';
+import { getFilesStorage } from '@server/utils/storage';
+
+/**
+ * Refresh agents' portrait signed URLs for display. `viewerId` is the REQUESTING user: the
+ * signed-URL write-back mutates the FabFile record, so it is gated to the file's OWNER - a viewer
+ * of a *shared* agent still gets a freshly minted display URL but never rewrites another user's
+ * FabFile record.
+ *
+ * Shared by GET /api/agents and GET /api/sessions/:id/agents. These carried byte-identical copies
+ * before; the owner gate must not drift between them, so it lives here once rather than in each
+ * route. Held/blocked avatars are never re-minted.
+ */
+export const refreshAgentAvatarUrls = async (agents: IAgent[], viewerId: string): Promise<IAgent[]> => {
+  const refreshedAgents = await Promise.all(
+    agents.map(async agent => {
+      // Skip if no portrait URL
+      if (!agent.visual?.portraitUrl) {
+        return agent;
+      }
+
+      try {
+        // Extract the filename from the S3 URL
+        // URLs look like: https://bucket.s3.region.amazonaws.com/filename.ext?params
+        const url = new URL(agent.visual.portraitUrl);
+        const pathname = url.pathname; // This gives us "/filename.ext"
+        const filename = pathname.substring(1); // Remove the leading "/"
+
+        if (!filename || !filename.includes('.')) {
+          return agent;
+        }
+
+        // The filePath in the database should be just the filename (without fab-files/ prefix)
+        const filePath = filename;
+
+        // Find the corresponding FabFile to get proper signed URL
+        const fabFile = await fabFileRepository.findOne({ filePath });
+        // Don't re-mint a signed URL for a held/blocked avatar image.
+        if (fabFile && fabFile.filePath && isImageServeable(fabFile)) {
+          // Check if the current URL is expired (older than 50 minutes)
+          const now = new Date();
+          const isExpired = !fabFile.fileUrlExpireAt || fabFile.fileUrlExpireAt <= now;
+
+          if (isExpired) {
+            // Generate a new signed URL
+            const newSignedUrl = await getFilesStorage().getSignedUrl(fabFile.filePath);
+
+            if (newSignedUrl) {
+              // Persist the fresh URL only on the owner's own record - a shared-agent viewer
+              // must not mutate a FabFile owned by someone else.
+              if (fabFile.userId === viewerId) {
+                const newExpireAt = new Date(now.getTime() + 3600 * 1000);
+                await fabFileRepository.update({
+                  ...fabFile,
+                  fileUrl: newSignedUrl,
+                  fileUrlExpireAt: newExpireAt,
+                });
+              }
+
+              // Return the agent with the new URL
+              return {
+                ...agent,
+                visual: {
+                  ...agent.visual,
+                  portraitUrl: newSignedUrl,
+                },
+              };
+            }
+          } else {
+            // URL is still valid, use the existing one
+            return {
+              ...agent,
+              visual: {
+                ...agent.visual,
+                portraitUrl: fabFile.fileUrl || agent.visual.portraitUrl,
+              },
+            };
+          }
+        }
+      } catch (error) {
+        console.error(`Error refreshing avatar URL for agent ${agent.name}:`, error);
+      }
+
+      return agent;
+    })
+  );
+
+  return refreshedAgents;
+};

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -798,6 +798,18 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   findAllInIds(ids: string[]): Promise<IFabFileDocument[]>;
 
   /**
+   * Like findAllInIds, but returns only the files the given user may access - owner,
+   * user-share, group-share, or global-read. For engine callers (@bike4mind/services)
+   * that hold only a userId and have no req.ability, so a caller-supplied FabFile id
+   * for a file they cannot see is never presigned or fed to a provider. The predicate
+   * must stay in sync with the CASL FabFile read rule (packages/database/src/utils/
+   * ability.ts) and buildOwnershipConditions.
+   * @param ids - The IDs of the files.
+   * @param access - The caller's userId and (optional) group ids.
+   */
+  findAccessibleInIds(ids: string[], access: { userId: string; userGroups?: string[] }): Promise<IFabFileDocument[]>;
+
+  /**
    * Find files by ID with the heavy and URL-bearing fields projected out, for
    * callers that need to know what a file IS without loading or linking to it.
    * Includes soft-deleted files, so a still-referenced deleted attachment stays

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -807,7 +807,11 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    * @param ids - The IDs of the files.
    * @param access - The caller's userId and (optional) group ids.
    */
-  findAccessibleInIds(ids: string[], access: { userId: string; userGroups?: string[] }): Promise<IFabFileDocument[]>;
+  findAccessibleInIds(
+    ids: string[],
+    access: { userId: string; userGroups?: string[] },
+    lakeAccess?: AttachmentLakeAccess
+  ): Promise<IFabFileDocument[]>;
 
   /**
    * Find files by ID with the heavy and URL-bearing fields projected out, for

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -65,6 +65,7 @@ export const createMockFabFileRepository = (): IFabFileRepository => ({
   confirmChunkClaim: vi.fn().mockResolvedValue(true),
   findByIdAndUserId: vi.fn(),
   findAllInIds: vi.fn(),
+  findAccessibleInIds: vi.fn(),
   findMetadataByIds: vi.fn(),
   findMetadataBySessionId: vi.fn(),
   deleteManyInIds: vi.fn(),

--- a/b4m-core/services/src/llm/ImageGeneration.test.ts
+++ b/b4m-core/services/src/llm/ImageGeneration.test.ts
@@ -112,22 +112,35 @@ describe('ImageGenerationService.selectInputImage', () => {
   });
 
   const makeService = (opts: { fabFilesById?: Record<string, FakeFile>; recentMessages?: unknown[] }) => {
-    const findAllInIds = vi.fn(async (ids: string[]) => (ids || []).map(id => opts.fabFilesById?.[id]).filter(Boolean));
+    // Access-scoped lookup: the mock returns only the ids configured as accessible in
+    // fabFilesById, mirroring the repo dropping ids the caller cannot access.
+    const findAccessibleInIds = vi.fn(async (ids: string[]) =>
+      (ids || []).map(id => opts.fabFilesById?.[id]).filter(Boolean)
+    );
     const getMostRecentChatHistory = vi.fn(async () => opts.recentMessages ?? []);
     const service = new ImageGenerationService({
-      db: { fabFiles: { findAllInIds }, quests: { getMostRecentChatHistory } },
+      db: { fabFiles: { findAccessibleInIds }, quests: { getMostRecentChatHistory } },
     } as any);
-    return { service, findAllInIds, getMostRecentChatHistory };
+    return { service, findAccessibleInIds, getMostRecentChatHistory };
   };
 
   const select = (
     service: ImageGenerationService,
-    args: { model: string; supportsImageVariation: boolean; intent?: 'fresh' | 'continuation'; fabFileIds?: string[] }
+    args: {
+      model: string;
+      supportsImageVariation: boolean;
+      intent?: 'fresh' | 'continuation';
+      fabFileIds?: string[];
+      userId?: string;
+      userGroups?: string[];
+    }
   ) =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (service as any).selectInputImage({
       sessionId: 's1',
       fabFileIds: args.fabFileIds ?? [],
+      userId: args.userId ?? 'u1',
+      userGroups: args.userGroups,
       model: args.model,
       modelInfo: { supportsImageVariation: args.supportsImageVariation } as ModelInfo,
       intent: args.intent ?? 'fresh',
@@ -194,6 +207,24 @@ describe('ImageGenerationService.selectInputImage', () => {
       intent: 'fresh',
     });
     expect(result.fileImage).toBeUndefined();
+  });
+
+  it("denies another user's fabFileId - the scoped lookup drops it, so no image is selected", async () => {
+    // The caller passes a workbench fabFileId that findAccessibleInIds does not return (not
+    // owned by / shared with the caller). It must never be presigned or fed to the provider.
+    const { service, findAccessibleInIds } = makeService({ fabFilesById: {} });
+    const result = await select(service, {
+      model: ImageModels.FLUX_KONTEXT_PRO,
+      supportsImageVariation: true,
+      fabFileIds: ['someone-elses-file'],
+      userId: 'attacker',
+      userGroups: ['g1'],
+    });
+    expect(result.fileImage).toBeUndefined();
+    expect(findAccessibleInIds).toHaveBeenCalledWith(['someone-elses-file'], {
+      userId: 'attacker',
+      userGroups: ['g1'],
+    });
   });
 
   it('prefers the workbench upload over any notebook-context image', async () => {
@@ -323,13 +354,13 @@ describe('ImageGenerationService.process (Gemini provider-dispatch parameter pas
     const findById = vi.fn(async () => quest as any);
     const update = vi.fn(async () => undefined);
     const updateMany = vi.fn(async () => undefined);
-    const findAllInIds = vi.fn(async () => []);
+    const findAccessibleInIds = vi.fn(async () => []);
     const service = new ImageGenerationService({
       db: {
         quests: { findById, update, updateMany },
         users: { findById: vi.fn(async () => ({ id: 'user1', currentCredits: 1_000_000 })) },
         organizations: { findById: vi.fn(async () => null) },
-        fabFiles: { findAllInIds },
+        fabFiles: { findAccessibleInIds },
       },
       logEvent: vi.fn().mockResolvedValue(undefined),
       abilityGetter: vi.fn().mockReturnValue({}),
@@ -469,7 +500,7 @@ describe('ImageGenerationService.process (prompt truncation)', () => {
         quests: { findById: vi.fn(async () => quest as any), update: vi.fn(), updateMany: vi.fn() },
         users: { findById: vi.fn(async () => ({ id: 'user1', currentCredits: 1_000_000 })) },
         organizations: { findById: vi.fn(async () => null) },
-        fabFiles: { findAllInIds: vi.fn(async () => []) },
+        fabFiles: { findAccessibleInIds: vi.fn(async () => []) },
       },
       logEvent: vi.fn().mockResolvedValue(undefined),
       abilityGetter: vi.fn().mockReturnValue({}),

--- a/b4m-core/services/src/llm/ImageGeneration.test.ts
+++ b/b4m-core/services/src/llm/ImageGeneration.test.ts
@@ -426,7 +426,7 @@ describe('ImageGenerationService.process (Gemini edit-path model passthrough)', 
     const findById = vi.fn(async () => quest as any);
     const update = vi.fn(async () => undefined);
     const updateMany = vi.fn(async () => undefined);
-    const findAllInIds = vi.fn(async () => [
+    const findAccessibleInIds = vi.fn(async () => [
       { id: 'f1', filePath: 'data:image/png;base64,AAAA', mimeType: 'image/png', moderationStatus: 'clean' },
     ]);
     const service = new ImageGenerationService({
@@ -434,7 +434,7 @@ describe('ImageGenerationService.process (Gemini edit-path model passthrough)', 
         quests: { findById, update, updateMany },
         users: { findById: vi.fn(async () => ({ id: 'user1', currentCredits: 1_000_000 })) },
         organizations: { findById: vi.fn(async () => null) },
-        fabFiles: { findAllInIds },
+        fabFiles: { findAccessibleInIds },
       },
       logEvent: vi.fn().mockResolvedValue(undefined),
       abilityGetter: vi.fn().mockReturnValue({}),

--- a/b4m-core/services/src/llm/ImageGeneration.test.ts
+++ b/b4m-core/services/src/llm/ImageGeneration.test.ts
@@ -150,7 +150,7 @@ describe('ImageGenerationService.selectInputImage', () => {
   it('resolves a Kontext input image from a user attachment earlier in the notebook (the bug)', async () => {
     // No workbench upload; the image the user attached to a prior message must be found so
     // Kontext (a required-input model) does not falsely report "no input image".
-    const { service } = makeService({
+    const { service, findAccessibleInIds } = makeService({
       fabFilesById: { f1: cleanImage('f1') },
       recentMessages: [{ id: 'm1', type: 'message', timestamp: new Date(0), fabFileIds: ['f1'] }],
     });
@@ -158,10 +158,17 @@ describe('ImageGenerationService.selectInputImage', () => {
     const result = await select(service, {
       model: ImageModels.FLUX_KONTEXT_PRO,
       supportsImageVariation: true,
+      userId: 'u1',
+      userGroups: ['g1'],
     });
 
     expect(result.fileImage?.id).toBe('f1');
     expect(result.imageSource).toBe('notebook_attachment');
+    // Pin the SECOND (message-history) call site independently of the workbench call: the
+    // notebook-attachment lookup must also run as the caller, with the same lakeAccess arg, so a
+    // regression that drops the principal here can no longer be masked by the workbench call
+    // satisfying a shared toHaveBeenCalledWith. Workbench call is #1 (empty ids), history is #2.
+    expect(findAccessibleInIds).toHaveBeenNthCalledWith(2, ['f1'], { userId: 'u1', userGroups: ['g1'] }, undefined);
   });
 
   it('returns no image for Kontext when the notebook has none (downstream throws the guidance error)', async () => {
@@ -221,10 +228,15 @@ describe('ImageGenerationService.selectInputImage', () => {
       userGroups: ['g1'],
     });
     expect(result.fileImage).toBeUndefined();
-    expect(findAccessibleInIds).toHaveBeenCalledWith(['someone-elses-file'], {
-      userId: 'attacker',
-      userGroups: ['g1'],
-    });
+    // Pin the workbench call exactly, third arg included: the scoped lookup runs as the caller
+    // (never a widened principal) and threads the caller's lakeAccess (undefined here - no resolver
+    // wired in this test), so the arm can never be silently dropped from the assertion.
+    expect(findAccessibleInIds).toHaveBeenNthCalledWith(
+      1,
+      ['someone-elses-file'],
+      { userId: 'attacker', userGroups: ['g1'] },
+      undefined
+    );
   });
 
   it('prefers the workbench upload over any notebook-context image', async () => {

--- a/b4m-core/services/src/llm/ImageGeneration.ts
+++ b/b4m-core/services/src/llm/ImageGeneration.ts
@@ -24,6 +24,7 @@ import {
   CreditHolderType,
   PromptIntentSchema,
   ImageModerationIncident as ImageModerationIncidentInput,
+  AttachmentLakeAccess,
 } from '@bike4mind/common';
 import {
   BFL_IMAGE_MODELS,
@@ -144,6 +145,13 @@ interface IImageGenerationServiceOptions {
   imageProcessorLambdaName?: string;
   /** Checks a generated image for explicit content before it's stored. Optional so existing callers/tests keep compiling; the moderation hook is a no-op when absent. */
   imageModerationService?: ImageModerationService;
+  /**
+   * Resolves the acting user's owner-wide data-lake access. Threaded to `findAccessibleInIds` so a
+   * lake-only image the workbench admitted still resolves as an image-gen input - parity with the
+   * lake arm that predicate now carries. Optional so existing callers/tests keep compiling; absent
+   * degrades to owner/share/global-read only (today's behaviour).
+   */
+  resolveLakeAccess?: (user: IUserDocument, logger: Logger) => Promise<AttachmentLakeAccess>;
 }
 
 async function downloadImage(url: string) {
@@ -183,6 +191,7 @@ export class ImageGenerationService {
   private invokeSummarizeSession: IImageGenerationServiceOptions['invokeSummarizeSession'];
   private imageProcessorLambdaName?: string;
   private imageModerationService?: ImageModerationService;
+  private resolveLakeAccess?: IImageGenerationServiceOptions['resolveLakeAccess'];
 
   constructor(options: IImageGenerationServiceOptions) {
     this.db = options.db;
@@ -197,6 +206,7 @@ export class ImageGenerationService {
     this.invokeSummarizeSession = options.invokeSummarizeSession;
     this.imageProcessorLambdaName = options.imageProcessorLambdaName;
     this.imageModerationService = options.imageModerationService;
+    this.resolveLakeAccess = options.resolveLakeAccess;
   }
 
   /**
@@ -499,6 +509,7 @@ export class ImageGenerationService {
     fabFileIds,
     userId,
     userGroups,
+    lakeAccess,
     model,
     modelInfo,
     intent,
@@ -508,6 +519,7 @@ export class ImageGenerationService {
     fabFileIds?: string[];
     userId: string;
     userGroups?: string[];
+    lakeAccess?: AttachmentLakeAccess;
     model: string;
     modelInfo: ModelInfo;
     intent: z.infer<typeof PromptIntentSchema>;
@@ -518,7 +530,7 @@ export class ImageGenerationService {
   }> {
     // Access-scoped: a caller-supplied fabFileId the caller cannot access is dropped here,
     // never presigned or fed to a provider (owner/share/group/global-read only).
-    const fabFiles = await this.db.fabFiles.findAccessibleInIds(fabFileIds || [], { userId, userGroups });
+    const fabFiles = await this.db.fabFiles.findAccessibleInIds(fabFileIds || [], { userId, userGroups }, lakeAccess);
     const workbenchImage = fabFiles.find(file => file.mimeType.startsWith('image'));
 
     // An explicit workbench upload must not be fed into generation while it's held (pending
@@ -556,7 +568,11 @@ export class ImageGenerationService {
         const attachedIds = [...new Set(recentMessages.flatMap(msg => msg.fabFileIds ?? []))];
         const attachedById = new Map<string, IFabFileDocument>();
         if (attachedIds.length) {
-          for (const file of await this.db.fabFiles.findAccessibleInIds(attachedIds, { userId, userGroups })) {
+          for (const file of await this.db.fabFiles.findAccessibleInIds(
+            attachedIds,
+            { userId, userGroups },
+            lakeAccess
+          )) {
             if (file.id) attachedById.set(file.id, file);
           }
         }
@@ -653,6 +669,11 @@ export class ImageGenerationService {
       organizationId ? this.db.organizations.findById(organizationId) : Promise.resolve(null),
     ]);
     if (!user) throw new NotFoundError('User not found');
+
+    // Owner-wide lake access for scoping the input-image lookup: a lake-only image the workbench
+    // admitted must still resolve here. Absent resolver (or a resolution outage) degrades to
+    // owner/share/global-read only - never widens, never fails the run.
+    const lakeAccess = this.resolveLakeAccess ? await this.resolveLakeAccess(user, logger) : undefined;
 
     const settings = await getSettingsMap(this.db);
     const adminSettingsEnforceCredits = getSettingsValue('enforceCredits', settings);
@@ -779,6 +800,7 @@ export class ImageGenerationService {
         fabFileIds,
         userId,
         userGroups: user.groups ?? undefined,
+        lakeAccess,
         model,
         modelInfo,
         intent,

--- a/b4m-core/services/src/llm/ImageGeneration.ts
+++ b/b4m-core/services/src/llm/ImageGeneration.ts
@@ -497,6 +497,8 @@ export class ImageGenerationService {
   private async selectInputImage({
     sessionId,
     fabFileIds,
+    userId,
+    userGroups,
     model,
     modelInfo,
     intent,
@@ -504,6 +506,8 @@ export class ImageGenerationService {
   }: {
     sessionId: string;
     fabFileIds?: string[];
+    userId: string;
+    userGroups?: string[];
     model: string;
     modelInfo: ModelInfo;
     intent: z.infer<typeof PromptIntentSchema>;
@@ -512,7 +516,9 @@ export class ImageGenerationService {
     fileImage?: SelectedImage;
     imageSource: 'workbench' | 'message_history' | 'notebook_attachment';
   }> {
-    const fabFiles = await this.db.fabFiles.findAllInIds(fabFileIds || []);
+    // Access-scoped: a caller-supplied fabFileId the caller cannot access is dropped here,
+    // never presigned or fed to a provider (owner/share/group/global-read only).
+    const fabFiles = await this.db.fabFiles.findAccessibleInIds(fabFileIds || [], { userId, userGroups });
     const workbenchImage = fabFiles.find(file => file.mimeType.startsWith('image'));
 
     // An explicit workbench upload must not be fed into generation while it's held (pending
@@ -550,7 +556,7 @@ export class ImageGenerationService {
         const attachedIds = [...new Set(recentMessages.flatMap(msg => msg.fabFileIds ?? []))];
         const attachedById = new Map<string, IFabFileDocument>();
         if (attachedIds.length) {
-          for (const file of await this.db.fabFiles.findAllInIds(attachedIds)) {
+          for (const file of await this.db.fabFiles.findAccessibleInIds(attachedIds, { userId, userGroups })) {
             if (file.id) attachedById.set(file.id, file);
           }
         }
@@ -771,6 +777,8 @@ export class ImageGenerationService {
       const { fileImage, imageSource } = await this.selectInputImage({
         sessionId,
         fabFileIds,
+        userId,
+        userGroups: user.groups ?? undefined,
         model,
         modelInfo,
         intent,

--- a/b4m-core/services/src/llm/tools/base/resolveAttachmentLakeAccess.ts
+++ b/b4m-core/services/src/llm/tools/base/resolveAttachmentLakeAccess.ts
@@ -1,0 +1,33 @@
+import { getDynamicDataLakeAccess, lakeMembershipsFrom } from '../../../dataLakeService/getDynamicDataLakeTags';
+import { unionPreauthorizedLakeAccess } from '../../../dataLakeService/unionPreauthorizedLakeAccess';
+import type { AttachmentLakeAccess } from '@bike4mind/common';
+import type { ToolContext } from './types';
+
+/**
+ * The caller's owner-wide data-lake access as an `AttachmentLakeAccess`, for a tool that must
+ * re-authorize a workbench file by the SAME door that admitted it - `FabFileModel.findAccessibleInIds`
+ * / `getAccessibleFiles`. Mirrors the chat door's `attachmentLakeAccess()` (getAccessibleDataLakeAccess):
+ * owner-wide and NOT session-narrowed, so a file the caller reaches only through lake membership still
+ * resolves. Deliberately differs from `resolveSessionLakeAccess`, which narrows to the session corpus.
+ *
+ * Fails safe: a lake-resolution outage degrades to ownership-only (empty access), never throws and
+ * never widens - the same fail direction as the two doors it mirrors.
+ */
+export async function resolveAttachmentLakeAccess(context: ToolContext): Promise<AttachmentLakeAccess> {
+  try {
+    const resolved = await getDynamicDataLakeAccess(context);
+    const unioned = await unionPreauthorizedLakeAccess(
+      resolved,
+      context.sessionPreauthorizedLakeIds,
+      context.userId,
+      context.db
+    );
+    return {
+      lakeMemberships: lakeMembershipsFrom(unioned.lakes),
+      dataLakeTags: unioned.dataLakeTags,
+      dataLakeTagPrefixes: unioned.dataLakeTagPrefixes,
+    };
+  } catch {
+    return {};
+  }
+}

--- a/b4m-core/services/src/llm/tools/implementation/imageEdit/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/imageEdit/index.test.ts
@@ -57,12 +57,13 @@ function createFakeContext(): ToolContext {
   };
 }
 
-// Builds a context whose `db.fabfiles.findById` resolves to the given fabFile stub, and
-// whose `storage.getSignedUrl` is mockable - everything `getImageFromFileId` touches.
+// Builds a context whose `db.fabfiles.findAccessibleInIds` resolves to the given fabFile stub
+// (null -> [], the shape the repo returns when the caller cannot access the id), and whose
+// `storage.getSignedUrl` is mockable - everything `getImageFromFileId` touches.
 function createFakeContextWithFabFile(fabFile: Record<string, unknown> | null): ToolContext {
   const context = createFakeContext();
-  (context.db as unknown as { fabfiles: { findById: ReturnType<typeof vi.fn> } }).fabfiles = {
-    findById: vi.fn().mockResolvedValue(fabFile),
+  (context.db as unknown as { fabfiles: { findAccessibleInIds: ReturnType<typeof vi.fn> } }).fabfiles = {
+    findAccessibleInIds: vi.fn().mockResolvedValue(fabFile ? [fabFile] : []),
   };
   context.storage = {
     upload: vi.fn(),
@@ -95,6 +96,15 @@ describe('getImageFromFileId serveability guard (sibling of the upload/edit agen
     });
 
     await expect(getImageFromFileId(VALID_FILE_ID, context)).rejects.toThrow('This image is not available.');
+    expect(context.storage.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('denies a file the caller cannot access - NotFoundError, no signed URL minted', async () => {
+    // Repo returns [] when the id is not owned by / shared with the caller (the IDOR fix): the
+    // tool must not distinguish "not found" from "not yours", and must never sign the file.
+    const context = createFakeContextWithFabFile(null);
+
+    await expect(getImageFromFileId(VALID_FILE_ID, context)).rejects.toThrow(`File with ID ${VALID_FILE_ID} not found`);
     expect(context.storage.getSignedUrl).not.toHaveBeenCalled();
   });
 

--- a/b4m-core/services/src/llm/tools/implementation/imageEdit/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/imageEdit/index.test.ts
@@ -106,6 +106,17 @@ describe('getImageFromFileId serveability guard (sibling of the upload/edit agen
 
     await expect(getImageFromFileId(VALID_FILE_ID, context)).rejects.toThrow(`File with ID ${VALID_FILE_ID} not found`);
     expect(context.storage.getSignedUrl).not.toHaveBeenCalled();
+    // Pin the principal that reaches the repo: the lookup runs as the caller (context.userId),
+    // never a widened one, and carries a lakeAccess arm so the denial cannot be an artifact of an
+    // over-narrow query. (lakeAccess resolves to {} here - the fake context wires no lake repos.)
+    const findAccessibleInIds = (
+      context.db as unknown as { fabfiles: { findAccessibleInIds: ReturnType<typeof vi.fn> } }
+    ).fabfiles.findAccessibleInIds;
+    expect(findAccessibleInIds).toHaveBeenCalledWith(
+      [VALID_FILE_ID],
+      { userId: context.userId, userGroups: undefined },
+      expect.anything()
+    );
   });
 
   it('resolves a signed URL for a clean image', async () => {

--- a/b4m-core/services/src/llm/tools/implementation/imageEdit/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/imageEdit/index.ts
@@ -68,7 +68,14 @@ export async function getImageFromFileId(fileId: string, context: ToolContext): 
     );
   }
 
-  const fabFile = await context.db.fabfiles?.findById(fileId);
+  // Access-scoped so the edit_image tool cannot sign and hand back a file the caller
+  // cannot access. Same NotFoundError shape for missing vs. not-yours so a probe can't
+  // tell them apart (owner/share/group/global-read only).
+  const accessible = await context.db.fabfiles?.findAccessibleInIds([fileId], {
+    userId: context.userId,
+    userGroups: context.user?.groups ?? undefined,
+  });
+  const fabFile = accessible?.[0];
   if (!fabFile) {
     throw new NotFoundError(`File with ID ${fileId} not found`);
   }

--- a/b4m-core/services/src/llm/tools/implementation/imageEdit/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/imageEdit/index.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@bike4mind/observability';
 import { ToolContext, ToolDefinition } from '../../base/types';
 import { isObjectIdShaped } from '../../base/objectId';
+import { resolveAttachmentLakeAccess } from '../../base/resolveAttachmentLakeAccess';
 import {
   ApiKeyType,
   ImageModels,
@@ -70,11 +71,17 @@ export async function getImageFromFileId(fileId: string, context: ToolContext): 
 
   // Access-scoped so the edit_image tool cannot sign and hand back a file the caller
   // cannot access. Same NotFoundError shape for missing vs. not-yours so a probe can't
-  // tell them apart (owner/share/group/global-read only).
-  const accessible = await context.db.fabfiles?.findAccessibleInIds([fileId], {
-    userId: context.userId,
-    userGroups: context.user?.groups ?? undefined,
-  });
+  // tell them apart (owner/share/group/global-read, plus the caller's lake arms so a
+  // lake-only image the workbench admitted is not falsely denied here).
+  const lakeAccess = await resolveAttachmentLakeAccess(context);
+  const accessible = await context.db.fabfiles?.findAccessibleInIds(
+    [fileId],
+    {
+      userId: context.userId,
+      userGroups: context.user?.groups ?? undefined,
+    },
+    lakeAccess
+  );
   const fabFile = accessible?.[0];
   if (!fabFile) {
     throw new NotFoundError(`File with ID ${fileId} not found`);

--- a/packages/database/src/models/content/FabFileModel.findAccessibleInIds.test.ts
+++ b/packages/database/src/models/content/FabFileModel.findAccessibleInIds.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+import { KnowledgeType } from '@bike4mind/common';
+import { createMongoServer } from '../../__test__/createMongoServer';
+import { FabFile, fabFileRepository } from './FabFileModel';
+
+let server: Awaited<ReturnType<typeof createMongoServer>>;
+
+beforeAll(async () => {
+  server = await createMongoServer();
+  await mongoose.connect(server.getUri());
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server.stop();
+});
+beforeEach(async () => {
+  await FabFile.deleteMany({});
+});
+
+// Shares-aware id lookup for engine callers (image generation / edit_image) that hold only a
+// userId and have no req.ability. Must match the CASL FabFile read rule: owner OR user-share
+// OR group-share OR global-read, and NOTHING else.
+describe('FabFileRepository.findAccessibleInIds', () => {
+  const owner = 'u-owner';
+  const other = 'u-other';
+
+  const makeImage = (userId: string, extra: Record<string, unknown> = {}) =>
+    FabFile.create({
+      userId,
+      fileName: 'img.png',
+      mimeType: 'image/png',
+      type: KnowledgeType.FILE,
+      filePath: `${new mongoose.Types.ObjectId().toString()}.png`,
+      ...extra,
+    });
+
+  it("denies another user's private file (the IDOR)", async () => {
+    const foreign = await makeImage(other);
+    const files = await fabFileRepository.findAccessibleInIds([foreign.id], { userId: owner });
+    expect(files).toEqual([]);
+  });
+
+  it('returns the caller-owned file', async () => {
+    const mine = await makeImage(owner);
+    const files = await fabFileRepository.findAccessibleInIds([mine.id], { userId: owner });
+    expect(files.map(f => f.id)).toEqual([mine.id]);
+  });
+
+  it('returns a file shared with the caller by userId', async () => {
+    const shared = await makeImage(other, { users: [{ userId: owner, permissions: ['read'] }] });
+    const files = await fabFileRepository.findAccessibleInIds([shared.id], { userId: owner });
+    expect(files.map(f => f.id)).toEqual([shared.id]);
+  });
+
+  it('returns a file shared with one of the caller groups', async () => {
+    const shared = await makeImage(other, { groups: [{ groupId: 'g1', permissions: ['read'] }] });
+    const files = await fabFileRepository.findAccessibleInIds([shared.id], { userId: owner, userGroups: ['g1'] });
+    expect(files.map(f => f.id)).toEqual([shared.id]);
+  });
+
+  it('does NOT return a group-shared file when the caller is not in that group', async () => {
+    const shared = await makeImage(other, { groups: [{ groupId: 'g1', permissions: ['read'] }] });
+    const files = await fabFileRepository.findAccessibleInIds([shared.id], { userId: owner, userGroups: ['g2'] });
+    expect(files).toEqual([]);
+  });
+
+  it('returns a global-read file owned by another user', async () => {
+    const global = await makeImage(other, { isGlobalRead: true });
+    const files = await fabFileRepository.findAccessibleInIds([global.id], { userId: owner });
+    expect(files.map(f => f.id)).toEqual([global.id]);
+  });
+
+  it('returns only the accessible subset from a mixed id list', async () => {
+    const mine = await makeImage(owner);
+    const foreign = await makeImage(other);
+    const files = await fabFileRepository.findAccessibleInIds([mine.id, foreign.id], { userId: owner });
+    expect(files.map(f => f.id)).toEqual([mine.id]);
+  });
+
+  it('drops invalid ObjectIds and returns [] for an empty/invalid-only list', async () => {
+    expect(await fabFileRepository.findAccessibleInIds([], { userId: owner })).toEqual([]);
+    expect(await fabFileRepository.findAccessibleInIds(['not-an-object-id'], { userId: owner })).toEqual([]);
+  });
+});

--- a/packages/database/src/models/content/FabFileModel.findAccessibleInIds.test.ts
+++ b/packages/database/src/models/content/FabFileModel.findAccessibleInIds.test.ts
@@ -82,4 +82,35 @@ describe('FabFileRepository.findAccessibleInIds', () => {
     expect(await fabFileRepository.findAccessibleInIds([], { userId: owner })).toEqual([]);
     expect(await fabFileRepository.findAccessibleInIds(['not-an-object-id'], { userId: owner })).toEqual([]);
   });
+
+  // Lake-only regression: a file the caller can reach ONLY through data-lake membership (not owned,
+  // not shared, not global-read) must resolve when lakeAccess names its lake - parity with the
+  // attachment door (getAccessibleFiles) that admits it. Without the lake arm these silently drop.
+  const lakeTag = 'datalake:org:kb';
+
+  it('drops a lake-only file when no lakeAccess is passed (owner/share/global only)', async () => {
+    const lakeFile = await makeImage(other, { tags: [{ name: lakeTag }] });
+    const files = await fabFileRepository.findAccessibleInIds([lakeFile.id], { userId: owner });
+    expect(files).toEqual([]);
+  });
+
+  it('returns a lake-only file when lakeAccess names its lake by exact tag', async () => {
+    const lakeFile = await makeImage(other, { tags: [{ name: lakeTag }] });
+    const files = await fabFileRepository.findAccessibleInIds(
+      [lakeFile.id],
+      { userId: owner },
+      { dataLakeTags: [lakeTag] }
+    );
+    expect(files.map(f => f.id)).toEqual([lakeFile.id]);
+  });
+
+  it('does NOT return a lake file whose lake is archived, even with lakeAccess', async () => {
+    const archived = await makeImage(other, { tags: [{ name: lakeTag }], archivedAt: new Date() });
+    const files = await fabFileRepository.findAccessibleInIds(
+      [archived.id],
+      { userId: owner },
+      { dataLakeTags: [lakeTag] }
+    );
+    expect(files).toEqual([]);
+  });
 });

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -667,6 +667,18 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return result.map(d => d.toObject());
   }
 
+  async findAccessibleInIds(ids: string[], access: { userId: string; userGroups?: string[] }) {
+    const validIds = ids.filter(id => mongoose.Types.ObjectId.isValid(id));
+    if (validIds.length === 0) return [];
+    const result = await this.fabFileModel.find({
+      _id: { $in: convertIds(validIds) },
+      // owner + user-share + group-share (buildOwnershipConditions) + global-read - the
+      // shares-aware equivalent of the CASL FabFile read rule for callers with no req.ability.
+      $or: [...buildOwnershipConditions(access.userId, { userGroups: access.userGroups }), { isGlobalRead: true }],
+    });
+    return result.map(d => d.toObject());
+  }
+
   /**
    * Metadata-only fetch for a set of ids. The heavy fields AND the URL-bearing
    * ones are projected out (see METADATA_ONLY_PROJECTION), so a caller that only

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -667,14 +667,31 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return result.map(d => d.toObject());
   }
 
-  async findAccessibleInIds(ids: string[], access: { userId: string; userGroups?: string[] }) {
+  async findAccessibleInIds(
+    ids: string[],
+    access: { userId: string; userGroups?: string[] },
+    lakeAccess?: AttachmentLakeAccess
+  ) {
     const validIds = ids.filter(id => mongoose.Types.ObjectId.isValid(id));
     if (validIds.length === 0) return [];
+    // Lake arms mirror `getAccessibleFiles` (the attachment door): a file the caller can reach ONLY
+    // through data-lake membership must resolve here too, or this predicate would be narrower than
+    // the door that admitted the file and silently drop lake-only images. Same builder, same
+    // `archivedAt: null` post-processing on each arm - so the two doors can never disagree.
+    const lakeArms = buildLakeArms({
+      lakeMemberships: lakeAccess?.lakeMemberships,
+      dataLakeTags: lakeAccess?.dataLakeTags,
+      dataLakeTagPrefixes: lakeAccess?.dataLakeTagPrefixes,
+    });
     const result = await this.fabFileModel.find({
       _id: { $in: convertIds(validIds) },
-      // owner + user-share + group-share (buildOwnershipConditions) + global-read - the
+      // owner + user-share + group-share (buildOwnershipConditions) + global-read + lake arms - the
       // shares-aware equivalent of the CASL FabFile read rule for callers with no req.ability.
-      $or: [...buildOwnershipConditions(access.userId, { userGroups: access.userGroups }), { isGlobalRead: true }],
+      $or: [
+        ...buildOwnershipConditions(access.userId, { userGroups: access.userGroups }),
+        { isGlobalRead: true },
+        ...lakeArms.map(arm => ({ $and: [arm, { archivedAt: null }] })),
+      ],
     });
     return result.map(d => d.toObject());
   }


### PR DESCRIPTION
# Pull Request

## Description

The image paths resolve a caller-supplied (or agent-derived) FabFile id and act on it - presign it, feed it to an image provider, or write a fresh signed URL back onto the record - without first checking the caller may access that file. The engine paths run in `@bike4mind/services`, which has no `req.ability`, so the HTTP CASL check that guards the file routes never applies here; the lookups (`findAllInIds`, `findById`) are raw and unscoped. This PR scopes those lookups to the requesting user.

The share model these must honor: a FabFile is accessible to its owner, to a user named in `users[]` with a read/write permission, to a member of a group named in `groups[]` with that permission, or when the file is `isGlobalRead`. The fix expresses that as a DB predicate so it works without a CASL ability, and keeps it in sync with the CASL FabFile rule in `packages/database/src/utils/ability.ts`.

## Changes

- Add `IFabFileRepository.findAccessibleInIds(ids, { userId, userGroups })` - returns only files the caller may access (owner, user-share, group-share, or `isGlobalRead`). It reuses the existing `buildOwnershipConditions` predicate (the one `search` already uses) and adds a global-read arm so the accessible set matches the CASL rule. It also takes an optional `AttachmentLakeAccess`: when present it ORs in the same data-lake arms as `getAccessibleFiles` (`buildLakeArms`, with `archivedAt: null` ANDed onto each arm), so a file the caller can reach only through data-lake membership still resolves and this predicate is never narrower than the door that admitted the file. Invalid ObjectIds are dropped; an empty or invalid-only list returns `[]`.
- `ImageGeneration.selectInputImage` now takes `userId` + `userGroups` and resolves both id sets (the workbench ids and the notebook message-history attached ids) through the scoped lookup. An id the caller cannot access is simply not selected, never presigned or sent to the provider. The caller's owner-wide data-lake access is resolved in `process()` (via an injected `resolveLakeAccess`) and threaded through, so a lake-only image the workbench admitted still resolves as an input rather than being silently dropped to text-to-image.
- The `edit_image` tool (`getImageFromFileId`) resolves its source id through the scoped lookup keyed on `context.userId` (+ groups) and denies an inaccessible id with the same `NotFoundError` shape it already returns for a missing id, so a probe cannot tell "missing" from "not accessible". It resolves the caller's owner-wide lake access at the leaf (`resolveAttachmentLakeAccess`, mirroring the chat door's `attachmentLakeAccess()`) and passes it to the lookup, so a lake-only image is not falsely denied with a hard `NotFoundError`.
- The agent-portrait refresh (`refreshAgentAvatarUrls`) gates its signed-URL write-back to the file owner: a viewer of a shared agent still receives a freshly minted display URL but no longer rewrites a FabFile record owned by another user. It is now a single shared helper (`apps/client/server/utils/refreshAgentAvatarUrls.ts`) imported by both `pages/api/agents/index.ts` and `pages/api/sessions/[id]/agents.ts`, which previously carried byte-identical copies - the shared helper keeps the owner gate from drifting between the two routes.
- Tests: DB test for the repo predicate including the lake arm (match / no-lakeAccess denial / archived-lake exclusion); the two engine paths with the call-site principal and lake-access args pinned at both the workbench and the message-history sites; and an owner-gate test for the shared portrait helper (non-owner gets a URL but never writes; owner writes). See Guide for Testers.

## Guide for Testers

Where to test: a per-PR preview stack is the intended home (the preview bot comments the exact URL once it deploys; it looks like `https://app.pr2508.<preview-domain>`). No preview is required by CI for this change, so it must be triggered on the PR. Failing a preview, a local dev stack with a seeded DB works for a developer; staging only reflects it after merge.

Requires two accounts - A (viewer) and B (owner), ideally in different orgs. As B, upload one image to keep private (`fB_private`) and one shared to A with read permission (`fB_sharedToA`). Optionally seed one group-shared and one `isGlobalRead` image for the over-denial checks.

1. Image generation - as A, trigger a generation whose request body carries `fabFileIds: ["<fB_private>"]` using a required-input model (e.g. Flux Kontext). Expect: B's image is NOT used as input (the model reports no input image / falls back to text-to-image); nothing of B's is presigned or sent to the provider.
2. edit_image - as A, in a chat, invoke `edit_image` with `<fB_private>` as the source id. Expect: `File with ID <fB_private> not found` (the same error as a genuinely missing id), and no signed URL is minted.
3. Agent portrait - with a B-owned agent shared to A whose portrait FabFile (`fB_portrait`) has an expired `fileUrlExpireAt`: record the FabFile's `fileUrl`/`fileUrlExpireAt`/`updatedAt` in Mongo, then as A GET `/api/agents` (and `/api/sessions/:id/agents`). Expect: the response still contains a working `portraitUrl` (portrait displays), but `fB_portrait`'s stored fields are UNCHANGED (A did not rewrite B's record).
4. Lake-only image (the regression this closes) - seed an image A can read ONLY via data-lake membership (not owned, shared, or global-read), e.g. a Drive-synced or curator-tagged image in a shared lake (`fLake`). As A: (a) image generation with `fabFileIds: ["<fLake>"]` on a required-input model uses it as input (not dropped to text-to-image); (b) `edit_image` with `<fLake>` resolves and edits it (no `File with ID ... not found`). Both silently failed before this fix.

## Regression Checks

- No over-denial. As A, repeat step 1 and step 2 with A's own image and with `fB_sharedToA` (and the group-shared / global-read files if seeded): each resolves and is used/edited normally.
- Owner write-back intact. As B (the owner), GET the agents list with the portrait expired: `fB_portrait`'s `fileUrl`/`fileUrlExpireAt` ARE refreshed (the owner path is untouched).
- Automated: `packages/database` `FabFileModel.findAccessibleInIds.test.ts` (owner / user-share / group-share / global-read all resolve; foreign and wrong-group denied; mixed list returns only the accessible subset; invalid ids dropped). `@bike4mind/services` `ImageGeneration` and `imageEdit/index` suites cover the two engine paths (including the lake-arm arg pinned at both call sites). The owner-gate is pinned by `apps/client/server/utils/refreshAgentAvatarUrls.test.ts` (non-owner never writes; owner writes).

## What NOT to test

- `ImageEdit.ts` (the queue-handler service, not the `edit_image` tool) and `fabFileService/delete.ts` still call the unscoped `findAllInIds`. They are out of scope for this PR and unchanged; deletion is owner-scoped by a different path.
- Non-image FabFile flows (search, knowledge retrieval, data lakes) are untouched - `findAccessibleInIds` is additive and used only by the three paths above.
- The 46 pre-existing Dependabot alerts on the default branch are unrelated to this change.

## Additional Information

Chose a dedicated repo method over reusing `ShareableDocumentRepository.findAllAccessibleByIds`, because that helper omits the global-read arm (would over-deny global-read images) and takes a full user document; a new method matches the CASL rule exactly and avoids widening any existing helper's blast radius. The portrait refresh previously existed as byte-identical copies in the agents-list and session-agents routes; it is now a single shared helper so the owner gate cannot drift between them. The image-tool lookup carries the data-lake arm so it is never narrower than the attachment door (`getAccessibleFiles`) that admits a file into the workbench; lake access is resolved owner-wide (not session-narrowed) to match that door, and fails safe to ownership-only, never widening.

## Checklist

- [x] Access predicate honors owner + user-share + group-share + global-read (not a bare owner check).
- [x] Regression tests added that fail before the change and pass after.
- [x] `pnpm turbo:core:build`, common/database/services/client typecheck, the affected test files, and eslint on changed files all pass.
- [x] No secrets, no internal identifiers, ASCII-only added lines.
- [ ] In-app end-to-end verification per Guide for Testers (QA stage).

