### PR TITLE
fix(api): verify caller access to client-supplied org and session ids

### DIFF
--- a/apps/client/__tests__/team-manager.test.ts
+++ b/apps/client/__tests__/team-manager.test.ts
@@ -349,9 +349,15 @@ describe('organizationService.revokeAccess - Manager Permissions', () => {
       findById: vi.fn().mockResolvedValue({ ...mockOrganization }),
       update: vi.fn().mockImplementation(org => Promise.resolve(org)),
     };
-    // revokeAccess now purges the removed member's org group ids + adminUserIds (org-groups #1172).
+    // revokeAccess now purges the removed member's org group ids + adminUserIds (org-groups #1172),
+    // and clears their organizationId when it pointed at this org (findById returns null here, so
+    // that clear is a no-op for these cases).
     mockGroupRepository = { findByOrganization: vi.fn().mockResolvedValue([]) };
-    mockUserRepository = { removeGroupsFromUser: vi.fn().mockResolvedValue(undefined) };
+    mockUserRepository = {
+      removeGroupsFromUser: vi.fn().mockResolvedValue(undefined),
+      findById: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
   });
 
   it('should allow manager to revoke access from members', async () => {

--- a/apps/client/pages/api/ai/__tests__/llm.integration.test.ts
+++ b/apps/client/pages/api/ai/__tests__/llm.integration.test.ts
@@ -26,6 +26,7 @@ const {
   mockInvoke,
   mockWillInjectAuthoredPrompt,
   mockLoadIdentityPrompts,
+  mockOrgFindAccessibleById,
 } = vi.hoisted(() => ({
   mockValidate: vi.fn(),
   mockUserFindById: vi.fn(),
@@ -36,6 +37,7 @@ const {
   mockInvoke: vi.fn(),
   mockWillInjectAuthoredPrompt: vi.fn(),
   mockLoadIdentityPrompts: vi.fn(),
+  mockOrgFindAccessibleById: vi.fn(),
 }));
 
 const RATE_LIMIT_HEADERS = {
@@ -94,6 +96,15 @@ vi.mock('@bike4mind/database', async orig => {
       ...(actual.cacheRepository as object),
       tryIncrementWithinLimitFixedWindow: (...a: unknown[]) => mockTryIncrement(...a),
     },
+    // resolveBillingOrgId -> resolveActiveOrg run for real here; only the org-membership repo call
+    // is stubbed, so the billing wiring (route -> resolver -> gate) is exercised end to end.
+    organizationRepository: {
+      ...(actual.organizationRepository as object),
+      shareable: {
+        ...((actual.organizationRepository as { shareable?: object })?.shareable ?? {}),
+        findAccessibleById: (...a: unknown[]) => mockOrgFindAccessibleById(...a),
+      },
+    },
   };
 });
 
@@ -135,6 +146,8 @@ import handler from '../llm';
 import { ApiKeyScope } from '@bike4mind/common';
 
 const VALID_KEY = 'sk-test-valid-key';
+const OWN_ORG = '650000000000000000000abc';
+const FOREIGN_ORG = '650000000000000000000def';
 
 function fire({
   apiKey = VALID_KEY as string | null,
@@ -217,6 +230,34 @@ describe('POST /api/ai/llm (integration - ai:chat scope enforcement)', () => {
     expect(res._getStatusCode()).toBe(200);
     expect(mockValidate).not.toHaveBeenCalled();
     expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  // Billing-org wiring: resolveBillingOrgId -> the real resolveActiveOrg -> the (stubbed) org
+  // membership gate. A body organizationId the caller cannot access must not reach invoke().
+  it('denies a client-supplied org the caller is not a member of (403, no completion dispatched)', async () => {
+    validateWithScopes([ApiKeyScope.AI_CHAT]);
+    mockOrgFindAccessibleById.mockResolvedValue(null); // non-member -> gate throws ForbiddenError
+    const { req, res } = fire({ body: { organizationId: FOREIGN_ORG } });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('bills the caller own org when the request omits organizationId', async () => {
+    validateWithScopes([ApiKeyScope.AI_CHAT]);
+    mockUserFindById.mockResolvedValue({
+      id: 'user-1',
+      _id: 'user-1',
+      organizationId: OWN_ORG,
+      isBanned: false,
+      disputePending: false,
+    });
+    mockOrgFindAccessibleById.mockResolvedValue({ id: OWN_ORG }); // member -> gate resolves
+    const { req, res } = fire(); // body carries no organizationId
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(mockInvoke.mock.calls[0][0].body.organizationId).toBe(OWN_ORG);
   });
 
   // invoke()'s own parse already rejects a bad systemPrompt, but only after getOrCreateSession

--- a/apps/client/pages/api/ai/generate-image.ts
+++ b/apps/client/pages/api/ai/generate-image.ts
@@ -49,7 +49,7 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(asyn
   try {
     // Resolve the billing org from the client-supplied value, rejecting any org the caller is
     // not a member of. null = personal account, undefined = fall back to the caller's own org.
-    const effectiveOrgId = await resolveBillingOrgId(req.user, invokeParams.organizationId);
+    const effectiveOrgId = await resolveBillingOrgId(req, invokeParams.organizationId);
 
     const originalPrompt = req.body?.prompt;
 

--- a/apps/client/pages/api/ai/generate-image.ts
+++ b/apps/client/pages/api/ai/generate-image.ts
@@ -5,6 +5,7 @@ import { Request } from 'express';
 import { z } from 'zod';
 import { GenerateImageRequestBodySchema, GenerateImageIvokeParams, ApiKeyScope } from '@bike4mind/common';
 import { getOrCreateSession } from '@server/managers/sessionManager';
+import { resolveBillingOrgId } from '@server/utils/orgAccess';
 import { questRepository } from '@bike4mind/database';
 import { resolveImagePrompt, HISTORY_LOOKBACK, type PromptResolution } from '@server/utils/resolveImagePrompt';
 
@@ -46,11 +47,9 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(asyn
   });
 
   try {
-    // organizationId: null means personal account (no org), undefined means not sent (fall back to user's org)
-    const effectiveOrgId =
-      invokeParams.organizationId !== undefined
-        ? invokeParams.organizationId
-        : (req.user.organizationId?.toString() ?? null);
+    // Resolve the billing org from the client-supplied value, rejecting any org the caller is
+    // not a member of. null = personal account, undefined = fall back to the caller's own org.
+    const effectiveOrgId = await resolveBillingOrgId(req.user, invokeParams.organizationId);
 
     const originalPrompt = req.body?.prompt;
 

--- a/apps/client/pages/api/ai/generate-video.ts
+++ b/apps/client/pages/api/ai/generate-video.ts
@@ -40,7 +40,7 @@ const handler = baseApi().post(async (req: GenerateVideoRequest, res) => {
 
     // Resolve the billing org from the client-supplied value, rejecting any org the caller is
     // not a member of. null = personal account, undefined = fall back to the caller's own org.
-    const effectiveOrgId = await resolveBillingOrgId(req.user, invokeParams.organizationId);
+    const effectiveOrgId = await resolveBillingOrgId(req, invokeParams.organizationId);
 
     const invokeBody: GenerateVideoInvokeParams = {
       ...invokeParams,

--- a/apps/client/pages/api/ai/generate-video.ts
+++ b/apps/client/pages/api/ai/generate-video.ts
@@ -4,6 +4,7 @@ import { Request } from 'express';
 import { z } from 'zod';
 import { GenerateVideoRequestBodySchema, GenerateVideoInvokeParams } from '@bike4mind/common';
 import { getOrCreateSession } from '@server/managers/sessionManager';
+import { resolveBillingOrgId } from '@server/utils/orgAccess';
 
 type GenerateVideoRequestBody = z.infer<typeof GenerateVideoRequestBodySchema>;
 
@@ -37,11 +38,9 @@ const handler = baseApi().post(async (req: GenerateVideoRequest, res) => {
     req.logger.log(`[DEBUG API] Calling videoGeneration.invoke...`);
     const startTime = performance.now();
 
-    // organizationId: null means personal account (no org), undefined means not sent (fall back to user's org)
-    const effectiveOrgId =
-      invokeParams.organizationId !== undefined
-        ? invokeParams.organizationId
-        : (req.user.organizationId?.toString() ?? null);
+    // Resolve the billing org from the client-supplied value, rejecting any org the caller is
+    // not a member of. null = personal account, undefined = fall back to the caller's own org.
+    const effectiveOrgId = await resolveBillingOrgId(req.user, invokeParams.organizationId);
 
     const invokeBody: GenerateVideoInvokeParams = {
       ...invokeParams,

--- a/apps/client/pages/api/ai/llm.ts
+++ b/apps/client/pages/api/ai/llm.ts
@@ -9,6 +9,7 @@ import {
 import { ChatCompletionInvoke } from '@bike4mind/services';
 import { SQSService } from '@bike4mind/utils';
 import { getOrCreateSession } from '@server/managers/sessionManager';
+import { resolveBillingOrgId } from '@server/utils/orgAccess';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { getDefaultChatCompletionOptions, getSharedTokenizer } from '@server/utils/chatCompletionDefaults';
@@ -97,13 +98,10 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT] })
       },
     });
 
-    // Call invoke with the proper structure, matching what the frontend sends
-    // organizationId: null means personal account (no org), undefined means not sent (fall back to user's org)
-    // Note: req.user.organizationId is a MongoDB ObjectId, must convert to string for Zod validation
-    const effectiveOrgId =
-      invokeParams.organizationId !== undefined
-        ? invokeParams.organizationId
-        : (req.user.organizationId?.toString() ?? null);
+    // Resolve the billing org from the client-supplied value, rejecting any org the caller is
+    // not a member of (a bare body value would otherwise let A bill B's credit pool).
+    // null = personal account, undefined = fall back to the caller's own org.
+    const effectiveOrgId = await resolveBillingOrgId(req.user, invokeParams.organizationId);
 
     const quest = await chatCompletion.invoke({
       body: {

--- a/apps/client/pages/api/ai/llm.ts
+++ b/apps/client/pages/api/ai/llm.ts
@@ -101,7 +101,7 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT] })
     // Resolve the billing org from the client-supplied value, rejecting any org the caller is
     // not a member of (a bare body value would otherwise let A bill B's credit pool).
     // null = personal account, undefined = fall back to the caller's own org.
-    const effectiveOrgId = await resolveBillingOrgId(req.user, invokeParams.organizationId);
+    const effectiveOrgId = await resolveBillingOrgId(req, invokeParams.organizationId);
 
     const quest = await chatCompletion.invoke({
       body: {

--- a/apps/client/server/managers/sessionCrud.test.ts
+++ b/apps/client/server/managers/sessionCrud.test.ts
@@ -11,6 +11,7 @@ const {
   userRepoUpdate,
   sessionRepoFindById,
   sessionRepoFindByIdAndUserId,
+  accessibleBySpy,
 } = vi.hoisted(() => {
   const sessionSave = vi.fn().mockResolvedValue(undefined);
   // any: a Mongoose model mock that is both newable (regular function so it works with
@@ -45,6 +46,7 @@ const {
     userRepoUpdate: vi.fn().mockResolvedValue(undefined),
     sessionRepoFindById: vi.fn(),
     sessionRepoFindByIdAndUserId: vi.fn(),
+    accessibleBySpy: vi.fn(() => ({ ofType: () => ({}) })),
   };
 });
 
@@ -88,7 +90,7 @@ vi.mock('@bike4mind/observability', () => ({
 }));
 
 vi.mock('@casl/mongoose', () => ({
-  accessibleBy: () => ({ ofType: () => ({}) }),
+  accessibleBy: accessibleBySpy,
 }));
 
 import { getOrCreateSession, createSession } from './sessionCrud';
@@ -128,6 +130,17 @@ describe('sessionCrud', () => {
       expect(sessionRepoFindById).not.toHaveBeenCalled();
       expect(notifySessionCreated).not.toHaveBeenCalled();
       expect(logSessionCreatedEvent).not.toHaveBeenCalled();
+    });
+
+    it('scopes the lookup with the update verb, so a read-only share cannot continue the session', async () => {
+      SessionModelMock.findOne.mockResolvedValueOnce({ id: 'existing', name: 'Existing' });
+
+      await getOrCreateSession({ sessionId: 'existing', user, ability: allowAbility, logger });
+
+      // Quests are appended to this session and the retry path clears an existing quest's reply,
+      // so `read` here would let a read-only share mutate the owner's notebook.
+      expect(accessibleBySpy).toHaveBeenCalledWith(allowAbility, 'update');
+      expect(accessibleBySpy).not.toHaveBeenCalledWith(allowAbility, 'read');
     });
 
     it('throws NotFoundError when the caller has no access to the requested session (foreign session)', async () => {

--- a/apps/client/server/managers/sessionCrud.test.ts
+++ b/apps/client/server/managers/sessionCrud.test.ts
@@ -10,6 +10,7 @@ const {
   UserMock,
   userRepoUpdate,
   sessionRepoFindById,
+  sessionRepoFindByIdAndUserId,
 } = vi.hoisted(() => {
   const sessionSave = vi.fn().mockResolvedValue(undefined);
   // any: a Mongoose model mock that is both newable (regular function so it works with
@@ -43,6 +44,7 @@ const {
     UserMock,
     userRepoUpdate: vi.fn().mockResolvedValue(undefined),
     sessionRepoFindById: vi.fn(),
+    sessionRepoFindByIdAndUserId: vi.fn(),
   };
 });
 
@@ -70,6 +72,7 @@ vi.mock('@bike4mind/database/auth', () => ({
   Session: { modelName: 'Session' },
   sessionRepository: {
     findById: sessionRepoFindById,
+    findByIdAndUserId: sessionRepoFindByIdAndUserId,
     shareable: { findAllShared: vi.fn() },
   },
 }));
@@ -113,21 +116,42 @@ describe('sessionCrud', () => {
   });
 
   describe('getOrCreateSession', () => {
-    it('fetches the existing session and fires no creation side effects', async () => {
-      sessionRepoFindById.mockResolvedValueOnce({ id: 'existing', name: 'Existing' });
+    it('fetches an accessible existing session via an access-scoped lookup (owner/share/org)', async () => {
+      SessionModelMock.findOne.mockResolvedValueOnce({ id: 'existing', name: 'Existing' });
 
-      const result = await getOrCreateSession({ sessionId: 'existing', user, logger });
+      const result = await getOrCreateSession({ sessionId: 'existing', user, ability: allowAbility, logger });
 
       expect(result.wasCreated).toBe(false);
       expect(result.sessionId).toBe('existing');
-      expect(sessionRepoFindById).toHaveBeenCalledWith('existing');
+      // access-scoped: filtered by _id AND accessibleBy(), never a bare findById
+      expect(SessionModelMock.findOne).toHaveBeenCalledWith(expect.objectContaining({ _id: 'existing' }));
+      expect(sessionRepoFindById).not.toHaveBeenCalled();
       expect(notifySessionCreated).not.toHaveBeenCalled();
       expect(logSessionCreatedEvent).not.toHaveBeenCalled();
     });
 
-    it('throws NotFoundError when an existing session id resolves to nothing', async () => {
-      sessionRepoFindById.mockResolvedValueOnce(null);
-      await expect(getOrCreateSession({ sessionId: 'missing', user, logger })).rejects.toThrow('Session not found');
+    it('throws NotFoundError when the caller has no access to the requested session (foreign session)', async () => {
+      // accessibleBy() filters the doc out -> findOne resolves null (same 404 as truly missing,
+      // so a caller cannot distinguish "not yours" from "does not exist")
+      SessionModelMock.findOne.mockResolvedValueOnce(null);
+      await expect(
+        getOrCreateSession({ sessionId: 'someone-elses', user, ability: allowAbility, logger })
+      ).rejects.toThrow('Session not found');
+    });
+
+    it('falls back to an owner-only lookup when no ability is supplied (e.g. the Slack path)', async () => {
+      sessionRepoFindByIdAndUserId.mockResolvedValueOnce({ id: 'owned', name: 'Owned' });
+
+      const result = await getOrCreateSession({ sessionId: 'owned', user, logger });
+
+      expect(result.sessionId).toBe('owned');
+      expect(sessionRepoFindByIdAndUserId).toHaveBeenCalledWith('owned', 'user-1');
+      expect(sessionRepoFindById).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundError when the owner-only fallback finds nothing', async () => {
+      sessionRepoFindByIdAndUserId.mockResolvedValueOnce(null);
+      await expect(getOrCreateSession({ sessionId: 'not-owned', user, logger })).rejects.toThrow('Session not found');
     });
 
     it('creates a session, notifies clients, and defers analytics + last-notebook update', async () => {

--- a/apps/client/server/managers/sessionCrud.ts
+++ b/apps/client/server/managers/sessionCrud.ts
@@ -108,14 +108,16 @@ export async function getOrCreateSession(params: GetOrCreateSessionParams): Prom
   if (reqSessionId) {
     // Resolve an existing session through an access-scoped lookup, never a bare findById -
     // otherwise any authenticated user could read/continue another user's session by id.
-    // With an ability, honor the full access shape (owner + shares + org) exactly as the
-    // list/update paths do; without one (e.g. the Slack path), fall back to owner-only.
+    // The verb is `update`, not `read`: quests are appended to this session, and the retry path
+    // in ChatCompletionInvoke clears an existing quest's reply, so a read-only share must not
+    // reach it. With an ability, honor the full access shape (owner + shares + org) exactly as
+    // the update path does; without one (e.g. the Slack path), fall back to owner-only.
     // A miss (not found OR no access) falls through to the NotFoundError below - a 404 that
     // does not distinguish the two, matching orgAccess's anti-enumeration behavior.
     session = ability
       ? await Session.findOne({
           _id: reqSessionId,
-          ...accessibleBy(ability, Permission.read).ofType(SessionModel),
+          ...accessibleBy(ability, Permission.update).ofType(SessionModel),
         })
       : await sessionRepository.findByIdAndUserId(reqSessionId, userId);
   } else {

--- a/apps/client/server/managers/sessionCrud.ts
+++ b/apps/client/server/managers/sessionCrud.ts
@@ -110,8 +110,9 @@ export async function getOrCreateSession(params: GetOrCreateSessionParams): Prom
     // otherwise any authenticated user could read/continue another user's session by id.
     // The verb is `update`, not `read`: quests are appended to this session, and the retry path
     // in ChatCompletionInvoke clears an existing quest's reply, so a read-only share must not
-    // reach it. With an ability, honor the full access shape (owner + shares + org) exactly as
-    // the update path does; without one (e.g. the Slack path), fall back to owner-only.
+    // reach it. With an ability, honor the Session write shape (owner + global-write + user/group
+    // shares - see ability.ts; Session has no org arm) exactly as the update path does; without
+    // one (e.g. the Slack path), fall back to owner-only.
     // A miss (not found OR no access) falls through to the NotFoundError below - a 404 that
     // does not distinguish the two, matching orgAccess's anti-enumeration behavior.
     session = ability

--- a/apps/client/server/managers/sessionCrud.ts
+++ b/apps/client/server/managers/sessionCrud.ts
@@ -106,7 +106,18 @@ export async function getOrCreateSession(params: GetOrCreateSessionParams): Prom
   let wasCreated = false;
 
   if (reqSessionId) {
-    session = await sessionRepository.findById(reqSessionId);
+    // Resolve an existing session through an access-scoped lookup, never a bare findById -
+    // otherwise any authenticated user could read/continue another user's session by id.
+    // With an ability, honor the full access shape (owner + shares + org) exactly as the
+    // list/update paths do; without one (e.g. the Slack path), fall back to owner-only.
+    // A miss (not found OR no access) falls through to the NotFoundError below - a 404 that
+    // does not distinguish the two, matching orgAccess's anti-enumeration behavior.
+    session = ability
+      ? await Session.findOne({
+          _id: reqSessionId,
+          ...accessibleBy(ability, Permission.read).ofType(SessionModel),
+        })
+      : await sessionRepository.findByIdAndUserId(reqSessionId, userId);
   } else {
     const createdSession = await sessionService.createSession(
       user,

--- a/apps/client/server/utils/__tests__/orgAccess.test.ts
+++ b/apps/client/server/utils/__tests__/orgAccess.test.ts
@@ -1,19 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { ForbiddenError } from '@bike4mind/common';
 
 const mockFindById = vi.fn();
 vi.mock('@bike4mind/database/infra', () => ({
   organizationRepository: { findById: (...a: unknown[]) => mockFindById(...a) },
 }));
 
-import { verifyOrgAccess, assertOrgBillingAccess, resolveBillingOrgId } from '../orgAccess';
+// resolveBillingOrgId delegates the membership decision to the canonical org gate; mock it so this
+// suite verifies only the tri-state routing and that the gate is consulted (the gate itself has its
+// own tests in resolveActiveOrg.test.ts).
+const mockResolveActiveOrg = vi.fn();
+vi.mock('../resolveActiveOrg', () => ({
+  resolveActiveOrg: (...a: unknown[]) => mockResolveActiveOrg(...a),
+}));
+
+import { verifyOrgAccess, resolveBillingOrgId } from '../orgAccess';
 
 // Valid 24-hex ObjectId strings (pass Types.ObjectId round-trip validation).
 const ORG = '650000000000000000000abc';
 const OWNER = '650000000000000000000111';
 const MANAGER = '650000000000000000000222';
 const STRANGER = '650000000000000000000333';
-const MEMBER = '650000000000000000000444';
 const OTHER_ORG = '650000000000000000000def';
 
 const org = { id: ORG, userId: OWNER, managerId: MANAGER };
@@ -61,73 +69,43 @@ describe('verifyOrgAccess', () => {
   });
 });
 
-// `users[]` is the authoritative membership ACL (see OrganizationModel schema comment).
-const orgWithMember = { id: ORG, userId: OWNER, managerId: MANAGER, users: [{ userId: MEMBER }] };
-
-describe('assertOrgBillingAccess', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockFindById.mockResolvedValue(orgWithMember);
-  });
-
-  it('rejects an invalid ObjectId without touching the DB', async () => {
-    await expect(assertOrgBillingAccess({ id: OWNER, isAdmin: false }, 'nope')).rejects.toBeInstanceOf(BadRequestError);
-    expect(mockFindById).not.toHaveBeenCalled();
-  });
-
-  it('grants a plain member (via users[]), unlike verifyOrgAccess', async () => {
-    const result = await assertOrgBillingAccess({ id: MEMBER, isAdmin: false }, ORG);
-    expect(result).toBe(orgWithMember);
-  });
-
-  it('grants owner and manager', async () => {
-    await expect(assertOrgBillingAccess({ id: OWNER, isAdmin: false }, ORG)).resolves.toBe(orgWithMember);
-    await expect(assertOrgBillingAccess({ id: MANAGER, isAdmin: false }, ORG)).resolves.toBe(orgWithMember);
-  });
-
-  it('404s a non-member (same error as missing, to prevent enumeration)', async () => {
-    await expect(assertOrgBillingAccess({ id: STRANGER, isAdmin: false }, ORG)).rejects.toBeInstanceOf(NotFoundError);
-  });
-
-  it('404s when the org does not exist', async () => {
-    mockFindById.mockResolvedValue(null);
-    await expect(assertOrgBillingAccess({ id: MEMBER, isAdmin: false }, ORG)).rejects.toBeInstanceOf(NotFoundError);
-  });
-});
-
 describe('resolveBillingOrgId', () => {
-  const user = { id: MEMBER, isAdmin: false, organizationId: ORG };
+  const asReq = (user: Record<string, unknown>) => ({ user }) as never;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindById.mockResolvedValue(orgWithMember);
   });
 
-  it('returns the caller own org when the request omits an org (undefined), without a DB check', async () => {
-    await expect(resolveBillingOrgId(user, undefined)).resolves.toBe(ORG);
-    expect(mockFindById).not.toHaveBeenCalled();
+  it('returns null (personal) for an explicit null request, without consulting the gate', async () => {
+    await expect(resolveBillingOrgId(asReq({ id: OWNER, organizationId: ORG }), null)).resolves.toBeNull();
+    expect(mockResolveActiveOrg).not.toHaveBeenCalled();
   });
 
-  it('returns null (personal) when the request explicitly passes null, without a DB check', async () => {
-    await expect(resolveBillingOrgId(user, null)).resolves.toBeNull();
-    expect(mockFindById).not.toHaveBeenCalled();
+  it('returns null when no org is supplied and the caller has no home org', async () => {
+    await expect(resolveBillingOrgId(asReq({ id: STRANGER, organizationId: null }), undefined)).resolves.toBeNull();
+    expect(mockResolveActiveOrg).not.toHaveBeenCalled();
   });
 
-  it('short-circuits the caller own org id without a membership DB read', async () => {
-    await expect(resolveBillingOrgId(user, ORG)).resolves.toBe(ORG);
-    expect(mockFindById).not.toHaveBeenCalled();
+  it('validates the caller home org through the canonical gate when the request omits one', async () => {
+    mockResolveActiveOrg.mockResolvedValue(ORG);
+    const req = asReq({ id: OWNER, organizationId: ORG });
+    await expect(resolveBillingOrgId(req, undefined)).resolves.toBe(ORG);
+    expect(mockResolveActiveOrg).toHaveBeenCalledWith(req, ORG);
   });
 
-  it('verifies membership for any other client-supplied org, rejecting a non-member', async () => {
-    // stranger tries to bill an org they do not belong to
-    const stranger = { id: STRANGER, isAdmin: false, organizationId: null };
-    await expect(resolveBillingOrgId(stranger, OTHER_ORG)).rejects.toBeInstanceOf(NotFoundError);
-    expect(mockFindById).toHaveBeenCalledWith(OTHER_ORG);
+  it('validates a client-supplied org through the canonical gate', async () => {
+    mockResolveActiveOrg.mockResolvedValue(OTHER_ORG);
+    const req = asReq({ id: OWNER, organizationId: ORG });
+    await expect(resolveBillingOrgId(req, OTHER_ORG)).resolves.toBe(OTHER_ORG);
+    expect(mockResolveActiveOrg).toHaveBeenCalledWith(req, OTHER_ORG);
   });
 
-  it('allows a valid member to bill an org other than their own after a membership check', async () => {
-    const user2 = { id: MEMBER, isAdmin: false, organizationId: null };
-    await expect(resolveBillingOrgId(user2, ORG)).resolves.toBe(ORG);
-    expect(mockFindById).toHaveBeenCalledWith(ORG);
+  it('propagates the gate rejection - even a stale home-org field cannot silently keep billing', async () => {
+    // A since-revoked member whose organizationId still points at the org: the gate rejects, and the
+    // billing path must surface that rather than trusting the stale field.
+    mockResolveActiveOrg.mockRejectedValue(new ForbiddenError('not a member'));
+    await expect(resolveBillingOrgId(asReq({ id: STRANGER, organizationId: ORG }), undefined)).rejects.toBeInstanceOf(
+      ForbiddenError
+    );
   });
 });

--- a/apps/client/server/utils/__tests__/orgAccess.test.ts
+++ b/apps/client/server/utils/__tests__/orgAccess.test.ts
@@ -70,7 +70,8 @@ describe('verifyOrgAccess', () => {
 });
 
 describe('resolveBillingOrgId', () => {
-  const asReq = (user: Record<string, unknown>) => ({ user }) as never;
+  const warn = vi.fn();
+  const asReq = (user: Record<string, unknown>) => ({ user, logger: { warn } }) as never;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -100,12 +101,27 @@ describe('resolveBillingOrgId', () => {
     expect(mockResolveActiveOrg).toHaveBeenCalledWith(req, OTHER_ORG);
   });
 
-  it('propagates the gate rejection - even a stale home-org field cannot silently keep billing', async () => {
-    // A since-revoked member whose organizationId still points at the org: the gate rejects, and the
-    // billing path must surface that rather than trusting the stale field.
+  it('degrades an implicit own-org fallback to personal (null) when the gate rejects a stale pointer', async () => {
+    // A since-revoked member whose organizationId still points at the org did not CHOOSE to bill it,
+    // so a stale pointer must fall back to personal billing rather than 403-lock the whole request.
+    // Security holds: the org is never billed either way.
     mockResolveActiveOrg.mockRejectedValue(new ForbiddenError('not a member'));
-    await expect(resolveBillingOrgId(asReq({ id: STRANGER, organizationId: ORG }), undefined)).rejects.toBeInstanceOf(
+    await expect(resolveBillingOrgId(asReq({ id: STRANGER, organizationId: ORG }), undefined)).resolves.toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the gate rejection for a CLIENT-SUPPLIED org (the strict trust boundary)', async () => {
+    // Unlike the implicit fallback, an org id the caller put in the request body must fail hard when
+    // the caller is not a member - it cannot silently degrade to personal and pretend success.
+    mockResolveActiveOrg.mockRejectedValue(new ForbiddenError('not a member'));
+    await expect(resolveBillingOrgId(asReq({ id: STRANGER, organizationId: ORG }), OTHER_ORG)).rejects.toBeInstanceOf(
       ForbiddenError
     );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-authorization error from the fallback path (transient DB failure -> 5xx)', async () => {
+    mockResolveActiveOrg.mockRejectedValue(new Error('db down'));
+    await expect(resolveBillingOrgId(asReq({ id: OWNER, organizationId: ORG }), undefined)).rejects.toThrow('db down');
   });
 });

--- a/apps/client/server/utils/__tests__/orgAccess.test.ts
+++ b/apps/client/server/utils/__tests__/orgAccess.test.ts
@@ -6,13 +6,15 @@ vi.mock('@bike4mind/database/infra', () => ({
   organizationRepository: { findById: (...a: unknown[]) => mockFindById(...a) },
 }));
 
-import { verifyOrgAccess } from '../orgAccess';
+import { verifyOrgAccess, assertOrgBillingAccess, resolveBillingOrgId } from '../orgAccess';
 
 // Valid 24-hex ObjectId strings (pass Types.ObjectId round-trip validation).
 const ORG = '650000000000000000000abc';
 const OWNER = '650000000000000000000111';
 const MANAGER = '650000000000000000000222';
 const STRANGER = '650000000000000000000333';
+const MEMBER = '650000000000000000000444';
+const OTHER_ORG = '650000000000000000000def';
 
 const org = { id: ORG, userId: OWNER, managerId: MANAGER };
 
@@ -56,5 +58,76 @@ describe('verifyOrgAccess', () => {
   it('404s a non-admin when the org does not exist', async () => {
     mockFindById.mockResolvedValue(null);
     await expect(verifyOrgAccess({ id: OWNER, isAdmin: false }, ORG)).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+// `users[]` is the authoritative membership ACL (see OrganizationModel schema comment).
+const orgWithMember = { id: ORG, userId: OWNER, managerId: MANAGER, users: [{ userId: MEMBER }] };
+
+describe('assertOrgBillingAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindById.mockResolvedValue(orgWithMember);
+  });
+
+  it('rejects an invalid ObjectId without touching the DB', async () => {
+    await expect(assertOrgBillingAccess({ id: OWNER, isAdmin: false }, 'nope')).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  it('grants a plain member (via users[]), unlike verifyOrgAccess', async () => {
+    const result = await assertOrgBillingAccess({ id: MEMBER, isAdmin: false }, ORG);
+    expect(result).toBe(orgWithMember);
+  });
+
+  it('grants owner and manager', async () => {
+    await expect(assertOrgBillingAccess({ id: OWNER, isAdmin: false }, ORG)).resolves.toBe(orgWithMember);
+    await expect(assertOrgBillingAccess({ id: MANAGER, isAdmin: false }, ORG)).resolves.toBe(orgWithMember);
+  });
+
+  it('404s a non-member (same error as missing, to prevent enumeration)', async () => {
+    await expect(assertOrgBillingAccess({ id: STRANGER, isAdmin: false }, ORG)).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('404s when the org does not exist', async () => {
+    mockFindById.mockResolvedValue(null);
+    await expect(assertOrgBillingAccess({ id: MEMBER, isAdmin: false }, ORG)).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe('resolveBillingOrgId', () => {
+  const user = { id: MEMBER, isAdmin: false, organizationId: ORG };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindById.mockResolvedValue(orgWithMember);
+  });
+
+  it('returns the caller own org when the request omits an org (undefined), without a DB check', async () => {
+    await expect(resolveBillingOrgId(user, undefined)).resolves.toBe(ORG);
+    expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  it('returns null (personal) when the request explicitly passes null, without a DB check', async () => {
+    await expect(resolveBillingOrgId(user, null)).resolves.toBeNull();
+    expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits the caller own org id without a membership DB read', async () => {
+    await expect(resolveBillingOrgId(user, ORG)).resolves.toBe(ORG);
+    expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  it('verifies membership for any other client-supplied org, rejecting a non-member', async () => {
+    // stranger tries to bill an org they do not belong to
+    const stranger = { id: STRANGER, isAdmin: false, organizationId: null };
+    await expect(resolveBillingOrgId(stranger, OTHER_ORG)).rejects.toBeInstanceOf(NotFoundError);
+    expect(mockFindById).toHaveBeenCalledWith(OTHER_ORG);
+  });
+
+  it('allows a valid member to bill an org other than their own after a membership check', async () => {
+    const user2 = { id: MEMBER, isAdmin: false, organizationId: null };
+    await expect(resolveBillingOrgId(user2, ORG)).resolves.toBe(ORG);
+    expect(mockFindById).toHaveBeenCalledWith(ORG);
   });
 });

--- a/apps/client/server/utils/orgAccess.ts
+++ b/apps/client/server/utils/orgAccess.ts
@@ -67,17 +67,23 @@ export async function verifyOrgAccess(user: { id: string; isAdmin: boolean }, or
  * - `undefined`  -> the caller's own organization (their `organizationId`), or null if they have none
  * - an org id    -> the client-supplied billing target
  *
- * The resolved org (own-org fallback included) is validated through `resolveActiveOrg` - the ONE
- * place a route turns a client-supplied active org into a trusted scope - so billing authorization
- * can't drift from data-lake scoping (both must use the same shareable ACL gate), and a stale
- * `organizationId` (e.g. a since-revoked member's, before revokeAccess clears it) can't silently
- * keep billing an org the caller no longer belongs to. `resolveActiveOrg` throws ForbiddenError /
- * NotFoundError for a non-member or missing org.
+ * A client-supplied org id is validated strictly through `resolveActiveOrg` - the ONE place a
+ * route turns a client-supplied active org into a trusted scope - so billing authorization can't
+ * drift from data-lake scoping (both must use the same shareable ACL gate); its ForbiddenError /
+ * NotFoundError propagates, because the caller explicitly asked to bill that org and may not.
+ *
+ * The IMPLICIT own-org fallback (`undefined` request) is different: the caller did not choose it,
+ * so a stale `organizationId` pointer must degrade to personal scope rather than 403-lock the
+ * caller out of a route they could always reach. Stale pointers already exist in the data (revoke,
+ * `deleteOrganization`, and `assignManager` paths leave them), so validating the fallback through
+ * the same gate and catching a non-member/missing rejection matches `chat.ts`: billing is never an
+ * automatic consequence of the home-org field. Security holds either way - a non-member org is
+ * never billed; the fallback just bills personally instead of failing the request.
  */
 export async function resolveBillingOrgId(
   // Accept any authenticated request shape: the LLM/media routes type `req` with a narrowed `Params`
-  // generic that a bare `Request` would reject, and only `req.user` is needed here (and by the gate).
-  req: Pick<Request, 'user'>,
+  // generic that a bare `Request` would reject, and only `req.user`/`req.logger` are needed here.
+  req: Pick<Request, 'user' | 'logger'>,
   requestedOrgId: string | null | undefined
 ): Promise<string | null> {
   // Explicit personal (null) carries no cross-tenant risk and skips org billing entirely.
@@ -85,13 +91,32 @@ export async function resolveBillingOrgId(
     return null;
   }
 
-  // undefined -> fall back to the caller's own org; anything else is the client-supplied target.
-  const orgId = requestedOrgId ?? req.user?.organizationId?.toString() ?? null;
-  if (orgId === null) {
-    return null;
+  // The caller always hands us a full express request (these are authenticated routes); the cast
+  // just bridges `Pick<Request, ...>` back to the `Request` the shared gate is typed against.
+  const reqAsExpress = req as Request;
+
+  // A client-supplied target is a hard trust boundary: validate strictly and let a rejection surface.
+  if (requestedOrgId !== undefined) {
+    return (await resolveActiveOrg(reqAsExpress, requestedOrgId)) ?? null;
   }
 
-  // The caller always hands us a full express request (these are authenticated routes); the cast
-  // just bridges `Pick<Request, 'user'>` back to the `Request` the shared gate is typed against.
-  return (await resolveActiveOrg(req as Request, orgId)) ?? null;
+  // Implicit own-org fallback: validate, but degrade to personal scope on a stale pointer.
+  const ownOrgId = req.user?.organizationId?.toString();
+  if (!ownOrgId) {
+    return null;
+  }
+  try {
+    return (await resolveActiveOrg(reqAsExpress, ownOrgId)) ?? null;
+  } catch (err) {
+    // Match by name, not instanceof: resolveActiveOrg throws @bike4mind/common's error classes,
+    // which are not identity-equal to this file's @bike4mind/utils imports.
+    const name = (err as { name?: string })?.name;
+    if (name === 'ForbiddenError' || name === 'NotFoundError') {
+      req.logger?.warn(
+        `resolveBillingOrgId: stale home-org pointer for user ${req.user?.id ?? 'unknown'} -> personal billing scope (${name})`
+      );
+      return null;
+    }
+    throw err; // a transient DB failure must surface as a 5xx, not silently bill personally
+  }
 }

--- a/apps/client/server/utils/orgAccess.ts
+++ b/apps/client/server/utils/orgAccess.ts
@@ -13,6 +13,7 @@
 import { organizationRepository } from '@bike4mind/database/infra';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 import { isValidObjectId } from '@server/utils/objectId';
+import { IUserDocument } from '@bike4mind/common';
 
 /**
  * Verify user has update access to the organization
@@ -54,4 +55,70 @@ export async function verifyOrgAccess(user: { id: string; isAdmin: boolean }, or
   }
 
   return org;
+}
+
+/**
+ * Verify the user may bill an organization's credit pool.
+ *
+ * Broader than `verifyOrgAccess` (owner/manager/admin only): any member may spend
+ * the org's credits, so this also accepts membership via the authoritative `users[]`
+ * ACL (see the OrganizationModel schema comment - `users[]` is the membership source
+ * of truth; `userDetails[]` is only a per-member credit side-table). Returns the same
+ * NotFoundError for missing and unauthorized orgs to prevent enumeration.
+ *
+ * @throws BadRequestError if orgId is malformed
+ * @throws NotFoundError if the org does not exist or the caller is not a member
+ */
+export async function assertOrgBillingAccess(user: { id: string; isAdmin: boolean }, orgId: string) {
+  if (!orgId || !isValidObjectId(orgId)) {
+    throw new BadRequestError('Invalid organization ID');
+  }
+
+  const org = await organizationRepository.findById(orgId);
+  if (!org) {
+    throw new NotFoundError('Organization not found');
+  }
+
+  if (user.isAdmin) {
+    return org;
+  }
+
+  const isOwner = org.userId === user.id;
+  const isManager = org.managerId === user.id;
+  const isMember = org.users?.some(u => u.userId === user.id) ?? false;
+
+  if (!isOwner && !isManager && !isMember) {
+    throw new NotFoundError('Organization not found');
+  }
+
+  return org;
+}
+
+/**
+ * Resolve the organization to bill for an AI action from a client-supplied value,
+ * rejecting any org the caller is not a member of. This is the trust boundary for
+ * the LLM/media routes, which otherwise pass `req.body.organizationId` through to the
+ * debit unverified.
+ *
+ * - `undefined`  -> the caller's own organization (their `organizationId`, trusted), or null
+ * - `null`       -> personal account (no org billing)
+ * - an org id    -> billed only if it is the caller's own org or one they are a member of;
+ *                   a non-member gets NotFoundError (see `assertOrgBillingAccess`)
+ */
+export async function resolveBillingOrgId(
+  user: Pick<IUserDocument, 'id' | 'isAdmin' | 'organizationId'>,
+  requestedOrgId: string | null | undefined
+): Promise<string | null> {
+  const ownOrgId = user.organizationId?.toString() ?? null;
+
+  if (requestedOrgId === undefined) {
+    return ownOrgId;
+  }
+  // personal (null) or the caller's own org carry no cross-tenant risk
+  if (requestedOrgId === null || requestedOrgId === ownOrgId) {
+    return requestedOrgId;
+  }
+
+  await assertOrgBillingAccess(user, requestedOrgId);
+  return requestedOrgId;
 }

--- a/apps/client/server/utils/orgAccess.ts
+++ b/apps/client/server/utils/orgAccess.ts
@@ -13,7 +13,8 @@
 import { organizationRepository } from '@bike4mind/database/infra';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 import { isValidObjectId } from '@server/utils/objectId';
-import { IUserDocument } from '@bike4mind/common';
+import { resolveActiveOrg } from './resolveActiveOrg';
+import type { Request } from 'express';
 
 /**
  * Verify user has update access to the organization
@@ -58,67 +59,39 @@ export async function verifyOrgAccess(user: { id: string; isAdmin: boolean }, or
 }
 
 /**
- * Verify the user may bill an organization's credit pool.
+ * Resolve the organization to bill for an AI action from a client-supplied value, rejecting any org
+ * the caller is not a member of. This is the trust boundary for the LLM/media routes, which
+ * otherwise pass `req.body.organizationId` through to the debit unverified.
  *
- * Broader than `verifyOrgAccess` (owner/manager/admin only): any member may spend
- * the org's credits, so this also accepts membership via the authoritative `users[]`
- * ACL (see the OrganizationModel schema comment - `users[]` is the membership source
- * of truth; `userDetails[]` is only a per-member credit side-table). Returns the same
- * NotFoundError for missing and unauthorized orgs to prevent enumeration.
- *
- * @throws BadRequestError if orgId is malformed
- * @throws NotFoundError if the org does not exist or the caller is not a member
- */
-export async function assertOrgBillingAccess(user: { id: string; isAdmin: boolean }, orgId: string) {
-  if (!orgId || !isValidObjectId(orgId)) {
-    throw new BadRequestError('Invalid organization ID');
-  }
-
-  const org = await organizationRepository.findById(orgId);
-  if (!org) {
-    throw new NotFoundError('Organization not found');
-  }
-
-  if (user.isAdmin) {
-    return org;
-  }
-
-  const isOwner = org.userId === user.id;
-  const isManager = org.managerId === user.id;
-  const isMember = org.users?.some(u => u.userId === user.id) ?? false;
-
-  if (!isOwner && !isManager && !isMember) {
-    throw new NotFoundError('Organization not found');
-  }
-
-  return org;
-}
-
-/**
- * Resolve the organization to bill for an AI action from a client-supplied value,
- * rejecting any org the caller is not a member of. This is the trust boundary for
- * the LLM/media routes, which otherwise pass `req.body.organizationId` through to the
- * debit unverified.
- *
- * - `undefined`  -> the caller's own organization (their `organizationId`, trusted), or null
  * - `null`       -> personal account (no org billing)
- * - an org id    -> billed only if it is the caller's own org or one they are a member of;
- *                   a non-member gets NotFoundError (see `assertOrgBillingAccess`)
+ * - `undefined`  -> the caller's own organization (their `organizationId`), or null if they have none
+ * - an org id    -> the client-supplied billing target
+ *
+ * The resolved org (own-org fallback included) is validated through `resolveActiveOrg` - the ONE
+ * place a route turns a client-supplied active org into a trusted scope - so billing authorization
+ * can't drift from data-lake scoping (both must use the same shareable ACL gate), and a stale
+ * `organizationId` (e.g. a since-revoked member's, before revokeAccess clears it) can't silently
+ * keep billing an org the caller no longer belongs to. `resolveActiveOrg` throws ForbiddenError /
+ * NotFoundError for a non-member or missing org.
  */
 export async function resolveBillingOrgId(
-  user: Pick<IUserDocument, 'id' | 'isAdmin' | 'organizationId'>,
+  // Accept any authenticated request shape: the LLM/media routes type `req` with a narrowed `Params`
+  // generic that a bare `Request` would reject, and only `req.user` is needed here (and by the gate).
+  req: Pick<Request, 'user'>,
   requestedOrgId: string | null | undefined
 ): Promise<string | null> {
-  const ownOrgId = user.organizationId?.toString() ?? null;
-
-  if (requestedOrgId === undefined) {
-    return ownOrgId;
-  }
-  // personal (null) or the caller's own org carry no cross-tenant risk
-  if (requestedOrgId === null || requestedOrgId === ownOrgId) {
-    return requestedOrgId;
+  // Explicit personal (null) carries no cross-tenant risk and skips org billing entirely.
+  if (requestedOrgId === null) {
+    return null;
   }
 
-  await assertOrgBillingAccess(user, requestedOrgId);
-  return requestedOrgId;
+  // undefined -> fall back to the caller's own org; anything else is the client-supplied target.
+  const orgId = requestedOrgId ?? req.user?.organizationId?.toString() ?? null;
+  if (orgId === null) {
+    return null;
+  }
+
+  // The caller always hands us a full express request (these are authenticated routes); the cast
+  // just bridges `Pick<Request, 'user'>` back to the `Request` the shared gate is typed against.
+  return (await resolveActiveOrg(req as Request, orgId)) ?? null;
 }

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -27,6 +27,7 @@ import {
   IMcpServerRepository,
   IMcpServerDocument,
   IQuestMasterPlanRepository,
+  IQuestMasterPlanDocument,
   IPromptDocument,
   ICacheRepository,
   ICreditTransactionRepository,
@@ -1139,6 +1140,21 @@ export class QuestMasterFeature implements ChatCompletionFeature {
     }
   }
 
+  /**
+   * Guard mutations of a QuestMaster plan. The plan/quest/sub-quest ids arrive from
+   * client-supplied `questMaster` params, so a bare findById would let one user drive
+   * status changes on another user's plan. Access = plan owner or explicit sharee;
+   * legacy plans without a userId bind to their owning notebook's owner.
+   */
+  private async callerCanWritePlan(plan: IQuestMasterPlanDocument): Promise<boolean> {
+    const userId = this.user.id;
+    if (plan.userId) {
+      return plan.userId === userId || (plan.sharedWith?.includes(userId) ?? false);
+    }
+    const session = plan.notebookId ? await this.chatCompletion.db.sessions.findById(plan.notebookId) : null;
+    return session?.userId === userId;
+  }
+
   async onComplete({
     quest,
     questMaster,
@@ -1151,6 +1167,13 @@ export class QuestMasterFeature implements ChatCompletionFeature {
     const questMasterPlan = await this.chatCompletion.db.questMasterPlans.findById(questMaster.questMasterPlanId);
     if (!questMasterPlan) {
       this.logger.warn(`QuestMaster plan with id ${questMaster.questMasterPlanId} not found`);
+      return;
+    }
+
+    if (!(await this.callerCanWritePlan(questMasterPlan))) {
+      this.logger.warn(
+        `User ${this.user.id} is not authorized to modify QuestMaster plan ${questMaster.questMasterPlanId}`
+      );
       return;
     }
 
@@ -1177,6 +1200,13 @@ export class QuestMasterFeature implements ChatCompletionFeature {
     const questMasterPlan = await this.chatCompletion.db.questMasterPlans.findById(questMaster.questMasterPlanId);
     if (!questMasterPlan) {
       this.logger.warn(`QuestMaster plan with id ${questMaster.questMasterPlanId} not found`);
+      return;
+    }
+
+    if (!(await this.callerCanWritePlan(questMasterPlan))) {
+      this.logger.warn(
+        `User ${this.user.id} is not authorized to modify QuestMaster plan ${questMaster.questMasterPlanId}`
+      );
       return;
     }
 

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -127,6 +127,7 @@ import { forcedRetrievalNoContextPrompt, type ForcedRetrievalNoContextFinding } 
 import { MCPClient } from '@bike4mind/mcp';
 import uniq from 'lodash/uniq.js';
 import { mergeRetrievalSummary, type RetrievalSummary } from './tools/retrievalSummaryMerge';
+import { isObjectIdShaped } from './tools/base/objectId';
 
 interface DatabaseAdapters {
   sessions: Pick<ISessionRepository, 'findById' | 'findAllByIds' | 'update' | 'attachAgent'>;
@@ -1145,13 +1146,20 @@ export class QuestMasterFeature implements ChatCompletionFeature {
    * client-supplied `questMaster` params, so a bare findById would let one user drive
    * status changes on another user's plan. Access = plan owner or explicit sharee;
    * legacy plans without a userId bind to their owning notebook's owner.
+   *
+   * Must stay in sync with apps/client/server/utils/questMasterPlanAccess.ts, which is the same
+   * predicate on the HTTP side (it also guards the notebook lookup on ObjectId shape below).
    */
   private async callerCanWritePlan(plan: IQuestMasterPlanDocument): Promise<boolean> {
     const userId = this.user.id;
     if (plan.userId) {
       return plan.userId === userId || (plan.sharedWith?.includes(userId) ?? false);
     }
-    const session = plan.notebookId ? await this.chatCompletion.db.sessions.findById(plan.notebookId) : null;
+    // notebookId is a schema String: placeholder plans carry `direct-<uuid>` / `clone-<uuid>`, so
+    // guard on ObjectId shape before findById to keep a non-id from casting into a CastError.
+    const session = isObjectIdShaped(plan.notebookId)
+      ? await this.chatCompletion.db.sessions.findById(plan.notebookId)
+      : null;
     return session?.userId === userId;
   }
 

--- a/b4m-core/services/src/llm/ChatCompletionInvoke.ts
+++ b/b4m-core/services/src/llm/ChatCompletionInvoke.ts
@@ -262,6 +262,13 @@ export class ChatCompletionInvoke {
               );
               return null;
             }
+            // Bind the retry to the caller's target session. `sessionId` was resolved through an
+            // access-scoped lookup upstream (getOrCreateSession), so refusing a quest that belongs
+            // to a different session stops a caller retrying/overwriting another user's quest by id.
+            if (q.sessionId !== sessionId) {
+              this.logger.warn(`Quest ${questId} does not belong to session ${sessionId}; refusing retry.`);
+              return null;
+            }
             // Retry path: clear prior replies and images.
             q.type = 'message';
             q.reply = null;

--- a/b4m-core/services/src/llm/ChatCompletionInvoke.ts
+++ b/b4m-core/services/src/llm/ChatCompletionInvoke.ts
@@ -12,6 +12,7 @@ import {
   BadRequestError,
   ForbiddenError,
   InternalServerError,
+  NotFoundError,
   isModelAccessible,
   isZodError,
   getSettingsByNames,
@@ -260,14 +261,18 @@ export class ChatCompletionInvoke {
               this.logger.warn(
                 `Quest not found for questId: ${questId}. Quest may have been deleted before the quest was started.`
               );
-              return null;
+              throw new NotFoundError('Quest not found');
             }
             // Bind the retry to the caller's target session. `sessionId` was resolved through an
             // access-scoped lookup upstream (getOrCreateSession), so refusing a quest that belongs
             // to a different session stops a caller retrying/overwriting another user's quest by id.
+            // Throw rather than returning null: a bare null flowed to `if (!quest) return` and made
+            // the invoke a silent no-op (a 200 with no quest on the media routes). The same generic
+            // NotFound as the missing-quest case keeps the refusal from leaking whether the quest
+            // exists in a session the caller cannot see.
             if (q.sessionId !== sessionId) {
               this.logger.warn(`Quest ${questId} does not belong to session ${sessionId}; refusing retry.`);
-              return null;
+              throw new NotFoundError('Quest not found');
             }
             // Retry path: clear prior replies and images.
             q.type = 'message';

--- a/b4m-core/services/src/llm/ChatCompletionInvokeRetryBinding.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionInvokeRetryBinding.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundError } from '@bike4mind/utils';
 
 // Only the two collaborators that reach out of process need mocking; the error classes and
 // helpers from @bike4mind/utils stay real so the code under test behaves normally.
@@ -60,10 +61,16 @@ describe('ChatCompletionInvoke retry path session binding', () => {
   it('refuses to overwrite a quest that belongs to a different session', async () => {
     const { invoke, questsUpdate } = makeHarness({ id: 'quest-1', sessionId: 'someone-elses-session' });
 
-    const result = await invoke.invoke({ body: body as never, userId: 'user-A' });
+    // Guard throws (not a silent no-op) before the retry overwrite; the foreign quest is untouched.
+    // A generic NotFound keeps the refusal from leaking that the quest exists.
+    await expect(invoke.invoke({ body: body as never, userId: 'user-A' })).rejects.toBeInstanceOf(NotFoundError);
+    expect(questsUpdate).not.toHaveBeenCalled();
+  });
 
-    // Guard returns null -> invoke bails before the retry overwrite; the foreign quest is untouched.
-    expect(result).toBeUndefined();
+  it('surfaces a NotFound when the retried quest no longer exists (same error, no enumeration)', async () => {
+    const { invoke, questsUpdate } = makeHarness(null);
+
+    await expect(invoke.invoke({ body: body as never, userId: 'user-A' })).rejects.toBeInstanceOf(NotFoundError);
     expect(questsUpdate).not.toHaveBeenCalled();
   });
 

--- a/b4m-core/services/src/llm/ChatCompletionInvokeRetryBinding.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionInvokeRetryBinding.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Only the two collaborators that reach out of process need mocking; the error classes and
+// helpers from @bike4mind/utils stay real so the code under test behaves normally.
+vi.mock('../apiKeyService', () => ({
+  getEffectiveLLMApiKeys: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('@bike4mind/llm-adapters', () => ({
+  getAvailableModels: vi.fn().mockResolvedValue([{ id: 'test-model', disabled: false }]),
+}));
+
+import { ChatCompletionInvoke } from './ChatCompletionInvoke';
+
+const SESSION = 'session-owned';
+
+const makeHarness = (questDoc: Record<string, unknown> | null) => {
+  const questsUpdate = vi.fn().mockResolvedValue(undefined);
+  const invokeLambda = vi.fn().mockResolvedValue(undefined);
+
+  const db = {
+    sessions: {
+      findById: vi.fn().mockResolvedValue({ id: SESSION, agentIds: [] }),
+      update: vi.fn().mockResolvedValue(undefined),
+    },
+    quests: {
+      findById: vi.fn().mockResolvedValue(questDoc),
+      update: questsUpdate,
+      create: vi.fn(),
+    },
+    organizations: { findById: vi.fn().mockResolvedValue(null) },
+    adminSettings: {
+      getSettingsValue: vi.fn().mockResolvedValue('text-embedding-3-small'),
+      findOne: vi.fn().mockResolvedValue({ settingValue: [] }),
+    },
+  };
+
+  const options = {
+    db,
+    logger: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    user: { id: 'user-A', isAdmin: false, tags: [] },
+    invokeLambda,
+  };
+
+  const invoke = new ChatCompletionInvoke(options as unknown as ConstructorParameters<typeof ChatCompletionInvoke>[0]);
+  return { invoke, questsUpdate, invokeLambda };
+};
+
+const body = {
+  sessionId: SESSION,
+  historyCount: 0,
+  fabFileIds: [],
+  message: 'retry this',
+  questId: 'quest-1',
+  params: { model: 'test-model' },
+};
+
+describe('ChatCompletionInvoke retry path session binding', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('refuses to overwrite a quest that belongs to a different session', async () => {
+    const { invoke, questsUpdate } = makeHarness({ id: 'quest-1', sessionId: 'someone-elses-session' });
+
+    const result = await invoke.invoke({ body: body as never, userId: 'user-A' });
+
+    // Guard returns null -> invoke bails before the retry overwrite; the foreign quest is untouched.
+    expect(result).toBeUndefined();
+    expect(questsUpdate).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with a legitimate same-session retry', async () => {
+    const { invoke, questsUpdate } = makeHarness({ id: 'quest-1', sessionId: SESSION });
+
+    const result = await invoke.invoke({ body: body as never, userId: 'user-A' });
+
+    expect(result).toBeDefined();
+    // guard let it through: the retry overwrite ran (status flipped to running)
+    expect(questsUpdate).toHaveBeenCalledWith(expect.objectContaining({ status: 'running' }));
+  });
+});

--- a/b4m-core/services/src/llm/ChatCompletionInvokeRetryBinding.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionInvokeRetryBinding.test.ts
@@ -19,7 +19,7 @@ const makeHarness = (questDoc: Record<string, unknown> | null) => {
 
   const db = {
     sessions: {
-      findById: vi.fn().mockResolvedValue({ id: SESSION, agentIds: [] }),
+      findById: vi.fn().mockResolvedValue({ id: SESSION, userId: 'user-A', agentIds: [] }),
       update: vi.fn().mockResolvedValue(undefined),
     },
     quests: {

--- a/b4m-core/services/src/llm/QuestMasterPlanAccess.test.ts
+++ b/b4m-core/services/src/llm/QuestMasterPlanAccess.test.ts
@@ -8,6 +8,9 @@ import type { IChatHistoryItemDocument } from '@bike4mind/common';
 
 const CALLER = 'user-A';
 const OTHER = 'user-B';
+// A legacy plan's notebookId is a real session _id, so it must be ObjectId-shaped: the plan-write
+// guard skips the notebook lookup for a non-ObjectId value (placeholder plans carry a userId).
+const NB = '650000000000000000000abc';
 
 const questMaster = { questMasterPlanId: 'plan1', questId: 'q1', subQuestId: 'sq1' };
 
@@ -70,21 +73,32 @@ describe('QuestMasterFeature.onComplete plan access guard', () => {
 
   it('binds a legacy plan (no userId) to its notebook owner - allows when the caller owns it', async () => {
     const { feature, findById, updateTaskStatus, sessionsFindById } = makeHarness();
-    findById.mockResolvedValueOnce({ id: 'plan1', notebookId: 'nb1', quests: [{ id: 'q1' }] });
-    sessionsFindById.mockResolvedValueOnce({ id: 'nb1', userId: CALLER });
+    findById.mockResolvedValueOnce({ id: 'plan1', notebookId: NB, quests: [{ id: 'q1' }] });
+    sessionsFindById.mockResolvedValueOnce({ id: NB, userId: CALLER });
 
     await call(feature);
 
+    expect(sessionsFindById).toHaveBeenCalledWith(NB);
     expect(updateTaskStatus).toHaveBeenCalledWith('plan1', 'q1', 'sq1', 'completed');
   });
 
   it('binds a legacy plan (no userId) to its notebook owner - refuses a foreign notebook', async () => {
     const { feature, findById, updateTaskStatus, sessionsFindById } = makeHarness();
-    findById.mockResolvedValueOnce({ id: 'plan1', notebookId: 'nb1', quests: [{ id: 'q1' }] });
-    sessionsFindById.mockResolvedValueOnce({ id: 'nb1', userId: OTHER });
+    findById.mockResolvedValueOnce({ id: 'plan1', notebookId: NB, quests: [{ id: 'q1' }] });
+    sessionsFindById.mockResolvedValueOnce({ id: NB, userId: OTHER });
 
     await call(feature);
 
+    expect(updateTaskStatus).not.toHaveBeenCalled();
+  });
+
+  it('refuses a legacy plan whose notebookId is not ObjectId-shaped, without a session lookup', async () => {
+    const { feature, findById, updateTaskStatus, sessionsFindById } = makeHarness();
+    findById.mockResolvedValueOnce({ id: 'plan1', notebookId: 'direct-abc', quests: [{ id: 'q1' }] });
+
+    await call(feature);
+
+    expect(sessionsFindById).not.toHaveBeenCalled();
     expect(updateTaskStatus).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/llm/QuestMasterPlanAccess.test.ts
+++ b/b4m-core/services/src/llm/QuestMasterPlanAccess.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QuestMasterFeature } from './ChatCompletionFeatures';
+import type { IChatHistoryItemDocument } from '@bike4mind/common';
+
+// Regression guard for the object-level authz fix: QuestMaster plan/quest/sub-quest ids arrive
+// from client-supplied `questMaster` params, so `onComplete` must not mutate a plan the caller
+// does not own or share. `updateTaskStatus` is the mutation we assert on.
+
+const CALLER = 'user-A';
+const OTHER = 'user-B';
+
+const questMaster = { questMasterPlanId: 'plan1', questId: 'q1', subQuestId: 'sq1' };
+
+const makeHarness = () => {
+  const updateTaskStatus = vi.fn().mockResolvedValue(undefined);
+  const findById = vi.fn();
+  const sessionsFindById = vi.fn();
+
+  const chatCompletion = {
+    logger: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    user: { id: CALLER },
+    db: {
+      questMasterPlans: { findById, updateTaskStatus },
+      sessions: { findById: sessionsFindById },
+    },
+  };
+
+  // Constructor only reads logger + user; the cast keeps the heavy ChatCompletionContext off the test.
+  const feature = new QuestMasterFeature(
+    chatCompletion as unknown as ConstructorParameters<typeof QuestMasterFeature>[0]
+  );
+  return { feature, findById, updateTaskStatus, sessionsFindById };
+};
+
+const call = (feature: QuestMasterFeature) =>
+  feature.onComplete({
+    quest: { id: 'quest1', sessionId: 'session1' } as unknown as IChatHistoryItemDocument,
+    questMaster: questMaster as never,
+  });
+
+describe('QuestMasterFeature.onComplete plan access guard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('marks the sub-quest complete when the caller owns the plan', async () => {
+    const { feature, findById, updateTaskStatus } = makeHarness();
+    findById.mockResolvedValueOnce({ id: 'plan1', userId: CALLER, quests: [{ id: 'q1' }] });
+
+    await call(feature);
+
+    expect(updateTaskStatus).toHaveBeenCalledWith('plan1', 'q1', 'sq1', 'completed');
+  });
+
+  it('marks the sub-quest complete when the plan is shared with the caller', async () => {
+    const { feature, findById, updateTaskStatus } = makeHarness();
+    findById.mockResolvedValueOnce({ id: 'plan1', userId: OTHER, sharedWith: [CALLER], quests: [{ id: 'q1' }] });
+
+    await call(feature);
+
+    expect(updateTaskStatus).toHaveBeenCalledWith('plan1', 'q1', 'sq1', 'completed');
+  });
+
+  it('refuses to mutate a plan owned by another user', async () => {
+    const { feature, findById, updateTaskStatus } = makeHarness();
+    findById.mockResolvedValueOnce({ id: 'plan1', userId: OTHER, quests: [{ id: 'q1' }] });
+
+    await call(feature);
+
+    expect(updateTaskStatus).not.toHaveBeenCalled();
+  });
+
+  it('binds a legacy plan (no userId) to its notebook owner - allows when the caller owns it', async () => {
+    const { feature, findById, updateTaskStatus, sessionsFindById } = makeHarness();
+    findById.mockResolvedValueOnce({ id: 'plan1', notebookId: 'nb1', quests: [{ id: 'q1' }] });
+    sessionsFindById.mockResolvedValueOnce({ id: 'nb1', userId: CALLER });
+
+    await call(feature);
+
+    expect(updateTaskStatus).toHaveBeenCalledWith('plan1', 'q1', 'sq1', 'completed');
+  });
+
+  it('binds a legacy plan (no userId) to its notebook owner - refuses a foreign notebook', async () => {
+    const { feature, findById, updateTaskStatus, sessionsFindById } = makeHarness();
+    findById.mockResolvedValueOnce({ id: 'plan1', notebookId: 'nb1', quests: [{ id: 'q1' }] });
+    sessionsFindById.mockResolvedValueOnce({ id: 'nb1', userId: OTHER });
+
+    await call(feature);
+
+    expect(updateTaskStatus).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/llm/QuestMasterStatus.test.ts
+++ b/b4m-core/services/src/llm/QuestMasterStatus.test.ts
@@ -69,6 +69,9 @@ describe('QuestMasterFeature - Status State Machine', () => {
 
   const mockQuestMasterPlan = {
     id: 'plan1',
+    // Owned by the caller so the plan-write guard in processQuestMasterTask lets the status
+    // transition run - these tests exercise the state machine, not the authz gate.
+    userId: 'user1',
     quests: [{ id: 'quest1', subQuests: [{ id: 'subquest1', title: 'Test SubQuest' }] }],
   };
 

--- a/b4m-core/services/src/organizationService/revokeAccess.test.ts
+++ b/b4m-core/services/src/organizationService/revokeAccess.test.ts
@@ -57,6 +57,11 @@ describe('organizationService - revokeAccess', () => {
         },
         users: {
           removeGroupsFromUser: vi.fn().mockResolvedValue(undefined),
+          // Default: the removed user has no home-org pointer, so the clear below is a no-op and the
+          // org-update assertions in the existing cases stay exact. Cases that exercise the clear
+          // override findById.
+          findById: vi.fn().mockResolvedValue(null),
+          update: vi.fn().mockResolvedValue(undefined),
         },
       },
     };
@@ -179,6 +184,23 @@ describe('organizationService - revokeAccess', () => {
         users: [secondUser],
       })
     );
+  });
+
+  it('clears the removed user organizationId when it pointed at this org (stale-org billing fix)', async () => {
+    mockAdapters.db.users.findById.mockResolvedValue({ id: 'user1', organizationId: 'org1' });
+
+    await revokeAccess(mockOwnerUser as IUserDocument, { id: 'org1', userId: 'user1' }, mockAdapters);
+
+    expect(mockAdapters.db.users.findById).toHaveBeenCalledWith('user1');
+    expect(mockAdapters.db.users.update).toHaveBeenCalledWith({ id: 'user1', organizationId: null });
+  });
+
+  it('leaves the removed user organizationId alone when it points at a different org', async () => {
+    mockAdapters.db.users.findById.mockResolvedValue({ id: 'user1', organizationId: 'other-org' });
+
+    await revokeAccess(mockOwnerUser as IUserDocument, { id: 'org1', userId: 'user1' }, mockAdapters);
+
+    expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
   });
 
   it('should validate and secure parameters', async () => {

--- a/b4m-core/services/src/organizationService/revokeAccess.ts
+++ b/b4m-core/services/src/organizationService/revokeAccess.ts
@@ -14,7 +14,7 @@ interface RevokeAccessAdapters {
   db: {
     organizations: IOrganizationRepository;
     groups: Pick<IGroupRepository, 'findByOrganization'>;
-    users: Pick<IUserRepository, 'removeGroupsFromUser'>;
+    users: Pick<IUserRepository, 'removeGroupsFromUser' | 'findById' | 'update'>;
   };
 }
 
@@ -52,6 +52,16 @@ export const revokeAccess = async (
   organization.adminUserIds = await purgeOrgMembershipArtifacts(userId, organization, adapters);
 
   await adapters.db.organizations.update(organization);
+
+  // Mirror leave.ts: if the org we just removed them from was the user's currently-selected org,
+  // clear it - otherwise org-scoped access (data-lake AccessContext, team-wide prompts) and billing
+  // keep being inferred from a stale organizationId, the inverse of the join-side invariant set in
+  // acceptOrganization/addMember. We hold only the removed user's id here, so fetch them to compare.
+  // Idempotent under a withTransaction retry (a re-run recomputes the same set-to-null).
+  const removed = await adapters.db.users.findById(userId);
+  if (removed?.organizationId?.toString() === id) {
+    await adapters.db.users.update({ id: userId, organizationId: null });
+  }
 
   return organization;
 };


### PR DESCRIPTION
## Description

Several LLM and media API routes accepted a client-supplied `organizationId`, `sessionId`, and `questId` and resolved them by a bare existence lookup, trusting the value without checking that the caller was allowed to use it. This adds access verification at those boundaries so a resource id from the request body is honored only when the caller can access it.

## Changes

- Billing organization: `resolveBillingOrgId` in `apps/client/server/utils/orgAccess.ts` resolves the org to bill through the ONE canonical org gate (`resolveActiveOrg`, the same shareable-ACL gate that authorizes data-lake scoping), wired into `ai/llm.ts`, `ai/generate-image.ts`, and `ai/generate-video.ts`, which shared this billing boundary. It distinguishes three inputs: `null` stays a personal (non-org) account; a client-supplied org id is a hard trust boundary, validated strictly, and a non-member/missing rejection propagates (the caller explicitly asked to bill that org and may not); an absent value falls back to the caller's own `organizationId`, but that IMPLICIT fallback degrades to personal scope on a non-member/missing rejection (a stale pointer must not 403-lock a route the caller could always reach, matching `chat.ts`: billing is never an automatic consequence of the home-org field). Security holds either way - a non-member org is never billed.
- Session lookup: `getOrCreateSession` now resolves an existing session through an access-scoped lookup (`accessibleBy(update)` honoring the Session write shape - owner + global-write + user/group shares; Session has no org arm - with an owner-only fallback when no ability is supplied) instead of a bare `findById`, so a session id the caller cannot access resolves to a 404 rather than being returned. The verb is `update`, not `read`, because quests are appended to the session and the retry path clears an existing quest's reply, so a read-only share must not reach it.
- Engine binding: the `ChatCompletionInvoke` retry path refuses a quest whose `sessionId` does not match the target session (throwing a generic `NotFoundError` so a refusal is not a silent no-op and cannot be told from a genuine miss), and `QuestMasterFeature` gates plan task-status mutations on plan ownership or sharing before updating status. The plan-write predicate (`callerCanWritePlan`) guards its legacy-plan notebook lookup on ObjectId shape and carries a `must stay in sync with questMasterPlanAccess.ts` cross-reference to the HTTP-side copy.

## Guide for Testers

Backend/authorization-only; no UI change. The access checks live at API boundaries and the denial paths are not observable by clicking, so this is a regression pass confirming legitimate flows still work. Sign in with a normal account at `<host>` (the preview host).

1. Open a chat session and send `Hello, how are you?`. Expected: a normal reply within ~10s, billed to your own account/org as before.
2. Generate an image and a video from their tools. Expected: both succeed as before.
3. Open a session another user has shared with you. Expected: it loads normally.
4. In QuestMaster, run a plan you own and let a task advance. Expected: task status updates as before.

### What NOT to test

The security behavior itself - supplying an `organizationId` / `sessionId` / `questId` the caller cannot access and confirming it is denied (404 / no-op) - is not a UI flow and is covered by the unit and route-level integration tests below. No preview or provider setup is involved.

### Regression Checks

Chat-completion billing (own org and as an org member), image/video generation, opening owned and shared sessions, and QuestMaster plan task-status updates - all should behave exactly as before this change. In particular, a user whose stored `organizationId` points at an org they are no longer a member of should still be able to chat (billed personally), not receive a 403.

## Tests

New and updated unit tests cover both directions:
- `orgAccess.test.ts` (unit): the billing tri-state and the P1 split - a client-supplied foreign org throws, while an implicit stale-home-org fallback degrades to null (personal) with a logged warn; plus a transient-error rethrow.
- `llm.integration.test.ts` (route-level, real `resolveBillingOrgId` -> real `resolveActiveOrg`, only the org-membership repo stubbed): a foreign body `organizationId` -> 403 with no completion dispatched; no `organizationId` -> billed to the caller's own org (asserted on `invoke().body.organizationId`). This exercises the resolver<->gate integration end to end.
- `sessionCrud.test.ts`, `QuestMasterPlanAccess.test.ts`, and `ChatCompletionInvokeRetryBinding.test.ts` assert that an inaccessible org/session/quest/plan is denied (404 or no-op) and that legitimate access - the caller's own org, an org member, a shared session, a same-session retry - still succeeds.

`pnpm --filter @bike4mind/services typecheck`, client typecheck, and `pnpm lint:check` all pass; the affected suites are green.

## Security Testing (for security-labeled PRs only)

- [ ] Reproduced/verified on a PR preview (output attached as a PR comment) -- pending a refreshed preview
- [x] Deterministic access checks covered by unit + route-level integration tests (inaccessible org/session/quest denied; legitimate access still succeeds; stale home-org pointer degrades to personal, never 403)
- [x] Verified the changed files against `origin/main`; detailed reproduction/verification recorded on the private security tracker

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) -- n/a, backend-only
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) -- n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- n/a
