### PR TITLE
feat(llm): tell the model when to reach for web search

### DIFF
--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -703,7 +703,9 @@ describe('WebSearchFreshnessPrompt default tells the model when to search', () =
   });
 
   it('requires an as-of date on any time-sensitive fact it reports', () => {
-    expect(WEB_SEARCH_FRESHNESS_PROMPT).toMatch(/as of/i);
+    // Not /as of/i - that also matches "as of today" in the search-trigger list, so the pin would
+    // survive deleting the reporting clause this test is named for.
+    expect(WEB_SEARCH_FRESHNESS_PROMPT).toMatch(/state what it is as of/i);
   });
 
   it('ships as the WebSearchFreshnessPrompt setting default (no drift between const and setting)', () => {

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -13,6 +13,7 @@ import {
   isMaskedSensitiveSettingValue,
   type AdminSettingDoc,
   ABSTENTION_PROMPT,
+  WEB_SEARCH_FRESHNESS_PROMPT,
 } from './settings';
 import {
   DEFAULT_PASSAGE_TOKEN_TARGET,
@@ -682,6 +683,31 @@ describe('AbstentionPrompt default carries the anti-invention licence', () => {
 
   it('ships as the AbstentionPrompt setting default (no drift between const and setting)', () => {
     expect(settingsMap.AbstentionPrompt.defaultValue).toBe(ABSTENTION_PROMPT);
+  });
+});
+
+describe('WebSearchFreshnessPrompt default tells the model when to search', () => {
+  // The measured failure it exists to fix is under-SELECTION, not weak search: web_search was
+  // offered on every turn of a 200-question internal eval and called on 16% of them, and the
+  // tool prompt instructed the model about clock time and chess and nothing about staleness.
+  // Two clauses carry the whole effect, so pin both.
+  it('directs the model to search before answering a time-sensitive question', () => {
+    expect(WEB_SEARCH_FRESHNESS_PROMPT).toMatch(/web_search/);
+    expect(WEB_SEARCH_FRESHNESS_PROMPT).toMatch(/training data has a cutoff/i);
+  });
+
+  // Without the negative clause the nudge over-triggers and every turn pays for a search it did
+  // not need; on the same eval it held the rate to 31% on questions with nothing to look up.
+  it('names the cases that do NOT need a search', () => {
+    expect(WEB_SEARCH_FRESHNESS_PROMPT).toMatch(/do not need to search/i);
+  });
+
+  it('requires an as-of date on any time-sensitive fact it reports', () => {
+    expect(WEB_SEARCH_FRESHNESS_PROMPT).toMatch(/as of/i);
+  });
+
+  it('ships as the WebSearchFreshnessPrompt setting default (no drift between const and setting)', () => {
+    expect(settingsMap.WebSearchFreshnessPrompt.defaultValue).toBe(WEB_SEARCH_FRESHNESS_PROMPT);
   });
 });
 

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -147,9 +147,11 @@ export const ABSTENTION_PROMPT = `When a request is underspecified or your sourc
  * Default text for the web-search freshness nudge, and the `WebSearchFreshnessPrompt` admin
  * setting's default.
  *
- * Unlike ABSTENTION_PROMPT / ARTIFACT_EMISSION_PROMPT / HELP_CENTER_PROMPT, this is NOT a runtime
- * fallback: ChatCompletionProcess reads the setting 2-arg, so a cleared value stays '' and drops
- * the section instead of reverting here. That divergence is deliberate - this section has no
+ * Unlike ABSTENTION_PROMPT / ARTIFACT_EMISSION_PROMPT / HELP_CENTER_PROMPT, this setting
+ * distinguishes an absent row from a cleared one. ChatCompletionProcess reads it 2-arg, so an
+ * absent row still falls back to this constant as the setting's registered default, but a cleared
+ * '' is returned verbatim and drops the section rather than reverting. The siblings are read 3-arg
+ * and collapse both cases to the constant. That divergence is deliberate - this section has no
  * companion boolean, so clearing the field is the only off switch it has. Keep the setting's
  * description in sync with that if either changes.
  *

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -143,11 +143,24 @@ export const HELP_CENTER_PROMPT = `HELP CENTER: Bike4Mind has a built-in Help Ce
  */
 export const ABSTENTION_PROMPT = `When a request is underspecified or your sources do not cover it, say so and name what is missing. "I do not have enough to answer that" is a correct, high-value answer. Never invent facts about the user, their business, or their data, and never state a specific customer, competitor, deal, or figure as fact - or cite a source for it - unless your sources support it, even when the question assumes it.`;
 
+/**
+ * Default text for the web-search freshness nudge, and the `WebSearchFreshnessPrompt` admin
+ * setting's default.
+ *
+ * Unlike ABSTENTION_PROMPT / ARTIFACT_EMISSION_PROMPT / HELP_CENTER_PROMPT, this is NOT a runtime
+ * fallback: ChatCompletionProcess reads the setting 2-arg, so a cleared value stays '' and drops
+ * the section instead of reverting here. That divergence is deliberate - this section has no
+ * companion boolean, so clearing the field is the only off switch it has. Keep the setting's
+ * description in sync with that if either changes.
+ *
+ * Names no tool but `web_search`: the section is gated on web_search being offered, and web_fetch
+ * is an independent toggle that may well be off.
+ */
 export const WEB_SEARCH_FRESHNESS_PROMPT = `# WEB SEARCH AND FRESHNESS
 
 Your training data has a cutoff. The current date is supplied to you in this conversation's system context - treat it as authoritative, and assume anything time-sensitive may have changed since your training.
 
-Call \`web_search\` BEFORE answering when the answer depends on a fact that changes over time: current prices or rates, product availability or roadmap status, funding, organizational or personnel changes, published benchmarks or performance figures, competitive positioning, or anything the user frames as "current", "latest", "now", or "as of today". When a stale answer would mislead, search instead of answering from memory. Use \`web_fetch\` to read a specific page that a search surfaces or that the user names.
+Call \`web_search\` BEFORE answering when the answer depends on a fact that changes over time: current prices or rates, product availability or roadmap status, funding, organizational or personnel changes, published benchmarks or performance figures, competitive positioning, or anything the user frames as "current", "latest", "now", or "as of today". When a stale answer would mislead, search instead of answering from memory. When a search surfaces a specific page that matters, or the user names one, read that page directly rather than answering from the snippet.
 
 You do not need to search for stable knowledge (definitions, mathematics, established theory), or for questions answerable purely from this conversation or from documents already retrieved for you.
 
@@ -2430,7 +2443,7 @@ export const settingsMap = {
     name: 'Web Search Freshness Prompt',
     defaultValue: WEB_SEARCH_FRESHNESS_PROMPT,
     description:
-      'System prompt telling the model when to reach for web_search rather than answer from training data, and to state the as-of date of any time-sensitive fact. Injected only when the web_search tool is enabled for the request - a model instructed to search without a search tool tends to claim it searched. Live-editable; clearing it reverts to the built-in default. After an upgrade, diff a saved copy against that default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since.',
+      'System prompt telling the model when to reach for web_search rather than answer from training data, and to state the as-of date of any time-sensitive fact. Injected only when the web_search tool is offered for the request - a model instructed to search without a search tool tends to claim it searched. Clearing this field turns the section OFF rather than restoring the built-in default, and it is the only off switch this section has; to get the stock wording back, paste it in. A change is not instantaneous: the settings cache is per-instance, so it applies immediately on the instance that served the change and within ~5 min (one cache TTL) everywhere else. After an upgrade, diff a saved copy against the built-in default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since.',
     category: 'AI',
     order: 12,
   }),

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -143,6 +143,16 @@ export const HELP_CENTER_PROMPT = `HELP CENTER: Bike4Mind has a built-in Help Ce
  */
 export const ABSTENTION_PROMPT = `When a request is underspecified or your sources do not cover it, say so and name what is missing. "I do not have enough to answer that" is a correct, high-value answer. Never invent facts about the user, their business, or their data, and never state a specific customer, competitor, deal, or figure as fact - or cite a source for it - unless your sources support it, even when the question assumes it.`;
 
+export const WEB_SEARCH_FRESHNESS_PROMPT = `# WEB SEARCH AND FRESHNESS
+
+Your training data has a cutoff. The current date is supplied to you in this conversation's system context - treat it as authoritative, and assume anything time-sensitive may have changed since your training.
+
+Call \`web_search\` BEFORE answering when the answer depends on a fact that changes over time: current prices or rates, product availability or roadmap status, funding, organizational or personnel changes, published benchmarks or performance figures, competitive positioning, or anything the user frames as "current", "latest", "now", or "as of today". When a stale answer would mislead, search instead of answering from memory. Use \`web_fetch\` to read a specific page that a search surfaces or that the user names.
+
+You do not need to search for stable knowledge (definitions, mathematics, established theory), or for questions answerable purely from this conversation or from documents already retrieved for you.
+
+When you report a time-sensitive fact, state what it is as of - the date of the source you used - and say plainly when you could not verify something and are answering from training data instead. Never present an unverified recollection as a current fact.`;
+
 /**
  * Default text for the formatting system message. Runtime fallback used by
  * `includeHardcodedSystemMessage` (b4m-core/utils/src/llm/utils.ts) when the `FormatPromptTemplate`
@@ -177,6 +187,7 @@ export const SettingKeySchema = z.enum([
   'ArtifactEmissionPrompt',
   'HelpCenterPrompt',
   'AbstentionPrompt',
+  'WebSearchFreshnessPrompt',
   'UseFormatPrompt',
   'EnableQuestMaster',
   'EnableQuestMasterDefault',
@@ -1429,6 +1440,7 @@ export const API_SERVICE_GROUPS = {
       { key: 'ArtifactEmissionPrompt', order: 9 },
       { key: 'HelpCenterPrompt', order: 10 },
       { key: 'AbstentionPrompt', order: 11 },
+      { key: 'WebSearchFreshnessPrompt', order: 12 },
     ],
   },
   EMBEDDING: {
@@ -2412,6 +2424,15 @@ export const settingsMap = {
       'Short system prompt licensing the model to say "I do not have enough to answer that" and to name what is missing instead of inventing facts about the user or their data. Injected on every chat completion. Live-editable; clearing it reverts to the built-in default. After an upgrade, diff a saved copy against that default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since.',
     category: 'AI',
     order: 11,
+  }),
+  WebSearchFreshnessPrompt: makeStringSetting({
+    key: 'WebSearchFreshnessPrompt',
+    name: 'Web Search Freshness Prompt',
+    defaultValue: WEB_SEARCH_FRESHNESS_PROMPT,
+    description:
+      'System prompt telling the model when to reach for web_search rather than answer from training data, and to state the as-of date of any time-sensitive fact. Injected only when the web_search tool is enabled for the request - a model instructed to search without a search tool tends to claim it searched. Live-editable; clearing it reverts to the built-in default. After an upgrade, diff a saved copy against that default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since.',
+    category: 'AI',
+    order: 12,
   }),
   UseFormatPrompt: makeBooleanSetting({
     key: 'UseFormatPrompt',

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -2783,7 +2783,10 @@ export class ChatCompletionProcess {
         hasContentTransform: hasContentTransform && blogDraftAvailable,
         hasChessEngine: enabledTools.includes('chess_engine'),
         hasCurrentDateTime: enabledTools.includes('current_datetime'),
-        hasWebSearch: enabledTools.includes('web_search'),
+        // Unlike the two lines above, web_search is key-gated (GATED_TOOLS in toolAvailability.ts)
+        // and can be dropped from the built schemas while the requested list still carries it, so
+        // this reads the offered set for the same reason blog_draft and navigate_view do above.
+        hasWebSearch: offeredToolNames.includes('web_search'),
         webSearchGuidance: getSettingsValue('WebSearchFreshnessPrompt', defaultAdminSettings),
         userTimezone,
         mcpTools: directMcpTools,

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -2783,6 +2783,8 @@ export class ChatCompletionProcess {
         hasContentTransform: hasContentTransform && blogDraftAvailable,
         hasChessEngine: enabledTools.includes('chess_engine'),
         hasCurrentDateTime: enabledTools.includes('current_datetime'),
+        hasWebSearch: enabledTools.includes('web_search'),
+        webSearchGuidance: getSettingsValue('WebSearchFreshnessPrompt', defaultAdminSettings),
         userTimezone,
         mcpTools: directMcpTools,
         sessionId,

--- a/b4m-core/services/src/llm/tools/ToolBuilder.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.ts
@@ -319,6 +319,12 @@ export interface BuildToolPromptArgs {
   hasContentTransform: boolean;
   hasChessEngine: boolean;
   hasCurrentDateTime: boolean;
+  hasWebSearch: boolean;
+  /**
+   * Resolved `WebSearchFreshnessPrompt` setting. Resolved by the caller, which owns the
+   * settings reader, so the injected text and its telemetry cannot disagree.
+   */
+  webSearchGuidance?: string;
   /**
    * User's IANA timezone (from the browser) when known, so the current-time
    * nudge can tell the model which timezone to pass to `current_datetime`.
@@ -921,6 +927,8 @@ export class ToolBuilder {
     hasContentTransform,
     hasChessEngine,
     hasCurrentDateTime,
+    hasWebSearch,
+    webSearchGuidance,
     userTimezone,
     mcpTools,
     sessionId,
@@ -1042,6 +1050,13 @@ Both calls happen in the same response — do NOT ask the user to repeat their m
           `For the current time of day, or to timestamp an action at the moment it executes, ` +
           `call the \`current_datetime\` tool — never guess or invent the time.${timezoneHint}`
       );
+    }
+
+    // 3c. Web-search freshness nudge. Gated on the tool actually being enabled: the ambient
+    // date context tells the model what today is, but nothing otherwise tells it when its own
+    // knowledge is too old to answer from.
+    if (hasWebSearch && webSearchGuidance) {
+      sections.push(webSearchGuidance);
     }
 
     // 4. MCP integration guidance (if MCP tools are available)

--- a/b4m-core/services/src/llm/tools/ToolBuilder.webSearchFreshness.test.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.webSearchFreshness.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ToolBuilder, type ToolBuilderConfig } from './ToolBuilder';
+
+/**
+ * The freshness nudge is gated on `web_search` actually being enabled for the request. A model
+ * told to search without a search tool tends to claim it searched, so the gate is the point of
+ * the feature and not an optimization. The wording itself is admin-editable
+ * (`WebSearchFreshnessPrompt`), and clearing that setting must drop the section entirely rather
+ * than inject an empty heading.
+ */
+describe('buildToolPrompt web-search freshness section', () => {
+  const GUIDANCE = '# WEB SEARCH AND FRESHNESS\n\nsearch when the answer can go stale.';
+
+  function makeBuilder(): ToolBuilder {
+    return new ToolBuilder({
+      user: { id: 'u1' },
+      db: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), updateMetadata: vi.fn() },
+      storage: {},
+      imageGenerateStorage: {},
+      toolCreditsMap: new Map(),
+      subagentTelemetryData: [],
+      sendStatusUpdate: vi.fn(),
+    } as unknown as ToolBuilderConfig);
+  }
+
+  async function build(overrides: { hasWebSearch: boolean; webSearchGuidance?: string }) {
+    return makeBuilder().buildToolPrompt({
+      hasContentTransform: false,
+      hasChessEngine: false,
+      hasCurrentDateTime: false,
+      mcpTools: [],
+      sessionId: 's1',
+      message: 'what is the current price',
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      processStartTime: Date.now(),
+      ...overrides,
+    });
+  }
+
+  it('injects the guidance when web_search is enabled', async () => {
+    const msg = await build({ hasWebSearch: true, webSearchGuidance: GUIDANCE });
+    expect(msg?.content).toContain('WEB SEARCH AND FRESHNESS');
+  });
+
+  // Every other section is switched off here, so a correctly gated build contributes no
+  // sections at all and buildToolPrompt returns null. Asserting on null rather than on the
+  // absence of the heading is what catches a guard that pushes an empty section.
+  it('omits it when web_search is not enabled', async () => {
+    const msg = await build({ hasWebSearch: false, webSearchGuidance: GUIDANCE });
+    expect(msg).toBeNull();
+  });
+
+  it('omits it when the admin setting has been cleared', async () => {
+    const msg = await build({ hasWebSearch: true, webSearchGuidance: '' });
+    expect(msg).toBeNull();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`buildToolPrompt` tells the model how to timestamp an action and gives it seven rules for playing chess. It says nothing about when its own training data is too old to answer from.

The effect is measurable. On a 200-question internal eval, `web_search` and `web_fetch` were offered on **all 200 turns and called on 32** (16%); **153 of 200 turns called no tool at all**, with 12 tools available. Splitting the recency score by whether the turn actually searched:

| | n | recency |
|---|---|---|
| turn called `web_search`/`web_fetch` | 32 | **0.731** |
| turn called no web tool | 168 | **0.375** |

A native-web-search baseline on the same bank and date scores 0.776. So our search is not weaker than native when it fires - it is not being selected. The model is even handed the current date already (the `dateTimeContext` system message in `ChatCompletionProcess`), so it has what it needs to know it should search, and no instruction to.

This adds the missing instruction.

## Changes

- **`WEB_SEARCH_FRESHNESS_PROMPT`** in `settings.ts`: tells the model to search before answering when the answer turns on a fact that changes over time, names the cases that do **not** need a search, and requires an as-of date on any time-sensitive fact it reports. It names `web_search` and no other tool: `web_fetch` is an independent toggle that may be off, and the section is not gated on it.
- **`WebSearchFreshnessPrompt`** admin setting (category AI, order 12), so the wording is retunable without a deploy. Deliberately **not** the sibling pattern: `ArtifactEmissionPrompt` / `AbstentionPrompt` are read 3-arg so clearing them reverts to the built-in default, whereas this one is read 2-arg and clearing **turns the section off**. That is intentional - it has no companion boolean, so clearing is the only off switch it has. The tradeoff is that there is no UI path back to the default wording; you paste it in. The setting description and a docblock on the constant both record this.
- **`buildToolPrompt` section 3c**, gated on `hasWebSearch`. The gate is the point, not an optimization: a model instructed to search without a search tool tends to claim it searched. It reads the **offered** tool list (`offeredToolNames`), not the requested one - `web_search` is key-gated, so a keyless deploy or a transient availability-lookup failure can drop it from the schemas while the request still carries it.
- Call site in `ChatCompletionProcess` resolves the setting and passes it in, so the injected text and its telemetry cannot disagree.
- Tests in both packages. The `ToolBuilder` ones were mutation-checked: dropping the `hasWebSearch` gate and weakening the cleared-setting guard each fail exactly one named test.

## Measured effect

Paired per question against an otherwise byte-identical arm (same bank, tools, model, judge; the only difference is this text):

| | treatment | control | paired delta |
|---|---|---|---|
| quality score | **81.5** | 77.4 | **+4.06** [+1.40, +6.72] SIG |
| recency | 0.724 | 0.469 | **+0.255** SIG |
| caveat fidelity | - | - | **+0.112** SIG |
| search rate | **58.7%** | 16.0% | |
| zero-tool turns | 81/196 | 153/200 | |
| provider cost | $9.65 | $8.72 | +11% |

That closes the gap to the native-web baseline (81.0) to +0.41, ns - from -3.65, SIG.

**The don't-search clause is load-bearing.** Search rate by question type: 83% where the answer turns on a current fact, 31% where there is nothing time-sensitive to look up. It discriminates rather than blanket-searching, which is why cost moved 11% instead of several fold, and why the formulation dimensions were undisturbed: `objective_correctness` -0.042, `constraint_coverage` +0.003, `decision_variables` -0.014, `family_classification` 0.000, none significant. Read that as no regression detected, not zero - the intervals bound a worst case near -0.13 on the widest.

Four honesty notes on the measurement. The eval delivered this text by prepending to the user message, which is the only channel that harness has; this PR ships it as a system-role section, which should do at least as well but was not the thing measured. The eval also injected the text unconditionally, on every turn, while the shipped section fires only when `web_search` survives into the built tool schemas; gating can only reduce how often it fires, so on that axis the shipped effect is bounded above by the measured one, and the channel change moves independently of it. That is what makes "offered on all 200 turns" above load-bearing rather than incidental. And the bank is single-turn, so a long multi-turn session could accumulate searches differently - which is the argument for it being a tunable setting. Third: review removed the one sentence naming `web_fetch`, so the shipped text is one sentence shorter than the arm that was measured. The eval did not isolate that sentence and the primary directive is untouched, but the measured text and the shipped text are no longer byte-identical.


### Fatal verdicts moved in both directions

The table above is aggregate. The judge's fatal flag is not, and it is the number that decides whether a bad answer reaches a user. Set-diffed per question across the two arms, fatals went **16 -> 12 of 200**: nine the change fixed, five it introduced, seven fatal under both. The rescues are much larger than the regressions (mean quality delta +50.6 on the nine, -14.0 on the five), so the net of four fewer fatal answers is the honest summary and the change is still a clear win.

The five new ones are on the record here because they are not the failure mode this prompt was written against, and they do not share a single mechanism. Two invent specifics absent from the source material. Two contradict a fact supplied in the prompt itself, one of them by reporting a completed event as still pending - a staleness miss on this PR's own axis, not an over-specification. One overstates a provisional status as settled. What they do share is length: the newly fatal rows run far above their control counterparts, well past the +93 output tokens the change adds across the bank. The nudge buys a more assertive and more elaborated answer; on nine rows that rescued a catastrophic one, on five it produced a confidently wrong one. Whether that is the retrieved material inviting over-specification or the assertiveness the prompt itself buys is not resolved by this data, and neither is addressed by this PR - it is a grounding and fact-extraction question, the same one the closing note points at.

## Guide for Testers

1. Sign in to `app.staging.bike4mind.com` as an admin.
2. Start a new chat. Enable the **Web Search** tool for the session.
3. Send: `What is the current list price of the product you know least about?`
4. Expect the model to call web search before answering, and to state an as-of date for any figure it gives. It should not present an unverified recollection as a current fact.
5. Start another new chat. Leave **Web Search disabled**.
6. Send the same message.
7. Expect no search (none is available) and no claim of having searched. Expect it to say plainly that it cannot verify a current price.
8. Go to **Sidebar -> Admin -> Settings -> AI**. Confirm a **Web Search Freshness Prompt** field appears with default text beginning `# WEB SEARCH AND FRESHNESS`.
9. **Copy the field's text somewhere first**, then clear the field and save. Repeat steps 2-4.
10. Expect the model to behave as it did before this PR: it may answer from memory without searching. This confirms the setting is live and clearing it fully removes the section.
11. Restore it by **pasting the text from step 9 back in** and saving, then confirm step 4 behaviour returns. Clearing a second time does not restore the default - clearing is the off switch, and there is no UI path back to the built-in wording.

### Regression Checks

12. In a session with web search enabled, ask a question with nothing time-sensitive in it, e.g. `Explain the difference between a hard and a soft constraint.` Expect a direct answer with **no** web search - the nudge must not make every turn search.
13. Confirm the current-time nudge still works: ask `What time is it?` in a session with the date/time tool enabled and expect a tool call rather than a guess.

### What NOT to test

- No UI beyond the one admin settings field. No schema or migration changes.
- Do not judge answer quality by hand; the numbers above come from the eval harness.

## Additional Information

Follow-on from the retrieval and grounding work in #2494 - #2497. The remaining gap to the grounded-cards ceiling on this bank is -7.28 and is now led by caveat fidelity and fact accuracy, which is a fact-extraction question rather than a prompt one.

## Developer Notes (Optional)

- **New extension point**: `buildToolPrompt` now takes a caller-resolved prompt string alongside a capability flag. That is the pattern to copy for any future per-tool guidance - keep the settings read at the call site so one resolution feeds both the prompt and its telemetry.
- **Reusable pattern**: gate tool guidance on the tool actually being enabled. Guidance for an absent tool does not merely waste tokens, it induces the model to claim it used the tool.



