### PR TITLE
feat(publish): add Save as PDF to the public artifact viewer

### DIFF
--- a/apps/client/app/utils/printToPdf.ts
+++ b/apps/client/app/utils/printToPdf.ts
@@ -14,7 +14,11 @@
  * cross-origin frame's `print()`, the trigger lives inside the frame and reports
  * back over `postMessage` so we can reclaim the node.
  *
- * Owner-path only. The public viewer footers stay CSP-locked (see publishExport.ts).
+ * This is the OWNER path, and it prints a FRESH render of the HTML export. The public
+ * viewer offers its own "Save as PDF" by a different route - it prints the artifact frame
+ * that is already on screen, so live interactive state survives (server/services/publish/
+ * printBridge.ts plus the button binder in pages/api/publish/widget.ts). The CSP-locked
+ * reply/fabfile footers still cannot offer either (see publishExport.ts).
  */
 
 const COMPLETE = 'b4m-print-complete';

--- a/apps/client/app/utils/publishExport.ts
+++ b/apps/client/app/utils/publishExport.ts
@@ -8,11 +8,12 @@
  * data helpers with no imports beyond the escaper - the serve surfaces run under
  * `script-src 'none'`, so anything here must work with zero JS.
  *
- * PDF is not a server `?export=` format: it is produced client-side on the owner
- * path (the Published tab) by printing the HTML export from an isolated sandboxed
- * frame - see printToPdf.ts. The CSP-locked viewer footers still cannot offer it
- * (the reply/fabfile page is served `script-src 'none'`, and the bundle wrapper's
- * script-src admits only the comment widget), so PDF stays owner-only.
+ * PDF is not a server `?export=` format: it is always produced client-side by the
+ * browser's print dialog. Two paths, neither of them a footer link here - the owner
+ * path prints a fresh render of the HTML export from an isolated sandboxed frame (see
+ * printToPdf.ts), and the public bundle wrapper prints the artifact frame in place via
+ * the first-party widget (pages/api/publish/widget.ts). The reply/fabfile footers still
+ * cannot offer PDF at all: that page is served `script-src 'none'`.
  */
 
 import { escapeAttr } from './htmlEscape';

--- a/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
@@ -487,6 +487,20 @@ describe('publish widget - Save as PDF binder', () => {
     expect(post).not.toHaveBeenCalled();
   });
 
+  it('does not hijack the shortcut while typing in the comment box', () => {
+    const { post } = mountWrapper('b4m-bar-print');
+    const box = document.createElement('textarea');
+    document.body.appendChild(box);
+
+    eval(widgetSource());
+    // macOS: Ctrl+P inside a text field is cursor-up, not print.
+    const ctrl = new KeyboardEvent('keydown', { key: 'p', ctrlKey: true, bubbles: true, cancelable: true });
+    box.dispatchEvent(ctrl);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(ctrl.defaultPrevented).toBe(false);
+  });
+
   it('does not throw on a wrapper with no iframe at all', () => {
     document.body.innerHTML = '<button class="b4m-bar-print" type="button" hidden></button>';
 

--- a/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
@@ -411,3 +411,86 @@ describe('publish comment widget - credential path', () => {
     expect(tokenGeneration).toBe(2); // re-exchanged rather than dead-ending
   });
 });
+
+/**
+ * The "Save as PDF" binder. It ships in the same file as the comment overlay because the
+ * Approach-B wrapper CSP admits exactly one script - so the binder must survive the
+ * overlay's early return on an artifact that has comments turned off, which is the case
+ * these cover. It never touches the network, hence no fetch stub here.
+ */
+describe('publish widget - Save as PDF binder', () => {
+  let docListeners: Array<[string, EventListener]> = [];
+  const realDocumentAdd = document.addEventListener.bind(document);
+
+  beforeEach(() => {
+    docListeners = [];
+    document.addEventListener = ((type: string, fn: EventListener, opts?: AddEventListenerOptions) => {
+      docListeners.push([type, fn]);
+      realDocumentAdd(type, fn, opts);
+    }) as typeof document.addEventListener;
+  });
+
+  afterEach(() => {
+    docListeners.forEach(([type, fn]) => document.removeEventListener(type, fn));
+    document.addEventListener = realDocumentAdd as typeof document.addEventListener;
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  /** A wrapper with the print button and NO annotate root - comments off. */
+  function mountWrapper(buttonClass: string): { button: HTMLButtonElement; post: ReturnType<typeof vi.fn> } {
+    document.body.innerHTML = `<button class="${buttonClass}" type="button" hidden>Save as PDF</button><iframe></iframe>`;
+    const frame = document.querySelector('iframe') as HTMLIFrameElement;
+    const post = vi.fn();
+    (frame.contentWindow as Window).postMessage = post as unknown as Window['postMessage'];
+    return { button: document.querySelector(`.${buttonClass}`) as HTMLButtonElement, post };
+  }
+
+  it('reveals the bar button and asks the frame to print itself on click', () => {
+    const { button, post } = mountWrapper('b4m-bar-print');
+
+    eval(widgetSource());
+
+    expect(button.hidden).toBe(false); // server ships it hidden; JS is what makes it real
+    button.click();
+
+    expect(post).toHaveBeenCalledWith({ b4m: 'print' }, '*');
+  });
+
+  it('binds the floating variant the same way', () => {
+    const { button, post } = mountWrapper('b4m-print');
+
+    eval(widgetSource());
+    button.click();
+
+    expect(button.hidden).toBe(false);
+    expect(post).toHaveBeenCalledWith({ b4m: 'print' }, '*');
+  });
+
+  it('claims Cmd+P on the wrapper, which would otherwise print the clipped frame', () => {
+    const { post } = mountWrapper('b4m-bar-print');
+
+    eval(widgetSource());
+    const meta = new KeyboardEvent('keydown', { key: 'p', metaKey: true, bubbles: true, cancelable: true });
+    document.dispatchEvent(meta);
+
+    expect(post).toHaveBeenCalledWith({ b4m: 'print' }, '*');
+    expect(meta.defaultPrevented).toBe(true);
+  });
+
+  it('leaves a plain p keypress alone', () => {
+    const { post } = mountWrapper('b4m-bar-print');
+
+    eval(widgetSource());
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p', bubbles: true, cancelable: true }));
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('does not throw on a wrapper with no iframe at all', () => {
+    document.body.innerHTML = '<button class="b4m-bar-print" type="button" hidden></button>';
+
+    expect(() => eval(widgetSource())).not.toThrow();
+    expect((document.querySelector('.b4m-bar-print') as HTMLButtonElement).hidden).toBe(true);
+  });
+});

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -101,6 +101,12 @@ import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
  * iframe srcdoc; `renderViewerPage` carries a `script-src 'none'` CSP meta so it stays
  * script-free inside the shell's sandboxed iframe.
  *
+ * Printing: the browser's own File > Print on this wrapper paginates only the iframe's visible
+ * first screen, so "Save as PDF" prints the FRAME's live document instead - `VIEWER_SANDBOX`
+ * carries `allow-modals` (without it `print()` is a silent no-op in a sandbox), every render
+ * carries the in-frame trigger (`printBridge.ts`), and the wrapper button that asks for it
+ * lives in the widget, the only script the Approach-B wrapper CSP admits.
+ *
  * Outbound links: a framed render (shelled or not, public or gated) obeys the iframe sandbox,
  * and framing another origin stays refused by `frame-src`. So `VIEWER_SANDBOX` carries
  * `allow-popups`/`allow-popups-to-escape-sandbox` and `renderSandboxedBundle` retargets a
@@ -924,8 +930,11 @@ function liveryBarMark(brandName: string): string {
 }
 
 /**
- * Minimal trusted wrapper page hosting the bundle in an iframe. Runs no script of
- * its own (besides the comment overlay). Two isolation modes:
+ * Minimal trusted wrapper page hosting the bundle in an iframe. Its only script is the
+ * first-party widget (`/api/publish/widget`), which binds the comment overlay when the
+ * artifact has comments and, on every non-embed wrapper, the "Save as PDF" button - the
+ * button asks the frame to print ITSELF, because printing the wrapper captures only the
+ * frame's visible first screen. Two isolation modes:
  *   - Approach B (`isolatedSrc` set): a CROSS-ORIGIN `<iframe src={isolatedSrc}>` to
  *     `{publicId}.usercontent.app.<domain>`. The separate origin is the isolation boundary;
  *     `allow-same-origin` is SAFE here (resolves to the usercontent origin, not the app).
@@ -974,6 +983,10 @@ function renderBundleWrapper(
   // The comment overlay lives in this trusted wrapper (app origin), floating over the
   // sandboxed iframe - never inside it (the opaque-origin bundle can't read the token).
   const overlay = buildAnnotateOverlayHtml(artifact);
+  // The one script on the wrapper, and the only one the Approach-B wrapper CSP admits.
+  // Emitted for every non-embed render, not just commented ones: it also binds "Save as
+  // PDF" (the mount node above stays conditional, and the widget no-ops without it).
+  const widgetScript = embed ? '' : `\n<script src="/api/publish/widget" defer></script>`;
   // Abuse-report affordance: a plain anchor floats over the iframe. It is a
   // top-level navigation (not blocked by the wrapper's script-src/form-action CSP) to
   // the app-origin report flow. The bundle in the opaque-origin iframe can't reach it.
@@ -992,8 +1005,9 @@ function renderBundleWrapper(
   //   - embed (chrome-less): a small floating "Built with {brand}" pill.
   //   - own-tab open-public: a persistent bottom bar with a "Try {brand}" CTA
   //     (Anthropic-style); the iframe is shortened so the bar covers nothing.
-  // Both are top-level links (CSP-safe, no JS). barPresent also relocates the Report
-  // affordance INTO the bar and lifts the version switcher above it.
+  // Both are top-level links (CSP-safe, no JS); only "Save as PDF" alongside them needs
+  // the widget. barPresent also relocates the Report affordance INTO the bar and lifts
+  // the version switcher above it.
   const brandBadge =
     embed && pillHref && brandName
       ? `\n<a class="b4m-brand" href="${escapeHtml(pillHref)}" rel="noopener" target="_top">Built with ${escapeHtml(
@@ -1002,14 +1016,18 @@ function renderBundleWrapper(
       : '';
   const barPresent = !embed && !!barHref && !!brandName;
   // Plain top-level `download` anchor - no JS, so it works under the tightened
-  // Approach-B wrapper CSP (script-src admits only the comment widget).
+  // Approach-B wrapper CSP (script-src admits only the first-party widget).
   const barExport = exportHtmlHref
     ? `\n    <a class="b4m-bar-export" href="${escapeHtml(exportHtmlHref)}" download target="_top">Save as HTML</a>`
     : '';
+  // "Save as PDF" prints the LIVE frame document via the widget, so unlike `?export=` it
+  // needs no re-authorization and rides along on every own-tab render. `hidden` until the
+  // widget binds it - a button that does nothing without JS is worse than no button.
+  const barPrint = `\n    <button class="b4m-bar-print" type="button" hidden>Save as PDF</button>`;
   const bar = barPresent
     ? `\n<div class="b4m-bar">
   <span class="b4m-bar-l">Built with ${liveryBarMark(brandName)}${LIVERY_REG}</span>
-  <span class="b4m-bar-r">${barExport}
+  <span class="b4m-bar-r">${barPrint}${barExport}
     <a class="b4m-bar-report" href="${reportHref}" rel="nofollow" target="_top">Report</a>
     <a class="b4m-bar-cta" href="${escapeHtml(
       barHref
@@ -1020,9 +1038,10 @@ function renderBundleWrapper(
   const floatingExport = exportHtmlHref
     ? `<a class="b4m-export" href="${escapeHtml(exportHtmlHref)}" download target="_top">&#8681; HTML</a>`
     : '';
+  const floatingPrint = embed ? '' : `<button class="b4m-print" type="button" hidden>&#8681; PDF</button>`;
   const floatingReport = barPresent
     ? ''
-    : `\n<div class="b4m-actions">${floatingExport}<a class="b4m-report" href="${reportHref}" rel="nofollow" target="_top">&#9873; Report</a></div>`;
+    : `\n<div class="b4m-actions">${floatingPrint}${floatingExport}<a class="b4m-report" href="${reportHref}" rel="nofollow" target="_top">&#9873; Report</a></div>`;
   const iframeHeight = barPresent ? 'calc(100vh - 52px)' : '100vh';
 
   return `<!doctype html>
@@ -1033,9 +1052,11 @@ function renderBundleWrapper(
 <title>${titleHtml}</title>${metaHead}
 <style>html,body{margin:0;padding:0;height:100%}iframe{border:0;display:block;width:100%;height:${iframeHeight}}
 .b4m-actions{position:fixed;bottom:10px;right:10px;z-index:2147483647;display:flex;gap:8px}
-.b4m-report,.b4m-export{font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
+.b4m-report,.b4m-export,.b4m-print{font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
   color:#cbd5e1;background:rgba(13,24,48,.78);padding:5px 9px;border-radius:8px;text-decoration:none;backdrop-filter:blur(4px)}
-.b4m-report:hover,.b4m-export:hover{color:#fff;background:rgba(13,24,48,.95)}
+.b4m-print{border:0;cursor:pointer}
+.b4m-report:hover,.b4m-export:hover,.b4m-print:hover{color:#fff;background:rgba(13,24,48,.95)}
+.b4m-bar-print[hidden],.b4m-print[hidden]{display:none}
 .b4m-brand{position:fixed;bottom:10px;left:10px;z-index:2147483647;font:600 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
   color:#fff;background:${LIVERY_ORANGE};padding:6px 11px;border-radius:8px;text-decoration:none;box-shadow:0 2px 10px rgba(0,0,0,.28)}
 .b4m-brand:hover{filter:brightness(1.07)}
@@ -1048,8 +1069,9 @@ function renderBundleWrapper(
 .b4m-bar-logo svg{height:22px;width:auto;display:block}
 .b4m-reg{font-size:.62em;vertical-align:super;font-weight:400;margin-left:1px}
 .b4m-bar-r{display:flex;align-items:center;gap:14px}
-.b4m-bar-report,.b4m-bar-export{color:#94a3b8;text-decoration:none;font-weight:500;font-size:12px}
-.b4m-bar-report:hover,.b4m-bar-export:hover{color:#cbd5e1}
+.b4m-bar-report,.b4m-bar-export,.b4m-bar-print{color:#94a3b8;text-decoration:none;font-weight:500;font-size:12px}
+.b4m-bar-print{background:none;border:0;padding:0;cursor:pointer;font-family:inherit}
+.b4m-bar-report:hover,.b4m-bar-export:hover,.b4m-bar-print:hover{color:#cbd5e1}
 .b4m-bar-cta{padding:8px 14px;border-radius:9px;background:${LIVERY_ORANGE};color:#fff;font-weight:700;text-decoration:none;white-space:nowrap}
 .b4m-bar-cta:hover{filter:brightness(1.07)}
 .b4m-ver{position:fixed;bottom:${barPresent ? '62px' : '10px'};left:10px;z-index:2147483647;display:flex;align-items:center;gap:8px;
@@ -1059,7 +1081,7 @@ function renderBundleWrapper(
 .b4m-ver .b4m-vd{opacity:.4}</style>
 </head>
 <body>
-${iframeTag}${hashBridge}${chromeBody}${brandBadge}${floatingReport}${bar}
+${iframeTag}${hashBridge}${chromeBody}${brandBadge}${floatingReport}${bar}${widgetScript}
 ${noscriptBody}
 </body>
 </html>`;
@@ -1171,10 +1193,10 @@ function buildWrapperCsp(req: Request, artifactHost?: string, embedOrigins: stri
   const appHostSrc = appHost ? ` ${appHost}` : '';
   // blessed libs at both the document origin and the canonical app host.
   const blessedScriptSrc = buildBundleScriptSrc(req.headers.host, req.headers['x-forwarded-proto']);
-  // The trusted comment-overlay widget loads from /api/publish/widget on the app origin
-  // (and doc origin for preview/staging hosts). Allowlisted explicitly - it runs in the
-  // wrapper (parent), never the sandboxed bundle. The app-host variant is added only when
-  // PUBLISH_HOST is configured.
+  // The trusted first-party widget (comment overlay + the Save as PDF button) loads from
+  // /api/publish/widget on the app origin (and doc origin for preview/staging hosts).
+  // Allowlisted explicitly - it runs in the wrapper (parent), never the sandboxed bundle.
+  // The app-host variant is added only when PUBLISH_HOST is configured.
   const widgetSrc = `${docOrigin}/api/publish/widget${appHost ? ` ${appHost}/api/publish/widget` : ''}`;
   // script-src: in Approach B (artifactHost set) the bundle runs on its OWN cross-origin
   // iframe, so the wrapper carries NO inline scripts and NO bundle libs - tighten to just the
@@ -1585,10 +1607,11 @@ ${footer}
 }
 
 /**
- * Build the comment-overlay mount node + trusted widget script tag, injected into
- * the WRAPPER page (app origin) - config passed via data-* attributes. Returns ''
- * when commentPolicy is `none` so opt-out artifacts get no widget. escapeHtml is
- * shared from viewerSecurity.
+ * Build the comment-overlay MOUNT NODE for the WRAPPER page (app origin) - config passed
+ * via data-* attributes. Returns '' when commentPolicy is `none`, which is what opts an
+ * artifact out: the widget script itself now ships on every non-embed wrapper (it also
+ * binds "Save as PDF") and early-returns when this node is absent. escapeHtml is shared
+ * from viewerSecurity.
  */
 /**
  * Trusted pin-bridge script injected INTO the sandboxed bundle (the iframe srcdoc) when
@@ -1636,8 +1659,7 @@ function buildAnnotateOverlayHtml(artifact: PublishedArtifactLean): string {
   const title = escapeHtml(artifact.title || '');
   return (
     `<div id="b4m-annotate-root" data-public-id="${publicId}" ` +
-    `data-comment-policy="${policy}" data-title="${title}"></div>` +
-    `<script src="/api/publish/widget" defer></script>`
+    `data-comment-policy="${policy}" data-title="${title}"></div>`
   );
 }
 

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -2360,3 +2360,67 @@ describe('GET /api/publish/serve - export affordances on the viewer surfaces (is
     expect(res._getData() as string).not.toContain('?export=');
   });
 });
+
+describe('GET /api/publish/serve - Save as PDF', () => {
+  const bundleHtml = Buffer.from('<html><head></head><body><h1>Hi</h1></body></html>');
+
+  it('offers the bar button and ships the widget even with comments disabled', async () => {
+    // The button prints the LIVE frame, so it needs no re-authorization and is offered
+    // regardless of `?export=` eligibility. The widget is the only script the wrapper CSP
+    // admits, so it must ship for every non-embed wrapper, not just commented artifacts.
+    mockArtifactFindOne.mockReturnValue(bundle()); // no commentPolicy -> 'none'
+    mockDownload.mockResolvedValue(bundleHtml);
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('class="b4m-bar-print"');
+    expect(data).toContain('<script src="/api/publish/widget" defer></script>');
+    expect(data).not.toContain('b4m-annotate-root'); // the comment mount stays opt-in
+    // Shipped hidden: the widget reveals it, so no-JS viewers never see a dead button.
+    expect(data).toContain('<button class="b4m-bar-print" type="button" hidden>');
+    expect(res.getHeader('Content-Security-Policy')).toContain('/api/publish/widget');
+  });
+
+  it('offers the floating variant on a share-token view, which has no lead-gen bar', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ visibility: 'private' }));
+    mockDownload.mockResolvedValue(bundleHtml);
+
+    const { res, promise } = run(['a', 'tok123']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('<div class="b4m-actions">');
+    expect(data).toContain('class="b4m-print"');
+    expect(data).not.toContain('class="b4m-bar-print"');
+  });
+
+  it('drops the button AND the widget in chrome-less embed mode', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(bundleHtml);
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { embed: true });
+    await promise;
+
+    const data = res._getData() as string;
+    // Assert on the ELEMENTS - the CSS rules for these classes always ship in <style>.
+    expect(data).not.toContain('<button class="b4m-bar-print"');
+    expect(data).not.toContain('<button class="b4m-print"');
+    expect(data).not.toContain('/api/publish/widget');
+  });
+
+  it('puts the in-frame print trigger in the bundle document, not the wrapper', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(bundleHtml);
+
+    const wrapper = run(['u', 'scope123', 'my-slug']);
+    await wrapper.promise;
+    const isolated = run(['u', 'scope123', 'my-slug'], { uc: 'pub1' });
+    await isolated.promise;
+
+    // The wrapper cannot call print() on the frame, so the trigger rides inside it.
+    expect(isolated.res._getData() as string).toContain('window.print');
+    expect(wrapper.res._getData() as string).not.toContain('window.print');
+  });
+});

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -1,17 +1,25 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**
- * GET /api/publish/widget - the trusted comment-overlay widget, served as
- * first-party JavaScript from the app origin so the bundle CSP (`script-src
- * 'self'`) permits it. Injected into every served bundle by the serve handler.
+ * GET /api/publish/widget - the trusted wrapper-side script for published artifacts,
+ * served as first-party JavaScript from the app origin so the wrapper CSP permits it.
+ * It is the ONLY script the tightened Approach-B wrapper CSP admits (no 'unsafe-inline'
+ * there), which is why both features below live in this one file. The serve handler
+ * emits it on every non-embed wrapper.
  *
- * This is the ONLY author-facing JS that runs on a published bundle page -
- * author inline scripts are stripped at serve time. The widget therefore must
- * be self-contained vanilla JS (no framework) and build its DOM with
- * createElement/textContent (NEVER innerHTML on user data - comment bodies are
- * untrusted user input rendered on the app origin).
+ * Two independent parts, in order:
+ *  1. The PRINT binder - shows the wrapper's "Save as PDF" button and asks the artifact
+ *     frame to print ITSELF (printing the wrapper captures only the frame's visible first
+ *     screen). The in-frame half is server/services/publish/printBridge.ts. It runs for
+ *     every wrapper, including artifacts with comments turned off.
+ *  2. The comment overlay, which early-returns unless the #b4m-annotate-root mount node
+ *     is present - that node's absence is how an artifact opts out of comments.
  *
- * It runs in the WRAPPER page on the app origin (see buildAnnotateOverlayHtml in
+ * Self-contained vanilla JS (no framework), building its DOM with createElement/
+ * textContent - NEVER innerHTML on user data, since comment bodies are untrusted user
+ * input rendered on the app origin.
+ *
+ * It runs in the WRAPPER page on the app origin (see renderBundleWrapper in
  * serve/[...path].ts), never inside the sandboxed bundle iframe - which is what
  * makes the same-origin cookie exchange in `ensureToken` reachable at all.
  *
@@ -25,6 +33,35 @@ const WIDGET_POWERED_BY = process.env.APP_NAME ? `Powered by ${process.env.APP_N
 
 const WIDGET_JS = String.raw`(function () {
   'use strict';
+
+  // ---- "Save as PDF" ----
+  // Self-contained and FIRST, because the comment overlay below early-returns on an
+  // artifact with comments disabled and printing must still work there.
+  (function () {
+    var frame = document.querySelector('iframe');
+    if (!frame) return;
+    function requestPrint() {
+      // targetOrigin '*': in the srcdoc model the frame's origin is opaque, so no other
+      // value is deliverable. Safe because the message carries no data - it is a bare
+      // request - and the in-frame bridge validates the sender's source (and, on the
+      // isolated cross-origin embed, its origin) before acting on it.
+      try { frame.contentWindow.postMessage({ b4m: 'print' }, '*'); } catch (e) {}
+    }
+    var buttons = document.querySelectorAll('.b4m-bar-print,.b4m-print');
+    for (var i = 0; i < buttons.length; i++) {
+      buttons[i].addEventListener('click', requestPrint);
+      buttons[i].hidden = false; // server ships it hidden so there is no dead button without JS
+    }
+    // Claim the shortcut while focus is on the WRAPPER: the browser would otherwise print
+    // this page, which paginates only the frame's visible first screen.
+    document.addEventListener('keydown', function (e) {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+      if (e.key !== 'p' && e.key !== 'P') return;
+      e.preventDefault();
+      requestPrint();
+    });
+  })();
+
   var root = document.getElementById('b4m-annotate-root');
   if (!root) return;
   var publicId = root.getAttribute('data-public-id');

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -52,11 +52,16 @@ const WIDGET_JS = String.raw`(function () {
       buttons[i].addEventListener('click', requestPrint);
       buttons[i].hidden = false; // server ships it hidden so there is no dead button without JS
     }
+    function isEditing(t) {
+      return !!t && (t.isContentEditable === true || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName || ''));
+    }
     // Claim the shortcut while focus is on the WRAPPER: the browser would otherwise print
-    // this page, which paginates only the frame's visible first screen.
+    // this page, which paginates only the frame's visible first screen. Not while typing
+    // (the comment box): on macOS Ctrl+P is cursor-up inside a text field.
     document.addEventListener('keydown', function (e) {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== 'p' && e.key !== 'P') return;
+      if (isEditing(e.target)) return;
       e.preventDefault();
       requestPrint();
     });

--- a/apps/client/server/services/publish/printBridge.dom.test.ts
+++ b/apps/client/server/services/publish/printBridge.dom.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// EXECUTION coverage for the in-frame print trigger. The static test asserts the tag's shape,
+// which cannot tell whether the message contract or the shortcut interception actually works -
+// and both are the whole feature: a bridge that never calls print() leaves the viewer with
+// Chrome's clipped one-page render of the wrapper and no error anywhere.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PRINT_BRIDGE_JS } from './printBridge';
+
+/**
+ * The bridge attaches to `window` and `document`, and jsdom keeps ONE of each for the whole
+ * file - so without detaching, every bridge an earlier test eval'd is still listening and a
+ * later dispatch runs all of them. Track what each run adds and remove it afterwards.
+ */
+let added: Array<[EventTarget, string, EventListener]> = [];
+const nativeWindowAdd = window.addEventListener.bind(window);
+const nativeDocumentAdd = document.addEventListener.bind(document);
+
+/** Run the REAL shipped bridge, exactly as it runs inside the sandboxed frame. */
+function runBridge(): void {
+  // eval, deliberately: a reimplementation of the message/shortcut guards would assert itself.
+  eval(PRINT_BRIDGE_JS);
+}
+
+function otherWindow(): Window {
+  const frame = document.createElement('iframe');
+  document.body.appendChild(frame);
+  return frame.contentWindow as Window;
+}
+
+describe('print bridge (in-frame)', () => {
+  let print: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    added = [];
+    window.addEventListener = ((type: string, fn: EventListener, opts?: AddEventListenerOptions) => {
+      added.push([window, type, fn]);
+      nativeWindowAdd(type, fn, opts);
+    }) as typeof window.addEventListener;
+    document.addEventListener = ((type: string, fn: EventListener, opts?: AddEventListenerOptions) => {
+      added.push([document, type, fn]);
+      nativeDocumentAdd(type, fn, opts);
+    }) as typeof document.addEventListener;
+    print = vi.fn();
+    vi.stubGlobal('print', print);
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    // Capture-phase listeners must be removed with the same flag, hence `true`.
+    added.forEach(([target, type, fn]) => {
+      target.removeEventListener(type, fn);
+      target.removeEventListener(type, fn, true);
+    });
+    window.addEventListener = nativeWindowAdd as typeof window.addEventListener;
+    document.addEventListener = nativeDocumentAdd as typeof document.addEventListener;
+    vi.unstubAllGlobals();
+  });
+
+  it('prints on the parent print message', () => {
+    runBridge();
+    // Top-level jsdom, so window.parent === window: this IS a message from the parent.
+    window.dispatchEvent(new MessageEvent('message', { data: { b4m: 'print' }, source: window }));
+
+    expect(print).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a print message from any window other than the parent', () => {
+    runBridge();
+    window.dispatchEvent(new MessageEvent('message', { data: { b4m: 'print' }, source: otherWindow() }));
+
+    expect(print).not.toHaveBeenCalled();
+  });
+
+  it('ignores a parent message that is not a print request', () => {
+    runBridge();
+    window.dispatchEvent(new MessageEvent('message', { data: { b4m: 'pinmode', on: true }, source: window }));
+    window.dispatchEvent(new MessageEvent('message', { data: 'print', source: window }));
+
+    expect(print).not.toHaveBeenCalled();
+  });
+
+  it('claims Cmd/Ctrl+P so the browser prints the frame instead of the clipped wrapper', () => {
+    runBridge();
+    const meta = new KeyboardEvent('keydown', { key: 'p', metaKey: true, bubbles: true, cancelable: true });
+    document.dispatchEvent(meta);
+
+    expect(print).toHaveBeenCalledTimes(1);
+    expect(meta.defaultPrevented).toBe(true);
+  });
+
+  it('leaves a plain p keypress alone', () => {
+    runBridge();
+    const plain = new KeyboardEvent('keydown', { key: 'p', bubbles: true, cancelable: true });
+    document.dispatchEvent(plain);
+
+    expect(print).not.toHaveBeenCalled();
+    expect(plain.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/client/server/services/publish/printBridge.dom.test.ts
+++ b/apps/client/server/services/publish/printBridge.dom.test.ts
@@ -97,4 +97,16 @@ describe('print bridge (in-frame)', () => {
     expect(print).not.toHaveBeenCalled();
     expect(plain.defaultPrevented).toBe(false);
   });
+
+  it('does not hijack the shortcut while the viewer is typing in an author text field', () => {
+    runBridge();
+    const field = document.createElement('textarea');
+    document.body.appendChild(field);
+    // macOS: Ctrl+P inside a text field is cursor-up, not print.
+    const ctrl = new KeyboardEvent('keydown', { key: 'p', ctrlKey: true, bubbles: true, cancelable: true });
+    field.dispatchEvent(ctrl);
+
+    expect(print).not.toHaveBeenCalled();
+    expect(ctrl.defaultPrevented).toBe(false);
+  });
 });

--- a/apps/client/server/services/publish/printBridge.test.ts
+++ b/apps/client/server/services/publish/printBridge.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrintBridgeTag, PRINT_BRIDGE_CSS, PRINT_BRIDGE_JS } from './printBridge';
+
+describe('buildPrintBridgeTag', () => {
+  it('ships the print trigger and the print stylesheet in one tag', () => {
+    const tag = buildPrintBridgeTag();
+    expect(tag).toContain('window.print');
+    expect(tag).toContain('print-color-adjust');
+    expect(tag).toContain(`<style>${PRINT_BRIDGE_CSS}</style>`);
+    expect(tag.endsWith('</script>')).toBe(true);
+  });
+
+  it('never contains a literal </script> inside the script body', () => {
+    const tag = buildPrintBridgeTag();
+    const inner = tag.slice(tag.indexOf('<script>') + '<script>'.length, -'</script>'.length);
+    expect(inner).not.toContain('</script>');
+    expect(PRINT_BRIDGE_JS).not.toContain('</script>');
+  });
+
+  it('undoes the two author defaults that clip a print to one blank-backgrounded page', () => {
+    // `body{height:100vh;overflow:auto}` paginates to a single page, and backgrounds are
+    // dropped unless the viewer ticks Chrome's "Background graphics" box.
+    expect(PRINT_BRIDGE_CSS).toContain('overflow:visible!important');
+    expect(PRINT_BRIDGE_CSS).toContain('height:auto!important');
+    expect(PRINT_BRIDGE_CSS).toContain('-webkit-print-color-adjust:exact!important');
+  });
+});

--- a/apps/client/server/services/publish/printBridge.ts
+++ b/apps/client/server/services/publish/printBridge.ts
@@ -1,0 +1,62 @@
+/**
+ * Publish - "Save as PDF" bridge injected INTO the sandboxed bundle.
+ *
+ * Chrome's File > Print on the wrapper page prints the WRAPPER, and a cross-document
+ * iframe paginates only the slice that is currently visible - so the viewer gets the
+ * artifact's first screen and nothing else. The fix is to print the FRAME's own
+ * document, from inside the frame, which preserves live interactive state (slider
+ * positions, canvas/SVG charts, computed colors) rather than re-rendering a fresh copy.
+ *
+ * The parent cannot call `print()` on a cross-origin (or opaque-origin) frame, so the
+ * trigger lives here and the wrapper asks for it over postMessage:
+ *   parent -> iframe : { b4m: 'print' }
+ * Message types must stay disjoint from the pin bridge's and fragmentNav's; all three
+ * ignore what they do not recognize. The frame validates `event.source` always, and in
+ * Approach B (a true cross-origin embed) also pins the parent origin from
+ * `document.referrer` and checks `event.origin` against it - same pattern as the pin
+ * bridge. In the same-origin srcdoc fallback the sandboxed doc has no referrer, so the
+ * pin stays '*' and the source check carries the check on its own.
+ *
+ * `VIEWER_SANDBOX` must carry `allow-modals` or `window.print()` is a silent no-op here.
+ * This script may never contain a literal `</script>`.
+ */
+
+/**
+ * Print stylesheet shipped with the bridge. Two long-standing print failures in
+ * hand-authored artifacts, both invisible on screen:
+ *  - `body{height:100vh;overflow:auto}` (or a flex app shell) clips the printed output
+ *    to a single page, because a scroll container does not paginate.
+ *  - backgrounds and chart fills are dropped unless the viewer happens to tick Chrome's
+ *    "Background graphics" box, which turns a dark-themed artifact into white-on-white.
+ */
+export const PRINT_BRIDGE_CSS =
+  '@media print{html,body{height:auto!important;overflow:visible!important}' +
+  '*{-webkit-print-color-adjust:exact!important;print-color-adjust:exact!important}}';
+
+export const PRINT_BRIDGE_JS = String.raw`(function(){
+  'use strict';
+  var PO=(function(){try{return document.referrer?new URL(document.referrer).origin:'*';}catch(e){return '*';}})();
+  function doPrint(){try{window.focus();window.print();}catch(e){}}
+  window.addEventListener('message',function(e){
+    if(e.source!==window.parent){return;}
+    if(PO!=='*'&&e.origin!==PO){return;}
+    var d=e.data||{};
+    if(d.b4m==='print'){doPrint();}
+  });
+  document.addEventListener('keydown',function(e){
+    if(!(e.metaKey||e.ctrlKey)||e.altKey||e.shiftKey){return;}
+    if(e.key!=='p'&&e.key!=='P'){return;}
+    e.preventDefault();
+    doPrint();
+  },true);
+})();`;
+
+/**
+ * Print stylesheet + trigger, appended to every rendered bundle. Capture phase on the
+ * keydown so the shortcut is claimed before author handlers: with focus inside the
+ * frame the browser would otherwise print the wrapper, which is the clipped render this
+ * whole bridge exists to avoid.
+ */
+export function buildPrintBridgeTag(): string {
+  return `<style>${PRINT_BRIDGE_CSS}</style><script>${PRINT_BRIDGE_JS}</script>`;
+}

--- a/apps/client/server/services/publish/printBridge.ts
+++ b/apps/client/server/services/publish/printBridge.ts
@@ -37,6 +37,7 @@ export const PRINT_BRIDGE_JS = String.raw`(function(){
   'use strict';
   var PO=(function(){try{return document.referrer?new URL(document.referrer).origin:'*';}catch(e){return '*';}})();
   function doPrint(){try{window.focus();window.print();}catch(e){}}
+  function isEditing(t){return !!t&&(t.isContentEditable===true||/^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName||''));}
   window.addEventListener('message',function(e){
     if(e.source!==window.parent){return;}
     if(PO!=='*'&&e.origin!==PO){return;}
@@ -46,6 +47,7 @@ export const PRINT_BRIDGE_JS = String.raw`(function(){
   document.addEventListener('keydown',function(e){
     if(!(e.metaKey||e.ctrlKey)||e.altKey||e.shiftKey){return;}
     if(e.key!=='p'&&e.key!=='P'){return;}
+    if(isEditing(e.target)){return;}
     e.preventDefault();
     doPrint();
   },true);
@@ -55,7 +57,8 @@ export const PRINT_BRIDGE_JS = String.raw`(function(){
  * Print stylesheet + trigger, appended to every rendered bundle. Capture phase on the
  * keydown so the shortcut is claimed before author handlers: with focus inside the
  * frame the browser would otherwise print the wrapper, which is the clipped render this
- * whole bridge exists to avoid.
+ * whole bridge exists to avoid. Editable targets are left alone: on macOS Ctrl+P is a
+ * cursor movement inside text fields, and a shortcut that hijacks typing is a bug.
  */
 export function buildPrintBridgeTag(): string {
   return `<style>${PRINT_BRIDGE_CSS}</style><script>${PRINT_BRIDGE_JS}</script>`;

--- a/apps/client/server/services/publish/renderSandboxedBundle.test.ts
+++ b/apps/client/server/services/publish/renderSandboxedBundle.test.ts
@@ -253,4 +253,50 @@ describe('renderSandboxedBundle', () => {
       expect(srcdoc).not.toContain(`b4m:'fragment'`);
     });
   });
+
+  describe('print bridge', () => {
+    it('appends the bridge after author content, inside the body', () => {
+      const html = `<html><head></head><body><h1 id="last">Hi</h1></body></html>`;
+      const { srcdoc } = renderSandboxedBundle({
+        indexHtml: html,
+        urlBase: URL_BASE,
+        origin: ORIGIN,
+        visibility: 'public',
+      });
+      expect(srcdoc).toContain(`b4m==='print'`);
+      expect(srcdoc.indexOf(`b4m==='print'`)).toBeGreaterThan(srcdoc.indexOf('id="last"'));
+      expect(srcdoc.indexOf(`b4m==='print'`)).toBeLessThan(srcdoc.indexOf('</body>'));
+    });
+
+    it('rides along on every render - gated, ?a= sub-document, and the ?export=html download', () => {
+      const html = `<html><head></head><body><h1>Hi</h1></body></html>`;
+      const gated = renderSandboxedBundle({
+        indexHtml: html,
+        urlBase: URL_BASE,
+        origin: ORIGIN,
+        visibility: 'private',
+        assets: new Map(),
+        pagePaths: [URL_BASE],
+      });
+      const subDoc = renderSandboxedBundle({
+        indexHtml: html,
+        urlBase: '',
+        origin: ORIGIN,
+        visibility: 'public',
+        assetMode: 'inline',
+      });
+      expect(gated.srcdoc).toContain('print-color-adjust');
+      expect(subDoc.srcdoc).toContain('print-color-adjust');
+    });
+
+    it('still lands when the author ships a bare fragment rather than a document', () => {
+      const { srcdoc } = renderSandboxedBundle({
+        indexHtml: `<h1>Hi</h1>`,
+        urlBase: URL_BASE,
+        origin: ORIGIN,
+        visibility: 'public',
+      });
+      expect(srcdoc).toContain('window.print');
+    });
+  });
 });

--- a/apps/client/server/services/publish/renderSandboxedBundle.ts
+++ b/apps/client/server/services/publish/renderSandboxedBundle.ts
@@ -2,6 +2,7 @@ import * as cheerio from 'cheerio';
 import type { PublishVisibility } from '@bike4mind/common';
 import { BLESSED_SCRIPT_PATHS, PUBLISH_HOST } from './validateBundle';
 import { buildFragmentNavScriptTag } from './fragmentNav';
+import { buildPrintBridgeTag } from './printBridge';
 
 /**
  * Publish - sandboxed-bundle serializer.
@@ -39,6 +40,11 @@ import { buildFragmentNavScriptTag } from './fragmentNav';
  *
  * Off-origin `<a href>`s are retargeted to a new tab (see `retargetOffOriginLinks`),
  * which is the only outbound navigation the viewer sandbox permits.
+ *
+ * Every render also carries the print bridge (see `printBridge.ts`) - the wrapper's
+ * "Save as PDF" prints THIS document rather than the frame-clipping wrapper, so the
+ * trigger has to live in the bundle. Unconditional, so the saved `?export=html` file
+ * and the isolated-origin render print the same way the wrapper does.
  */
 
 export interface SandboxAsset {
@@ -153,14 +159,16 @@ export function renderSandboxedBundle(input: RenderSandboxedBundleInput): Render
   if (input.pagePaths?.length) {
     // After author content so author click handlers run first (the helper skips
     // defaultPrevented events); the pin bridge appends after this, order-independent.
-    const tag = buildFragmentNavScriptTag({
-      origins: [origin, PUBLISH_HOST ? `https://${PUBLISH_HOST}` : ''],
-      paths: input.pagePaths,
-    });
-    const body = $('body');
-    if (body.length) body.append(tag);
-    else $.root().append(tag);
+    appendToBody(
+      $,
+      buildFragmentNavScriptTag({
+        origins: [origin, PUBLISH_HOST ? `https://${PUBLISH_HOST}` : ''],
+        paths: input.pagePaths,
+      })
+    );
   }
+
+  appendToBody($, buildPrintBridgeTag());
 
   return { srcdoc: $.html(), droppedAssets };
 }
@@ -190,6 +198,13 @@ function retargetOffOriginLinks($: cheerio.CheerioAPI, origin: string): void {
     rel.add('noopener');
     $(el).attr('rel', [...rel].join(' '));
   });
+}
+
+/** Append markup after the author's content, tolerating a bundle with no `<body>`. */
+function appendToBody($: cheerio.CheerioAPI, markup: string): void {
+  const body = $('body');
+  if (body.length) body.append(markup);
+  else $.root().append(markup);
 }
 
 /** Insert (or update) a single `<base href>` as the first child of `<head>`. */

--- a/apps/client/server/services/publish/viewerSecurity.test.ts
+++ b/apps/client/server/services/publish/viewerSecurity.test.ts
@@ -291,9 +291,13 @@ describe('buildBundleScriptSrc hosted regression (byte-identical, B4M_SELF_HOST 
 });
 
 describe('VIEWER_SANDBOX', () => {
-  it('grants scripts + escaping popups and never allow-same-origin', () => {
-    expect(VIEWER_SANDBOX).toBe('allow-scripts allow-popups allow-popups-to-escape-sandbox');
+  it('grants scripts + escaping popups + modals and never allow-same-origin', () => {
+    expect(VIEWER_SANDBOX).toBe('allow-scripts allow-popups allow-popups-to-escape-sandbox allow-modals');
     // The opaque-origin invariant: reclaiming the app origin here is an ATO.
     expect(VIEWER_SANDBOX.split(' ')).not.toContain('allow-same-origin');
+  });
+
+  it('carries allow-modals, without which window.print() is a silent no-op in the frame', () => {
+    expect(VIEWER_SANDBOX.split(' ')).toContain('allow-modals');
   });
 });

--- a/apps/client/server/services/publish/viewerSecurity.ts
+++ b/apps/client/server/services/publish/viewerSecurity.ts
@@ -212,8 +212,16 @@ export function buildBundleScriptSrc(hostHeader?: string, forwardedProtoHeader?:
  * typed themselves; the bundle cannot script it (opaque origin -> cross-origin), and
  * `renderSandboxedBundle` adds `rel="noopener"` on top.
  *
+ * `allow-modals` is what lets the framed document open the PRINT dialog: `window.print()` is
+ * gated on the sandboxed-modals flag, so without this token it is a silent no-op and both the
+ * wrapper's "Save as PDF" (see printBridge.ts) and the `window.print()` export button the
+ * artifact-authoring prompt tells models to write would do nothing. It also admits
+ * alert/confirm/prompt, which are nuisance-only here: the origin stays opaque, so a modal
+ * cannot reach the app's cookies, storage or DOM - it can only annoy the viewer of a page
+ * that is already running the author's own JS.
+ *
  * `allow-same-origin` is NEVER part of this list - the srcdoc/reply frames must stay on an
  * opaque origin. Approach B adds it at its own call site, where it resolves to the isolated
  * usercontent origin rather than the app's.
  */
-export const VIEWER_SANDBOX = 'allow-scripts allow-popups allow-popups-to-escape-sandbox';
+export const VIEWER_SANDBOX = 'allow-scripts allow-popups allow-popups-to-escape-sandbox allow-modals';


### PR DESCRIPTION
## Summary

Viewers of a published artifact (`/p/u/<scope>/<slug>`) had no way to get a usable PDF: the browser's File > Print prints the wrapper page, and a cross-document iframe paginates only its visible first screen. This adds a **Save as PDF** button next to **Save as HTML** that prints the artifact frame's **live** document, so slider state, canvas/SVG charts and background colors all survive.

## What changed

- **`VIEWER_SANDBOX` gains `allow-modals`** (`server/services/publish/viewerSecurity.ts`). `window.print()` is gated on the sandboxed-modals flag, so it was a silent no-op inside every viewer frame. This also un-breaks the `window.print()` export buttons the artifact-authoring prompt already tells models to write. The origin stays opaque (no `allow-same-origin`); the only new capability is nuisance dialogs (alert/confirm/prompt) from a page already running the author's own JS.
- **Print bridge injected into every bundle render** (`server/services/publish/printBridge.ts`, appended by `renderSandboxedBundle`): a print stylesheet (`print-color-adjust: exact`, and releases `html,body` height/overflow so scroll-container shells paginate) plus a trigger that accepts `{ b4m: 'print' }` only from `window.parent` (and, on the isolated cross-origin embed, only from the pinned parent origin, same pattern as the pin bridge). It also claims Cmd/Ctrl+P while focus is inside the frame.
- **Wrapper button** (`pages/api/publish/serve/[...path].ts`): `Save as PDF` in the branded bar, a floating `PDF` chip in the no-bar variant, neither in embed mode. Buttons ship `hidden` and are revealed by the script, so there is no dead button without JS.
- **Binder in `/api/publish/widget`** (`pages/api/publish/widget.ts`), because that is the only script the tightened Approach-B wrapper CSP admits. The widget now ships on every non-embed wrapper; the comment overlay still early-returns without its mount node. No CSP change.
- Stale header comments in `printToPdf.ts` / `publishExport.ts` corrected: the owner-path helper prints a fresh render of the export; the public viewer prints the live frame.

## Verification

- `vitest run --project node server/services/publish pages/api/publish`: 50 files, 631 tests passed (new: `printBridge.test.ts`, `printBridge.dom.test.ts`, new describes in `serve.test.ts`, `widget.dom.test.ts`, `renderSandboxedBundle.test.ts`, `viewerSecurity.test.ts`).
- `tsc --noEmit` clean for all touched files; `eslint` clean on all 13 files; ASCII guards clean.
- Headless Chromium against the dev server on a real published artifact: the frame carries `allow-modals` and the bridge, the button is visible, and button click, wrapper Cmd+P and in-frame Cmd+P each invoke the frame's `window.print` (stubbed). Print-media render keeps chart fills and card backgrounds.
- Manually tested on the dev server: Save as PDF opens the print dialog with the full multi-page artifact, charts and colors intact.

## Rollout note

Public renders are CDN-cached for up to an hour (`s-maxage=3600`), and the widget script for up to an hour as well. During that window a stale cached render lacks the bridge, so the button and the intercepted shortcut do nothing until the cache turns over. No action needed.

## Not in this PR

The in-app artifact viewers (`KnowledgeViewer` toolbar over `HtmlArtifactViewer` / `ReactArtifactViewer`) use a different sandbox shell (`/api/artifact-sandbox`) and have no print action either. Same approach would apply; follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuMBpE7kiPDpxgxXZkgPgy
