### PR TITLE
feat(publish): inline script-free HTML artifacts on gated reply pages and lead with them

### DIFF
--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -1420,38 +1420,93 @@ function cleanViewerTitle(rawTitle: string | undefined, artifacts: ParsedArtifac
   return named?.title || SHARED_FALLBACK_TITLE;
 }
 
+/** An artifact carrying its own JS. Non-global so `.test` stays stateless across calls. */
+const ARTIFACT_HAS_SCRIPT = /<script[\s>]/i;
+
+/**
+ * How one embedded artifact renders. Single source of truth so `renderArtifactBlock` and the
+ * lead-artifact hero check in `renderViewerPage` can never disagree about what appears:
+ * - `sub-document`: an iframe at `?a={index}`, which needs a path whose fresh, credential-free
+ *   sub-request re-authorizes (`canFrame`).
+ * - `srcdoc`: the document inlined into the frame, so no sub-request happens at all.
+ * - `card`: a placeholder, for a type the static viewer cannot host or a document whose JS
+ *   would not survive inlining.
+ */
+type ArtifactRenderMode = 'sub-document' | 'srcdoc' | 'card';
+
+function artifactRenderMode(
+  artifact: ParsedArtifact,
+  selfPath: string,
+  canFrame: boolean,
+  standalone: boolean
+): ArtifactRenderMode {
+  if (artifact.type !== 'html' && artifact.type !== 'svg') return 'card';
+  if (standalone) return 'srcdoc';
+  if (canFrame && selfPath) return 'sub-document';
+  // Bearer-gated page: no `?a=` sub-request can carry the header, but a script-free document
+  // renders identically inline. A scripted one would not (see renderArtifactBlock), so: card.
+  return ARTIFACT_HAS_SCRIPT.test(artifact.content) ? 'card' : 'srcdoc';
+}
+
+/** Whether this artifact renders as a frame rather than a placeholder card. */
+function willFrame(artifact: ParsedArtifact, selfPath: string, canFrame: boolean, standalone: boolean): boolean {
+  return artifactRenderMode(artifact, selfPath, canFrame, standalone) !== 'card';
+}
+
+/** Opaque-origin frame whose document travels in the attribute, so it needs no sub-request. */
+function srcdocFrame(titleHtml: string, content: string, extraClass = ''): string {
+  // srcdoc attribute escape: inside a double-quoted value only `&` and `"` are unsafe -
+  // `<`/`>` are literal data. Escaping them would corrupt the framed document (see the
+  // identical note in renderBundleWrapper). `&` first so it can't double-escape `&quot;`.
+  const doc = content.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  return `<iframe class="${artifactFrameClass(
+    extraClass
+  )}" sandbox="${VIEWER_SANDBOX}" title="${titleHtml}" srcdoc="${doc}"></iframe>`;
+}
+
+function artifactFrameClass(extraClass: string): string {
+  return extraClass ? `b4m-artifact ${extraClass}` : 'b4m-artifact';
+}
+
 /**
  * Render one embedded artifact as viewer markup. An HTML/SVG artifact renders in its own
  * SANDBOXED iframe pointed at the `?a={index}` sub-document (so its JS runs isolated on an
  * opaque origin, never on the script-free reply page) - but ONLY when `canFrame` says the
- * sub-request will authorize (see the call site); a Bearer-gated reply falls back to the card so
- * we never emit a frame that dead-ends at a loader shell. Every other type (react/code/python/
- * mermaid/recharts) needs the app runtime the static viewer can't provide, so it also gets a
+ * sub-request will authorize (see the call site). Every other type (react/code/python/
+ * mermaid/recharts) needs the app runtime the static viewer can't provide, so it gets a
  * clean placeholder card instead of leaking raw markup. `index` MUST match the position in the
  * same parseArtifactsWithFallback result the `?a` handler indexes into.
  *
  * `standalone` (the `?export=html` download) has no `?a=` route to point at, so an html/svg
  * artifact is inlined as an iframe `srcdoc` instead - same `VIEWER_SANDBOX` opaque-origin
  * posture, but self-contained, so the saved file renders offline.
+ *
+ * A Bearer-gated page (org/domain visibility, reached through the loader shell) can't frame
+ * `?a=` either, since an iframe navigation carries no Authorization header. There it inlines
+ * the SAME srcdoc, which is the identical opaque-origin posture minus script execution: the
+ * page's `script-src 'none'` CSP is inherited by an about:srcdoc child, so a SCRIPTED artifact
+ * would render half-broken (markup and CSS, dead JS) and is kept as a card instead. Script-free
+ * documents (a styled report, an SVG) render fully, which is what the gated owner came for.
  */
 function renderArtifactBlock(
   artifact: ParsedArtifact,
   index: number,
   selfPath: string,
   canFrame: boolean,
-  standalone = false
+  standalone = false,
+  opts: { hero?: boolean } = {}
 ): string {
   const title = escapeHtml(artifact.title || 'Artifact');
-  if (standalone && (artifact.type === 'html' || artifact.type === 'svg')) {
-    // srcdoc attribute escape: inside a double-quoted value only `&` and `"` are unsafe -
-    // `<`/`>` are literal data. Escaping them would corrupt the framed document (see the
-    // identical note in renderBundleWrapper). `&` first so it can't double-escape `&quot;`.
-    const doc = artifact.content.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-    return `<iframe class="b4m-artifact" sandbox="${VIEWER_SANDBOX}" title="${title}" srcdoc="${doc}"></iframe>`;
+  const extraClass = opts.hero ? 'b4m-hero' : '';
+  const mode = artifactRenderMode(artifact, selfPath, canFrame, standalone);
+  if (mode === 'srcdoc') {
+    return srcdocFrame(title, artifact.content, extraClass);
   }
-  if (canFrame && selfPath && (artifact.type === 'html' || artifact.type === 'svg')) {
+  if (mode === 'sub-document') {
     const src = escapeHtml(`${selfPath}?a=${index}`);
-    return `<iframe class="b4m-artifact" sandbox="${VIEWER_SANDBOX}" loading="lazy" title="${title}" src="${src}"></iframe>`;
+    return `<iframe class="${artifactFrameClass(
+      extraClass
+    )}" sandbox="${VIEWER_SANDBOX}" loading="lazy" title="${title}" src="${src}"></iframe>`;
   }
   return `<div class="b4m-artifact-card"><strong>${title}</strong><span>${escapeHtml(
     artifact.type
@@ -1461,8 +1516,10 @@ function renderArtifactBlock(
 /**
  * Render a reply/fabfile snapshot to a standalone HTML page. Replies are markdown (rendered via
  * marked) with any embedded `<artifact>` blocks extracted: the surrounding prose renders inline,
- * and each HTML/SVG artifact renders in its own sandboxed `?a=` iframe (non-embeddable types get
- * a placeholder card). Fabfiles render their literal text as an escaped <pre>, with only explicit
+ * and each HTML/SVG artifact renders in its own sandboxed iframe (non-embeddable types get a
+ * placeholder card). A reply that OPENS with a frameable artifact leads with it as a full-bleed
+ * hero above the prose; every other reply keeps prose-then-artifacts order. Fabfiles render
+ * their literal text as an escaped <pre> in the original order, with only explicit
  * embedded `<artifact>` blocks extracted and framed the same way. The PAGE is served with
  * script-src 'none' so injected markup cannot execute; artifact JS runs only inside the sandbox.
  */
@@ -1503,10 +1560,26 @@ function renderViewerPage(
     const article = cleanedContent
       ? sanitizeRenderedHtml(marked.parse(cleanedContent, { async: false }) as string)
       : '';
-    const blocks = artifacts
-      .map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts, standalone))
-      .join('\n');
-    contentHtml = `${article}${blocks}`;
+    const block = (a: ParsedArtifact, i: number, hero = false) =>
+      renderArtifactBlock(a, i, selfPath, canFrameArtifacts, standalone, { hero });
+    // A reply that LEADS with an html/svg artifact IS that artifact; the prose after it is the
+    // text fallback. Hoist that first block above the article as a full-bleed hero, but only if
+    // it actually renders as a frame - promoting a placeholder card to hero would be a downgrade.
+    // Ordering only; `i` stays the artifact's position in this same parser result, so `?a={i}`
+    // still resolves to the block rendered at slot i.
+    const leadsWithArtifact =
+      /^<artifact\b/i.test(body.trim()) &&
+      artifacts.length > 0 &&
+      willFrame(artifacts[0], selfPath, canFrameArtifacts, standalone);
+    if (leadsWithArtifact) {
+      const rest = artifacts
+        .slice(1)
+        .map((a, i) => block(a, i + 1))
+        .join('\n');
+      contentHtml = `${block(artifacts[0], 0, true)}${article}${rest}`;
+    } else {
+      contentHtml = `${article}${artifacts.map((a, i) => block(a, i)).join('\n')}`;
+    }
     displayTitle = cleanViewerTitle(artifact.title, artifacts);
   } else {
     // Fabfile: a file is literal text, not markdown prose, so the non-artifact remainder stays an
@@ -1571,6 +1644,9 @@ function renderViewerPage(
   img { max-width: 100%; height: auto; }
   iframe.b4m-artifact { display: block; width: 100%; height: 600px; margin: 1.5rem 0; border: 1px solid rgba(127,127,127,.3);
          border-radius: 8px; background: #fff; }
+  /* Lead artifact: break out of the 760px column to full-bleed. The negative top margin
+     cancels the body's 2rem top padding so the hero starts at the very top of the page. */
+  iframe.b4m-artifact.b4m-hero { width: 100vw; margin: -2rem 0 2rem calc(50% - 50vw); height: 100vh; border: 0; border-radius: 0; }
   .b4m-artifact-card { display: flex; flex-direction: column; gap: .25rem; margin: 1.5rem 0; padding: 1rem 1.25rem;
          border: 1px solid rgba(127,127,127,.3); border-radius: 8px; background: rgba(127,127,127,.08); }
   .b4m-artifact-card span { font-size: .85rem; opacity: .75; }

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -712,6 +712,135 @@ describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
   });
 });
 
+describe('GET /api/publish/serve - inline artifact fallback and lead-artifact hero', () => {
+  // A script-free document renders identically whether it is fetched as a `?a=` sub-document or
+  // inlined as a srcdoc, so a Bearer-gated reply (no header on a sub-request) inlines instead of
+  // showing a card. HERO_CLASS is the frame marker; the class name also appears in the page CSS,
+  // so assertions match the attribute, never the bare token.
+  const HERO_CLASS = 'class="b4m-artifact b4m-hero"';
+  const CARD_ELEMENT = '<div class="b4m-artifact-card"';
+  const SCRIPT_FREE_HTML =
+    '<artifact identifier="rep" type="text/html" title="Report">' +
+    '<!DOCTYPE html><html><head><style>h1{color:red}</style></head>' +
+    '<body><h1>QUARTERLY_REPORT</h1></body></html>' +
+    '</artifact>';
+  const SCRIPTED_HTML =
+    '<artifact identifier="tip" type="text/html" title="Tip">' +
+    '<body><h1>SCRIPTED_BODY</h1><script>window.ok=1</script></body>' +
+    '</artifact>';
+
+  const reply = (over: Record<string, unknown> = {}) => ({
+    publicId: 'rinline',
+    title: 'Report reply',
+    visibility: 'public',
+    ownerId: 'owner1',
+    source: { kind: 'reply' },
+    renderedBody: SCRIPT_FREE_HTML,
+    storageKeyPrefix: '',
+    manifest: [],
+    tier: 'user',
+    scopeId: 's',
+    slug: 'rinline',
+    ...over,
+  });
+
+  const gatedReply = (over: Record<string, unknown> = {}) =>
+    reply({
+      publicId: 'r-gated-inline',
+      slug: 'r-gated-inline',
+      visibility: 'organization',
+      tier: 'organization',
+      scopeId: 'org_42',
+      ...over,
+    });
+
+  const member = { id: 'member', organizationId: 'org_42' };
+
+  it('inlines a script-free artifact as srcdoc on a Bearer-gated reply (the shell ?raw=1 re-fetch)', async () => {
+    mockArtifactFindOne.mockReturnValue(gatedReply());
+    const { res, promise } = run(['r', 'r-gated-inline'], { raw: true, user: member });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    // An iframe navigation cannot send the Authorization header, so the document travels
+    // WITH the page instead of being fetched from `?a=` - same opaque-origin sandbox.
+    expect(data).toContain('class="b4m-artifact');
+    expect(data).toContain('srcdoc="');
+    expect(data).toContain(`sandbox="${VIEWER_SANDBOX}"`);
+    expect(data).toContain('QUARTERLY_REPORT');
+    expect(data).not.toContain(CARD_ELEMENT);
+    expect(data).not.toContain('?a=0');
+  });
+
+  it('keeps the placeholder card for a SCRIPTED artifact on a Bearer-gated reply', async () => {
+    // The page's inherited `script-src 'none'` would leave an inlined scripted artifact
+    // half-broken (markup and CSS, dead JS), so it stays a card that points at the app.
+    mockArtifactFindOne.mockReturnValue(gatedReply({ renderedBody: SCRIPTED_HTML }));
+    const { res, promise } = run(['r', 'r-gated-inline'], { raw: true, user: member });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain(CARD_ELEMENT);
+    expect(data).not.toContain('srcdoc=');
+    expect(data).not.toContain('window.ok=1');
+    expect(data).not.toContain('SCRIPTED_BODY');
+  });
+
+  it('leads with a full-bleed hero frame when the reply OPENS with an artifact, prose after it', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      reply({
+        publicId: 'rhero',
+        slug: 'rhero',
+        renderedBody: `${SCRIPT_FREE_HTML}\n\nSome *fallback* prose.\n\n<artifact type="text/html" title="Appendix"><body><h1>APPENDIX</h1></body></artifact>`,
+      })
+    );
+    const { res, promise } = run(['r', 'rhero']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    const hero = data.indexOf(HERO_CLASS);
+    const prose = data.indexOf('<em>fallback</em>');
+    const appendix = data.indexOf('src="/p/r/rhero?a=1"');
+    expect(hero).toBeGreaterThan(-1);
+    expect(prose).toBeGreaterThan(hero);
+    expect(appendix).toBeGreaterThan(prose);
+    // Hoisting reorders blocks, it never renumbers them: the lead artifact keeps index 0.
+    expect(data).toContain('src="/p/r/rhero?a=0"');
+    expect(data.split(HERO_CLASS).length - 1).toBe(1); // only the lead block is a hero
+  });
+
+  it('keeps prose-then-artifact order (no hero) when the reply does not open with an artifact', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      reply({ publicId: 'rprose', slug: 'rprose', renderedBody: `Intro *prose* first.\n\n${SCRIPT_FREE_HTML}` })
+    );
+    const { res, promise } = run(['r', 'rprose']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).not.toContain(HERO_CLASS);
+    expect(data.indexOf('<em>prose</em>')).toBeLessThan(data.indexOf('src="/p/r/rprose?a=0"'));
+  });
+
+  it('inlines AND heroes a leading artifact in a standalone ?export=html download', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      reply({ publicId: 'rexport', slug: 'rexport', renderedBody: `${SCRIPT_FREE_HTML}\n\nFallback prose.` })
+    );
+    const { res, promise } = run(['r', 'rexport'], { exportAs: 'html' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain(HERO_CLASS);
+    expect(data).toContain('srcdoc="');
+    expect(data).toContain('QUARTERLY_REPORT');
+    expect(data).not.toContain('?a=0');
+  });
+});
+
 describe('GET /api/publish/serve - fabfile embedded HTML artifact (#722)', () => {
   // A fabfile is literal file text (kept as escaped <pre>), but an embedded <artifact> block frames
   // via the same sandboxed ?a= path as the reply viewer. The leading text uses markdown syntax to


### PR DESCRIPTION
## Summary

A published reply that embeds an HTML artifact renders that artifact only when the page can re-authorize a `?a=` sub-request (open-public, `/a/` share, passphrase-verified). On a **Bearer-gated** reply (private or organization visibility, viewed through the loader shell) the sub-frame navigation cannot carry the Authorization header, so the owner of their own reply got the placeholder card "html artifact - open in the app to view" and the flat markdown fallback. The reply viewer also always rendered prose first and artifacts after, even when the artifact is the point of the reply.

## What changed

- **Inline srcdoc fallback on gated pages** (`pages/api/publish/serve/[...path].ts`, `renderArtifactBlock`): a script-free html/svg artifact is inlined as an opaque-origin `srcdoc` frame, the same posture the `?export=html` standalone path already uses, minus script execution: the page's `script-src 'none'` meta CSP is inherited by an `about:srcdoc` child. A scripted artifact would render half-broken under that, so it keeps the card. A single `artifactRenderMode()` decides `sub-document | srcdoc | card` for both the renderer and the hero check.
- **Lead-artifact hero**: a reply whose body opens with a frameable artifact now renders it first as a full-bleed, viewport-height frame above the prose. `?a=` indexes are unchanged (position in the same parser result). Fabfile ordering is untouched.

## Verification

- `vitest run --project node pages/api/publish/serve server/services/publish`: all green, five new cases (gated + script-free inlines, gated + scripted keeps the card, lead artifact becomes hero and the second artifact stays index 1, prose-first keeps order, standalone export still inlines and gets the hero).
- Loaded the gated `?raw=1` render through a loader-shell simulation (sandboxed iframe with the page injected as srcdoc, so nested srcdoc + inherited meta CSP are exercised): one hero frame, zero placeholder cards, the inner document rendered with its stylesheet, no console errors.
- `tsc --noEmit` clean for the touched files; eslint and the ASCII guards clean.

## Notes

- The inline fallback lives in the shared block renderer, so a gated fabfile with a script-free embedded artifact benefits too.
- The hero sub-document frame keeps `loading="lazy"`; it is in the viewport at load so it fetches immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuMBpE7kiPDpxgxXZkgPgy
