### PR TITLE
feat(agents): make the lake-memory belief budget an admin setting

### DIFF
--- a/apps/client/server/integrations/slack/feedbackMessage.test.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.test.ts
@@ -19,6 +19,23 @@ describe('buildPromptMetaSummary', () => {
     expect(summary).toContain('Lake beliefs: 3 (support-docs)');
   });
 
+  it('shows the belief budget alongside the count when the turn recorded one', () => {
+    // A report reading "Lake beliefs: 24" is the saturated case worth acting on; "3" out of the
+    // same 24 is not. Without the budget both render identically.
+    const summary = buildPromptMetaSummary({
+      context: { lakeMemory: { beliefCount: 24, beliefBudget: 24, dataLakeTags: ['support-docs'] } },
+    });
+    expect(summary).toContain('Lake beliefs: 24/24 (support-docs)');
+  });
+
+  it('falls back to the bare count for a turn recorded before the budget was tracked', () => {
+    const summary = buildPromptMetaSummary({
+      context: { lakeMemory: { beliefCount: 3, dataLakeTags: ['support-docs'] } },
+    });
+    expect(summary).toContain('Lake beliefs: 3 (support-docs)');
+    expect(summary).not.toContain('Lake beliefs: 3/');
+  });
+
   it('renders only the signals actually present', () => {
     const summary = buildPromptMetaSummary({ model: { name: 'claude-sonnet-5' } });
     expect(summary).toBe('Model: claude-sonnet-5');

--- a/apps/client/server/integrations/slack/feedbackMessage.ts
+++ b/apps/client/server/integrations/slack/feedbackMessage.ts
@@ -19,7 +19,10 @@ export interface FeedbackPromptMetaInput {
   finishReason?: string;
   functionCalls?: Array<{ name?: string }> | null;
   citables?: unknown[];
-  context?: { lakeMemory?: { beliefCount?: number; dataLakeTags?: string[] } };
+  // beliefBudget is an explicit addition to this allowlist (#2496), not an inherited field: it is
+  // the admin-configured lakeMemoryRecallK in force for the turn, so it carries no user or document
+  // content, and without it `beliefCount` cannot say whether the cap bound the turn.
+  context?: { lakeMemory?: { beliefCount?: number; beliefBudget?: number; dataLakeTags?: string[] } };
 }
 
 const MAX_FUNCTION_CALL_NAMES = 5;
@@ -146,7 +149,14 @@ export function buildPromptMetaSummary(promptMeta: FeedbackPromptMetaInput | nul
   if (lakeMemory?.beliefCount !== undefined) {
     const tags = lakeMemory.dataLakeTags?.map(escapeLine) ?? [];
     const tagsPart = tags.length ? ` (${joinWithOverflow(tags, MAX_DATA_LAKE_TAGS)})` : '';
-    lines.push(`Lake beliefs: ${lakeMemory.beliefCount}${tagsPart}`);
+    // `8/24` rather than `8`: the count alone cannot say whether the lakeMemoryRecallK budget bound
+    // the turn, which is the first thing worth knowing when a report shows thin lake grounding.
+    // Bare when the budget is absent - turns recorded before that field existed have none.
+    const countPart =
+      lakeMemory.beliefBudget !== undefined
+        ? `${lakeMemory.beliefCount}/${lakeMemory.beliefBudget}`
+        : `${lakeMemory.beliefCount}`;
+    lines.push(`Lake beliefs: ${countPart}${tagsPart}`);
   }
 
   return lines.length ? lines.join('\n') : 'none';

--- a/apps/client/server/memory/lakeMemoryRecall.ts
+++ b/apps/client/server/memory/lakeMemoryRecall.ts
@@ -21,6 +21,8 @@ export async function recallLakeMemoryForSession(input: {
   query: string;
   dataLakeTags: string[];
   retrievalFilter?: RetrievalExclusionOptions;
+  /** Belief budget for the turn (`lakeMemoryRecallK`), resolved by the caller. */
+  k: number;
 }): Promise<LakeBeliefRecall[]> {
   if (input.dataLakeTags.length === 0 || !input.query.trim()) return [];
 
@@ -54,5 +56,11 @@ export async function recallLakeMemoryForSession(input: {
     retrievalFilter: input.retrievalFilter,
   });
 
-  return recallLakeMemory({ userId: input.userId, query: input.query, lakes, resolveReachableSources });
+  return recallLakeMemory({
+    userId: input.userId,
+    query: input.query,
+    lakes,
+    resolveReachableSources,
+    k: input.k,
+  });
 }

--- a/apps/client/server/memory/recallLakeMemory.test.ts
+++ b/apps/client/server/memory/recallLakeMemory.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { recallLakeMemory } from './recallLakeMemory';
+
+/**
+ * The belief budget is the caller's `k` (the `lakeMemoryRecallK` admin setting), not the 8 this
+ * module used to hardcode (#2496). LakeMemoryFeature's own suite covers resolving the setting; what
+ * is only provable here is the last hop - that the resolved number is what `recall` actually caps
+ * on, which is what makes `promptMeta.context.lakeMemory.beliefCount` move when an admin raises it.
+ *
+ * `@bike4mind/common` is deliberately NOT mocked: it contributes only MEMENTO_MIN_SIMILARITY here,
+ * and a whole-barrel mock would break the moment this module imports anything else from it.
+ */
+const mocks = vi.hoisted(() => ({
+  recall: vi.fn(),
+  embeddingScorer: vi.fn(),
+  readProfile: vi.fn(),
+  embedMementoQuery: vi.fn(),
+}));
+
+vi.mock('@bike4mind/memory', () => ({
+  recall: mocks.recall,
+  embeddingScorer: mocks.embeddingScorer,
+}));
+vi.mock('@bike4mind/database', () => ({
+  memoryLedgerRepository: {},
+  memoryPrincipalKeyRepository: {},
+}));
+vi.mock('./factCipher', () => ({ createKeyProvider: () => ({}) }));
+vi.mock('./ledgerMemoryStore', () => ({
+  createLedgerMemoryStore: () => ({ readProfile: mocks.readProfile }),
+}));
+vi.mock('./mementoQueryEmbedding', () => ({ embedMementoQuery: mocks.embedMementoQuery }));
+
+const belief = (id: string) => ({ id, fact: `fact ${id}`, sources: ['doc-1'], shredded: false });
+
+const run = (k: number) =>
+  recallLakeMemory({
+    userId: 'u1',
+    query: 'when does acme ship',
+    lakes: [{ datalakeTag: 'datalake:acme', ownerUserId: 'creator-1' }],
+    resolveReachableSources: async ids => new Set(ids),
+    k,
+  });
+
+describe('recallLakeMemory belief budget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.embeddingScorer.mockReturnValue(() => 1);
+    mocks.embedMementoQuery.mockResolvedValue({ vector: [1, 0], model: 'text-embedding-ada-002' });
+    mocks.readProfile.mockResolvedValue({ beliefs: Array.from({ length: 50 }, (_, i) => belief(`b${i}`)) });
+    // Echo the cap back the way the real `recall` does (filter, sort, then slice) so the assertions
+    // below are about the budget reaching the recall, not a re-test of recall's own ranking.
+    mocks.recall.mockImplementation((beliefs: Array<{ fact: string }>, _q: string, opts: { k: number }) =>
+      beliefs.slice(0, opts.k).map(b => ({ belief: b, relevance: 0.9 }))
+    );
+  });
+
+  it("caps the card at the caller's k, not a module constant", async () => {
+    const beliefs = await run(24);
+    expect(mocks.recall).toHaveBeenCalledWith(
+      expect.anything(),
+      'when does acme ship',
+      expect.objectContaining({ k: 24 })
+    );
+    // The behavior the acceptance criterion is written against: with the budget raised, a lake with
+    // a large belief set injects MORE than the eight this used to be pinned at.
+    expect(beliefs).toHaveLength(24);
+  });
+
+  it('honors a lowered k too, so the setting is a budget and not just a raised floor', async () => {
+    // Guards the direction a "raise the default" change makes it easy to stop testing: an admin who
+    // sets 2 must get 2, which a Math.max(8, k) style regression would silently ignore.
+    const beliefs = await run(2);
+    expect(mocks.recall).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ k: 2 }));
+    expect(beliefs).toHaveLength(2);
+  });
+
+  it('passes the budget through on the lexical-degradation path as well', async () => {
+    // A failed query embed drops the scorer and the cosine floor; the cap must survive that branch,
+    // which assembles its recall options from a different conditional spread.
+    mocks.embedMementoQuery.mockRejectedValue(new Error('embeddings down'));
+    await run(24);
+    const opts = mocks.recall.mock.calls[0][2] as { k: number; minRelevance?: number; scorer?: unknown };
+    expect(opts.k).toBe(24);
+    expect(opts.scorer).toBeUndefined();
+    expect(opts.minRelevance).toBeUndefined();
+  });
+});

--- a/apps/client/server/memory/recallLakeMemory.ts
+++ b/apps/client/server/memory/recallLakeMemory.ts
@@ -6,15 +6,14 @@ import { createLedgerMemoryStore } from './ledgerMemoryStore';
 import { embedMementoQuery } from './mementoQueryEmbedding';
 
 /**
- * How many lake beliefs to inject at most - the same k the user-memento recall settled on
- * (recallMementosV2). One merged card across the user's accessible lakes, so this is a shared budget.
- */
-const LAKE_RECALL_K = 8;
-
-/**
  * How far heat (ACT-R activation) may move a belief relative to topicality, matching the user-memento
  * recall. A lake decays far slower (LAKE_ACTIVATION), so months-old reference facts stay warm; the
  * query is still the primary axis and heat the tiebreak.
+ *
+ * Stays a coded constant while the belief budget (`opts.k`) became an admin setting: #2496 was a
+ * volume diagnosis - 8 beliefs is too little grounding for a document corpus - and this weight
+ * changes the ORDER of what fits the budget, not how much fits. Worth exposing once something
+ * measures the ranking as the limiter; nothing has.
  */
 const LAKE_ACTIVATION_WEIGHT = 0.025;
 
@@ -37,6 +36,17 @@ export interface RecallLakeMemoryOptions {
   query: string;
   /** The user's accessible lakes, each paired with its DEK owner. Resolved by the caller. */
   lakes: AccessibleLake[];
+  /**
+   * Most beliefs to return, a SHARED budget across `lakes` (one merged card). The
+   * `lakeMemoryRecallK` admin setting, resolved per turn in LakeMemoryFeature with a coded
+   * fallback. Required rather than defaulted: a default here would be a second copy of
+   * LAKE_RECALL_K_DEFAULT that could drift from the setting's own, which is the exact trap the
+   * hardcoded 8 this replaced represented.
+   *
+   * `recall` applies it as a pure cap AFTER the cosine floor (recall.ts: filter, then sort, then
+   * slice), so raising it admits more QUALIFYING beliefs and never a sub-floor one.
+   */
+  k: number;
   /**
    * Which of these source FabFile ids are currently retrievable for citation. A belief is surfaced
    * only if at least one of its source docs is reachable, so the card never leans on content the
@@ -117,7 +127,7 @@ export async function recallLakeMemory(opts: RecallLakeMemoryOptions): Promise<L
   if (citable.length === 0) return [];
 
   return recall(citable, opts.query, {
-    k: LAKE_RECALL_K,
+    k: opts.k,
     activationWeight: LAKE_ACTIVATION_WEIGHT,
     // The cosine floor is calibrated for the MEMENTO space, so it only applies when we actually scored
     // with an embedding; a lexical fallback uses an unrelated scale and no floor.

--- a/b4m-core/common/src/constants/lakeMemory.ts
+++ b/b4m-core/common/src/constants/lakeMemory.ts
@@ -1,0 +1,30 @@
+/**
+ * Lake-memory recall defaults, shared between the admin-settings schema in this package and
+ * `ChatCompletionFeatures.ts` (which cannot import from `common`'s settings schema without a
+ * dependency cycle, so the constant lives here instead - same reason `forcedRetrieval.ts` exists).
+ */
+
+/**
+ * Beliefs the lake-memory hot-card may inject per turn, shared across every lake in scope.
+ *
+ * 8 was inherited verbatim from user-memento recall, where it is a sensible number of facts about
+ * one person; lake memory is reference material extracted from a document corpus, and 8 one-liners
+ * split across two or more lakes is very little grounding. 24 is deliberately a 3x raise rather
+ * than a measured optimum - nothing has ever varied this - and it anchors on the sibling block's
+ * size: at the 500-char per-fact cap in `buildLakeMemoryContext`, 24 beliefs is a ~12,000-char
+ * worst case, the same order as `FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT` injected on the same turn.
+ */
+export const LAKE_RECALL_K_DEFAULT = 24;
+
+/**
+ * Write-time ceiling for the belief budget. Not a technical limit - `recall` will happily return
+ * more - but a fat-fingered extra zero (24 -> 240) has the same failure mode the forced-retrieval
+ * budget's `max` exists to stop: nothing rejects the value, and the oversized system block is not
+ * something the overflow-guard safety net can shed. `dropOldestHistoryTurn` only ever slices
+ * conversation turns, so the turn silently loses history and then hard-errors once fewer than two
+ * turns remain - a symptom that looks nothing like a misconfigured setting.
+ *
+ * 200 x the 500-char per-fact cap in `buildLakeMemoryContext` is ~100,000 chars, matching
+ * `forcedRetrievalCharBudget`'s own declared ceiling for the retrieval block alongside it.
+ */
+export const LAKE_RECALL_K_MAX = 200;

--- a/b4m-core/common/src/index.ts
+++ b/b4m-core/common/src/index.ts
@@ -43,6 +43,7 @@ export * from './constants/lakeAccessAudit';
 export * from './constants/feedbackRetention';
 export * from './constants/lakeConfigAudit';
 export * from './constants/forcedRetrieval';
+export * from './constants/lakeMemory';
 export * from './constants/knowledgeBaseSearch';
 export * from './constants/publish';
 export * from './constants/artifactElision';

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -173,6 +173,13 @@ const PromptMetaContextSchema = z.object({
   lakeMemory: z
     .object({
       beliefCount: z.number(),
+      // The `lakeMemoryRecallK` budget in force for the turn (#2496). Without it `beliefCount`
+      // is ambiguous on exactly the question the knob exists to answer: a row reading 8 could be
+      // "the cap bound" or "only 8 beliefs qualified", and telling those apart used to mean
+      // knowing what the setting happened to be when the turn ran. beliefCount === beliefBudget
+      // is now a readable saturation signal. Optional: turns recorded before this field existed
+      // have none, and it must not fail their Zod re-parse.
+      beliefBudget: z.number().optional(),
       dataLakeTags: z.array(z.string()),
     })
     .optional(),

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -25,6 +25,7 @@ import {
   LAKE_ACCESS_AUDIT_RETENTION_FLOOR_DAYS,
 } from '../constants/lakeAccessAudit';
 import { FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT } from '../constants/forcedRetrieval';
+import { LAKE_RECALL_K_DEFAULT, LAKE_RECALL_K_MAX } from '../constants/lakeMemory';
 import {
   KB_SEARCH_DEFAULT_RESULTS_DEFAULT,
   KB_SEARCH_MIN_RELEVANCE_PCT_DEFAULT,
@@ -627,6 +628,77 @@ describe('kbSearchMinRelevancePct (#1955)', () => {
     expect(settingsMap.kbSearchMinRelevancePct.schema.parse(100)).toBe(100);
     expect(() => settingsMap.kbSearchMinRelevancePct.schema.parse(-1)).toThrow();
     expect(() => settingsMap.kbSearchMinRelevancePct.schema.parse(101)).toThrow();
+  });
+});
+
+describe('lakeMemoryRecallK agrees with the lake-memory recall fallback (#2496)', () => {
+  // Same drift class as forcedRetrievalCharBudget above: before this setting existed the belief
+  // budget was a literal 8 in recallLakeMemory.ts. The setting's default and the coded fallback a
+  // settings outage returns to now both import LAKE_RECALL_K_DEFAULT, so this pins that they
+  // cannot silently diverge.
+  it('defaults to the shared constant, not a hand-copied literal', () => {
+    expect(settingsMap.lakeMemoryRecallK.defaultValue).toBe(LAKE_RECALL_K_DEFAULT);
+    // Pin the literal too, and say why: the whole point of the change is that the budget is no
+    // longer 8, so a default that drifted back down to the old value should fail here.
+    expect(settingsMap.lakeMemoryRecallK.defaultValue).toBeGreaterThan(8);
+  });
+
+  it('is platform-only, like its sibling forcedRetrievalCharBudget', () => {
+    // Deliberate, not an oversight - see the setting's own description. LakeMemoryFeature reads it
+    // directly rather than through the scoped-settings resolver, so a settableAt block here would
+    // be inert at best and could arm the resolver's fail-loud owner check at worst.
+    expect(settingsMap.lakeMemoryRecallK.scope).toBeUndefined();
+  });
+
+  it('prefaults to the shared constant rather than makeNumberSetting fallback 0', () => {
+    // 0 would be worse than the old hardcoded 8: it disables the card outright, and silently.
+    expect(settingsMap.lakeMemoryRecallK.schema.parse(undefined)).toBe(LAKE_RECALL_K_DEFAULT);
+  });
+
+  it('rejects 0 and negatives at write time', () => {
+    expect(settingsMap.lakeMemoryRecallK.min).toBe(1);
+    expect(() => settingsMap.lakeMemoryRecallK.schema.parse(0)).toThrow();
+    expect(() => settingsMap.lakeMemoryRecallK.schema.parse(-1)).toThrow();
+    expect(settingsMap.lakeMemoryRecallK.schema.parse(1)).toBe(1);
+  });
+
+  it('rejects a value above the declared ceiling at write time', () => {
+    // A fat-fingered extra zero (24 -> 240) otherwise passes validation cleanly and then sheds
+    // conversation history via the overflow-recovery loop, which looks nothing like a
+    // misconfigured setting. Same reasoning as forcedRetrievalCharBudget's max.
+    expect(settingsMap.lakeMemoryRecallK.max).toBe(LAKE_RECALL_K_MAX);
+    expect(() => settingsMap.lakeMemoryRecallK.schema.parse(LAKE_RECALL_K_MAX + 1)).toThrow();
+    expect(settingsMap.lakeMemoryRecallK.schema.parse(LAKE_RECALL_K_MAX)).toBe(LAKE_RECALL_K_MAX);
+  });
+
+  it('rejects a fractional budget rather than letting a reader floor it', () => {
+    // A belief count has no fractional meaning, so 1.5 is a typo, not a lower setting. Without the
+    // `int` flag it passes min/max cleanly and is then floored to 1 by positiveIntOr at read time -
+    // a 24x cut to lake grounding that reports as a successful save. Verified live: the real
+    // PUT /api/settings/update returns 422 for 1.5 and leaves the stored value untouched.
+    expect(() => settingsMap.lakeMemoryRecallK.schema.parse(1.5)).toThrow();
+    // The admin UI submits its number field as a string, so coercion must still work.
+    expect(settingsMap.lakeMemoryRecallK.schema.parse('24')).toBe(24);
+  });
+
+  it('does not make integrality the default for every number setting', () => {
+    // `int` is opt-in on makeNumberSetting precisely because genuine fractions exist. If a future
+    // change flips it to the factory default, this fails instead of silently rejecting every
+    // fraction setting's own default value.
+    expect(settingsMap.ContextVerbatimWindowFraction.schema.parse(0.55)).toBe(0.55);
+  });
+
+  it('is registered in the EMBEDDING group at the order the admin UI actually sorts by', () => {
+    // Two surfaces that can disagree: AdminSettingsTab buckets by `settingsMap[key].group` and
+    // sorts by `settingsMap[key].order`, while API_SERVICE_GROUPS.settings is the declared
+    // manifest. A setting present in only one, or carrying two different orders, renders somewhere
+    // nobody intended - so pin that both agree and the order is still unique in the group.
+    const entry = API_SERVICE_GROUPS.EMBEDDING.settings.find(s => s.key === 'lakeMemoryRecallK');
+    expect(entry).toBeDefined();
+    expect(settingsMap.lakeMemoryRecallK.group).toBe(API_SERVICE_GROUPS.EMBEDDING.id);
+    expect(settingsMap.lakeMemoryRecallK.order).toBe(entry!.order);
+    const orders = API_SERVICE_GROUPS.EMBEDDING.settings.map(s => s.order);
+    expect(new Set(orders).size).toBe(orders.length);
   });
 });
 

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -19,6 +19,7 @@ import {
   LAKE_CONFIG_AUDIT_RETENTION_MAX_DAYS,
 } from '../constants/lakeConfigAudit';
 import { FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT } from '../constants/forcedRetrieval';
+import { LAKE_RECALL_K_DEFAULT, LAKE_RECALL_K_MAX } from '../constants/lakeMemory';
 import {
   KB_SEARCH_DEFAULT_RESULTS_DEFAULT,
   KB_SEARCH_MIN_RELEVANCE_PCT_DEFAULT,
@@ -334,6 +335,7 @@ export const SettingKeySchema = z.enum([
   'dataLakeSearchMaxFiles',
   'dataLakeSearchMaxChunks',
   'forcedRetrievalCharBudget',
+  'lakeMemoryRecallK',
   'kbSearchDefaultResults',
   'kbSearchResultTokenBudget',
   'kbSearchMinRelevancePct',
@@ -856,8 +858,13 @@ export const DATA_LAKE_EMBEDDING_TIER_MULTIPLIER_INDIVIDUAL_DEFAULT = 1;
 export const DATA_LAKE_EMBEDDING_TIER_MULTIPLIER_ORGANIZATION_DEFAULT = 5;
 export const DATA_LAKE_EMBEDDING_TIER_MULTIPLIER_MAX = 100;
 
-function makeNumberSetting(config: { defaultValue?: number; min?: number; max?: number } & BaseSetting) {
+function makeNumberSetting(config: { defaultValue?: number; min?: number; max?: number; int?: boolean } & BaseSetting) {
   let numberSchema = z.coerce.number();
+  // Opt-in, not the factory default: several settings are genuine fractions (see
+  // ContextVerbatimWindowFraction), so integrality is a property of the setting rather than of
+  // "number setting". Where it IS set, it rejects at the write boundary instead of leaving a
+  // fractional value to be floored later by whichever reader happens to floor it.
+  if (config.int) numberSchema = numberSchema.int();
   if (config.min !== undefined) numberSchema = numberSchema.min(config.min);
   if (config.max !== undefined) numberSchema = numberSchema.max(config.max);
   return {
@@ -1471,6 +1478,7 @@ export const API_SERVICE_GROUPS = {
       { key: 'kbSearchDefaultResults', order: 5 },
       { key: 'kbSearchResultTokenBudget', order: 6 },
       { key: 'kbSearchMinRelevancePct', order: 7 },
+      { key: 'lakeMemoryRecallK', order: 8 },
     ],
   },
   DATA_LAKE_COST: {
@@ -3451,6 +3459,29 @@ export const settingsMap = {
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 7,
     scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
+  }),
+  lakeMemoryRecallK: makeNumberSetting({
+    key: 'lakeMemoryRecallK',
+    name: 'Lake Memory Belief Budget',
+    defaultValue: LAKE_RECALL_K_DEFAULT,
+    min: 1,
+    max: LAKE_RECALL_K_MAX,
+    // A belief count, so 1.5 is not a lower setting - it is a typo. Without this the write path
+    // accepts it and `positiveIntOr` floors it silently at read time, which reports as 1.
+    int: true,
+    description:
+      'Most beliefs the lake memory hot-card injects on a Data-Lake-mode turn, shared across every ' +
+      'lake in scope. Recall still applies its cosine floor and the source-reachability gate first, ' +
+      'so raising this does not admit low-quality beliefs - it raises the ceiling on how many ' +
+      'QUALIFYING beliefs can actually be used, which was pinned at 8 (inherited from personal-' +
+      'memento recall) on no evidence beyond that inheritance. The sibling lever on the same turn is ' +
+      'Forced Retrieval Char Budget, which governs raw chunk text rather than extracted beliefs. ' +
+      'Platform-only for now, like that sibling: this read does not go through the scoped-settings ' +
+      'resolver, so a settableAt block here would be inert metadata at best and could arm the ' +
+      "resolver's fail-loud owner check at worst.",
+    category: 'AI',
+    group: API_SERVICE_GROUPS.EMBEDDING.id,
+    order: 8,
   }),
   LakeAccessAuditRetentionDays: makeNumberSetting({
     key: 'LakeAccessAuditRetentionDays',

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -10,7 +10,11 @@ import {
 } from './ChatCompletionFeatures';
 import { GROUNDED_NO_INVENTION_RULE } from './prompts';
 import { mergeRetrievalSummary } from './tools/retrievalSummaryMerge';
-import { UNLIMITED_HISTORY_COUNT, FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT } from '@bike4mind/common';
+import {
+  UNLIMITED_HISTORY_COUNT,
+  FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+  LAKE_RECALL_K_DEFAULT,
+} from '@bike4mind/common';
 import type { ISessionDocument, IChatHistoryItemDocument } from '@bike4mind/common';
 import type { Logger } from '@bike4mind/observability';
 
@@ -2526,6 +2530,132 @@ describe('LakeMemoryFeature personal-corpus skip', () => {
     // returns [] (no entitled tags to resolve), so asserting the empty result alone would pass
     // whether or not the skip fired - which is exactly the vacuity this assertion replaces.
     expect(ctx.logger.log).toHaveBeenCalledWith(expect.stringContaining('[lakeMemory] skipped'));
+  });
+});
+
+/**
+ * The belief budget is the `lakeMemoryRecallK` admin setting, not the 8 this path used to hardcode
+ * (#2496). Resolution mirrors `resolveForcedRetrievalCharBudget` below, so these pin the same three
+ * properties: a configured value reaches the recall, anything unusable falls back LOUDLY, and a
+ * settings outage costs the turn its budget but never its card.
+ */
+describe('LakeMemoryFeature belief budget (lakeMemoryRecallK)', () => {
+  const LAKE_DOC = {
+    id: 'lake-acme',
+    slug: 'acme',
+    name: 'Acme',
+    datalakeTag: 'datalake:acme',
+    fileTagPrefix: 'acme:',
+    createdByUserId: 'creator-1',
+  };
+
+  const makeCtx = (opts: { getSettingsValue?: () => unknown; lakes?: Array<Record<string, unknown>> } = {}) => ({
+    logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger,
+    user: { id: 'viewer-1', tags: [], groups: [] },
+    personalCorpusOnly: false,
+    db: {
+      organizations: { findMembershipOrgIds: vi.fn().mockResolvedValue([]) },
+      dataLakes: {
+        findActiveByUserTagsAndEntitlements: vi.fn().mockResolvedValue(opts.lakes ?? [LAKE_DOC]),
+      },
+      adminSettings: {
+        getSettingsValue: vi.fn(async (key: string) =>
+          key === 'lakeMemoryRecallK' ? (opts.getSettingsValue ?? (() => undefined))() : undefined
+        ),
+      },
+    },
+    resolveEntitlementKeys: vi.fn().mockResolvedValue([]),
+    sendStatusUpdate: vi.fn().mockResolvedValue(undefined),
+    recallLakeMemory: vi.fn().mockResolvedValue([{ fact: 'Acme ships on Fridays', relevance: 0.9, sources: ['f1'] }]),
+  });
+
+  const run = async (ctx: ReturnType<typeof makeCtx>, quest = makeQuest()) => {
+    const feature = new LakeMemoryFeature(ctx as unknown as ConstructorParameters<typeof LakeMemoryFeature>[0], []);
+    const messages = await feature.getContextMessages(
+      quest,
+      undefined as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'when does acme ship'
+    );
+    return { messages, k: ctx.recallLakeMemory.mock.calls[0]?.[0]?.k as number | undefined };
+  };
+
+  const warnedAbout = (ctx: ReturnType<typeof makeCtx>) =>
+    (ctx.logger.warn as unknown as ReturnType<typeof vi.fn>).mock.calls.some(([first]) =>
+      String(first).includes('lakeMemoryRecallK')
+    );
+
+  it('forwards a configured value to the injected recall', async () => {
+    const ctx = makeCtx({ getSettingsValue: () => 40 });
+    const { k } = await run(ctx);
+    expect(k).toBe(40);
+    expect(warnedAbout(ctx)).toBe(false);
+  });
+
+  it('stamps the budget alongside beliefCount so a saturated turn is readable', async () => {
+    // beliefCount on its own cannot say whether the cap bound the turn. Recording the budget that
+    // was in force is what makes `beliefCount === beliefBudget` mean "saturated" on an eval row,
+    // rather than requiring someone to know what the setting was when the turn ran.
+    const ctx = makeCtx({ getSettingsValue: () => 40 });
+    const quest = makeQuest();
+    await run(ctx, quest);
+    expect(quest.promptMeta?.context?.lakeMemory).toEqual({
+      beliefCount: 1,
+      beliefBudget: 40,
+      dataLakeTags: ['datalake:acme'],
+    });
+  });
+
+  it('an unset setting falls back to LAKE_RECALL_K_DEFAULT, silently', async () => {
+    // Unset is the normal state of a fresh deployment, so it must not warn - only a set-but-
+    // unusable value or a failed read does.
+    const ctx = makeCtx({ getSettingsValue: () => undefined });
+    const { k } = await run(ctx);
+    expect(k).toBe(LAKE_RECALL_K_DEFAULT);
+    expect(warnedAbout(ctx)).toBe(false);
+  });
+
+  /**
+   * Defense-in-depth, not a production-reachable path: the real `getSettingsValue` runs the
+   * setting's own schema via `safeParse` first, so an unusable stored shape cannot reach
+   * `positiveIntOr`. This injects the raw shape directly to pin `positiveIntOr`'s OWN contract,
+   * which is what protects the call if that upstream sanitization is ever bypassed.
+   */
+  it('an unusable raw value falls back to the default and warns', async () => {
+    const ctx = makeCtx({ getSettingsValue: () => 'not-a-number' });
+    const { k } = await run(ctx);
+    expect(k).toBe(LAKE_RECALL_K_DEFAULT);
+    expect(warnedAbout(ctx)).toBe(true);
+  });
+
+  it('a settings-read failure costs the turn its budget but not its card', async () => {
+    const ctx = makeCtx({
+      getSettingsValue: () => {
+        throw new Error('settings store unavailable');
+      },
+    });
+    const { messages, k } = await run(ctx);
+    expect(k).toBe(LAKE_RECALL_K_DEFAULT);
+    expect(warnedAbout(ctx)).toBe(true);
+    // The whole point of the inner catch: a settings outage must not route into
+    // getContextMessages' outer catch, which would drop the hot card entirely.
+    expect(messages).toHaveLength(1);
+  });
+
+  it('reads the setting only once, and only after the no-lakes exit', async () => {
+    const grounded = makeCtx({ getSettingsValue: () => 40 });
+    await run(grounded);
+    const reads = (key: string, ctx: ReturnType<typeof makeCtx>) =>
+      (ctx.db.adminSettings.getSettingsValue as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([k]) => k === key
+      );
+    expect(reads('lakeMemoryRecallK', grounded)).toHaveLength(1);
+
+    // A turn with nothing in scope returns before the recall, so it must not spend a settings read
+    // on a budget it will never use.
+    const noLakes = makeCtx({ getSettingsValue: () => 40, lakes: [] });
+    await run(noLakes);
+    expect(reads('lakeMemoryRecallK', noLakes)).toHaveLength(0);
+    expect(noLakes.recallLakeMemory).not.toHaveBeenCalled();
   });
 });
 

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -56,6 +56,7 @@ import {
   lakeMemoryFacts,
   FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
   FORCED_RETRIEVAL_MIN_SIMILARITY_DEFAULT,
+  LAKE_RECALL_K_DEFAULT,
   DATALAKE_TAG_PREFIX,
   PROMPT_TEXT_MAX,
   type SupportedEmbeddingModel,
@@ -321,6 +322,18 @@ export interface IChatCompletionServiceOptions {
     query: string;
     dataLakeTags: string[];
     retrievalFilter?: RetrievalExclusionOptions;
+    /**
+     * Most beliefs to return, across all of `dataLakeTags`: the `lakeMemoryRecallK` admin setting,
+     * resolved per turn by the caller with a coded fallback.
+     *
+     * Required rather than optional so the in-repo chain (recallLakeMemoryForSession ->
+     * recallLakeMemory) is typechecked end to end - each hop re-declares it required, so dropping
+     * it anywhere along the way fails the build. That does NOT extend to an out-of-repo host:
+     * parameters are bivariant, so an implementation whose own signature omits `k` still satisfies
+     * this type and would silently keep whatever budget it hardcodes. No such host exists today
+     * (this is the only in-tree injection slot), but an added one needs forwarding by hand.
+     */
+    k: number;
   }) => Promise<{ fact: string; relevance: number; sources: string[] }[]>;
   /**
    * Resolve a session-activatable registry prompt's CURRENT content by id (e.g. 'triage_router').
@@ -789,11 +802,15 @@ export class LakeMemoryFeature implements ChatCompletionFeature {
         return [];
       }
 
+      // Resolved AFTER the no-lakes exit above, so a turn with nothing in scope spends no settings
+      // read on a budget it will never use.
+      const beliefBudget = await this.resolveLakeRecallK();
       const beliefs = await this.chatCompletion.recallLakeMemory({
         userId: this.user.id,
         query,
         dataLakeTags,
         retrievalFilter: this.retrievalFilter,
+        k: beliefBudget,
       });
       if (beliefs.length === 0) {
         // A legitimate zero: recall ran to completion and found nothing. This is the case the
@@ -806,7 +823,12 @@ export class LakeMemoryFeature implements ChatCompletionFeature {
       // independent of whether the model then also called the knowledge tools.
       quest.promptMeta = quest.promptMeta ?? {};
       quest.promptMeta.context = quest.promptMeta.context ?? {};
-      quest.promptMeta.context.lakeMemory = { beliefCount: beliefs.length, dataLakeTags };
+      // beliefBudget rides along so `beliefCount` is readable on its own: below the budget means that
+      // is all that qualified, AT the budget means the turn saturated it. Saturation is not proof the
+      // cap excluded anything - a lake holding exactly `k` qualifying beliefs reads identically, and
+      // nothing overfetches k+1 to tell those apart - but it is the signal that raising the budget is
+      // worth trying, which is the diagnosis behind #2496.
+      quest.promptMeta.context.lakeMemory = { beliefCount: beliefs.length, beliefBudget, dataLakeTags };
 
       this.logger.log(`🌊 Lake memory: injecting ${beliefs.length} belief(s) from ${dataLakeTags.length} lake(s)`);
       // Lake-specific framing (buildLakeMemoryContext): reference material, NOT personal memory, and it
@@ -834,6 +856,34 @@ export class LakeMemoryFeature implements ChatCompletionFeature {
           (error instanceof Error ? `${error.name}: ${error.message}` : String(error))
       );
       return [];
+    }
+  }
+
+  /**
+   * The admin's configured `lakeMemoryRecallK`, or the coded default on anything unusable. Mirrors
+   * `resolveForcedRetrievalCharBudget` in KnowledgeRetrievalFeature below: same try/catch shape,
+   * same loud-fallback policy, resolved once per turn.
+   *
+   * `positiveIntOr`'s unusable-value branch is defense-in-depth, not a production-reachable path:
+   * `getSettingsValue` runs the setting's own schema (`.min(1)`, `.max(LAKE_RECALL_K_MAX)`) via
+   * `safeParse` before this sees the value, whatever wrote it. The genuinely reachable branch is
+   * the outer catch (a settings-read failure or outage), which must not cost the turn its card.
+   */
+  private async resolveLakeRecallK(): Promise<number> {
+    try {
+      const configured = await this.chatCompletion.db.adminSettings.getSettingsValue('lakeMemoryRecallK');
+      return positiveIntOr(
+        configured as string | number | null | undefined,
+        LAKE_RECALL_K_DEFAULT,
+        'lakeMemoryRecallK',
+        this.logger
+      );
+    } catch (err) {
+      this.logger.warn(
+        `🌊 Lake memory: failed to read lakeMemoryRecallK; falling back to ${LAKE_RECALL_K_DEFAULT}`,
+        err
+      );
+      return LAKE_RECALL_K_DEFAULT;
     }
   }
 }

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -45,6 +45,7 @@ const MessageTruncationSchema = subSchema({
 // `beliefCount` is required). Absent-or-fully-present, matching how the feature writes it.
 const LakeMemorySchema = subSchema({
   beliefCount: { type: Number, required: false },
+  beliefBudget: { type: Number, required: false },
   dataLakeTags: [{ type: String, required: false }],
 });
 


### PR DESCRIPTION
# Pull Request

## Description

`LAKE_RECALL_K` (the belief budget the lake-memory hot-card injects on a Data-Lake-mode turn)
was a hardcoded `8` in `recallLakeMemory.ts`, shared across every accessible lake and inherited
verbatim from personal-memento recall's own budget. Reference material extracted from a
document corpus needs more grounding than 8 one-liners, and there was no way to raise it without
a code change.

This makes the cap an admin setting, `lakeMemoryRecallK`, following the same pattern as the
existing `forcedRetrievalCharBudget` sibling: a platform-only number setting (default 24, range
1-200), resolved once per turn with a coded fallback and a loud warning on a settings-read
failure.

Closes #2496

## Changes

- New `lakeMemoryRecallK` admin setting (Admin Settings -> AI -> Embedding Service), default 24,
  min 1, max 200, platform-only (mirrors `forcedRetrievalCharBudget`'s scoping).
- `LakeMemoryFeature.resolveLakeRecallK()` reads it once per turn (after the no-lakes early
  return), with the same try/catch + loud-fallback shape as `resolveForcedRetrievalCharBudget`.
- The resolved budget threads end to end: `LakeMemoryFeature` -> `recallLakeMemoryForSession` ->
  `recallLakeMemory` -> the existing `recall()` cap (applied *after* the cosine floor, so raising
  it admits more qualifying beliefs, never a sub-floor one).
- `promptMeta.context.lakeMemory.beliefBudget` is now recorded alongside `beliefCount`, so a
  report is readable on its own: `beliefCount === beliefBudget` means the turn saturated the
  budget. Threaded through the Zod schema, the Mongoose parity schema, and the Slack feedback
  summary's read allowlist (renders `8/24` instead of a bare `8`).
- `makeNumberSetting` gains an opt-in `int` flag (inert for every other number setting), set on
  this one so a fractional value like `1.5` is rejected at the write boundary (422) instead of
  being silently floored to `1` at read time.

## Guide for Testers

1. Log in as an admin user.
2. Navigate to **Admin -> Admin Settings -> AI Configuration -> Embedding Service**.
3. Confirm a row labeled **Lake Memory Belief Budget** is present, showing `24`.
4. Change the value to `12` and click its **Save** icon. Reload the page - the value persists as `12`.
5. Attempt to set it to `0`, a negative number, `201`, or `1.5` via the field and save. Each is
   rejected (the request returns a 4xx and the stored value is unchanged); only whole numbers
   from 1 to 200 are accepted.
6. Start a new notebook, enable **Data Lakes** grounding mode, and select a lake that has
   `lakeMemoryEnabled` set and an existing belief profile (an operator-only per-lake toggle -
   most self-host lakes won't have this enabled yet, since it's independent of this change).
   Ask a question the lake's beliefs cover. Expected: the turn's `promptMeta.context.lakeMemory`
   shows `beliefCount` up to the configured budget (e.g. up to 12), where before this change it
   was capped at 8 regardless of the setting.

### Regression Checks

- The sibling `Forced Retrieval Char Budget` setting is unaffected - its own schema, resolver,
  and tests are untouched by this change.
- Every other number setting (e.g. `ContextVerbatimWindowFraction`, a genuine fraction) still
  accepts and saves its normal range of values; the new `int` validation is opt-in per setting,
  not a default.

### What NOT to test

- This is backend/settings-schema work with one small admin-panel surface; there is no new
  chat-facing UI beyond the existing Data Lakes toggle.
- The per-lake `lakeMemoryEnabled` flag and the `EnableLakeMemory` platform flag are pre-existing
  gates, unrelated to this change - don't file findings against lake-memory not firing at all if
  those are off, that's expected and orthogonal to this PR.

## Developer Notes (Optional)

- **New pattern**: `makeNumberSetting` now supports an opt-in `int: true` for settings with no
  fractional meaning (a count, a budget), rejecting non-integers at the write boundary rather
  than relying on each reader to floor silently. Available to any future setting that needs it.
- **Data model**: `promptMeta.context.lakeMemory.beliefBudget` (optional, so pre-existing quest
  records without it still parse) is new telemetry recording which budget was in force for the
  turn, making `beliefCount` interpretable without knowing what the setting happened to be at
  the time.
