### PR TITLE
fix(data-lakes): stop offering Drive connect on a personal lake

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeIngestPickerModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeIngestPickerModal.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/joy';
 import { DataLakeIcon } from '@client/app/components/datalake/dataLakeBranding';
 import { useGetDataLakes } from '@client/app/hooks/data/dataLakes';
-import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { toWizardTargetLake, useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 
 interface DataLakeIngestPickerModalProps {
   open: boolean;
@@ -40,16 +40,7 @@ export default function DataLakeIngestPickerModal({ open, files, onClose }: Data
   const setStep = useDataLakeWizardStore(s => s.setStep);
 
   const handlePick = (lake: NonNullable<typeof lakes>[number]) => {
-    openWizardForLake({
-      id: lake.id,
-      slug: lake.slug,
-      name: lake.name,
-      fileTagPrefix: lake.fileTagPrefix,
-      requiredUserTag: lake.requiredUserTag,
-      requiredEntitlement: lake.requiredEntitlement,
-      organizationId: lake.organizationId ?? null,
-      canManage: lake.canManage ?? false,
-    });
+    openWizardForLake(toWizardTargetLake(lake));
     setFiles(files);
     // Preview is opt-in elsewhere, but a drop can carry a whole traversed folder the user
     // never itemized, so this entry point turns it on and lands there - skipping straight to

--- a/apps/client/app/components/DataLakeWizard/DataLakeIngestPickerModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeIngestPickerModal.tsx
@@ -47,6 +47,8 @@ export default function DataLakeIngestPickerModal({ open, files, onClose }: Data
       fileTagPrefix: lake.fileTagPrefix,
       requiredUserTag: lake.requiredUserTag,
       requiredEntitlement: lake.requiredEntitlement,
+      organizationId: lake.organizationId ?? null,
+      canManage: lake.canManage ?? false,
     });
     setFiles(files);
     // Preview is opt-in elsewhere, but a drop can carry a whole traversed folder the user

--- a/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
@@ -36,7 +36,7 @@ import {
 } from '@client/app/hooks/data/dataLakes';
 import PsychologyOutlinedIcon from '@mui/icons-material/PsychologyOutlined';
 import { toast } from 'sonner';
-import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { toWizardTargetLake, useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import useStartChatWithLake from '@client/app/hooks/useStartChatWithLake';
 import DataLakeEmptyState from '@client/app/components/datalake/DataLakeEmptyState';
 import LakeHealthBadge from '@client/app/components/datalake/LakeHealthBadge';
@@ -195,18 +195,7 @@ export function LakeInfoPanel({
                 color="primary"
                 startDecorator={<AddIcon sx={{ fontSize: 16 }} />}
                 data-testid={`datalake-addfiles-btn-${lake.id}`}
-                onClick={() =>
-                  openWizardForLake({
-                    id: lake.id,
-                    slug: lake.slug,
-                    name: lake.name,
-                    fileTagPrefix: lake.fileTagPrefix,
-                    requiredUserTag: lake.requiredUserTag,
-                    requiredEntitlement: lake.requiredEntitlement,
-                    organizationId: lake.organizationId ?? null,
-                    canManage: lake.canManage ?? false,
-                  })
-                }
+                onClick={() => openWizardForLake(toWizardTargetLake(lake))}
                 sx={{ flexShrink: 0, fontSize: '13px' }}
               >
                 Add files

--- a/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx
@@ -203,6 +203,8 @@ export function LakeInfoPanel({
                     fileTagPrefix: lake.fileTagPrefix,
                     requiredUserTag: lake.requiredUserTag,
                     requiredEntitlement: lake.requiredEntitlement,
+                    organizationId: lake.organizationId ?? null,
+                    canManage: lake.canManage ?? false,
                   })
                 }
                 sx={{ flexShrink: 0, fontSize: '13px' }}

--- a/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { useDataLakeWizardStore, type WizardTargetLake } from '@client/app/stores/useDataLakeWizardStore';
 import SourceSelectionStep from './SourceSelectionStep';
 
 const { lakes, selectedAccount, toastInfo } = vi.hoisted(() => ({
@@ -249,7 +249,7 @@ describe('SourceSelectionStep - optional step opt-ins', () => {
     // on a personal lake and 403s for a non-manager. This render site was ungated, so opening Add
     // files on a personal lake fired a guaranteed-404 GET /drive-connection and rendered a
     // permanently disabled Connect button. SelectedLakeHeader already gates on exactly this.
-    const appendTo = (over: Record<string, unknown>) =>
+    const appendTo = (over: Partial<WizardTargetLake> = {}) =>
       useDataLakeWizardStore.setState({
         targetLake: {
           id: 'lake-1',
@@ -259,7 +259,7 @@ describe('SourceSelectionStep - optional step opt-ins', () => {
           organizationId: 'org-1',
           canManage: true,
           ...over,
-        } as never,
+        },
       });
 
     it('renders NO connect control on a personal lake', () => {

--- a/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.test.tsx
@@ -23,11 +23,13 @@ vi.mock('sonner', () => ({ toast: { info: toastInfo } }));
 // Both Drive actions pull in React Query (useConfig / lake-connection hooks); stub them so these
 // step-order/name-validation tests need no QueryClientProvider. Their own behavior is covered by
 // DriveConnectAction.test.tsx and DrivePendingConnectAction.test.tsx.
+// Rendered as markers rather than null: these tests assert WHICH of the two appears, which is the
+// gate this step owns. Their own behaviour stays covered by their own test files.
 vi.mock('@client/app/components/DataLakeWizard/steps/DriveConnectAction', () => ({
-  default: () => null,
+  default: () => <div data-testid="drive-connect-action" />,
 }));
 vi.mock('@client/app/components/DataLakeWizard/steps/DrivePendingConnectAction', () => ({
-  default: () => null,
+  default: () => <div data-testid="drive-pending-connect-action" />,
 }));
 
 const appTheme = extendTheme({ ...getThemeConfig() });
@@ -141,7 +143,14 @@ describe('SourceSelectionStep - lake name', () => {
 
   it('offers no name field in append mode - the target lake owns its identity', () => {
     useDataLakeWizardStore.setState({
-      targetLake: { id: 'lake-1', name: 'Niche', slug: 'niche', fileTagPrefix: 'niche:' },
+      targetLake: {
+        id: 'lake-1',
+        name: 'Niche',
+        slug: 'niche',
+        fileTagPrefix: 'niche:',
+        organizationId: 'org-1',
+        canManage: true,
+      },
     });
 
     renderStep();
@@ -220,12 +229,69 @@ describe('SourceSelectionStep - optional step opt-ins', () => {
 
   it('offers no taxonomy opt-in in append mode, where the lake tags already exist', () => {
     useDataLakeWizardStore.setState({
-      targetLake: { id: 'lake-1', name: 'Niche', slug: 'niche', fileTagPrefix: 'niche:' },
+      targetLake: {
+        id: 'lake-1',
+        name: 'Niche',
+        slug: 'niche',
+        fileTagPrefix: 'niche:',
+        organizationId: 'org-1',
+        canManage: true,
+      },
     });
     const { container } = renderStep();
     selectFiles(container, [file('a.txt')]);
 
     expect(screen.getByTestId('source-toggle-preview')).toBeInTheDocument();
     expect(screen.queryByTestId('source-toggle-taxonomy')).toBeNull();
+  });
+  describe('the Drive connect control is gated the way its sibling is', () => {
+    // Connecting Drive is an org-lake, owner/manager capability server-side: the status route 404s
+    // on a personal lake and 403s for a non-manager. This render site was ungated, so opening Add
+    // files on a personal lake fired a guaranteed-404 GET /drive-connection and rendered a
+    // permanently disabled Connect button. SelectedLakeHeader already gates on exactly this.
+    const appendTo = (over: Record<string, unknown>) =>
+      useDataLakeWizardStore.setState({
+        targetLake: {
+          id: 'lake-1',
+          name: 'Niche',
+          slug: 'niche',
+          fileTagPrefix: 'niche:',
+          organizationId: 'org-1',
+          canManage: true,
+          ...over,
+        } as never,
+      });
+
+    it('renders NO connect control on a personal lake', () => {
+      appendTo({ organizationId: null });
+      renderStep();
+
+      expect(screen.queryByTestId('drive-connect-action')).toBeNull();
+      // And not the create-mode fallback either - there IS a target lake, it just cannot connect.
+      expect(screen.queryByTestId('drive-pending-connect-action')).toBeNull();
+    });
+
+    it('renders NO connect control for a non-manager on an org lake', () => {
+      // The 403 half of the same gate. Without it the two render sites disagree, which is what let
+      // this one drift in the first place.
+      appendTo({ canManage: false });
+      renderStep();
+
+      expect(screen.queryByTestId('drive-connect-action')).toBeNull();
+    });
+
+    it('renders the connect control for a manager on an org lake', () => {
+      appendTo({});
+      renderStep();
+
+      expect(screen.getByTestId('drive-connect-action')).toBeInTheDocument();
+    });
+
+    it('still parks the selection in create mode, where there is no lake to gate on yet', () => {
+      renderStep();
+
+      expect(screen.getByTestId('drive-pending-connect-action')).toBeInTheDocument();
+      expect(screen.queryByTestId('drive-connect-action')).toBeNull();
+    });
   });
 });

--- a/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
@@ -47,6 +47,8 @@ export default function SourceSelectionStep() {
   const config = useDataLakeWizardStore(s => s.config);
   const setConfig = useDataLakeWizardStore(s => s.setConfig);
   const targetLake = useDataLakeWizardStore(s => s.targetLake);
+  // Same expression as SelectedLakeHeader's, deliberately - see the render site below.
+  const canConnectDrive = !!targetLake?.organizationId && !!targetLake?.canManage;
   const optionalSteps = useDataLakeWizardStore(s => s.optionalSteps);
   const setOptionalStep = useDataLakeWizardStore(s => s.setOptionalStep);
   const folderInputRef = useRef<HTMLInputElement>(null);
@@ -308,8 +310,14 @@ export default function SourceSelectionStep() {
         </Box>
 
         {/* Append mode has a lake to bind to, so the folder connects on the spot. Create mode
-            does not, so the selection is parked and connected on commit (#1916). */}
-        {targetLake ? <DriveConnectAction lake={targetLake} /> : <DrivePendingConnectAction />}
+            does not, so the selection is parked and connected on commit (#1916).
+
+            Gated on the SAME condition as the other render site (SelectedLakeHeader): connecting
+            Drive is an org-lake, owner/manager capability server-side - the status route 404s on a
+            personal lake and 403s for a non-manager. Ungated, opening Add files on a personal lake
+            fired a guaranteed-404 `GET /drive-connection` and rendered a permanently disabled
+            Connect button. The two sites must keep agreeing; this one was simply missed. */}
+        {targetLake ? canConnectDrive && <DriveConnectAction lake={targetLake} /> : <DrivePendingConnectAction />}
       </Stack>
 
       {/* Once files are in hand: what was picked up, plus the two opt-in steps. Both default

--- a/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
@@ -30,6 +30,7 @@ import { slugifyDataLakeName } from '@client/app/hooks/data/dataLakeSlug';
 import { useGetDataLakes } from '@client/app/hooks/data/dataLakes';
 import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
 import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
+import { canConnectLakeDrive } from '@client/app/components/datalake/lakeVisibility';
 import DriveConnectAction from './DriveConnectAction';
 import DrivePendingConnectAction from './DrivePendingConnectAction';
 
@@ -47,8 +48,7 @@ export default function SourceSelectionStep() {
   const config = useDataLakeWizardStore(s => s.config);
   const setConfig = useDataLakeWizardStore(s => s.setConfig);
   const targetLake = useDataLakeWizardStore(s => s.targetLake);
-  // Same expression as SelectedLakeHeader's, deliberately - see the render site below.
-  const canConnectDrive = !!targetLake?.organizationId && !!targetLake?.canManage;
+  const canConnectDrive = !!targetLake && canConnectLakeDrive(targetLake);
   const optionalSteps = useDataLakeWizardStore(s => s.optionalSteps);
   const setOptionalStep = useDataLakeWizardStore(s => s.setOptionalStep);
   const folderInputRef = useRef<HTMLInputElement>(null);
@@ -310,13 +310,7 @@ export default function SourceSelectionStep() {
         </Box>
 
         {/* Append mode has a lake to bind to, so the folder connects on the spot. Create mode
-            does not, so the selection is parked and connected on commit (#1916).
-
-            Gated on the SAME condition as the other render site (SelectedLakeHeader): connecting
-            Drive is an org-lake, owner/manager capability server-side - the status route 404s on a
-            personal lake and 403s for a non-manager. Ungated, opening Add files on a personal lake
-            fired a guaranteed-404 `GET /drive-connection` and rendered a permanently disabled
-            Connect button. The two sites must keep agreeing; this one was simply missed. */}
+            does not, so the selection is parked and connected on commit. */}
         {targetLake ? canConnectDrive && <DriveConnectAction lake={targetLake} /> : <DrivePendingConnectAction />}
       </Stack>
 

--- a/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
@@ -157,7 +157,10 @@ const { openManagerSpy, openWizardForLakeSpy } = vi.hoisted(() => ({
   openManagerSpy: vi.fn(),
   openWizardForLakeSpy: vi.fn(),
 }));
-vi.mock('@client/app/stores/useDataLakeWizardStore', () => ({
+vi.mock('@client/app/stores/useDataLakeWizardStore', async importOriginal => ({
+  // Keep the real toWizardTargetLake: it is a pure projection, and stubbing it would hide a
+  // drifted field from every caller this suite covers.
+  ...(await importOriginal<typeof import('@client/app/stores/useDataLakeWizardStore')>()),
   useDataLakeWizardStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({ openManager: openManagerSpy, openWizardForLake: openWizardForLakeSpy }),
 }));

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -435,6 +435,8 @@ export default function DataLakeExplorer({
       fileTagPrefix: selectedLake.fileTagPrefix,
       requiredUserTag: selectedLake.requiredUserTag,
       requiredEntitlement: selectedLake.requiredEntitlement,
+      organizationId: selectedLake.organizationId ?? null,
+      canManage: selectedLake.canManage ?? false,
     });
   }, [selectedLake, openWizardForLake]);
 

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -33,7 +33,7 @@ import {
 } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import DataLakeIngestPickerModal from '@client/app/components/DataLakeWizard/DataLakeIngestPickerModal';
 import { RemoveFileFromLakeCopy } from '@client/app/components/DataLakeWizard/RemoveFileFromLakeDialog';
-import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { toWizardTargetLake, useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { readDroppedItems } from '@client/app/utils/dropReader';
 import { toast } from 'sonner';
 import type { IFabFileDocument, ManageableDataLakeConfig } from '@bike4mind/common';
@@ -428,16 +428,7 @@ export default function DataLakeExplorer({
 
   const addFilesToSelectedLake = useCallback(() => {
     if (!selectedLake) return;
-    openWizardForLake({
-      id: selectedLake.id,
-      slug: selectedLake.slug,
-      name: selectedLake.name,
-      fileTagPrefix: selectedLake.fileTagPrefix,
-      requiredUserTag: selectedLake.requiredUserTag,
-      requiredEntitlement: selectedLake.requiredEntitlement,
-      organizationId: selectedLake.organizationId ?? null,
-      canManage: selectedLake.canManage ?? false,
-    });
+    openWizardForLake(toWizardTargetLake(selectedLake));
   }, [selectedLake, openWizardForLake]);
 
   // Switching lake scope invalidates the breadcrumb: it names a path in the OUTGOING lake's tree,

--- a/apps/client/app/components/datalake/SelectedLakeHeader.test.tsx
+++ b/apps/client/app/components/datalake/SelectedLakeHeader.test.tsx
@@ -13,7 +13,10 @@ const { openWizardForLake, openManager } = vi.hoisted(() => ({
   openWizardForLake: vi.fn(),
   openManager: vi.fn(),
 }));
-vi.mock('@client/app/stores/useDataLakeWizardStore', () => ({
+vi.mock('@client/app/stores/useDataLakeWizardStore', async importOriginal => ({
+  // Keep the real toWizardTargetLake: it is a pure projection, and stubbing it would hide a
+  // drifted field from every caller this suite covers.
+  ...(await importOriginal<typeof import('@client/app/stores/useDataLakeWizardStore')>()),
   useDataLakeWizardStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({ openWizardForLake, openManager }),
 }));

--- a/apps/client/app/components/datalake/SelectedLakeHeader.tsx
+++ b/apps/client/app/components/datalake/SelectedLakeHeader.tsx
@@ -67,6 +67,8 @@ export default function SelectedLakeHeader({ lake }: { lake: ManageableDataLakeC
                 fileTagPrefix: lake.fileTagPrefix,
                 requiredUserTag: lake.requiredUserTag,
                 requiredEntitlement: lake.requiredEntitlement,
+                organizationId: lake.organizationId ?? null,
+                canManage: lake.canManage ?? false,
               })
             }
           >

--- a/apps/client/app/components/datalake/SelectedLakeHeader.tsx
+++ b/apps/client/app/components/datalake/SelectedLakeHeader.tsx
@@ -2,8 +2,8 @@ import { Box, Button, Chip, Stack, Tooltip } from '@mui/joy';
 import AddIcon from '@mui/icons-material/Add';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import DriveConnectAction from '@client/app/components/DataLakeWizard/steps/DriveConnectAction';
-import { lakeVisibilityLabel } from '@client/app/components/datalake/lakeVisibility';
-import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { canConnectLakeDrive, lakeVisibilityLabel } from '@client/app/components/datalake/lakeVisibility';
+import { toWizardTargetLake, useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import type { ManageableDataLakeConfig } from '@bike4mind/common';
 
 /**
@@ -29,7 +29,7 @@ export default function SelectedLakeHeader({ lake }: { lake: ManageableDataLakeC
   // personal lake and 403s for a non-manager). Gating on the same condition keeps a permanently
   // disabled button off every personal lake's header, rather than offering an action that can only
   // ever fail.
-  const canConnectDrive = !!lake.organizationId && !!lake.canManage;
+  const canConnectDrive = canConnectLakeDrive(lake);
 
   return (
     <Box
@@ -59,18 +59,7 @@ export default function SelectedLakeHeader({ lake }: { lake: ManageableDataLakeC
             color="neutral"
             startDecorator={<AddIcon sx={{ fontSize: 16 }} />}
             data-testid="datalake-selected-lake-addfiles-btn"
-            onClick={() =>
-              openWizardForLake({
-                id: lake.id,
-                slug: lake.slug,
-                name: lake.name,
-                fileTagPrefix: lake.fileTagPrefix,
-                requiredUserTag: lake.requiredUserTag,
-                requiredEntitlement: lake.requiredEntitlement,
-                organizationId: lake.organizationId ?? null,
-                canManage: lake.canManage ?? false,
-              })
-            }
+            onClick={() => openWizardForLake(toWizardTargetLake(lake))}
           >
             Add files
           </Button>

--- a/apps/client/app/components/datalake/lakeVisibility.ts
+++ b/apps/client/app/components/datalake/lakeVisibility.ts
@@ -41,3 +41,16 @@ export function lakeVisibilityLabelShort(lake: LakeVisibilityScope): string {
   if (lake.isPublic) return 'Public';
   return lake.organizationId ? 'Org' : 'Private';
 }
+
+/**
+ * Whether to offer the Drive connect control for a lake.
+ *
+ * Connecting Drive is an org-lake, owner/manager capability server-side: the status route 404s on
+ * a personal lake and 403s for a non-manager, so offering it in either case is a control that can
+ * only fail. Both render sites (SelectedLakeHeader and the wizard's SourceSelectionStep) derive
+ * the gate here - they drifted once when each held its own copy of the expression.
+ *
+ * Absent fields fail closed: an unknown scope or manage status renders no control.
+ */
+export const canConnectLakeDrive = (lake: { organizationId?: string | null; canManage?: boolean }): boolean =>
+  !!lake.organizationId && !!lake.canManage;

--- a/apps/client/app/components/datalake/manageKnowledge.test.tsx
+++ b/apps/client/app/components/datalake/manageKnowledge.test.tsx
@@ -19,7 +19,10 @@ vi.mock('@client/app/contexts/UserContext', () => ({
 }));
 
 const openManager = vi.fn();
-vi.mock('@client/app/stores/useDataLakeWizardStore', () => ({
+vi.mock('@client/app/stores/useDataLakeWizardStore', async importOriginal => ({
+  // Keep the real toWizardTargetLake: it is a pure projection, and stubbing it would hide a
+  // drifted field from every caller this suite covers.
+  ...(await importOriginal<typeof import('@client/app/stores/useDataLakeWizardStore')>()),
   useDataLakeWizardStore: (selector: (s: { openManager: typeof openManager }) => unknown) => selector({ openManager }),
 }));
 

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -155,6 +155,19 @@ export interface WizardTargetLake {
   fileTagPrefix: string;
   requiredUserTag?: string;
   requiredEntitlement?: string;
+  /**
+   * The lake's org scope, `null` for a personal lake. Carried so the wizard can gate the Drive
+   * connect control the way `SelectedLakeHeader` does: connecting is an org-lake capability
+   * server-side, so offering it on a personal lake is a button that can only ever fail.
+   *
+   * REQUIRED-and-nullable rather than optional, matching `isOwn` on ManageableDataLakeConfig and for
+   * the same reason: an absent field would read as "personal" and silently hide the control on a
+   * real org lake, with a green typecheck. Required makes a call site that forgets it a compile
+   * error instead.
+   */
+  organizationId: string | null;
+  /** Whether the caller may manage this lake. Same gate as above - the status route 403s otherwise. */
+  canManage: boolean;
 }
 
 interface DataLakeWizardStore {

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -170,6 +170,34 @@ export interface WizardTargetLake {
   canManage: boolean;
 }
 
+/**
+ * The one projection from a fetched lake (a `useGetDataLakes` element or a `ManageableDataLakeConfig`)
+ * to the wizard's narrower target. Every "Add files" entry point maps through here, so a new field on
+ * `WizardTargetLake` is one edit rather than one per call site.
+ *
+ * Both nullable fields fail closed: an absent scope reads as personal and an absent manage status as
+ * not-manageable, which is the safe side of the Drive connect gate.
+ */
+export const toWizardTargetLake = (lake: {
+  id: string;
+  slug: string;
+  name: string;
+  fileTagPrefix: string;
+  requiredUserTag?: string;
+  requiredEntitlement?: string;
+  organizationId?: string | null;
+  canManage?: boolean;
+}): WizardTargetLake => ({
+  id: lake.id,
+  slug: lake.slug,
+  name: lake.name,
+  fileTagPrefix: lake.fileTagPrefix,
+  requiredUserTag: lake.requiredUserTag,
+  requiredEntitlement: lake.requiredEntitlement,
+  organizationId: lake.organizationId ?? null,
+  canManage: lake.canManage ?? false,
+});
+
 interface DataLakeWizardStore {
   // State
   isOpen: boolean;


### PR DESCRIPTION
Closes #2507

## Description

Opening **Add files** on a personal lake fired an unconditional `GET /api/data-lakes/:id/drive-connection` that is a guaranteed `404`, and rendered a permanently disabled Connect button.

Connecting Drive is an org-lake, owner/manager capability server-side - the status route 404s on a personal lake and 403s for a non-manager. `SelectedLakeHeader` already gates on exactly this and explains why; `SourceSelectionStep` did not. Same component, one render site, simply missed.

## Changes

**Both render sites now compute the same condition**, and the render site says the two must keep agreeing.

**Gated on `canManage` as well as org scope.** The issue left that open. Matching the sibling is what stops the two drifting again, and without it a non-manager on an org lake still gets a control that 403s.

**`WizardTargetLake` gains `organizationId` and `canManage`, both required rather than optional.** The issue's suggested one-liner (`targetLake?.organizationId`) does not typecheck - the wizard store carries a narrower type than `ManageableDataLakeConfig`, so the fields had to be threaded.

Required-and-nullable follows the reasoning already recorded on `ManageableDataLakeConfig.isOwn`: an absent `organizationId` would read as "personal" and **silently hide the control on a real org lake with a green typecheck**. Required makes a forgetful call site a compile error - which is how all four were found. `canManage` defaults to `false` where the source type has it optional, so an unknown manage status renders no control (the fail-closed side).

## Testing

- [x] `turbo typecheck:fast` 37/37, eslint clean
- [x] `DataLakeWizard` + `datalake` 676 passed
- [x] Four arms pinned: personal lake renders nothing, non-manager renders nothing, manager on an org lake renders the control, create mode still parks the selection (no lake to gate on yet)
- [x] Mutation-checked - restoring the ungated render site fails the two negative tests
- [ ] Reviewer check: I gated on `canManage` too rather than org scope alone; if you would rather the two sites differ, that difference wants a comment the way `PurgeDriveWarning`'s does

### Note on the test file

The step's Drive stubs rendered `null`, so **neither control's presence was assertable at all** - only that nothing crashed. They now render markers. Also fixed the existing append-mode fixture, which predates the two new fields and would otherwise be a type error the repo's test-exclude hides.

## Acceptance

- [x] Add files on a personal lake issues no `drive-connection` request and shows no Drive connect control
- [x] The two `DriveConnectAction` render sites gate on the same condition
- [x] A test asserts the personal-lake case renders no control

## Review follow-up (f3ae93ba)

- **P2** - the gate is now one derivation, `canConnectLakeDrive`, next to `lakeVisibilityLabel`. Both render sites call it, so the invariant is held by the compiler rather than by the comment that failed to hold it last time.
- **P3** - `toWizardTargetLake` exported alongside `WizardTargetLake`; all four call sites map through it. The next field is one edit.
- **P3** - the test fixture is typed `Partial<WizardTargetLake>` instead of `as never`, so `organizationId` and `canManage` are actually checked.
- Three suites factory-mocked the wizard store, which shadowed the new mapper; they now spread `importOriginal` so the real (pure) projection is used.
- `turbo:typecheck` 40/40, eslint + prettier clean on the changed files, DataLakeWizard + datalake 676/676.
