### PR TITLE
fix(scripts): guard the embedding-model backfill against unaddressable fabFileIds

### DIFF
--- a/packages/scripts/datalake/backfill-chunk-embedding-model.ts
+++ b/packages/scripts/datalake/backfill-chunk-embedding-model.ts
@@ -26,6 +26,7 @@
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import mongoose from 'mongoose';
 import { Resource } from 'sst';
 import { connectDB, fabFileChunkRepository, fabFileRepository } from '@bike4mind/database';
 import { fabFilesService } from '@bike4mind/services';
@@ -45,6 +46,7 @@ async function main(opts: Options): Promise<number> {
   let stampedFiles = 0;
   let stampedChunks = 0;
   const unresolvedFiles = new Set<string>();
+  const unaddressableFileIds = new Set<string>();
 
   for (;;) {
     const missing = await fabFileChunkRepository.findChunksMissingEmbeddingModel({
@@ -55,10 +57,26 @@ async function main(opts: Options): Promise<number> {
     afterChunkId = missing[missing.length - 1].id;
 
     const fileIds = [...new Set(missing.map(c => c.fabFileId))];
-    const files = await Promise.all(fileIds.map(id => fabFileRepository.findById(id)));
-    const fileEmbeddingModels = new Map(fileIds.map((id, i) => [id, files[i]?.embeddingModel]));
 
-    const { plans, unresolved } = planFileBackfills(missing, fileEmbeddingModels);
+    // `fabFileId` is declared as a plain String, so a legacy chunk can hold a value that cannot
+    // address a row by `_id` (observed on real data: a stringified FabFile document). Handing one
+    // to `findById` throws a CastError that rejects the whole `Promise.all`, and since the cursor
+    // is in-process a rerun restarts on the same page - so a single bad row blocks the entire
+    // backfill permanently rather than costing one file. Same rationale, and the same
+    // `isObjectIdOrHexString` over `isValidObjectId` choice, as `usableObjectIds` in
+    // b4m-core/db-core/src/utils/mongo.ts.
+    const addressableIds = new Set(fileIds.filter(id => mongoose.isObjectIdOrHexString(id)));
+    for (const id of fileIds) if (!addressableIds.has(id)) unaddressableFileIds.add(id);
+
+    // Planning is filtered too, not just the lookup: `planFileBackfills` would otherwise guess a
+    // model from vector width for one of these and hand `stampChunkEmbeddingModel` an id it cannot
+    // write, moving the same crash one step later.
+    const stampable = missing.filter(c => addressableIds.has(c.fabFileId));
+    const lookupIds = [...addressableIds];
+    const files = await Promise.all(lookupIds.map(id => fabFileRepository.findById(id)));
+    const fileEmbeddingModels = new Map(lookupIds.map((id, i) => [id, files[i]?.embeddingModel]));
+
+    const { plans, unresolved } = planFileBackfills(stampable, fileEmbeddingModels);
 
     for (const plan of plans) {
       if (opts.execute) {
@@ -83,9 +101,20 @@ async function main(opts: Options): Promise<number> {
     );
     for (const fileId of unresolvedFiles) console.warn(`  UNRESOLVED ${fileId}`);
     console.warn('These remain unlabeled and will keep falling back to the brute-force scan.');
-    return 1;
   }
-  return 0;
+  if (unaddressableFileIds.size > 0) {
+    console.warn(
+      `\n${unaddressableFileIds.size} chunk fabFileId value(s) are not ObjectIds and cannot address a file. ` +
+        'These need data repair; this script cannot stamp them:'
+    );
+    // Truncated: an unaddressable value is not necessarily short - the ones observed in practice
+    // are a whole serialized document, which would bury the rest of this summary.
+    for (const fileId of unaddressableFileIds) {
+      const shown = fileId.length > 60 ? `${fileId.slice(0, 60)}... (${fileId.length} chars)` : fileId;
+      console.warn(`  UNADDRESSABLE ${JSON.stringify(shown)}`);
+    }
+  }
+  return unresolvedFiles.size > 0 || unaddressableFileIds.size > 0 ? 1 : 0;
 }
 
 const argv = yargs(hideBin(process.argv))


### PR DESCRIPTION
# Pull Request

## Description

`packages/scripts/datalake/backfill-chunk-embedding-model.ts` could never make any progress
against real data.

`FabFileChunk.fabFileId` is declared `type: String` with no format validator, so a legacy chunk
can hold a value that cannot address a row by `_id`. On the staging corpus, 106 chunks hold a
425-character *stringified FabFile document* in that field. The script passed every distinct
`fabFileId` in a page straight to `fabFileRepository.findById` inside a `Promise.all`, so one such
value threw a `CastError` that rejected the whole batch. Because the paging cursor
(`afterChunkId`) lives in process memory, a rerun restarted from the beginning and hit the same
row again.

The earliest corrupt row sorts **first** among missing-model chunks (zero missing-model chunks
order before it), so batch one always contained it. The script therefore crashed on its first
batch every single time, having stamped nothing.

This matters beyond the script: `chunkEmbeddingModelStampedAt` is the readiness gate the Atlas
`$vectorSearch` cutover reads (`vectorSearchEligibility.ts:21` returns false unconditionally when
it is absent), and the stamp is only ever written at vectorization time. A legacy vectorized file
can therefore only become ANN-eligible via this backfill, which could not run.

## Changes

- Filter each page to `fabFileId` values that can address a row (`mongoose.isObjectIdOrHexString`,
  matching the documented choice in `usableObjectIds`) before both the `findById` lookup and
  `planFileBackfills`. Filtering the plan too, not just the lookup, matters: otherwise
  `planFileBackfills` guesses a model from vector width for one of these and hands
  `stampChunkEmbeddingModel` an id it cannot write, moving the same crash one step later.
- Report the rejects as their own summary category (`UNADDRESSABLE`), separate from
  `UNRESOLVED`. They need data repair, not a model guess, so collapsing them into the existing
  bucket would misdescribe the remedy. Values are truncated in the output because the ones
  observed in practice are whole serialized documents that would otherwise bury the summary.
- Both categories now contribute to the non-zero exit code, and neither returns early, so a run
  reports every problem it found rather than only the first kind.

## Guide for Testers

This is a backend one-off script with no UI surface. It cannot be exercised from the app.

1. From a checkout with dependencies installed and core packages built
   (`pnpm install && pnpm turbo:core:build`), run the script in its default dry-run mode against
   the staging stage:
   `for-env dev ./node_modules/.bin/sst shell --stage dev -- ./packages/scripts/node_modules/.bin/tsx packages/scripts/datalake/backfill-chunk-embedding-model.ts`
2. Expected: the run completes instead of throwing. The final lines report
   `Would stamp <N> file(s), <M> chunk(s).` On staging at time of writing this was
   `Would stamp 9040 file(s), 24696 chunk(s).`
3. Expected: a second section reports
   `106 chunk fabFileId value(s) are not ObjectIds and cannot address a file.` followed by 106
   `UNADDRESSABLE "..."` lines, each truncated with a `(425 chars)` suffix.
4. Expected: the process exits with code 1 (because unaddressable values were found), not 0.
   Check with `echo $?`.
5. Before this change, the same command instead failed with
   `CastError: Cast to ObjectId failed` originating from `FabFileRepository.findById`, and printed
   no summary at all. That is the regression this fixes.

### Regression Checks

1. Confirm the stamping path itself is unchanged: the dry-run's `Would stamp` count should equal
   the number of files that have chunks missing `embeddingModel` and a resolvable model. No file
   that was previously stampable should now be skipped.
2. Confirm `UNRESOLVED` reporting still works. It is reported before `UNADDRESSABLE` and no longer
   returns early, so if a corpus has both, both sections must appear.
3. Run the script twice in a row with `--execute` on a non-production stage; the second run should
   report `Would stamp 0` / `Stamped 0`, confirming idempotency is preserved.

### What NOT to test

- No UI, route, or API behavior changes. There is nothing to click.
- Retrieval behavior does not change from this PR. The script writes chunk `embeddingModel` and
  the file's `chunkEmbeddingModelStampedAt`; the brute-force scan path reads the *parent file's*
  `embeddingModel` (see `classifyLoadedChunk`, `semanticDataLakeSearch.ts:521-529`), never the
  chunk's, and the stamp only gates the ANN path, which is off by default behind the
  `EnableDataLakeVectorSearch` admin setting.
- Do not run with `--execute` against production as part of testing this PR.

## Additional Information

Found while investigating whether the Atlas `$vectorSearch` cutover could be enabled. The 106
unaddressable rows are orphans: each embeds a recoverable ObjectId inside the stringified
document, but none of those ids resolves to an existing FabFile, and they are sequential. They are
chunks of long-deleted files, unreachable by any `fabFileId` query and therefore already invisible
to both the scan and ANN paths. Deleting them, plus adding a format guard on the field, is filed
separately; this PR only stops them from blocking the backfill.

Every current write path derives `fabFileId` from a string id (`file.id`, or a Zod-validated
`z.string()` queue payload), so this is historical data rather than an active bug. The affected
chunk `_id`s date to around 2024-10-03.
