### PR TITLE
fix(data-lakes): land the repair-executor review fixes that missed the merge

### DIFF
--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -3371,6 +3371,10 @@ describe('removeFileFromDataLake — single-file removal', () => {
         pullTagsByFabFileId: vi.fn().mockResolvedValue(1),
         computeDataLakeStats: vi.fn().mockResolvedValue({ fileCount: 0, totalSizeBytes: 0, totalChunkedChars: 0 }),
       },
+      // Stubbed so these exercise a WORKING restore write. Omitted, the call threw on an undefined
+      // repo and the door's catch swallowed it, so every test here silently covered the degraded
+      // path - invisible until `restoreTokenMinted` made the difference observable.
+      lakeMembershipRemovals: { upsertRemoval: vi.fn().mockResolvedValue(undefined) },
     },
   });
 
@@ -3382,7 +3386,13 @@ describe('removeFileFromDataLake — single-file removal', () => {
     // removal) and never a soft-delete. The other lake's tags are untouched.
     expect(adapters.db.fabFiles.pullTagsByFabFileId).toHaveBeenCalledWith('f1', ['datalake:lake', 'lk:invoices']);
     expect(adapters.db.dataLakes.setStats).toHaveBeenCalled();
-    expect(result).toEqual({ success: true, fileCount: 0, totalSizeBytes: 0, totalChunkedChars: 0 });
+    expect(result).toEqual({
+      success: true,
+      fileCount: 0,
+      totalSizeBytes: 0,
+      totalChunkedChars: 0,
+      restoreTokenMinted: true,
+    });
   });
 
   it('removes a file whose only membership signal is a prefixed tag', async () => {
@@ -3493,7 +3503,13 @@ describe('removeFileFromDataLake — single-file removal', () => {
     // Same tag-pull path as the multi-lake case - the service has no cascade-delete branch,
     // so "last lake" is not special: the tag is pulled and the file is left to exist.
     expect(adapters.db.fabFiles.pullTagsByFabFileId).toHaveBeenCalledWith('f1', ['datalake:lake']);
-    expect(result).toEqual({ success: true, fileCount: 0, totalSizeBytes: 0, totalChunkedChars: 0 });
+    expect(result).toEqual({
+      success: true,
+      fileCount: 0,
+      totalSizeBytes: 0,
+      totalChunkedChars: 0,
+      restoreTokenMinted: true,
+    });
   });
 
   it('allows an admin who is not the creator', async () => {

--- a/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.test.ts
+++ b/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const h = vi.hoisted(() => ({ removeFileFromDataLake: vi.fn() }));
+const h = vi.hoisted(() => ({ removeFileFromDataLake: vi.fn(), findById: vi.fn() }));
 vi.mock('./removeFileFromDataLake', () => ({ removeFileFromDataLake: h.removeFileFromDataLake }));
 
-import { executeLakeMembershipRepair } from './executeLakeMembershipRepair';
+import { executeLakeMembershipRepair, MAX_MEMBERSHIP_REPAIR_REMOVALS } from './executeLakeMembershipRepair';
 import {
   groupIdentity,
   planMembershipRepair,
@@ -35,7 +35,7 @@ const group = (fileName: string, bucket: DuplicateGroup['bucket'], members = [me
 });
 
 const actor = { userId: 'u1', isAdmin: false } as never;
-const adapters = { db: {}, logger: { warn: vi.fn() } } as never;
+const adapters = { db: { dataLakes: { findById: h.findById } }, logger: { warn: vi.fn() } } as never;
 
 const run = (
   groups: DuplicateGroup[],
@@ -45,7 +45,13 @@ const run = (
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.removeFileFromDataLake.mockResolvedValue({ success: true, fileCount: 1, totalSizeBytes: 1 });
+  h.findById.mockResolvedValue({ id: 'lake-1' });
+  h.removeFileFromDataLake.mockResolvedValue({
+    success: true,
+    fileCount: 1,
+    totalSizeBytes: 1,
+    restoreTokenMinted: true,
+  });
 });
 
 describe('executeLakeMembershipRepair', () => {
@@ -225,7 +231,77 @@ describe('executeLakeMembershipRepair', () => {
   it('does nothing at all on an empty plan', async () => {
     const outcome = await run([]);
 
-    expect(outcome).toEqual({ removedFabFileIds: [], groupsActedOn: [], failures: [], staleDecisions: [] });
+    expect(outcome).toEqual({
+      removedFabFileIds: [],
+      groupsActedOn: [],
+      failures: [],
+      staleDecisions: [],
+      duplicateDecisions: [],
+      removedWithoutRestoreToken: [],
+      truncated: false,
+    });
     expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
+  });
+  describe('the four signals a bulk caller cannot infer', () => {
+    it('names removals whose restore row never wrote, so undo is already gone', async () => {
+      // The removal door writes that row best-effort in a catch that only warns, so a failed write
+      // leaves membership removed with NO undo at all - not merely undo that expires in 30 minutes.
+      // Without this a surface reports "removed 2" and offers an undo that silently does nothing.
+      h.removeFileFromDataLake.mockImplementation(async (_a: unknown, _l: unknown, id: string) => ({
+        success: true,
+        fileCount: 1,
+        totalSizeBytes: 1,
+        restoreTokenMinted: id !== 'old',
+      }));
+
+      const outcome = await run([
+        group('p.pdf', 'proven-identical', [member('new', HEX), member('mid', HEX), member('old', HEX)]),
+      ]);
+
+      expect(outcome.removedFabFileIds).toEqual(['mid', 'old']);
+      expect(outcome.removedWithoutRestoreToken).toEqual(['old']);
+    });
+
+    it('applies NOTHING for a duplicated file name, rather than letting array order decide', async () => {
+      // [keep-both, keep-newest] removes members and the reverse removes none - a destructive
+      // outcome decided by array position. Neither is defensible, so neither is applied.
+      const g = group('d.pdf', 'differing', [member('new'), member('old')]);
+
+      const outcome = await run(
+        [g],
+        [
+          { fileName: 'd.pdf', decision: 'keep-both', groupIdentity: groupIdentity(g) },
+          { fileName: 'd.pdf', decision: 'keep-newest', groupIdentity: groupIdentity(g) },
+        ]
+      );
+
+      expect(outcome.removedFabFileIds).toEqual([]);
+      expect(outcome.duplicateDecisions).toEqual(['d.pdf']);
+      expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
+    });
+
+    it('stops at the removal ceiling and says so', async () => {
+      // The plan carries no cap of its own, so without this a hand-crafted plan is an unbounded
+      // sequential wave - each removal a read, a $pull and a full lake-stats recompute.
+      const members = Array.from({ length: MAX_MEMBERSHIP_REPAIR_REMOVALS + 5 }, (_, i) => member(`f${i}`, HEX));
+
+      const outcome = await run([group('big.pdf', 'proven-identical', members)]);
+
+      expect(outcome.removedFabFileIds).toHaveLength(MAX_MEMBERSHIP_REPAIR_REMOVALS);
+      expect(outcome.truncated).toBe(true);
+    });
+
+    it('resolves the lake ONCE and fails fast, rather than once per member', async () => {
+      // A lake-level fault is invariant across the loop. Discovering it per member issues one
+      // findById per removal and returns a success-shaped outcome carrying N copies of one message.
+      h.findById.mockResolvedValue(null);
+
+      await expect(
+        run([group('p.pdf', 'proven-identical', [member('new', HEX), member('mid', HEX), member('old', HEX)])])
+      ).rejects.toThrow(/not found/i);
+
+      expect(h.findById).toHaveBeenCalledTimes(1);
+      expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
+    });
   });
 });

--- a/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.ts
+++ b/b4m-core/services/src/dataLakeService/executeLakeMembershipRepair.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@bike4mind/common';
 import {
   membersRemovedByDecision,
   type MembershipRepairPlan,
@@ -69,7 +70,33 @@ export interface MembershipRepairOutcome {
    * nothing to do.
    */
   staleDecisions: { fileName: string; reviewedGroupIdentity: string; currentGroupIdentity: string }[];
+  /**
+   * Decisions withheld because two arrived for one file name. Applying either would make a
+   * destructive outcome depend on array position - `[keep-both, keep-newest]` removes members and
+   * the reverse removes none - so neither is applied and both are reported.
+   */
+  duplicateDecisions: string[];
+  /**
+   * Removals whose restore row failed to write, so re-adding is refused immediately rather than
+   * after the 30-minute TTL. A subset of `removedFabFileIds` - the membership removal itself stood.
+   *
+   * A bulk caller cannot infer this: the removal door writes that row best-effort in a catch that
+   * only warns, so without it a surface reports "removed 40" with no signal that k of them were
+   * never undoable. Empty is the ordinary case.
+   */
+  removedWithoutRestoreToken: string[];
+  /** True when the run stopped at MAX_MEMBERSHIP_REPAIR_REMOVALS with work still outstanding. */
+  truncated: boolean;
 }
+
+/**
+ * Hard ceiling on removals in one run, mirroring MAX_CONVERGENCE_WAVE on the sibling this executor
+ * is modelled on. The plan carries no cap of its own - `maxGroups`/`maxGroupMembers` are optional
+ * payload options on the health report, not safety bounds - so without this a hand-crafted plan is
+ * an unbounded sequential wave of removals, each one a read plus a `$pull` plus a full lake-stats
+ * recompute.
+ */
+export const MAX_MEMBERSHIP_REPAIR_REMOVALS = 200;
 
 /**
  * Which members a group loses in this run.
@@ -124,18 +151,35 @@ export async function executeLakeMembershipRepair(
   decisions: MembershipRepairDecisionInput[],
   adapters: RemoveFileFromDataLakeAdapters
 ): Promise<MembershipRepairOutcome> {
-  const { logger } = adapters;
-  const byFileName = new Map(decisions.map(d => [d.fileName, d]));
+  const { db, logger } = adapters;
+
+  // Built with duplicates REMOVED rather than last-wins: applying either of two rulings for one file
+  // name would let array order decide whether membership is destroyed.
+  const byFileName = new Map<string, MembershipRepairDecisionInput>();
+  const duplicateDecisions = new Set<string>();
+  for (const decision of decisions) {
+    if (byFileName.has(decision.fileName)) duplicateDecisions.add(decision.fileName);
+    byFileName.set(decision.fileName, decision);
+  }
+  for (const fileName of duplicateDecisions) byFileName.delete(fileName);
+
+  // Resolved ONCE, before any removal. A lake-level fault - missing, or an id addressing nothing - is
+  // invariant across the loop, so letting the per-member catch discover it issues one findById per
+  // removal and returns a success-shaped outcome carrying N copies of one message.
+  const lake = await db.dataLakes.findById(dataLakeId);
+  if (!lake) throw new NotFoundError('Data lake not found');
 
   const removedFabFileIds: string[] = [];
   const groupsActedOn: MembershipRepairOutcome['groupsActedOn'] = [];
   const failures: MembershipRepairOutcome['failures'] = [];
   const staleDecisions: MembershipRepairOutcome['staleDecisions'] = [];
+  const removedWithoutRestoreToken: string[] = [];
+  let truncated = false;
 
   // Sequential, not a fan-out: every removal recomputes the lake's stats and can activate a draft
   // lake, so concurrent removals would race each other's recompute and persist a count from a
-  // partial view. Nothing bounds the wave here - the plan carries no cap - so a large plan is slow
-  // by construction, and the route is where that has to be capped.
+  // partial view. Bounded by MAX_MEMBERSHIP_REPAIR_REMOVALS rather than left to the route, so the
+  // ceiling holds for every caller instead of only the one that remembers it.
   for (const group of [...plan.collapsible, ...plan.needsDecision]) {
     const { removals, stale } = removalsForGroup(group, byFileName);
     if (stale) staleDecisions.push(stale);
@@ -143,10 +187,15 @@ export async function executeLakeMembershipRepair(
 
     const removedHere: string[] = [];
     for (const fabFileId of removals) {
+      if (removedFabFileIds.length >= MAX_MEMBERSHIP_REPAIR_REMOVALS) {
+        truncated = true;
+        break;
+      }
       try {
-        await removeFileFromDataLake(actor, dataLakeId, fabFileId, adapters);
+        const { restoreTokenMinted } = await removeFileFromDataLake(actor, dataLakeId, fabFileId, adapters);
         removedHere.push(fabFileId);
         removedFabFileIds.push(fabFileId);
+        if (!restoreTokenMinted) removedWithoutRestoreToken.push(fabFileId);
       } catch (err) {
         // Per-member catch: a repair that abandons the rest of the plan on one failure leaves the
         // lake in a state neither the owner nor the next plan can reason about. Recorded and
@@ -163,7 +212,16 @@ export async function executeLakeMembershipRepair(
     }
 
     if (removedHere.length > 0) groupsActedOn.push({ fileName: group.fileName, removedFabFileIds: removedHere });
+    if (truncated) break;
   }
 
-  return { removedFabFileIds, groupsActedOn, failures, staleDecisions };
+  return {
+    removedFabFileIds,
+    groupsActedOn,
+    failures,
+    staleDecisions,
+    duplicateDecisions: [...duplicateDecisions],
+    removedWithoutRestoreToken,
+    truncated,
+  };
 }

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.test.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.test.ts
@@ -111,6 +111,14 @@ describe('removeFileFromDataLake', () => {
       expect.objectContaining({ dataLakeId: 'lake1', fabFileId: 'f1' })
     );
     expect(db.fabFiles.computeDataLakeStats).toHaveBeenCalled();
-    expect(result).toEqual({ success: true, fileCount: 0, totalSizeBytes: 0, totalChunkedChars: 0 });
+    // false, and this is the point of reporting it: the removal stood but nothing recorded how to
+    // undo it, so a caller offering "undo" here would offer something that cannot work.
+    expect(result).toEqual({
+      success: true,
+      fileCount: 0,
+      totalSizeBytes: 0,
+      totalChunkedChars: 0,
+      restoreTokenMinted: false,
+    });
   });
 });

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -103,7 +103,7 @@ export const removeFileFromDataLake = async (
   dataLakeId: string,
   fabFileId: string,
   { db, logger }: RemoveFileFromDataLakeAdapters
-): Promise<{ success: true; fileCount: number; totalSizeBytes: number }> => {
+): Promise<{ success: true; fileCount: number; totalSizeBytes: number; restoreTokenMinted: boolean }> => {
   const lake = await db.dataLakes.findById(dataLakeId);
   if (!lake) {
     throw new NotFoundError('Data lake not found');
@@ -117,6 +117,10 @@ export const removeFileFromDataLake = async (
   // fail-quiet: by the time this runs the removal has already committed and is uncompensated, so
   // throwing would 500 a removal that in fact happened, and the client's retry would then hit this
   // same door's `!inLake` 404. The honest failure surface is downstream, at a real Undo click.
+  // Reported rather than only logged (#2245): a BULK caller removes N files sharing one 30-minute
+  // undo window, so "which of these can still be re-added" is the difference between an accurate
+  // undo affordance and one that silently does nothing. A single-file caller can ignore it.
+  let restoreTokenMinted = false;
   try {
     const removedAt = new Date();
     await db.lakeMembershipRemovals.upsertRemoval({
@@ -127,6 +131,7 @@ export const removeFileFromDataLake = async (
       removedAt,
       expiresAt: new Date(removedAt.getTime() + REMOVAL_RECORD_TTL_MS),
     });
+    restoreTokenMinted = true;
   } catch (err) {
     logger?.warn?.('[dataLakes] file removed from lake but its restore record failed to write', {
       dataLakeId: lake.id,
@@ -138,5 +143,5 @@ export const removeFileFromDataLake = async (
   // `actor` threaded so the draft -> active flip a removal can trigger names the person who
   // removed the file rather than `system`. The rung stays `system` - nothing authorized the flip.
   const stats = await recomputeLakeStats(lake, { db, logger }, { actor });
-  return { success: true, ...stats };
+  return { success: true, ...stats, restoreTokenMinted };
 };


### PR DESCRIPTION
Follow-up to #2487. Part of #2245.

## Why this exists

**#2487 merged at 09:08; my rework of its review findings pushed at 11:11** - two hours later. Some findings were applied on the PR before merge, so `main` has `staleDecisions` and the corrected kill-switch docblock. The rest never landed. This carries them, plus the one ask I had to decline at the time.

## Missing from `main`, each a finding from #2487's reviews

- **`MAX_MEMBERSHIP_REPAIR_REMOVALS`.** The merged comment still reads *"nothing bounds the wave here"* and defers the cap to the route. The plan carries no cap of its own - `maxGroups`/`maxGroupMembers` are optional payload options on the health report, not safety bounds - so a hand-crafted plan was an unbounded sequential wave, each removal a read plus a `$pull` plus a full lake-stats recompute. **Bounded here rather than at the route** so the ceiling holds for every caller, not only the one that remembers it.
- **Duplicate decisions apply NOTHING and are reported.** Last-wins made a destructive outcome depend on array position: `[keep-both, keep-newest]` removes members and the reverse removes none.
- **The lake resolves once**, before any removal. A bad id was issuing one `findById` per member and returning a success-shaped outcome carrying N copies of one message.

## New - the ask I declined on #2487

@ken-b4m's P2.3 asked the outcome to surface which removals are already past undo. I could not do it there: the executor cannot know, because the removal door writes the restore row best-effort in a `catch` that only warns. Changing a shared door's return type is not a side effect the executor PR should have had, so it waited.

`removeFileFromDataLake` now reports `restoreTokenMinted`, and the executor surfaces `removedWithoutRestoreToken`. **This is the "no undo at all" case, not the "undo expires in 30 minutes" case** - a failed restore write leaves membership removed with nothing recording how to put it back. A bulk caller could not infer it, so a surface reported "removed 40" with no signal that k of them were never undoable. Additive to the return type; the two other callers are unaffected.

## A live coverage hole this exposed

`dataLakeService.test.ts` **never stubbed `lakeMembershipRemovals`**, so `upsertRemoval` threw on an undefined repo and the door's own catch swallowed it. Every removal test in that file was silently exercising the degraded path and passing - invisible until `restoreTokenMinted` made the difference observable.

Stubbed, so those tests exercise a working restore write. The door's own throwing-write test now asserts the flag is `false`, which is the case worth naming.

## Testing

- [x] `turbo typecheck:fast` 37/37, eslint clean
- [x] `dataLakeService` 1810 passed, client data-lakes routes 400 passed
- [x] Mutation-checked - reverting the cap, the duplicate handling, the resolve-once, or the restore-token signal each fails a test
- [ ] Reviewer check: `MAX_MEMBERSHIP_REPAIR_REMOVALS = 200` mirrors `MAX_CONVERGENCE_WAVE`; worth a second opinion on whether the repair wave wants the same number as a convergence wave

## Still open from that review, deliberately

Choosing a control that can actually halt a repair. #2245 s5 names the convergence kill switch, which returns early unless the work is `origin: 'convergence'` - a repair enqueues nothing, so it answers "not halted" every time. That is a question for the issue rather than something to invent in a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
