### PR TITLE
feat(services)!: add a knowledge-base retrieval prompt section and record whether it shipped

### DIFF
--- a/apps/client/app/components/admin/RetrievalRateTab.test.tsx
+++ b/apps/client/app/components/admin/RetrievalRateTab.test.tsx
@@ -29,6 +29,11 @@ const summary = (over: Partial<OptionalPathRetrievalRate> = {}): OptionalPathRet
   offeredTurns: 40,
   retrievedTurns: 10,
   rate: 0.25,
+  guidance: {
+    injected: { turns: 20, retrievedTurns: 7, rate: 0.35 },
+    notInjected: { turns: 15, retrievedTurns: 3, rate: 0.2 },
+    unrecorded: { turns: 5, retrievedTurns: 0, rate: 0 },
+  },
   forcedSuppressed: {
     turns: 8,
     retrievedTurns: 4,

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -428,9 +428,11 @@ export const RetrievalSummarySchema = z.object({
    * explicit `false` rather than collapse it into absent - see mergeRetrievalSummary, which uses
    * `??` and deliberately not `||` for that reason.
    *
-   * MUST STAY IN SYNC with the gate in ToolBuilder.buildToolPrompt: the section ships iff the tool
-   * is offered AND the guidance string is non-empty, and this records that same conjunction. The
-   * two are computed from one const at the ChatCompletionProcess seed site so they cannot drift.
+   * MUST STAY IN SYNC with TWO gates, not one. ToolBuilder.buildToolPrompt emits the section iff
+   * the tool is offered AND the guidance string is non-empty; filterByPromptMode then drops the
+   * whole `toolPrompt` source, which no promptMode admits, so an offered tool is not sufficient.
+   * The ChatCompletionProcess seed site conjoins all three, and hands the first two to
+   * buildToolPrompt as the same consts, so the flag and the actual emission cannot drift.
    */
   knowledgeBaseGuidanceInjected: z.boolean().optional(),
   /**

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -418,6 +418,22 @@ export const RetrievalSummarySchema = z.object({
    */
   mode: z.enum(['forced', 'optional']).optional(),
   /**
+   * Whether the knowledge-base when-to-retrieve guidance section actually shipped in this turn's
+   * tool prompt. Written only on turns that were OFFERED the knowledge tool, so absence means
+   * "not an offered turn" or "recorded before this field landed" - it never means "cleared".
+   *
+   * `false` is the load-bearing value here, not filler. Clearing the KnowledgeBaseRetrievalPrompt
+   * setting is the section's only off switch, so a turn recording `false` is the CONTROL arm of
+   * the A/B this field exists to make readable. Anything merging or folding this must preserve an
+   * explicit `false` rather than collapse it into absent - see mergeRetrievalSummary, which uses
+   * `??` and deliberately not `||` for that reason.
+   *
+   * MUST STAY IN SYNC with the gate in ToolBuilder.buildToolPrompt: the section ships iff the tool
+   * is offered AND the guidance string is non-empty, and this records that same conjunction. The
+   * two are computed from one const at the ChatCompletionProcess seed site so they cannot drift.
+   */
+  knowledgeBaseGuidanceInjected: z.boolean().optional(),
+  /**
    * Why the forced arm did not run on a turn that had it enabled. Only ever set with
    * `mode: 'forced'`, and only for the deliberate suppressions in
    * ChatCompletionFeatures.getContextMessages - a forced turn that ran and failed reports that

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -14,6 +14,7 @@ import {
   type AdminSettingDoc,
   ABSTENTION_PROMPT,
   WEB_SEARCH_FRESHNESS_PROMPT,
+  KNOWLEDGE_BASE_RETRIEVAL_PROMPT,
 } from './settings';
 import {
   DEFAULT_PASSAGE_TOKEN_TARGET,
@@ -710,6 +711,58 @@ describe('WebSearchFreshnessPrompt default tells the model when to search', () =
 
   it('ships as the WebSearchFreshnessPrompt setting default (no drift between const and setting)', () => {
     expect(settingsMap.WebSearchFreshnessPrompt.defaultValue).toBe(WEB_SEARCH_FRESHNESS_PROMPT);
+  });
+});
+
+describe('KnowledgeBaseRetrievalPrompt default tells the model when to retrieve', () => {
+  // Same shape of failure as the web-search nudge, measured the same way: search_knowledge_base
+  // was offered on 1,591 optional-path production turns over 30 days and called on 319 of them
+  // (20.1%), while its tool description covered only HOW to search and never WHEN. Two clauses
+  // carry the whole effect, so pin both.
+  it('directs the model to search before answering from its weights', () => {
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).toMatch(/search_knowledge_base/);
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).toMatch(/labels, not content/i);
+  });
+
+  // Without the negative clause the nudge over-triggers and every turn pays for a retrieval it did
+  // not need - the same failure global forced retrieval already showed on out-of-corpus questions,
+  // arriving by a different route.
+  it('names the cases that do NOT need a search', () => {
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).toMatch(/do not search when/i);
+  });
+
+  // A small attached corpus is INLINED rather than deferred to retrieval, and forced retrieval
+  // steps aside entirely on an attached-files turn. Without these two clauses the section sends
+  // the model searching for text already sitting in its context, and its opening paragraph asserts
+  // the documents are invisible - which on that path is simply false.
+  it('exempts content already placed in the conversation', () => {
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).toMatch(/from an attached document/i);
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).toMatch(/unless its content has been placed in this conversation/i);
+  });
+
+  // On a forced turn that retrieved nothing, forcedRetrievalNoContextPrompt instructs the model to
+  // say the library does not cover the question. Without this clause the nudge invites a second
+  // identical search: a billed query embedding, and a chance to hedge out of a correct abstention.
+  it('forbids re-searching a library already searched this turn', () => {
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).toMatch(/already been searched on this turn/i);
+  });
+
+  // The abstention half. Without it a nudge to search converts a clean "I could not find that"
+  // into an ungrounded answer wearing the corpus's authority.
+  it('requires saying so when the corpus does not cover the question', () => {
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).toMatch(/does not turn up what was asked for/i);
+  });
+
+  // Naming retrieve_knowledge_content here would instruct the model to call a tool a session
+  // denylist can strip while search survives (ChatCompletionProcess warns on exactly that pair),
+  // and a model told to call a tool it was not given emits the call as leaked JSON text.
+  it('names no knowledge tool the gate does not guarantee', () => {
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).not.toMatch(/retrieve_knowledge_content/);
+    expect(KNOWLEDGE_BASE_RETRIEVAL_PROMPT).not.toMatch(/count_knowledge_base/);
+  });
+
+  it('ships as the KnowledgeBaseRetrievalPrompt setting default (no drift between const and setting)', () => {
+    expect(settingsMap.KnowledgeBaseRetrievalPrompt.defaultValue).toBe(KNOWLEDGE_BASE_RETRIEVAL_PROMPT);
   });
 });
 

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -169,6 +169,53 @@ You do not need to search for stable knowledge (definitions, mathematics, establ
 When you report a time-sensitive fact, state what it is as of - the date of the source you used - and say plainly when you could not verify something and are answering from training data instead. Never present an unverified recollection as a current fact.`;
 
 /**
+ * Default text for the knowledge-base retrieval nudge, and the `KnowledgeBaseRetrievalPrompt`
+ * admin setting's default.
+ *
+ * The gap this closes: the tool prompt has a when-to-use section for the clock, for web search,
+ * for MCP and for agent delegation, and none for the user's own corpus. The
+ * `search_knowledge_base` description is entirely HOW to search ("Make ONE good search per
+ * distinct topic") and never WHEN, so on the optional path the model decides unaided - and over 30
+ * days of production it reached for the corpus on 20.1% of the turns it was offered on.
+ *
+ * Read 2-arg by ChatCompletionProcess, exactly as WEB_SEARCH_FRESHNESS_PROMPT is and unlike the
+ * 3-arg siblings: an absent row falls back to this constant as the registered default, but a
+ * cleared '' is returned verbatim and drops the section instead of reverting. Deliberate - the
+ * section has no companion boolean, so clearing the field is its only off switch, and that off
+ * switch is what makes it A/B-able without a deploy. Keep the setting's description in sync.
+ *
+ * Names no tool but `search_knowledge_base`, for the same reason the web-search section names no
+ * `web_fetch`: the companion `retrieve_knowledge_content` is paired in at build time but a session
+ * denylist can still strip it (ChatCompletionProcess warns on exactly that case), and instructing
+ * the model to call a tool it was not given makes it emit the call as leaked JSON text.
+ *
+ * The "do not search" paragraph is load-bearing, not padding. A when-to-retrieve nudge without a
+ * don't-retrieve clause buys retrieval on turns that need none - the same failure mode global
+ * forced retrieval already shows on out-of-corpus questions, reached by a different route. Three of
+ * its clauses are load-bearing for a specific co-resident path, not general hedging:
+ * - "from an attached document" - a small attached corpus is INLINED rather than deferred to
+ *   retrieval (`shouldDeferCorpusToRetrieval`), and forced retrieval deliberately steps aside on
+ *   an attached-files turn (`forcedRetrievalAbstention` emits nothing there). Without this clause
+ *   the section tells the model to go searching for content already sitting in its context.
+ * - "already been searched on this turn" - on a forced turn that found nothing,
+ *   `forcedRetrievalNoContextPrompt` instructs the model to say the library does not cover the
+ *   question. A nudge to search then invites a second identical query - a billed query embedding,
+ *   and a chance to talk itself out of a correct abstention.
+ * - the opening scope, "unless its content has been placed in this conversation" - the reason the
+ *   first paragraph does not simply claim the documents are invisible, which is false whenever a
+ *   corpus was inlined.
+ */
+export const KNOWLEDGE_BASE_RETRIEVAL_PROMPT = `# KNOWLEDGE BASE
+
+\`search_knowledge_base\` searches a library of documents the user has made available to you - their own uploads, and any shared or organization library they can reach. You cannot see what a document holds unless its content has been placed in this conversation or you search for it; file names and tags are labels, not content.
+
+Call \`search_knowledge_base\` BEFORE answering when that library would settle the question: anything about their organization, projects, customers, products, processes or people; a term, name, acronym or identifier that is not general public knowledge; a policy, decision, figure or date specific to them; or a question that assumes context this conversation never gave you. If you are about to answer in general terms a question the user means specifically, search first. A general-knowledge answer that sounds right is the failure this library exists to prevent.
+
+Do not search when the answer is already in front of you or out of scope: general knowledge (definitions, mathematics, established theory, public facts); anything answerable from this conversation, from an attached document, or from content already retrieved for you this turn; or a request to transform, summarize or reformat text the user has just supplied. If the library has already been searched on this turn, do not search it again for the same question - a repeat spends a round trip to return the same passages.
+
+When a search does not turn up what was asked for, say so plainly rather than filling the gap from training data, and never imply an answer came from the user's documents when it did not.`;
+
+/**
  * Default text for the formatting system message. Runtime fallback used by
  * `includeHardcodedSystemMessage` (b4m-core/utils/src/llm/utils.ts) when the `FormatPromptTemplate`
  * admin setting is blank; that setting's own default is intentionally '' - keep this the sole home.
@@ -203,6 +250,7 @@ export const SettingKeySchema = z.enum([
   'HelpCenterPrompt',
   'AbstentionPrompt',
   'WebSearchFreshnessPrompt',
+  'KnowledgeBaseRetrievalPrompt',
   'UseFormatPrompt',
   'EnableQuestMaster',
   'EnableQuestMasterDefault',
@@ -1456,6 +1504,7 @@ export const API_SERVICE_GROUPS = {
       { key: 'HelpCenterPrompt', order: 10 },
       { key: 'AbstentionPrompt', order: 11 },
       { key: 'WebSearchFreshnessPrompt', order: 12 },
+      { key: 'KnowledgeBaseRetrievalPrompt', order: 13 },
     ],
   },
   EMBEDDING: {
@@ -2448,6 +2497,15 @@ export const settingsMap = {
       'System prompt telling the model when to reach for web_search rather than answer from training data, and to state the as-of date of any time-sensitive fact. Injected only when the web_search tool is offered for the request - a model instructed to search without a search tool tends to claim it searched. Clearing this field turns the section OFF rather than restoring the built-in default, and it is the only off switch this section has; to get the stock wording back, paste it in. A change is not instantaneous: the settings cache is per-instance, so it applies immediately on the instance that served the change and within ~5 min (one cache TTL) everywhere else. After an upgrade, diff a saved copy against the built-in default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since.',
     category: 'AI',
     order: 12,
+  }),
+  KnowledgeBaseRetrievalPrompt: makeStringSetting({
+    key: 'KnowledgeBaseRetrievalPrompt',
+    name: 'Knowledge Base Retrieval Prompt',
+    defaultValue: KNOWLEDGE_BASE_RETRIEVAL_PROMPT,
+    description:
+      'System prompt telling the model when to reach for search_knowledge_base rather than answer from training data, and when NOT to. Injected only when the search_knowledge_base tool is offered for the request - a model instructed to search a corpus it has no tool for tends to claim it searched. Clearing this field turns the section OFF rather than restoring the built-in default, and it is the only off switch this section has; to get the stock wording back, paste it in. A change is not instantaneous: the settings cache is per-instance, so it applies immediately on the instance that served the change and within ~5 min (one cache TTL) everywhere else. After an upgrade, diff a saved copy against the built-in default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since.',
+    category: 'AI',
+    order: 13,
   }),
   UseFormatPrompt: makeBooleanSetting({
     key: 'UseFormatPrompt',

--- a/b4m-core/common/src/utils/retrievalRate.test.ts
+++ b/b4m-core/common/src/utils/retrievalRate.test.ts
@@ -20,6 +20,94 @@ const offeredRetrieved = turn({
 });
 
 describe('summarizeOptionalPathRetrieval', () => {
+  describe('guidance A/B arms', () => {
+    const injectedRetrieved = turn({
+      mode: 'optional',
+      attempted: true,
+      outcome: 'ok',
+      surfaces: ['knowledgeBaseSearch'],
+      knowledgeBaseGuidanceInjected: true,
+    });
+    const injectedNoRetrieval = turn({ mode: 'optional', knowledgeBaseGuidanceInjected: true });
+    const clearedRetrieved = turn({
+      mode: 'optional',
+      attempted: true,
+      outcome: 'ok',
+      surfaces: ['knowledgeBaseSearch'],
+      knowledgeBaseGuidanceInjected: false,
+    });
+    const clearedNoRetrieval = turn({ mode: 'optional', knowledgeBaseGuidanceInjected: false });
+
+    it('splits the offered population into the two arms the A/B compares', () => {
+      const summary = summarizeOptionalPathRetrieval([
+        injectedRetrieved,
+        injectedRetrieved,
+        injectedRetrieved,
+        injectedNoRetrieval,
+        clearedRetrieved,
+        clearedNoRetrieval,
+        clearedNoRetrieval,
+        clearedNoRetrieval,
+      ]);
+      expect(summary.guidance.injected).toEqual({ turns: 4, retrievedTurns: 3, rate: 0.75 });
+      expect(summary.guidance.notInjected).toEqual({ turns: 4, retrievedTurns: 1, rate: 0.25 });
+      expect(summary.guidance.unrecorded).toEqual({ turns: 0, retrievedTurns: 0, rate: null });
+    });
+
+    it('keeps an explicit false in its own arm rather than with the unrecorded turns', () => {
+      // The distinction the whole field exists for: "the section was switched off" is the control
+      // arm, while "we never recorded it" is missing data. Collapsing them would let pre-field
+      // traffic masquerade as control turns and wash out the comparison.
+      const summary = summarizeOptionalPathRetrieval([clearedNoRetrieval, offeredNoRetrieval]);
+      expect(summary.guidance.notInjected.turns).toBe(1);
+      expect(summary.guidance.unrecorded.turns).toBe(1);
+    });
+
+    it('reports turns predating the flag as unrecorded, not as either arm', () => {
+      const summary = summarizeOptionalPathRetrieval([offeredRetrieved, offeredNoRetrieval]);
+      expect(summary.guidance.unrecorded).toEqual({ turns: 2, retrievedTurns: 1, rate: 0.5 });
+      expect(summary.guidance.injected.turns).toBe(0);
+      expect(summary.guidance.notInjected.turns).toBe(0);
+    });
+
+    it('always sums the three arms back to offeredTurns', () => {
+      const summary = summarizeOptionalPathRetrieval([
+        injectedRetrieved,
+        clearedNoRetrieval,
+        offeredRetrieved,
+        turn({ mode: 'forced', attempted: true, outcome: 'ok', surfaces: ['forced-retrieval'] }),
+        turn({ attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'] }),
+      ]);
+      const { injected, notInjected, unrecorded } = summary.guidance;
+      expect(injected.turns + notInjected.turns + unrecorded.turns).toBe(summary.offeredTurns);
+      expect(injected.retrievedTurns + notInjected.retrievedTurns + unrecorded.retrievedTurns).toBe(
+        summary.retrievedTurns
+      );
+    });
+
+    it('reports a null arm rate rather than a phantom zero when an arm is empty', () => {
+      const summary = summarizeOptionalPathRetrieval([injectedNoRetrieval]);
+      expect(summary.guidance.injected.rate).toBe(0);
+      expect(summary.guidance.notInjected.rate).toBeNull();
+    });
+
+    it('leaves forced turns out of both arms even when the flag is set', () => {
+      // A forced turn is never in the experiment. The seed only writes the flag on offered turns,
+      // but a forced turn that somehow carried one must still not enter the comparison.
+      const summary = summarizeOptionalPathRetrieval([
+        turn({
+          mode: 'forced',
+          attempted: true,
+          outcome: 'ok',
+          surfaces: ['forced-retrieval'],
+          knowledgeBaseGuidanceInjected: true,
+        }),
+      ]);
+      expect(summary.guidance.injected.turns).toBe(0);
+      expect(summary.forcedTurns).toBe(1);
+    });
+  });
+
   it('reports a null rate rather than a phantom zero when nothing is in the population', () => {
     const summary = summarizeOptionalPathRetrieval([]);
     expect(summary.rate).toBeNull();

--- a/b4m-core/common/src/utils/retrievalRate.ts
+++ b/b4m-core/common/src/utils/retrievalRate.ts
@@ -16,16 +16,6 @@ type RetrievalSummary = NonNullable<PromptMeta['retrieval']>;
  * write a retrieval summary through persistRunAsQuest but never pass the seed site and so would
  * otherwise land in the denominator with no offer behind them.
  */
-/**
- * One arm of the guidance A/B. Same numerator as the headline rate (the model choosing to
- * retrieve), over the subset of offered turns in that arm.
- */
-export type GuidanceArm = {
-  turns: number;
-  retrievedTurns: number;
-  rate: number | null;
-};
-
 export type OptionalPathRetrievalRate = {
   /** Turns the model was offered retrieval on, with nothing forcing it. */
   offeredTurns: number;
@@ -86,6 +76,16 @@ export type OptionalPathRetrievalRate = {
    * it is worth telling them apart before concluding it is all agent mode.
    */
   unclassifiedTurns: number;
+};
+
+/**
+ * One arm of the guidance A/B. Same numerator as the headline rate (the model choosing to
+ * retrieve), over the subset of offered turns in that arm.
+ */
+export type GuidanceArm = {
+  turns: number;
+  retrievedTurns: number;
+  rate: number | null;
 };
 
 const emptyRate = (): OptionalPathRetrievalRate => ({

--- a/b4m-core/common/src/utils/retrievalRate.ts
+++ b/b4m-core/common/src/utils/retrievalRate.ts
@@ -16,6 +16,16 @@ type RetrievalSummary = NonNullable<PromptMeta['retrieval']>;
  * write a retrieval summary through persistRunAsQuest but never pass the seed site and so would
  * otherwise land in the denominator with no offer behind them.
  */
+/**
+ * One arm of the guidance A/B. Same numerator as the headline rate (the model choosing to
+ * retrieve), over the subset of offered turns in that arm.
+ */
+export type GuidanceArm = {
+  turns: number;
+  retrievedTurns: number;
+  rate: number | null;
+};
+
 export type OptionalPathRetrievalRate = {
   /** Turns the model was offered retrieval on, with nothing forcing it. */
   offeredTurns: number;
@@ -23,6 +33,26 @@ export type OptionalPathRetrievalRate = {
   retrievedTurns: number;
   /** retrievedTurns / offeredTurns, or null when the denominator is empty - never a phantom 0. */
   rate: number | null;
+  /**
+   * The offered turns above, partitioned by whether the knowledge-base when-to-retrieve guidance
+   * section shipped on the turn. This is the A/B readout: compare `injected.rate` against
+   * `notInjected.rate`, where the second arm is produced by clearing the
+   * KnowledgeBaseRetrievalPrompt setting - the section's only off switch, and one that needs no
+   * deploy to throw.
+   *
+   * `unrecorded` is turns written before the flag existed, or by a path that never passed the
+   * seed. Reported as its own arm rather than folded into either side: crediting them to one arm
+   * would bias the exact comparison this exists to serve, and silently dropping them would make
+   * the arms not sum. The three arms always sum to `offeredTurns`.
+   *
+   * A zero `notInjected.turns` does not mean the section is always on - it means nobody has run
+   * the experiment. The arms describe traffic, not configuration.
+   */
+  guidance: {
+    injected: GuidanceArm;
+    notInjected: GuidanceArm;
+    unrecorded: GuidanceArm;
+  };
   /**
    * Turns where forced retrieval was ON but a rule suppressed it, leaving the model on the
    * optional path. Counted separately rather than folded into the numbers above: they reach the
@@ -62,6 +92,11 @@ const emptyRate = (): OptionalPathRetrievalRate => ({
   offeredTurns: 0,
   retrievedTurns: 0,
   rate: null,
+  guidance: {
+    injected: { turns: 0, retrievedTurns: 0, rate: null },
+    notInjected: { turns: 0, retrievedTurns: 0, rate: null },
+    unrecorded: { turns: 0, retrievedTurns: 0, rate: null },
+  },
   forcedSuppressed: {
     turns: 0,
     retrievedTurns: 0,
@@ -108,7 +143,10 @@ const modelRetrieved = (turn: RetrievalRateInput): boolean =>
  * RetrievalSummarySchema). `surfaces` names retrieval MECHANISMS, not lakes, so it carries no
  * identity out with it.
  */
-export type RetrievalRateInput = Pick<RetrievalSummary, 'attempted' | 'mode' | 'forcedSkipReason' | 'surfaces'>;
+export type RetrievalRateInput = Pick<
+  RetrievalSummary,
+  'attempted' | 'mode' | 'forcedSkipReason' | 'surfaces' | 'knowledgeBaseGuidanceInjected'
+>;
 
 /**
  * The projection a caller must select for the fold to read a complete turn, derived from the input
@@ -121,6 +159,7 @@ const RETRIEVAL_RATE_FIELD_SET: Record<keyof RetrievalRateInput, true> = {
   mode: true,
   forcedSkipReason: true,
   surfaces: true,
+  knowledgeBaseGuidanceInjected: true,
 };
 
 export const RETRIEVAL_RATE_FIELDS = Object.keys(RETRIEVAL_RATE_FIELD_SET) as (keyof RetrievalRateInput)[];
@@ -144,7 +183,18 @@ export function summarizeOptionalPathRetrieval(
 
     if (turn.mode === 'optional') {
       summary.offeredTurns += 1;
-      if (modelRetrieved(turn)) summary.retrievedTurns += 1;
+      const retrieved = modelRetrieved(turn);
+      if (retrieved) summary.retrievedTurns += 1;
+      // Explicit undefined check, not truthiness: `false` is a real arm (the section was gated
+      // off) and must not fall in with turns that never recorded the flag at all.
+      const arm =
+        turn.knowledgeBaseGuidanceInjected === undefined
+          ? summary.guidance.unrecorded
+          : turn.knowledgeBaseGuidanceInjected
+            ? summary.guidance.injected
+            : summary.guidance.notInjected;
+      arm.turns += 1;
+      if (retrieved) arm.retrievedTurns += 1;
       continue;
     }
 
@@ -165,6 +215,9 @@ export function summarizeOptionalPathRetrieval(
   }
 
   summary.rate = ratio(summary.retrievedTurns, summary.offeredTurns);
+  for (const arm of [summary.guidance.injected, summary.guidance.notInjected, summary.guidance.unrecorded]) {
+    arm.rate = ratio(arm.retrievedTurns, arm.turns);
+  }
   summary.forcedSuppressed.rate = ratio(summary.forcedSuppressed.retrievedTurns, summary.forcedSuppressed.turns);
   return summary;
 }

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -2794,6 +2794,7 @@ describe('ChatCompletionProcess', () => {
       getAccessibleFilesImpl?: () => Promise<unknown>;
       dataLakeTags?: string[];
       promptMode?: 'raw';
+      requestTools?: string[];
       fabPromptMessages?: IMessage[];
       fabFileNotices?: FabFileNotice[];
     }) => {
@@ -2859,7 +2860,7 @@ describe('ChatCompletionProcess', () => {
       const body = {
         ...startQuestParams,
         ...(opts.promptMode ? { promptMode: opts.promptMode } : {}),
-        tools: [],
+        tools: opts.requestTools ?? [],
         projectId: undefined,
         organizationId: undefined,
       };
@@ -3094,6 +3095,25 @@ describe('ChatCompletionProcess', () => {
           });
           expect(retrieval?.knowledgeBaseGuidanceInjected).toBe(false);
           expect(retrieval).toHaveProperty('knowledgeBaseGuidanceInjected');
+        });
+
+        // The gate ToolBuilder does not own. A promptMode caller cannot receive the section at
+        // all - filterByPromptMode admits `toolPrompt` under no mode - but naming the tool itself
+        // still gets it OFFERED, since resolveEnabledTools unions requestTools ahead of
+        // skipAutoOffers. `raw` also leaves forced retrieval off, so the turn lands in the
+        // optional fold: recording `true` here would credit the treatment arm with a turn that
+        // saw no guidance, the one contamination the three-arm split exists to prevent.
+        it('records false under promptMode, where the tool prompt is filtered out entirely', async () => {
+          withGuidance('# KNOWLEDGE BASE\n\nsearch when it would settle the question.');
+          const { enabledToolsArg, retrieval } = await runKnowledgeGatingCase({
+            knowledgeIds: ['f1'],
+            files: [{ id: 'f1', fileName: 'f1.pdf', vectorized: true, chunkCount: 2 }],
+            promptMode: 'raw',
+            requestTools: ['search_knowledge_base'],
+          });
+
+          expect(enabledToolsArg).toContain('search_knowledge_base');
+          expect(retrieval).toMatchObject({ mode: 'optional', knowledgeBaseGuidanceInjected: false });
         });
       });
 

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -3049,7 +3049,52 @@ describe('ChatCompletionProcess', () => {
         });
 
         expect(enabledToolsArg).toContain('search_knowledge_base');
-        expect(retrieval).toEqual({ attempted: false, mode: 'optional', surfaces: [], dataLakeTags: [] });
+        expect(retrieval).toEqual({
+          attempted: false,
+          mode: 'optional',
+          surfaces: [],
+          dataLakeTags: [],
+          // false: this suite stubs getSettingsValue to undefined, so no guidance string resolves
+          // and the section does not ship. The populated case is its own test below.
+          knowledgeBaseGuidanceInjected: false,
+        });
+      });
+
+      /**
+       * Both arms of the A/B flag, driven through the real seed. Everything else in this suite runs
+       * with getSettingsValue stubbed to undefined, which only ever produces the `false` arm - so
+       * without these two the field could be hardwired to false and every other test would pass.
+       */
+      describe('records whether the guidance section shipped', () => {
+        const withGuidance = (value: string | undefined) => {
+          mockedGetSettingsValue.mockImplementation(((key: string) =>
+            key === 'KnowledgeBaseRetrievalPrompt' ? value : undefined) as typeof getSettingsValue);
+        };
+        afterEach(() => {
+          mockedGetSettingsValue.mockReset();
+        });
+
+        it('records true when the setting resolves a non-empty guidance string', async () => {
+          withGuidance('# KNOWLEDGE BASE\n\nsearch when it would settle the question.');
+          const { retrieval } = await runKnowledgeGatingCase({
+            knowledgeIds: ['f1'],
+            files: [{ id: 'f1', fileName: 'f1.pdf', vectorized: true, chunkCount: 2 }],
+          });
+          expect(retrieval?.knowledgeBaseGuidanceInjected).toBe(true);
+        });
+
+        it('records false when the setting is cleared - the A/B control arm', async () => {
+          // A cleared admin setting resolves to '' (this section is read 2-arg precisely so that
+          // stays '' instead of reverting to the default). The section drops, and the turn has to
+          // land in the control arm rather than look like a turn that was never instrumented.
+          withGuidance('');
+          const { retrieval } = await runKnowledgeGatingCase({
+            knowledgeIds: ['f1'],
+            files: [{ id: 'f1', fileName: 'f1.pdf', vectorized: true, chunkCount: 2 }],
+          });
+          expect(retrieval?.knowledgeBaseGuidanceInjected).toBe(false);
+          expect(retrieval).toHaveProperty('knowledgeBaseGuidanceInjected');
+        });
       });
 
       it('writes no retrieval record at all when there was nothing to retrieve from', async () => {
@@ -3088,6 +3133,10 @@ describe('ChatCompletionProcess', () => {
           mode: 'optional',
           surfaces: ['knowledgeBaseSearch'],
           dataLakeTags: [],
+          // Survives the tool arm's later write, which never sets it - the flag is seeded once
+          // and must reach the fold intact or the A/B loses the turn. False here for the same
+          // stubbed-settings reason as above; what this pins is survival, not the value.
+          knowledgeBaseGuidanceInjected: false,
         });
       });
     });
@@ -3962,6 +4011,7 @@ describe('ChatCompletionProcess', () => {
         // preamble and `- ` bullets would inflate it by a fixed overhead and make it mean
         // something different here than on the surfaces this field is summed with.
         injected: { chunks: 1, chars: 'The X-200 pump has a 5-year warranty.'.length },
+        knowledgeBaseGuidanceInjected: false,
       });
     });
 
@@ -3995,6 +4045,10 @@ describe('ChatCompletionProcess', () => {
         // Recall completed, so the zero is RECORDED rather than unknown - the same distinction
         // 'ok' draws for the outcome, now drawn for the volume.
         injected: { chunks: 0, chars: 0 },
+        // false because this suite stubs getSettingsValue to undefined (see the restore note
+        // above), not because a forced turn cannot ship the section - these turns are forced AND
+        // offered the tool, so in production the resolved default would make this true.
+        knowledgeBaseGuidanceInjected: false,
       });
     });
 
@@ -4013,6 +4067,7 @@ describe('ChatCompletionProcess', () => {
         mode: 'forced',
         surfaces: ['lake-memory'],
         dataLakeTags: ['datalake:corpus'],
+        knowledgeBaseGuidanceInjected: false,
       });
     });
 
@@ -4035,6 +4090,7 @@ describe('ChatCompletionProcess', () => {
         mode: 'forced',
         surfaces: ['lake-memory'],
         dataLakeTags: [],
+        knowledgeBaseGuidanceInjected: false,
       });
     });
   });

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -2711,12 +2711,23 @@ export class ChatCompletionProcess {
       // and the knowledge tools write the same field later in the turn (mergeRetrievalSummary
       // keeps 'forced' and never lets this not-attempted seed erase a real outcome).
       const knowledgeToolOffered = offeredToolNames.includes('search_knowledge_base');
+      // Resolved here rather than inline at the buildToolPrompt call below so the seed can record
+      // whether the guidance section actually shipped. Read 2-arg on purpose: a cleared setting
+      // returns '' and the section drops out, which is its documented off switch.
+      const knowledgeBaseGuidance = getSettingsValue('KnowledgeBaseRetrievalPrompt', defaultAdminSettings);
+      // Mirrors ToolBuilder.buildToolPrompt's gate exactly. One const feeds both the seed and the
+      // call below so the recorded flag and the actual injection cannot drift apart.
+      const knowledgeBaseGuidanceInjected = knowledgeToolOffered && Boolean(knowledgeBaseGuidance);
       if (quest.promptMeta && (forcedRetrievalEnabled || knowledgeToolOffered)) {
         quest.promptMeta.retrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, {
           attempted: false,
           mode: forcedRetrievalEnabled ? 'forced' : 'optional',
           surfaces: [],
           dataLakeTags: [],
+          // Recorded only when the tool was offered: a forced-only turn never had a section to
+          // ship, and writing `false` there would pad the A/B's control arm with turns that were
+          // never in the experiment.
+          ...(knowledgeToolOffered ? { knowledgeBaseGuidanceInjected } : {}),
         });
       }
 
@@ -2789,15 +2800,13 @@ export class ChatCompletionProcess {
         hasWebSearch: offeredToolNames.includes('web_search'),
         webSearchGuidance: getSettingsValue('WebSearchFreshnessPrompt', defaultAdminSettings),
         // Same offered-set check that seeds `promptMeta.retrieval.mode` above, so the nudge covers
-        // the optional-path turns that fold measures. Two caveats a reader re-running that
-        // measurement needs: the seed splits this set by `forcedRetrievalEnabled`, so forced turns
-        // are nudged too and land in a different bucket; and the seed does NOT see the guidance
-        // string, so clearing the `KnowledgeBaseRetrievalPrompt` setting (the section's documented
-        // off switch) leaves those turns counted in `offeredTurns` with no nudge shipped. Nothing
-        // in promptMeta records that the section was injected - so an A/B driven by clearing the
-        // field cannot be read off the fold alone.
+        // the optional-path turns that fold measures. One caveat for a reader re-running that
+        // measurement: the seed splits this set by `forcedRetrievalEnabled`, so forced turns are
+        // nudged too and land in a different bucket. Whether the section actually shipped is
+        // recorded per turn as `retrieval.knowledgeBaseGuidanceInjected`, which is what makes an
+        // A/B driven by clearing the setting readable straight off the fold.
         hasKnowledgeBase: knowledgeToolOffered,
-        knowledgeBaseGuidance: getSettingsValue('KnowledgeBaseRetrievalPrompt', defaultAdminSettings),
+        knowledgeBaseGuidance,
         userTimezone,
         mcpTools: directMcpTools,
         sessionId,

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -2788,6 +2788,16 @@ export class ChatCompletionProcess {
         // this reads the offered set for the same reason blog_draft and navigate_view do above.
         hasWebSearch: offeredToolNames.includes('web_search'),
         webSearchGuidance: getSettingsValue('WebSearchFreshnessPrompt', defaultAdminSettings),
+        // Same offered-set check that seeds `promptMeta.retrieval.mode` above, so the nudge covers
+        // the optional-path turns that fold measures. Two caveats a reader re-running that
+        // measurement needs: the seed splits this set by `forcedRetrievalEnabled`, so forced turns
+        // are nudged too and land in a different bucket; and the seed does NOT see the guidance
+        // string, so clearing the `KnowledgeBaseRetrievalPrompt` setting (the section's documented
+        // off switch) leaves those turns counted in `offeredTurns` with no nudge shipped. Nothing
+        // in promptMeta records that the section was injected - so an A/B driven by clearing the
+        // field cannot be read off the fold alone.
+        hasKnowledgeBase: knowledgeToolOffered,
+        knowledgeBaseGuidance: getSettingsValue('KnowledgeBaseRetrievalPrompt', defaultAdminSettings),
         userTimezone,
         mcpTools: directMcpTools,
         sessionId,

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -150,6 +150,7 @@ import {
   filterByPromptMode,
   filterFeaturesByPromptMode,
   markShareablePrefixBoundary,
+  PROMPT_MODE_SOURCES,
   PROMPT_SOURCE_METADATA,
   resolveForcedRetrieval,
   SYSTEM_PROMPT_PRIORITY,
@@ -2715,9 +2716,20 @@ export class ChatCompletionProcess {
       // whether the guidance section actually shipped. Read 2-arg on purpose: a cleared setting
       // returns '' and the section drops out, which is its documented off switch.
       const knowledgeBaseGuidance = getSettingsValue('KnowledgeBaseRetrievalPrompt', defaultAdminSettings);
-      // Mirrors ToolBuilder.buildToolPrompt's gate exactly. One const feeds both the seed and the
-      // call below so the recorded flag and the actual injection cannot drift apart.
-      const knowledgeBaseGuidanceInjected = knowledgeToolOffered && Boolean(knowledgeBaseGuidance);
+      // ToolBuilder's gate is not the last word: its output is tagged `toolPrompt`, which
+      // filterByPromptMode admits under no promptMode. A promptMode caller naming
+      // search_knowledge_base itself still gets knowledgeToolOffered (resolveEnabledTools unions
+      // requestTools before skipAutoOffers is consulted), so without this a `raw` turn - forced
+      // retrieval off, hence in the optional fold - would record `true` having received no
+      // section, biasing the exact arm the flag exists to measure. Read off PROMPT_MODE_SOURCES
+      // rather than `!promptMode` so admitting `toolPrompt` to a mode moves the flag with it.
+      const toolPromptAdmitted = !promptMode || PROMPT_MODE_SOURCES[promptMode].includes('toolPrompt');
+      // Mirrors ToolBuilder.buildToolPrompt's gate, narrowed by the prompt-mode filter above. The
+      // two ToolBuilder conditions are the same consts handed to the call below, so the recorded
+      // flag and the actual emission cannot drift; the third sits downstream of that call and has
+      // no ToolBuilder input to mirror.
+      const knowledgeBaseGuidanceInjected =
+        toolPromptAdmitted && knowledgeToolOffered && Boolean(knowledgeBaseGuidance);
       if (quest.promptMeta && (forcedRetrievalEnabled || knowledgeToolOffered)) {
         quest.promptMeta.retrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, {
           attempted: false,

--- a/b4m-core/services/src/llm/tools/ToolBuilder.knowledgeBaseRetrieval.test.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.knowledgeBaseRetrieval.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ToolBuilder, type ToolBuilderConfig } from './ToolBuilder';
+
+/**
+ * The retrieval nudge is gated on `search_knowledge_base` actually surviving into the offered tool
+ * set. Telling a model to search a corpus it has no tool for makes it claim it searched, so the
+ * gate is the feature and not an optimization. The wording is admin-editable
+ * (`KnowledgeBaseRetrievalPrompt`) and clearing that setting is the section's only off switch, so
+ * a cleared value must drop it entirely rather than inject an empty heading.
+ *
+ * Mirrors ToolBuilder.webSearchFreshness.test.ts - the two sections share a gating shape, and a
+ * change to one that skips the other is the drift these two files are here to catch.
+ */
+describe('buildToolPrompt knowledge-base retrieval section', () => {
+  const GUIDANCE = '# KNOWLEDGE BASE\n\nsearch when the answer is in the user documents.';
+
+  function makeBuilder(): ToolBuilder {
+    return new ToolBuilder({
+      user: { id: 'u1' },
+      db: {},
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), updateMetadata: vi.fn() },
+      storage: {},
+      imageGenerateStorage: {},
+      toolCreditsMap: new Map(),
+      subagentTelemetryData: [],
+      sendStatusUpdate: vi.fn(),
+    } as unknown as ToolBuilderConfig);
+  }
+
+  async function build(overrides: { hasKnowledgeBase: boolean; knowledgeBaseGuidance?: string }) {
+    return makeBuilder().buildToolPrompt({
+      hasContentTransform: false,
+      hasChessEngine: false,
+      hasCurrentDateTime: false,
+      hasWebSearch: false,
+      mcpTools: [],
+      sessionId: 's1',
+      message: 'what did we decide about pricing',
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      processStartTime: Date.now(),
+      ...overrides,
+    });
+  }
+
+  it('injects the guidance when search_knowledge_base is offered', async () => {
+    const msg = await build({ hasKnowledgeBase: true, knowledgeBaseGuidance: GUIDANCE });
+    expect(msg?.content).toContain('KNOWLEDGE BASE');
+  });
+
+  // Every other section is switched off here, so a correctly gated build contributes no sections
+  // at all and buildToolPrompt returns null. Asserting on null rather than on the absence of the
+  // heading is what catches a guard that pushes an empty section.
+  it('omits it when the knowledge tool is not offered', async () => {
+    const msg = await build({ hasKnowledgeBase: false, knowledgeBaseGuidance: GUIDANCE });
+    expect(msg).toBeNull();
+  });
+
+  it('omits it when the admin setting has been cleared', async () => {
+    const msg = await build({ hasKnowledgeBase: true, knowledgeBaseGuidance: '' });
+    expect(msg).toBeNull();
+  });
+});

--- a/b4m-core/services/src/llm/tools/ToolBuilder.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.ts
@@ -326,6 +326,18 @@ export interface BuildToolPromptArgs {
    */
   webSearchGuidance?: string;
   /**
+   * Whether `search_knowledge_base` survived into the offered tool set. Read from the offered list
+   * rather than the requested one for the same reason `hasWebSearch` is: the tool is auto-offered
+   * server-side from attached documents or an accessible lake, and a session denylist can still
+   * strip it afterwards - so only the post-build list says what the model actually got.
+   */
+  hasKnowledgeBase: boolean;
+  /**
+   * Resolved `KnowledgeBaseRetrievalPrompt` setting. Resolved by the caller, which owns the
+   * settings reader, so the injected text and its telemetry cannot disagree.
+   */
+  knowledgeBaseGuidance?: string;
+  /**
    * User's IANA timezone (from the browser) when known, so the current-time
    * nudge can tell the model which timezone to pass to `current_datetime`.
    */
@@ -929,6 +941,8 @@ export class ToolBuilder {
     hasCurrentDateTime,
     hasWebSearch,
     webSearchGuidance,
+    hasKnowledgeBase,
+    knowledgeBaseGuidance,
     userTimezone,
     mcpTools,
     sessionId,
@@ -1057,6 +1071,19 @@ Both calls happen in the same response — do NOT ask the user to repeat their m
     // knowledge is too old to answer from.
     if (hasWebSearch && webSearchGuidance) {
       sections.push(webSearchGuidance);
+    }
+
+    // 3d. Knowledge-base retrieval nudge. Same gate and same reason as 3c: the tool description
+    // says how to search and never when, so on the optional path nothing tells the model that the
+    // user's library is outside its weights.
+    //
+    // Injected on forced-retrieval turns too, rather than gated off them. The section carries its
+    // own "already been searched on this turn" and "from an attached document" clauses for that
+    // case (see KNOWLEDGE_BASE_RETRIEVAL_PROMPT's docblock, which spells out which co-resident
+    // prompt each one is defending against) - prompt-level rather than a second gate here, because
+    // the tool stays callable on those turns and the model needs to know when NOT to call it.
+    if (hasKnowledgeBase && knowledgeBaseGuidance) {
+      sections.push(knowledgeBaseGuidance);
     }
 
     // 4. MCP integration guidance (if MCP tools are available)

--- a/b4m-core/services/src/llm/tools/ToolBuilder.webSearchFreshness.test.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.webSearchFreshness.test.ts
@@ -29,6 +29,7 @@ describe('buildToolPrompt web-search freshness section', () => {
       hasContentTransform: false,
       hasChessEngine: false,
       hasCurrentDateTime: false,
+      hasKnowledgeBase: false,
       mcpTools: [],
       sessionId: 's1',
       message: 'what is the current price',

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
@@ -225,6 +225,33 @@ describe('mergeRetrievalSummary', () => {
     });
   });
 
+  describe('knowledgeBaseGuidanceInjected', () => {
+    it('preserves an explicit false through a merge that never asserts the field', () => {
+      // The regression this pins: `false || undefined` is undefined, so a boolean-OR merge would
+      // drop the A/B's control arm into the unrecorded bucket and quietly bias the comparison.
+      const merged = mergeRetrievalSummary(base({ knowledgeBaseGuidanceInjected: false }), base());
+      expect(merged?.knowledgeBaseGuidanceInjected).toBe(false);
+    });
+
+    it('preserves a true through a later tool-arm write', () => {
+      const merged = mergeRetrievalSummary(
+        base({ knowledgeBaseGuidanceInjected: true }),
+        base({ attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'] })
+      );
+      expect(merged?.knowledgeBaseGuidanceInjected).toBe(true);
+    });
+
+    it('stays absent when neither side recorded it', () => {
+      const merged = mergeRetrievalSummary(base(), base());
+      expect(merged && 'knowledgeBaseGuidanceInjected' in merged).toBe(false);
+    });
+
+    it('takes the incoming value when the existing side never recorded it', () => {
+      const merged = mergeRetrievalSummary(base(), base({ knowledgeBaseGuidanceInjected: false }));
+      expect(merged?.knowledgeBaseGuidanceInjected).toBe(false);
+    });
+  });
+
   describe('preauthorizedLakeIdsUsed', () => {
     it('unions ids without duplicates, independent of injectedLakePromptIds', () => {
       const merged = mergeRetrievalSummary(

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
@@ -71,6 +71,9 @@ function mergeInjected(
  *   makes this first-writer-wins under the accumulator convention (`existing` is the earlier
  *   write), not last-writer-wins. Unlike the fields above it is NOT commutative when both sides
  *   carry a different reason.
+ * - knowledgeBaseGuidanceInjected: first-writer-wins pass-through. Only the seed writes it, and
+ *   `??` rather than `||` because an explicit `false` is a real value (the A/B control arm) that
+ *   a boolean OR against an absent incoming side would silently discard.
  * - surfaces / dataLakeTags / injectedLakePromptIds / preauthorizedLakeIdsUsed: union, deduped.
  *   injectedLakePromptCount is derived from the merged injectedLakePromptIds, not merged
  *   independently, so a two-sided merge can never leave the two disagreeing.
@@ -99,6 +102,8 @@ export function mergeRetrievalSummary(
     outcomeSeverity(incoming.outcome) > outcomeSeverity(existing.outcome) ? incoming.outcome : existing.outcome;
   const mode = existing.mode === 'forced' || incoming.mode === 'forced' ? 'forced' : (existing.mode ?? incoming.mode);
   const forcedSkipReason = existing.forcedSkipReason ?? incoming.forcedSkipReason;
+  const knowledgeBaseGuidanceInjected =
+    existing.knowledgeBaseGuidanceInjected ?? incoming.knowledgeBaseGuidanceInjected;
   const injectedLakePromptIds =
     existing.injectedLakePromptIds || incoming.injectedLakePromptIds
       ? [...new Set([...(existing.injectedLakePromptIds ?? []), ...(incoming.injectedLakePromptIds ?? [])])]
@@ -116,6 +121,7 @@ export function mergeRetrievalSummary(
     ...(outcome !== undefined ? { outcome } : {}),
     ...(mode !== undefined ? { mode } : {}),
     ...(forcedSkipReason !== undefined ? { forcedSkipReason } : {}),
+    ...(knowledgeBaseGuidanceInjected !== undefined ? { knowledgeBaseGuidanceInjected } : {}),
     surfaces: [...new Set([...existing.surfaces, ...incoming.surfaces])],
     dataLakeTags: [...new Set([...existing.dataLakeTags, ...incoming.dataLakeTags])],
     ...(injectedLakePromptIds ? { injectedLakePromptIds, injectedLakePromptCount: injectedLakePromptIds.length } : {}),

--- a/b4m-core/utils/src/settings.test.ts
+++ b/b4m-core/utils/src/settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getSettingsValue, getSettingByName, getSettingsByNames } from './settings';
+import { KNOWLEDGE_BASE_RETRIEVAL_PROMPT, WEB_SEARCH_FRESHNESS_PROMPT } from '@bike4mind/common';
 import { AdminSettingsCache } from './cache/AdminSettingsCache';
 import { Logger } from '@bike4mind/observability';
 
@@ -45,6 +46,20 @@ describe('getSettingsValue - blank string reverts to a provided default', () => 
     // No third arg: a cleared FormatPromptTemplate stays ''. Its only reader,
     // includeHardcodedSystemMessage, substitutes FORMAT_PROMPT_TEMPLATE for the blank itself.
     expect(getSettingsValue('FormatPromptTemplate', { FormatPromptTemplate: '' })).toBe('');
+  });
+
+  // The two tool-prompt sections (web-search freshness, knowledge-base retrieval) are read 2-arg
+  // ON PURPOSE: neither has a companion boolean, so clearing the field is the section's only off
+  // switch, and that off switch is what makes the wording A/B-able with no deploy. Both halves are
+  // pinned here because both are load-bearing and neither is reachable from a ToolBuilder unit
+  // test - that test can only be handed a string, never the resolver that produces it. Hardening
+  // the blank->default guard to fire when no default was passed would make these sections
+  // impossible to turn off, and every other test in the suite would still pass.
+  it('leaves the tool-prompt sections turn-off-able: absent row -> constant, cleared row -> blank', () => {
+    expect(getSettingsValue('KnowledgeBaseRetrievalPrompt', {})).toBe(KNOWLEDGE_BASE_RETRIEVAL_PROMPT);
+    expect(getSettingsValue('KnowledgeBaseRetrievalPrompt', { KnowledgeBaseRetrievalPrompt: '' })).toBe('');
+    expect(getSettingsValue('WebSearchFreshnessPrompt', {})).toBe(WEB_SEARCH_FRESHNESS_PROMPT);
+    expect(getSettingsValue('WebSearchFreshnessPrompt', { WebSearchFreshnessPrompt: '' })).toBe('');
   });
 
   it('does NOT apply blank->default to a non-string setting - a stored boolean false still wins', () => {

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -74,6 +74,9 @@ const RetrievalSummarySchema = subSchema({
   // Optional because it is present iff `attempted`: the seeded not-attempted turn has no outcome.
   outcome: { type: String, required: false },
   mode: { type: String, required: false },
+  // Optional, and an explicit `false` is meaningful (the A/B control arm) rather than a blank -
+  // see the field's comment on the Zod side.
+  knowledgeBaseGuidanceInjected: { type: Boolean, required: false },
   forcedSkipReason: { type: String, required: false },
   surfaces: [{ type: String, required: false }],
   dataLakeTags: [{ type: String, required: false }],

--- a/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
+++ b/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
@@ -123,6 +123,9 @@ const FULL_PROMPT_META = {
     // what covers the BSON-type half, so a Number-vs-String slip on any of these three fails here
     // rather than shipping as a field that saves and then fails its Zod re-parse on read.
     injected: { chunks: 5, chars: 1300, topScore: 0.88 },
+    // Deliberately `false`, not `true`: a falsy leaf is where a Mongoose/Zod mismatch silently
+    // drops a value, and `false` is this field's load-bearing case (the A/B's control arm).
+    knowledgeBaseGuidanceInjected: false,
   },
   // Top-level for the same reason as `retrieval` above. The chat coverage banner keys on this
   // field surviving the round-trip, so a shape that persists but fails the Zod re-parse would


### PR DESCRIPTION
# Pull Request

## Description

When the knowledge base tools are offered, the model gets the tool schemas but no guidance on **when** to use them. `search_knowledge_base` reads as one option among many, so the model answers org-specific questions from training data instead of searching -- confidently, and in a register that reads like it knows.

This adds a when-to-retrieve section to the tool prompt, gated exactly like the existing web-search freshness section: it ships only when the knowledge tool is actually offered *and* the admin-configured string is non-empty.

The section is deliberately narrow. It names one tool (`search_knowledge_base`), states what the corpus is and that filenames are labels rather than content, gives the search-first triggers (anything about the user's organization, projects, customers, products, processes or people; a term or identifier that is not general public knowledge; a policy, figure or date specific to them), gives the don't-search exemptions, and closes by telling the model not to imply an answer came from the user's documents when it did not.

Each don't-search clause defends against a specific co-resident prompt that would otherwise push the model into a wasted round trip -- general knowledge, content already in the conversation or in an attached document, and a same-turn repeat search. Those are documented at the constant.

It also records, per turn, whether the section actually shipped -- without that the off switch
below is an A/B you can run but cannot read, which makes the section's own value unmeasurable.

Part of #1394 -- ticks "add the section" and the telemetry that makes it A/B-able. The issue stays
open for running the A/B, the document-answerability instrumentation, and the classifier.
Deliberately not `Closes`.

## Changes

- **New `KnowledgeBaseRetrievalPrompt` admin setting** (`b4m-core/common/src/schemas/settings.ts`) -- enum key, `settingsMap` entry via `makeStringSetting`, and an `API_SERVICE_GROUPS.OPENAI` row so it renders in the admin UI directly after its sibling, Web Search Freshness Prompt. Default text lives in the exported `KNOWLEDGE_BASE_RETRIEVAL_PROMPT` constant.
- **`ToolBuilder.buildToolPrompt` gains the section** (`b4m-core/services/src/llm/tools/ToolBuilder.ts`) -- new `hasKnowledgeBase` (required) and `knowledgeBaseGuidance` (optional) args, pushed as a numbered section when both are set.
- **Wired at the call site** (`b4m-core/services/src/llm/ChatCompletionProcess.ts`) -- `hasKnowledgeBase` is the existing `knowledgeToolOffered`, so the section tracks the real tool-offer decision rather than a second, drifting one.
- **`promptMeta.retrieval.knowledgeBaseGuidanceInjected`** -- a per-turn boolean recording whether
  the section shipped, added to the Zod schema (`b4m-core/common/src/schemas/promptMeta.ts`) and its
  Mongoose mirror (`packages/database/src/models/content/QuestModel.ts`). Seeded from the same
  conjunction that gates the injection - the tool being offered, the guidance string being
  non-empty, and `PROMPT_MODE_SOURCES` admitting the `toolPrompt` source - computed once so the
  flag and the injection cannot drift.
- **The fold reports the A/B** (`b4m-core/common/src/utils/retrievalRate.ts`) --
  `summarizeOptionalPathRetrieval` now splits the offered population into `injected` /
  `notInjected` / `unrecorded` arms. The admin endpoint at `/api/admin/retrieval-rate` needed no
  change: its Mongo projection is derived from `RETRIEVAL_RATE_FIELDS`, so widening the fold's
  input type forced a build break there instead of a silently unselected column.
- **Tests** -- three gating tests for the new section, four assertions pinning the resolver contract in both directions, content pins on the load-bearing clauses (including negative pins that the sibling knowledge tools are *not* named), and a const/setting no-drift check.

### The off switch is a design decision, not an oversight

The guidance is read with a 2-arg `getSettingsValue` (no default passed). That matters: with 3 args a cleared field reverts to the built-in constant, so the section could never be turned off. With 2 args, clearing the field in the admin UI returns `''` and the section drops out entirely -- **which makes the wording A/B-able with no deploy**, on the same setting the operator already edits.

That contract is invisible from `ToolBuilder`'s own tests, which can only be handed a string, never the resolver that produced it. So it is pinned in `b4m-core/utils/src/settings.test.ts` for both this section and the web-search one. Without that test, hardening the blank-to-default guard would make both sections permanently unturnoffable and every other test in the repo would still pass.

## Guide for Testers

Requires a superuser account. Works on any environment where the knowledge base tools are enabled.

### Setup

1. Log in as a superuser.
2. Upload at least one document containing a fact that is **not** public knowledge -- e.g. a text file containing `Our internal deploy freeze window is the last Tuesday of each month.` Wait for it to finish processing (the file shows as ready in the Files list).

### A. The setting exists and is editable

3. Navigate to **Admin -> General Ops -> Admin Settings**.
4. Click the **AI Configuration** tab.
5. **Expected:** a field named **Knowledge Base Retrieval Prompt** appears immediately after **Web Search Freshness Prompt**. It is pre-filled with the default guidance text (starts with `# KNOWLEDGE BASE`) and its description explains that clearing it removes the section.

### B. The guidance ships to the model

6. Start a new chat session. Attach or make available the document from step 2 so the knowledge tools are offered.
7. Ask a question the document answers and that the model could not know otherwise: `When is our internal deploy freeze window?`
8. **Expected:** the model calls `search_knowledge_base` and answers from the document, rather than answering in general terms or saying it has no information.

### C. The off switch works

9. Return to **Admin -> General Ops -> Admin Settings -> AI Configuration**.
10. Clear the **Knowledge Base Retrieval Prompt** field completely (delete all text) and save.
11. Start a **new** chat session (the tool prompt is assembled per turn, but start fresh to avoid conversation history influencing the model).
12. Ask the same question from step 7.
13. **Expected:** the setting saves as empty and stays empty on reload. The section is no longer sent. Model behavior here is a judgment call, not a hard assertion -- it may still search. What is being verified is that the operator's off switch takes effect, not that the model necessarily regresses.
14. Restore it. Note that clearing the field is *not* how you get the default back -- an empty field is a real, saved value meaning "off". Paste the default text back in and save, then reload and confirm it persists.

### D. No section when the tool is not offered

15. Start a chat session with no documents available and the knowledge tools not offered.
16. **Expected:** normal responses, no errors. The guidance section is simply absent -- there is nothing user-visible to check here beyond "nothing broke".

### E. The A/B readout (superuser, optional)

20. With the setting populated, send a few chat turns in a session that has documents available.
21. Clear the setting and send a few more turns in a new session.
22. Query the admin retrieval-rate endpoint (`/api/admin/retrieval-rate`).
23. **Expected:** the response carries a `guidance` object with `injected`, `notInjected` and
    `unrecorded` arms. Your populated-setting turns land in `injected`, your cleared-setting turns
    in `notInjected`, and any older traffic in `unrecorded`. The three `turns` counts sum to
    `offeredTurns`. Each arm's `rate` is `null` rather than `0` when that arm has no turns.
24. **The promptMode arm (needs an API key).** `POST /api/chat` with `promptMode: 'raw'` and
    `tools: ['search_knowledge_base']`, against a session that has documents available. Re-query
    the endpoint. **Expected:** that turn lands in `notInjected`, not `injected` - it was offered
    the tool, but `toolPrompt` survives no prompt mode, so it received no guidance section.
    An earlier revision of this PR recorded `injected` here, which would have biased the
    treatment arm; the mode filter is now a gate on the flag.

### Regression Checks

17. **Web search freshness guidance still ships.** In a session with web search enabled, ask a question requiring current information. The existing freshness behavior must be unchanged -- this PR added an argument to the same function and must not have disturbed the sibling section.
18. **Other admin prompt settings still revert on clear.** In **AI Configuration**, clear **Artifact Emission Prompt** and save, then reload. It must come back populated with its default (that setting reads 3-arg and *does* revert). This confirms the 2-arg read added here did not change the shared resolver's behavior for everyone else.
19. **Existing retrieval telemetry is unchanged.** The `offeredTurns` / `retrievedTurns` / `rate`
    figures and the `forcedSuppressed` breakdown must behave exactly as before -- the guidance
    split is additive and must not move the headline numbers.
20. **Normal chat is unaffected.** Send a few ordinary messages in a session with no documents. No new latency, no errors, no change in response shape.

### What NOT to test

- **Retrieval quality or ranking.** This PR changes *when* the model decides to search, not what the search returns or how passages are ranked.
- **Forced retrieval.** The forced-retrieval path (`resolveForcedRetrieval`) is untouched. This section is about the model's own decision on the optional path.
- **Agent mode.** Agent mode builds its tool list from `OrchestrationDefaults.allowedTools` rather than this path -- see Additional Information.
- **A conclusion from the A/B.** The plumbing to read it ships here; actually running it needs
  merged code and days of real traffic. A `notInjected` arm of zero means nobody has thrown the
  switch yet, not that the section is always on.

## Additional Information

**Token footprint.** The section is ~358 tokens (1619 characters, scaled from the sibling web-search section's production-measured 279 tokens at 1260 characters). It sits inside the shareable cache prefix, so on repeat turns in a session it is a cached read rather than fresh input.

**Agent mode is not covered.** Agent mode assembles its tool list from `OrchestrationDefaults.allowedTools`, not from the offered-tools path this section is gated on, so agent loops do not receive this guidance. That is a known gap, not a regression -- they did not receive when-to-use guidance before either.

**Interaction with the relevance floor (#1993).** The closing clause tells the model to say so plainly when a search does not turn up what was asked for. #1993 reports that `kbSearchMinRelevancePct` defaults to a floor of 0, so the tool always returns *something* -- meaning the model has no signal that the passages are irrelevant. That clause is therefore weaker in practice than it reads. The fix is a threshold, not wording.

**Interaction with promptMode (#2523).** The section never reaches a `promptMode` caller, but the mechanism is `filterByPromptMode`, not the suppressed auto-offer. `PROMPT_MODE_SOURCES` admits the `toolPrompt` source under none of `raw` / `grounded` / `surface`, so the whole tool prompt is dropped downstream of `buildToolPrompt`. The auto-offer being suppressed is not what does it: `resolveEnabledTools` unions `requestTools` ahead of the `skipAutoOffers` gate, so a caller who names `search_knowledge_base` explicitly still gets it offered. That is why the recorded flag is gated on the mode table too and not on the tool offer alone. #2523 notes that the same filter also strips `ABSTENTION_PROMPT` -- so the one switch that turns this section off also removes the abstention licence, and those are two prompts that most want to travel together. Out of scope here; it needs a `filterByPromptMode` change.

**Four details in the telemetry that are easy to get backwards.** Each is pinned by a test.

1. `mergeRetrievalSummary` passes the flag through with `??`, not `||`. An explicit `false` is the
   A/B's control arm, and `false || undefined` is `undefined` -- a boolean OR would quietly move
   every control turn into the unrecorded bucket and the comparison would still look healthy.
2. `unrecorded` is its own arm, not folded into either side. A turn predating the field is missing
   data; a turn where the operator cleared the setting is a control observation. Collapsing them
   lets pre-change traffic masquerade as control turns. The three arms always sum to `offeredTurns`.
3. The flag is written only on turns that were offered the tool. A forced-only turn never had a
   section to ship, so recording `false` there would pad the control arm with turns that were never
   in the experiment.
4. An offered tool is not sufficient - the mode filter is a second gate. `buildToolPrompt`'s output
   is a filterable prompt source, and `toolPrompt` survives no `promptMode`, so a `raw` caller who
   names `search_knowledge_base` gets the tool offered, gets no guidance section, and (since `raw`
   leaves forced retrieval off) lands in the optional fold. Recording `true` there would credit the
   treatment arm with a turn that saw no guidance, which is the one contamination the three-arm
   split exists to prevent.

**No migration.** The field is optional on both sides, so existing documents simply land in the
`unrecorded` arm, which is what they are.

## Developer Notes

- **New extension point:** `BuildToolPromptArgs` now carries `hasKnowledgeBase` / `knowledgeBaseGuidance` alongside the existing `hasWebSearch` / `webSearchGuidance` pair. Adding a third when-to-use section for another tool is now a visible, copyable two-line pattern rather than a decision.
- **Reusable pattern -- the deploy-free prompt A/B:** an admin-editable prompt string read *2-arg* gives you an operator-controlled off switch with no companion boolean and no schema change. The cost is that it inverts the usual "clearing reverts to default" contract, so it only works where the section is genuinely optional, and the inversion must be pinned by a test at the resolver (not at the consumer, which never sees it).
- **Gate on the existing decision, not a new one:** `hasKnowledgeBase` reuses `knowledgeToolOffered` rather than recomputing whether the tool is available. A second predicate would drift from the first the moment tool-offer rules change, and the failure would be silent -- guidance describing a tool the model was never given.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a: string prompt settings carry their `defaultValue` in `makeStringSetting`, which is what serves every environment until an admin edits it. There is no separate hydration script for this family (confirmed against `WebSearchFreshnessPrompt` / `ArtifactEmissionPrompt`).
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) -- the setting renders in the existing AI Configuration list with no new UI code.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) -- n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc -- the new
  field is a boolean about prompt composition. It carries no user, document, lake or org identity,
  so it adds no new data class to `promptMeta.retrieval`, which already documents its own
  redaction posture. Flagging it here rather than silently ticking: if a reviewer reads that doc as
  needing a row per field regardless of class, say so and I will add one.


