### PR TITLE
fix(client): restore accordion tab stops after a panel is collapsed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./
 COPY apps ./apps
 COPY b4m-core ./b4m-core
 COPY packages ./packages
+# pnpm hashes every patchedDependencies entry during install, so a missing patches/
+# fails the install with ENOENT rather than silently skipping the patch.
+COPY patches ./patches
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 # ── Builder: build all @bike4mind/* packages, then the Next app (shim active) ─

--- a/apps/client/Dockerfile.chatcompletion
+++ b/apps/client/Dockerfile.chatcompletion
@@ -42,6 +42,11 @@ COPY --parents **/package.json ./
 #     Copied here (not with source) so it's available before the install step below.
 COPY apps/client/scripts ./apps/client/scripts
 
+# 1b) pnpm hashes every patchedDependencies entry during install, so a missing patches/
+#     fails the install with ENOENT rather than silently skipping the patch. Must be
+#     copied before the install step, not with the source below.
+COPY patches ./patches
+
 # 2) Install the client workspace + all its workspace dependencies, INCLUDING devDeps
 #    (tsx lives in devDependencies). Do not pass --prod here for that reason. The native
 #    compiles happen here; this layer is reused until the lockfile/manifests change.

--- a/apps/client/Dockerfile.chatcompletion.selfhost
+++ b/apps/client/Dockerfile.chatcompletion.selfhost
@@ -32,6 +32,10 @@ COPY --parents **/package.json ./
 # 1a) apps/client's postinstall needs its scripts present before install.
 COPY apps/client/scripts ./apps/client/scripts
 
+# 1b) pnpm hashes every patchedDependencies entry during install, so patches/ must be
+#     present before it runs or the install ENOENTs.
+COPY patches ./patches
+
 # 2) Install the client workspace + all workspace deps INCLUDING devDeps (tsx). No --prod.
 RUN pnpm install --frozen-lockfile --filter @bike4mind/client...
 

--- a/apps/client/app/components/common/__tests__/joyAccordionDetailsTabIndex.test.tsx
+++ b/apps/client/app/components/common/__tests__/joyAccordionDetailsTabIndex.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { Accordion, AccordionDetails, AccordionGroup, AccordionSummary, Button, ListItemButton } from '@mui/joy';
+import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
+
+// Guards patches/@mui__joy@5.0.0-beta.52.patch, which fixes two defects in Joy's
+// AccordionDetails focus-management effect. On collapse Joy stashes each focusable
+// descendant's tabindex in data-prev-tabindex and sets tabindex="-1"; on expand it is
+// supposed to put them back.
+//
+//   1. Its restore branches required the stashed and current values to be BOTH truthy
+//      or BOTH falsy, so a native <button> with no tabindex of its own (stashed as "")
+//      paired with "-1" matched neither branch and kept the -1 forever.
+//   2. The expand pass reused the collapse pass's focusable-element selector, which
+//      cannot match what that pass untabbed: an element that is not natively focusable
+//      matches none of the tag names, and its fresh tabindex="-1" is excluded by the
+//      selector's own :not([tabindex="-1"]) clause. Joy's own ListItemButton renders a
+//      div, so those were never even visited on expand.
+//
+// These assert against the real Joy component rather than a re-implementation, so they
+// fail on an unpatched install. If this suite breaks after a dependency change, check
+// that the patch still applies before touching the assertions.
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const Harness = () => (
+  <CssVarsProvider theme={appTheme}>
+    <AccordionGroup>
+      <Accordion defaultExpanded>
+        <AccordionSummary slotProps={{ button: { 'data-testid': 'section-toggle' } }}>Section</AccordionSummary>
+        <AccordionDetails>
+          {/* No tabindex of its own - the shape every nav item in the admin sidebar has. */}
+          <Button data-testid="plain-item">Plain</Button>
+          {/* An author-set tabindex must survive the collapse/expand round trip. */}
+          <Button data-testid="explicit-item" tabIndex={5}>
+            Explicit
+          </Button>
+          {/* Renders a div, so it is only reachable via its own tabindex - the case Joy's
+              expand-pass selector could not match. */}
+          <ListItemButton data-testid="list-item">List item</ListItemButton>
+        </AccordionDetails>
+      </Accordion>
+    </AccordionGroup>
+  </CssVarsProvider>
+);
+
+const plainItem = () => screen.getByTestId('plain-item');
+const explicitItem = () => screen.getByTestId('explicit-item');
+const listItem = () => screen.getByTestId('list-item');
+const toggle = () => screen.getByTestId('section-toggle');
+
+describe('Joy AccordionDetails tabindex restoration', () => {
+  it('leaves an expanded panel tabbable on mount', () => {
+    render(<Harness />);
+
+    expect(plainItem().getAttribute('tabindex')).toBeNull();
+    expect(plainItem().tabIndex).toBe(0);
+  });
+
+  it('untabs descendants while collapsed and restores them on expand', () => {
+    render(<Harness />);
+
+    fireEvent.click(toggle());
+    expect(plainItem().getAttribute('tabindex')).toBe('-1');
+    expect(plainItem().tabIndex).toBe(-1);
+
+    fireEvent.click(toggle());
+    // The reported bug: unpatched Joy leaves tabindex="-1" here, so the item is visible
+    // and mouse-clickable but permanently skipped by Tab.
+    expect(plainItem().getAttribute('tabindex')).toBeNull();
+    expect(plainItem().tabIndex).toBe(0);
+  });
+
+  it('restores a focusable that is not a natively focusable element', () => {
+    render(<Harness />);
+
+    // Guards the selector half of the fix. ListItemButton is a div carrying its own
+    // tabindex, which is what the original expand pass could not select.
+    expect(listItem().tagName).toBe('DIV');
+    expect(listItem().getAttribute('tabindex')).toBe('0');
+
+    fireEvent.click(toggle());
+    expect(listItem().getAttribute('tabindex')).toBe('-1');
+
+    fireEvent.click(toggle());
+    expect(listItem().getAttribute('tabindex')).toBe('0');
+  });
+
+  it('stays tabbable across repeated collapse/expand cycles', () => {
+    render(<Harness />);
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      fireEvent.click(toggle());
+      expect(plainItem().tabIndex, `collapse cycle ${cycle}`).toBe(-1);
+      expect(listItem().tabIndex, `collapse cycle ${cycle}`).toBe(-1);
+
+      fireEvent.click(toggle());
+      expect(plainItem().getAttribute('tabindex'), `expand cycle ${cycle}`).toBeNull();
+      expect(plainItem().tabIndex, `expand cycle ${cycle}`).toBe(0);
+      expect(listItem().getAttribute('tabindex'), `expand cycle ${cycle}`).toBe('0');
+    }
+  });
+
+  it('preserves an author-set tabindex through a collapse/expand cycle', () => {
+    render(<Harness />);
+
+    expect(explicitItem().getAttribute('tabindex')).toBe('5');
+
+    fireEvent.click(toggle());
+    expect(explicitItem().getAttribute('tabindex')).toBe('-1');
+
+    fireEvent.click(toggle());
+    expect(explicitItem().getAttribute('tabindex')).toBe('5');
+  });
+
+  it('leaves no bookkeeping attribute behind once expanded', () => {
+    const { container } = render(<Harness />);
+
+    fireEvent.click(toggle());
+    fireEvent.click(toggle());
+
+    // A leftover marker is what let a second collapse overwrite the stashed value with
+    // "-1", making the lost tab stop unrecoverable even by a later correct restore.
+    expect(container.querySelectorAll('[data-prev-tabindex]')).toHaveLength(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -155,6 +155,9 @@
       "isolated-vm",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mui/joy@5.0.0-beta.52": "patches/@mui__joy@5.0.0-beta.52.patch"
+    }
   }
 }

--- a/patches/@mui__joy@5.0.0-beta.52.patch
+++ b/patches/@mui__joy@5.0.0-beta.52.patch
@@ -1,0 +1,147 @@
+diff --git a/AccordionDetails/AccordionDetails.js b/AccordionDetails/AccordionDetails.js
+index 664c83c0416d08981c87f185cd2aab364753af25..c249032d824f3a29d5d799ae3fdcf17549458aed 100644
+--- a/AccordionDetails/AccordionDetails.js
++++ b/AccordionDetails/AccordionDetails.js
+@@ -103,21 +103,35 @@ const AccordionDetails = /*#__PURE__*/React.forwardRef(function AccordionDetails
+   React.useEffect(() => {
+     // When accordion is closed, prevent tabbing into the details content.
+     if (rootRef.current) {
+-      const elements = rootRef.current.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])');
++      // The [data-prev-tabindex] clause is what makes the expand pass able to find what
++      // the collapse pass untabbed. Without it an element that is not natively focusable
++      // is unreachable on expand: it matches none of the tag names, and the tabindex="-1"
++      // this effect just wrote is excluded by the :not() clause. Joy's own ListItemButton
++      // renders a div, so those panels never got their tab stops back.
++      const elements = rootRef.current.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), [data-prev-tabindex]');
+       elements.forEach(elm => {
+         if (expanded) {
+           const prevTabIndex = elm.getAttribute('data-prev-tabindex');
+-          const currentTabIndex = elm.getAttribute('tabindex');
+-          if (currentTabIndex && prevTabIndex) {
+-            // restore tabindex
+-            elm.setAttribute('tabindex', prevTabIndex);
++          // No marker means this element was never untabbed by a collapse, so there is
++          // nothing to restore and its own tabindex must be left alone.
++          if (prevTabIndex !== null) {
++            // An empty marker means the element had no tabindex of its own (every native
++            // button/anchor), so removing the attribute IS the restore. The original code
++            // branched on prevTabIndex and currentTabIndex being both truthy or both
++            // falsy, and "" with "-1" satisfied neither - so the -1 was never lifted.
++            if (prevTabIndex === '') {
++              elm.removeAttribute('tabindex');
++            } else {
++              elm.setAttribute('tabindex', prevTabIndex);
++            }
+             elm.removeAttribute('data-prev-tabindex');
+           }
+-          if (!prevTabIndex && !currentTabIndex) {
+-            elm.removeAttribute('tabindex');
+-          }
+         } else {
+-          elm.setAttribute('data-prev-tabindex', elm.getAttribute('tabindex') || '');
++          // Stash only on the first collapse. Re-stashing would capture the -1 this
++          // effect itself wrote and make the original value unrecoverable.
++          if (elm.getAttribute('data-prev-tabindex') === null) {
++            elm.setAttribute('data-prev-tabindex', elm.getAttribute('tabindex') || '');
++          }
+           elm.setAttribute('tabindex', '-1');
+         }
+       });
+diff --git a/modern/AccordionDetails/AccordionDetails.js b/modern/AccordionDetails/AccordionDetails.js
+index 307bf5e9f2e380093382dcab88ce4e042ee43b50..f0bcd1dc89fb7ae0d043060b4a628d6afb2d8e61 100644
+--- a/modern/AccordionDetails/AccordionDetails.js
++++ b/modern/AccordionDetails/AccordionDetails.js
+@@ -100,21 +100,35 @@ const AccordionDetails = /*#__PURE__*/React.forwardRef(function AccordionDetails
+   React.useEffect(() => {
+     // When accordion is closed, prevent tabbing into the details content.
+     if (rootRef.current) {
+-      const elements = rootRef.current.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])');
++      // The [data-prev-tabindex] clause is what makes the expand pass able to find what
++      // the collapse pass untabbed. Without it an element that is not natively focusable
++      // is unreachable on expand: it matches none of the tag names, and the tabindex="-1"
++      // this effect just wrote is excluded by the :not() clause. Joy's own ListItemButton
++      // renders a div, so those panels never got their tab stops back.
++      const elements = rootRef.current.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), [data-prev-tabindex]');
+       elements.forEach(elm => {
+         if (expanded) {
+           const prevTabIndex = elm.getAttribute('data-prev-tabindex');
+-          const currentTabIndex = elm.getAttribute('tabindex');
+-          if (currentTabIndex && prevTabIndex) {
+-            // restore tabindex
+-            elm.setAttribute('tabindex', prevTabIndex);
++          // No marker means this element was never untabbed by a collapse, so there is
++          // nothing to restore and its own tabindex must be left alone.
++          if (prevTabIndex !== null) {
++            // An empty marker means the element had no tabindex of its own (every native
++            // button/anchor), so removing the attribute IS the restore. The original code
++            // branched on prevTabIndex and currentTabIndex being both truthy or both
++            // falsy, and "" with "-1" satisfied neither - so the -1 was never lifted.
++            if (prevTabIndex === '') {
++              elm.removeAttribute('tabindex');
++            } else {
++              elm.setAttribute('tabindex', prevTabIndex);
++            }
+             elm.removeAttribute('data-prev-tabindex');
+           }
+-          if (!prevTabIndex && !currentTabIndex) {
+-            elm.removeAttribute('tabindex');
+-          }
+         } else {
+-          elm.setAttribute('data-prev-tabindex', elm.getAttribute('tabindex') || '');
++          // Stash only on the first collapse. Re-stashing would capture the -1 this
++          // effect itself wrote and make the original value unrecoverable.
++          if (elm.getAttribute('data-prev-tabindex') === null) {
++            elm.setAttribute('data-prev-tabindex', elm.getAttribute('tabindex') || '');
++          }
+           elm.setAttribute('tabindex', '-1');
+         }
+       });
+diff --git a/node/AccordionDetails/AccordionDetails.js b/node/AccordionDetails/AccordionDetails.js
+index 0efb90aaf03331ab6993dbccd3a1123c1a4a0901..526909d2de5ec12840fcce04769b6cd912ed8ded 100644
+--- a/node/AccordionDetails/AccordionDetails.js
++++ b/node/AccordionDetails/AccordionDetails.js
+@@ -111,21 +111,35 @@ const AccordionDetails = /*#__PURE__*/React.forwardRef(function AccordionDetails
+   React.useEffect(() => {
+     // When accordion is closed, prevent tabbing into the details content.
+     if (rootRef.current) {
+-      const elements = rootRef.current.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])');
++      // The [data-prev-tabindex] clause is what makes the expand pass able to find what
++      // the collapse pass untabbed. Without it an element that is not natively focusable
++      // is unreachable on expand: it matches none of the tag names, and the tabindex="-1"
++      // this effect just wrote is excluded by the :not() clause. Joy's own ListItemButton
++      // renders a div, so those panels never got their tab stops back.
++      const elements = rootRef.current.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), [data-prev-tabindex]');
+       elements.forEach(elm => {
+         if (expanded) {
+           const prevTabIndex = elm.getAttribute('data-prev-tabindex');
+-          const currentTabIndex = elm.getAttribute('tabindex');
+-          if (currentTabIndex && prevTabIndex) {
+-            // restore tabindex
+-            elm.setAttribute('tabindex', prevTabIndex);
++          // No marker means this element was never untabbed by a collapse, so there is
++          // nothing to restore and its own tabindex must be left alone.
++          if (prevTabIndex !== null) {
++            // An empty marker means the element had no tabindex of its own (every native
++            // button/anchor), so removing the attribute IS the restore. The original code
++            // branched on prevTabIndex and currentTabIndex being both truthy or both
++            // falsy, and "" with "-1" satisfied neither - so the -1 was never lifted.
++            if (prevTabIndex === '') {
++              elm.removeAttribute('tabindex');
++            } else {
++              elm.setAttribute('tabindex', prevTabIndex);
++            }
+             elm.removeAttribute('data-prev-tabindex');
+           }
+-          if (!prevTabIndex && !currentTabIndex) {
+-            elm.removeAttribute('tabindex');
+-          }
+         } else {
+-          elm.setAttribute('data-prev-tabindex', elm.getAttribute('tabindex') || '');
++          // Stash only on the first collapse. Re-stashing would capture the -1 this
++          // effect itself wrote and make the original value unrecoverable.
++          if (elm.getAttribute('data-prev-tabindex') === null) {
++            elm.setAttribute('data-prev-tabindex', elm.getAttribute('tabindex') || '');
++          }
+           elm.setAttribute('tabindex', '-1');
+         }
+       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,11 @@ overrides:
   sharp@<0.35.0: ^0.35.3
   '@hono/node-server@<2.0.5': ^2.0.5
 
+patchedDependencies:
+  '@mui/joy@5.0.0-beta.52':
+    hash: 6279adfa79ae9e84eae3d5b5a9328ab690a33a0794f3b44d0b7c8dafa8825bd4
+    path: patches/@mui__joy@5.0.0-beta.52.patch
+
 importers:
 
   .:
@@ -301,7 +306,7 @@ importers:
         version: 5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/joy':
         specifier: ^5.0.0-beta.52
-        version: 5.0.0-beta.52(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 5.0.0-beta.52(patch_hash=6279adfa79ae9e84eae3d5b5a9328ab690a33a0794f3b44d0b7c8dafa8825bd4)(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/material-nextjs':
         specifier: ^7.3.9
         version: 7.3.9(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@24.12.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -15272,7 +15277,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@mui/joy@5.0.0-beta.52(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/joy@5.0.0-beta.52(patch_hash=6279adfa79ae9e84eae3d5b5a9328ab690a33a0794f3b44d0b7c8dafa8825bd4)(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/base': 5.0.0-beta.40-1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## Optional Screenshot/Video

None. The defect is an invisible one: affected controls look and mouse-click normally, they are just skipped by Tab. The behaviour is asserted in the new unit test instead.

## Description

Once any Joy `AccordionDetails` panel is collapsed, its focusable descendants keep `tabindex="-1"` forever. After re-expanding they are visible and mouse-clickable but permanently skipped by Tab, leaving keyboard and screen-reader users with no way into the panel. This affects every Joy accordion in the app (18 files render `AccordionDetails`), not just the admin rail where it was first spotted.

The cause is in `@mui/joy@5.0.0-beta.52`, `AccordionDetails/AccordionDetails.js:103-124`. On collapse the effect stashes each focusable descendant's tabindex into `data-prev-tabindex` and writes `tabindex="-1"`; on expand it is supposed to put them back. Two independent defects stop that:

1. **Restore logic.** Both restore branches required the stashed and current values to be either both truthy or both falsy. A native `<button>` with no tabindex of its own stashes `data-prev-tabindex=""`, which pairs with `"-1"` and satisfies neither branch, so the `-1` is never lifted. A second collapse then re-stashes `"-1"` over the empty marker, making the original value unrecoverable even by a later correct restore.
2. **Selector.** The expand pass reuses the collapse pass's selector, `'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])'`, which cannot match what that pass just untabbed: an element that is not natively focusable matches none of the tag names, and its fresh `tabindex="-1"` is excluded by the selector's own `:not()` clause. Joy's own `ListItemButton` renders a `div`, so those elements were never even visited on expand.

The issue reported the first defect; the second was found while confirming it and is fixed here too.

**Why a `pnpm patch` rather than a wrapper component.** A theme or CSS override cannot work, because CSS cannot restore an attribute. That left a patch or a wrapper `AccordionDetails` swapped in at 18 call sites plus a `no-restricted-imports` rule to keep it swapped in. The patch wins on three counts: it lands at every call site, including ones a wrapper in `apps/client` cannot reach; it is ~20 lines of behaviour change instead of an 18-file diff; and Joy UI is frozen upstream (beta.52 is its last release), so "revert once a fix ships" is not a real path and the patch needs no ongoing maintenance. A future version bump makes the install fail loudly rather than silently dropping the fix. This is the repo's first `patchedDependencies` entry, so that precedent is the main thing worth a reviewer's opinion.

## Changes

- `patches/@mui__joy@5.0.0-beta.52.patch` (new) - fixes both defects in the `AccordionDetails` focus-management effect. Three hunks, one per build output (`AccordionDetails/`, `modern/`, `node/`), whose effect bodies were byte-identical; Next resolves the ESM root and the Pages API the CJS `node/` copy, so all three have to carry the fix. Restore now keys off the presence of the marker rather than the truthiness of two values, an empty marker restores by removing the attribute, and the collapse pass stashes only on the first collapse so it can never overwrite a good value with `-1`. The selector gains a `[data-prev-tabindex]` clause so the expand pass can find what the collapse pass untabbed.
- `package.json` - adds the `pnpm.patchedDependencies` entry.
- `pnpm-lock.yaml` - +7/-2, all of it the patch hash and the re-keyed `@mui/joy` snapshot.
- `Dockerfile`, `apps/client/Dockerfile.chatcompletion`, `apps/client/Dockerfile.chatcompletion.selfhost` - add `COPY patches ./patches` before their `pnpm install --frozen-lockfile`. This is a required consequence of the first `patchedDependencies` entry, not incidental cleanup: pnpm hashes every patch file during install, so a missing `patches/` fails the install outright with `ENOENT` rather than quietly skipping the patch. The GitHub workflows check out the whole repo and were unaffected; these three copy only the paths they need, and none listed `patches/`. `selfhost/ws-gateway/Dockerfile` is plain npm against its own manifest, so it is not affected. The root `Dockerfile` is the one PR CI builds and it went red on the first push; the two chatcompletion images are built by the deploy pipeline rather than PR CI, so that breakage would otherwise have surfaced at deploy time.
- `apps/client/app/components/common/__tests__/joyAccordionDetailsTabIndex.test.tsx` (new) - 6 cases asserting against the **real** Joy component rather than a local re-implementation, so the suite fails on an unpatched install and the patch cannot silently stop applying. Covers mount-expanded, the collapse/expand round trip, the non-native (`ListItemButton`/div) case, three repeated cycles, an author-set `tabIndex={5}` surviving the round trip, and no leftover `data-prev-tabindex`.

Since `patches/` is a new mechanism for this repo, a short `CLAUDE.md` writeup of the patched-dependency workflow (the `pnpm patch-commit` cwd trap, the need to cover every build output, the lockfile churn to watch for) is written and will follow as its own small `docs:` PR once this lands, so it can point at a test that already exists on `main`. Kept out of this PR to keep the diff to the fix itself.

## Guide for Testers

Any Joy accordion exercises this. The path below needs no admin rights.

1. Open the app (`app.staging.bike4mind.com`, or the PR preview URL once a maintainer posts one) and sign in.
2. Open the profile modal from the avatar in the top-right corner.
3. Click the **API** tab.
4. Under **User API Keys**, click **Create New API Key**. A modal opens with a name field and a scopes list.
5. Scroll to the bottom of that modal and click the **Advanced settings** accordion header. Expected: the panel expands and reveals an **Expiration** dropdown.
6. Click the **Advanced settings** header again to collapse it. Expected: the panel closes.
7. Click the **Advanced settings** header once more to re-expand it. Expected: the panel reopens with the **Expiration** dropdown visible.
8. Click the **Advanced settings** header text once to put keyboard focus on it, then press **Tab** repeatedly. Expected: focus moves into the panel and lands on the **Expiration** dropdown with a visible focus ring, then continues through the remaining controls inside the panel. Before this fix, focus jumped straight past the whole panel to the Cancel/Create buttons and the Expiration dropdown could not be reached by keyboard at all.
9. With the **Expiration** dropdown focused, press **Enter** or **Space**. Expected: the dropdown opens and the options (30 days / 90 days / 1 year / Never expires) are selectable with the arrow keys.
10. Repeat steps 6-8 two more times. Expected: the tab stops come back every time, not just on the first re-expand.

### Regression Checks

11. Repeat steps 5-8 on a second accordion elsewhere in the app to confirm the fix is app-wide, for example a Help article's collapsible section, or any accordion under **Sidebar -> Admin** if you have admin rights. Expected: the same behaviour.
12. Confirm collapsing still does its job: with a panel collapsed, Tab through the surrounding form. Expected: focus skips the collapsed panel's contents entirely and never lands on something hidden.
13. Confirm mouse behaviour is unchanged: expand and collapse a few accordions and click the controls inside them. Expected: everything works exactly as before.

### What NOT to test

- No API, data, or persistence behaviour changes. Creating an actual API key is not part of this; step 4 only needs the modal open, and you can Cancel out of it.
- No visual change of any kind. Spacing, colours, animation, and the expand/collapse transition are all untouched. A pixel diff is not useful here.
- The patch changes a dependency's runtime behaviour only, so there is nothing to check in the build output or bundle size.

## Additional Information

**The browser repro has not been walked.** Verification here is a jsdom unit test, which asserts the attribute transitions that constitute the defect, but jsdom does not implement real Tab order, so it does not prove sequential focus navigation in a browser. The steps above are worth a manual pass, ideally by @gsreyson who filed the issue, or on a preview deploy. No Playwright e2e was added (vitest only, by agreement). Please treat that manual pass as outstanding when reviewing: everything else here is verified, but the sequential-focus behaviour the issue is actually about has only been proven at the attribute level.

**Verification run** (on the current `main` base, after rebase):

| Check | Result |
|---|---|
| New test against an unpatched install | 3 of 5 failed (bug reproduced) |
| New test, final | 6/6 pass |
| `pnpm turbo:typecheck` | 40/40 successful |
| `pnpm lint:check` | clean |
| `pnpm install --frozen-lockfile` | passes; lockfile diff stays at +7/-2, patch lines only |
| Full client suite, `node` + `jsdom` (1178 files) | 1168 passed, 10 skipped, 0 failed (12759 tests) |
| `docker build --target deps` (root `Dockerfile`) | builds; patch present in all 3 `@mui/joy` outputs inside the image |
| chatcompletion install layer, built locally | builds; patch present inside the image |

Patch confirmed applied to all three `@mui/joy` build outputs after a clean frozen install, and again inside both Docker images. The `.selfhost` variant takes the identical one-line change at the identical position as the chatcompletion image it mirrors, and is covered by that proof rather than a separate build.

**Lockfile note.** `pnpm patch-commit` runs a full non-frozen install, which had re-resolved two unrelated `vitest`-peer lines from `@types/node@25.4.0` to `24.12.3`. Those were reverted so the diff stays patch-only, and the drift did not reappear across the rebase onto current `main`. If you re-run a non-frozen `pnpm install` on this branch, expect it back; revert it rather than committing it.

**Two further pre-existing Joy defects were found and deliberately left alone** (out of scope, no reported user impact, each would widen the patch): the effect's dep array is `[expanded]` only, so content mounted into an already-collapsed panel is never untabbed; and Joy's collapse relies on this tabindex dance rather than `hidden` because its own CSS overrides `hidden`'s `display: none`.

## Developer Notes

- **Architecture decision:** `patches/` becomes a supported mechanism in this repo. Reach for it only when a fix has to land at every call site including ones a local wrapper cannot reach; a wrapper component remains the right answer otherwise. The rationale and the operational traps are written up for a follow-up `docs:` PR.
- **Reusable pattern:** `joyAccordionDetailsTabIndex.test.tsx` shows how to guard a patch so it cannot silently stop applying - render the **real** dependency and assert the patched behaviour, rather than testing a local reimplementation. Any future patch should ship with an equivalent. The loud half of the safety net is the version pin: a bump fails the install outright.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - restores keyboard access; no visual change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - written, following as its own `docs:` PR
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry changes

Closes #2488
