### PR TITLE
fix(api-keys): screen an admin-minted lake binding against the target user

### DIFF
--- a/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
 /**
- * Two guards on the admin key-minting endpoint:
+ * Three concerns on the admin key-minting endpoint:
  *
  * 1. Scope allowlist - the endpoint may mint overwatch-ingest:write (admin-provisioned) but not
  *    admin:* or cc-bridge:connect, which still have no minting path. All standard user scopes
@@ -11,6 +11,7 @@ import { createMocks } from 'node-mocks-http';
  *    grant, so an id the TARGET user cannot manage is inert rather than an escalation. The screen
  *    exists to stop that silent no-op being persisted, and to canonicalize the ids: the containment
  *    check in sessions/create is a byte comparison, so an uppercase-hex id would never match.
+ * 3. Canonical target id - the same byte-comparison hazard one field over; see the third describe.
  */
 
 const LAKE_A = '0123456789abcdef01234567';
@@ -404,6 +405,70 @@ describe('POST /api/admin/users/:userId/generate-api-key - preauthorizedLakeIds 
       scopes: ['notebooks:read'],
       preauthorizedLakeIds: [LAKE_A],
     });
+    await mockRefs.postHandler!(req, res);
+    const logged = ((req as any).logger.info as any).mock.calls[0][0] as string;
+    expect(logged).not.toContain('\n');
+    expect(logged).toContain('\\n');
+  });
+});
+
+/**
+ * The target id is canonicalized once, off `targetUser.id`, and used for the mint as well as the
+ * lake screen. `userRepository.findById` casts to ObjectId and so resolves the user under any hex
+ * casing, but `UserApiKeyModel.userId` is `type: String`: a key minted under a non-canonical
+ * segment authenticates (apiKeyAuth casts too) and is then invisible to every byte-exact
+ * owner-scoped query - findByUserId, countActiveByUserId, findByUserIdAndId.
+ */
+describe('POST /api/admin/users/:userId/generate-api-key - canonical target id', () => {
+  const SEGMENT_UPPER = '0123456789ABCDEF01234567';
+  const CANONICAL = '0123456789abcdef01234567';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFind.mockResolvedValue({ id: CANONICAL, username: 'targetUser' });
+    mockCreateKey.mockResolvedValue({ id: 'k1', name: 'key', scopes: ['notebooks:read'] });
+    mockLogEvent.mockResolvedValue(undefined);
+  });
+
+  it('mints under the resolved user id, not the raw URL segment', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] }, { userId: SEGMENT_UPPER });
+    await mockRefs.postHandler!(req, res);
+    expect(mockUserFind).toHaveBeenCalledWith(SEGMENT_UPPER);
+    expect(mockCreateKey).toHaveBeenCalledWith(CANONICAL, expect.anything(), expect.anything());
+  });
+
+  it('attributes the analytics event to the resolved user id', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] }, { userId: SEGMENT_UPPER });
+    await mockRefs.postHandler!(req, res);
+    expect(mockLogEvent).toHaveBeenCalledWith(expect.objectContaining({ userId: CANONICAL }), expect.anything());
+  });
+
+  it('records the resolved user id on the audit line', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] }, { userId: SEGMENT_UPPER });
+    await mockRefs.postHandler!(req, res);
+    const logged = ((req as any).logger.info as any).mock.calls[0][0] as string;
+    expect(logged).toContain(CANONICAL);
+    expect(logged).not.toContain(SEGMENT_UPPER);
+  });
+
+  it('screens the lake binding against the resolved user id', async () => {
+    mockLakeFind.mockImplementation(async (id: string) => activeLake(id));
+    mockFilterManaged.mockImplementation(async (lakes: { id: string }[]) => lakes);
+    const { req, res } = post(
+      { name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] },
+      { userId: SEGMENT_UPPER }
+    );
+    await mockRefs.postHandler!(req, res);
+    expect(mockFilterManaged.mock.calls[0][1]).toBe(CANONICAL);
+  });
+
+  it('escapes a forged newline in either username so it cannot fake a sibling audit entry', async () => {
+    mockUserFind.mockResolvedValue({
+      id: CANONICAL,
+      username: 'victim\nAdmin nobody (0) generated API key "evil" for user someone',
+    });
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] });
+    (req as any).user.username = 'admin\nforged';
     await mockRefs.postHandler!(req, res);
     const logged = ((req as any).logger.info as any).mock.calls[0][0] as string;
     expect(logged).not.toContain('\n');

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
@@ -9,8 +9,9 @@ import { createMocks } from 'node-mocks-http';
  *    remain mintable here.
  * 2. Lake-binding screen - `preauthorizedLakeIds` is a CEILING on what the key may admit, never a
  *    grant, so an id the TARGET user cannot manage is inert rather than an escalation. The screen
- *    exists to stop that silent no-op being persisted, and to canonicalize the ids: the containment
- *    check in sessions/create is a byte comparison, so an uppercase-hex id would never match.
+ *    exists to stop that silent no-op being persisted, and to canonicalize the ids: downstream
+ *    containment (unionPreauthorizedLakeAccess, the preauthorizedSet filters) is byte equality
+ *    against a lake's always-lowercase `id` virtual, so an uppercase-hex id would never match.
  * 3. Canonical target id - the same byte-comparison hazard one field over; see the third describe.
  */
 
@@ -341,6 +342,74 @@ describe('POST /api/admin/users/:userId/generate-api-key - preauthorizedLakeIds 
     await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(
       new RegExp(`does not manage data lake\\(s\\): ${LAKE_B}\\.`)
     );
+  });
+
+  /**
+   * The admin modal renders these messages through parseValidationError
+   * (app/hooks/data/userApiKeys.ts:6-31), which splits a message containing a colon on ', ' and
+   * reformats each piece as its own "field: message" pair. A comma-joined id list is therefore
+   * shredded into an unreadable toast; a semicolon leaves the formatter nothing to split on. These
+   * pin the separator at each of the three refusal sites so the toast cannot silently regress.
+   */
+  describe('multi-id refusals survive the client error formatter', () => {
+    it.each([
+      ['unmanaged', () => mockFilterManaged.mockResolvedValue([])],
+      ['not found', () => mockLakeFind.mockResolvedValue(null)],
+      [
+        'not active',
+        () => mockLakeFind.mockImplementation(async (id: string) => ({ ...activeLake(id), status: 'draft' })),
+      ],
+    ])('joins ids with a semicolon, not ", ", for a %s refusal', async (_label, arrange) => {
+      arrange();
+      const { req, res } = post({
+        name: 'key',
+        scopes: ['notebooks:read'],
+        preauthorizedLakeIds: [LAKE_A, LAKE_B],
+      });
+      const err = await mockRefs.postHandler!(req, res).then(
+        () => null,
+        (e: Error) => e
+      );
+      expect(err).toBeInstanceOf(BadRequestError);
+      expect(err!.message).toContain(`${LAKE_A}; ${LAKE_B}`);
+      expect(err!.message).not.toContain(`${LAKE_A}, ${LAKE_B}`);
+    });
+  });
+
+  it('warns with the admin, target and refused ids when the target manages none of them', async () => {
+    mockFilterManaged.mockResolvedValue([]);
+    const { req, res } = post({
+      name: 'key',
+      scopes: ['notebooks:read'],
+      preauthorizedLakeIds: [LAKE_A, LAKE_B],
+    });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    const warned = ((req as any).logger.warn as any).mock.calls[0][0] as string;
+    expect(warned).toContain('"admin-user" (caller)');
+    expect(warned).toContain('"targetUser" (target-user)');
+    expect(warned).toContain(`${LAKE_A}; ${LAKE_B}`);
+    // The 400 alone leaves no trace, so the refusal must not also be silent in the log.
+    expect(((req as any).logger.info as any).mock.calls).toHaveLength(0);
+  });
+
+  it('does not warn for a miss or an inactive lake - those are operator typos, not authority reaches', async () => {
+    mockLakeFind.mockResolvedValue(null);
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(((req as any).logger.warn as any).mock.calls).toHaveLength(0);
+  });
+
+  it('escapes a forged newline in a username on the refusal warning too', async () => {
+    mockFilterManaged.mockResolvedValue([]);
+    mockUserFind.mockResolvedValue({
+      id: 'target-user',
+      username: 'victim\nAdmin nobody (0) generated API key "evil" for user someone',
+    });
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    const warned = ((req as any).logger.warn as any).mock.calls[0][0] as string;
+    expect(warned).not.toContain('\n');
+    expect(warned).toContain('\\n');
   });
 
   it('offers no override: an unmanaged lake is refused however the body is dressed up', async () => {

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/generate-api-key.test.ts
@@ -2,11 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
 /**
- * Scope allowlist guard for the admin key-minting endpoint. The admin endpoint
- * may mint overwatch-ingest:write (admin-provisioned) but not admin:* or
- * cc-bridge:connect - those still have no minting path. All standard user
- * scopes remain mintable here too.
+ * Two guards on the admin key-minting endpoint:
+ *
+ * 1. Scope allowlist - the endpoint may mint overwatch-ingest:write (admin-provisioned) but not
+ *    admin:* or cc-bridge:connect, which still have no minting path. All standard user scopes
+ *    remain mintable here.
+ * 2. Lake-binding screen - `preauthorizedLakeIds` is a CEILING on what the key may admit, never a
+ *    grant, so an id the TARGET user cannot manage is inert rather than an escalation. The screen
+ *    exists to stop that silent no-op being persisted, and to canonicalize the ids: the containment
+ *    check in sessions/create is a byte comparison, so an uppercase-hex id would never match.
  */
+
+const LAKE_A = '0123456789abcdef01234567';
+const LAKE_A_UPPER = '0123456789ABCDEF01234567';
+const LAKE_B = '89abcdef0123456789abcdef';
 
 const mockRefs = vi.hoisted(() => ({
   postHandler: null as null | ((req: any, res: any) => unknown),
@@ -42,8 +51,12 @@ vi.mock('@bike4mind/utils', () => ({
 }));
 
 const mockUserFind = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'target-user', username: 'targetUser' }));
+const mockLakeFind = vi.hoisted(() => vi.fn());
 vi.mock('@bike4mind/database', () => ({
   userRepository: { findById: (...a: unknown[]) => mockUserFind(...a) },
+  dataLakeRepository: { findById: (...a: unknown[]) => mockLakeFind(...a) },
+  dataLakeAccessGrantRepository: { listActiveByLakes: vi.fn().mockResolvedValue([]) },
+  organizationRepository: { findIdsWithAdminRights: vi.fn().mockResolvedValue([]) },
 }));
 
 vi.mock('@bike4mind/database/auth', () => ({
@@ -53,17 +66,22 @@ vi.mock('@bike4mind/database/auth', () => ({
 const mockCreateKey = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ id: 'k1', name: 'key', scopes: ['notebooks:read'] })
 );
+const mockFilterManaged = vi.hoisted(() => vi.fn());
 vi.mock('@bike4mind/services', () => ({
   userApiKeyService: { createUserApiKey: (...a: unknown[]) => mockCreateKey(...a) },
+  dataLakeService: { filterStillManagedLakes: (...a: unknown[]) => mockFilterManaged(...a) },
 }));
 
+const mockLogEvent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock('@server/utils/analyticsLog', () => ({
-  logEvent: vi.fn().mockResolvedValue(undefined),
+  logEvent: (...a: unknown[]) => mockLogEvent(...a),
 }));
 
 import '../generate-api-key';
 import { ForbiddenError } from '@server/utils/errors';
 import { BadRequestError } from '@bike4mind/utils';
+
+const activeLake = (id: string) => ({ id, status: 'active', createdByUserId: 'someone', name: id, slug: id });
 
 function post(body: unknown, opts: { isAdmin?: boolean; userId?: string } = {}) {
   const { req, res } = createMocks({
@@ -79,14 +97,16 @@ function post(body: unknown, opts: { isAdmin?: boolean; userId?: string } = {}) 
   (req as any).ability = {};
   (req as any).ip = '127.0.0.1';
   (req as any).headers = { 'user-agent': 'test' };
-  (req as any).logger = { info: vi.fn() };
+  (req as any).logger = { info: vi.fn(), warn: vi.fn() };
   return { req, res };
 }
 
 describe('POST /api/admin/users/:userId/generate-api-key - scope allowlist guard', () => {
   beforeEach(() => {
-    mockCreateKey.mockClear();
+    vi.clearAllMocks();
     mockUserFind.mockResolvedValue({ id: 'target-user', username: 'targetUser' });
+    mockCreateKey.mockResolvedValue({ id: 'k1', name: 'key', scopes: ['notebooks:read'] });
+    mockLogEvent.mockResolvedValue(undefined);
   });
 
   it('rejects non-admin callers with ForbiddenError before touching the service', async () => {
@@ -138,18 +158,7 @@ describe('POST /api/admin/users/:userId/generate-api-key - scope allowlist guard
     expect(mockCreateKey).not.toHaveBeenCalled();
   });
 
-  it('forwards preauthorizedLakeIds to the service', async () => {
-    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: ['lake1', 'lake2'] });
-    await mockRefs.postHandler!(req, res);
-    expect(res._getStatusCode()).toBe(201);
-    expect(mockCreateKey).toHaveBeenCalledWith(
-      'target-user',
-      expect.objectContaining({ preauthorizedLakeIds: ['lake1', 'lake2'] }),
-      expect.anything()
-    );
-  });
-
-  it('omits preauthorizedLakeIds from the service call when not given', async () => {
+  it('omits preauthorizedLakeIds from the service call when not given, without reading any lake', async () => {
     const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] });
     await mockRefs.postHandler!(req, res);
     expect(mockCreateKey).toHaveBeenCalledWith(
@@ -157,5 +166,247 @@ describe('POST /api/admin/users/:userId/generate-api-key - scope allowlist guard
       expect.objectContaining({ preauthorizedLakeIds: undefined }),
       expect.anything()
     );
+    expect(mockLakeFind).not.toHaveBeenCalled();
+    expect(mockFilterManaged).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty preauthorizedLakeIds array as no binding at all', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [] });
+    await mockRefs.postHandler!(req, res);
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      'target-user',
+      expect.objectContaining({ preauthorizedLakeIds: undefined }),
+      expect.anything()
+    );
+    expect(mockLakeFind).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/admin/users/:userId/generate-api-key - preauthorizedLakeIds screen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFind.mockResolvedValue({ id: 'target-user', username: 'targetUser' });
+    mockCreateKey.mockResolvedValue({ id: 'k1', name: 'key', scopes: ['notebooks:read'] });
+    mockLogEvent.mockResolvedValue(undefined);
+    mockLakeFind.mockImplementation(async (id: string) => activeLake(id));
+    // Default: the target manages everything handed to the screen.
+    mockFilterManaged.mockImplementation(async (lakes: { id: string }[]) => lakes);
+  });
+
+  it('forwards a screened, target-managed binding to the service', async () => {
+    const { req, res } = post({
+      name: 'key',
+      scopes: ['notebooks:read'],
+      preauthorizedLakeIds: [LAKE_A, LAKE_B],
+    });
+    await mockRefs.postHandler!(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      'target-user',
+      expect.objectContaining({ preauthorizedLakeIds: [LAKE_A, LAKE_B] }),
+      expect.anything()
+    );
+  });
+
+  it('screens against the TARGET user, not the admin caller', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await mockRefs.postHandler!(req, res);
+    const [lakes, actorId] = mockFilterManaged.mock.calls[0];
+    expect(lakes).toEqual([expect.objectContaining({ id: LAKE_A })]);
+    expect(actorId).toBe('target-user');
+  });
+
+  it('wires both manage rungs into the re-check adapter', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await mockRefs.postHandler!(req, res);
+    // Both adapter members are OPTIONAL on ManageRecheckAdapter and both degrade CLOSED, so a
+    // renamed or dropped key would silently deny legitimate maintainers with every other
+    // assertion in this file still green. Pin the shape, not just that something was passed.
+    const adapter = mockFilterManaged.mock.calls[0][2];
+    expect(typeof adapter.dataLakeAccessGrants?.listActiveByLakes).toBe('function');
+    expect(typeof adapter.organizations?.findIdsWithAdminRights).toBe('function');
+  });
+
+  it('screens against the canonical target id, not the raw URL segment', async () => {
+    // findById casts to ObjectId so an uppercase-hex segment resolves the user, but every manage
+    // rung compares the actor id byte-wise against a `type: String` field.
+    mockUserFind.mockResolvedValue({ id: 'target-user', username: 'targetUser' });
+    const { req, res } = post(
+      { name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] },
+      { userId: 'TARGET-USER' }
+    );
+    await mockRefs.postHandler!(req, res);
+    expect(mockFilterManaged.mock.calls[0][1]).toBe('target-user');
+  });
+
+  it('lowercases an uppercase-hex id, which would otherwise never match at session-create', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A_UPPER] });
+    await mockRefs.postHandler!(req, res);
+    expect(mockLakeFind).toHaveBeenCalledWith(LAKE_A);
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      'target-user',
+      expect.objectContaining({ preauthorizedLakeIds: [LAKE_A] }),
+      expect.anything()
+    );
+  });
+
+  it('dedupes ids that differ only in case', async () => {
+    const { req, res } = post({
+      name: 'key',
+      scopes: ['notebooks:read'],
+      preauthorizedLakeIds: [LAKE_A, LAKE_A_UPPER, LAKE_A],
+    });
+    await mockRefs.postHandler!(req, res);
+    expect(mockLakeFind).toHaveBeenCalledTimes(1);
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      'target-user',
+      expect.objectContaining({ preauthorizedLakeIds: [LAKE_A] }),
+      expect.anything()
+    );
+  });
+
+  it('rejects a malformed lake id without reading a lake or minting', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: ['lake1'] });
+    // BadRequestError specifically, not any throw: a plain Error would be mapped to a 500 by the
+    // error handler and every message assertion in this file would still pass.
+    await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockLakeFind).not.toHaveBeenCalled();
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string entry', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [{ id: LAKE_A }] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Invalid data lake id/i);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-array preauthorizedLakeIds', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: LAKE_A });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/must be an array/i);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects more ids than the service would accept, before spending a read per id', async () => {
+    const many = Array.from({ length: 26 }, (_, i) => `0123456789abcdef${String(i).padStart(8, '0')}`);
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: many });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/At most 25/i);
+    expect(mockLakeFind).not.toHaveBeenCalled();
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('caps the RAW array, so a flood of duplicates cannot drive the dedupe loop', async () => {
+    // The cap has to sit before the dedupe, not after: the dedupe is itself work proportional to
+    // the input, so capping the deduped result would leave the loop unbounded.
+    const flood = Array.from({ length: 5000 }, (_, i) => `0123456789abcdef${String(i).padStart(8, '0')}`);
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: flood });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/At most 25/i);
+    expect(mockLakeFind).not.toHaveBeenCalled();
+  });
+
+  it('rejects an id that names no lake, listing it', async () => {
+    mockLakeFind.mockImplementation(async (id: string) => (id === LAKE_A ? activeLake(id) : null));
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A, LAKE_B] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(new RegExp(`Data lake not found: ${LAKE_B}`));
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes a non-active lake from a missing one', async () => {
+    // An admin picking from the lake list CAN see a draft lake, so "not found" for a lake on
+    // their screen would read as a bug.
+    mockLakeFind.mockImplementation(async (id: string) => ({ ...activeLake(id), status: 'draft' }));
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(new RegExp(`Data lake is not active: ${LAKE_A}`));
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects an archived lake too', async () => {
+    mockLakeFind.mockImplementation(async (id: string) => ({ ...activeLake(id), status: 'archived' }));
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/not active/i);
+  });
+
+  it('rejects a lake the target user does not manage, naming it, and does not mint', async () => {
+    mockFilterManaged.mockResolvedValue([]);
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(
+      new RegExp(`does not manage data lake\\(s\\): ${LAKE_A}`)
+    );
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('keeps the managed subset out of the rejection message', async () => {
+    mockFilterManaged.mockImplementation(async (lakes: { id: string }[]) => lakes.filter(l => l.id === LAKE_A));
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A, LAKE_B] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(
+      new RegExp(`does not manage data lake\\(s\\): ${LAKE_B}\\.`)
+    );
+  });
+
+  it('offers no override: an unmanaged lake is refused however the body is dressed up', async () => {
+    mockFilterManaged.mockResolvedValue([]);
+    const { req, res } = post({
+      name: 'preprovisioned',
+      scopes: ['notebooks:read'],
+      preauthorizedLakeIds: [LAKE_A],
+      allowUnmanagedLakes: true,
+    });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockCreateKey).not.toHaveBeenCalled();
+  });
+
+  it('tells the operator to fix the grant rather than to bypass the screen', async () => {
+    mockFilterManaged.mockResolvedValue([]);
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/Grant the user access to the lake first/i);
+  });
+
+  it('names the bound lakes in the audit line', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'], preauthorizedLakeIds: [LAKE_A] });
+    await mockRefs.postHandler!(req, res);
+    const logged = ((req as any).logger.info as any).mock.calls[0][0] as string;
+    expect(logged).toContain(`bound to data lake(s) ${LAKE_A}`);
+  });
+
+  it('leaves the audit line unchanged when no lake is bound', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] });
+    await mockRefs.postHandler!(req, res);
+    const logged = ((req as any).logger.info as any).mock.calls[0][0] as string;
+    expect(logged).not.toContain('bound to data lake');
+  });
+
+  it('records the binding on the analytics event', async () => {
+    const { req, res } = post({
+      name: 'key',
+      scopes: ['notebooks:read'],
+      preauthorizedLakeIds: [LAKE_A, LAKE_B],
+    });
+    await mockRefs.postHandler!(req, res);
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ preauthorizedLakeIds: [LAKE_A, LAKE_B] }),
+      }),
+      expect.anything()
+    );
+  });
+
+  it('leaves the analytics lake field absent when no lake is bound', async () => {
+    const { req, res } = post({ name: 'key', scopes: ['notebooks:read'] });
+    await mockRefs.postHandler!(req, res);
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ preauthorizedLakeIds: undefined }) }),
+      expect.anything()
+    );
+  });
+
+  it('escapes a forged newline in the key name so it cannot fake a sibling audit entry', async () => {
+    const { req, res } = post({
+      name: 'ok\nAdmin nobody (0) generated API key "evil" for user victim',
+      scopes: ['notebooks:read'],
+      preauthorizedLakeIds: [LAKE_A],
+    });
+    await mockRefs.postHandler!(req, res);
+    const logged = ((req as any).logger.info as any).mock.calls[0][0] as string;
+    expect(logged).not.toContain('\n');
+    expect(logged).toContain('\\n');
   });
 });

--- a/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
+++ b/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
@@ -62,17 +62,28 @@ interface CreateApiKeyBody {
  * the only thing the field is for. Screening here turns that silent no-op into a 400 at mint time,
  * rather than a confusing "You do not manage data lake X" the first time someone uses the key.
  *
- * Ids are lowercased, not merely shape-checked: both stores are `type: [String]`, so the
- * containment check in sessions/create is byte equality against a lake's own (always lowercase)
- * `id` virtual. An uppercase-hex id persists happily here and then never matches.
+ * Ids are lowercased, not merely shape-checked: both stores are `type: [String]`, so downstream
+ * containment is byte equality against a lake's own (always lowercase) `id` virtual - see
+ * `unionPreauthorizedLakeAccess.ts:33-34` (`existingIds` off `access.lakes.map(l => l.id)`) and the
+ * `preauthorizedSet.has(p.id)` filters in `ChatCompletionFeatures.ts` and
+ * `tools/implementation/retrievedLakePrompts.ts`. NOT sessions/create's `.includes(lakeId)`, which
+ * compares against the raw request string (shape-checked by a case-insensitive `isValidObjectId`
+ * and never lowercased) and so answers a 403 rather than missing silently. Lowercasing at mint is
+ * the only casing that matches end to end.
  *
  * The manage check reuses `filterStillManagedLakes` rather than open-coding a rule, so the mint
- * gate, the session-create gate and the per-turn re-check cannot drift apart. That helper bakes in
- * `isAdmin: false`, which is the subtle part: platform-adminness is deliberately not a manage rung
- * for this admission, so a target whose only relationship to the lake is being a platform admin is
- * refused here exactly as sessions/create would refuse them.
+ * gate, the session-create gate and the per-turn re-check apply the same rule. They are still two
+ * call sites into it - sessions/create calls `resolveCanManageLake` directly - so this buys a
+ * shared rule, not a single choke point. That helper bakes in `isAdmin: false`, which is the subtle
+ * part: platform-adminness is deliberately not a manage rung for this admission, so a target whose
+ * only relationship to the lake is being a platform admin is refused here exactly as
+ * sessions/create would refuse them.
  */
-async function screenPreauthorizedLakeIds(raw: unknown, targetUserId: string): Promise<string[] | undefined> {
+async function screenPreauthorizedLakeIds(
+  raw: unknown,
+  targetUserId: string,
+  audit: { logger: { warn: (message: string) => void }; adminLabel: string; targetLabel: string }
+): Promise<string[] | undefined> {
   if (raw === undefined || raw === null) return undefined;
   if (!Array.isArray(raw)) {
     throw new BadRequestError('preauthorizedLakeIds must be an array of data lake ids');
@@ -103,18 +114,23 @@ async function screenPreauthorizedLakeIds(raw: unknown, targetUserId: string): P
   // Every way this field can be wrong answers BadRequest, not the NotFound/Forbidden
   // sessions/create returns for the same conditions: there the lake id is the request's subject,
   // here it is one field of a mint body.
+  //
+  // Id lists below are joined with '; ', never ', '. The admin modal renders these through
+  // parseValidationError (app/hooks/data/userApiKeys.ts), which splits a message containing a colon
+  // on ', ' and reformats each piece as its own "field: message" pair - so a comma-joined list of
+  // ids is shredded into an unreadable toast. A semicolon leaves it nothing to split on.
   const fetched = await Promise.all(ids.map(id => dataLakeRepository.findById(id)));
   const byId = new Map(ids.map((id, i) => [id, fetched[i]]));
   const missing = ids.filter(id => !byId.get(id));
   if (missing.length > 0) {
-    throw new BadRequestError(`Data lake not found: ${missing.join(', ')}`);
+    throw new BadRequestError(`Data lake not found: ${missing.join('; ')}`);
   }
   // Reported apart from a miss because an admin picking from the lake list CAN see a draft lake,
   // and "not found" for a lake on their screen reads as a bug. `status` is the same gate
   // unionPreauthorizedLakeAccess applies before its own re-check.
   const inactive = ids.filter(id => byId.get(id)!.status !== 'active');
   if (inactive.length > 0) {
-    throw new BadRequestError(`Data lake is not active: ${inactive.join(', ')}`);
+    throw new BadRequestError(`Data lake is not active: ${inactive.join('; ')}`);
   }
   const lakes = ids.map(id => byId.get(id)!);
   const manageable = await dataLakeService.filterStillManagedLakes(lakes, targetUserId, {
@@ -124,8 +140,15 @@ async function screenPreauthorizedLakeIds(raw: unknown, targetUserId: string): P
   const manageableIds = new Set(manageable.map(lake => lake.id));
   const unmanaged = ids.filter(id => !manageableIds.has(id));
   if (unmanaged.length > 0) {
+    // Logged, unlike the miss and inactive refusals above: those are operator typos, while this is
+    // an admin reaching for a lake the target has no authority over. The 400 alone is invisible to
+    // an auditor, so a pattern - one admin refused across several targets - would leave no trace.
+    audit.logger.warn(
+      `Admin ${audit.adminLabel} was refused a data lake binding for user ${audit.targetLabel}: ` +
+        `target does not manage ${unmanaged.join('; ')}`
+    );
     throw new BadRequestError(
-      `User does not manage data lake(s): ${unmanaged.join(', ')}. Grant the user access to the lake first.`
+      `User does not manage data lake(s): ${unmanaged.join('; ')}. Grant the user access to the lake first.`
     );
   }
   return ids;
@@ -163,6 +186,15 @@ const handler = baseApi({ auth: true })
       // owner's key list, uncounted by the per-user cap, unreachable by the owner-scoped revoke.
       const targetUserId = targetUser.id;
 
+      // Built once so the success audit line and the refusal warning below name their principals
+      // identically. Usernames go through JSON.stringify - `username` is only
+      // `{ type: String, unique: true }` on UserModel, so it carries no schema-level shape
+      // constraint, and a newline in one would otherwise forge a sibling log entry now that these
+      // lines are the audit record for a cross-tenant lake binding. Both ids are canonical
+      // ObjectId strings and need no escaping.
+      const adminLabel = `${JSON.stringify(req.user.username)} (${req.user.id})`;
+      const targetLabel = `${JSON.stringify(targetUser.username)} (${targetUserId})`;
+
       const { name, scopes, expiresAt, rateLimit, preauthorizedLakeIds } = req.body as CreateApiKeyBody;
 
       // Reject any scope outside the mintable allowlist, including admin:* and cc-bridge:connect.
@@ -172,7 +204,11 @@ const handler = baseApi({ auth: true })
         throw new BadRequestError(`Scope not allowed: ${invalidScopes.join(', ')}`);
       }
 
-      const lakeBinding = await screenPreauthorizedLakeIds(preauthorizedLakeIds, targetUserId);
+      const lakeBinding = await screenPreauthorizedLakeIds(preauthorizedLakeIds, targetUserId, {
+        logger: req.logger,
+        adminLabel,
+        targetLabel,
+      });
 
       const newApiKey = await userApiKeyService.createUserApiKey(
         targetUserId,
@@ -215,14 +251,12 @@ const handler = baseApi({ auth: true })
         { ability: req.ability }
       );
 
-      // Audit trail with admin details. Every free-form field goes through JSON.stringify - the
-      // same surrounding quotes for any ordinary value - so a newline cannot forge a sibling entry
-      // now that this line is the audit record for a cross-tenant lake binding. `username` is only
-      // `{ type: String, unique: true }` on UserModel, so it carries no schema-level shape
-      // constraint; both ids are canonical ObjectId strings and need no escaping.
+      // Audit trail with admin details. `name` is escaped for the same reason the usernames inside
+      // adminLabel/targetLabel are: it is caller-chosen, and this line is the audit record for a
+      // cross-tenant lake binding.
       req.logger.info(
-        `Admin ${JSON.stringify(req.user.username)} (${req.user.id}) generated API key ${JSON.stringify(name)} for user ${JSON.stringify(targetUser.username)} (${targetUserId})` +
-          (lakeBinding ? ` bound to data lake(s) ${lakeBinding.join(', ')}` : '')
+        `Admin ${adminLabel} generated API key ${JSON.stringify(name)} for user ${targetLabel}` +
+          (lakeBinding ? ` bound to data lake(s) ${lakeBinding.join('; ')}` : '')
       );
 
       return res.status(201).json(newApiKey);

--- a/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
+++ b/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
@@ -1,12 +1,18 @@
-import { userApiKeyService } from '@bike4mind/services';
+import { userApiKeyService, dataLakeService } from '@bike4mind/services';
 import { userApiKeyRepository } from '@bike4mind/database/auth';
-import { userRepository } from '@bike4mind/database';
+import {
+  dataLakeAccessGrantRepository,
+  dataLakeRepository,
+  organizationRepository,
+  userRepository,
+} from '@bike4mind/database';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { csrfProtection } from '@server/middlewares/csrfProtection';
 import { ForbiddenError } from '@server/utils/errors';
 import { BadRequestError } from '@bike4mind/utils';
 import { logEvent } from '@server/utils/analyticsLog';
+import { toObjectIdString } from '@server/utils/objectId';
 import { UserApiKeyEvents } from '@bike4mind/common';
 import { ADMIN_ONLY_API_KEY_SCOPES, USER_API_KEY_SCOPE_VALUES } from '@client/app/constants/apiKeyScopes';
 
@@ -17,6 +23,18 @@ const ADMIN_ENDPOINT_MINTABLE_SCOPES = new Set<string>([
   ...USER_API_KEY_SCOPE_VALUES,
   ...ADMIN_ONLY_API_KEY_SCOPES.map(s => s.value),
 ]);
+
+/**
+ * Bounds the lake screen below, which dedupes and then spends one `findById` per id before
+ * `createUserApiKey`'s own `.max(25)` is ever reached. Same 25, applied to the RAW array rather
+ * than to the deduped set the service counts - so 26 entries that dedupe to 23 are refused here
+ * and would have been accepted there. Deliberate: the looser reading would put the cap after the
+ * dedupe, which is the walk it exists to bound.
+ *
+ * Deliberately larger than sessions/create.ts's per-SESSION cap: a key is a ceiling spanning many
+ * sessions, so the two bound different things and are not a mismatch to be reconciled.
+ */
+const MAX_PREAUTHORIZED_LAKES = 25;
 
 interface RequestQuery {
   userId: string;
@@ -32,6 +50,85 @@ interface CreateApiKeyBody {
   };
   /** Lake ids to bind this key to for the manage-but-not-member session admission. Admin-only. */
   preauthorizedLakeIds?: string[];
+}
+
+/**
+ * Screen an admin-supplied lake binding against the TARGET user.
+ *
+ * The binding is a CEILING, never a grant: pages/api/sessions/create.ts requires the key's list to
+ * contain the lake AND independently re-checks the acting user's live manage rights, and the read
+ * path re-derives those every turn (dataLakeService.filterStillManagedLakes). So an id the target
+ * cannot manage escalates nothing - it just makes the binding fail to narrow anything, which is
+ * the only thing the field is for. Screening here turns that silent no-op into a 400 at mint time,
+ * rather than a confusing "You do not manage data lake X" the first time someone uses the key.
+ *
+ * Ids are lowercased, not merely shape-checked: both stores are `type: [String]`, so the
+ * containment check in sessions/create is byte equality against a lake's own (always lowercase)
+ * `id` virtual. An uppercase-hex id persists happily here and then never matches.
+ *
+ * The manage check reuses `filterStillManagedLakes` rather than open-coding a rule, so the mint
+ * gate, the session-create gate and the per-turn re-check cannot drift apart. That helper bakes in
+ * `isAdmin: false`, which is the subtle part: platform-adminness is deliberately not a manage rung
+ * for this admission, so a target whose only relationship to the lake is being a platform admin is
+ * refused here exactly as sessions/create would refuse them.
+ */
+async function screenPreauthorizedLakeIds(raw: unknown, targetUserId: string): Promise<string[] | undefined> {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) {
+    throw new BadRequestError('preauthorizedLakeIds must be an array of data lake ids');
+  }
+  // Capped on the RAW array, before the loop below rather than on its deduped result: the body
+  // cap admits tens of thousands of ids, so a cap applied afterwards would bound the reads and
+  // leave the walk over `raw` unbounded. The Set is the other half - deduping via `ids.includes`
+  // would be quadratic in the input even with this cap in place.
+  if (raw.length > MAX_PREAUTHORIZED_LAKES) {
+    throw new BadRequestError(`At most ${MAX_PREAUTHORIZED_LAKES} pre-authorized data lakes per key`);
+  }
+
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const entry of raw) {
+    const id = typeof entry === 'string' ? toObjectIdString(entry) : undefined;
+    if (!id) {
+      // The echoed value is unvalidated input, so bound it.
+      throw new BadRequestError(`Invalid data lake id: ${String(entry).slice(0, 64)}`);
+    }
+    if (!seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+  if (ids.length === 0) return undefined;
+
+  // Every way this field can be wrong answers BadRequest, not the NotFound/Forbidden
+  // sessions/create returns for the same conditions: there the lake id is the request's subject,
+  // here it is one field of a mint body.
+  const fetched = await Promise.all(ids.map(id => dataLakeRepository.findById(id)));
+  const byId = new Map(ids.map((id, i) => [id, fetched[i]]));
+  const missing = ids.filter(id => !byId.get(id));
+  if (missing.length > 0) {
+    throw new BadRequestError(`Data lake not found: ${missing.join(', ')}`);
+  }
+  // Reported apart from a miss because an admin picking from the lake list CAN see a draft lake,
+  // and "not found" for a lake on their screen reads as a bug. `status` is the same gate
+  // unionPreauthorizedLakeAccess applies before its own re-check.
+  const inactive = ids.filter(id => byId.get(id)!.status !== 'active');
+  if (inactive.length > 0) {
+    throw new BadRequestError(`Data lake is not active: ${inactive.join(', ')}`);
+  }
+  const lakes = ids.map(id => byId.get(id)!);
+  const manageable = await dataLakeService.filterStillManagedLakes(lakes, targetUserId, {
+    dataLakeAccessGrants: dataLakeAccessGrantRepository,
+    organizations: organizationRepository,
+  });
+  const manageableIds = new Set(manageable.map(lake => lake.id));
+  const unmanaged = ids.filter(id => !manageableIds.has(id));
+  if (unmanaged.length > 0) {
+    throw new BadRequestError(
+      `User does not manage data lake(s): ${unmanaged.join(', ')}. Grant the user access to the lake first.`
+    );
+  }
+  return ids;
 }
 
 /**
@@ -68,6 +165,13 @@ const handler = baseApi({ auth: true })
         throw new BadRequestError(`Scope not allowed: ${invalidScopes.join(', ')}`);
       }
 
+      // `targetUser.id`, NOT the `userId` URL segment: findById casts to ObjectId and so resolves
+      // the user under any hex casing, but every manage rung compares the actor id against a
+      // `type: String` field (createdByUserId, a grant's principalId, an Organization's admin ids)
+      // by byte equality. A non-canonical id would resolve the user and then read as managing
+      // nothing, refusing a target who genuinely manages the lake. Same hazard as the lake ids.
+      const lakeBinding = await screenPreauthorizedLakeIds(preauthorizedLakeIds, targetUser.id);
+
       const newApiKey = await userApiKeyService.createUserApiKey(
         userId,
         {
@@ -75,7 +179,7 @@ const handler = baseApi({ auth: true })
           scopes: scopes as Parameters<typeof userApiKeyService.createUserApiKey>[1]['scopes'],
           expiresAt: expiresAt ? new Date(expiresAt) : undefined,
           rateLimit,
-          preauthorizedLakeIds,
+          preauthorizedLakeIds: lakeBinding,
           metadata: {
             clientIP: req.ip,
             userAgent: req.headers['user-agent'],
@@ -89,7 +193,10 @@ const handler = baseApi({ auth: true })
         }
       );
 
-      // Log analytics event attributed to the target user
+      // Log analytics event attributed to the target user. The lake binding rides along because it
+      // is the one part of this mint that reaches another tenant's asset and it is invisible on the
+      // lake side - it grants nothing there, so it appears in no grant listing. Recording it here
+      // makes "which keys are bound to this lake" answerable without grepping logs.
       await logEvent(
         {
           userId,
@@ -100,14 +207,18 @@ const handler = baseApi({ auth: true })
             scopes: newApiKey.scopes,
             expiresAt: newApiKey.expiresAt?.toISOString(),
             createdFrom: 'dashboard',
+            preauthorizedLakeIds: lakeBinding,
           },
         },
         { ability: req.ability }
       );
 
-      // Audit trail with admin details
+      // Audit trail with admin details. `name` goes through JSON.stringify - the same surrounding
+      // quotes for any ordinary name - so a newline in a caller-chosen name cannot forge a sibling
+      // log entry now that this line is the audit record for a cross-tenant lake binding.
       req.logger.info(
-        `Admin ${req.user.username} (${req.user.id}) generated API key "${name}" for user ${targetUser.username} (${userId})`
+        `Admin ${req.user.username} (${req.user.id}) generated API key ${JSON.stringify(name)} for user ${targetUser.username} (${userId})` +
+          (lakeBinding ? ` bound to data lake(s) ${lakeBinding.join(', ')}` : '')
       );
 
       return res.status(201).json(newApiKey);

--- a/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
+++ b/apps/client/pages/api/admin/users/[userId]/generate-api-key.ts
@@ -155,6 +155,13 @@ const handler = baseApi({ auth: true })
       if (!targetUser) {
         throw new BadRequestError('User not found');
       }
+      // Canonical target id for everything below, NOT the `userId` URL segment: findById casts to
+      // ObjectId and resolves the user under any hex casing, but every field this id is compared
+      // against afterwards is a `type: String` matched by byte equality - the key's own `userId`,
+      // and each manage rung the lake screen walks. A non-canonical segment minted a key that
+      // authenticates (apiKeyAuth casts too) yet findByUserId never returns: invisible in the
+      // owner's key list, uncounted by the per-user cap, unreachable by the owner-scoped revoke.
+      const targetUserId = targetUser.id;
 
       const { name, scopes, expiresAt, rateLimit, preauthorizedLakeIds } = req.body as CreateApiKeyBody;
 
@@ -165,15 +172,10 @@ const handler = baseApi({ auth: true })
         throw new BadRequestError(`Scope not allowed: ${invalidScopes.join(', ')}`);
       }
 
-      // `targetUser.id`, NOT the `userId` URL segment: findById casts to ObjectId and so resolves
-      // the user under any hex casing, but every manage rung compares the actor id against a
-      // `type: String` field (createdByUserId, a grant's principalId, an Organization's admin ids)
-      // by byte equality. A non-canonical id would resolve the user and then read as managing
-      // nothing, refusing a target who genuinely manages the lake. Same hazard as the lake ids.
-      const lakeBinding = await screenPreauthorizedLakeIds(preauthorizedLakeIds, targetUser.id);
+      const lakeBinding = await screenPreauthorizedLakeIds(preauthorizedLakeIds, targetUserId);
 
       const newApiKey = await userApiKeyService.createUserApiKey(
-        userId,
+        targetUserId,
         {
           name,
           scopes: scopes as Parameters<typeof userApiKeyService.createUserApiKey>[1]['scopes'],
@@ -199,7 +201,7 @@ const handler = baseApi({ auth: true })
       // makes "which keys are bound to this lake" answerable without grepping logs.
       await logEvent(
         {
-          userId,
+          userId: targetUserId,
           type: UserApiKeyEvents.CREATED,
           metadata: {
             keyId: newApiKey.id,
@@ -213,11 +215,13 @@ const handler = baseApi({ auth: true })
         { ability: req.ability }
       );
 
-      // Audit trail with admin details. `name` goes through JSON.stringify - the same surrounding
-      // quotes for any ordinary name - so a newline in a caller-chosen name cannot forge a sibling
-      // log entry now that this line is the audit record for a cross-tenant lake binding.
+      // Audit trail with admin details. Every free-form field goes through JSON.stringify - the
+      // same surrounding quotes for any ordinary value - so a newline cannot forge a sibling entry
+      // now that this line is the audit record for a cross-tenant lake binding. `username` is only
+      // `{ type: String, unique: true }` on UserModel, so it carries no schema-level shape
+      // constraint; both ids are canonical ObjectId strings and need no escaping.
       req.logger.info(
-        `Admin ${req.user.username} (${req.user.id}) generated API key ${JSON.stringify(name)} for user ${targetUser.username} (${userId})` +
+        `Admin ${JSON.stringify(req.user.username)} (${req.user.id}) generated API key ${JSON.stringify(name)} for user ${JSON.stringify(targetUser.username)} (${targetUserId})` +
           (lakeBinding ? ` bound to data lake(s) ${lakeBinding.join(', ')}` : '')
       );
 

--- a/b4m-core/common/src/schemas/analytics/events/userApiKey.ts
+++ b/b4m-core/common/src/schemas/analytics/events/userApiKey.ts
@@ -24,6 +24,12 @@ export interface IUserApiKeyCreatedEvent extends IBaseEvent {
     billingOwnerType?: string;
     /** Set for org-billed keys: the organization charged for this key's usage. */
     organizationId?: string;
+    /**
+     * Lake ids an admin-minted key was bound to for the manage-but-not-member session admission.
+     * A CEILING on what the key may admit, never a grant (see pages/api/sessions/create.ts), and
+     * invisible on the lake side - so this is where a lake's bindings are discoverable.
+     */
+    preauthorizedLakeIds?: string[];
   };
 }
 

--- a/b4m-core/services/src/dataLakeService/index.ts
+++ b/b4m-core/services/src/dataLakeService/index.ts
@@ -22,6 +22,9 @@ export {
   type LakeGrant,
 } from './manageRule';
 export * from './authorizeLakeManage';
+// The per-turn manage re-check. Exported so the admin key-mint route screens a lake binding
+// with the SAME rule the read path re-derives it with, instead of open-coding a second gate.
+export * from './filterStillManagedLakes';
 export * from './transferLakeOwnership';
 export * from './lakeOwnershipCandidates';
 export * from './authorizeBatchAccess';

--- a/b4m-core/services/src/userApiKeyService/create.ts
+++ b/b4m-core/services/src/userApiKeyService/create.ts
@@ -54,10 +54,14 @@ const createUserApiKeySchema = z.object({
   billingOwnerType: z.enum(CreditHolderType).optional(),
   organizationId: z.string().optional(),
   // Manage-but-not-member session admission (see pages/api/sessions/create.ts): the lakes this
-  // key may bind a session to. No existence/manage check at mint time - session-create
+  // key may bind a session to. No existence/manage check at THIS layer - session-create
   // independently re-verifies the ACTING user's live manage rights against the lake on every
-  // request, so a stale or made-up id here is inert, never a privilege. No new ApiKeyScope: the
-  // widening is bound to specific lake ids rather than gated by a scope.
+  // request, so a stale or made-up id reaching the document is inert, never a privilege. That is
+  // why this schema stays a shape check; it is not a statement that no caller should screen. The
+  // admin mint route (pages/api/admin/users/[userId]/generate-api-key.ts) does screen, and must
+  // keep doing so: an id the target cannot manage is a binding that narrows nothing, which is the
+  // only thing the field is for. No new ApiKeyScope: the widening is bound to specific lake ids
+  // rather than gated by a scope.
   preauthorizedLakeIds: z.array(z.string().min(1)).max(25).optional(),
 });
 


### PR DESCRIPTION
## Description

Closes #2524

`POST /api/admin/users/[userId]/generate-api-key` accepted `preauthorizedLakeIds` and persisted it with no validation of any kind. This PR screens that list against the **target user** at mint time.

**The issue's premise does not hold - read the change with that in mind.** #2524 calls a stored entry "a durable, silent widening of someone else's authority". It is not: the field is a **ceiling, not a grant**, and every consumer was checked. `apps/client/pages/api/sessions/create.ts:101-113` requires the lake to be in the key's list **and then** re-checks the acting user's live manage rights independently (the comment at `:96-100` states the invariant outright). The read path re-derives manage rights every turn (`unionPreauthorizedLakeAccess.ts:40`, `getDataLakePrompts.ts:194`), and `vetPreauthorizedLakeIds.ts:12` blanks the field entirely unless the actor is the session owner. No consumer treats the value as a grant, so an id the target cannot manage escalated nothing. The absent check was also a stated decision rather than silence - `b4m-core/services/src/userApiKeyService/create.ts:56-61` says so in as many words, one layer below where the issue looked. The field was already capped at 25 and is unreachable from the self-service mint route.

Two real defects were sitting underneath that premise, and a third would have been introduced by the obvious fix:

1. **A binding whose only purpose is to NARROW was accepted without any check that it narrows anything.** Bind a lake the target cannot manage and you persist an entry that reads like a binding and does nothing. `AdminGenerateApiKeyModal.tsx:238-247` renders a checkbox per lake **the admin** can see, unfiltered, so this is an easy silent operator mistake that only surfaces later as a confusing `You do not manage data lake X` at session-create.

2. **An uppercase-hex ObjectId broke the binding permanently** (previously unreported). `UserApiKeyModel.preauthorizedLakeIds` and `SessionModel.preauthorizedLakeIds` are both `type: [String]`, so the containment check at `sessions/create.ts:101` is a byte comparison against a lake's always-lowercase `id` virtual. An uppercase id stored fine and then never matched. It fails closed, so this is a correctness/DX bug rather than a hole.

3. **The same byte-comparison bug one field over, which the fix itself would have introduced:** the screen's actor must be `targetUser.id`, not the `userId` URL segment. `userRepository.findById` casts to ObjectId and so resolves the user under any casing, but every manage rung compares the actor id against a `type: String` field (`createdByUserId`, a grant's `principalId`, an Organization's admin ids). A non-canonical segment would have resolved the user and then read as managing nothing, refusing a legitimate maintainer.

## Changes

- `apps/client/pages/api/admin/users/[userId]/generate-api-key.ts` - new `screenPreauthorizedLakeIds()`, run only when a binding is requested (an ordinary mint reads no lake at all). In order: reject a non-array; cap the **raw** array before walking it; canonicalize each id to lowercase via `toObjectIdString`, rejecting malformed and non-string entries; dedupe through a `Set` preserving request order; reject ids naming no lake; reject ids naming a non-`active` lake (reported separately from a miss, because an admin picking from the lake list can see a `draft` lake and "not found" for a lake on their screen reads as a bug); reject ids the **target** cannot manage. An empty array normalizes to `undefined`, which the models and `sessions/create.ts:101` already treat identically.
- The manage check **reuses `dataLakeService.filterStillManagedLakes`** rather than open-coding a rule, so the mint gate, the session-create gate and the per-turn re-check cannot drift. That helper bakes in `isAdmin: false` - the subtle part, since platform-adminness is deliberately not a manage rung for this admission, so a target whose only relationship to the lake is being a platform admin is refused here exactly as `sessions/create` would refuse them. It also batches grants into one `listActiveByLakes`, so the screen costs N+2 reads rather than 2N.
- The audit line now names the bound lakes, with `name` passed through `JSON.stringify` (the same surrounding quotes for any ordinary name) so a newline in a caller-chosen key name cannot forge a sibling log entry now that this line is the audit record for a cross-tenant binding.
- `b4m-core/services/src/dataLakeService/index.ts` - export `filterStillManagedLakes` (was module-private).
- `b4m-core/common/src/schemas/analytics/events/userApiKey.ts` - add `preauthorizedLakeIds?: string[]` to `IUserApiKeyCreatedEvent`, so "which keys are bound to this lake" is answerable without grepping logs.
- `b4m-core/services/src/userApiKeyService/create.ts` - comment only. The old note said no caller screens these ids, which this change makes false; it now scopes that statement to the service layer and points at the route that does screen.
- Route test file rewritten: 32 tests.

## Guide for Testers

**Preconditions.** You need a platform-admin account, a separate non-admin target user, and two active data lakes: **Lake A**, which the *target user* manages (they created it, hold a manage grant on it, or are an org admin over its organization), and **Lake B**, which the target user does *not* manage (e.g. one the admin created).

1. Sign in to `app.staging.bike4mind.com` as a platform admin.
2. Navigate: Sidebar -> Admin -> Users.
3. Search for the target user's username and click their row to open the user detail view.
4. Click the `Generate API Key` button. Expected: a modal titled `Generate API Key for <username>` opens.
5. In `Key Name`, type `lake-binding-negative`.
6. Scroll to the `Pre-authorized lakes (0 selected)` section and check the box for **Lake B** (the lake the target does NOT manage). Expected: the label updates to `Pre-authorized lakes (1 selected)`.
7. Click the modal's `Generate API Key` submit button. Expected: **no key is generated**, and a red error toast appears reading ` user does not manage data lake(s): <Lake B id>. Grant the user access to the lake first.` (the leading space and lowercase `user` come from a pre-existing client-side error formatter - see Additional Information). **Before this PR this returned 201 and silently stored a binding that never worked.**
8. Uncheck Lake B, check **Lake A** instead, and click `Generate API Key`. Expected: success - the modal reveals the generated key and a green toast reads `API key created for <username>`.
9. Copy the generated key. Open a new browser session, use that key to create a session bound to Lake A, and confirm the target user can read Lake A content in that session. Expected: unchanged from before this PR - the binding still only narrows, it never grants.
10. If the lake list shows a lake in `draft` status, check it alone and submit. Expected: refusal with a red toast reading ` data lake is not active: <lake id>`.

**Regression Checks**

11. Close and reopen the modal, type `no-lake-binding` in `Key Name`, leave **every** lake checkbox unchecked, and click `Generate API Key`. Expected: success exactly as before - an ordinary mint touches no lake code at all.
12. In the same modal, select a scope the admin endpoint disallows and submit. Expected: the pre-existing `Scope not allowed: <scope>` refusal, unchanged.
13. Navigate: Sidebar -> Settings -> API Keys and create a key from the self-service flow. Expected: unchanged - that route never forwarded this field.
14. Confirm an API key minted **before** this PR still behaves as it did. Expected: unchanged. Nothing is migrated or re-validated; the screen applies at mint time only.

**What NOT to test**

- The uppercase-hex ObjectId fix is not reachable from the admin modal (it submits lowercase ids straight from the lake list). It is covered by unit tests; exercising it needs a direct API call.
- The new `preauthorizedLakeIds` field on the `api-key-created` analytics event is not user-visible.
- No permission boundary changes in this PR, so there is nothing to probe for escalation - see the Description for why the issue's escalation framing does not hold.

## Additional Information

**Deliberate, user-visible behavior change.** An admin who checks a lake the target user does not manage now gets a **400 naming the lake** instead of a silent success, and a `draft` lake gets a **400 saying it is not active**. That is the point - neither binding ever worked - but it does change the admin modal's happy path. It was not softened to a warning, because a silent no-op is the defect.

**Known cosmetic wart in how the refusal reads.** `parseValidationError` in `apps/client/app/hooks/data/userApiKeys.ts:6-30` reformats any error message containing a colon: it splits on `', '`, splits each piece on `': '`, and lowercases the leading segment. Every 400 from this modal already went through it, but the new messages trip it visibly. A single-lake refusal renders as ` user does not manage data lake(s): <id>. Grant the user access to the lake first.` - intelligible, with a stray leading space. A **multi**-lake refusal is genuinely garbled, because the ids are comma-joined and the formatter treats each as a separate validation error. Left alone deliberately: fixing that formatter is a client-wide change that would alter every other error toast in the file, and it is not this PR's subject. Worth a follow-up.

**Deliberately left out**

- **No override flag.** An `allowUnmanagedLakes: true` escape hatch was built first (the issue's own sanctioned fallback) and then cut. It buys no capability - "grant the lake, then mint" already covers pre-provisioning - and it is a bypass on a guard that is explicitly *not* a security control. It was discoverable only via the 400 that named it, which teaches the next engineer to set it rather than fix the grant, and it would sit ready to become a real bypass if the ceiling-vs-grant invariant ever weakened. The refusal now names the lakes and says to fix the grant instead. Happy to reinstate it if a reviewer disagrees; the shape is in the branch history.
- **No lake-side visibility surface.** The issue asks for the binding to be visible to a lake owner. The binding confers nothing on the lake side, so a grant audit is already complete; the analytics field covers the legitimate "find the bindings" need. **This is the one part of the issue's ask answered with a design call rather than a surface - say so on review if you read it differently.**
- **No modal change - and this is the highest-value follow-up.** The obvious next step is to stop offering lakes that will be refused. The tempting one-liner (filter on the existing `ManageableDataLakeConfig.canPreauthorize`) is **wrong**: `listDataLakes.ts:405-421` resolves that flag for the **caller** with `isAdmin: false`, so for a platform admin who personally manages no lakes it is `false` for everything and the modal would render an empty list, breaking the feature outright. The correct fix is a target-scoped "lakes this user can preauthorize" read, which is a new endpoint and out of scope here.
- **#2464 untouched** (unvalidated `dataLakeId` strings cast into an `ObjectId $in`), per that issue's note that it is tracked separately.

**Verification**

- `pnpm turbo:typecheck` - 40/40 pass. `pnpm lint:check` - clean. `prettier --check` on the diff - clean. Both ASCII guards (`check-no-control-bytes.sh`, `check-no-smart-punctuation.sh`) - clean.
- `vitest run --project node generate-api-key` - **32/32 pass**.
- `pnpm --filter @bike4mind/client test` (node **and** jsdom) - 1160 files, **12637 pass**, 0 failed.
- `pnpm --filter @bike4mind/services` - 6456 pass; `@bike4mind/common` - 2220 pass; `@bike4mind/scripts` - 725 pass; `@bike4mind/utils` - 910 pass.
- Honest caveat: the aggregate `pnpm turbo:test` never went green in a single run locally. Every failure was chased to root cause and none was this diff - CPU oversubscription, the `MongoMemoryServer` port-collision race CLAUDE.md documents, and `dist` races from concurrent invocations of my own. Each package was then verified green standalone. CI's sharded matrix is the real check here.
- No integration test against a real Mongo. The manage rule itself is already pinned by `filterStillManagedLakes.test.ts` and `manageRule.test.ts`, and the route test pins the wiring by asserting the adapter actually carries `listActiveByLakes` and `findIdsWithAdminRights` - both are optional on `ManageRecheckAdapter` and both degrade **closed**, so a renamed key would silently deny legitimate maintainers with every other assertion still green. A `createMongoServer()` test driving the curator / org-admin / platform-admin-only rungs end to end through the route would be stronger and is worth adding.

## Developer Notes (Optional)

- **New extension point:** `dataLakeService.filterStillManagedLakes` is now exported. Any future gate that needs "does this user manage these lakes, right now" should call it rather than re-deriving the rule - that is what keeps the mint gate, the session-create gate and the per-turn read re-check from drifting. Note its baked-in `isAdmin: false`.
- **Reusable pattern - cap before you walk, not after.** `MAX_PREAUTHORIZED_LAKES` is checked against the **raw** array, ahead of the dedupe loop. `baseApi` admits a 1 MiB body (roughly 38k ids at ~27 bytes each), so a cap applied after an `Array.includes` dedupe is an unbounded O(n^2) walk blocking the event loop on an admin-authenticated route. `sessions/create.ts` caps after its dedupe and is safe only because it uses a `Set`; the comment in the new code says so rather than claiming a false symmetry.
- **Deliberate status divergence:** this route answers `400` for conditions where `sessions/create` answers `NotFound`/`Forbidden`. There the lake id is the request's subject; here it is one field of a mint body. Noted in a comment so the two intentionally-in-lockstep gates disagreeing on status reads as intentional.
- **Data model:** `IUserApiKeyCreatedEvent.data.preauthorizedLakeIds` is the queryable record of a cross-tenant binding, since the binding is invisible on the lake side by design.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - the refusal toast is intelligible for a single lake but garbled for several, via a pre-existing client-side formatter; see Additional Information
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - this PR does add one telemetry field (lake ObjectIds, no PII), but that doc does not exist in this repo (`docs-site/docs/security/` is absent); flagging rather than silently checking the box
