### PR TITLE
fix(services): classify malformed model-supplied file ids, and repair edit_file's dead lookup

### DIFF
--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -384,6 +384,11 @@ export const RetrievalSummarySchema = z.object({
    *   record it without anything throwing). What separates it from 'not_indexed' is the remedy,
    *   not the tempo: fix the outage or the host wiring, never re-index content. An unwired host
    *   reports continuously too, so "chronic" alone does not pick out 'not_indexed'.
+   *   NOT this: a model-supplied argument that is not a well-formed id. knowledgeBaseRetrieve
+   *   shape-checks `file_id` and answers a malformed one as a single-file miss ('ok'), because the
+   *   remedy is for the model to search for the right id - there is nothing for an operator to
+   *   fix. It is logged rather than counted here, so the rate stays observable without this field
+   *   reporting an outage that is not happening.
    * On multiple retrieval calls within one turn, merge priority is failed > not_indexed > ok >
    * no_lakes (see retrievalSummaryMerge.ts's mergeRetrievalSummary): a single failure is never
    * masked by a later success or abstain, an unsearchable corpus outranks a legitimate zero so a

--- a/b4m-core/services/src/llm/tools/base/objectId.test.ts
+++ b/b4m-core/services/src/llm/tools/base/objectId.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { isObjectIdShaped } from './objectId';
+
+/**
+ * The truth table, pinned. This predicate decides whether caller-controlled, unbounded input is
+ * allowed to reach Mongoose's `_id` cast, so the enumeration matters more than any single case -
+ * a point fix to the expression moves the boundary somewhere new instead of settling it.
+ */
+describe('isObjectIdShaped', () => {
+  it.each([
+    ['a real lowercase ObjectId', '68b0f3a2c1d4e5f60718293a'],
+    ['the same id uppercased', '68B0F3A2C1D4E5F60718293A'],
+    ['the same id in mixed case', '68b0F3a2C1d4E5f60718293A'],
+  ])('accepts %s', (_label, id) => {
+    expect(isObjectIdShaped(id)).toBe(true);
+  });
+
+  it.each([
+    ['a filename token, the shape production actually sent', 'w7154539641'],
+    ['an arXiv id lifted from chunk text, dot mangled to a space', '2506 07866'],
+    ['a bare filename', 'Handbook.pdf'],
+    ['a 12-char string (raw-byte form Mongoose no longer casts)', 'abcdefghijkl'],
+    ['one hex digit short', '68b0f3a2c1d4e5f6071829'],
+    ['one hex digit long', '68b0f3a2c1d4e5f60718293ab'],
+    ['24 non-hex characters', 'zzzzzzzzzzzzzzzzzzzzzzzz'],
+    ['a well-formed id with surrounding whitespace', ' 68b0f3a2c1d4e5f60718293a '],
+    ['the empty string', ''],
+  ])('rejects %s', (_label, id) => {
+    expect(isObjectIdShaped(id)).toBe(false);
+  });
+
+  it.each([
+    ['a number, which isValidObjectId would accept and cast to a fabricated id', 12],
+    ['null', null],
+    ['undefined', undefined],
+    ['an object', { $ne: null }],
+  ])('rejects %s', (_label, id) => {
+    expect(isObjectIdShaped(id)).toBe(false);
+  });
+
+  it('rejects an artifact id, which is matched on a string `id` field and never on `_id`', () => {
+    expect(isObjectIdShaped('artifact_chart_revenue_1788929620_0')).toBe(false);
+  });
+
+  // Guards the collapse of imageEdit's hand-rolled regex onto this helper: the two agreed on
+  // every class above, so that swap was behaviour-preserving. lattice's `/^[a-f0-9]{24}$/` is
+  // NOT equivalent - it rejects the uppercase and mixed-case ids asserted above - so it is
+  // deliberately left on its own regex rather than widened as a drive-by.
+  it('agrees with the case-insensitive 24-hex regex that callers used to hand-roll', () => {
+    const handRolled = /^[0-9a-fA-F]{24}$/;
+    const cases = [
+      '68b0f3a2c1d4e5f60718293a',
+      '68B0F3A2C1D4E5F60718293A',
+      '68b0F3a2C1d4E5f60718293A',
+      'w7154539641',
+      '2506 07866',
+      'abcdefghijkl',
+      '',
+      ' 68b0f3a2c1d4e5f60718293a ',
+      'Handbook.pdf',
+      '68b0f3a2c1d4e5f6071829',
+      '68b0f3a2c1d4e5f60718293ab',
+    ];
+    for (const value of cases) {
+      expect({ value, shaped: isObjectIdShaped(value) }).toEqual({ value, shaped: handRolled.test(value) });
+    }
+  });
+});

--- a/b4m-core/services/src/llm/tools/base/objectId.ts
+++ b/b4m-core/services/src/llm/tools/base/objectId.ts
@@ -1,0 +1,23 @@
+import { isObjectIdOrHexString } from 'mongoose';
+
+/**
+ * Is this value shaped like something Mongoose can cast to an `_id`?
+ *
+ * Tool arguments are composed by the model out of conversation text and reach us as unvalidated
+ * JSON, so an id parameter routinely holds something that is not an id at all - a filename token,
+ * an arXiv number, a bare integer. Mongoose casts `_id` and throws a CastError on those, which a
+ * generic catch upstream then reports as an outage rather than the bad argument it is (#2530).
+ * Call this before handing a model-supplied id to `findById` and answer a false the same way the
+ * surface answers a genuinely missing row.
+ *
+ * `isObjectIdOrHexString`, not `isValidObjectId`: the latter also accepts a number and casts it to
+ * a fabricated id, and a model emitting `{"file_id": 12}` gives us exactly that despite the
+ * `string` type. Same choice, same reason, as `usableObjectIds` in @bike4mind/db-core, which is
+ * the array-shaped version of this check.
+ *
+ * NOT usable for artifact ids (`artifact_<...>`), which are matched on a string `id` field rather
+ * than `_id` - see `createArtifactId` in @bike4mind/common.
+ */
+export function isObjectIdShaped(id: unknown): boolean {
+  return isObjectIdOrHexString(id);
+}

--- a/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
@@ -39,7 +39,7 @@ describe('editFileTool cancellation handling', () => {
       userId: 'u1',
       user: {},
       logger,
-      db: { fabfiles: { findById: vi.fn(async () => FILE) } },
+      db: { fabfiles: { findByIdAndUserId: vi.fn(async () => FILE) } },
       llm: { complete },
       statusUpdate: vi.fn(),
       model: 'test-model',

--- a/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
@@ -48,10 +48,14 @@ describe('editFileTool cancellation handling', () => {
     return { context, logger };
   }
 
+  // ObjectId-shaped on purpose: `fileId` is shape-checked before the lookup, so a fixture that is
+  // not an id at all is rejected up front and never reaches the LLM call these tests are about.
+  const FILE_ID = '68b0f3a2c1d4e5f60718293a';
+
   function run(context: ToolContext) {
     return editFileTool
       .implementation(context, undefined)
-      .toolFn({ fileId: 'f1', instruction: 'uppercase it' }, {} as never);
+      .toolFn({ fileId: FILE_ID, instruction: 'uppercase it' }, {} as never);
   }
 
   it('passes the live signal through as abortSignal', async () => {

--- a/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/abortSignal.test.ts
@@ -39,7 +39,7 @@ describe('editFileTool cancellation handling', () => {
       userId: 'u1',
       user: {},
       logger,
-      db: { fabFiles: { findById: vi.fn(async () => FILE) } },
+      db: { fabfiles: { findById: vi.fn(async () => FILE) } },
       llm: { complete },
       statusUpdate: vi.fn(),
       model: 'test-model',

--- a/b4m-core/services/src/llm/tools/implementation/editFile/access.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/access.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { editFileTool } from './index';
+import type { ToolContext } from '../../base/types';
+
+/**
+ * Repairing the `fabFiles` -> `fabfiles` typo took this tool's lookup from "always undefined" to
+ * "resolves a row", so the authorization that was never needed while the read was dead is needed
+ * now. These pin the three properties that come with a live read: the row must belong to the
+ * caller, a curated kbScope refuses the tool outright (ToolContext.kbScope's invariant for any
+ * db.fabfiles reader), and an unwired repo is a loud wiring fault rather than a quiet miss.
+ */
+describe('editFileTool access control', () => {
+  const FILE_ID = '68b0f3a2c1d4e5f60718293a';
+  const FILE = {
+    fileName: 'a.txt',
+    mimeType: 'text/plain',
+    fileUrl: 'https://files.example/a.txt',
+    moderationStatus: 'clean',
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, statusText: 'OK', text: async () => 'original content' }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function makeContext(overrides: Partial<ToolContext>, fabfiles: unknown) {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    return {
+      userId: 'owner-1',
+      user: {},
+      logger,
+      db: { fabfiles },
+      llm: { complete: vi.fn(async (_m, _msgs, _o, cb) => cb(['edited'], undefined)) },
+      statusUpdate: vi.fn(),
+      model: 'test-model',
+      ...overrides,
+    } as unknown as ToolContext;
+  }
+
+  function run(context: ToolContext) {
+    return editFileTool
+      .implementation(context, undefined)
+      .toolFn({ fileId: FILE_ID, instruction: 'uppercase it' }, {} as never);
+  }
+
+  it('scopes the lookup to the caller, so a row owned by someone else is not found', async () => {
+    // The repository does the scoping: findByIdAndUserId returns null for a row the caller does
+    // not own, exactly as it would for an id with no row at all.
+    const findByIdAndUserId = vi.fn(async () => null);
+    const context = makeContext({}, { findByIdAndUserId });
+
+    await expect(run(context)).rejects.toThrow(`File with ID ${FILE_ID} not found`);
+    expect(findByIdAndUserId).toHaveBeenCalledWith(FILE_ID, 'owner-1');
+  });
+
+  it('answers a foreign row exactly as it answers a nonexistent one', async () => {
+    // The existence-oracle property, on the ownership axis: a caller must not be able to tell
+    // "someone else owns this" from "nothing is here".
+    const foreign = makeContext({}, { findByIdAndUserId: vi.fn(async () => null) });
+    const missing = makeContext({}, { findByIdAndUserId: vi.fn(async () => null) });
+
+    const foreignError = await run(foreign).catch((e: Error) => e.message);
+    const missingError = await run(missing).catch((e: Error) => e.message);
+
+    expect(foreignError).toBe(missingError);
+  });
+
+  it('refuses outright in a knowledge-base-scoped session, before touching the repository', async () => {
+    const findByIdAndUserId = vi.fn(async () => FILE);
+    const context = makeContext({ kbScope: { fileIds: [FILE_ID] } }, { findByIdAndUserId });
+
+    // Even for an id INSIDE the scope: a curated corpus is read-only, so the answer is a refusal
+    // rather than a restriction.
+    await expect(run(context)).rejects.toThrow(/not available in a knowledge-base-scoped session/);
+    expect(findByIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('reports an unwired repository as a wiring fault, not as a missing file', async () => {
+    // `fabfiles` is optional on ToolContext['db']. Answering its absence with the not-found
+    // message is the failure mode that hid the dead lookup for this tool's whole lifetime.
+    const context = makeContext({}, undefined);
+
+    const message = await run(context).catch((e: Error) => e.message);
+
+    expect(message).toMatch(/not wired on this host/);
+    expect(message).not.toMatch(/not found/);
+  });
+});

--- a/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
@@ -110,8 +110,11 @@ export const editFileTool: ToolDefinition = {
           throw new NotFoundError(`File with ID ${fileId} not found`);
         }
 
-        // context.db's type doesn't expose fabFiles; reached via the cast below.
-        const fabFile = await (context.db as any).fabFiles?.findById(fileId);
+        // `fabfiles`, lowercase, and no cast: this read used to be `(context.db as any).fabFiles`,
+        // a key no host that can reach this tool actually populates. The cast silenced the
+        // compiler and `?.` silenced the miss, so every edit - including one naming a real row -
+        // fell through to the not-found below. The tool had never edited a file.
+        const fabFile = await context.db.fabfiles?.findById(fileId);
         if (!fabFile) {
           throw new NotFoundError(`File with ID ${fileId} not found`);
         }

--- a/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
@@ -1,4 +1,5 @@
 import { ToolDefinition } from '../../base/types';
+import { isObjectIdShaped } from '../../base/objectId';
 import { recordToolOperationalUsage } from '../../base/recordToolOperationalUsage';
 import { z } from 'zod';
 import { NotFoundError } from '@bike4mind/utils';
@@ -99,6 +100,16 @@ export const editFileTool: ToolDefinition = {
       context.logger.info(`📝 Edit File Tool: Instruction: ${instruction}`);
 
       try {
+        // Same not-found answer a missing row gets, for the same reason: `fileId` is composed by
+        // the model, so a value Mongoose cannot cast to an `_id` is a bad argument rather than a
+        // fault. Without this the CastError reaches the catch below and the model is told
+        // "Failed to edit file: Cast to ObjectId failed for value ..." - our internals, and no
+        // hint that it should go and find the real id (#2530 fixed the same shape in
+        // knowledgeBaseRetrieve).
+        if (!isObjectIdShaped(fileId)) {
+          throw new NotFoundError(`File with ID ${fileId} not found`);
+        }
+
         // context.db's type doesn't expose fabFiles; reached via the cast below.
         const fabFile = await (context.db as any).fabFiles?.findById(fileId);
         if (!fabFile) {

--- a/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/index.ts
@@ -100,6 +100,22 @@ export const editFileTool: ToolDefinition = {
       context.logger.info(`📝 Edit File Tool: Instruction: ${instruction}`);
 
       try {
+        // A curated kbScope is a read-only corpus: the agent owner chose which files this
+        // audience may READ, not which it may rewrite. ToolContext.kbScope carries the invariant
+        // that every db.fabfiles reader either rejects or restricts to scope.fileIds, and for a
+        // tool whose whole job is to rewrite a file, rejecting is the only honest half of that.
+        if (context.kbScope) {
+          throw new Error('edit_file is not available in a knowledge-base-scoped session');
+        }
+
+        // An absent repo is a host wiring fault, not a missing row - and answering it as
+        // not-found is exactly what let the dead `fabFiles` lookup below survive this tool's
+        // entire lifetime. Fail loudly rather than `?.` into the same silence.
+        const fabfiles = context.db.fabfiles;
+        if (!fabfiles) {
+          throw new Error('edit_file is unavailable: the file repository is not wired on this host');
+        }
+
         // Same not-found answer a missing row gets, for the same reason: `fileId` is composed by
         // the model, so a value Mongoose cannot cast to an `_id` is a bad argument rather than a
         // fault. Without this the CastError reaches the catch below and the model is told
@@ -114,7 +130,15 @@ export const editFileTool: ToolDefinition = {
         // a key no host that can reach this tool actually populates. The cast silenced the
         // compiler and `?.` silenced the miss, so every edit - including one naming a real row -
         // fell through to the not-found below. The tool had never edited a file.
-        const fabFile = await context.db.fabfiles?.findById(fileId);
+        //
+        // Owner-scoped, and NOT the bare `findById` that repairing the name would otherwise
+        // revive: `findById` matches on `_id` alone, so it would resolve any row in the
+        // collection and hand its full text back to the model as `result.original`. This is the
+        // same read knowledgeBaseRetrieve reaches for first; a row the caller does not own is
+        // answered as not-found, so a direct id probe leaks nothing - not even that it exists.
+        // Widening to shared or lake-visible files would mean mirroring that tool's tag,
+        // prefix, membership, share and group verification, not relaxing back to `findById`.
+        const fabFile = await fabfiles.findByIdAndUserId(fileId, context.userId);
         if (!fabFile) {
           throw new NotFoundError(`File with ID ${fileId} not found`);
         }

--- a/b4m-core/services/src/llm/tools/implementation/editFile/malformedFileId.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/malformedFileId.test.ts
@@ -27,7 +27,7 @@ describe('editFileTool malformed fileId handling', () => {
       userId: 'u1',
       user: {},
       logger,
-      db: { fabFiles: { findById } },
+      db: { fabfiles: { findById } },
       llm: { complete: vi.fn(async (_m, _msgs, _o, cb) => cb(['edited'], undefined)) },
       statusUpdate: vi.fn(),
       model: 'test-model',
@@ -65,7 +65,11 @@ describe('editFileTool malformed fileId handling', () => {
     expect(malformedError).not.toMatch(/Cast to ObjectId/);
   });
 
-  it('leaves a well-formed id on the normal path', async () => {
+  // Doubles as the regression pin for a lookup that read `db.fabFiles` through an `as any`
+  // cast - a key no host wiring this tool populates, so `?.` returned undefined and EVERY id,
+  // real ones included, fell through to the not-found above. Mock the key the hosts actually
+  // wire (`fabfiles`) or this test pins the bug instead of the behaviour.
+  it('reaches the repository for a well-formed id and goes on to edit', async () => {
     const findById = vi.fn(async () => ({
       fileName: 'a.txt',
       mimeType: 'text/plain',
@@ -74,8 +78,9 @@ describe('editFileTool malformed fileId handling', () => {
     }));
     const context = makeContext(findById);
 
-    await run(context, WELL_FORMED_FILE_ID);
+    const result = await run(context, WELL_FORMED_FILE_ID);
 
     expect(findById).toHaveBeenCalledWith(WELL_FORMED_FILE_ID);
+    expect(JSON.stringify(result)).not.toMatch(/not found/);
   });
 });

--- a/b4m-core/services/src/llm/tools/implementation/editFile/malformedFileId.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/malformedFileId.test.ts
@@ -21,13 +21,13 @@ describe('editFileTool malformed fileId handling', () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  function makeContext(findById: ReturnType<typeof vi.fn>) {
+  function makeContext(findByIdAndUserId: ReturnType<typeof vi.fn>) {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
     return {
       userId: 'u1',
       user: {},
       logger,
-      db: { fabfiles: { findById } },
+      db: { fabfiles: { findByIdAndUserId } },
       llm: { complete: vi.fn(async (_m, _msgs, _o, cb) => cb(['edited'], undefined)) },
       statusUpdate: vi.fn(),
       model: 'test-model',
@@ -44,12 +44,12 @@ describe('editFileTool malformed fileId handling', () => {
     ['an id with the dot mangled to a space', '2506 07866'],
     ['a 23-hex near-miss', '68b0f3a2c1d4e5f6071829'],
   ])('rejects %s without querying for it', async (_label, fileId) => {
-    const findById = vi.fn();
-    const context = makeContext(findById);
+    const findByIdAndUserId = vi.fn();
+    const context = makeContext(findByIdAndUserId);
 
     await expect(run(context, fileId)).rejects.toThrow(`File with ID ${fileId} not found`);
     // The point of the guard: the value never reaches the `_id` cast that would throw a CastError.
-    expect(findById).not.toHaveBeenCalled();
+    expect(findByIdAndUserId).not.toHaveBeenCalled();
   });
 
   it('tells the model the same thing a well-formed id with no row behind it does', async () => {
@@ -70,17 +70,17 @@ describe('editFileTool malformed fileId handling', () => {
   // real ones included, fell through to the not-found above. Mock the key the hosts actually
   // wire (`fabfiles`) or this test pins the bug instead of the behaviour.
   it('reaches the repository for a well-formed id and goes on to edit', async () => {
-    const findById = vi.fn(async () => ({
+    const findByIdAndUserId = vi.fn(async () => ({
       fileName: 'a.txt',
       mimeType: 'text/plain',
       fileUrl: 'https://files.example/a.txt',
       moderationStatus: 'clean',
     }));
-    const context = makeContext(findById);
+    const context = makeContext(findByIdAndUserId);
 
     const result = await run(context, WELL_FORMED_FILE_ID);
 
-    expect(findById).toHaveBeenCalledWith(WELL_FORMED_FILE_ID);
+    expect(findByIdAndUserId).toHaveBeenCalledWith(WELL_FORMED_FILE_ID, 'u1');
     expect(JSON.stringify(result)).not.toMatch(/not found/);
   });
 });

--- a/b4m-core/services/src/llm/tools/implementation/editFile/malformedFileId.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/editFile/malformedFileId.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { editFileTool } from './index';
+import type { ToolContext } from '../../base/types';
+
+/**
+ * `fileId` is a bare `z.string()` composed by the model, so it routinely holds something that is
+ * not an id at all. Unguarded it reaches Mongoose's `_id` cast, and the CastError surfaces to the
+ * model as `Failed to edit file: Cast to ObjectId failed for value "..." at path "_id"` - our
+ * internals, with no hint that it should go and find the real id. The guard answers it as the
+ * miss it is, identically to a well-formed id with no row behind it.
+ */
+describe('editFileTool malformed fileId handling', () => {
+  const MALFORMED_FILE_ID = 'Handbook.pdf';
+  const WELL_FORMED_FILE_ID = '68b0f3a2c1d4e5f60718293a';
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, statusText: 'OK', text: async () => 'original content' }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function makeContext(findById: ReturnType<typeof vi.fn>) {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    return {
+      userId: 'u1',
+      user: {},
+      logger,
+      db: { fabFiles: { findById } },
+      llm: { complete: vi.fn(async (_m, _msgs, _o, cb) => cb(['edited'], undefined)) },
+      statusUpdate: vi.fn(),
+      model: 'test-model',
+    } as unknown as ToolContext;
+  }
+
+  function run(context: ToolContext, fileId: string) {
+    return editFileTool.implementation(context, undefined).toolFn({ fileId, instruction: 'uppercase it' }, {} as never);
+  }
+
+  it.each([
+    ['a bare filename', 'Handbook.pdf'],
+    ['a filename token', 'w7154539641'],
+    ['an id with the dot mangled to a space', '2506 07866'],
+    ['a 23-hex near-miss', '68b0f3a2c1d4e5f6071829'],
+  ])('rejects %s without querying for it', async (_label, fileId) => {
+    const findById = vi.fn();
+    const context = makeContext(findById);
+
+    await expect(run(context, fileId)).rejects.toThrow(`File with ID ${fileId} not found`);
+    // The point of the guard: the value never reaches the `_id` cast that would throw a CastError.
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('tells the model the same thing a well-formed id with no row behind it does', async () => {
+    const malformed = makeContext(vi.fn());
+    const missing = makeContext(vi.fn(async () => null));
+
+    const malformedError = await run(malformed, MALFORMED_FILE_ID).catch((e: Error) => e.message);
+    const missingError = await run(missing, WELL_FORMED_FILE_ID).catch((e: Error) => e.message);
+
+    // Identical modulo the echoed id: a malformed id must not be distinguishable from a missing
+    // one, and specifically must not hand the model the cast internals it used to get.
+    expect(malformedError).toBe(missingError.replace(WELL_FORMED_FILE_ID, MALFORMED_FILE_ID));
+    expect(malformedError).not.toMatch(/Cast to ObjectId/);
+  });
+
+  it('leaves a well-formed id on the normal path', async () => {
+    const findById = vi.fn(async () => ({
+      fileName: 'a.txt',
+      mimeType: 'text/plain',
+      fileUrl: 'https://files.example/a.txt',
+      moderationStatus: 'clean',
+    }));
+    const context = makeContext(findById);
+
+    await run(context, WELL_FORMED_FILE_ID);
+
+    expect(findById).toHaveBeenCalledWith(WELL_FORMED_FILE_ID);
+  });
+});

--- a/b4m-core/services/src/llm/tools/implementation/imageEdit/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/imageEdit/index.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@bike4mind/observability';
 import { ToolContext, ToolDefinition } from '../../base/types';
+import { isObjectIdShaped } from '../../base/objectId';
 import {
   ApiKeyType,
   ImageModels,
@@ -61,8 +62,7 @@ async function imageUrlToBase64(imageUrl: string): Promise<string> {
 // guard below is otherwise only reachable through the full `edit_image` toolFn, which
 // requires mocking an entire provider edit call.
 export async function getImageFromFileId(fileId: string, context: ToolContext): Promise<string> {
-  // Validate that fileId is a valid MongoDB ObjectId (24-char hex string) before querying
-  if (!/^[0-9a-fA-F]{24}$/.test(fileId)) {
+  if (!isObjectIdShaped(fileId)) {
     throw new Error(
       `Invalid file ID "${fileId}". Expected a MongoDB ObjectId (24-character hex string), not a filename. Please provide the file ID from the workbench, or use a full URL (https://...) to reference the image.`
     );
@@ -130,7 +130,7 @@ async function resolveImageInputUrl(input: string, context: ToolContext): Promis
   if (input.startsWith('http://') || input.startsWith('https://') || input.startsWith('data:')) {
     return input;
   }
-  if (/^[0-9a-fA-F]{24}$/.test(input)) {
+  if (isObjectIdShaped(input)) {
     return getImageFromFileId(input, context);
   }
   return getGeneratedImageUrl(input, context);

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.test.ts
@@ -24,7 +24,13 @@ import { GROUNDED_NO_INVENTION_RULE } from '../../../prompts';
 
 const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() } as never;
 
-const FILE_ID = 'file-1';
+// ObjectId-shaped on purpose: `file_id` reaches Mongoose's `_id` cast, so a fixture that is not
+// an ObjectId cannot exercise the real Path A at all (it now stops at the shape guard). The
+// malformed pair below is what production actually saw - a trailing token of a corpus filename,
+// and an arXiv id whose dot the model turned into a space.
+const FILE_ID = '68b0f3a2c1d4e5f60718293a';
+const MALFORMED_FILE_ID = 'w7154539641';
+const MALFORMED_FILE_ID_FROM_CHUNK_TEXT = '2506 07866';
 
 function makeFile(overrides: Record<string, unknown> = {}) {
   return {
@@ -856,6 +862,149 @@ describe('retrieve_knowledge_content retrieval summary (#1867)', () => {
 });
 
 /**
+ * A model composes `file_id` from conversation text, so it routinely supplies something that is
+ * not an ObjectId. Before the shape guard, Mongoose raised a CastError that the outer catch turned
+ * into `outcome: 'failed'` - reporting a bad tool argument as a retrieval OUTAGE, which is the one
+ * telemetry field operators would page on (#2530).
+ */
+describe('retrieve_knowledge_content rejects a malformed file_id without reporting an outage (#2530)', () => {
+  const retrievalOf = (ctx: ToolContext) => {
+    const calls = (ctx.statusUpdate as ReturnType<typeof vi.fn>).mock.calls;
+    const call = calls.find(c => (c[0] as { promptMeta?: { retrieval?: unknown } })?.promptMeta?.retrieval);
+    return (call?.[0] as { promptMeta: { retrieval: unknown } } | undefined)?.promptMeta.retrieval;
+  };
+
+  const castError = (value: unknown) =>
+    Object.assign(new Error(`Cast to ObjectId failed for value "${String(value)}" at path "_id"`), {
+      name: 'CastError',
+      value,
+    });
+
+  /**
+   * Mongoose casts `_id`, so the real repository THROWS on a non-ObjectId rather than returning
+   * null. A mock that just resolves undefined cannot reproduce the production failure at all,
+   * which is why the previous fixture (a plain 'file-1' id) never caught this.
+   */
+  const withCastingRepo = (ctx: ToolContext) => {
+    const cast = async (id: string) => {
+      if (!/^[0-9a-fA-F]{24}$/.test(id)) throw castError(id);
+      return null;
+    };
+    (ctx.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockImplementation(cast);
+    (ctx.db.fabfiles!.findById as ReturnType<typeof vi.fn>).mockImplementation(cast);
+    return ctx;
+  };
+
+  it.each([
+    ['a filename token', MALFORMED_FILE_ID],
+    ['an id lifted from chunk text', MALFORMED_FILE_ID_FROM_CHUNK_TEXT],
+  ])('%s is answered as not-found and never reaches the database', async (_label, badId) => {
+    const ctx = withCastingRepo(makeContext());
+
+    const tool = knowledgeBaseRetrieveTool.implementation(ctx, undefined);
+    const out = (await tool.toolFn({ file_id: badId })) as string;
+
+    expect(out).toContain(`No document found with ID "${badId}"`);
+    expect(out).toContain('Try using search_knowledge_base to find the correct file ID');
+    expect(ctx.db.fabfiles!.findByIdAndUserId).not.toHaveBeenCalled();
+    expect(ctx.db.fabfiles!.findById).not.toHaveBeenCalled();
+  });
+
+  it('records outcome:ok, not failed - a bad argument is a single-file miss, not a retrieval outage', async () => {
+    const ctx = withCastingRepo(makeContext());
+
+    const tool = knowledgeBaseRetrieveTool.implementation(ctx, undefined);
+    await tool.toolFn({ file_id: MALFORMED_FILE_ID });
+
+    expect(retrievalOf(ctx)).toEqual({
+      attempted: true,
+      outcome: 'ok',
+      surfaces: ['knowledgeBaseRetrieve'],
+      dataLakeTags: [],
+    });
+  });
+
+  it('answers a malformed id exactly as it answers a well-formed missing one (no existence oracle)', async () => {
+    const malformed = makeContext();
+    const missing = makeContext();
+    (missing.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (missing.db.fabfiles!.findById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const malformedOut = (await knowledgeBaseRetrieveTool
+      .implementation(malformed, undefined)
+      .toolFn({ file_id: MALFORMED_FILE_ID })) as string;
+    const missingOut = (await knowledgeBaseRetrieveTool
+      .implementation(missing, undefined)
+      .toolFn({ file_id: FILE_ID })) as string;
+
+    // Same sentence, same outcome - the only difference is the id each quotes back.
+    expect(malformedOut.replace(MALFORMED_FILE_ID, FILE_ID)).toBe(missingOut);
+    expect(retrievalOf(malformed)).toEqual(retrievalOf(missing));
+  });
+
+  it('the agent-scoped branch also stops at the shape guard, before the scope membership check', async () => {
+    const ctx = makeContext({ retrievalFilter: undefined, kbScope: { fileIds: [FILE_ID] } });
+
+    const tool = knowledgeBaseRetrieveTool.implementation(ctx, undefined);
+    const out = (await tool.toolFn({ file_id: MALFORMED_FILE_ID })) as string;
+
+    expect(out).toContain(`No document found with ID "${MALFORMED_FILE_ID}"`);
+    expect(ctx.db.fabfiles!.findById).not.toHaveBeenCalled();
+    expect(retrievalOf(ctx)).toMatchObject({ outcome: 'ok' });
+  });
+
+  it('a well-formed id is unaffected and still retrieves', async () => {
+    const ctx = makeContext();
+    (ctx.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeFile({ fileName: 'Current Protocol.pdf' })
+    );
+
+    const out = await runById(ctx);
+
+    expect(out).toContain('chunk body');
+    expect(ctx.db.fabfiles!.findByIdAndUserId).toHaveBeenCalledWith(FILE_ID, 'u1');
+  });
+
+  describe('catch backstop, for a cast that gets past the shape guard', () => {
+    it("a CastError on the MODEL's own file_id is reclassified as a miss, not an outage", async () => {
+      const ctx = makeContext();
+      (ctx.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockRejectedValue(castError(FILE_ID));
+      // `logger` is shared across this file, so clear it or a prior test satisfies the assertion.
+      (logger.error as ReturnType<typeof vi.fn>).mockClear();
+
+      const out = await runById(ctx);
+
+      expect(out).toContain(`No document found with ID "${FILE_ID}"`);
+      expect(retrievalOf(ctx)).toMatchObject({ outcome: 'ok' });
+      // Reclassified, never silenced - the throw is still logged so the rate stays greppable.
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('a CastError on a SERVER-side id still reports failed', async () => {
+      const ctx = makeContext();
+      (ctx.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockRejectedValue(
+        castError('some-corrupt-row-id')
+      );
+
+      const out = await runById(ctx);
+
+      expect(out).toContain('An error occurred while retrieving document content');
+      expect(retrievalOf(ctx)).toMatchObject({ outcome: 'failed' });
+    });
+
+    it('a non-cast fault still reports failed', async () => {
+      const ctx = makeContext();
+      (ctx.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('db down'));
+
+      const out = await runById(ctx);
+
+      expect(out).toContain('An error occurred while retrieving document content');
+      expect(retrievalOf(ctx)).toMatchObject({ outcome: 'failed' });
+    });
+  });
+});
+
+/**
  * The two guards on the paged read that no other test reaches: the page cap, and the cursor that
  * fails to advance. Both were added with the paging and neither would fail if it were deleted.
  */
@@ -989,12 +1138,12 @@ describe('retrieve_knowledge_content untrusted-content delimiter (#1659)', () =>
    */
   it('heads the document with its date, and omits the clause when it has none', async () => {
     const dated = await runById(retrievableCtx('body', { createdAt: new Date('2026-08-14T09:30:00.000Z') }));
-    expect(dated).toContain('### Handbook.pdf (ID: file-1) - dated 2026-08-14');
+    expect(dated).toContain(`### Handbook.pdf (ID: ${FILE_ID}) - dated 2026-08-14`);
     // The suffix must not create a second header or defang ours.
     expect(dated.match(/^### /gm)).toHaveLength(1);
 
     const undated = await runById(retrievableCtx('body'));
-    expect(undated).toContain('### Handbook.pdf (ID: file-1)\n');
+    expect(undated).toContain(`### Handbook.pdf (ID: ${FILE_ID})\n`);
     expect(undated).not.toContain(' - dated');
   });
 

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.ts
@@ -1,3 +1,5 @@
+import { isObjectIdOrHexString } from 'mongoose';
+
 import { ToolDefinition } from '../../base/types';
 import { CitableSource, IFabFileDocument } from '@bike4mind/common';
 import { filterRetrievalExcluded, isRetrievalExcluded } from '@bike4mind/utils/retrievalExclusion';
@@ -149,6 +151,29 @@ export const knowledgeBaseRetrieveTool: ToolDefinition = {
 
           // Path A: direct file_id lookup
           if (file_id) {
+            // The model composes this id from conversation text, so it is routinely not an id at
+            // all - a filename token, an arXiv number. Mongoose casts `_id` and throws a CastError
+            // on those, and the catch below would then report a bad tool argument as a retrieval
+            // OUTAGE. Check the shape first and answer it as the single-file miss it is: same
+            // message and same 'ok' outcome as an out-of-scope or genuinely-missing id, which also
+            // tightens the existence-oracle invariant the branches below are careful about -
+            // "not even well-formed" is no longer distinguishable from "not found".
+            // `isObjectIdOrHexString`, not `isValidObjectId`: tool args are cast from JSON without
+            // validation, so a model that emits a bare number gives us a runtime number despite the
+            // `string` type - and `isValidObjectId` accepts one, casting it to a fabricated id.
+            // Same choice, same reason, as usableObjectIds in @bike4mind/db-core.
+            if (!isObjectIdOrHexString(file_id)) {
+              context.logger.log('📖 Knowledge Retrieve: file_id is not an ObjectId, answering as not-found', {
+                file_id,
+              });
+              await context.statusUpdate({
+                promptMeta: {
+                  retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseRetrieve'], dataLakeTags: [] },
+                },
+              } as any);
+              return notFoundMsg(file_id);
+            }
+
             if (scope) {
               // Positive membership assertion BEFORE any DB lookup: an out-of-scope id never
               // touches the database, and the owner/shared access machinery below (including
@@ -611,12 +636,26 @@ export const knowledgeBaseRetrieveTool: ToolDefinition = {
           return prependRetrievedLakePrompts(context, result, datalakeTags, injectedLakeTags);
         } catch (error) {
           context.logger.error('❌ Knowledge Retrieve: Error during retrieval:', error);
+          // Backstop for the shape guard above, so the classification survives a future code path
+          // that hands another model-supplied id to Mongoose: a cast failure ON THE MODEL'S OWN
+          // file_id is a bad argument, not an outage, and must not spend the one telemetry field
+          // operators would page on. Matched by `value` rather than by name alone so a cast of a
+          // SERVER-side id (a corrupt row, a chunk read) still reports `failed`. Either way the
+          // throw is logged above, so both stay greppable.
+          const cast = error as { name?: string; value?: unknown };
+          const malformedFileId = file_id !== undefined && cast?.name === 'CastError' && cast.value === file_id;
           // A retrieval that threw must not be byte-identical to one never attempted (#1867).
           await context.statusUpdate({
             promptMeta: {
-              retrieval: { attempted: true, outcome: 'failed', surfaces: ['knowledgeBaseRetrieve'], dataLakeTags: [] },
+              retrieval: {
+                attempted: true,
+                outcome: malformedFileId ? 'ok' : 'failed',
+                surfaces: ['knowledgeBaseRetrieve'],
+                dataLakeTags: [],
+              },
             },
           } as any);
+          if (malformedFileId) return notFoundMsg(file_id);
           return 'An error occurred while retrieving document content. Please try again.';
         }
       },
@@ -630,7 +669,7 @@ export const knowledgeBaseRetrieveTool: ToolDefinition = {
             file_id: {
               type: 'string',
               description:
-                'The file ID to retrieve (from search_knowledge_base results). Most efficient for single-document retrieval.',
+                'The file ID to retrieve: the 24-character hex id shown as "(ID: ...)" in search_knowledge_base results. Not a filename, a title, or any identifier appearing in document text. Most efficient for single-document retrieval.',
             },
             tags: {
               type: 'array',

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.ts
@@ -1,6 +1,5 @@
-import { isObjectIdOrHexString } from 'mongoose';
-
 import { ToolDefinition } from '../../base/types';
+import { isObjectIdShaped } from '../../base/objectId';
 import { CitableSource, IFabFileDocument } from '@bike4mind/common';
 import { filterRetrievalExcluded, isRetrievalExcluded } from '@bike4mind/utils/retrievalExclusion';
 import { normalizeId } from '@bike4mind/utils/normalizeId';
@@ -158,11 +157,7 @@ export const knowledgeBaseRetrieveTool: ToolDefinition = {
             // message and same 'ok' outcome as an out-of-scope or genuinely-missing id, which also
             // tightens the existence-oracle invariant the branches below are careful about -
             // "not even well-formed" is no longer distinguishable from "not found".
-            // `isObjectIdOrHexString`, not `isValidObjectId`: tool args are cast from JSON without
-            // validation, so a model that emits a bare number gives us a runtime number despite the
-            // `string` type - and `isValidObjectId` accepts one, casting it to a fabricated id.
-            // Same choice, same reason, as usableObjectIds in @bike4mind/db-core.
-            if (!isObjectIdOrHexString(file_id)) {
+            if (!isObjectIdShaped(file_id)) {
               context.logger.log('📖 Knowledge Retrieve: file_id is not an ObjectId, answering as not-found', {
                 file_id,
               });


### PR DESCRIPTION
## Description

On production, 16 of the 40 `retrieve_knowledge_content` invocations since 2026-09-01 threw and were recorded as `retrieval.outcome: 'failed'` - a reported 39% outage rate on a surface that was not out.

Every one is the same thing: the model passes a `file_id` that is not an ObjectId, Mongoose raises a `CastError` on the `_id` cast, and the generic `catch` turns a malformed tool argument into a reported retrieval outage. The model then gets back `"An error occurred while retrieving document content. Please try again."` - an invitation to retry the same bad id - instead of the correction it needs.

That misclassification matters beyond the crash. `RetrievalSummarySchema` documents `'failed'` as *"recall did not complete: it threw, OR the retrieval repository is not wired on this host"*. Both readings are outage-class. A model passing a badly-shaped argument is neither, and `failed` outranks `ok` in the per-turn merge, so one arm's crash relabels the whole turn - which is why the 16 `knowledgeBaseSearch` failures in the same window are the *same* 16 turns.

Verified: `w7154539641`, `w7154539550` and `w7159734520` each match exactly one real `fabfiles` document by filename suffix. These were live corpus documents the model was correctly trying to read; `prettyFileName` strips the extension and turns `[-_]+` into spaces, so `2026_<author>_<title>_w7154539641.pdf` renders with that trailing token as the only id-shaped string in the model's view. A rarer variant is an identifier lifted from chunk text (an arXiv id arrived as `"2506 07866"`, its dot mangled to a space).

Guarding one tool made it obvious the same parameter was unguarded in `edit_file`, and chasing
that turned up something worse, which this PR also fixes: **`edit_file` has never worked.** Its
lookup reads `(context.db as any).fabFiles?.findById(fileId)`, and no host that can reach the
tool populates `fabFiles` - the declared property is `fabfiles`. The cast defeated the compiler,
`?.` swallowed the miss, and every call returned `File with ID <id> not found`, including calls
naming a real document. Verified live: a genuine `fabfiles._id` gets the same "not found" as a
made-up one. It is a one-word fix, and it is what makes the guard above load-bearing rather than
decorative.

The correct response already existed a few lines up. `notFoundMsg(id)` says *"...Try using search_knowledge_base to find the correct file ID."* - exactly the guidance an uncastable id should get, and already what a **well-formed but missing** id gets. A malformed id was being treated worse than a missing one.

## Changes

- **One shared shape check** (`tools/base/objectId.ts`). `isObjectIdShaped` wraps Mongoose's own
  `isObjectIdOrHexString`, which is the predicate that decides whether the `_id` cast will throw.
  Its truth table is pinned in `objectId.test.ts` rather than left to a regex each caller re-derives.
- **Shape-check `file_id` before any lookup** (`knowledgeBaseRetrieve/index.ts`). A non-ObjectId returns the existing `notFoundMsg(file_id)` and records `outcome: 'ok'`, matching the single-file-miss precedent already set for the out-of-scope branch. It also tightens the existence-oracle invariant the surrounding code is careful about: "not even well-formed" and "not found" no longer return different strings.
- **Narrow the catch.** A `CastError` whose `value` is the model's own `file_id` is reclassified the same way; anything else - including a cast of a *server*-side id - still reports `failed`. This is a backstop so the classification survives a future path that hands another model-supplied id to Mongoose, not the primary fix.
- **Revive `edit_file`, which has never once edited a file.** Its lookup read
  `(context.db as any).fabFiles?.findById(fileId)`. No host that can reach this tool populates
  `fabFiles` - `ToolContext['db']` declares the repo as **`fabfiles`**, lowercase, and the chat,
  Slack, agent-executor and embed paths all wire it that way. The `as any` silenced the compiler
  and `?.` silenced the miss, so the read produced `undefined` and *every* call - including one
  naming a real row - fell through to `File with ID <id> not found`. The cast is gone and the
  property is spelled the way the type declares it, so the compiler checks it from here on.
- **The same shape guard in `edit_file`.** With the lookup repaired, a model-composed `fileId`
  (`z.string()`, no constraint) genuinely reaches Mongoose's `_id` cast for the first time, so it
  gets the same guard, and the same not-found answer a well-formed-but-missing id gets.
- **Authorize that lookup, because reviving it is what makes authorization necessary.** `findById`
  matches on `_id` alone, so a repaired-but-bare read would go from "always undefined" to
  "resolves any row in the collection" and hand its full text back to the model as
  `result.original`. The read is `findByIdAndUserId(fileId, context.userId)` - the same one
  `knowledgeBaseRetrieve` reaches for first, `findOne({ _id: id, userId })` underneath. A row the
  caller does not own answers exactly as a nonexistent one does, so the existence-oracle property
  this PR is already careful about holds on the ownership axis too. Not widened to shared or
  lake-visible files: that would mean mirroring retrieval's tag, prefix, membership, share and
  group verification, which is its own change.
- **Refuse `edit_file` outright under `kbScope`.** `ToolContext.kbScope` carries the invariant that
  any tool reading `db.fabfiles` must reject or restrict to `scope.fileIds` (`base/types.ts:183`).
  Before this PR the read was dead, so `edit_file` was not really in that set; it is now. Reject
  rather than restrict: a curated scope is a set of files an agent owner chose for an audience to
  *read*, and there is no reading of that which also grants a rewrite. Refused even for an id
  inside the scope, and before any DB call.
- **Throw on an unwired `fabfiles` repo instead of `?.`-ing into not-found.** The handle is
  optional on `ToolContext['db']`, so keeping `?.` would leave a wiring fault reported to the
  model as a missing row - the exact indistinguishability that let the dead lookup survive this
  tool's whole lifetime. Fixing the spelling closes this instance; failing loudly closes the class.
- **Collapse `imageEdit`'s two hand-rolled `/^[0-9a-fA-F]{24}$/` checks onto the helper.** Proven
  behaviour-preserving by executing both over the enumeration below (0 disagreements); the test
  pins that equivalence so the collapse cannot silently drift.
- **Tighten the `file_id` tool-schema description** to name the shape and where to find it, so the model stops reaching for filename tokens.
- **Keep the `RetrievalSummarySchema` JSDoc true** - it is what an operator reads to decide whether `failed` is worth paging on.
- Tests: the `knowledgeBaseRetrieve` fixture id was `'file-1'`, which is why no test ever exercised the real cast. It is now ObjectId-shaped, and the new repository double throws a `CastError` on a non-ObjectId the way Mongoose actually does. `editFile/abortSignal.test.ts` needed the same fixture correction for the same reason, and its mocks (plus `malformedFileId.test.ts`'s) now stand in for `findByIdAndUserId` so they exercise the scoped read rather than the unscoped one. `editFile/access.test.ts` is new and pins the three properties above, including the ownership-axis existence-oracle equality.

`isObjectIdOrHexString`, not `isValidObjectId`: tool args are cast from JSON without validation, so a model emitting a bare number hands us a runtime number despite the `string` type, and `isValidObjectId` accepts one and casts it to a fabricated id.

**Not in this PR, deliberately:** `lattice/index.ts` has a third copy of the check as
`/^[a-f0-9]{24}$/` - lowercase-only, so it rejects uppercase hex that Mongo accepts. It gates a
"persist if the model is persisted" branch that silently skips on failure, so collapsing it onto
the helper *widens* that branch. That is a real behaviour change to a tool this PR does not
otherwise touch; filed separately.

**Also not in this PR:** the original issue asked for the file id to be emitted in `formatSemanticResults`. That already shipped - `knowledgeBaseSearch/index.ts:129` now renders `**Name** (ID: ..., relevance ...)` as a side effect of #2458.

### Behaviour table (executed, not reasoned about)

No input class that worked before is rejected now. Every id the guard turns away was already a `CastError` on the base branch:

| `file_id` | before | after |
|---|---|---|
| 24-hex, any case | lookup runs | lookup runs (unchanged) |
| `w7154539641` (filename token) | CastError -> `failed` | not-found -> `ok` |
| `2506 07866` (from chunk text) | CastError -> `failed` | not-found -> `ok` |
| 23-hex / 25-hex / non-hex / padded | CastError -> `failed` | not-found -> `ok` |
| 12-char string, bare number | CastError -> `failed` | not-found -> `ok` |

Also confirmed the guard cannot reject a legitimately servable id: `FabFile` uses the default ObjectId `_id`, and the only production construction site for `kbScope.fileIds` (`embedRoute.ts:273`) stores resolved `FabFile._id.toString()` values that already passed through `usableObjectIds`.

## Guide for Testers

This is a backend LLM-tool change with no UI surface, but the fixed path **is** reachable from the chat box - you just have to ask the model for the bad id directly, since it will otherwise use the correct one now that search returns it.

**The fix itself** (on a PR preview, or `app.staging.bike4mind.com`):

1. Open a new chat in a workspace that has an active data lake, so the knowledge-base tools are offered.
2. Type exactly: `Call the retrieve_knowledge_content tool exactly once with file_id set to the literal string w7154539641 and nothing else. Do not search first. Then tell me verbatim what the tool returned.`
3. Expected: the model reports back `No document found with ID "w7154539641". The file may not exist or you may not have access to it. Try using search_knowledge_base to find the correct file ID.`
4. Expected (NOT): `An error occurred while retrieving document content. Please try again.` That is the old behaviour.
5. Repeat step 2 with `2506 07866` in place of `w7154539641` (the arXiv-shaped variant). Same expected result.

**`edit_file` - it is NOT in the chat Tools picker.** There is no `edit_file` row in
ToolsSection and agent mode denies it by default, so the only way to reach it is an API call that
names it: `POST /api/chat` with `toolMode: "smart"` and `tools: ["edit_file"]`. A bare
`enableTools: true` silently drops the `tools` array - that path ignores it.

6. Send that request with the message `Use the edit_file tool now with fileId "<a real fabfiles id you own>" and instruction "uppercase the first line". Report the tool result verbatim.`
7. Expected: an edit, with a diff. It is a **preview** - the tool returns `original` / `modified` / `diff` and writes nothing back to the row or to S3. **On main this returns `Failed to edit file: File with ID <id> not found` for every id, real or not** - so this step is the regression check that matters most here.
8. Repeat with a real `fabfiles` id belonging to **another user**. Expected: `Failed to edit file: File with ID <id> not found` - byte-identical to the answer for an id with no row at all. The lookup is owner-scoped, and a direct id probe must not reveal that someone else's file exists.
9. Repeat with `fileId` set to the literal string `Handbook.pdf`. Expected: `Failed to edit file: File with ID Handbook.pdf not found`, and specifically NOT anything containing `Cast to ObjectId failed for value` - which is what the repaired lookup would otherwise now produce.
10. Send the same request as an **agent with a curated knowledge-base scope** (kbScope), naming a file that IS inside that scope. Expected: `Failed to edit file: edit_file is not available in a knowledge-base-scoped session`. In-scope or not, the tool refuses there.

**Regression checks** - a real id must still work:

11. In the same chat, ask a question whose answer is in one of the lake's documents, e.g. `What does the Q3 market overview say?`
12. Expected: a grounded answer with document citations. No error text, and specifically not `An error occurred while retrieving document content`.
13. Note the id the model cites in its search results - it appears as `(ID: <24 hex chars>)`. Ask: `Use retrieve_knowledge_content on file_id <that id> and quote one sentence.`
14. Expected: the model returns real document content, not a not-found message.
15. Repeat steps 11-14 with an **agent** that has a curated knowledge-base scope (kbScope), to cover the scoped branch.
16. Expected: identical behaviour - the agent answers from its curated files only.
17. Generate or edit an image via `image_edit` on a real attached image. Expected: unchanged - this PR only swaps its regex for the equivalent helper.

**Observability check** (for whoever has prod/staging Mongo access, after this deploys):

18. Query `quests.promptMeta.retrieval` for `surfaces: 'knowledgeBaseRetrieve'`, `attempted: true`.
19. Expected: `outcome: 'failed'` stops appearing for malformed-argument turns. It should still appear if the retrieval repository is genuinely unwired or the DB is down.
20. The malformed-id rate is now in the logs instead - grep CloudWatch for `file_id is not an ObjectId`.

**What NOT to test:**

- No UI, no styling, no admin settings, no migration, no new env var, no new AdminSettings key.
- **Do expect `edit_file` to behave differently.** It goes from "always fails" to "works on a file
  you own", which is the point, but it means the tool now really fetches file bytes, calls an LLM
  and spends credits when invoked. It still writes nothing back - the result is a preview. Its
  reach is narrow - no Tools-picker row, denied by default in agent mode - so the only callers are
  API requests that name it explicitly.
- No change to what documents are **retrievable** or who can retrieve them: the knowledge tools' access control, retrieval exclusion, sharing and lake membership are all untouched. `edit_file` is the one surface whose reachable set moves, and it moves from "nothing, for anyone" to "files you own" - narrower than the bare `findById` that repairing the lookup would otherwise have exposed.
- No behaviour change in `image_edit`. Its regex and the helper were executed over the same 13 input classes and agreed on every one; the swap is a de-duplication, not a fix.
- Do not expect the model to reach for a bad id on its own any more. Since #2458 the search results carry `(ID: <the real id>)`, so the natural trigger is now rare - which is why step 2 asks for it explicitly.

## Additional Information

Verification run: `pnpm turbo:typecheck`, `pnpm --filter @bike4mind/services test`, `pnpm --filter @bike4mind/common test`, `pnpm lint:check`, and both ASCII guard scripts.

The new tests were confirmed load-bearing by reverting the source and re-running: 4 fail in `knowledgeBaseRetrieve` without its guard, and reverting `editFile/index.ts` fails 9 of that tool's 14 tests, including all three access ones (foreign row, `kbScope` refusal, unwired repo). Two of the `knowledgeBaseRetrieve` tests (the scoped branch, the existence-oracle equality) pass on base as well - they are characterization pins, not proofs of the fix, and are labelled as such.

### Verified live, not just in unit tests

Run end to end on a local self-host stack (Docker mongo/minio/sqs/ws + the app from this branch), driving real `sonnet-5` turns through `POST /api/chat` against an active data lake. Same session, same prompt, only the build differs:

| build | tool returned | `promptMeta.retrieval.outcome` |
|---|---|---|
| base `6d818a246` | `An error occurred while retrieving document content. Please try again.` | `failed` |
| this branch | `No document found with ID "w7154539641". ... Try using search_knowledge_base to find the correct file ID.` | `ok` |

The base run logged the exact production stack - `CastError: Cast to ObjectId failed for value "w7154539641" (type string) at path "_id"` followed by `Knowledge Retrieve: Error during retrieval`. On this branch that throw is gone and the guard's own line appears instead, which is what keeps the rate greppable now that it no longer lands in `outcome`.

`edit_file` on the same stack, driven through `POST /api/chat` with `tools: ["edit_file"]`:

| `fileId` | base `6d818a246` | this branch |
|---|---|---|
| `6a9f8af00f29d493e54cbdc5` (a real `fabfiles` row) | `Failed to edit file: File with ID ... not found` | reaches the row, then `Could not retrieve file content for editing` |
| `Handbook.pdf` (malformed) | `... not found` | `... not found` (now from the guard) |
| `68b0f3a2c1d4e5f60718293a` (well-formed, no row) | `... not found` | `... not found` |

The first row is the dead-lookup bug: on base a real, existing document is indistinguishable from
a nonexistent one. On this branch the row is found and the tool proceeds to fetch its bytes; the
fetch then fails because this stack's MinIO object URL answers 403 to an unsigned GET (confirmed
with a direct `curl`), which is a fixture limitation rather than tool behaviour - the point is
that execution got past the lookup at all. The other two rows are the existence-oracle property:
malformed and missing stay indistinguishable.

That live run predates the ownership scoping and has **not** been repeated against it - the row it
used belonged to the driving user, so the observed path is the one that still runs today, but
"another user's row answers as not-found" and the `kbScope` refusal are pinned in unit tests only
so far. Steps 8 and 10 of the tester guide are exactly those two cases.

Also verified live on this branch:

- the arXiv-shaped variant `2506 07866` - same not-found answer, `outcome: 'ok'`;
- a **well-formed** id (`6a8449e55e2cf87e4c3b5335`) still retrieves: `Retrieved content from 1 of 1 document(s)`, `outcome: 'ok'`, `surfaces: ['knowledgeBaseRetrieve']` - the guard does not block real ids;
- `search_knowledge_base` renders `**Name** (ID: <ObjectId>, relevance ...)` in the model's actual view, confirming #2458 already covers the "emit the id" half of the original issue.

One follow-up found while tracing this and left out on purpose: `lattice/index.ts:399`,
`:536` and `:675` all use `/^[a-f0-9]{24}$/`. Swapping it for the helper would accept
uppercase hex that the regex currently rejects, which changes which branch a silent-skip
persistence path takes. Filed rather than folded in.

## Developer Notes (Optional)

- **The telemetry invariant is now structural, not incidental.** `outcome: 'failed'` means "an operator has something to fix". A bad model argument is not that. The catch discriminates on the `CastError`'s `value` rather than on its name, so the property holds even if a future path forgets the up-front guard - and a cast of a server-side id still reports `failed`, which is the case that would otherwise get quietly swallowed by a name-only check.
- **Reviving a dead code path is a security change, not a bug fix.** The `fabFiles` typo meant no
  caller had ever reached the row, so the tool had never needed an access check and did not have
  one; correcting one word would have shipped an unauthenticated read of any `fabfiles` row by id.
  The lesson generalises past this tool: when a lookup has never resolved, the authorization it is
  missing is invisible in every test, log and prod trace, because nothing downstream of it has run.
- **The `edit_file` tests were pinned to the bug, not the behaviour.** Its four pre-existing
  `abortSignal` tests mocked `db: { fabFiles: ... }` - the same misspelling as the source - so
  they exercised, and protected, a lookup that could never resolve against a real host. Reverting
  just the property name now fails five tests. A mock that mirrors the code instead of the
  contract is not a test; the compiler could not catch it either, because the `as any` was there.
- **Fixture realism is the actual lesson.** A `'file-1'` id sailed through 80-odd tests because the mocked repository returned `undefined` where the real one throws - and `editFile`'s `'f1'` did the same. Any fixture standing in for something Mongoose casts should be shaped like the real value, or the test cannot see the failure mode it exists to catch. Both fixtures are now ObjectId-shaped.
- **Why a helper rather than three regexes.** The check is a classifier over caller-controlled input, so the thing worth owning is the enumeration, not the expression. `objectId.test.ts` holds the table; a future caller gets the settled boundary instead of re-deriving one that is subtly narrower (which is exactly what `lattice`'s lowercase-only copy is).

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI surface
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - the `RetrievalSummarySchema` JSDoc, which is the doc for this field
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification - no field added or removed; the classification doc does not enumerate `retrieval.outcome` values, and the schema JSDoc that does is updated

Closes #2530

