### PR TITLE
feat(services): suppress knowledge auto-offers without entering a prompt mode

### DIFF
--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -388,6 +388,7 @@ function transformToInternalFormat(
     },
     enableArtifacts: false,
     ...(request.promptMode ? { promptMode: request.promptMode } : {}),
+    ...(request.skip_auto_offers ? { skipAutoOffers: true } : {}),
     includeSystemPrompt: request.includeSystemPrompt,
     ...(request.systemPrompt ? { systemPrompt: request.systemPrompt } : {}),
     ...(isToolsEnabled

--- a/apps/client/public/openapi.json
+++ b/apps/client/public/openapi.json
@@ -246,7 +246,7 @@
           },
           "skip_auto_offers": {
             "type": "boolean",
-            "description": "Suppress tools the server would otherwise attach on its own for this session (the knowledge-base search offer, and in-app view navigation). Tools you request explicitly are unaffected, as is the system-prompt content. This does not switch off retrieval: a session with forced knowledge retrieval still retrieves, and documents already attached to the session are still placed in the prompt directly. Any promptMode suppresses these too, so false has no effect alongside one."
+            "description": "Suppress tools the server would otherwise attach on its own for this session (the knowledge-base search offer, in-app view navigation, blog drafting/editing/publishing, and skill invocation). Tools you request explicitly are unaffected. One system-prompt block goes with them: withholding in-app view navigation also drops the view-registry block that exists only to describe it. No other prompt content changes. This does not switch off retrieval: a session with forced knowledge retrieval still retrieves, and documents already attached to the session are still placed in the prompt directly. Any promptMode suppresses these too, so false has no effect alongside one."
           },
           "includePromptDetails": {
             "type": "boolean"

--- a/apps/client/public/openapi.json
+++ b/apps/client/public/openapi.json
@@ -244,6 +244,10 @@
               "surface"
             ]
           },
+          "skip_auto_offers": {
+            "type": "boolean",
+            "description": "Suppress tools the server would otherwise attach on its own for this session (the knowledge-base search offer, and in-app view navigation). Tools you request explicitly are unaffected, as is the system-prompt content. This does not switch off retrieval: a session with forced knowledge retrieval still retrieves, and documents already attached to the session are still placed in the prompt directly. Any promptMode suppresses these too, so false has no effect alongside one."
+          },
           "includePromptDetails": {
             "type": "boolean"
           },

--- a/b4m-core/common/src/llm.ts
+++ b/b4m-core/common/src/llm.ts
@@ -223,6 +223,21 @@ export const ChatCompletionInvokeParamsSchema = z.object({
    */
   promptMode: z.enum(['raw', 'grounded', 'surface']).optional(),
   /**
+   * Suppress OUR server-side auto-offers without entering a promptMode. Exists because promptMode
+   * was the only switch for the offer and it also strips every authored prompt, so no caller could
+   * have an arm that went unoffered AND kept the abstention licence.
+   *
+   * Gates the three auto-add sites listed in AUTO_ADDED_TOOL_NAMES (the knowledge offer, the
+   * navigate_view auto-add, the blog/skill gate), unioned with `Boolean(promptMode)` by
+   * resolveSkipAutoOffers. A force-on, not an override: `false` under a promptMode still suppresses.
+   * Withholding navigate_view also drops the viewRegistry system block, which only describes it.
+   *
+   * Withholds the OFFER, not knowledge: `session.forceKnowledgeRetrieval` is untouched, and an
+   * already-attached corpus is inlined rather than deferred to the tool. An arm that must see no
+   * knowledge at all also needs a session with no attachments and forced retrieval off.
+   */
+  skipAutoOffers: z.boolean().optional(),
+  /**
    * Caller-supplied system-prompt text. Rendered as a defended, deference-postured block
    * appended last in the system-prompt stack. Reached by both POST /api/chat and /api/ai/llm.
    *

--- a/b4m-core/common/src/llm.ts
+++ b/b4m-core/common/src/llm.ts
@@ -227,8 +227,8 @@ export const ChatCompletionInvokeParamsSchema = z.object({
    * was the only switch for the offer and it also strips every authored prompt, so no caller could
    * have an arm that went unoffered AND kept the abstention licence.
    *
-   * Gates the three auto-add sites listed in AUTO_ADDED_TOOL_NAMES (the knowledge offer, the
-   * navigate_view auto-add, the blog/skill gate), unioned with `Boolean(promptMode)` by
+   * Gates the three auto-add sites (the knowledge offer in resolveEnabledTools, the navigate_view
+   * auto-add, the blog/skill gate), unioned with `Boolean(promptMode)` by
    * resolveSkipAutoOffers. A force-on, not an override: `false` under a promptMode still suppresses.
    * Withholding navigate_view also drops the viewRegistry system block, which only describes it.
    *

--- a/b4m-core/common/src/schemas/chat.ts
+++ b/b4m-core/common/src/schemas/chat.ts
@@ -86,11 +86,13 @@ export const SimplifiedChatRequestSchema = z.object({
     .optional()
     .describe(
       'Suppress tools the server would otherwise attach on its own for this session (the ' +
-        'knowledge-base search offer, and in-app view navigation). Tools you request explicitly ' +
-        'are unaffected, as is the system-prompt content. This does not switch off retrieval: a ' +
-        'session with forced knowledge retrieval still retrieves, and documents already attached ' +
-        'to the session are still placed in the prompt directly. Any promptMode suppresses these ' +
-        'too, so false has no effect alongside one.'
+        'knowledge-base search offer, in-app view navigation, blog drafting/editing/publishing, ' +
+        'and skill invocation). Tools you request explicitly are unaffected. One system-prompt ' +
+        'block goes with them: withholding in-app view navigation also drops the view-registry ' +
+        'block that exists only to describe it. No other prompt content changes. This does not ' +
+        'switch off retrieval: a session with forced knowledge retrieval still retrieves, and ' +
+        'documents already attached to the session are still placed in the prompt directly. Any ' +
+        'promptMode suppresses these too, so false has no effect alongside one.'
     ),
   // With wait, also return the per-source system prompt breakdown the completion was
   // assembled from (promptDetails), so callers can verify what fed the model instead of

--- a/b4m-core/common/src/schemas/chat.ts
+++ b/b4m-core/common/src/schemas/chat.ts
@@ -78,6 +78,20 @@ export const SimplifiedChatRequestSchema = z.object({
   // 'grounded' adds data-lake retrieval only; 'surface' adds the org/session prompts on top.
   // Retrieval itself comes from the session (forceKnowledgeRetrieval), not from this flag.
   promptMode: z.enum(['raw', 'grounded', 'surface']).optional(),
+  // Wire spelling is snake_case per api-contract/CONVENTIONS.md; transformToInternalFormat maps it
+  // to the camelCase `skipAutoOffers` of the flag it feeds. Exists so the offer can be suppressed
+  // WITHOUT a promptMode, which also strips every authored prompt including the abstention licence.
+  skip_auto_offers: z
+    .boolean()
+    .optional()
+    .describe(
+      'Suppress tools the server would otherwise attach on its own for this session (the ' +
+        'knowledge-base search offer, and in-app view navigation). Tools you request explicitly ' +
+        'are unaffected, as is the system-prompt content. This does not switch off retrieval: a ' +
+        'session with forced knowledge retrieval still retrieves, and documents already attached ' +
+        'to the session are still placed in the prompt directly. Any promptMode suppresses these ' +
+        'too, so false has no effect alongside one.'
+    ),
   // With wait, also return the per-source system prompt breakdown the completion was
   // assembled from (promptDetails), so callers can verify what fed the model instead of
   // inferring it from behavior.

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -3061,12 +3061,13 @@ describe('ChatCompletionProcess', () => {
         expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringMatching(/search_knowledge_base is not offered/));
       });
 
-      // The gap this field routes around. Both modes are pinned, for opposite reasons: `raw` must
-      // never admit the licence (an admin prompt would invalidate the bare-model arm it exists to
+      // The gap this field routes around. The list is every PromptMode, so a fourth one cannot be
+      // added without deciding this, but raw and surface are the interesting ends: `raw` must never
+      // admit the licence (an admin prompt would invalidate the bare-model arm it exists to
       // provide), whereas `surface` claims no such bareness and dropping a safety counterweight
       // there is arguable - so if PROMPT_MODE_SOURCES.surface ever admits `abstention`, that is a
       // deliberate decision and this test is where it surfaces.
-      it.each(['raw', 'surface'] as const)(
+      it.each(['raw', 'grounded', 'surface'] as const)(
         'promptMode %s strips the licence along with every other authored prompt',
         async mode => {
           const { contextAndSystemMessages } = await runKnowledgeGatingCase({

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -1263,6 +1263,33 @@ describe('ChatCompletionProcess', () => {
         }
       });
 
+      // Third auto-add site (see AUTO_ADDED_TOOL_NAMES). It keyed on promptMode alone until the
+      // skipAutoOffers field existed, so a caller suppressing our offers WITHOUT a mode still got
+      // blog_draft, and with it the tool-use preamble the suppression exists to keep out. Same
+      // admin user and same message as the test above, so the flag is the only difference.
+      it('withholds blog_draft under skipAutoOffers, on the very message that offers it', async () => {
+        (service as any).user.isAdmin = true;
+        try {
+          mockTextModel();
+          const body = {
+            ...startQuestParams,
+            message: 'Turn this conversation into a blog post',
+            skipAutoOffers: true,
+            tools: [],
+            projectId: undefined,
+            organizationId: undefined,
+          };
+
+          await service.process({ body, logger: mockLogger });
+          const tools = vi.mocked(mockedGetLlmByModel.mock.results[0].value.complete).mock.calls[0][2].tools;
+          expect(tools?.map((t: { toolSchema: { name: string } }) => t.toolSchema.name) ?? []).not.toContain(
+            'blog_draft'
+          );
+        } finally {
+          delete (service as any).user.isAdmin;
+        }
+      });
+
       // The no-signal path: an ordinary "Hello" carries no blog intent and continues no prior
       // blog workflow, so blog_draft is not worth its tokens on this turn.
       it('does not offer blog_draft on an ordinary message with no blog intent', async () => {
@@ -2793,8 +2820,9 @@ describe('ChatCompletionProcess', () => {
       files?: Array<Partial<{ id: string; fileName: string; vectorized: boolean; chunkCount: number }>>;
       getAccessibleFilesImpl?: () => Promise<unknown>;
       dataLakeTags?: string[];
-      promptMode?: 'raw';
+      promptMode?: 'raw' | 'grounded' | 'surface';
       requestTools?: string[];
+      skipAutoOffers?: boolean;
       fabPromptMessages?: IMessage[];
       fabFileNotices?: FabFileNotice[];
     }) => {
@@ -2860,6 +2888,7 @@ describe('ChatCompletionProcess', () => {
       const body = {
         ...startQuestParams,
         ...(opts.promptMode ? { promptMode: opts.promptMode } : {}),
+        ...(opts.skipAutoOffers ? { skipAutoOffers: true } : {}),
         tools: opts.requestTools ?? [],
         projectId: undefined,
         organizationId: undefined,
@@ -3001,6 +3030,53 @@ describe('ChatCompletionProcess', () => {
       expect(enabledToolsArg).not.toContain('search_knowledge_base');
       expect(enabledToolsArg).not.toContain('retrieve_knowledge_content');
       expect(getAccessibleFiles).not.toHaveBeenCalled();
+    });
+
+    // The offer and the authored prompts used to be one switch, so both halves are asserted
+    // together: either alone still describes a control arm nobody can build. Note the attachment
+    // fixture is deliberately never read - under this flag the file lookup is skipped entirely and
+    // hasAttachedKnowledge comes from the null fail-open, which the first test pins.
+    describe('skipAutoOffers separates the offer from the prompt stack', () => {
+      const ABSTENTION_SENTINEL = 'ABSTENTION-LICENCE-SENTINEL';
+      beforeEach(() => {
+        mockedGetSettingsValue.mockImplementation(((key: string) =>
+          key === 'AbstentionPrompt' ? ABSTENTION_SENTINEL : undefined) as typeof getSettingsValue);
+      });
+      afterEach(() => {
+        mockedGetSettingsValue.mockReset();
+      });
+
+      it('withholds both knowledge tools while the abstention licence still reaches the model', async () => {
+        const { enabledToolsArg, contextAndSystemMessages, getAccessibleFiles } = await runKnowledgeGatingCase({
+          knowledgeIds: ['f1'],
+          skipAutoOffers: true,
+          files: [{ id: 'f1', fileName: 'f1.pdf', vectorized: true, chunkCount: 2 }],
+        });
+        expect(enabledToolsArg).not.toContain('search_knowledge_base');
+        expect(enabledToolsArg).not.toContain('retrieve_knowledge_content');
+        expect(contextAndSystemMessages.map(m => String(m.content)).join('\n')).toContain(ABSTENTION_SENTINEL);
+        // The attachment DB read is elided too, same as the promptMode case above.
+        expect(getAccessibleFiles).not.toHaveBeenCalled();
+        // Withholding is deliberate here, so the invisible-failure warning must stay silent.
+        expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringMatching(/search_knowledge_base is not offered/));
+      });
+
+      // The gap this field routes around. Both modes are pinned, for opposite reasons: `raw` must
+      // never admit the licence (an admin prompt would invalidate the bare-model arm it exists to
+      // provide), whereas `surface` claims no such bareness and dropping a safety counterweight
+      // there is arguable - so if PROMPT_MODE_SOURCES.surface ever admits `abstention`, that is a
+      // deliberate decision and this test is where it surfaces.
+      it.each(['raw', 'surface'] as const)(
+        'promptMode %s strips the licence along with every other authored prompt',
+        async mode => {
+          const { contextAndSystemMessages } = await runKnowledgeGatingCase({
+            knowledgeIds: ['f1'],
+            promptMode: mode,
+            files: [{ id: 'f1', fileName: 'f1.pdf', vectorized: true, chunkCount: 2 }],
+          });
+          expect(contextAndSystemMessages.map(m => String(m.content)).join('\n')).not.toContain(ABSTENTION_SENTINEL);
+        }
+      );
     });
 
     it('fails OPEN (still offers the tools) and completes the turn when the file lookup throws', async () => {

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -434,6 +434,8 @@ export const QuestStartBodySchema = z.object({
   enableArtifacts: z.boolean().optional(),
   /** See ChatCompletionInvokeParamsSchema.promptMode - must stay in sync with it. */
   promptMode: z.enum(['raw', 'grounded', 'surface']).optional(),
+  /** See ChatCompletionInvokeParamsSchema.skipAutoOffers - must stay in sync with it. */
+  skipAutoOffers: z.boolean().optional(),
   /** See ChatCompletionInvokeParamsSchema.systemPrompt - must stay in sync with it. */
   systemPrompt: z.string().max(PROMPT_TEXT_MAX).optional(),
   enableAgents: z.boolean().optional(),

--- a/b4m-core/services/src/llm/ChatCompletionInvoke.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionInvoke.test.ts
@@ -91,4 +91,27 @@ describe('ChatCompletionInvoke.invoke - session access', () => {
     const invoke = makeInvoke();
     await expect(invoke.invoke({ body, userId: EDITOR_ID })).rejects.toThrow(/Invalid model/);
   });
+
+  // questStartParams - NOT the parsed request - is what dispatchQuest ships to the async worker, so
+  // a request field missing from that literal is silently dropped on every path except `wait: true`.
+  // promptMode is asserted alongside because the two must travel together: it is the sibling that
+  // already worked, so a failure here names the asymmetry rather than just "field missing".
+  it('carries skipAutoOffers and promptMode onto questStartParams, across the async boundary', async () => {
+    mockedGetAvailableModels.mockResolvedValue([
+      { id: 'gpt-4', type: 'text', name: 'GPT-4', max_tokens: 100, contextWindow: 1000, pricing: {} },
+    ] as any);
+    mockDb.quests.create.mockResolvedValue({ id: 'quest-1', promptMeta: {} });
+    // Unset, invoke() short-circuits into an error quest before questStartParams is ever built.
+    mockDb.adminSettings.getSettingsValue.mockResolvedValue('text-embedding-ada-002');
+
+    const invoke = makeInvoke();
+    await invoke.invoke({
+      body: { ...body, skipAutoOffers: true, promptMode: 'raw' as const },
+      userId: OWNER_ID,
+    });
+
+    expect((invoke as any).questStartParams).toEqual(
+      expect.objectContaining({ skipAutoOffers: true, promptMode: 'raw' })
+    );
+  });
 });

--- a/b4m-core/services/src/llm/ChatCompletionInvoke.ts
+++ b/b4m-core/services/src/llm/ChatCompletionInvoke.ts
@@ -88,6 +88,7 @@ export class ChatCompletionInvoke {
       enableAgents,
       enableLattice,
       promptMode,
+      skipAutoOffers,
       systemPrompt,
       tools,
       projectId,
@@ -363,6 +364,10 @@ export class ChatCompletionInvoke {
         enableAgents,
         enableLattice,
         promptMode,
+        // Must be carried explicitly: this literal - not the parsed request - is what
+        // dispatchQuest ships to the async worker, so a field omitted here is silently dropped on
+        // every path except `wait: true`.
+        skipAutoOffers,
         systemPrompt,
         promptMeta: PromptMetaZodSchema.parse(quest.promptMeta),
         sessionId: session.id,

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -154,6 +154,7 @@ import {
   PROMPT_SOURCE_METADATA,
   resolveForcedRetrieval,
   SYSTEM_PROMPT_PRIORITY,
+  resolveSkipAutoOffers,
   toPromptDetails,
   type PromptSourceId,
 } from './systemPromptSources';
@@ -589,12 +590,15 @@ export interface ResolveEnabledToolsInput {
    */
   hasAccessibleDataLake?: boolean;
   /**
-   * Skip OUR server-side auto-offers (step 2, the knowledge offer). Set for any `promptMode`,
-   * matching the auto-add gate at the request-parse site (`if (!parsedBody.promptMode)`): auto-adds
-   * are our additions, not the caller's, and attaching a tool also pulls the provider's tool-use
-   * preamble into the request - so a mode-driven eval, above all `raw` (the bare-model control
-   * arm), must not get surprise tools. Caller-selected and session-forced tools are unaffected;
-   * only step 2 is gated.
+   * Skip OUR server-side auto-offers (step 2, the knowledge offer). Resolved by
+   * resolveSkipAutoOffers from either trigger - any `promptMode`, or the `skipAutoOffers` request
+   * field - and every auto-add site reads that same helper: auto-adds are our additions, not the
+   * caller's, and attaching a tool also pulls the provider's tool-use preamble into the request, so
+   * a mode-driven eval, above all `raw` (the bare-model control arm), must not get surprise tools.
+   * The request field is that same suppression without a mode, for an arm that must not be OFFERED
+   * knowledge while keeping the authored prompts a mode would strip - it withholds the tool, not
+   * knowledge (same caveat as ChatCompletionInvokeParamsSchema.skipAutoOffers). Caller-selected and
+   * session-forced tools are unaffected; only step 2 is gated.
    */
   skipAutoOffers?: boolean;
 }
@@ -1180,12 +1184,12 @@ export class ChatCompletionProcess {
     if ((skipAutoOffers || knowledgeSearchDisabled) && mode === 'retrieve') {
       this.logger.warn(
         `[dataLakes] grounding mode 'retrieve' requested but the knowledge tool is ${
-          skipAutoOffers ? 'not offered (promptMode)' : 'disabled for this session'
+          skipAutoOffers ? 'not offered (auto-offers suppressed)' : 'disabled for this session'
         }; inlining the corpus (${attachedCount} doc(s)) to avoid stranding it.`
       );
     }
-    // promptMode is an eval/passthrough surface where the tool is NOT offered - deferring there
-    // would strand the corpus with no retrieval path. Symmetric with the tool-offer gate.
+    // Whatever suppressed the offer (a promptMode, or the request field), the tool is NOT there -
+    // deferring to it would strand the corpus with no reader. Symmetric with the tool-offer gate.
     if (skipAutoOffers) return noDefer;
     // Same reasoning one step further: `session.disabledTools` wins over every other tool gate
     // (including the post-build denylist pass, which runs AFTER this plan), so deferring to a
@@ -1353,7 +1357,7 @@ export class ChatCompletionProcess {
     // intent-or-continuation check needs the fetched history; `skill` needs the invocable-skill
     // catalog SkillsFeature populates later) - see the conditional auto-add in process(), after
     // previous messages are fetched and the feature loop has run.
-    if (!parsedBody.promptMode) {
+    if (!resolveSkipAutoOffers(parsedBody)) {
       if (!enabledTools.includes('navigate_view') && shouldAutoEnableNavigateView(parsedBody.extraContextMessages)) {
         finalEnabledTools.push('navigate_view');
       }
@@ -1700,8 +1704,11 @@ export class ChatCompletionProcess {
       this.turnPreauthorizedLakeIds = vetPreauthorizedLakeIds(session, this.user.id);
 
       const hasAnyAttachment = (session.knowledgeIds?.length ?? 0) > 0;
-      // Any promptMode is an eval/passthrough that must not receive our server-side offers.
-      const skipAutoOffers = Boolean(promptMode);
+      // Withholds OUR auto-offers, via a promptMode or the caller's request field - see
+      // resolveSkipAutoOffers. Every gate after this point reads this local rather than re-deriving
+      // the rule; the one site that cannot is the navigate_view auto-add, which runs in
+      // initializeProcessContext before this exists and so calls the same helper directly.
+      const skipAutoOffers = resolveSkipAutoOffers(parsedBody);
       // Kicked off here (not awaited yet) so its DB read overlaps with the models/admin-settings
       // fetch below instead of serializing in front of it - folded into that Promise.all.
       //
@@ -2308,7 +2315,7 @@ export class ChatCompletionProcess {
       // tool list (below, near buildTools) already strips any session-forbidden tool regardless
       // of when it was added to enabledTools.
       let hasContentTransform = false;
-      if (!promptMode) {
+      if (!skipAutoOffers) {
         const blogGates = shouldOfferBlogTools({
           isAdmin: this.user.isAdmin,
           hasBlogIntegration: Boolean(this.user.blogIntegration),
@@ -2444,7 +2451,8 @@ export class ChatCompletionProcess {
       // Once the knowledge tools are offered (above), stop ALSO force-inlining a large retrievable
       // corpus - the even-split inline goes breadth-shallow and the tool can fetch the relevant
       // docs on demand. Off by default; defers only the tool-retrievable subset. `skipAutoOffers`
-      // mirrors the tool-offer gate (the tool isn't offered under promptMode, so we don't defer).
+      // mirrors the tool-offer gate (the tool isn't offered when it is set, so we don't defer -
+      // the corpus is inlined instead, which is why suppressing the offer is not "no knowledge").
       const corpusInlinePlan = await this.resolveCorpusInlinePlan({
         sessionKnowledgeIds: session.knowledgeIds ?? [],
         attachedFileTokenBudget,
@@ -2749,7 +2757,7 @@ export class ChatCompletionProcess {
       // this is the authoritative post-build list - it sees the post-build denylist pass, the
       // Ollama auto-added trim, and tools injected inside buildTools, none of which the pre-build
       // enabledTools filter can. Skipped under promptMode, where withholding the offer is
-      // deliberate (see skipAutoOffers), not a failure. Silent otherwise means the model answers
+      // deliberate (auto-offers suppressed, see resolveSkipAutoOffers), not a failure. Silent otherwise means the model answers
       // from its weights while the user believes their knowledge was consulted.
       // The lake signal is held to a stricter bar than attached documents. The warning speaks to a
       // user belief that their knowledge was consulted, and attaching documents creates that belief
@@ -2760,7 +2768,7 @@ export class ChatCompletionProcess {
       const knowledgeToolWithheldByConfig =
         (Array.isArray(session.disabledTools) && session.disabledTools.includes('search_knowledge_base')) ||
         offeredToolNames.length === 0;
-      if ((hasAttachedKnowledge || (hasAccessibleDataLake && !knowledgeToolWithheldByConfig)) && !promptMode) {
+      if ((hasAttachedKnowledge || (hasAccessibleDataLake && !knowledgeToolWithheldByConfig)) && !skipAutoOffers) {
         const source = hasAttachedKnowledge
           ? `${session.knowledgeIds!.length} attached document(s)`
           : 'an accessible data lake';

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -611,8 +611,9 @@ export interface ResolveEnabledToolsInput {
  *      knowledge: documents attached to THIS session (hasAttachedKnowledge) OR a data lake they
  *      can reach (hasAccessibleDataLake). Attaching files / having a lake is a far stronger
  *      retrieval signal than any phrase match, and offering a tool is cheap (the model may
- *      decline) whereas withholding it is unrecoverable. Skipped when `skipAutoOffers` is set
- *      (prompt-mode requests), since the offer is our addition, not the caller's.
+ *      decline) whereas withholding it is unrecoverable. Skipped when `skipAutoOffers` is set -
+ *      by a promptMode or by the caller's own request field, see resolveSkipAutoOffers - since the
+ *      offer is our addition, not the caller's.
  *   3. companion pairing        - a tool useless without its partner rides along
  *      (search_knowledge_base -> retrieve_knowledge_content, image_generation ->
  *      edit_image). Runs AFTER the union/offer so session-forced and auto-offered tools
@@ -2756,9 +2757,10 @@ export class ChatCompletionProcess {
       // offered set. Checked here against offeredToolNames (not at resolveEnabledTools) because
       // this is the authoritative post-build list - it sees the post-build denylist pass, the
       // Ollama auto-added trim, and tools injected inside buildTools, none of which the pre-build
-      // enabledTools filter can. Skipped under promptMode, where withholding the offer is
-      // deliberate (auto-offers suppressed, see resolveSkipAutoOffers), not a failure. Silent otherwise means the model answers
-      // from its weights while the user believes their knowledge was consulted.
+      // enabledTools filter can. Skipped whenever auto-offers are suppressed (a promptMode or the
+      // request field - see resolveSkipAutoOffers), where withholding the offer is deliberate, not
+      // a failure. Silent otherwise means the model answers from its weights while the user
+      // believes their knowledge was consulted.
       // The lake signal is held to a stricter bar than attached documents. The warning speaks to a
       // user belief that their knowledge was consulted, and attaching documents creates that belief
       // where merely owning a lake does not. So for the lake-only case we warn on an UNEXPECTED

--- a/b4m-core/services/src/llm/prompts/index.ts
+++ b/b4m-core/services/src/llm/prompts/index.ts
@@ -7,9 +7,15 @@
  *
  * NOT every grounding surface. An inlined file attachment (fabFileIds skips forced retrieval) carries no
  * retrieved-content wrapper for this to sit in; on a normal turn it leans on the always-on
- * ABSTENTION_PROMPT instead. A promptMode session is a real gap, not a covered case: filterByPromptMode
- * strips ABSTENTION_PROMPT along with every authored prompt (ChatCompletionProcess.ts:2495), so neither
- * this rule nor the abstention licence reaches it - an eval/passthrough surface uncovered by design.
+ * ABSTENTION_PROMPT instead. Under a promptMode the two part company, and the distinction matters:
+ * filterByPromptMode strips ABSTENTION_PROMPT in ALL THREE modes (no mode admits the `abstention`
+ * source), but this rule is not an authored prompt - KnowledgeRetrievalFeature splices it into the
+ * retrieved-content block itself, and `grounded`/`surface` both admit `knowledgeRetrieval` and keep
+ * forced retrieval on, so a retrieval that finds content still carries it. The uncovered surface is
+ * any turn answering with NO retrieved content: `raw` always, and a grounded/surface turn that found
+ * nothing. A caller who needs the knowledge auto-offer withheld without opening even that gap sets
+ * the `skipAutoOffers` request field instead of a mode; the two were one switch until it cost a
+ * measurement.
  *
  * Under a leading question ("what did we win against <competitor>", "what was the <customer>
  * contract worth"), a grounded model tends to answer from the retrieved passages AND top them off

--- a/b4m-core/services/src/llm/systemPromptSources.ts
+++ b/b4m-core/services/src/llm/systemPromptSources.ts
@@ -252,6 +252,25 @@ export function resolveForcedRetrieval(mode: PromptMode | undefined, sessionFlag
 }
 
 /**
+ * Whether this turn withholds OUR server-side tool auto-offers. Two independent triggers: any
+ * `promptMode` (an eval/passthrough surface), or the caller's explicit `skipAutoOffers`. Unioned
+ * here rather than at each gate because the rule was previously spelled out per-site and a site was
+ * missed - the three auto-add sites named in AUTO_ADDED_TOOL_NAMES must agree, and a fourth trigger
+ * should mean editing this function and nothing else.
+ *
+ * A force-on, not an override: `skipAutoOffers: false` under a promptMode still suppresses, because
+ * a mode that promises a bare model cannot also carry the provider's tool-use preamble.
+ *
+ * Siblings below/above resolve the other promptMode-derived axes. Several more are still spelled out
+ * inline in ChatCompletionProcess (`skipAdminPromptTemplates`, `excludeCurrentPrompt`,
+ * `omitIdentityReminder`) - each has the same miss-a-site failure mode, and each should get a named
+ * resolver here rather than a second inline derivation when a caller needs it on its own.
+ */
+export function resolveSkipAutoOffers(body: { promptMode?: PromptMode; skipAutoOffers?: boolean }): boolean {
+  return Boolean(body.promptMode) || body.skipAutoOffers === true;
+}
+
+/**
  * How each source is reported in telemetry. `origin` answers "who authored this text" (we, an
  * admin, the org, the user's own data); `name` is the stable identifier dashboards group on, so
  * the pre-existing names are kept verbatim even where they read a little oddly.

--- a/b4m-core/services/src/llm/systemPromptSources.ts
+++ b/b4m-core/services/src/llm/systemPromptSources.ts
@@ -255,7 +255,7 @@ export function resolveForcedRetrieval(mode: PromptMode | undefined, sessionFlag
  * Whether this turn withholds OUR server-side tool auto-offers. Two independent triggers: any
  * `promptMode` (an eval/passthrough surface), or the caller's explicit `skipAutoOffers`. Unioned
  * here rather than at each gate because the rule was previously spelled out per-site and a site was
- * missed - the three auto-add sites named in AUTO_ADDED_TOOL_NAMES must agree, and a fourth trigger
+ * missed - all three auto-add sites in ChatCompletionProcess must agree, and a fourth trigger
  * should mean editing this function and nothing else.
  *
  * A force-on, not an override: `skipAutoOffers: false` under a promptMode still suppresses, because


### PR DESCRIPTION
# Pull Request

Closes #2523

## Description

`promptMode` was the only switch for the server-side knowledge auto-offer, and it also strips every authored system prompt via `filterByPromptMode` — including the abstention licence. The two were welded together, so an evaluation arm could have **either** no knowledge offered **or** the anti-fabrication prompts, never both:

| arm intent | without `promptMode` | with `promptMode` |
|---|---|---|
| no knowledge offered | still offered/retrieves | suppressed, **but** abstention licence stripped |

That is not a tidiness problem — it corrupted a measurement. Across arms run over one question bank, arms built to have no knowledge access produced retrieval events on 72/200 and 25/200 turns while a lake-enabled arm retrieved on only 36/200, so the intended contrast was close to inverted.

This adds an optional `skip_auto_offers` request field that triggers the offer suppression **on its own**, leaving the prompt stack alone.

## Changes

- **`skip_auto_offers`** — new optional boolean on the public `POST /api/chat` request. Wire spelling is snake_case per `api-contract/CONVENTIONS.md` §2; it maps to the internal camelCase `skipAutoOffers`.
- **`resolveSkipAutoOffers`** in `systemPromptSources.ts`, beside its three siblings (`filterByPromptMode`, `filterFeaturesByPromptMode`, `resolveForcedRetrieval`). Unions the field with `Boolean(promptMode)` in one place, so all three auto-add sites named in `AUTO_ADDED_TOOL_NAMES` agree.
  - The blog/skill auto-add gate had keyed on `promptMode` alone and is now covered.
- **Carried onto `questStartParams`** in `ChatCompletionInvoke`, so the field survives the async dispatch rather than working only on the synchronous `wait: true` path (`/api/ai/llm` has no synchronous path at all).
- Corrected several docblocks that overstated the field or misdescribed `promptMode`, including a pre-existing claim in `prompts/index.ts` that `grounded`/`surface` receive neither the no-invention rule nor the abstention licence. Only the licence is stripped in all three modes; `KnowledgeRetrievalFeature` still carries the rule when retrieval finds content.

### Deliberately not changed

Offers only. `filterByPromptMode`, `filterFeaturesByPromptMode` and `resolveForcedRetrieval` are untouched, and `skipAdminPromptTemplates` stays on `promptMode` — routing the new field into any of them would reopen the hole this closes.

It withholds the **tool**, not knowledge: forced retrieval still runs off `session.forceKnowledgeRetrieval`, and an already-attached corpus is inlined rather than deferred. An arm that must see no knowledge at all also needs a session with no attachments and forced retrieval off.

## Guide for Testers

Backend/API only — there is no UI surface. No SPA control authors `promptMode` or `skip_auto_offers`.

1. Get an API key or bearer token for the preview environment.
2. `POST https://app.pr<N>.preview.bike4mind.com/api/chat` with body `{"message":"...","sessionId":"<session with an attached, indexed document>","wait":true,"includePromptDetails":true}`. Expect HTTP 200, and `promptDetails` contains an entry named `abstention`.
3. Repeat step 2 with `"skip_auto_offers": true` added. Expect HTTP 200, `promptDetails` **still** contains `abstention`, and the model does not call `search_knowledge_base`.
4. Repeat step 2 with `"promptMode": "raw"` instead. Expect HTTP 200 and **no** `abstention` entry in `promptDetails` — the pre-existing behaviour, unchanged by this PR.
5. Repeat step 3 with `"wait"` omitted, then `GET /api/quests/{quest_id}` from the response's `tracking_info`. Expect `promptMeta.offeredTools` to exclude `search_knowledge_base` — this is the async path, which is the one that would silently ignore the field if it were not threaded through `questStartParams`.

### Regression Checks

6. Send an ordinary chat turn with no new field and no `promptMode` on a session with an attached document. Expect `search_knowledge_base` to be offered exactly as before.
7. Send a turn with `"promptMode": "grounded"` on a lake session. Expect forced retrieval to run and the answer to cite retrieved documents, unchanged.

### What NOT to test

No UI, no styling, no theme, no routing. Nothing in the SPA changes.

## Additional Information

Draft while a temporary-logging commit is added on top to capture the four cells of the table above from a preview deploy. That commit will be reverted before review.

## Developer Notes

- **New extension point:** `resolveSkipAutoOffers` establishes the pattern of a named resolver for one `promptMode`-derived axis. Three axes are still derived inline in `ChatCompletionProcess` (`skipAdminPromptTemplates`, `excludeCurrentPrompt`, `omitIdentityReminder`); each has the same miss-a-site failure mode and should get a named resolver rather than a second inline derivation when a caller needs it alone.
- **Architecture:** `promptMode` is a preset, and a preset is the right shape for three named comparison arms. The defect was that it had no primitives underneath it. This extracts one, demand-driven; a future decomposition keeps `skip_auto_offers` rather than deleting it.
- **Known gap, deliberately deferred:** `PROMPT_MODE_SOURCES.surface` does not admit `abstention`, so `surface` silently drops a safety counterweight despite making no claim to bareness. Changing that alters behaviour for existing callers and needs its own eval, so it is pinned by a test instead — if `surface` ever admits `abstention`, that test is where the decision surfaces.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a, no new admin setting
- [ ] I have made the UI/UX feel good — n/a, no UI surface
- [ ] I have made corresponding changes to the documentation (if applicable) — `openapi.json` regenerated from the Zod schema
- [ ] If adding/modifying telemetry fields — n/a
