### PR TITLE
chore(client): measure the server bundle against Lambda's unzipped limit

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -20,6 +20,7 @@
     "clean": "rm -rf node_modules/ .next/ .sst/ public/pdfjs public/pdf.worker.min.mjs public/highs.wasm",
     "start": "next start",
     "lint": "eslint .",
+    "check:bundle-size": "node scripts/check-server-bundle-size.mjs",
     "format": "prettier --write './**/*.{ts,tsx}'",
     "typecheck": "NODE_OPTIONS='--max-old-space-size=8192' tsc --noEmit",
     "typecheck:native": "tsgo --noEmit",

--- a/apps/client/scripts/check-server-bundle-size.mjs
+++ b/apps/client/scripts/check-server-bundle-size.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Measure the OpenNext server-function bundles against Lambda's unzipped-size limit.
+ *
+ * Lambda rejects a deployment package whose UNZIPPED contents exceed 262144000 bytes, and that
+ * limit is not adjustable - there is no quota increase to request, and the only escape hatch is
+ * container-image packaging. Nothing measured this before, so the bundle reached 92.8% of the
+ * ceiling unnoticed and the first signal was a failed deploy whose error named a Lambda that had
+ * nothing to do with the cause. This script exists so the number is always printed.
+ *
+ * The zipped size is NOT a usable proxy: this bundle compresses about 3x, so the S3 object looks
+ * comfortable at ~78 MB while the unzipped contents sit against the ceiling.
+ *
+ * Every directory under `.open-next/server-functions/` is measured, not just `default`: OpenNext
+ * can split the server into several functions and each one is its own deployment package with its
+ * own copy of this limit. The layout is OpenNext v3's - it is coupled to `openNextVersion` in
+ * infra/web.ts, so a major bump there wants a look at this path.
+ *
+ * Modes:
+ *   --enforce      exit non-zero when any bundle is over budget
+ *   --dir=<path>   measure exactly this one directory instead of discovering them
+ */
+
+import { readdir, stat } from 'node:fs/promises';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/** Lambda's hard cap on unzipped deployment-package bytes. Not raisable. */
+export const LAMBDA_UNZIPPED_LIMIT_BYTES = 262144000;
+
+/** Fraction of the limit we allow before the budget is considered breached. */
+export const DEFAULT_BUDGET_FRACTION = 0.9;
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SERVER_FUNCTIONS_ROOT = join(REPO_ROOT, 'apps/client/.open-next/server-functions');
+
+/**
+ * Budget arithmetic, split out from the filesystem walk so it is unit-testable.
+ *
+ * `over-limit` means AWS itself would reject the package; `over-budget` means we are inside the
+ * red zone we refuse to operate in, with headroom left to react.
+ */
+export function evaluateBudget({
+  totalBytes,
+  limitBytes = LAMBDA_UNZIPPED_LIMIT_BYTES,
+  budgetFraction = DEFAULT_BUDGET_FRACTION,
+}) {
+  const budgetBytes = Math.floor(limitBytes * budgetFraction);
+  const status = totalBytes > limitBytes ? 'over-limit' : totalBytes > budgetBytes ? 'over-budget' : 'ok';
+  return {
+    status,
+    totalBytes,
+    limitBytes,
+    budgetBytes,
+    percentOfLimit: (totalBytes / limitBytes) * 100,
+    headroomBytes: limitBytes - totalBytes,
+  };
+}
+
+const STATUS_SEVERITY = { ok: 0, 'over-budget': 1, 'over-limit': 2 };
+
+/** The worst status across several bundles, since one oversized package fails the whole deploy. */
+export function worstStatus(statuses) {
+  return statuses.reduce((worst, next) => (STATUS_SEVERITY[next] > STATUS_SEVERITY[worst] ? next : worst), 'ok');
+}
+
+const megabytes = bytes => (bytes / 1048576).toFixed(1);
+
+/** Recursively collect [relativePath, bytes] for every regular file under `root`. */
+async function collectFiles(root) {
+  const files = [];
+  const walk = async dir => {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      // Symlinks are dereferenced by the packager, but counting a target twice would overstate
+      // the total, so they are skipped here and the budget margin absorbs the difference.
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        files.push([relative(root, full), (await stat(full)).size]);
+      }
+    }
+  };
+  await walk(root);
+  return files;
+}
+
+/**
+ * Group by the first three path segments, which is the granularity that names a culprit:
+ * `node_modules/.pnpm/googleapis@173.0.0` is actionable, `node_modules` is not.
+ */
+export function topContributors(files, count = 15) {
+  const totals = new Map();
+  for (const [path, bytes] of files) {
+    const key = path.split(sep).slice(0, 3).join('/');
+    totals.set(key, (totals.get(key) ?? 0) + bytes);
+  }
+  return [...totals.entries()].sort((a, b) => b[1] - a[1]).slice(0, count);
+}
+
+/** Repo-relative where possible; an explicit --dir outside the repo prints as given. */
+function label(dir) {
+  const rel = relative(REPO_ROOT, dir);
+  return !rel || rel.startsWith('..') ? dir : rel;
+}
+
+async function measure(dir) {
+  const files = await collectFiles(dir);
+  const totalBytes = files.reduce((sum, [, bytes]) => sum + bytes, 0);
+  return { dir, fileCount: files.length, contributors: topContributors(files), ...evaluateBudget({ totalBytes }) };
+}
+
+function report(result) {
+  console.log(`\n${label(result.dir)}`);
+  console.log(`  ${megabytes(result.totalBytes)} MB unzipped across ${result.fileCount} files`);
+  console.log(
+    `  limit ${megabytes(result.limitBytes)} MB, budget ${megabytes(result.budgetBytes)} MB ` +
+      `(${(DEFAULT_BUDGET_FRACTION * 100).toFixed(0)}%), now ${result.percentOfLimit.toFixed(1)}% ` +
+      `with ${megabytes(result.headroomBytes)} MB headroom`
+  );
+  console.log('  heaviest paths:');
+  for (const [path, bytes] of result.contributors) {
+    console.log(`    ${megabytes(bytes).padStart(8)} MB  ${path}`);
+  }
+}
+
+function summarize(result) {
+  return (
+    `${label(result.dir)} is ${megabytes(result.totalBytes)} MB unzipped ` +
+    `(${result.percentOfLimit.toFixed(1)}% of Lambda's ${megabytes(result.limitBytes)} MB unzipped limit, ` +
+    `budget ${megabytes(result.budgetBytes)} MB). Trim it or move the Next server to container-image ` +
+    `packaging; the limit itself cannot be raised.`
+  );
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const enforce = args.includes('--enforce');
+  const dirArg = args.find(a => a.startsWith('--dir='));
+
+  let dirs;
+  try {
+    dirs = dirArg
+      ? [resolve(dirArg.slice('--dir='.length))]
+      : (await readdir(SERVER_FUNCTIONS_ROOT, { withFileTypes: true }))
+          .filter(entry => entry.isDirectory())
+          .map(entry => join(SERVER_FUNCTIONS_ROOT, entry.name));
+  } catch (error) {
+    // Deliberately not a soft skip: the point of this script is that the number is never missing.
+    // A caller that runs it when the build may legitimately not have happened must decide that
+    // for itself rather than have an absent measurement read as a pass.
+    console.error(`::error::Could not find the server functions at ${SERVER_FUNCTIONS_ROOT}: ${error.message}`);
+    process.exit(2);
+  }
+
+  if (dirs.length === 0) {
+    console.error(`::error::No server-function directories under ${SERVER_FUNCTIONS_ROOT}`);
+    process.exit(2);
+  }
+
+  const results = [];
+  for (const dir of dirs) {
+    try {
+      const result = await measure(dir);
+      report(result);
+      results.push(result);
+    } catch (error) {
+      console.error(`::error::Could not measure the server bundle at ${label(dir)}: ${error.message}`);
+      process.exit(2);
+    }
+  }
+
+  await writeStepSummary(results);
+
+  const breached = results.filter(r => r.status !== 'ok');
+  for (const result of breached) {
+    console.log(`${enforce ? '::error::' : '::warning::'}${summarize(result)}`);
+  }
+
+  if (enforce && worstStatus(results.map(r => r.status)) !== 'ok') process.exit(1);
+}
+
+/** Put the number on the run's summary page, so nobody has to open the log to find it. */
+async function writeStepSummary(results) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  const { appendFile } = await import('node:fs/promises');
+  const rows = results.map(
+    r =>
+      `| ${label(r.dir)} | ${megabytes(r.totalBytes)} MB | ${r.percentOfLimit.toFixed(1)}% | ` +
+      `${megabytes(r.headroomBytes)} MB | ${r.status} |`
+  );
+  const heaviest = results
+    .flatMap(r => r.contributors.slice(0, 10).map(([path, bytes]) => `| ${path} | ${megabytes(bytes)} MB |`))
+    .join('\n');
+  await appendFile(
+    summaryPath,
+    [
+      '### Server bundle vs Lambda unzipped limit',
+      '',
+      '| bundle | unzipped | of limit | headroom | status |',
+      '| --- | --- | --- | --- | --- |',
+      ...rows,
+      '',
+      '<details><summary>Heaviest paths</summary>',
+      '',
+      '| path | size |',
+      '| --- | --- |',
+      heaviest,
+      '',
+      '</details>',
+      '',
+    ].join('\n')
+  );
+}
+
+// Only run when invoked directly, so the exported helpers stay importable from tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/apps/client/scripts/check-server-bundle-size.test.ts
+++ b/apps/client/scripts/check-server-bundle-size.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - plain .mjs build script, intentionally not part of the TS program
+import {
+  evaluateBudget,
+  topContributors,
+  worstStatus,
+  LAMBDA_UNZIPPED_LIMIT_BYTES,
+} from './check-server-bundle-size.mjs';
+
+const LIMIT = LAMBDA_UNZIPPED_LIMIT_BYTES;
+const BUDGET = Math.floor(LIMIT * 0.9);
+
+describe('evaluateBudget', () => {
+  it('holds the documented Lambda limit, so a silent edit cannot loosen the gate', () => {
+    // 250 MiB. Hard-coded rather than derived: AWS does not expose it and it is not adjustable.
+    expect(LIMIT).toBe(262144000);
+  });
+
+  it.each([
+    ['well under budget', 100_000_000, 'ok'],
+    ['exactly at budget', BUDGET, 'ok'],
+    ['one byte over budget', BUDGET + 1, 'over-budget'],
+    ['exactly at the AWS limit', LIMIT, 'over-budget'],
+    ['over the AWS limit', LIMIT + 1, 'over-limit'],
+  ])('classifies %s (%d bytes) as %s', (_label, totalBytes, expected) => {
+    expect(evaluateBudget({ totalBytes }).status).toBe(expected);
+  });
+
+  it('reports the real pre-fix bundle as over budget while still deployable', () => {
+    // The measured size of the deployed bundle that preceded the googleapis narrowing. AWS
+    // accepted it, yet it was only 17.9 MB from rejection - precisely the state this budget
+    // exists to surface rather than discover through a failed deploy.
+    const result = evaluateBudget({ totalBytes: 243_393_532 });
+    expect(result.status).toBe('over-budget');
+    expect(result.percentOfLimit).toBeCloseTo(92.8, 1);
+  });
+
+  it('computes headroom against the limit, not the budget', () => {
+    expect(evaluateBudget({ totalBytes: LIMIT - 1_048_576 }).headroomBytes).toBe(1_048_576);
+  });
+
+  it('honours an explicit budget fraction', () => {
+    expect(evaluateBudget({ totalBytes: 200_000_000, budgetFraction: 0.5 }).status).toBe('over-budget');
+    expect(evaluateBudget({ totalBytes: 200_000_000, budgetFraction: 0.99 }).status).toBe('ok');
+  });
+});
+
+describe('worstStatus', () => {
+  it.each([
+    [['ok', 'ok'], 'ok'],
+    [['ok', 'over-budget'], 'over-budget'],
+    [['over-budget', 'over-limit', 'ok'], 'over-limit'],
+    [[], 'ok'],
+  ])('reduces %j to %s', (statuses, expected) => {
+    expect(worstStatus(statuses)).toBe(expected);
+  });
+});
+
+describe('topContributors', () => {
+  it('groups by the first three path segments so the culprit is named, not just node_modules', () => {
+    const files: Array<[string, number]> = [
+      ['node_modules/.pnpm/googleapis@173.0.0/build/one.js', 30],
+      ['node_modules/.pnpm/googleapis@173.0.0/build/two.js', 5],
+      ['node_modules/.pnpm/tiktoken@1.0.22/index.js', 20],
+      ['apps/client/.next/server/page.js', 10],
+    ];
+
+    expect(topContributors(files)).toEqual([
+      ['node_modules/.pnpm/googleapis@173.0.0', 35],
+      ['node_modules/.pnpm/tiktoken@1.0.22', 20],
+      ['apps/client/.next', 10],
+    ]);
+  });
+
+  it('limits the list to the requested count', () => {
+    const files: Array<[string, number]> = Array.from({ length: 30 }, (_unused, i) => [`a/b/pkg${i}/f.js`, i]);
+    expect(topContributors(files, 3)).toHaveLength(3);
+  });
+
+  it('handles a shallow path without inventing segments', () => {
+    expect(topContributors([['index.mjs', 7]])).toEqual([['index.mjs', 7]]);
+  });
+});


### PR DESCRIPTION
## Description

Lambda rejects a deployment package whose **unzipped** contents exceed 262,144,000 bytes. That limit is not adjustable - there is no quota increase to request, and the only escape hatch is container-image packaging.

Nothing in this repo or in the deploy pipeline measured it. So the Next.js server bundle grew to **243,393,532 bytes, 92.8% of the ceiling**, with no signal at any point, and the first signal was a failed staging deploy whose error named a Lambda unrelated to the cause. That cost about 5.5 hours.

This PR adds the measurement. It does not trim anything (that is #2545) and it does not fix the growth pattern (#2547) - it makes the number impossible to miss.

`apps/client/scripts/check-server-bundle-size.mjs`:

- Walks **every** directory under `apps/client/.open-next/server-functions/`, not just `default`. OpenNext can split the server into several functions and each one is a separate deployment package carrying its own copy of the limit, so checking only `default` would miss a split.
- Sums unzipped bytes and prints the heaviest paths grouped to the first three path segments - the granularity that names a culprit (`node_modules/.pnpm/googleapis@173.0.0` is actionable, `node_modules` is not).
- Writes a markdown table to `$GITHUB_STEP_SUMMARY` when one exists, so the number lands on the run summary page rather than only in a log.
- Report-only by default; `--enforce` exits 1 when a bundle is over the 90% budget. `--dir=<path>` measures one directory explicitly.

The **zipped** size is not a usable proxy, which is worth stating because it is the number that is easy to look at: this bundle compresses about 3x, so the S3 object looks comfortable at ~78 MB while the unzipped contents sit against the ceiling.

### Two deliberate choices

**A missing bundle directory is a hard `exit 2`, not a soft skip.** The entire point of this script is that the number is never absent, and an empty measurement that reads as a pass would recreate the exact blind spot. A caller that legitimately might run this before a build exists has to decide that for itself - and the deploy workflow does, with an explicit directory check and a `::notice::`.

**`--enforce` is not wired into the deploy pipeline in this PR.** The obvious placement is wrong: failing the size check inside the deployer's `deploy` job fails that job, and the preview workflow feeds the job's result into the PR's sticky comment, commit status and `preview-deployed` label. A budget breach would report a deployed, working preview as a failed deploy. Where the red signal belongs - along with the budget fraction and whether to gate on an absolute threshold or a per-PR delta - is a deployer-repo decision and is tracked there. The report step is already wired in on that side with `if: always()`, so the size prints on every deploy **including a failed one**, which is when it is most wanted.

## Changes

- `apps/client/scripts/check-server-bundle-size.mjs` (new) - the checker.
- `apps/client/scripts/check-server-bundle-size.test.ts` (new) - 16 tests over the pure parts: budget classification at every boundary, the real pre-incident 243,393,532-byte measurement, headroom arithmetic, worst-status reduction across bundles, and contributor grouping.
- `apps/client/package.json` - adds `check:bundle-size`.

## Guide for Testers

This is a build-tooling script with no runtime surface. It is verified by running it, not by clicking through the app.

1. From the repo root, run `pnpm --filter @bike4mind/client exec vitest run scripts/check-server-bundle-size.test.ts`. Expected: `Test Files 1 passed`, `Tests 16 passed`.
2. Run `pnpm --filter @bike4mind/client check:bundle-size` without having built the app. Expected: it exits **2** and prints `::error::Could not find the server functions at .../apps/client/.open-next/server-functions: ENOENT ...`. A silent pass here is a fail.
3. Create a fake bundle and measure it:
   ```
   mkdir -p /tmp/fake/node_modules/.pnpm/tiktoken@1.0.22
   truncate -s 240M /tmp/fake/node_modules/.pnpm/tiktoken@1.0.22/huge.js
   node apps/client/scripts/check-server-bundle-size.mjs --dir=/tmp/fake
   ```
   Expected: `240.0 MB unzipped across 1 files`, then `limit 250.0 MB, budget 225.0 MB (90%), now 96.0% with 10.0 MB headroom`, then a `heaviest paths:` line naming `node_modules/.pnpm/tiktoken@1.0.22`, then a `::warning::` line. Exit code **0** (check with `echo $?`).
4. Re-run step 3's last command with `--enforce` appended. Expected: identical output except the last line is `::error::` instead of `::warning::`, and the exit code is **1**.
5. Run `node apps/client/scripts/check-server-bundle-size.mjs --dir=/tmp/does-not-exist`. Expected: exit code **2** and a single `::error::Could not measure the server bundle at ...` line - **not** a Node stack trace.
6. Verify the multi-bundle discovery path:
   ```
   mkdir -p apps/client/.open-next/server-functions/default apps/client/.open-next/server-functions/image-optimizer
   truncate -s 230M apps/client/.open-next/server-functions/default/a.js
   truncate -s 5M apps/client/.open-next/server-functions/image-optimizer/b.js
   pnpm --filter @bike4mind/client check:bundle-size
   rm -rf apps/client/.open-next
   ```
   Expected: **both** directories are reported, each with its own percentage (92.0% and 2.0%), and only the oversized one produces a `::warning::`.
7. Verify the step-summary output: `GITHUB_STEP_SUMMARY=/tmp/summary.md node apps/client/scripts/check-server-bundle-size.mjs --dir=/tmp/fake && cat /tmp/summary.md`. Expected: a markdown table headed `### Server bundle vs Lambda unzipped limit` with a row for the bundle, plus a collapsed `Heaviest paths` section.

### Regression Checks

8. `pnpm --filter @bike4mind/client run typecheck:fast` - expected: clean. The test file imports a `.mjs` script that is intentionally outside the TS program, so the `@ts-expect-error` on that import must stay both present and *used*; a stray TS2578 here means the import started resolving and the directive should be dropped.
9. `pnpm lint:check` - expected: clean, nothing reported under `apps/client/scripts/`.
10. `pnpm --filter @bike4mind/client test --shard=1/3`, `2/3`, `3/3` - expected: all three green. The new test file lands in exactly one shard; vitest tiles the file set by a hash of the path, so nothing needed updating, but confirm no leg broke.
11. Confirm the new test runs in a **node** environment despite living outside `server/`/`pages/`. The `// @vitest-environment node` docblock on line 1 is what does it: the file is assigned to the `jsdom` *project* by path glob, and the docblock overrides the environment within it. Verified by asserting `typeof document === 'undefined'` in a throwaway probe; if you want to re-check, add that assertion temporarily rather than trusting the project label in vitest's output.
12. Confirm nothing in the app imports the script: `grep -rn "check-server-bundle-size" apps b4m-core packages infra --include=*.ts --include=*.tsx | grep -v node_modules`. Expected: only the test file.

### What NOT to test

- **The app.** No runtime code, no API route, no component, no infra changed. Nothing in the product behaves differently.
- **Enforcement in CI.** `--enforce` exists and is tested, but is deliberately not called by any workflow in this PR. Do not expect a red check from an oversized bundle yet.
- **The bundle size itself.** This PR measures; the trim is #2545 and the structural fix is #2547.
- **The `postinstall`/`prebuild` chain.** The script is not wired into any lifecycle hook, on purpose - it needs a built bundle, so it belongs after the build, not before it.

## Additional Information

The `.open-next/server-functions/` layout is OpenNext v3's, and `openNextVersion: '3.9.16'` is pinned in `infra/web.ts`. A major bump there wants a look at this path; the script's header says so. If the layout ever changes, the failure mode is the loud `exit 2` rather than a silent zero - which is the right way round.

## Developer Notes

- **`pnpm --filter @bike4mind/client check:bundle-size`** is now the way to answer "how close are we to the limit, and what is taking the space". It works from any working directory: the discovery root is resolved from the script's own location, not from `process.cwd()`.
- **The budget arithmetic is a pure exported function** (`evaluateBudget`), separate from the filesystem walk, which is why the boundary behaviour is unit-testable at all. Same for `topContributors` and `worstStatus`. If you extend this, keep new logic on that side of the line.
- **Precedent for a `.mjs` build script with a co-located vitest file.** `apps/client/scripts/` had no tests before. A `// @vitest-environment node` docblock plus one `@ts-expect-error` on the import is the whole cost, and it means a build script's logic can be tested like anything else instead of being verified by running the pipeline.
- **A lazily-imported package is still in the bundle.** Worth knowing before anyone tries to fix a size problem with `import()`: Next's output file tracer follows a literal-string specifier at build time. `tokenCounting.ts`, `IsolatedVmExecutor.ts` and `transpileReactArtifact.ts` all defer their heavy loads, and all three packages are physically present in the deployed archive. Deferring helps cold-start init; it does nothing for unzipped size.


Part of #2549.
