### PR TITLE
fix(client): keep the upload spool path opaque to the file tracer

### DIFF
--- a/apps/client/server/utils/spoolRequestToFile.ts
+++ b/apps/client/server/utils/spoolRequestToFile.ts
@@ -1,7 +1,6 @@
 import { createWriteStream } from 'fs';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
 
@@ -46,8 +45,11 @@ export async function spoolRequestToFile(
   maxBytes: number,
   options: SpoolOptions = {}
 ): Promise<SpooledUpload> {
-  const dir = await mkdtemp(join(tmpdir(), 'b4m-upload-'));
-  const path = join(dir, options.filename ?? 'upload.bin');
+  // Template literals, not path.join: @vercel/nft partially evaluates a join() whose arguments it
+  // cannot resolve, gives up on a concrete path, and falls back to globbing the app directory -
+  // which drags all of apps/client into the traced Lambda bundle. Keep these opaque to the tracer.
+  const dir = await mkdtemp(`${tmpdir()}/b4m-upload-`);
+  const path = `${dir}/${options.filename ?? 'upload.bin'}`;
   options.onPath?.(path);
 
   let removed = false;


### PR DESCRIPTION
## Description

Preview deploys started failing with `InvalidParameterValueException: Unzipped size must be smaller than 262144000 bytes` on `frontendServerUseast2Function`. The cause is two `path.join()` calls in the upload spool helper.

`@vercel/nft` partially evaluates a `path.join()` whose arguments it cannot resolve statically. When it cannot produce a concrete path it falls back to globbing the app directory. The two joins here chained onto `mkdtemp`'s runtime value, so every route that reaches this helper traced the whole of `apps/client`: raw `.ts`/`.tsx` source, `public/`, and the `e2e/` Playwright specs and their fixtures. The bundle went from 9 raw first-party files to 3,918.

Building the paths as template literals keeps them opaque to the tracer, which emits nothing rather than a directory glob.

## Changes

- `apps/client/server/utils/spoolRequestToFile.ts` builds the temp dir and file paths as template literals instead of `path.join()`, and drops the now-unused `join` import. A comment records why, since reverting to `path.join()` looks like a harmless cleanup and silently costs 41 MB.

## Guide for Testers

This is a build-output fix with no runtime behaviour change. The upload routes behave identically.

### Bundle size (the actual fix)

1. Check out this branch and run `pnpm install`, then `pnpm turbo:core:build`.
2. Run `cd apps/client && NODE_OPTIONS='--max-old-space-size=12288' npx --yes @opennextjs/aws@3.9.16 build`. Expected: exit 0.
3. Measure the server function: `cd .open-next/server-functions/default && find . \( -type f -o -type l \) -print0 | xargs -0 stat -f '%z' | awk '{s+=$1}END{print s}'`. Expected: roughly 214,900,000 bytes, about 82% of the 262,144,000 limit. On `main` the same command returns 258,011,859, about 98%.
4. Confirm the sweep is gone structurally, not just numerically: `find . -path '*/apps/client/*' \( -name '*.ts' -o -name '*.tsx' \) | wc -l` and the same for `*apps/client/public/*` and `*apps/client/e2e/*`. Expected: `0` for all three. On `main` these return thousands.

### Regression Checks

5. Run `pnpm --filter @bike4mind/client exec vitest run --project node server/utils/spoolRequestToFile.test.ts pages/api/import-history/__tests__/upload.test.ts pages/api/notebooks/import/__tests__/upload.test.ts`. Expected: 3 files, 20 tests, all passing. These exercise the new path construction against the real filesystem, including that an aborted over-cap spool leaves no temp file behind.
6. On a preview deploy, import an LLM history export through Sidebar -> Profile -> General Settings and a notebook through the notebook import modal. Expected: both upload and process exactly as before, with the temp file still landing in the OS temp dir.

### What NOT to test

- No UI change, no new settings, no API contract change. A non-obvious detail worth knowing is that the spooled file path is now assembled with `/` rather than the platform separator. That is correct on Lambda and on macOS, and Node accepts forward slashes on Windows too, so no caller needs adjusting.

## Additional Information

Measured with `@opennextjs/aws` 3.9.16 on darwin-arm64 without the premium overlay, which is the same method and the same machine for both numbers:

| build | bytes | % of 262,144,000 |
| --- | --- | --- |
| `main` | 258,011,859 | 98.42% |
| this branch | 214,986,674 | 82.01% |
| last known-good base (`707c577f`) | 214,900,425 | 81.98% |

That is a drop of 43,025,185 bytes, landing within 0.04% of the pre-regression baseline. The remaining 86,249 bytes are the weight of the 26 commits that landed in between, not measurement noise: two independent OpenNext builds of identical source on the same host produced byte-identical totals, 14,344 entries and 214,986,674 bytes both times.

The darwin figure understates what the deployer builds. Platform binaries account for a measured +3,605,504 bytes on linux-x64 (esbuild +833,680, `isolated-vm` prebuilds +2,771,824), which puts `main` at 261,617,363 bytes, 99.80% of the limit, before the premium overlay the deployer hydrates on top. That is why the deploy fails while a local open-core build reads just under.

Two other `path.join(os.tmpdir(), ...)` sites exist in traced server code, at `apps/client/server/utils/files.ts:22` and `apps/client/pages/api/files/download.ts:19`. Both were checked directly against the emitted `.nft.json` traces and neither sweeps: they join a literal filename rather than chaining onto a runtime value, and their non-`node_modules` traced entries are all ordinary compiled server chunks. No second fix is needed.

Nothing in CI would have caught this. There is no bundle-size assertion anywhere in the repo, and the one job that does build the Next.js production output, the `Build amd64` leg of the self-host image workflow, ran green on the commit that introduced the regression because it asserts nothing about what it built. A follow-up to add that assertion is worth doing separately.

## Developer Notes

- **`path.join()` is not free in traced server code.** Any `join()` in a file reachable from a route, whose arguments nft cannot resolve statically, risks a directory-glob fallback that pulls the whole app tree into the Lambda. The pattern to avoid specifically is joining onto a value only known at runtime, such as the result of `mkdtemp`. A literal-only join is fine.
- The 250 MB unzipped Lambda limit is a hard AWS quota. It cannot be raised through Service Quotas or support, and layers draw from the same budget, so the only headroom is a leaner bundle.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry change

