### PR TITLE
fix(infra): remove the provisioned concurrency that never served traffic

### DIFF
--- a/infra/agentExecutor.ts
+++ b/infra/agentExecutor.ts
@@ -96,13 +96,15 @@ const SHARED_AGENT_EXECUTOR_CONFIG = {
 
 export const agentExecutor = new sst.aws.Function('AgentExecutor', {
   ...SHARED_AGENT_EXECUTOR_CONFIG,
-  versioning: true,
-  concurrency: ['production', 'dev'].includes($app.stage)
-    ? {
-        provisioned: $app.stage === 'production' ? 3 : 1,
-        reserved: 10,
-      }
-    : undefined,
+  // Deliberately no provisioned concurrency, and so no `versioning`. Provisioned concurrency can
+  // only be allocated to a numbered version or an alias, never to $LATEST - and every invoke of
+  // this function passes a bare name with no Qualifier, which resolves to $LATEST. The allocation
+  // was therefore unreachable on every stage while still billing for warm capacity, and each
+  // aborted apply left an orphaned ProvisionedConcurrencyConfig that counts against the `reserved`
+  // below - so the orphans eventually saturate it and the NEXT deploy fails at the concurrency
+  // step, burying whatever the real failure was. Fixing cold starts here takes an alias plus a
+  // Qualifier on the invoke; re-adding this flag on its own would only recreate the leak.
+  concurrency: ['production', 'dev'].includes($app.stage) ? { reserved: 10 } : undefined,
 });
 
 // Subscribe to the continuation queue for Lambda self-dispatch resume

--- a/infra/functions.ts
+++ b/infra/functions.ts
@@ -27,13 +27,10 @@ export const slackQuestProcessor = new sst.aws.Function('SlackQuestProcessor', {
   timeout: '15 minutes',
   memory: '2048 MB',
   vpc: lambdaVpc,
-  versioning: true,
-  concurrency: ['production', 'dev'].includes($app.stage)
-    ? {
-        provisioned: $app.stage === 'production' ? 2 : 1,
-        reserved: 10,
-      }
-    : undefined,
+  // See the note on AgentExecutor in infra/agentExecutor.ts: provisioned concurrency never served
+  // this function either (no alias, and every invoke is unqualified), and its orphaned configs
+  // saturate `reserved` and then fail the next deploy at the concurrency step.
+  concurrency: ['production', 'dev'].includes($app.stage) ? { reserved: 10 } : undefined,
   link: [
     ...allSecrets,
     fabFileBucket,

--- a/infra/mcp.ts
+++ b/infra/mcp.ts
@@ -18,13 +18,9 @@ export const mcpHandler = new sst.aws.Function('mcpHandler', {
   handler: 'apps/client/server/utils/mcpCall.handler',
   runtime: 'nodejs24.x',
   vpc: lambdaVpc,
-  // Enable versioning to create published versions (required for provisioned concurrency)
-  versioning: true,
-  concurrency: ['production', 'dev'].includes($app.stage)
-    ? {
-        provisioned: 1,
-      }
-    : undefined,
+  // No provisioned concurrency: see the note on AgentExecutor in infra/agentExecutor.ts. This
+  // function carried no `reserved`, so its orphans never blocked a deploy - they accumulated
+  // silently (18 of them) and billed for idle capacity nothing could route to.
   link: [secrets.RATE_LIMIT_INGEST_TOKEN],
   logging: {
     retention: '3 days',


### PR DESCRIPTION
## Description

Removes `provisioned` concurrency (and the `versioning: true` that existed only to enable it) from `AgentExecutor`, `SlackQuestProcessor` and `mcpHandler`.

Closes #563.

### The capacity was never reachable

Provisioned concurrency can only be allocated to a **numbered version or an alias**, never to `$LATEST`. And:

- `aws lambda list-aliases` returns empty for all three functions, on `dev` and on `production`.
- `Qualifier` appears in **no** Lambda invocation anywhere in this codebase.
- Every `InvokeCommand` passes a bare function name, which resolves to `$LATEST`:
  - `apps/client/server/websocket/agentExecute.ts` (`Resource.AgentExecutor.name`)
  - `apps/client/server/utils/startAgentExecution.ts`
  - `apps/client/server/utils/invokeMcpHandler.ts` (`Resource.mcpHandler.name`)
  - `apps/client/server/cron/warmer.ts`

So the warm capacity served no traffic on any stage, production included, while still being billed. This is not a cost-vs-latency trade-off - it is a mechanism that has never functioned.

### And it leaked, which is the expensive part

SST publishes a new version on each deploy and attaches a `ProvisionedConcurrencyConfig` to it. An aborted apply leaves the previous version's config behind. Those orphans count against `reservedConcurrentExecutions`, so on the two functions that also declare `reserved: 10` they accumulate one per failed retry until the budget is full - after which the apply fails **earlier**, at the concurrency step, and the surfaced error names the wrong function.

That is exactly what happened on 2026-09-09. The deploy was already failing for an unrelated reason (the Next server bundle crossing Lambda's 262,144,000-byte unzipped limit - #2545), and once the orphans saturated `reserved` the error started pointing at `AgentExecutor`. It buried the real error for about five hours.

Measured before this change:

| Function | `reserved` | Orphaned configs | On versions | Live version |
|---|---|---|---|---|
| `AgentExecutor` | 10 | 10 (10/10, budget full) | 1071-1080 | 1083 |
| `SlackQuestProcessor` | 10 | 10 (10/10, budget full) | 1195-1204 | 1207 |
| `mcpHandler` | none | 18 | - | - |

Every orphan sat on a dead version, none on the live version, and with no aliases none of that allocation was reachable even in principle. `mcpHandler` never blocked a deploy only because it declares no `reserved`; it just accumulated silently and billed. Production holds one config per function on the current version, serving nothing for the same reason.

So removing `provisioned` does not trade latency for cost - it eliminates a leak class outright. The alternatives only manage it: an alias-targeted allocation would make the feature work but needs a matching change to invoke the alias, and a post-deploy prune keeps paying for capacity that serves nothing.

## Changes

- `infra/agentExecutor.ts` - `AgentExecutor`: drop `provisioned` and `versioning`, keep `reserved: 10`. Carries the full explanation; the other two sites point at it.
- `infra/functions.ts` - `SlackQuestProcessor`: same, keep `reserved: 10`.
- `infra/mcp.ts` - `mcpHandler`: drop `provisioned` and `versioning`. It declared no `reserved`, so the whole `concurrency` block goes. The stale comment claiming versioning is "required for provisioned concurrency" goes with it.

`reserved` is deliberately kept on the two functions that had it: it is a real ceiling and a real guarantee, and it has nothing to do with the leak.

## Guide for Testers

Infra-only. Verify from AWS, not from the app - and the point of the change is that nothing about request handling should differ.

1. Merge this. Staging deploys itself on merge to `main` (do **not** dispatch Tier Deploy Dispatch for staging).
2. Wait for the deploy to go green, then confirm the deploy reached the concurrency step without error - previously this is where it failed once the orphans saturated `reserved`.
3. For each of `AgentExecutor`, `SlackQuestProcessor` and `mcpHandler` on the `dev` stage, run `aws lambda list-provisioned-concurrency-configs --function-name <name>`. Expected: an empty list. Any config still present after a green deploy means the removal did not take.
4. Run `aws lambda get-function-concurrency --function-name <AgentExecutor>` and the same for `SlackQuestProcessor`. Expected: `ReservedConcurrentExecutions: 10` on both - unchanged. This is the check that the wrong property was not removed.
5. Same call for `mcpHandler`. Expected: no reserved concurrency, which is what it had before.
6. Exercise the agent path end-to-end: open a chat, ask a question that requires a tool call (e.g. `What is 47 * 1329?` to force the math tool), and confirm a correct answer arrives. Expected: normal behaviour. `AgentExecutor` is invoked unqualified, so this must be unaffected.
7. Exercise the MCP path: use a feature that calls an MCP tool and confirm it returns. Expected: normal behaviour.
8. Exercise the Slack path: send a message that routes to `SlackQuestProcessor` and confirm the reply arrives. Expected: normal behaviour.
9. Deploy a second time. Expected: no new provisioned-concurrency config appears, and no new function version is published (`aws lambda list-versions-by-function --function-name <name>` should not grow). Version growth would mean `versioning` is still on.

### Regression Checks

10. **Latency.** Compare `Duration`/`InitDuration` on `AgentExecutor` in CloudWatch for the hour before and the hour after the deploy. Expected: no change. The provisioned capacity was on dead versions, so nothing was being served from it - if init duration *does* move, that contradicts the finding in this PR and is worth stopping for.
11. **Throttles.** Check the `Throttles` metric on all three functions for 24 hours after the deploy. Expected: zero, same as before. `reserved` is unchanged, so the ceiling is unchanged.
12. **No accidental version deletion.** `versioning: true` going away means SST stops publishing versions and drops the version resource from state. Confirm the deploy does not error on a version delete, and that nothing invoking these functions broke (see steps 6-8). Nothing reads a version and no aliases exist, so there is nothing to point at a deleted version.
13. **Production promotion.** After staging is verified, promote through the console as usual and repeat steps 3-8 against production. Production held one config per function; expect it to be gone and behaviour unchanged.

### What NOT to test

- **Cold-start improvements.** There are none to find, in either direction. The capacity was unreachable, so removing it neither helps nor hurts latency. Cold starts on these functions are unmitigated today and were unmitigated before this PR.
- **Bundle size or deploy duration.** Unrelated; that is #2545 / #2549.
- **The orphaned configs already in AWS.** Two of them were cleared manually to unblock staging, and `mcpHandler`'s 18 are still there. This PR stops new ones being created; it does not retroactively delete the existing ones. If any survive a green deploy after this merges, delete them with `aws lambda delete-provisioned-concurrency-config`.
- **Anything in the app UI.** No runtime code changed.

## Additional Information

The preview gate is expected to fail on this PR by design - it fails on any PR touching `infra/`, `sst.config.ts` or the overlay pins.

One caveat on the manual cleanup already applied: I left the newest config in place on each of the two blocked functions rather than deleting all of them, because Pulumi tracks one provisioned-concurrency resource per function and pointing its state at a deleted resource seemed the worse failure mode. This deploy removes the resource properly.

## Developer Notes

- **Provisioned concurrency needs an alias or a `Qualifier`, always.** `concurrency: { provisioned: N }` on an `sst.aws.Function` whose callers invoke it by bare name is a no-op that bills. If you want warm capacity on a function in this repo, you need an alias and a `Qualifier` on the invoke side; the flag alone does nothing.
- **`versioning: true` is not free.** It publishes a version per deploy (the `dev` stage was at 1083) and is what gives the leak somewhere to accumulate. Only enable it if something actually resolves a version.
- **A deploy error can name the wrong resource.** When a Pulumi apply fails at an earlier step than the real problem, the surfaced error is about whatever it reached first. If an error names a resource that has no plausible connection to what you changed, suspect ordering before you suspect the resource.
