### PR TITLE
fix(data-lakes): normalize the lake tag prefix inside the tag builders

### DIFF
--- a/apps/client/app/hooks/data/dataLakeUploadPipeline.test.ts
+++ b/apps/client/app/hooks/data/dataLakeUploadPipeline.test.ts
@@ -108,4 +108,14 @@ describe('foldersTagsForBatch', () => {
     expect(new Set(names).size).toBe(names.length);
     expect(names.length).toBeGreaterThan(0);
   });
+
+  it('normalizes a stored prefix that carries edge whitespace (#2467)', () => {
+    // The pipeline passes the lake's RAW fileTagPrefix, and a row predating the create schema's
+    // trim can hold " legal: ". folderTagForFile normalizes, so upload's tag matches the one
+    // applyTaxonomySuggestions later subtracts from its taxonomy result - and both are visible
+    // to the read arms, which trim before matching.
+    expect(foldersTagsForBatch([{ relativePath: 'legal/contracts/a.pdf' }], ' legal: ')).toEqual(
+      foldersTagsForBatch([{ relativePath: 'legal/contracts/a.pdf' }], 'legal:')
+    );
+  });
 });

--- a/apps/client/app/hooks/data/dataLakeUploadPipeline.test.ts
+++ b/apps/client/app/hooks/data/dataLakeUploadPipeline.test.ts
@@ -110,10 +110,11 @@ describe('foldersTagsForBatch', () => {
   });
 
   it('normalizes a stored prefix that carries edge whitespace (#2467)', () => {
-    // The pipeline passes the lake's RAW fileTagPrefix, and a row predating the create schema's
-    // trim can hold " legal: ". folderTagForFile normalizes, so upload's tag matches the one
-    // applyTaxonomySuggestions later subtracts from its taxonomy result - and both are visible
-    // to the read arms, which trim before matching.
+    // runUploadPipeline already trims via submittedTagPrefix before it reaches this helper, so
+    // this pins the belt rather than the braces: foldersTagsForBatch is exported and callable
+    // with a lake's raw fileTagPrefix, and a row predating the create schema's trim can hold
+    // " legal: ". The name it builds has to be the trimmed one either way, since that is the
+    // form the read arms and the apply door both match on (#2467).
     expect(foldersTagsForBatch([{ relativePath: 'legal/contracts/a.pdf' }], ' legal: ')).toEqual(
       foldersTagsForBatch([{ relativePath: 'legal/contracts/a.pdf' }], 'legal:')
     );

--- a/b4m-core/common/src/utils/dataLakeTaxonomy.test.ts
+++ b/b4m-core/common/src/utils/dataLakeTaxonomy.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { TaxonomyTag, TaxonomyTagSet } from '../types/entities/DataLakeTypes';
-import { appliedTagsForBatch, folderMatches, sanitizeCategories, tagsForFile } from './dataLakeTaxonomy';
+import {
+  appliedTagsForBatch,
+  folderMatches,
+  folderTagForFile,
+  sanitizeCategories,
+  tagsForFile,
+} from './dataLakeTaxonomy';
 
 /**
  * Regression coverage: the Taxonomy step used to be pure theater - inference returned
@@ -124,6 +130,18 @@ describe('tagsForFile', () => {
     expect(names(result)).toEqual([':legal', ':type:contract']);
   });
 
+  it('trims a stored prefix so every tag lands under the normalized namespace', () => {
+    // A lake row predating the create schema's trim can hold " acme:" (#2467). The write doors
+    // gate on the NORMALIZED prefix and every read arm trims before matching, so a builder that
+    // appended to the raw value would write " acme:legal" - a name nothing can see.
+    const result = tagsForFile(
+      'root/legal/vendor.pdf',
+      taxonomy({ tags: [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })] }),
+      ' acme: '
+    );
+    expect(names(result)).toEqual(['acme:legal', 'acme:type:contract']);
+  });
+
   it('caps how many categories a single file can accumulate, keeping the strongest', () => {
     const many = Array.from({ length: 12 }, (_, i) =>
       tag({ suffix: `cat${i}`, matchingFolders: ['legal'], strength: i / 12 })
@@ -159,6 +177,19 @@ describe('tagsForFile', () => {
   });
 });
 
+describe('folderTagForFile', () => {
+  it('trims a stored prefix, so the upload pipeline and the apply door share one namespace', () => {
+    // The upload pipeline passes the lake's RAW fileTagPrefix (dataLakeUploadPipeline.ts) while
+    // applyTaxonomySuggestions passes the gate's normalized one. Both must produce the same name
+    // for the same file, or a re-apply's folder-tag subtraction stops matching what upload wrote
+    // and the file picks up the folder tag twice under two spellings.
+    expect(folderTagForFile('root/legal/vendor.pdf', ' acme: ')).toEqual(
+      folderTagForFile('root/legal/vendor.pdf', 'acme:')
+    );
+    expect(folderTagForFile('root/legal/vendor.pdf', ' acme: ')).toEqual([{ name: 'acme:legal', strength: 1.0 }]);
+  });
+});
+
 describe('sanitizeCategories', () => {
   it('caps the number of categories at 100, mirroring ApplyTaxonomyRequestInput', () => {
     const categories = Array.from({ length: 150 }, (_, i) => ({ tagName: `type:cat${i}` }));
@@ -191,6 +222,19 @@ describe('sanitizeCategories', () => {
     const result = sanitizeCategories([{ tagName: 'type:contract', matchingFolders: [longFolder] }], 'acme');
 
     expect(result[0]?.matchingFolders[0]?.length).toBeLessThanOrEqual(512);
+  });
+});
+
+describe('sanitizeCategories with an un-trimmed source prefix', () => {
+  it('still strips the inferred prefix, so the suffix does not carry it a second time', () => {
+    // deriveSuffix compares against the same normalized prefix the builders apply. Without that,
+    // a lake stored as " acme:" would keep "acme:contract" whole as the suffix and tagsForFile
+    // would then emit "acme:acme:contract".
+    const [category] = sanitizeCategories(
+      [{ tagName: 'acme:contract', confidence: 0.8, matchingFolders: [] }],
+      ' acme:'
+    );
+    expect(category.suffix).toBe('contract');
   });
 });
 

--- a/b4m-core/common/src/utils/dataLakeTaxonomy.test.ts
+++ b/b4m-core/common/src/utils/dataLakeTaxonomy.test.ts
@@ -179,10 +179,11 @@ describe('tagsForFile', () => {
 
 describe('folderTagForFile', () => {
   it('trims a stored prefix, so the upload pipeline and the apply door share one namespace', () => {
-    // The upload pipeline passes the lake's RAW fileTagPrefix (dataLakeUploadPipeline.ts) while
-    // applyTaxonomySuggestions passes the gate's normalized one. Both must produce the same name
-    // for the same file, or a re-apply's folder-tag subtraction stops matching what upload wrote
-    // and the file picks up the folder tag twice under two spellings.
+    // Callers reach this with the prefix in whatever form their own path left it: the upload
+    // pipeline normalizes first (submittedTagPrefix), applyTaxonomySuggestions passes the gate's
+    // normalized value, and the analyze job passes lake.fileTagPrefix raw. All three must produce
+    // the same name for the same file, or one lake's files split across two namespaces of which
+    // only the trimmed one is visible to the read arms.
     expect(folderTagForFile('root/legal/vendor.pdf', ' acme: ')).toEqual(
       folderTagForFile('root/legal/vendor.pdf', 'acme:')
     );

--- a/b4m-core/common/src/utils/dataLakeTaxonomy.ts
+++ b/b4m-core/common/src/utils/dataLakeTaxonomy.ts
@@ -23,14 +23,36 @@ const clampStrength = (value: unknown, fallback: number): number =>
   typeof value === 'number' && Number.isFinite(value) ? Math.min(Math.max(value, 0), 1) : fallback;
 
 /**
+ * THE raw-vs-normalized contract for every tag name this module builds.
+ *
+ * Callers hand these builders a lake's STORED `fileTagPrefix`, which is not guaranteed to equal
+ * its `normalizeTagPrefix` form: the create schema trims it (schemas/dataLake.ts) but rows
+ * predating that trim can still hold edge whitespace. The write doors gate on the NORMALIZED
+ * prefix (`decideStampPrefix` -> `decision.prefix`), and every read arm - `satisfiesTagPrefix`,
+ * the tag-tree roots, the tag-count aggregates - normalizes too. So a builder that appended a
+ * suffix to the raw value would write ` acme:legal`, a name all of those read straight past.
+ *
+ * Normalizing HERE rather than at each call site is what keeps the lake to one namespace: the
+ * upload pipeline's folder tag (dataLakeUploadPipeline.ts), `applyTaxonomySuggestions`, and the
+ * analyze job's suffix derivation all reach a prefixed name through this function, so they cannot
+ * land on opposite sides of the trim. It appends the colon itself rather than delegating to
+ * `normalizeTagPrefix`, which rejects the colon-less form outright: these builders are specified
+ * to apply whatever prefix they are given, colon or not.
+ */
+const ensureColon = (prefix: string): string => {
+  const trimmed = prefix.trim();
+  return trimmed.endsWith(':') ? trimmed : `${trimmed}:`;
+};
+
+/**
  * The editable suffix is the tag name with its inferred prefix stripped, so the prefix is
  * never stored per-tag (it lives once in the caller's tagPrefix). A name that does not carry
  * the inferred prefix keeps its whole text as the suffix.
  */
 const deriveSuffix = (fullName: string, sourcePrefix: string): string => {
   const trimmed = fullName.trim();
-  if (!sourcePrefix) return trimmed;
-  const p = sourcePrefix.endsWith(':') ? sourcePrefix : `${sourcePrefix}:`;
+  if (!sourcePrefix.trim()) return trimmed;
+  const p = ensureColon(sourcePrefix);
   return trimmed.toLowerCase().startsWith(p.toLowerCase()) ? trimmed.slice(p.length) : trimmed;
 };
 
@@ -105,8 +127,6 @@ export function sanitizeFileAssignments(
  * only - the folder tag is added on top, so a file can carry this many + 1.
  */
 const MAX_TAXONOMY_TAGS_PER_FILE = 8;
-
-const ensureColon = (prefix: string): string => (prefix.endsWith(':') ? prefix : `${prefix}:`);
 
 /**
  * One normalization shared by the folder tag and folder matching. Both sides must agree:

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { IDataLakeBatchDocument, IDataLakeDocument, TaxonomyTag } from '@bike4mind/common';
+import { folderTagForFile } from '@bike4mind/common';
 import { applyTaxonomySuggestions } from './applyTaxonomySuggestions';
 
 const lake = (overrides: Partial<IDataLakeDocument> = {}): IDataLakeDocument =>
@@ -96,6 +97,37 @@ describe('applyTaxonomySuggestions', () => {
     expect(updates[0].id).toBe('f1');
     const names = updates[0].tags.map((t: { name: string }) => t.name).sort();
     // Folder tag kept (unchanged), category tag added - never duplicated.
+    expect(names).toEqual(['acme:legal', 'acme:type:contract']);
+  });
+
+  it('lands under one namespace for a lake whose stored prefix has edge whitespace (#2467)', async () => {
+    // The end-to-end shape of the bug: a lake row predating the create schema's trim stores
+    // " acme: ". The upload pipeline built the file's folder tag from that RAW value
+    // (dataLakeUploadPipeline.ts passes lake.fileTagPrefix straight to folderTagForFile), while
+    // this door builds its tags from the gate's NORMALIZED one. The two agree only because the
+    // builders themselves trim - which is what makes the folder-tag subtraction below still
+    // match, so a re-apply cannot re-add the folder tag under a second spelling.
+    const RAW_PREFIX = ' acme: ';
+    const uploadedFolderTags = folderTagForFile('legal/vendor.pdf', RAW_PREFIX);
+    expect(uploadedFolderTags).toEqual([{ name: 'acme:legal', strength: 1 }]);
+
+    const adapters = makeAdapters({
+      lakeDoc: lake({ fileTagPrefix: RAW_PREFIX }),
+      files: [file({ tags: uploadedFolderTags })],
+    });
+
+    const result = await applyTaxonomySuggestions(
+      { userId: 'owner', isAdmin: false },
+      'b1',
+      [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })],
+      adapters as any
+    );
+
+    expect(result).toEqual({ success: true, filesUpdated: 1, unchanged: 0, skipped: 0 });
+    const updates = adapters.db.fabFiles.bulkUpdateTags.mock.calls[0][0];
+    const names = updates[0].tags.map((t: { name: string }) => t.name).sort();
+    // Every tag under `acme:`, the form the read arms and the tag-count aggregates match, and
+    // exactly one folder tag - not the raw " acme:legal" the un-normalized builders would write.
     expect(names).toEqual(['acme:legal', 'acme:type:contract']);
   });
 

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { IDataLakeBatchDocument, IDataLakeDocument, TaxonomyTag } from '@bike4mind/common';
-import { folderTagForFile } from '@bike4mind/common';
+import { folderTagForFile, submittedTagPrefix } from '@bike4mind/common';
 import { applyTaxonomySuggestions } from './applyTaxonomySuggestions';
 
 const lake = (overrides: Partial<IDataLakeDocument> = {}): IDataLakeDocument =>
@@ -101,14 +101,22 @@ describe('applyTaxonomySuggestions', () => {
   });
 
   it('lands under one namespace for a lake whose stored prefix has edge whitespace (#2467)', async () => {
-    // The end-to-end shape of the bug: a lake row predating the create schema's trim stores
-    // " acme: ". The upload pipeline built the file's folder tag from that RAW value
-    // (dataLakeUploadPipeline.ts passes lake.fileTagPrefix straight to folderTagForFile), while
-    // this door builds its tags from the gate's NORMALIZED one. The two agree only because the
-    // builders themselves trim - which is what makes the folder-tag subtraction below still
-    // match, so a re-apply cannot re-add the folder tag under a second spelling.
-    const RAW_PREFIX = ' acme: ';
-    const uploadedFolderTags = folderTagForFile('legal/vendor.pdf', RAW_PREFIX);
+    // The end-to-end shape of the bug, for a lake row predating the create schema's trim.
+    //
+    // The upload pipeline normalizes before it builds anything - `runUploadPipeline` passes
+    // `submittedTagPrefix(config.tagPrefix)` to folderTagForFile, and in append mode
+    // config.tagPrefix is seeded from lake.fileTagPrefix - so the file already carries
+    // `acme:legal`, under the same form every read arm matches. This door was the one on the
+    // other side: it built from the RAW stored value, so the taxonomy tags it added landed under
+    // ` acme:` while the folder tag beside them stayed under `acme:`. One file, two namespaces,
+    // and the taxonomy half invisible to `satisfiesTagPrefix`, the tag-tree roots and the
+    // tag-count aggregates. Deriving the fixture from the pipeline's own normalizer is what pins
+    // that asymmetry - hand-writing the name would hide which side was wrong.
+    //
+    // The folder-tag subtraction did NOT break pre-fix: it compared the door's own two raw
+    // computations against each other, so it stayed self-consistent while both were wrong.
+    const RAW_PREFIX = ' acme:';
+    const uploadedFolderTags = folderTagForFile('legal/vendor.pdf', submittedTagPrefix(RAW_PREFIX));
     expect(uploadedFolderTags).toEqual([{ name: 'acme:legal', strength: 1 }]);
 
     const adapters = makeAdapters({
@@ -127,7 +135,7 @@ describe('applyTaxonomySuggestions', () => {
     const updates = adapters.db.fabFiles.bulkUpdateTags.mock.calls[0][0];
     const names = updates[0].tags.map((t: { name: string }) => t.name).sort();
     // Every tag under `acme:`, the form the read arms and the tag-count aggregates match, and
-    // exactly one folder tag - not the raw " acme:legal" the un-normalized builders would write.
+    // exactly ONE folder tag - the pre-fix door also emitted " acme:legal" here.
     expect(names).toEqual(['acme:legal', 'acme:type:contract']);
   });
 

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
@@ -89,6 +89,13 @@ export const applyTaxonomySuggestions = async (
   if (prefixDecision.overlapCheckFailed) {
     throw new BadRequestError(UNVERIFIED_PREFIX_OVERLAP_REFUSAL);
   }
+  // The gate's NORMALIZED prefix, never `lake.fileTagPrefix` - same as the sibling door
+  // (`setDataLakeFileTags`, step 5) and the backfill migration. Writing under the raw stored value
+  // for a row that predates the create schema's trim would mint ` acme:legal`, which the read arms
+  // and the tag-count aggregates normalize straight past (#2467). The tag builders below normalize
+  // too, so this is belt-and-braces rather than the only guard - but it is what makes the door's
+  // intent readable, and it keeps every write door quoting one value.
+  const prefix = prefixDecision.prefix;
 
   // Guarded claim: only a batch whose suggestions are 'ready' (and not already being applied
   // by a concurrent request) proceeds. Also blocks re-applying an already-'applied' batch
@@ -143,13 +150,11 @@ export const applyTaxonomySuggestions = async (
 
     const updates = files.flatMap(file => {
       const relativePath = file.relativePath ?? file.fileName;
-      const folderTags = folderTagForFile(relativePath, lake.fileTagPrefix);
+      const folderTags = folderTagForFile(relativePath, prefix);
       const folderTagNames = new Set(folderTags.map(t => t.name));
       // The folder tag is already on the file from upload - keep only the taxonomy-derived
       // portion so re-running this can never duplicate it.
-      const newTags = tagsForFile(relativePath, taxonomySet, lake.fileTagPrefix).filter(
-        t => !folderTagNames.has(t.name)
-      );
+      const newTags = tagsForFile(relativePath, taxonomySet, prefix).filter(t => !folderTagNames.has(t.name));
       if (newTags.length === 0) return [];
 
       const existingTags = file.tags ?? [];

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -1016,7 +1016,10 @@ DataLakeBatchSchema.index({ userId: 1, taxonomyStatus: 1, updatedAt: -1 });
 // updatedAt, is the correct clock for "how long has this taxonomy attempt been stuck."
 DataLakeBatchSchema.index({ taxonomyStatus: 1, taxonomyStartedAt: 1 });
 
-const DataLakeBatchModel =
+// Exported like its sibling `DataLakeModel` above: app code goes through
+// `dataLakeBatchRepository`, but the operator scripts under packages/scripts/migrate read models
+// directly (see check-datalake-prefix-whitespace.ts, which reads stored taxonomy suffixes).
+export const DataLakeBatchModel =
   (mongoose.models['DataLakeBatch'] as unknown as mongoose.Model<IDataLakeBatchDocument>) ||
   mongoose.model<IDataLakeBatchDocument>('DataLakeBatch', DataLakeBatchSchema);
 

--- a/packages/scripts/migrate/check-datalake-prefix-whitespace.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-whitespace.ts
@@ -1,0 +1,99 @@
+import { connectDB, DataLakeModel } from '@bike4mind/database';
+import { Resource } from 'sst';
+import { Config } from '../utils/config';
+
+/**
+ * READ-ONLY census of data lakes whose stored `fileTagPrefix` is not already its own
+ * `normalizeTagPrefix` form - i.e. it carries edge whitespace (#2467).
+ *
+ * The gate every tag-write door runs (`decideStampPrefix`) hands back the TRIMMED prefix, and
+ * every read arm - `satisfiesTagPrefix`, the tag-tree roots, the tag-count aggregates - trims
+ * before matching. A row storing " acme:" therefore reads under `acme:` everywhere, and any
+ * writer that appended a suffix to the raw value produced a name nothing could see. The tag
+ * builders now normalize (`ensureColon` in dataLakeTaxonomy.ts), so no NEW tag can land on the
+ * wrong side of the trim; this script answers the remaining question - how many rows are on the
+ * wrong side already, and therefore whether the tags written for them BEFORE that change need a
+ * backfill.
+ *
+ * Expected to report zero: `CreateDataLakeRequestInput` has trimmed `fileTagPrefix` for some
+ * time and there is no update path for the field, so only rows predating that trim can qualify.
+ * A non-empty result is the trigger for a repair migration (trim the stored prefix, rewrite the
+ * files' raw-prefix tags), not something to fix by hand one row at a time.
+ *
+ * Reports only; exits 0 either way. An un-trimmed prefix is a legacy-data question, not a reason
+ * to block a deploy.
+ *
+ * Usage:
+ *   ./for-env <env> pnpm sst shell --stage <stage> -- pnpm --filter scripts datalake:check-prefix-whitespace
+ */
+interface LakeRow {
+  _id: unknown;
+  name?: string;
+  slug?: string;
+  fileTagPrefix?: string;
+  createdByUserId?: string;
+  organizationId?: string | null;
+}
+
+/** Render the raw value so leading/trailing space is visible in the output at all. */
+const quoteRaw = (value: string | undefined) => JSON.stringify(value ?? null);
+
+async function main() {
+  const dbUri = Config.MONGODB_URI;
+  if (!dbUri) throw new Error('MONGODB_URI is required');
+  const stage = Resource.App.stage;
+  await connectDB(dbUri.replace('%STAGE%', stage));
+
+  console.log(`Checking DataLake fileTagPrefix normalization on stage="${stage}"...`);
+
+  // Matched in JS rather than by a `$expr` trim comparison: the set is small, the raw value has
+  // to be printed anyway, and this keeps the predicate identical to normalizeTagPrefix's own.
+  const lakes = await DataLakeModel.find(
+    {},
+    { name: 1, slug: 1, fileTagPrefix: 1, createdByUserId: 1, organizationId: 1 }
+  ).lean<LakeRow[]>();
+
+  console.log(`Scanned ${lakes.length} data lakes.`);
+
+  const untrimmed = lakes.filter(
+    l => typeof l.fileTagPrefix === 'string' && l.fileTagPrefix !== l.fileTagPrefix.trim()
+  );
+
+  // Separate bucket: a prefix that survives trimming but still is not usable (blank, or missing
+  // its trailing colon) is refused by the gate outright rather than silently written past, so it
+  // is a different problem from this one - counted here only so the census is not read as a
+  // clean bill of health for the field as a whole.
+  const unusable = lakes.filter(l => {
+    const trimmed = (l.fileTagPrefix ?? '').trim();
+    return trimmed.length === 0 || !trimmed.endsWith(':');
+  });
+
+  if (untrimmed.length === 0) {
+    console.log('No lake stores an un-trimmed fileTagPrefix - stored prefixes already equal their normalized form.');
+  } else {
+    console.log(`Found ${untrimmed.length} lake(s) whose stored fileTagPrefix is not trimmed. Tags written for these`);
+    console.log('before the builders normalized are under the RAW prefix and invisible to every read arm:');
+    for (const l of untrimmed) {
+      console.log(
+        `  "${l.name}" (slug=${l.slug}, id=${l._id}) prefix=${quoteRaw(l.fileTagPrefix)} -> ${quoteRaw(
+          l.fileTagPrefix?.trim()
+        )} [org=${l.organizationId ?? '<none>'} creator=${l.createdByUserId ?? '<none>'}]`
+      );
+    }
+  }
+
+  if (unusable.length > 0) {
+    console.log(`\nAlso ${unusable.length} lake(s) with a prefix that is unusable even trimmed (blank, or no trailing`);
+    console.log('colon). These are refused by decideStampPrefix rather than mis-written - separate problem:');
+    for (const l of unusable) {
+      console.log(`  "${l.name}" (slug=${l.slug}, id=${l._id}) prefix=${quoteRaw(l.fileTagPrefix)}`);
+    }
+  }
+
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/scripts/migrate/check-datalake-prefix-whitespace.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-whitespace.ts
@@ -1,4 +1,4 @@
-import { connectDB, DataLakeModel } from '@bike4mind/database';
+import { connectDB, DataLakeBatchModel, DataLakeModel } from '@bike4mind/database';
 import { Resource } from 'sst';
 import { Config } from '../utils/config';
 
@@ -17,8 +17,21 @@ import { Config } from '../utils/config';
  *
  * Expected to report zero: `CreateDataLakeRequestInput` has trimmed `fileTagPrefix` for some
  * time and there is no update path for the field, so only rows predating that trim can qualify.
- * A non-empty result is the trigger for a repair migration (trim the stored prefix, rewrite the
- * files' raw-prefix tags), not something to fix by hand one row at a time.
+ * A non-empty result is the trigger for a repair migration, not something to fix by hand one row
+ * at a time - and that repair has THREE legs, which is why this reports more than a lake count:
+ *
+ *   1. the stored `fileTagPrefix` itself (trim it),
+ *   2. the tags already written onto that lake's files under the raw prefix, which no read arm
+ *      can see,
+ *   3. the stored `taxonomySuggestions[].suffix` values on that lake's batches.
+ *
+ * Leg 3 is the non-obvious one. `deriveSuffix` used to compare an inferred tag name against the
+ * RAW prefix, so for a lake stored as " acme:" it could not strip anything and banked the whole
+ * name as the suffix ("acme:contract"). Applying such a batch now composes it against the
+ * NORMALIZED prefix and yields `acme:acme:contract` - which, unlike the old " acme:acme:contract",
+ * is visible in the tag tree and counted by the aggregates. Re-analyze re-derives suffixes with
+ * the current code, so only batches sitting in a directly-appliable state carry live exposure;
+ * the report flags those separately below.
  *
  * Reports only; exits 0 either way. An un-trimmed prefix is a legacy-data question, not a reason
  * to block a deploy.
@@ -34,6 +47,20 @@ interface LakeRow {
   createdByUserId?: string;
   organizationId?: string | null;
 }
+
+interface BatchRow {
+  _id: unknown;
+  dataLakeId?: string;
+  taxonomyStatus?: string;
+  taxonomySuggestions?: { tags?: { suffix?: string }[] };
+}
+
+/**
+ * A batch in one of these can be applied without re-analysis, so its stored suffixes compose into
+ * tag names as-is. Every other taxonomy state has to pass through re-analyze first, which
+ * re-derives them with the current `deriveSuffix`.
+ */
+const DIRECTLY_APPLIABLE = new Set(['ready', 'applying']);
 
 /** Render the raw value so leading/trailing space is visible in the output at all. */
 const quoteRaw = (value: string | undefined) => JSON.stringify(value ?? null);
@@ -79,6 +106,45 @@ async function main() {
           l.fileTagPrefix?.trim()
         )} [org=${l.organizationId ?? '<none>'} creator=${l.createdByUserId ?? '<none>'}]`
       );
+    }
+  }
+
+  // Leg 3, only worth the query when leg 1 found something: a suffix that already starts with the
+  // lake's normalized prefix is one the old raw comparison failed to strip, and applying it now
+  // builds a visible double-prefixed tag.
+  if (untrimmed.length > 0) {
+    const lakeIds = untrimmed.map(l => String(l._id));
+    const batches = await DataLakeBatchModel.find(
+      { dataLakeId: { $in: lakeIds }, 'taxonomySuggestions.tags.0': { $exists: true } },
+      { dataLakeId: 1, taxonomyStatus: 1, 'taxonomySuggestions.tags': 1 }
+    ).lean<BatchRow[]>();
+
+    const prefixByLakeId = new Map(untrimmed.map(l => [String(l._id), (l.fileTagPrefix ?? '').trim().toLowerCase()]));
+    const affected = batches.flatMap(b => {
+      const prefix = prefixByLakeId.get(String(b.dataLakeId)) ?? '';
+      const stale = (b.taxonomySuggestions?.tags ?? []).filter(
+        t => typeof t.suffix === 'string' && prefix.length > 0 && t.suffix.toLowerCase().startsWith(prefix)
+      );
+      return stale.length > 0 ? [{ batch: b, stale }] : [];
+    });
+
+    if (affected.length === 0) {
+      console.log('\nNo batch on those lakes stores a suffix that would double-prefix on apply.');
+    } else {
+      const appliable = affected.filter(a => DIRECTLY_APPLIABLE.has(a.batch.taxonomyStatus ?? ''));
+      console.log(`\nAlso ${affected.length} batch(es) on those lakes store suffixes that already carry the prefix.`);
+      console.log(`${appliable.length} of them are directly appliable and would write a visible double-prefixed tag;`);
+      console.log('the rest must pass through re-analyze, which re-derives the suffix and self-heals:');
+      for (const { batch, stale } of affected) {
+        const sample = stale
+          .slice(0, 3)
+          .map(t => quoteRaw(t.suffix))
+          .join(', ');
+        console.log(
+          `  batch=${batch._id} lake=${batch.dataLakeId} taxonomyStatus=${batch.taxonomyStatus ?? '<none>'}` +
+            ` stale=${stale.length} e.g. ${sample}`
+        );
+      }
     }
   }
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -21,6 +21,7 @@
     "datalake:check-slug-dupes": "tsx migrate/check-datalake-slug-dupes.ts",
     "datalake:check-prefix-overlaps": "tsx migrate/check-datalake-prefix-overlaps.ts",
     "datalake:check-prefix-dupes": "tsx migrate/check-datalake-prefix-dupes.ts",
+    "datalake:check-prefix-whitespace": "tsx migrate/check-datalake-prefix-whitespace.ts",
     "datalake:check-prefix-only-members": "tsx migrate/check-datalake-prefix-only-members.ts",
     "datalake:ingest-pdfs": "tsx datalake/ingest-pdf-datalake.ts",
     "datalake:check-stranded-drive-connections": "tsx datalake/check-stranded-drive-connections.ts",


### PR DESCRIPTION
## Description

Closes #2467.

`applyTaxonomySuggestions` asked `decideStampPrefix` whether the lake's prefix was usable, then ignored the normalized prefix the gate handed back and built its tag names from `lake.fileTagPrefix`. For a row storing `" acme:"` the two disagree: the gate permits under `acme:`, and the door wrote `" acme:<suffix>"` - a name that `satisfiesTagPrefix`, the tag-tree roots, and the tag-count aggregates all normalize straight past.

### Correction to the issue's framing

The issue says the fix can't be a one-liner because "the upload pipeline writes each file's folder tag from the same raw value." **It doesn't.** `runUploadPipeline` passes `submittedTagPrefix(config.tagPrefix)` to `folderTagForFile` ([dataLakeUploadPipeline.ts:341](apps/client/app/hooks/data/dataLakeUploadPipeline.ts#L341)), and in append mode `config.tagPrefix` is seeded from `lake.fileTagPrefix` and then trimmed. Upload was already writing the normalized name. Credit to the review pass for catching this - I carried the issue's claim forward without tracing it back past the call sites it cited.

So the pre-fix damage is the opposite shape from the one described. Upload wrote `acme:legal`; this door, building from the raw stored value, added its taxonomy tags under `" acme:"` beside it. **One file, two namespaces, with the taxonomy half invisible to every read arm.** The folder-tag subtraction never broke - it compared the door's own two raw computations against each other, so it stayed self-consistent while both were wrong. The duplicated-folder-tag hazard the issue predicted was not reachable, then or under a two-line change.

That also means the two-line change *would* have been sufficient for this door. I still think normalizing centrally is the better fix, on two grounds that survive the correction:

1. It fixes a second bug the two-line change doesn't touch - the analyze job passes `lake.fileTagPrefix` raw to `sanitizeCategories`, so for an untrimmed lake `deriveSuffix` failed to strip an `acme:`-prefixed inferred name and the applied tag came out `acme:acme:<suffix>`.
2. It puts the guarantee at the seam every future caller goes through, rather than leaving the next one to remember. `ensureColon` is the one function every prefixed name in `dataLakeTaxonomy.ts` passes through.

That is the issue's option 1, done in one place instead of three, composing with option 2 (the create schema's existing `.trim()`, which is why the census is expected to come back zero).

No behavior change for any lake whose stored prefix is already trimmed, which the create schema makes the overwhelming majority.

## Changes

- **`b4m-core/common/src/utils/dataLakeTaxonomy.ts`** - `ensureColon` now trims edge whitespace before appending the colon, and carries the raw-vs-normalized contract as a doc comment so the next reader does not have to derive it. `deriveSuffix` uses it too, closing a second-order bug: a lake stored as `" acme:"` previously failed to strip an `acme:`-prefixed inferred name, so the applied tag came out as `acme:acme:<suffix>`.
- **`b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts`** - reads `decision.prefix` from the gate, matching `setDataLakeFileTags` (step 5) and the backfill migration. Belt-and-braces now that the builders normalize, but it is what makes the door's intent readable and keeps every write door quoting one value.
- **`packages/scripts/migrate/check-datalake-prefix-whitespace.ts`** (new, read-only) + `datalake:check-prefix-whitespace` script - the census the issue asks for: how many lakes store a `fileTagPrefix` that is not already its own `normalizeTagPrefix` form. Modeled on the sibling `check-datalake-prefix-dupes` / `check-datalake-prefix-overlaps` scripts. It reports all three legs of the repair a non-empty result would imply (see below), plus a separate bucket for prefixes unusable even trimmed, so the census is not read as a clean bill of health for the field as a whole.
- **Tests** - the end-to-end case the issue's acceptance calls for: a lake whose stored prefix has edge whitespace, with the upload folder tag and the taxonomy apply landing under one prefix. It derives its fixture from the pipeline's own `submittedTagPrefix` rather than hand-writing the expected name, so it pins which side was wrong. Verified to fail against the pre-fix source with `" acme:type:contract"`. Plus unit coverage on `folderTagForFile`, `tagsForFile`, `sanitizeCategories`, and `foldersTagsForBatch`.

## Not in this PR

**The repair migration.** The census has not been run - it needs a stage's DB, which I do not have from here. If it reports zero, nothing further is needed: the builders now guarantee no new tag can land on the wrong side of the trim, and there is no legacy row to repair. If it reports non-zero, the repair has three legs, and the script reports each so the migration is not written against a partial picture:

1. The stored `fileTagPrefix` itself (trim it).
2. The tags already written onto that lake's files under the raw prefix, which no read arm can see.
3. The stored `taxonomySuggestions[].suffix` values on that lake's batches. This one is not obvious and was caught in review: the old `deriveSuffix` compared against the raw prefix, so for a lake stored as `" acme:"` it stripped nothing and banked the whole name (`"acme:contract"`). Applying such a batch now composes it against the normalized prefix and yields `acme:acme:contract` - which, unlike the old `" acme:acme:contract"`, is visible in the tag tree and counted by the aggregates. No new membership is minted (the file is already in the lake, and an overlapping-prefix lake is refused at create), so it is visible junk rather than an access change. The script separates the directly-appliable batches from those that must pass through re-analyze, which re-derives the suffix and self-heals.

That is the issue's option 2 tail, and it is gated on the census by design.

To run it:

```
./for-env <env> pnpm sst shell --stage <stage> -- pnpm --filter scripts datalake:check-prefix-whitespace
```

## Guide for Testers

Test on the **PR preview** env for this PR: `pr2561.preview.bike4mind.com`. A maintainer has to trigger the preview through the internal deploy pipeline (there is no label or comment command); the bot comment with the URL appears on this PR once it exists. Do not run these steps on staging - staging does not carry this branch, so a pass there says nothing about the change.

This is a backend/contract change with no UI surface. The behavior it corrects is only reachable for a data lake whose stored `fileTagPrefix` carries leading or trailing whitespace, which the create form cannot produce (the request schema trims it) - so there is nothing to reproduce through the app. The steps below are regression checks that the normal path still works.

### Regression checks

1. Open `pr2561.preview.bike4mind.com` and sign in.
2. Sidebar -> Data Lakes -> create a new lake named `Tag Prefix Check`, accepting the derived tag prefix. Expected: the lake is created and its prefix chip reads `tag_prefix_check:` (or similar) with no leading space.
3. Open the lake's upload wizard and upload a small folder containing at least one nested file, e.g. `legal/vendor.pdf`. Expected: the upload completes and the batch appears.
4. Open the file in the Explorer and check its tags. Expected: it carries a folder tag `<prefix>legal` - one tag, under the lake's prefix exactly as shown in the lake header.
5. Wait for the batch's tag suggestions to reach "ready", open the review panel, and click Apply Tags. Expected: a success toast reporting the number of files updated.
6. Re-open the same file's tags. Expected: the folder tag `<prefix>legal` still appears exactly ONCE, now alongside the accepted category tags, all under the same prefix.
7. In the Explorer's tag tree, expand the lake's prefix root. Expected: every tag from steps 4 and 6 is listed under it - none missing, and no near-duplicate root with a leading space.
8. Check the lake's file/tag counts in the lake header. Expected: they match the number of files uploaded.

### What NOT to test

- There is no way to create a lake with an un-trimmed prefix through the UI, so the bug class itself is not reproducible on the preview env either. Steps 2-8 confirm the normal path is unchanged; the un-trimmed case is covered by the unit and end-to-end tests, one of which was verified to fail against the pre-fix source.
- Do not test on staging or production - neither carries this branch.
- The census script is read-only and operator-run against a stage's DB; it is not reachable from the app and is not part of this test pass.

## Additional Information

Found while reviewing #2435, which added the gate call to this door and deliberately left this for a separate change.

Two follow-up commits after the automated review: 88c2a7f41 is comments and one test only, and a50db360b extends the census (plus an `export` on `DataLakeBatchModel` to read batches). No change to the fix itself in either.

Verified locally: `pnpm turbo:typecheck` clean; `@bike4mind/common` (2223), `@bike4mind/services` (6457) and `@bike4mind/client` (12754) suites pass. One pre-existing client failure (`__tests__/premiumMigrationsWiring.test.ts`) is an artifact of a locally checked-out overlay and fails identically on a clean tree.

## Developer Notes

- **Contract stated once**: `ensureColon` in `dataLakeTaxonomy.ts` is now the documented seam where a lake's stored `fileTagPrefix` becomes a normalized tag name. Anything that needs to build a prefixed tag should go through the builders rather than concatenating the stored value, and the doc comment says why.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
