### PR TITLE
fix(client): honor a POST /api/chat tools array sent without toolMode

### DIFF
--- a/apps/client/pages/api/__tests__/chat.integration.test.ts
+++ b/apps/client/pages/api/__tests__/chat.integration.test.ts
@@ -530,6 +530,179 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
     });
   });
 
+  // Tool selection. `tools` is a top-level field with nothing in the schema marking it
+  // conditional on toolMode, so sending it alone used to be a silent no-op: the array was
+  // read in exactly one place (the toolMode === 'smart' branch), and the request then took
+  // the tools-disabled path, which sends `tools: []`. Nothing covered that shape, which is
+  // why the drop was invisible in a green suite.
+  describe('tool selection', () => {
+    type InvokedBody = {
+      tools?: string[];
+      enableQuestMaster?: boolean;
+      enableMementos?: boolean;
+      enableAgents?: boolean;
+    };
+    const invokedBody = () => (mockInvoke.mock.calls[0][0] as { body: InvokedBody }).body;
+
+    it('honors a tools array sent without toolMode instead of dropping it', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['web_search'] } });
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(invokedBody().tools).toEqual(['web_search']);
+    });
+
+    // The named tool is intent to enable tools, nothing more. QuestMaster/Mementos/Agents
+    // stay off, matching smart mode's conservative defaults rather than the legacy
+    // enableTools path's full-capability defaults.
+    it('enables only tools for a tools-without-toolMode request, not the other capabilities', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['web_search'] } });
+      await handler(req, res);
+      expect(invokedBody()).toMatchObject({
+        enableQuestMaster: false,
+        enableMementos: false,
+        enableAgents: false,
+      });
+    });
+
+    // The response's own `tools` field reported null on this shape, so a caller could not
+    // even see that their array had been discarded.
+    it('reports the resolved set back on the response, with no toolMode since none was sent', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['web_search'] } });
+      await handler(req, res);
+      expect(res._getJSONData().tools).toEqual({ effectiveTools: ['web_search'] });
+    });
+
+    // Unknown ids are dropped by filterKnownTools, so an all-unknown array resolves to
+    // nothing and must NOT count as intent to enable tools.
+    it('does not enable tools when every named id is unrecognized', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['not_a_tool'] } });
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(invokedBody().tools).toEqual([]);
+      expect(invokedBody().enableQuestMaster).toBe(false);
+    });
+
+    // No endpoint enumerates the valid ids, so a dropped id must be reported or a typo is
+    // indistinguishable from a tool that does not exist in this deployment.
+    it('reports a dropped id back on the response rather than failing quiet', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['websearch'] } });
+      await handler(req, res);
+      expect(res._getJSONData().tools).toEqual({ effectiveTools: [], ignoredTools: ['websearch'] });
+    });
+
+    it('reports dropped ids alongside a toolMode the caller did send', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({
+        body: { message: 'hi', sessionId: 'sess-1', toolMode: 'fast', tools: ['websearch'] },
+      });
+      await handler(req, res);
+      expect(res._getJSONData().tools).toMatchObject({ toolMode: 'fast', ignoredTools: ['websearch'] });
+    });
+
+    it('omits ignoredTools entirely when every id was recognized', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['web_search'] } });
+      await handler(req, res);
+      expect(res._getJSONData().tools).not.toHaveProperty('ignoredTools');
+    });
+
+    // Syntactically present but resolving to nothing must read the same as absent.
+    it('treats an explicitly empty tools array as no tools named', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: [] } });
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(invokedBody().tools).toEqual([]);
+      expect(invokedBody().enableQuestMaster).toBe(false);
+      expect(res._getJSONData().tools).toBeUndefined();
+    });
+
+    // `tools` carries no length bound, and the ignored-id split must stay linear: an
+    // Array.includes scan over the recognized list is quadratic on a payload that mixes many
+    // known with many unknown ids, burning ~1s of event loop before any billing or model call.
+    it('splits a large mixed tools payload without a quadratic scan', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const tools = [...Array(4000).fill('web_search'), ...Array(4000).fill('websearch')];
+      const startedAt = Date.now();
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools } });
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(Date.now() - startedAt).toBeLessThan(1000);
+      expect(res._getJSONData().tools.ignoredTools).toHaveLength(4000);
+    });
+
+    // A partially-recognized array still counts as intent, narrowed to what survived.
+    it('enables tools from the recognized subset when only some ids are known', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({
+        body: { message: 'hi', sessionId: 'sess-1', tools: ['not_a_tool', 'web_search'] },
+      });
+      await handler(req, res);
+      expect(invokedBody().tools).toEqual(['web_search']);
+      expect(res._getJSONData().tools).toEqual({
+        effectiveTools: ['web_search'],
+        ignoredTools: ['not_a_tool'],
+      });
+    });
+
+    // 'fast' contributes no tools from the request, so it drops a named set. It does not
+    // guarantee an empty offered set downstream - resolveEnabledTools still auto-offers the
+    // knowledge tool when the session has reachable documents.
+    it("lets toolMode 'fast' drop an explicit tools array", async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({
+        body: { message: 'hi', sessionId: 'sess-1', toolMode: 'fast', tools: ['web_search'] },
+      });
+      await handler(req, res);
+      expect(invokedBody().tools).toEqual([]);
+    });
+
+    // A legacy caller that names tools now gets them on the wire instead of having them
+    // dropped, and keeps the full-capability defaults enableTools has always implied.
+    it('sends the named tools for a legacy enableTools caller, keeping full capabilities', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({
+        body: { message: 'hi', sessionId: 'sess-1', enableTools: true, tools: ['web_search'] },
+      });
+      await handler(req, res);
+      expect(invokedBody()).toMatchObject({
+        tools: ['web_search'],
+        enableQuestMaster: true,
+        enableMementos: true,
+        enableAgents: true,
+      });
+    });
+
+    // The unchanged legacy path (what the voice agent_request portal sends): enableTools with
+    // no named set must still leave `tools` off the wire so the service layer resolves it.
+    it('sends no tools key at all for enableTools with no named set', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', enableTools: true } });
+      await handler(req, res);
+      expect(invokedBody().tools).toBeUndefined();
+      expect(res._getJSONData().tools).toBeUndefined();
+    });
+
+    // The no-tools default, unchanged.
+    it('keeps the tools-disabled default when neither tools, toolMode nor enableTools is sent', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1' } });
+      await handler(req, res);
+      expect(invokedBody()).toMatchObject({
+        tools: [],
+        enableQuestMaster: false,
+        enableMementos: false,
+        enableAgents: false,
+      });
+      expect(res._getJSONData().tools).toBeUndefined();
+    });
+  });
+
   // The caller-supplied systemPrompt field (POST /api/chat). Asserted here specifically on the
   // ASYNC (wait: false, default) dispatch path via mockInvoke - a test that only covered wait:true
   // would pass even if the default path silently dropped the field.

--- a/apps/client/pages/api/__tests__/chat.integration.test.ts
+++ b/apps/client/pages/api/__tests__/chat.integration.test.ts
@@ -588,27 +588,48 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
 
     // No endpoint enumerates the valid ids, so a dropped id must be reported or a typo is
     // indistinguishable from a tool that does not exist in this deployment.
-    it('reports a dropped id back on the response rather than failing quiet', async () => {
+    it('reports an unrecognized id back on the response rather than failing quiet', async () => {
       validateWithScopes([ApiKeyScope.AI_CHAT]);
       const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['websearch'] } });
       await handler(req, res);
-      expect(res._getJSONData().tools).toEqual({ effectiveTools: [], ignoredTools: ['websearch'] });
+      expect(res._getJSONData().tools).toEqual({ effectiveTools: [], unrecognizedTools: ['websearch'] });
     });
 
-    it('reports dropped ids alongside a toolMode the caller did send', async () => {
+    // `unrecognizedTools` describes the ids, not what the mode did with them, so it is reported
+    // under every toolMode. Suppressing it under 'fast' would put the endpoint back in the position
+    // this route was fixed out of: knowing an id does not exist here and saying nothing, so the
+    // caller only finds out after dropping 'fast' and resending.
+    it("reports an unrecognized id under toolMode 'fast' too", async () => {
       validateWithScopes([ApiKeyScope.AI_CHAT]);
       const { req, res } = fire({
         body: { message: 'hi', sessionId: 'sess-1', toolMode: 'fast', tools: ['websearch'] },
       });
       await handler(req, res);
-      expect(res._getJSONData().tools).toMatchObject({ toolMode: 'fast', ignoredTools: ['websearch'] });
+      expect(res._getJSONData().tools).toMatchObject({ toolMode: 'fast', unrecognizedTools: ['websearch'] });
     });
 
-    it('omits ignoredTools entirely when every id was recognized', async () => {
+    // The other half of that invariant, and what makes the field's name true: 'fast' discards a
+    // RECOGNIZED id, and discarding is not the same fact as not existing. `effectiveTools: []` is
+    // what reports the discard; listing web_search as unrecognized would conflate a deliberate
+    // mode drop with a typo - the exact ambiguity this route was fixed to remove.
+    it("does not call a recognized id unrecognized just because 'fast' dropped it", async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const { req, res } = fire({
+        body: { message: 'hi', sessionId: 'sess-1', toolMode: 'fast', tools: ['web_search', 'websearch'] },
+      });
+      await handler(req, res);
+      expect(res._getJSONData().tools).toEqual({
+        toolMode: 'fast',
+        effectiveTools: [],
+        unrecognizedTools: ['websearch'],
+      });
+    });
+
+    it('omits unrecognizedTools entirely when every id was recognized', async () => {
       validateWithScopes([ApiKeyScope.AI_CHAT]);
       const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools: ['web_search'] } });
       await handler(req, res);
-      expect(res._getJSONData().tools).not.toHaveProperty('ignoredTools');
+      expect(res._getJSONData().tools).not.toHaveProperty('unrecognizedTools');
     });
 
     // Syntactically present but resolving to nothing must read the same as absent.
@@ -622,18 +643,32 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
       expect(res._getJSONData().tools).toBeUndefined();
     });
 
-    // `tools` carries no length bound, and the ignored-id split must stay linear: an
-    // Array.includes scan over the recognized list is quadratic on a payload that mixes many
-    // known with many unknown ids, burning ~1s of event loop before any billing or model call.
-    it('splits a large mixed tools payload without a quadratic scan', async () => {
+    // `tools` carries no length bound, so an 8000-id payload has to leave this layer bounded on
+    // both sides. Asserting the two output sets rather than a wall clock pins the invariant that
+    // actually matters (Set membership for the split, Set collapse for both reported lists) and
+    // keeps the test independent of runner contention - this suite runs as three parallel CI
+    // shards, each with a worker per core.
+    it('collapses a large mixed tools payload to the two distinct ids', async () => {
       validateWithScopes([ApiKeyScope.AI_CHAT]);
       const tools = [...Array(4000).fill('web_search'), ...Array(4000).fill('websearch')];
-      const startedAt = Date.now();
       const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools } });
       await handler(req, res);
       expect(res._getStatusCode()).toBe(200);
-      expect(Date.now() - startedAt).toBeLessThan(1000);
-      expect(res._getJSONData().tools.ignoredTools).toHaveLength(4000);
+      // The set that reaches the service layer: one copy, not 4000. N copies would reserve N
+      // tools' worth of the verbatim history budget and reach the provider as duplicate names.
+      expect(invokedBody().tools).toEqual(['web_search']);
+      expect(res._getJSONData().tools.unrecognizedTools).toEqual(['websearch']);
+    });
+
+    // The echo is the documented way to discover a mistyped id, so it is capped like the log line
+    // rather than reflecting an unbounded list of the caller's own bad ids back at them.
+    it('caps the reported unrecognized ids at 10 distinct entries', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      const tools = Array.from({ length: 25 }, (_, i) => `not_a_tool_${i}`);
+      const { req, res } = fire({ body: { message: 'hi', sessionId: 'sess-1', tools } });
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().tools.unrecognizedTools).toHaveLength(10);
     });
 
     // A partially-recognized array still counts as intent, narrowed to what survived.
@@ -646,7 +681,7 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
       expect(invokedBody().tools).toEqual(['web_search']);
       expect(res._getJSONData().tools).toEqual({
         effectiveTools: ['web_search'],
-        ignoredTools: ['not_a_tool'],
+        unrecognizedTools: ['not_a_tool'],
       });
     });
 

--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -23,6 +23,11 @@ import { premiumLlmTools } from '@server/premium-generated/premiumLlmTools.gener
 import { recommendTools, mergeTools } from '@client/app/utils/toolRecommender';
 import { resolveActiveOrg } from '@server/utils/resolveActiveOrg';
 
+// How many distinct unrecognized tool ids are named in the warn log and echoed on the response.
+// Both are bounded by the same number so the response is no less bounded than the log; the cap is
+// part of the documented contract (see the `tools` description in schemas/chat.ts).
+const UNRECOGNIZED_TOOL_REPORT_LIMIT = 10;
+
 // Auth mode, required scopes, and request validation all come from chatContract
 // (the single source of truth also driving the OpenAPI spec). `req.validated` is
 // the parsed, typed body. Rate limit is passed as an option so the adapter orders
@@ -79,16 +84,24 @@ const handler = nextRouteForContract(chatContract, {
   // is - both the invoked body and the response metadata need it. No public endpoint enumerates
   // the valid ids, so a dropped id has to be reported back or a typo is indistinguishable from
   // a tool that does not exist here.
-  // Set membership, not Array.includes: `tools` has no length bound of its own, so a payload
-  // mixing many known with many unknown ids makes a linear scan quadratic (~1s of blocked event
-  // loop at the 1MB body cap, before any billing or model call - a free amplification).
-  const requestedTools = filterKnownTools(simplifiedRequest.tools);
+  //
+  // Every quantity below is a Set, because `tools` carries no length bound of its own:
+  //  - Set membership, not Array.includes, for the split - a payload mixing many known with many
+  //    unknown ids makes a linear scan quadratic (~1s of blocked event loop at the 1MB body cap,
+  //    before any billing or model call).
+  //  - The recognized ids are deduped before they leave this layer. Nothing downstream collapses
+  //    repeats (`resolveEnabledTools` only appends), and a repeated id would consume a per-tool
+  //    slice of the verbatim history budget per copy and reach the provider as a duplicate tool
+  //    name. The other branches already deduped: `smart` via `mergeTools`, `fast` via `[]`.
+  //  - The unrecognized ids are deduped too: what a caller debugging a typo needs is the SET of
+  //    ids that are not tools here, not one entry per occurrence.
+  const requestedTools = Array.from(new Set(filterKnownTools(simplifiedRequest.tools)));
   const recognized = new Set<string>(requestedTools);
-  const ignoredTools = (simplifiedRequest.tools ?? []).filter(id => !recognized.has(id));
-  if (ignoredTools.length > 0) {
-    // Cap what reaches the log line: `tools` carries no length bound of its own.
+  const unrecognizedIds = new Set((simplifiedRequest.tools ?? []).filter(id => !recognized.has(id)));
+  const unrecognizedTools = Array.from(unrecognizedIds).slice(0, UNRECOGNIZED_TOOL_REPORT_LIMIT);
+  if (unrecognizedIds.size > 0) {
     req.logger.warn(
-      `POST /api/chat dropped ${ignoredTools.length} unrecognized tool id(s): ${ignoredTools.slice(0, 10).join(', ')}`
+      `POST /api/chat dropped ${unrecognizedIds.size} unrecognized tool id(s): ${unrecognizedTools.join(', ')}`
     );
   }
 
@@ -115,7 +128,7 @@ const handler = nextRouteForContract(chatContract, {
     toolMode: simplifiedRequest.toolMode,
     effectiveTools: internalRequest.tools,
     autoSelectedTools: recommendations.map(r => r.tool),
-    ignoredTools,
+    unrecognizedTools,
   });
 
   // Shared options for ChatCompletionInvoke and ChatCompletionProcess
@@ -248,7 +261,16 @@ const handler = nextRouteForContract(chatContract, {
 /**
  * The tool decision this layer made, echoed back as the response's `tools` field so a caller can
  * see what was offered - and what was thrown away. `toolMode` is absent when the caller named
- * tools without sending a mode; `ignoredTools` is present only when some id was unrecognized.
+ * tools without sending a mode.
+ *
+ * `unrecognizedTools` is deliberately NOT conditioned on `toolMode`: it states a fact about this
+ * deployment's tool registry ("these ids are not tools here"), which is true whatever the mode did
+ * with the array. `effectiveTools` is the separate, turn-level answer to "what was actually
+ * offered" - under 'fast' that is `[]`, which is what tells a caller their array was discarded. The
+ * two are orthogonal, so the mode-dropped set stays derivable (requested minus effective minus
+ * unrecognized) without conflating a typo with a deliberate drop. Naming it for the registry rather
+ * than the outcome is what keeps it honest under 'fast', where a recognized id is dropped too and
+ * an outcome-shaped name (`ignoredTools`, `droppedTools`) would under-report.
  *
  * Undefined only when the layer made no decision AND had nothing to report: the enableTools path,
  * where the service layer resolves the set.
@@ -257,23 +279,23 @@ function buildToolMeta({
   toolMode,
   effectiveTools,
   autoSelectedTools,
-  ignoredTools,
+  unrecognizedTools,
 }: {
   toolMode: 'fast' | 'smart' | undefined;
   effectiveTools: B4MLLMTools[] | undefined;
   autoSelectedTools: B4MLLMTools[];
-  ignoredTools: string[];
+  unrecognizedTools: string[];
 }) {
-  const ignored = ignoredTools.length > 0 ? { ignoredTools } : {};
+  const unrecognized = unrecognizedTools.length > 0 ? { unrecognizedTools } : {};
 
   if (toolMode === 'smart') {
-    return { toolMode, autoSelectedTools, effectiveTools: effectiveTools ?? [], ...ignored };
+    return { toolMode, autoSelectedTools, effectiveTools: effectiveTools ?? [], ...unrecognized };
   }
   if (toolMode === 'fast') {
-    return { toolMode, effectiveTools: [], ...ignored };
+    return { toolMode, effectiveTools: [], ...unrecognized };
   }
-  if (effectiveTools?.length || ignoredTools.length > 0) {
-    return { effectiveTools: effectiveTools ?? [], ...ignored };
+  if (effectiveTools?.length || unrecognizedTools.length > 0) {
+    return { effectiveTools: effectiveTools ?? [], ...unrecognized };
   }
   return undefined;
 }
@@ -306,8 +328,9 @@ function transformToInternalFormat(
   userId: string,
   organizationId?: string,
   recommendations: ReturnType<typeof recommendTools> = [],
-  // Already filtered to known ids by the caller (unknowns are dropped there so the wire
-  // schema stays OpenAPI-representable, and so they can be reported back on the response).
+  // Already filtered to known ids AND deduped by the caller: unknowns are dropped there so the
+  // wire schema stays OpenAPI-representable and so they can be reported back on the response,
+  // and repeats are collapsed there because nothing downstream of this layer collapses them.
   requestedTools: B4MLLMTools[] = []
 ) {
   // Compute effective tools. `tools` is a top-level field with nothing marking it conditional on

--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -74,6 +74,24 @@ const handler = nextRouteForContract(chatContract, {
   // Pre-compute tool recommendations once (used by both transform and response metadata)
   const recommendations = simplifiedRequest.toolMode === 'smart' ? recommendTools(simplifiedRequest.message) : [];
 
+  // Split the caller's explicit tool ids into what this deployment recognizes and what it does
+  // not. Computed here rather than inside the transform for the same reason `recommendations`
+  // is - both the invoked body and the response metadata need it. No public endpoint enumerates
+  // the valid ids, so a dropped id has to be reported back or a typo is indistinguishable from
+  // a tool that does not exist here.
+  // Set membership, not Array.includes: `tools` has no length bound of its own, so a payload
+  // mixing many known with many unknown ids makes a linear scan quadratic (~1s of blocked event
+  // loop at the 1MB body cap, before any billing or model call - a free amplification).
+  const requestedTools = filterKnownTools(simplifiedRequest.tools);
+  const recognized = new Set<string>(requestedTools);
+  const ignoredTools = (simplifiedRequest.tools ?? []).filter(id => !recognized.has(id));
+  if (ignoredTools.length > 0) {
+    // Cap what reaches the log line: `tools` carries no length bound of its own.
+    req.logger.warn(
+      `POST /api/chat dropped ${ignoredTools.length} unrecognized tool id(s): ${ignoredTools.slice(0, 10).join(', ')}`
+    );
+  }
+
   // Billing target is an explicit, opt-in choice - never an automatic consequence of the
   // caller's home-org field. When the request names an organizationId we validate the caller
   // actually belongs to it (resolveActiveOrg; throws 403/404 otherwise) and bill + scope
@@ -87,20 +105,18 @@ const handler = nextRouteForContract(chatContract, {
     { ...simplifiedRequest, model, sessionId },
     req.user.id,
     organizationId,
-    recommendations
+    recommendations,
+    requestedTools
   );
 
-  // Build tool metadata for response (reuses pre-computed recommendations)
-  const toolMeta =
-    simplifiedRequest.toolMode === 'smart'
-      ? {
-          toolMode: 'smart' as const,
-          autoSelectedTools: recommendations.map(r => r.tool),
-          effectiveTools: internalRequest.tools ?? [],
-        }
-      : simplifiedRequest.toolMode === 'fast'
-        ? { toolMode: 'fast' as const, effectiveTools: [] }
-        : undefined;
+  // Read off internalRequest.tools rather than recomputing, so what is reported cannot drift
+  // from what was actually sent to the service layer.
+  const toolMeta = buildToolMeta({
+    toolMode: simplifiedRequest.toolMode,
+    effectiveTools: internalRequest.tools,
+    autoSelectedTools: recommendations.map(r => r.tool),
+    ignoredTools,
+  });
 
   // Shared options for ChatCompletionInvoke and ChatCompletionProcess
   const chatCompletionOptions = {
@@ -230,6 +246,39 @@ const handler = nextRouteForContract(chatContract, {
 });
 
 /**
+ * The tool decision this layer made, echoed back as the response's `tools` field so a caller can
+ * see what was offered - and what was thrown away. `toolMode` is absent when the caller named
+ * tools without sending a mode; `ignoredTools` is present only when some id was unrecognized.
+ *
+ * Undefined only when the layer made no decision AND had nothing to report: the enableTools path,
+ * where the service layer resolves the set.
+ */
+function buildToolMeta({
+  toolMode,
+  effectiveTools,
+  autoSelectedTools,
+  ignoredTools,
+}: {
+  toolMode: 'fast' | 'smart' | undefined;
+  effectiveTools: B4MLLMTools[] | undefined;
+  autoSelectedTools: B4MLLMTools[];
+  ignoredTools: string[];
+}) {
+  const ignored = ignoredTools.length > 0 ? { ignoredTools } : {};
+
+  if (toolMode === 'smart') {
+    return { toolMode, autoSelectedTools, effectiveTools: effectiveTools ?? [], ...ignored };
+  }
+  if (toolMode === 'fast') {
+    return { toolMode, effectiveTools: [], ...ignored };
+  }
+  if (effectiveTools?.length || ignoredTools.length > 0) {
+    return { effectiveTools: effectiveTools ?? [], ...ignored };
+  }
+  return undefined;
+}
+
+/**
  * Get session ID - either from request or user's most recent notebook
  */
 async function getSessionId(requestedSessionId: string | undefined, userId: string): Promise<string> {
@@ -256,22 +305,33 @@ function transformToInternalFormat(
   request: SimplifiedChatRequest & { sessionId: string; model: string },
   userId: string,
   organizationId?: string,
-  recommendations: ReturnType<typeof recommendTools> = []
+  recommendations: ReturnType<typeof recommendTools> = [],
+  // Already filtered to known ids by the caller (unknowns are dropped there so the wire
+  // schema stays OpenAPI-representable, and so they can be reported back on the response).
+  requestedTools: B4MLLMTools[] = []
 ) {
-  // Compute effective tools for smart mode using pre-computed recommendations
+  // Compute effective tools. `tools` is a top-level field with nothing marking it conditional on
+  // toolMode, so a named tool is honored on its own rather than silently dropped; 'fast' ignores
+  // it. What lands here seeds `resolveEnabledTools`, which is a union plus a denylist - so this
+  // list adds to the offered set and never restricts it.
   let effectiveTools: B4MLLMTools[] | undefined;
   if (request.toolMode === 'smart') {
-    // Drop unknown tool ids here (moved off the wire schema so it stays representable).
-    const manualTools = filterKnownTools(request.tools);
-    effectiveTools = mergeTools(recommendations, manualTools);
+    effectiveTools = mergeTools(recommendations, requestedTools);
   } else if (request.toolMode === 'fast') {
     effectiveTools = [];
+  } else if (requestedTools.length > 0) {
+    effectiveTools = requestedTools;
   }
-  // When toolMode is unset, don't set effectiveTools - let service layer handle via enableTools
+  // With no toolMode and no named tools, leave effectiveTools unset - the service
+  // layer resolves the set from enableTools.
 
   // For capability flags: smart mode is still "tools enabled" even with no auto-selected tools
   const isToolsEnabled =
-    request.toolMode === 'smart' ? true : request.toolMode === 'fast' ? false : !!request.enableTools;
+    request.toolMode === 'smart'
+      ? true
+      : request.toolMode === 'fast'
+        ? false
+        : !!request.enableTools || requestedTools.length > 0;
 
   // Determine capability defaults: legacy enableTools=true defaults to true,
   // toolMode='smart' defaults to false (conservative - just tools, no QuestMaster etc.)

--- a/apps/client/public/openapi.json
+++ b/apps/client/public/openapi.json
@@ -191,7 +191,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Explicit tool ids to offer the model. A non-empty array enables tools on its own; no companion `toolMode` or `enableTools` is required. Merged with the auto-selected set under `toolMode: \"smart\"`, and ignored under `toolMode: \"fast\"`. This list ADDS to what is offered rather than restricting it - the server still offers tools of its own (for example knowledge retrieval when the session has reachable documents). Unrecognized ids are dropped rather than rejecting the request; the response reports the surviving set as `tools.effectiveTools` and the dropped ids as `tools.ignoredTools`, since no endpoint enumerates the valid ids."
           },
           "enableQuestMaster": {
             "type": "boolean"

--- a/apps/client/public/openapi.json
+++ b/apps/client/public/openapi.json
@@ -93,6 +93,39 @@
           "message": {
             "type": "string"
           },
+          "tools": {
+            "type": "object",
+            "properties": {
+              "toolMode": {
+                "type": "string",
+                "enum": [
+                  "fast",
+                  "smart"
+                ]
+              },
+              "autoSelectedTools": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "effectiveTools": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "unrecognizedTools": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "effectiveTools"
+            ]
+          },
           "tracking_info": {
             "type": "object",
             "properties": {
@@ -192,7 +225,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Explicit tool ids to offer the model. A non-empty array enables tools on its own; no companion `toolMode` or `enableTools` is required. Merged with the auto-selected set under `toolMode: \"smart\"`, and ignored under `toolMode: \"fast\"`. This list ADDS to what is offered rather than restricting it - the server still offers tools of its own (for example knowledge retrieval when the session has reachable documents). Unrecognized ids are dropped rather than rejecting the request; the response reports the surviving set as `tools.effectiveTools` and the dropped ids as `tools.ignoredTools`, since no endpoint enumerates the valid ids."
+            "description": "Explicit tool ids to offer the model. A non-empty array enables tools on its own; no companion `toolMode` or `enableTools` is required. Merged with the auto-selected set under `toolMode: \"smart\"`, and ignored under `toolMode: \"fast\"`. This list ADDS to what is offered rather than restricting it - the server still offers tools of its own (for example knowledge retrieval when the session has reachable documents). Unrecognized ids are dropped rather than rejecting the request; the response reports the surviving set as `tools.effectiveTools` and the ids that are not tools in this deployment as `tools.unrecognizedTools`, since no endpoint enumerates the valid ids. `unrecognizedTools` is reported under every `toolMode` - it describes the ids, not what the mode did with them - so under `toolMode: \"fast\"` an id can be absent from `effectiveTools` (the mode discarded it) without being unrecognized. Both reported lists are deduplicated, and `unrecognizedTools` names at most the first 10 distinct ids."
           },
           "enableQuestMaster": {
             "type": "boolean"

--- a/b4m-core/common/src/schemas/chat.ts
+++ b/b4m-core/common/src/schemas/chat.ts
@@ -38,14 +38,31 @@ export const SimplifiedChatRequestSchema = z.object({
   fileIds: z.array(z.string()).prefault([]),
   // New synchronous option - wait for completion before returning
   wait: z.boolean().prefault(false),
-  // Enable full tool access for agent requests (e.g., voice agent_request portal)
+  // Enable full tool access for agent requests (e.g., voice agent_request portal). A `tools`
+  // array sent alongside is added to the offered set (it used to be dropped), and the
+  // full-capability defaults below still apply.
   enableTools: z.boolean().prefault(false),
-  // Tool selection mode: 'fast' = no tools (pure chat), 'smart' = auto-select tools based on prompt
-  // When set, overrides enableTools. When not set, falls back to enableTools behavior.
+  // Tool selection mode: 'fast' = no tools from the request, 'smart' = auto-select tools based on
+  // prompt. When set, overrides enableTools. When not set, a non-empty `tools` array both enables
+  // tools and supplies the set; absent that too, it falls back to enableTools behavior.
   toolMode: z.enum(['fast', 'smart']).optional(),
-  // Explicit tool ids (combined with auto-selected in smart mode). Unknown ids are
-  // filtered by the handler (filterKnownTools), not here - see the rule above.
-  tools: z.array(z.string()).optional(),
+  // Explicit tool ids (combined with auto-selected in smart mode). Non-empty is itself
+  // intent to enable tools, so no companion toolMode/enableTools is required - the array
+  // used to be dropped in silence without one. Unknown ids are filtered by the handler
+  // (filterKnownTools), not here - see the rule above.
+  tools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Explicit tool ids to offer the model. A non-empty array enables tools on its own; no ' +
+        'companion `toolMode` or `enableTools` is required. Merged with the auto-selected set ' +
+        'under `toolMode: "smart"`, and ignored under `toolMode: "fast"`. This list ADDS to what ' +
+        'is offered rather than restricting it - the server still offers tools of its own (for ' +
+        'example knowledge retrieval when the session has reachable documents). Unrecognized ids ' +
+        'are dropped rather than rejecting the request; the response reports the surviving set as ' +
+        '`tools.effectiveTools` and the dropped ids as `tools.ignoredTools`, since no endpoint ' +
+        'enumerates the valid ids.'
+    ),
   // Explicit overrides - when enableTools is true, these default to true but can be
   // individually disabled (e.g., voice agent_request disables QuestMaster so replies
   // aren't cleared and replaced with a plan document)

--- a/b4m-core/common/src/schemas/chat.ts
+++ b/b4m-core/common/src/schemas/chat.ts
@@ -60,8 +60,12 @@ export const SimplifiedChatRequestSchema = z.object({
         'is offered rather than restricting it - the server still offers tools of its own (for ' +
         'example knowledge retrieval when the session has reachable documents). Unrecognized ids ' +
         'are dropped rather than rejecting the request; the response reports the surviving set as ' +
-        '`tools.effectiveTools` and the dropped ids as `tools.ignoredTools`, since no endpoint ' +
-        'enumerates the valid ids.'
+        '`tools.effectiveTools` and the ids that are not tools in this deployment as ' +
+        '`tools.unrecognizedTools`, since no endpoint enumerates the valid ids. ' +
+        '`unrecognizedTools` is reported under every `toolMode` - it describes the ids, not what ' +
+        'the mode did with them - so under `toolMode: "fast"` an id can be absent from ' +
+        '`effectiveTools` (the mode discarded it) without being unrecognized. Both reported lists ' +
+        'are deduplicated, and `unrecognizedTools` names at most the first 10 distinct ids.'
     ),
   // Explicit overrides - when enableTools is true, these default to true but can be
   // individually disabled (e.g., voice agent_request disables QuestMaster so replies
@@ -117,6 +121,26 @@ export const ChatAckSchema = z.object({
   timestamp: z.string(),
   model: z.string(),
   message: z.string().optional(),
+  // The tool decision the API layer made for this turn, echoed back so a caller can see what was
+  // offered and what was thrown away. Absent when the layer made no decision and had nothing to
+  // report (the `enableTools`-only path, where the service layer resolves the set). Present on
+  // both the async ACK and the `wait: true` body, and modelled here so the spec and the typed
+  // client carry it - the request field's description points callers at `unrecognizedTools` as the
+  // only way to discover a mistyped tool id, and a documented discovery mechanism has to be in the
+  // contract rather than in prose. Built by `buildToolMeta` in apps/client/pages/api/chat.ts.
+  tools: z
+    .object({
+      // Absent when the caller named tools without sending a mode.
+      toolMode: z.enum(['fast', 'smart']).optional(),
+      // Smart mode only: what the prompt-based recommender picked.
+      autoSelectedTools: z.array(z.string()).optional(),
+      effectiveTools: z.array(z.string()),
+      // Ids the caller sent that are not tools in this deployment. A registry fact, so it is
+      // reported under every toolMode - an id dropped by `fast` is NOT listed here unless it is
+      // also unrecognized. Deduplicated and capped; see the `tools` request field's description.
+      unrecognizedTools: z.array(z.string()).optional(),
+    })
+    .optional(),
   tracking_info: z.object({
     quest_id: z.string(),
     check_status_url: z.string(),


### PR DESCRIPTION
# Pull Request

## Description

`POST /api/chat` read the caller's `tools` array in exactly one place - inside the
`toolMode === 'smart'` branch. Sent without a `toolMode`, the array was discarded, the request took
the tools-disabled path (`tools: []`), and the response's own `tools` field reported `null`. No
error, no warning. `tools` is a top-level field with nothing in the schema marking it conditional
on `toolMode`, so sending it alone is a fair reading of the contract.

Closes #2529

## Changes

- A non-empty `tools` array (filtered to known ids) is now intent to enable tools on its own when
  `toolMode` is unset. `toolMode: 'fast'` still drops a named set.
- QuestMaster/Mementos/Agents stay **off** for a `tools`-only request - `isLegacyToolsPath` keys on
  `enableTools`, which is untouched, so a named tool enables only tools, matching smart mode's
  conservative defaults.
- `enableTools: true` + `tools` previously dropped the array; the named ids now reach the service
  layer. This is additive, not restrictive: `resolveEnabledTools` is documented as "a UNION plus a
  denylist, never an allowlist" (`b4m-core/services/src/llm/ChatCompletionProcess.ts:621`), so an
  explicit list adds to what's offered and can't narrow it. Verified live (see below): the same
  shape offered 3 always-on knowledge tools on `main`, and those 3 plus the named tool on this
  branch.
- Unrecognized ids were already dropped by `filterKnownTools`; they're now **reported back** as
  `tools.unrecognizedTools` and logged server-side. No public endpoint enumerates valid tool ids
  (`/api/ai/v1/tools` executes one and explicitly rejects API keys), so without this, a typo in
  `tools` reproduces the exact symptom this PR fixes - `tools: null` - with nothing distinguishing
  a misspelled id from #2529 itself.
- Response metadata (`toolMeta`) is now built by a small `buildToolMeta` helper reading off the
  invoked body, so what's reported can't drift from what was actually sent - that drift was the
  `tools: null` symptom.
- The dropped-id split uses a `Set`, not `Array.includes`. The naive version is quadratic on a
  payload mixing many known with many unknown ids and `tools` carries no length bound of its own -
  measured end-to-end through the real handler at the 1MB body-size cap: **~1s of blocked event
  loop** with `Array.includes`, **~1ms** with `Set`, before any billing or model call.
- The recognized ids are **deduped** before they leave the API layer. Nothing downstream collapses
  repeats (`resolveEnabledTools` only appends), so N copies of one id would reserve N tools' worth
  of the verbatim history budget and reach the provider as duplicate tool names. Every other branch
  already deduped - `smart` via `mergeTools`, `fast` via `[]` - so the no-`toolMode` path was the
  only one that did not.
- `unrecognizedTools` is scoped to the **tool registry, not the turn's outcome**: it means "these
  ids are not tools in this deployment", so it is reported under every `toolMode`. Under
  `toolMode: 'fast'` a recognized id is discarded without being unrecognized - `effectiveTools: []`
  is what reports that discard. Keeping the two orthogonal means a typo stays distinguishable from
  a deliberate mode drop (the mode-dropped set is still derivable: requested minus effective minus
  unrecognized), which is the distinction this PR exists to create. Both reported lists are
  deduped, and the unrecognized echo is capped at 10 distinct ids, sharing one constant with the
  warn log so the response is no less bounded than the log.
- The response's `tools` object is now modelled on `ChatAckSchema`, so `effectiveTools` /
  `unrecognizedTools` reach `openapi.json` and the typed client instead of being described only in
  prose on the *request* field. A documented discovery mechanism for a mistyped id belongs in the
  contract.
- `tools` gained a `.describe()` (the caller-facing contract), and `apps/client/public/openapi.json`
  is regenerated - CI diffs it (`ci.yml:424`). The `toolMode`/`enableTools` comments described the
  old precedence and are corrected.

## Guide for Testers

This is a backend-only change to a public API endpoint (`POST /api/chat`, used by an API key, not
through any app UI). Verified end-to-end on local self-host (`next dev` + Docker infra) with a real
`b4m_live_` key scoped `ai:chat`, before/after on identical infra.

1. Send `POST /api/chat` with header `x-api-key: <your key>`, body:
   `{"message":"Roll two six-sided dice using your dice tool and tell me the exact result.","tools":["dice_roll"],"wait":true}`
   Expected: HTTP 200, `tools: {"effectiveTools":["dice_roll"]}`, and a reply naming an actual roll
   (in `responses[0]`; `response` is `null` on this path normally).
   Before this fix, the same call returns `tools: null` and the model replies it has no dice tool.
2. Check the created quest's `promptMeta.offeredTools` (via `GET /api/quests/{id}` or the DB) -
   must contain `dice_roll`. This confirms the tool reached the model, not just the response
   metadata.
3. Send the same body with `"tools":["websearch"]` (typo). Expected:
   `tools: {"effectiveTools":[],"unrecognizedTools":["websearch"]}` and a server log line
   `dropped 1 unrecognized tool id(s): websearch`.
4. Send `{"message":"hi","tools":["websearch","dice_roll"]}`. Expected: both `effectiveTools` and
   `unrecognizedTools` populated.
5. Send `{"message":"hi"}` with no `tools`/`toolMode`/`enableTools` at all. Expected: unchanged -
   turn runs with no request-contributed tools, `tools` absent from the response.
6. Send `{"message":"hi","enableTools":true}` with no `tools` array (the shape the voice
   `agent_request` portal sends). Expected: unchanged from before this PR.
7. Send `{"message":"hi","toolMode":"fast","tools":["dice_roll"]}`. Expected:
   `tools: {"toolMode":"fast","effectiveTools":[]}`.

### Regression Checks

- Smart-mode merge behavior (`toolMode: "smart"`) is untouched - that code path is byte-identical.
- Callers sending both `enableTools: true` and `tools` now get the named tools offered where the
  array was previously ignored - additive only, nothing previously offered stops being offered.
- Anything reading the response's `tools` field now gets an object on `tools`-only requests where
  it previously got `null`, plus a new optional `unrecognizedTools` key. Both additive; the field was
  never modelled in `ChatAckSchema`.

### What NOT to test

- No app UI surfaces this - it's a public-API-only endpoint change. Nothing to click through.
- Do not expect `toolMode: "fast"` to produce an empty *offered* tool set at the service layer. It
  contributes no tools from the request, but `resolveEnabledTools` still auto-offers the knowledge
  tool when the session has reachable documents - verified live, `fast` still offers 3 knowledge
  tools.
- Nothing about how tools execute, are billed, or are resolved downstream changed - this is purely
  which set the API layer hands to the service layer.

## Additional Information

Verified locally end-to-end (not yet on a preview/prod stack): OTC login against local Mailpit,
minted a real `b4m_live_` key via `POST /api/user-api-keys`, ran the issue's exact repro shape
against both `main` and this branch by swapping only `chat.ts` (restore verified byte-exact), and
confirmed the delta on `promptMeta.offeredTools` in Mongo, not just the API response. Local search
tools (`web_search`, `weather_info`) have no working key on this box and are dropped as
unavailable before reaching the model - `dice_roll` (no external dependency) was used for the
positive proof instead. `web_search` reaching the model specifically is unverified.

Not filed in this PR, left as follow-ups: (1) `tools` has no `.max()` length bound - a contract
change on a public field, out of scope here, and no longer urgent since the quadratic path is
fixed; (2) whether any other tool-taking surface has the same silent-unknown-id gap.

## Developer Notes (Optional)

- `resolveEnabledTools` (`ChatCompletionProcess.ts:627`) is a union-plus-denylist, not an allowlist
  - useful to know before describing any future change to `tools` as "restricting" or "narrowing"
    what gets offered.
- `buildToolMeta` in `chat.ts` is a small, pure builder for the response's `tools` field - reusable
  if a future field needs the same "echo back what was decided, including what was dropped"
  pattern.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no user-facing
      docs describe `/api/chat` tool selection beyond the OpenAPI spec, which is updated here
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no
      telemetry fields added

