### PR TITLE
fix(client): keep test code out of the Next server bundle

### DIFF
--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -54,6 +54,40 @@ const nextConfig = {
   // Must match turbopack.root — SST/OpenNext may also inject this value
   outputFileTracingRoot: monorepoRoot,
 
+  // Test code has no business in a production server bundle, and here it is not merely dead
+  // weight: the server function sits against Lambda's 262144000-byte UNZIPPED limit, which is
+  // not adjustable, and it crossed that limit on 2026-09-09 and blocked every staging deploy.
+  // Measured, these excludes drop it from 250.0 MB to 244.7 MB across 799 fewer files - the
+  // 5.3 MB that turned a rejected package into an accepted one.
+  //
+  // It is also a correctness hazard, not just a size one. Next compiles every file under
+  // `pages/` into a routable entry, including `__tests__/` subdirectories, and a preloaded test
+  // module executes its side effects: one of them calls aws-sdk-client-mock's
+  // `mockClient(S3Client)`, which replaces `S3Client.prototype.send` process-wide with a stub
+  // that resolves undefined. `apps/client/scripts/pruneTestRoutes.mjs` exists to strip those
+  // entries out of a built `.next` for exactly that reason; excluding them from the trace in the
+  // first place is the same fix applied one step earlier, and it covers every deploy target
+  // rather than only the one that remembers to run the pruner.
+  //
+  // A `**/`-prefixed glob matches wherever the base is resolved from, which is why the patterns
+  // below are written that way. The two `e2e` entries are deliberate: a monorepo-root-relative
+  // path did not match on its own (the Playwright fixtures survived the first measured run and
+  // only the `*.spec.ts` files went), so the package-relative form is listed alongside it rather
+  // than swapped in, since exactly one of them being inert costs nothing.
+  outputFileTracingExcludes: {
+    '*': [
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+      '**/__tests__/**',
+      '**/__test__/**',
+      '**/__mocks__/**',
+      'e2e/**',
+      'apps/client/e2e/**',
+    ],
+  },
+
   transpilePackages: [
     'react-syntax-highlighter',
     '@icons-pack/react-simple-icons',


### PR DESCRIPTION
# Pull Request

## Description

The Next server function is packaged as a Lambda zip, so its unzipped contents are capped at **262,144,000 bytes**. That cap is not adjustable and there is no quota increase to request. The bundle crossed it on 2026-09-08 at 23:33Z and every staging deploy has failed since, with `UpdateFunctionCode ... Unzipped size must be smaller than 262144000 bytes`.

Test code was being packaged into it: unit tests, `__tests__` / `__test__` / `__mocks__` directories, and the Playwright suite with its fixtures. This excludes them from Next's output file trace.

**Measured**, not estimated - two preview deploys of the same tree, the second differing only by this change:

| | unzipped | files | % of limit | AWS verdict |
|---|---|---|---|---|
| without this change | 250.0 MB | 17,571 | 100.0% | **rejected** |
| with this change | 244.7 MB | 16,772 | 97.9% | **accepted** |

5.3 MB, 799 files, and it is the difference between a package AWS refuses and one it takes.

It is also a correctness fix, independent of size. Next compiles every file under `pages/` into a routable entry, `__tests__/` subdirectories included, and loading one runs its side effects - one of those test modules calls `mockClient(S3Client)`, which replaces `S3Client.prototype.send` process-wide with a stub that resolves undefined. `apps/client/scripts/pruneTestRoutes.mjs` was written to strip those entries out of a built `.next` for exactly that reason, and **nothing in this repo invokes it**. Excluding them from the trace applies the same fix one step earlier, and covers every deploy target rather than the one that remembers to run the pruner.

## Changes

- `apps/client/next.config.mjs`: add `outputFileTracingExcludes` for test files, test/mock directories and the e2e suite.

Both a package-relative (`e2e/**`) and a monorepo-root-relative (`apps/client/e2e/**`) form of the e2e path are listed. That is deliberate and the comment says why: on the measured run the root-relative form did not match on its own - the Playwright fixtures survived and only the `*.spec.ts` files went - so rather than swap one for the other on a guess, both are listed, since exactly one being inert costs nothing. Whichever it is, this PR's own preview deploy prints the number.

## Guide for Testers

This changes what is *packaged*, not what runs, so the test is that nothing is missing at runtime.

1. **The deploy itself is the primary assertion.** The preview deploy must reach `CREATE_COMPLETE` / `UPDATE_COMPLETE`. Before this change, on this same tree, it failed with the unzipped-size error. Check the deploy job log for `Unzipped size must be smaller than 262144000 bytes` - it must not appear.
2. **Read the printed size.** The deploy log has a "Measure the server bundle against the Lambda limit" step (added in the deployer repo). Expect roughly `244.7 MB unzipped ... 97.9%` or lower. If the e2e glob now bites, expect closer to 242 MB.
3. **Exercise the server surfaces**, because a too-aggressive exclude would show up as a missing module at runtime, not at build time:
   - Log in, open a quest, send a message and get a streamed reply.
   - Upload a file (S3 path - this is the one the `mockClient(S3Client)` hazard would have corrupted, so confirm a real upload lands and is retrievable).
   - Open Files, then Files > Upload Files > Data Lakes and confirm the manager modal loads.
   - Hit a Pages-API route directly, e.g. `/api/chat`, and confirm a normal response rather than a 500.
4. **Watch the server function's CloudWatch log group** for `Cannot find module` or `MODULE_NOT_FOUND` during the above. That is the failure signature if a glob over-matched. There should be none.

## Regression Checks

- `pnpm turbo:typecheck`, `pnpm turbo:test`, `pnpm lint:check` - the config change does not touch the TS program, so these are unchanged, but the e2e suite in particular must still *run locally*: excluding a path from the deployment trace must not affect `pnpm --filter @bike4mind/client exec playwright test`. Confirm the e2e suite still collects its specs and fixtures.
- The self-host build (`B4M_SELF_HOST`, `output: 'standalone'`) uses the same config - confirm it still builds.
- Image optimization and static asset serving still work (`apps/client/public` is untouched by these globs and still in the bundle).

## What NOT to test

- Do not test whether the bundle is *comfortable*. It is not: 97.9% with 5.3 MB of headroom. This PR only gets deploys moving again. The durable trims are #2547 (the eager `@bike4mind/services` tools barrel, ~35 MB) and #2562 (container-image packaging, which raises the ceiling from 250 MB to 10 GB).
- Do not test provisioned concurrency or the `AgentExecutor` errors seen during the incident - that is #2552 and unrelated to this change.
- No UI changed, so there is nothing visual to review.

## Additional Information

Closes nothing on its own; this is the unblock step of #2549.

Depends on #2545 being present: with `googleapis` still in the tree the bundle is roughly 278 MB even with these excludes, so **neither PR unblocks staging alone**. Both need to be on main before a staging deploy can succeed. Queue them together - main's merge queue batches up to 5 entries, so two entries queued inside the 5-minute window become one merge commit and therefore one staging deploy attempt rather than two, the first of which would be a guaranteed failure.

## Developer Notes (Optional)

`@vercel/nft` follows a literal-string dynamic `import()` at build time, so the several places in this codebase that lazily load heavy modules (`tokenCounting.ts`, `IsolatedVmExecutor.ts`, `transpileReactArtifact.ts`) do not keep those modules out of the package - they only help cold-start init. That is why the size problem has to be attacked by excluding or by not depending, never by deferring. Recorded in #2547.
