### PR TITLE
fix(services): contain org-principal grants on the lake manage rung

### DIFF
--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -662,37 +662,63 @@ describe('listDataLakes - grant-reachable lakes (#2034)', () => {
     expect(result.find(l => l.id === 'granted')).toBeUndefined();
   });
 
-  it.each([
-    ['listDataLakes', listDataLakes] as const,
-    ['listArchivedDataLakes', listArchivedDataLakes] as const,
-    ['listDeletedDataLakes', listDeletedDataLakes] as const,
-  ])('%s hands findAccessible an org grant keyed by the ISSUING org', async (_name, listFn) => {
+  const orgGrantDb = () => {
+    const findAccessible = vi.fn().mockResolvedValue([]);
+    return {
+      findAccessible,
+      db: {
+        dataLakes: { findAccessible, find: vi.fn() },
+        settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+        dataLakeAccessGrants: {
+          listActiveByLakes: vi.fn().mockResolvedValue([]),
+          listByPrincipal: vi.fn(async (type: string, id: string) =>
+            type === 'organization' && id === 'orgA'
+              ? [{ dataLakeId: 'granted', principalType: type, principalId: id, role: 'reader' }]
+              : []
+          ),
+        },
+      },
+    };
+  };
+
+  it('listDataLakes hands findAccessible an org grant keyed by the ISSUING org', async () => {
     // The issuer is the only thing that makes the org half safe: the datastore ANDs each org's ids
     // with `organizationId: <that org>` (DataLakeModel `orgGrantArms`), which is the only place the
     // lake's own org is known. Flattening the map into `grantedLakeIds` on the way here routes it
     // into the unconditional USER arm, and an orgA grant then lifts an orgB lake's gate for a caller
     // who belongs to both. Deep equality on purpose - `objectContaining` on `grantedLakeIds` alone
     // cannot see the org half move.
-    const findAccessible = vi.fn().mockResolvedValue([]);
-    const db = {
-      dataLakes: { findAccessible, find: vi.fn() },
-      settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
-      dataLakeAccessGrants: {
-        listActiveByLakes: vi.fn().mockResolvedValue([]),
-        listByPrincipal: vi.fn(async (type: string, id: string) =>
-          type === 'organization' && id === 'orgA'
-            ? [{ dataLakeId: 'granted', principalType: type, principalId: id, role: 'reader' }]
-            : []
-        ),
-      },
-    };
+    const { findAccessible, db } = orgGrantDb();
 
-    await listFn(ctx({ userId: 'me', organizationIds: ['orgA', 'orgB'] }), { db } as never);
+    await listDataLakes(ctx({ userId: 'me', organizationIds: ['orgA', 'orgB'] }), { db } as never);
 
     expect(findAccessible.mock.calls[0]![1]).toMatchObject({
       grantedLakeIds: [],
       orgGrantedLakes: { orgA: ['granted'] },
     });
+  });
+
+  it.each([
+    ['listArchivedDataLakes', listArchivedDataLakes] as const,
+    ['listDeletedDataLakes', listDeletedDataLakes] as const,
+  ])('%s hands findAccessible no org reach at all, and no reader row', async (_name, listFn) => {
+    // The management views ask the MANAGE reach, which is user-principal owner/curator only. The org
+    // half is not merely empty here, it is never resolved: `findAccessible` drops `orgGrantArms`
+    // under includePublic:false, so passing one would be inert, and an org grant carries no role to
+    // narrow it by. Absence rather than a flattened id list is the point - flattening would route it
+    // into the unconditional USER arm, which is the hazard the sibling test above describes.
+    const { findAccessible, db } = orgGrantDb();
+
+    await listFn(ctx({ userId: 'me', organizationIds: ['orgA', 'orgB'] }), { db } as never);
+
+    const opts = findAccessible.mock.calls[0]![1];
+    expect(opts).toMatchObject({ includePublic: false, grantedLakeIds: [] });
+    expect(opts.orgGrantedLakes).toBeUndefined();
+    expect(db.dataLakeAccessGrants.listByPrincipal).not.toHaveBeenCalledWith(
+      'organization',
+      expect.anything(),
+      expect.anything()
+    );
   });
 
   it('labels a reader-granted lake unmanageable even when another arm returns it', async () => {
@@ -1280,6 +1306,196 @@ describe('redactLakeForActor - editor-only fields on the raw-document exits', ()
     const result = await listDeletedDataLakes(ctx({ userId: 'me', organizationIds: ['orgA'] }), { db });
 
     expect('systemPrompt' in result[0]!).toBe(false);
+  });
+});
+
+/**
+ * The archived/deleted views pass includePublic:false on the stated ground that restore/cleanup is
+ * owner/admin-only, so a stranger must not see someone else's lake there - and then handed
+ * findAccessible the full READ reach, which admits `reader` rows and any-role org rows. A reader
+ * grant therefore did through the grant arm exactly what includePublic:false suppressed through the
+ * public arm. These pin the reach split by ROLE.
+ *
+ * Asserted on the findAccessible spy's `opts`, not on the returned rows: the reach is the thing
+ * under test, and a stub that echoed its input could not tell a narrowed reach from a wide one.
+ */
+describe('management views - the grant reach is manage-scoped, not read-scoped', () => {
+  // Dispatches on the principal so a membership org and an administered org are distinguishable -
+  // a stub returning one row for every call could not tell which arm asked.
+  const grantRepoFor = (rows: Record<string, { dataLakeId: string; role: string }[]>) => ({
+    listByPrincipal: vi
+      .fn()
+      .mockImplementation(
+        async (principalType: string, principalId: string) => rows[`${principalType}:${principalId}`] ?? []
+      ),
+    listActiveByLakes: vi.fn().mockResolvedValue([]),
+  });
+
+  // The cutover setting is ON here to prove the manage reach does not consult it. That is the only
+  // thing it proves at this level: the read reach's reader/org arms are ALSO held back by the
+  // source-level READ_GRANT_ENFORCEMENT_READY interlock, so with it false the two reaches happen to
+  // agree on a reader row here. The reaches are compared where they provably differ in
+  // resolveLakeReadAccess.test.ts; these cases guard the wiring and the role split.
+  const dbFor = (grants: ReturnType<typeof grantRepoFor>) => ({
+    dataLakes: { findAccessible: vi.fn().mockResolvedValue([]), find: vi.fn() },
+    dataLakeAccessGrants: grants,
+    settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+  });
+
+  const reachPassedTo = (db: ReturnType<typeof dbFor>): string[] =>
+    db.dataLakes.findAccessible.mock.calls[0][1].grantedLakeIds;
+
+  it('withholds a reader-granted lake from the archived view even with the cutover ON', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'reader' }] }));
+
+    await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(reachPassedTo(db)).toEqual([]);
+  });
+
+  it('still reaches an owner/curator-granted lake (the reach is narrowed, not closed)', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+
+    await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(reachPassedTo(db)).toEqual(['granted']);
+  });
+
+  it('withholds an ORG-principal grant whatever the caller holds in the granting org', async () => {
+    const orgRows = { 'organization:orgA': [{ dataLakeId: 'granted', role: 'owner' }] };
+
+    // Not by admin rights and not by membership: with no lake document in hand the reach cannot
+    // apply canManageLake's lake-org containment, and these views redact rather than exclude, so an
+    // org grant admitted here would disclose a lake in a DIFFERENT org (see the cross-org case
+    // below). A same-org lake is unaffected - findAccessible's own administeredOrgIds arm carries it.
+    const asAdmin = dbFor(grantRepoFor(orgRows));
+    await listArchivedDataLakes(ctx({ userId: 'me', administeredOrgIds: ['orgA'] }), { db: asAdmin });
+    expect(reachPassedTo(asAdmin)).toEqual([]);
+
+    const asMember = dbFor(grantRepoFor(orgRows));
+    await listDeletedDataLakes(ctx({ userId: 'me', organizationIds: ['orgA'] }), { db: asMember });
+    expect(reachPassedTo(asMember)).toEqual([]);
+  });
+
+  // The deleted view's docblock claims the archived view's rationale, so it must behave the same way.
+  it('applies the same split in the deleted view', async () => {
+    const reader = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'reader' }] }));
+    await listDeletedDataLakes(ctx({ userId: 'me' }), { db: reader });
+    expect(reachPassedTo(reader)).toEqual([]);
+
+    const curator = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+    await listDeletedDataLakes(ctx({ userId: 'me' }), { db: curator });
+    expect(reachPassedTo(curator)).toEqual(['granted']);
+  });
+
+  // The transitional view post-filters on canManageLake, so narrowing its reach cannot change its
+  // output - but it must not go the other way and start withholding a lake the filter would keep.
+  it('keeps a curator-granted lake reachable in the transitional view', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+
+    await listTransitionalDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(reachPassedTo(db)).toEqual(['granted']);
+  });
+
+  it('does not read the read-grant cutover flag at all', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+
+    await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    // A flag read here would mean an owner/curator grant - whose producers are live and unflagged -
+    // could be withheld by an operator toggle that has nothing to do with management.
+    expect(db.settings.getSettingsValue).not.toHaveBeenCalled();
+  });
+
+  it('degrades to an empty reach when no grant repo is wired', async () => {
+    const db = {
+      dataLakes: { findAccessible: vi.fn().mockResolvedValue([]), find: vi.fn() },
+      settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+    };
+
+    await listArchivedDataLakes(ctx({ userId: 'me', administeredOrgIds: ['orgA'] }), { db });
+
+    expect(db.dataLakes.findAccessible.mock.calls[0][1].grantedLakeIds).toEqual([]);
+  });
+});
+
+/**
+ * The cases above assert the reach on findAccessible's INPUT. These assert the views' output,
+ * because what the org arm's removal closes is a disclosure: the archived/deleted views redact
+ * fields and keep the row, so every lake the reach admits is a lake whose name and slug leave the
+ * service, however little the caller may then do with it.
+ *
+ * findAccessible is faked rather than stubbed here - the four arms these cases turn on (creator,
+ * member org, administered org, granted ids), mirroring DataLakeModel.findAccessible. It must stay
+ * in sync with that method's arms to keep meaning what it claims.
+ */
+describe("management views - an org grant on another org's lake discloses nothing", () => {
+  const findAccessibleFake = (all: IDataLakeDocument[]) =>
+    vi
+      .fn()
+      .mockImplementation(async (actor: AccessContext, opts: { grantedLakeIds?: string[] }) =>
+        all.filter(
+          l =>
+            l.createdByUserId === actor.userId ||
+            (!!l.organizationId &&
+              ((actor.organizationIds ?? []).includes(l.organizationId) ||
+                (actor.administeredOrgIds ?? []).includes(l.organizationId))) ||
+            (opts.grantedLakeIds ?? []).includes(l.id)
+        )
+      );
+
+  const dbWith = (all: IDataLakeDocument[], rows: Record<string, { dataLakeId: string; role: string }[]>) => ({
+    dataLakes: { findAccessible: findAccessibleFake(all), find: vi.fn() },
+    dataLakeAccessGrants: {
+      listByPrincipal: vi
+        .fn()
+        .mockImplementation(
+          async (principalType: string, principalId: string) => rows[`${principalType}:${principalId}`] ?? []
+        ),
+      listActiveByLakes: vi.fn().mockResolvedValue([]),
+    },
+    settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+  });
+
+  // orgB's lake, an orgA owner grant, an orgA admin who has nothing else on it: canManageLake denies
+  // the manage, so the list must not name the lake either.
+  const crossOrg = () => ({
+    lakes: [lake({ id: 'theirs', slug: 'theirs', createdByUserId: 'other', organizationId: 'orgB' })],
+    grants: { 'organization:orgA': [{ dataLakeId: 'theirs', role: 'owner' }] },
+    actor: ctx({ userId: 'me', administeredOrgIds: ['orgA'] }),
+  });
+
+  it('keeps it out of the archived view', async () => {
+    const { lakes, grants, actor } = crossOrg();
+    const db = dbWith(lakes, grants);
+
+    expect(await listArchivedDataLakes(actor, { db })).toEqual([]);
+  });
+
+  it('keeps it out of the deleted view', async () => {
+    const { lakes, grants, actor } = crossOrg();
+    const db = dbWith(lakes, grants);
+
+    expect(await listDeletedDataLakes(actor, { db })).toEqual([]);
+  });
+
+  it("still shows an org MEMBER their own org's archived lake (the membership arm is untouched)", async () => {
+    const theirs = lake({ id: 'ours', slug: 'ours', createdByUserId: 'other', organizationId: 'orgA' });
+    const db = dbWith([theirs], {});
+
+    const result = await listArchivedDataLakes(ctx({ userId: 'me', organizationIds: ['orgA'] }), { db });
+
+    expect(result.map(l => l.id)).toEqual(['ours']);
+  });
+
+  it('still shows a USER owner grant, which carries its own authorization', async () => {
+    const theirs = lake({ id: 'theirs', slug: 'theirs', createdByUserId: 'other', organizationId: 'orgB' });
+    const db = dbWith([theirs], { 'user:me': [{ dataLakeId: 'theirs', role: 'owner' }] });
+
+    const result = await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(result.map(l => l.id)).toEqual(['theirs']);
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -22,7 +22,12 @@ import {
 } from '@bike4mind/common';
 import { canManageLake, canShredLakeMemory, isEffectiveOwner, type LakeGrant } from './manageRule';
 import { redactLakesForActor, type ReaderDataLake } from './redactLakeForActor';
-import { grantedLakeReachFor, resolveEnforceReadGrants, type LakeAccessLogger } from './resolveLakeReadAccess';
+import {
+  grantedLakeReachFor,
+  manageGrantedLakeIdsFor,
+  resolveEnforceReadGrants,
+  type LakeAccessLogger,
+} from './resolveLakeReadAccess';
 
 /** Grant-repo slice the list labels need: batch-read a set of lakes' grants, and one principal's. */
 type GrantLookup = Pick<IDataLakeAccessGrantRepository, 'listActiveByLakes' | 'listByPrincipal'>;
@@ -517,25 +522,25 @@ export const listAllDataLakes = async (
  * this is a management view (restore is owner/admin-only), so it must NOT surface strangers'
  * public lakes; the owner still sees their own archived public lake via the owner arm.
  *
- * Returns raw documents, and the org arm still yields lakes the caller does not own, so the
- * editor-only fields are redacted per lake before they leave the service.
+ * The grant reach is MANAGE-scoped (`manageGrantedLakeIdsFor`), not the read reach the browse list
+ * uses: a `reader` grant is read access and confers no restore, so admitting one here would have
+ * surfaced a stranger's lake in a cleanup list - the same outcome includePublic:false is set to
+ * prevent, arriving through the grant arm instead of the public one. No cutover flag is read: the
+ * roles this reach admits are live and unflagged (see manageGrantedLakeIdsFor).
+ *
+ * Returns raw documents, and the org-MEMBERSHIP arm still yields lakes the caller cannot manage
+ * (pre-existing and intended - org members see their org's archived lakes), so the editor-only
+ * fields are still redacted per lake before they leave the service.
  */
 export const listArchivedDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
 ): Promise<(IDataLakeDocument | ReaderDataLake)[]> => {
-  const includeReaders = await resolveEnforceReadGrants(db.settings);
-  const { grantedLakeIds, orgGrantedLakes } = await grantedLakeReachFor(
-    ctx.userId,
-    ctx.organizationIds ?? [],
-    db.dataLakeAccessGrants,
-    includeReaders
-  );
+  const grantedLakeIds = await manageGrantedLakeIdsFor(ctx.userId, db.dataLakeAccessGrants);
   const lakes = await db.dataLakes.findAccessible(ctx, {
     statuses: ['archived'],
     includePublic: false,
     grantedLakeIds,
-    orgGrantedLakes,
   });
   const grantsByLake = await grantsByLakeIdFor(lakes, db.dataLakeAccessGrants);
   return redactLakesForActor(lakes, ctx, grantsByLake);
@@ -544,25 +549,15 @@ export const listArchivedDataLakes = async (
 /**
  * Soft-deleted lakes accessible to the user (management view: cleanup / restore). includePublic:
  * false for the same reason as the archived view - a stranger has no management role on someone
- * else's public lake. Editor-only fields are redacted per lake, as in the archived view.
+ * else's public lake. The grant reach is MANAGE-scoped and the editor-only fields are redacted per
+ * lake, both for the archived view's reasons.
  */
 export const listDeletedDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
 ): Promise<(IDataLakeDocument | ReaderDataLake)[]> => {
-  const includeReaders = await resolveEnforceReadGrants(db.settings);
-  const { grantedLakeIds, orgGrantedLakes } = await grantedLakeReachFor(
-    ctx.userId,
-    ctx.organizationIds ?? [],
-    db.dataLakeAccessGrants,
-    includeReaders
-  );
-  const lakes = await db.dataLakes.findAccessible(ctx, {
-    statuses: ['deleted'],
-    includePublic: false,
-    grantedLakeIds,
-    orgGrantedLakes,
-  });
+  const grantedLakeIds = await manageGrantedLakeIdsFor(ctx.userId, db.dataLakeAccessGrants);
+  const lakes = await db.dataLakes.findAccessible(ctx, { statuses: ['deleted'], includePublic: false, grantedLakeIds });
   const grantsByLake = await grantsByLakeIdFor(lakes, db.dataLakeAccessGrants);
   return redactLakesForActor(lakes, ctx, grantsByLake);
 };
@@ -574,9 +569,11 @@ export const listDeletedDataLakes = async (
  * nowhere and can only be found by reading its id out of the datastore.
  *
  * Narrowed three ways against the archived/deleted views it otherwise mirrors:
- * - MANAGE-scoped, not read-scoped. The only action offered is a retry, which each lifecycle
- *   service restricts to owner/admin/org-manager, so a caller who cannot manage the lake could do
- *   nothing with the row. Filtering on `canManageLake` here also means nothing needs redacting.
+ * - MANAGE-scoped, not read-scoped, at BOTH ends: the grant reach is `manageGrantedLakeIdsFor` and
+ *   the rows are then filtered on `canManageLake`. The only action offered is a retry, which each
+ *   lifecycle service restricts to owner/admin/org-manager, so a caller who cannot manage the lake
+ *   could do nothing with the row. The post-filter also means nothing needs redacting, and it makes
+ *   the reach narrowing a no-op here: the rows it drops are rows the filter was already dropping.
  * - includePublic:false, for the same reason the archived view passes it: a stranger holds no
  *   management role on someone else's public lake.
  * - Cutoff-filtered, per status (see strandedCutoffMsFor). A lake that entered 'archiving'
@@ -587,18 +584,11 @@ export const listTransitionalDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
 ): Promise<TransitionalDataLakeSummary[]> => {
-  const includeReaders = await resolveEnforceReadGrants(db.settings);
-  const { grantedLakeIds, orgGrantedLakes } = await grantedLakeReachFor(
-    ctx.userId,
-    ctx.organizationIds ?? [],
-    db.dataLakeAccessGrants,
-    includeReaders
-  );
+  const grantedLakeIds = await manageGrantedLakeIdsFor(ctx.userId, db.dataLakeAccessGrants);
   const lakes = await db.dataLakes.findAccessible(ctx, {
     statuses: [...DATA_LAKE_TRANSITIONAL_STATUSES],
     includePublic: false,
     grantedLakeIds,
-    orgGrantedLakes,
   });
   const grantsByLake = await grantsByLakeIdFor(lakes, db.dataLakeAccessGrants);
   const now = Date.now();

--- a/b4m-core/services/src/dataLakeService/manageRule.test.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.test.ts
@@ -125,6 +125,20 @@ describe('canManageLake', () => {
     ).toBe(false);
   });
 
+  // Rung 5 used to compare the grant's org against the actor's admin rights and NOTHING else, so an
+  // orgX admin holding an org grant managed - and, since canAccessLake calls this first, also read -
+  // a lake belonging to orgY. Rung 4 above always compared; rung 5 did not.
+  it('rung 5: an ORG grant never reaches across orgs', () => {
+    const orgXAdmin = actor({ userId: 'member', administeredOrgIds: ['orgX'] });
+    const orgXGrant = [grant('organization', 'orgX', 'owner')];
+
+    // The hole: a lake owned by a DIFFERENT org.
+    expect(canManageLake(lake('creator', 'orgY'), orgXAdmin, orgXGrant)).toBe(false);
+    // Still granting, for the two shapes the rung exists to serve.
+    expect(canManageLake(lake('creator'), orgXAdmin, orgXGrant)).toBe(true);
+    expect(canManageLake(lake('creator', 'orgX'), orgXAdmin, orgXGrant)).toBe(true);
+  });
+
   it('denies a stranger with no grant and no org rights', () => {
     expect(canManageLake(lake('creator', 'org1'), actor({ userId: 'stranger' }))).toBe(false);
   });
@@ -152,6 +166,19 @@ describe('resolveLakeManageRung', () => {
         grant('organization', 'org-2', 'curator'),
       ])
     ).toBe('org-grant');
+  });
+
+  it('names no rung for a cross-org ORG grant, and still org-grant on the org-less lake', () => {
+    const orgXAdmin = actor({ userId: 'member', administeredOrgIds: ['orgX'] });
+    const orgXGrant = [grant('organization', 'orgX', 'owner')];
+
+    expect(resolveLakeManageRung(lake('creator', 'orgY'), orgXAdmin, orgXGrant)).toBeNull();
+    expect(resolveLakeManageRung(lake('creator'), orgXAdmin, orgXGrant)).toBe('org-grant');
+    // The org-LESS lake is the only shape that reports this rung: on a same-org lake the org-admin
+    // rung above fires first, and cross-org is now denied outright. Which is why the containment
+    // admits the org-less lake rather than demanding strict equality - strict equality would make
+    // rung 5 a subset of rung 4, and this rung (plus its persisted audit value) dead code.
+    expect(resolveLakeManageRung(lake('creator', 'orgX'), orgXAdmin, orgXGrant)).toBe('org-admin');
   });
 
   it('returns null for an actor who cannot manage the lake at all', () => {

--- a/b4m-core/services/src/dataLakeService/manageRule.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.ts
@@ -107,6 +107,23 @@ export function isEffectiveOwner(
 }
 
 /**
+ * Is an ORGANIZATION-principal grant contained to the lake it is granted on? True for an org-less
+ * lake (nothing to cross) or when the granted org IS the lake's own org; false for a lake belonging
+ * to a DIFFERENT org. Both sides are normalized because `lake.organizationId` may arrive as an
+ * ObjectId while `principalId` is always a string.
+ *
+ * Factored out rather than inlined twice: `canManageLake` and `resolveLakeManageRung` must agree on
+ * the org-grant rung, and a shared conjunct cannot drift between them.
+ *
+ * Org membership never crosses orgs (epic decision 12). The read arm enforces that at grant-WRITE
+ * time (see resolveReadGrant's sync note); the MANAGE rung enforces it here, at decision time, so an
+ * admin of orgA holding an org grant cannot manage - and therefore cannot read - an orgB lake.
+ */
+function isGrantOrgContained(grant: LakeGrant, lakeOrg: string | undefined): boolean {
+  return !lakeOrg || normalizeId(grant.principalId) === lakeOrg;
+}
+
+/**
  * The single WRITE/MANAGE decision for a lake, in ascending rungs (none weakens the gate; each only
  * ADDS a manager):
  *   1. platform admin;
@@ -115,7 +132,8 @@ export function isEffectiveOwner(
  *      ownership transfer and the visibility expose gate, which stay effective-owner-only;
  *   4. an admin of the lake's org (`lake.organizationId in actor.administeredOrgIds`) - the
  *      org-manageable rung: org lakes survive their creator because org admins manage them by role;
- *   5. an `owner`/`curator` ORG grant for an org the actor administers.
+ *   5. an `owner`/`curator` ORG grant for an org the actor administers, where that org is the
+ *      lake's OWN org (or the lake has none) - an org grant never reaches across orgs.
  *
  * Deliberately narrower than `canAccessLake` (read): a tag/entitlement/org-READ grant lets a member
  * read a lake but not write into it. `canAccessLake` calls THIS first, so every rung here also
@@ -146,7 +164,8 @@ export function canManageLake(
     g =>
       g.principalType === 'organization' &&
       (g.role === 'owner' || g.role === 'curator') &&
-      administeredOrgIds.includes(g.principalId)
+      administeredOrgIds.includes(g.principalId) &&
+      isGrantOrgContained(g, lakeOrg)
   );
 }
 
@@ -197,7 +216,8 @@ export function resolveLakeManageRung(
     g =>
       g.principalType === 'organization' &&
       (g.role === 'owner' || g.role === 'curator') &&
-      administeredOrgIds.includes(g.principalId)
+      administeredOrgIds.includes(g.principalId) &&
+      isGrantOrgContained(g, lakeOrg)
   );
   if (hasOrgGrant) return 'org-grant';
 

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
@@ -7,6 +7,7 @@ import {
   resolveReadGrant,
   resolveLakeReadAccess,
   resolveEnforceReadGrants,
+  manageGrantedLakeIdsFor,
   ENFORCE_LAKE_READ_GRANTS_KEY,
   READ_GRANT_ENFORCEMENT_READY,
 } from './resolveLakeReadAccess';
@@ -342,5 +343,60 @@ describe('grantedLakeReachFor - the two reach sets earn different bypasses', () 
 
   it('an unwired grant repo reaches nothing', async () => {
     expect(await grantedLakeReachFor('u1', ['orgA'])).toEqual({ grantedLakeIds: [], orgGrantedLakes: {} });
+  });
+});
+
+/**
+ * The two reaches, side by side on the SAME grant rows. The management views (archived/deleted/
+ * transitional) offer only restore/cleanup/retry, so they must ask the manage reach; the browse and
+ * read views ask the wide one. Compared directly rather than only through a list view because a
+ * view also depends on which arms `findAccessible` keeps - this is where the reaches themselves
+ * provably differ.
+ */
+describe('grant reach - read vs manage', () => {
+  const repo = (rows: Record<string, { dataLakeId: string; role: string }[]>) => ({
+    listByPrincipal: vi
+      .fn()
+      .mockImplementation(
+        async (principalType: string, principalId: string) => rows[`${principalType}:${principalId}`] ?? []
+      ),
+  });
+
+  it('the read reach admits a reader row under enforce; the manage reach never does', async () => {
+    const rows = { 'user:me': [{ dataLakeId: 'lake1', role: 'reader' }] };
+
+    // Called with includeReaders=true directly rather than through the setting, so this asserts the
+    // reach's own contract rather than the cutover's current position.
+    expect((await grantedLakeReachFor('me', [], repo(rows) as never, true)).grantedLakeIds).toEqual(['lake1']);
+    expect(await manageGrantedLakeIdsFor('me', repo(rows) as never)).toEqual([]);
+  });
+
+  it('both reaches admit owner and curator rows', async () => {
+    for (const role of ['owner', 'curator']) {
+      const rows = { 'user:me': [{ dataLakeId: 'lake1', role }] };
+      expect((await grantedLakeReachFor('me', [], repo(rows) as never, true)).grantedLakeIds).toEqual(['lake1']);
+      expect(await manageGrantedLakeIdsFor('me', repo(rows) as never)).toEqual(['lake1']);
+    }
+  });
+
+  it('the read reach resolves ORG-principal rows; the manage reach does not ask for them at all', async () => {
+    const rows = { 'organization:orgA': [{ dataLakeId: 'lake1', role: 'owner' }] };
+    const manageRepo = repo(rows);
+
+    // Read reach: membership in the granting org resolves the row, keyed by that org so the repo
+    // can AND it with the lake's own org.
+    expect(await grantedLakeReachFor('me', ['orgA'], repo(rows) as never, true)).toEqual({
+      grantedLakeIds: [],
+      orgGrantedLakes: { orgA: ['lake1'] },
+    });
+    // Manage reach: a bare id list, so it carries no granting org and asks for no org rows. The
+    // management views drop `orgGrantArms` anyway under includePublic:false.
+    expect(await manageGrantedLakeIdsFor('me', manageRepo as never)).toEqual([]);
+    expect(manageRepo.listByPrincipal).not.toHaveBeenCalledWith('organization', expect.anything(), expect.anything());
+  });
+
+  it('both degrade to an empty reach with no repo wired', async () => {
+    expect(await grantedLakeReachFor('me', ['orgA'])).toEqual({ grantedLakeIds: [], orgGrantedLakes: {} });
+    expect(await manageGrantedLakeIdsFor('me', undefined)).toEqual([]);
   });
 });

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
@@ -46,11 +46,16 @@ export interface LakeAccessLogger {
  * reader/curator/owner and to org-shared lakes) and it bypasses Private-by-default. `grants` is
  * pre-filtered to ACTIVE (expiry) by the caller, so a lapsed grant never reaches here.
  *
- * Role is intentionally not inspected here: any grant a principal holds admits a READ. Owner/curator
- * (and org owner/curator for an org ADMIN) already pass the legacy `owner-admin` arm via
- * canManageLake, so the outcomes this newly flips are (a) a user `reader` grant and (b) an org grant
- * of any role reaching a plain member - the gaps #1673 closes. The org read arm keys off MEMBERSHIP
- * (`ctx.organizationIds`), distinct from canManageLake's org-MANAGE arm, which keys off admin rights.
+ * Role is intentionally not inspected here: any grant a principal holds admits a READ. A user
+ * owner/curator grant already passes the legacy `owner-admin` arm via canManageLake, so the outcomes
+ * this newly flips are (a) a user `reader` grant and (b) an org grant of any role reaching a plain
+ * member - the gaps #1673 closes. The org read arm keys off MEMBERSHIP (`ctx.organizationIds`),
+ * distinct from canManageLake's org-MANAGE arm, which keys off admin rights.
+ *
+ * An org owner/curator grant held by an org ADMIN pre-passes that legacy arm only when the grant is
+ * contained to the lake's own org (or the lake has none) - canManageLake's org-grant rung compares
+ * the two. A CROSS-org org grant is denied there, so it arrives un-allowed and this arm would be
+ * what decides it; `containedGrants` strips the row before it gets here, so the two gates agree.
  *
  * THIS ARM never lets an org grant reach a lake outside the granting org. Scoped deliberately: the
  * claim is about the read-grant arm, not about the whole decision - the legacy `canManageLake` org
@@ -267,4 +272,33 @@ export const grantedLakeReachFor = async (
     grantedLakeIds: Array.from(ids),
     orgGrantedLakes: Object.fromEntries(Array.from(byOrg, ([orgId, lakeIds]) => [orgId, Array.from(lakeIds)])),
   };
+};
+
+/**
+ * Lake ids the caller can reach via a MANAGE-conferring active grant - the narrower sibling of
+ * `grantedLakeReachFor`, for the management views (archived / deleted / transitional) whose only
+ * offered action is a restore, cleanup or retry.
+ *
+ * Narrower two ways. By ROLE: owner/curator only, allow-listed rather than excluding `reader`, so a
+ * role added to DATA_LAKE_ACCESS_ROLES (called out there as an additive change) fails closed here
+ * until someone decides it manages. A reader grant is read access and confers no restore - the same
+ * ground these views already pass includePublic:false on.
+ *
+ * By PRINCIPAL: user grants only, so the return type is a bare id list rather than a
+ * `LakeGrantReach`. An org grant carries no role through `orgGrantArms`, so DataLakeModel already
+ * suppresses those arms alongside the public one whenever `includePublic:false` - which is exactly
+ * the three views this feeds. Resolving an org reach here would therefore be dead weight. Given up
+ * with it either way: an org-LESS lake carrying an org grant, which `orgGrantArms` also never
+ * matches. A SAME-org lake is unaffected - it arrives via findAccessible's own administeredOrgIds
+ * arm, which carries the lake-org containment an id list cannot.
+ *
+ * Reads no cutover flag, unlike `grantedLakeReachFor`'s `includeReaders`: owner/curator grants have
+ * live, unflagged producers (createDataLake, transferLakeOwnership) and the rungs that honor them
+ * are live too, so gating this on the read-grant cutover would withhold ids the manage gate accepts.
+ */
+export const manageGrantedLakeIdsFor = async (userId: string, grants?: PrincipalGrantLookup): Promise<string[]> => {
+  if (!grants) return [];
+  const rows = await grants.listByPrincipal('user', userId, { activeAsOf: new Date() });
+  const manageable = rows.filter(row => row.role === 'owner' || row.role === 'curator');
+  return Array.from(new Set(manageable.map(row => row.dataLakeId)));
 };


### PR DESCRIPTION
# Pull Request

## Description
An organization-principal `owner`/`curator` grant on the data lake manage gate (`canManageLake` / `resolveLakeManageRung`) was matched against the caller's administered orgs without ever comparing the *lake's* own org. Once the upstream grant-write path (issue #2525, still open) mints an org-principal grant, this let an admin of orgA manage - and therefore read - a lake that belongs to orgB or has no org at all. This PR closes that gap at the decision point, and fixes a second gap in the same family: the archived/deleted/transitional lake-management views resolved their grant reach without regard to grant role, so a plain `reader` grant (not just an org grant) could surface a lake the caller cannot manage in those views.

Both defects are latent today - no caller currently mints an org-principal grant - and become live only once #2525 ships. No production behavior changes with this PR alone.

## Changes
- Added `isGrantOrgContained`, a shared predicate applied identically in `canManageLake` and `resolveLakeManageRung`: an org grant authorizes management only when the lake has no org, or the lake's org matches the granted org.
- Added `manageGrantedLakeIdsFor`, a manage-only grant reach (owner/curator, user-principal grants, unflagged) and pointed `listArchivedDataLakes` / `listDeletedDataLakes` / `listTransitionalDataLakes` at it, replacing their prior read-scoped reach.
- The org-principal arm of the new manage reach was considered and dropped: a reach resolves ids with no lake document in hand, so it cannot apply the lake-org containment, and the archived/deleted views only redact (not filter) - so admitting it would have handed a cross-org lake's name/slug to an admin who holds an unrelated grant. Same-org lakes are unaffected; they still arrive through `findAccessible`'s own administered-org arm, which does carry the containment.
- Docblocks on the read-arm pass-through (`resolveLakeReadAccess.ts`) updated to state that the org-grant containment now enforced at manage-decision time is what makes the unconditional read pass-through safe.

## Guide for Testers
Backend-only, no UI surface change, and both defects require an org-principal grant that no code path can currently create (blocked on issue #2525). Nothing here is manually reproducible on staging today.

**What NOT to test:** there is no user-facing flow to click through. Verification is unit-level only (see below).

**Regression checks (automated, already run):**
1. `pnpm --filter @bike4mind/services test` - 6473 passed, 12 skipped, 0 failed.
2. `pnpm --filter @bike4mind/database test` - 2501 passed, 1 skipped, 0 failed.
3. `pnpm turbo:typecheck` - 40/40 packages.
4. `pnpm lint:check` - clean.

## Additional Information
Two review rounds. Round 1 approved the manage-rung fix but flagged a P1: the first version of the reach fix re-keyed the org arm to `administeredOrgIds` with no flag guard, which would have opened a *new* cross-org disclosure in the archived/deleted views (an org-owner grant on orgA's admin would see orgB's lake name/slug, where `main` shows nothing). Round 2 closed that by dropping the org arm from the reach entirely rather than trying to narrow it, verified against real Mongo repositories and with output-level tests asserting the cross-org lake is absent from both views. Approved with 0 P0/P1.

Left open (P2/P3, non-blocking):
- [ ] One consciously accepted gap: an org-less lake carrying only an org-principal grant now renders in no management view (stated in `manageGrantedLakeIdsFor`'s docblock).
- [ ] Minor docblock-volume nit on `manageRule.ts` (unaddressed by design - the reviewer read it as acceptable).
- [ ] A pre-existing `#1673` reference on a reflowed comment line in `resolveLakeReadAccess.ts` - not introduced by this PR, a pre-existing convention collision across these files.

## Developer Notes (Optional)
- `isGrantOrgContained(grant, lakeOrg)` is the one place both manage predicates should keep sharing this conjunct - do not let `canManageLake` and `resolveLakeManageRung` diverge on it again.
- `manageGrantedLakeIdsFor` is deliberately narrower than `grantedLakeIdsFor`: allow-listed roles (fails closed if a new role is ever added to `DATA_LAKE_ACCESS_ROLES`), user-principal only, no read-grant cutover flag (owner/curator grants are already live and unflagged).

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no external docs
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)