### PR TITLE
feat(retrieval): rank forced retrieval on a relative floor, not a fixed cosine

### DIFF
--- a/b4m-core/common/src/constants/forcedRetrieval.ts
+++ b/b4m-core/common/src/constants/forcedRetrieval.ts
@@ -1,16 +1,54 @@
 /**
- * Forced-retrieval budget defaults, shared between the admin-settings schema in this package and
- * `ChatCompletionFeatures.ts` (which cannot import from `common`'s settings schema without a
- * dependency cycle, so the constant lives here instead).
+ * Forced-retrieval budget and relevance defaults, shared between the admin-settings schema in this
+ * package and `ChatCompletionFeatures.ts` (which cannot import from `common`'s settings schema
+ * without a dependency cycle, so the constants live here instead).
  *
- * Only `FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT` is a lever (see the `forcedRetrievalCharBudget`
- * setting) - the char budget is the measured binding constraint on how much of a corpus reaches
- * the model on every Data-Lake-mode turn. The relevance floor is exported alongside it so the two
- * stay next to each other, not because it is tunable today.
+ * All three are levers. The char budget is the measured binding constraint on how much of a corpus
+ * reaches the model on every Data-Lake-mode turn; the two floors decide which passages are eligible
+ * to spend it (see `forcedRetrievalRelativeFloorPct` and `forcedRetrievalMinSimilarityPct`).
  */
 
 /** Total characters of retrieved chunk text injected into a forced-retrieval prompt. */
 export const FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT = 12_000;
 
-/** Minimum cosine similarity (ada-002) for a chunk to count as relevant on the forced path. */
+/**
+ * The absolute cosine floor (ada-002) the forced path applied before either floor was configurable.
+ *
+ * No longer read at runtime - `forcedRetrievalMinSimilarityPct` is. It stays exported as the
+ * HISTORICAL anchor that `settings.test.ts` pins the percent default against, so moving that default
+ * off the value production actually shipped is a deliberate, visible edit rather than a silent one.
+ */
 export const FORCED_RETRIEVAL_MIN_SIMILARITY_DEFAULT = 0.75;
+
+/**
+ * `FORCED_RETRIEVAL_MIN_SIMILARITY_DEFAULT` as the whole-number percent the admin setting stores.
+ *
+ * Percent rather than a 0-1 fraction because the admin settings number input has no `step`, which
+ * makes a fractional value's spinner unusable - the same reason `KB_SEARCH_MIN_RELEVANCE_PCT_DEFAULT`
+ * is a percent. The resolver divides by 100 once, at the one place that consumes it. `settings.test.ts`
+ * pins this against the fraction above so the two cannot drift.
+ */
+export const FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT = 75;
+
+/**
+ * How close to the turn's best-scoring passage a chunk must score to be injected, as a percent of
+ * that top score. This is the floor that RANKS; the absolute one above only rejects.
+ *
+ * An absolute cosine floor assumes scores are spread widely enough for the line to sit somewhere
+ * meaningful between "relevant" and "irrelevant". Measured over 166 injected chunks on a production
+ * lake that does not hold: the whole distribution sat between 0.8025 and 0.9140 and NOTHING was ever
+ * rejected by the 0.75 line, which is ~0.05 below the entire band. A fixed floor set outside the live
+ * band is inert - it provides no protection while reading like a quality gate - and a corpus whose
+ * band sits lower would see the opposite failure, rejecting everything.
+ *
+ * A relative floor moves with the turn instead of assuming where the band is, so it keeps working
+ * across corpora and survives a change of embedding model (which shifts the band wholesale).
+ *
+ * The 85 default is deliberately BEHAVIOR-PRESERVING, not tuned: the weakest-accepted-to-top ratio
+ * observed on that lake was 0.8025/0.9140 ~= 0.878, so 85% admits everything the absolute floor
+ * admitted and this default changes no production behavior on its own. It is a mechanism plus a
+ * safe starting point, and it is meant to be tuned UPWARD once the band is known - which should
+ * wait for the embedding migration (#471) and the ANN-cutover decision (#2526), both of which move
+ * the distribution any value chosen today would have been fitted to.
+ */
+export const FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT = 85;

--- a/b4m-core/common/src/constants/forcedRetrieval.ts
+++ b/b4m-core/common/src/constants/forcedRetrieval.ts
@@ -44,9 +44,11 @@ export const FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT = 75;
  * A relative floor moves with the turn instead of assuming where the band is, so it keeps working
  * across corpora and survives a change of embedding model (which shifts the band wholesale).
  *
- * The 85 default is deliberately BEHAVIOR-PRESERVING, not tuned: the weakest-accepted-to-top ratio
- * observed on that lake was 0.8025/0.9140 ~= 0.878, so 85% admits everything the absolute floor
- * admitted and this default changes no production behavior on its own. It is a mechanism plus a
+ * The 85 default is BEHAVIOR-PRESERVING ON THE MEASURED BAND, not tuned: the weakest-accepted-to-top
+ * ratio observed on that lake was 0.8025/0.9140 ~= 0.878, so 85% admits everything the absolute floor
+ * admitted there. Read that as a claim about THAT band rather than a general no-op - the relative
+ * floor binds harder than a 75 absolute floor once a turn's top score exceeds ~0.882, so a corpus
+ * with a wider band can see chunks newly rejected at this default. It is a mechanism plus a
  * safe starting point, and it is meant to be tuned UPWARD once the band is known - which should
  * wait for the embedding migration (#471) and the ANN-cutover decision (#2526), both of which move
  * the distribution any value chosen today would have been fitted to.

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -582,10 +582,8 @@ describe('forced-retrieval relevance floors are levers (#2497)', () => {
     expect(settingsMap.forcedRetrievalRelativeFloorPct.min).toBe(0);
     expect(settingsMap.forcedRetrievalRelativeFloorPct.schema.parse(0)).toBe(0);
 
-    // The ABSOLUTE floor stops at 1, because 0 there is not "disabled" but "unreachable": clearing
-    // a number field in the admin UI coerces to 0, and a 0 similarity floor makes the "no chunk
-    // cleared the floor" abstention impossible, so a wholly off-topic corpus would inject its best
-    // band instead of abstaining. 1% still effectively disables the gate for anyone who means to.
+    // The ABSOLUTE floor stops at 1, because clearing a number field in the admin UI coerces to 0,
+    // so 0 reads as an emptied field rather than as intent. 1% still effectively disables the gate.
     expect(settingsMap.forcedRetrievalMinSimilarityPct.min).toBe(1);
     expect(() => settingsMap.forcedRetrievalMinSimilarityPct.schema.parse(0)).toThrow();
     expect(settingsMap.forcedRetrievalMinSimilarityPct.schema.parse(1)).toBe(1);

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -562,18 +562,33 @@ describe('forced-retrieval relevance floors are levers (#2497)', () => {
     );
   });
 
-  it('bounds both floors to 0-100 at write time', () => {
+  it('bounds both floors at write time, integrally, and floors them differently at the bottom', () => {
     // The 100 ceiling is load-bearing, not cosmetic: the relative floor is multiplied by the turn's
     // top score, so a value above 100 would put the cutoff ABOVE the best candidate and starve
-    // every turn. min 0 is what makes "disabled" expressible.
+    // every turn.
     for (const key of FLOOR_KEYS) {
-      expect(settingsMap[key].min).toBe(0);
       expect(settingsMap[key].max).toBe(100);
       expect(() => settingsMap[key].schema.parse(-1)).toThrow();
       expect(() => settingsMap[key].schema.parse(101)).toThrow();
-      expect(settingsMap[key].schema.parse(0)).toBe(0);
       expect(settingsMap[key].schema.parse(100)).toBe(100);
+      // Integral at the write boundary rather than floored later by a reader, so the percent an
+      // admin sees is the percent the retrieval path actually compares against.
+      expect(settingsMap[key].int).toBe(true);
+      expect(() => settingsMap[key].schema.parse(85.5)).toThrow();
     }
+
+    // The two differ at the bottom of the range, and deliberately. 0 is what makes the RELATIVE
+    // floor's "disabled" expressible.
+    expect(settingsMap.forcedRetrievalRelativeFloorPct.min).toBe(0);
+    expect(settingsMap.forcedRetrievalRelativeFloorPct.schema.parse(0)).toBe(0);
+
+    // The ABSOLUTE floor stops at 1, because 0 there is not "disabled" but "unreachable": clearing
+    // a number field in the admin UI coerces to 0, and a 0 similarity floor makes the "no chunk
+    // cleared the floor" abstention impossible, so a wholly off-topic corpus would inject its best
+    // band instead of abstaining. 1% still effectively disables the gate for anyone who means to.
+    expect(settingsMap.forcedRetrievalMinSimilarityPct.min).toBe(1);
+    expect(() => settingsMap.forcedRetrievalMinSimilarityPct.schema.parse(0)).toThrow();
+    expect(settingsMap.forcedRetrievalMinSimilarityPct.schema.parse(1)).toBe(1);
   });
 
   it('is settable at org and owner but NOT per lake, unlike dataLakeSearchMaxChunks', () => {

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -25,7 +25,12 @@ import {
   LAKE_ACCESS_AUDIT_RETENTION_DEFAULT_DAYS,
   LAKE_ACCESS_AUDIT_RETENTION_FLOOR_DAYS,
 } from '../constants/lakeAccessAudit';
-import { FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT } from '../constants/forcedRetrieval';
+import {
+  FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+  FORCED_RETRIEVAL_MIN_SIMILARITY_DEFAULT,
+  FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+  FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+} from '../constants/forcedRetrieval';
 import { LAKE_RECALL_K_DEFAULT, LAKE_RECALL_K_MAX } from '../constants/lakeMemory';
 import {
   KB_SEARCH_DEFAULT_RESULTS_DEFAULT,
@@ -528,6 +533,97 @@ describe('forcedRetrievalCharBudget agrees with the forced-retrieval fallback (#
     expect(settingsMap.forcedRetrievalCharBudget.max).toBe(100_000);
     expect(() => settingsMap.forcedRetrievalCharBudget.schema.parse(100_001)).toThrow();
     expect(settingsMap.forcedRetrievalCharBudget.schema.parse(100_000)).toBe(100_000);
+  });
+});
+
+describe('forced-retrieval relevance floors are levers (#2497)', () => {
+  const FLOOR_KEYS = ['forcedRetrievalRelativeFloorPct', 'forcedRetrievalMinSimilarityPct'] as const;
+
+  it('defaults to the shared constants rather than hand-copied literals', () => {
+    expect(settingsMap.forcedRetrievalRelativeFloorPct.defaultValue).toBe(FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT);
+    expect(settingsMap.forcedRetrievalMinSimilarityPct.defaultValue).toBe(FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT);
+  });
+
+  it('keeps the absolute floor percent in step with the cosine fraction it replaced', () => {
+    // The percent is what an admin edits; the fraction is what the retrieval path compares against.
+    // Pinned together because the setting exists to REPLACE a hardcoded use of the fraction, and a
+    // change to one that missed the other would silently move the floor.
+    expect(FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT / 100).toBe(FORCED_RETRIEVAL_MIN_SIMILARITY_DEFAULT);
+  });
+
+  it('prefaults to the shared constant rather than makeNumberSetting fallback 0', () => {
+    // 0 is a MEANINGFUL value for both (disabled relative floor / absent absolute floor), so a
+    // prefault that silently landed on it would disable the lever instead of defaulting it.
+    expect(settingsMap.forcedRetrievalRelativeFloorPct.schema.parse(undefined)).toBe(
+      FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT
+    );
+    expect(settingsMap.forcedRetrievalMinSimilarityPct.schema.parse(undefined)).toBe(
+      FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT
+    );
+  });
+
+  it('bounds both floors to 0-100 at write time', () => {
+    // The 100 ceiling is load-bearing, not cosmetic: the relative floor is multiplied by the turn's
+    // top score, so a value above 100 would put the cutoff ABOVE the best candidate and starve
+    // every turn. min 0 is what makes "disabled" expressible.
+    for (const key of FLOOR_KEYS) {
+      expect(settingsMap[key].min).toBe(0);
+      expect(settingsMap[key].max).toBe(100);
+      expect(() => settingsMap[key].schema.parse(-1)).toThrow();
+      expect(() => settingsMap[key].schema.parse(101)).toThrow();
+      expect(settingsMap[key].schema.parse(0)).toBe(0);
+      expect(settingsMap[key].schema.parse(100)).toBe(100);
+    }
+  });
+
+  it('is settable at org and owner but NOT per lake, unlike dataLakeSearchMaxChunks', () => {
+    // Deliberate, and the reason is structural rather than an oversight: one forced-retrieval turn
+    // scans an uncapped SET of lakes into a single pool with a single top score, so there is no one
+    // lake for a narrower rung to key on. Same call as kbSearchMinRelevancePct, whose corpus has the
+    // same shape. If a per-lake floor is ever wanted it needs per-lake top scores first, not just
+    // this rung.
+    for (const key of FLOOR_KEYS) {
+      expect(settingsMap[key].scope?.settableAt).toEqual([SettingScopeLevel.Organization, SettingScopeLevel.Owner]);
+      expect(settingsMap[key].scope?.settableAt).not.toContain(SettingScopeLevel.Lake);
+    }
+    expect(settingsMap.dataLakeSearchMaxChunks.scope?.settableAt).toContain(SettingScopeLevel.Lake);
+  });
+
+  it('declares a scope, so the read path must go through the scoped resolver', () => {
+    // The inverse of forcedRetrievalCharBudget's assertion above. That one is platform-only because
+    // it is read via getSettingsValue, which ignores settableAt; these two are read via
+    // resolveScopedSettingValues, which honors it. A future change that pointed them back at
+    // getSettingsValue would silently drop every override, so the scope block is the signal that
+    // the resolver is required.
+    for (const key of FLOOR_KEYS) {
+      expect(settingsMap[key].scope).toBeDefined();
+    }
+  });
+
+  it('defaults the relative floor low enough to preserve behavior on the measured band', () => {
+    // The shipped default is a mechanism plus a safe starting point, NOT a tuned value. On the
+    // production lake this issue was measured against (166 injected chunks) the weakest accepted
+    // score was 0.8025 against a per-turn best of 0.9140, so anything at or below that ratio admits
+    // everything the absolute floor admitted and changes no production behavior on its own.
+    // Raising this default is a deliberate tuning decision that should follow the embedding
+    // migration, not precede it - this test is what makes such a change visible in review.
+    const weakestAcceptedRatio = 0.8025 / 0.914;
+    expect(FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT / 100).toBeLessThan(weakestAcceptedRatio);
+  });
+
+  it('renders in the embedding group so an admin can actually reach both', () => {
+    // A lever nobody can find is the failure mode this issue cites in its own Related section.
+    // The two assertions below are not the same check, and only the second one is the runtime gate:
+    // AdminSettingsTab enumerates `Object.values(settingsMap)` and buckets each entry by its OWN
+    // `group` field (AdminSettingsTab.tsx:134 and :407), then orders within a group by its `order`
+    // (:571) - which is also what makes the two descriptions' "above"/"below" wording true. The
+    // group's `settings` array is never dereferenced by the render path; it is a hand-maintained
+    // index that only this suite enforces, so it is checked here to keep the two from drifting.
+    const keys = API_SERVICE_GROUPS.EMBEDDING.settings.map(entry => entry.key);
+    for (const key of FLOOR_KEYS) {
+      expect(keys).toContain(key);
+      expect(settingsMap[key].group).toBe(API_SERVICE_GROUPS.EMBEDDING.id);
+    }
   });
 });
 

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3561,6 +3561,7 @@ export const settingsMap = {
     defaultValue: FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
     min: 0,
     max: 100,
+    int: true,
     description:
       'How close to the best-scoring passage of the SAME turn a chunk must score to be injected on ' +
       'a Data-Lake-mode turn, as a percent of that top score. This is the floor that ranks; the ' +
@@ -3585,8 +3586,13 @@ export const settingsMap = {
     key: 'forcedRetrievalMinSimilarityPct',
     name: 'Forced Retrieval Absolute Floor (%)',
     defaultValue: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
-    min: 0,
+    // min 1, not 0: clearing a number field in the admin UI coerces to 0, and 0 here makes the
+    // "no chunk cleared the similarity floor" abstention unreachable, so a wholly off-topic corpus
+    // would inject its best band instead of abstaining. 1% still effectively disables the gate for
+    // anyone who means to.
+    min: 1,
     max: 100,
+    int: true,
     description:
       'Absolute minimum cosine similarity, as a percent, a chunk must clear to be injected on a ' +
       'Data-Lake-mode turn. This is a sanity floor for genuinely unrelated content, NOT the ranking ' +

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3586,10 +3586,9 @@ export const settingsMap = {
     key: 'forcedRetrievalMinSimilarityPct',
     name: 'Forced Retrieval Absolute Floor (%)',
     defaultValue: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
-    // min 1, not 0: clearing a number field in the admin UI coerces to 0, and 0 here makes the
-    // "no chunk cleared the similarity floor" abstention unreachable, so a wholly off-topic corpus
-    // would inject its best band instead of abstaining. 1% still effectively disables the gate for
-    // anyone who means to.
+    // min 1, not 0: clearing a number field in the admin UI coerces to 0, so a 0 here is far more
+    // likely to be an emptied field than an intent to disable the gate. 1% still effectively
+    // disables it for anyone who means to, while keeping an accidental clear out of range.
     min: 1,
     max: 100,
     int: true,

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -18,7 +18,11 @@ import {
   LAKE_CONFIG_AUDIT_RETENTION_FLOOR_DAYS,
   LAKE_CONFIG_AUDIT_RETENTION_MAX_DAYS,
 } from '../constants/lakeConfigAudit';
-import { FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT } from '../constants/forcedRetrieval';
+import {
+  FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+  FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+  FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+} from '../constants/forcedRetrieval';
 import { LAKE_RECALL_K_DEFAULT, LAKE_RECALL_K_MAX } from '../constants/lakeMemory';
 import {
   KB_SEARCH_DEFAULT_RESULTS_DEFAULT,
@@ -387,6 +391,8 @@ export const SettingKeySchema = z.enum([
   'kbSearchDefaultResults',
   'kbSearchResultTokenBudget',
   'kbSearchMinRelevancePct',
+  'forcedRetrievalRelativeFloorPct',
+  'forcedRetrievalMinSimilarityPct',
 
   // DATA LAKE COST GOVERNANCE (spend levers - see resolveSpendLevers)
   'dataLakeEmbeddingSpendEnabled',
@@ -1528,6 +1534,8 @@ export const API_SERVICE_GROUPS = {
       { key: 'kbSearchResultTokenBudget', order: 6 },
       { key: 'kbSearchMinRelevancePct', order: 7 },
       { key: 'lakeMemoryRecallK', order: 8 },
+      { key: 'forcedRetrievalRelativeFloorPct', order: 9 },
+      { key: 'forcedRetrievalMinSimilarityPct', order: 10 },
     ],
   },
   DATA_LAKE_COST: {
@@ -3546,6 +3554,54 @@ export const settingsMap = {
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 8,
+  }),
+  forcedRetrievalRelativeFloorPct: makeNumberSetting({
+    key: 'forcedRetrievalRelativeFloorPct',
+    name: 'Forced Retrieval Relative Floor (%)',
+    defaultValue: FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+    min: 0,
+    max: 100,
+    description:
+      'How close to the best-scoring passage of the SAME turn a chunk must score to be injected on ' +
+      'a Data-Lake-mode turn, as a percent of that top score. This is the floor that ranks; the ' +
+      'absolute floor below only rejects. Unlike an absolute cosine line, it moves with the turn, so ' +
+      'it keeps working when a corpus or an embedding model puts the whole score band somewhere ' +
+      'else. Raising it injects fewer, more sharply-ranked passages and leaves char budget unspent; ' +
+      'lowering it admits more of the tail. 0 disables the relative floor and leaves the absolute ' +
+      'one as the only gate (the pre-#2497 behavior). The default is behavior-preserving rather ' +
+      'than tuned: it admits everything the absolute floor admitted on the measured band, so it ' +
+      'changes nothing until raised. Tune it AFTER an embedding-model change, never before - a ' +
+      'migration shifts the band any value fitted to today would have been chosen against.',
+    category: 'AI',
+    group: API_SERVICE_GROUPS.EMBEDDING.id,
+    order: 9,
+    // Organization/Owner only, no Lake rung - deliberately matching kbSearchMinRelevancePct rather
+    // than dataLakeSearchMaxChunks. A forced-retrieval turn scans an uncapped SET of lakes into one
+    // pool with one top score, so there is no single lake for a narrower rung to key on, and the
+    // relative floor is a per-turn quantity by construction. See scopeForCaller's doc comment.
+    scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
+  }),
+  forcedRetrievalMinSimilarityPct: makeNumberSetting({
+    key: 'forcedRetrievalMinSimilarityPct',
+    name: 'Forced Retrieval Absolute Floor (%)',
+    defaultValue: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+    min: 0,
+    max: 100,
+    description:
+      'Absolute minimum cosine similarity, as a percent, a chunk must clear to be injected on a ' +
+      'Data-Lake-mode turn. This is a sanity floor for genuinely unrelated content, NOT the ranking ' +
+      'gate - the relative floor above does the ranking. Measured over 166 injected chunks on a ' +
+      'production lake the 75 default never once bound (the whole band sat between 80 and 91), so ' +
+      'it currently reads like a quality gate while providing no protection. Lowering it toward ' +
+      '30-40 is the intended companion to raising the relative floor: it lets the relative rule ' +
+      'govern a corpus whose band sits low, which a 75 line would otherwise reject wholesale. ' +
+      'Cosine similarity is not comparable across embedding models, so a value tuned for one model ' +
+      'does not transfer to another.',
+    category: 'AI',
+    group: API_SERVICE_GROUPS.EMBEDDING.id,
+    order: 10,
+    // Same rung set and same reason as forcedRetrievalRelativeFloorPct above.
+    scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
   }),
   LakeAccessAuditRetentionDays: makeNumberSetting({
     key: 'LakeAccessAuditRetentionDays',

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -13,8 +13,11 @@ import { mergeRetrievalSummary } from './tools/retrievalSummaryMerge';
 import {
   UNLIMITED_HISTORY_COUNT,
   FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+  FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
   LAKE_RECALL_K_DEFAULT,
+  SettingScopeLevel,
 } from '@bike4mind/common';
+import { invalidateScopedSettingsCache, invalidateSettingsCache } from '@bike4mind/utils';
 import type { ISessionDocument, IChatHistoryItemDocument } from '@bike4mind/common';
 import type { Logger } from '@bike4mind/observability';
 
@@ -2147,6 +2150,255 @@ describe('KnowledgeRetrievalFeature configurable char budget (#1831)', () => {
       ([key]) => key === 'forcedRetrievalCharBudget'
     );
     expect(calls).toHaveLength(1);
+  });
+});
+
+describe('KnowledgeRetrievalFeature relative relevance floor (#2497)', () => {
+  const embeddingFactory = {
+    createEmbeddingService: () => ({ generateEmbedding: vi.fn().mockResolvedValue([1, 0]) }),
+    getDefaultEmbeddingModel: () => 'text-embedding-ada-002',
+  };
+
+  /**
+   * A unit vector whose cosine against the query [1, 0] IS `score`, so each fixture states the
+   * score it wants directly instead of leaving it to be derived from coordinates.
+   */
+  const vectorScoring = (score: number) => [score, Math.sqrt(1 - score * score)];
+
+  /** Unique per chunk and long enough to be visible, short enough that the char budget never binds. */
+  const passageText = (index: number) => `PASSAGE_${index}_ ${'detail '.repeat(10)}`;
+
+  const makeCtx = (opts: {
+    scores: number[];
+    platform?: Record<string, string>;
+    orgOverride?: string;
+    /** Omit the scoped overlay to exercise the platform-only read path instead. */
+    withScopedOverlay?: boolean;
+  }) => {
+    const platform = opts.platform ?? {};
+    const rows = opts.scores.map((score, index) => ({
+      id: `ch${index}`,
+      fabFileId: 'fileA',
+      text: passageText(index),
+      vector: vectorScoring(score),
+    }));
+    return {
+      // `debug` is part of the Logger contract and the scoped resolver uses it - a mock without it
+      // makes the resolver throw into its own never-throw guard and silently serve coded defaults,
+      // which looks exactly like a floor that ignores its configuration.
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger,
+      user: { id: 'u1', organizationId: 'org1', tags: [], groups: [] },
+      db: {
+        organizations: { findMembershipOrgIds: vi.fn().mockResolvedValue([]) },
+        fabfiles: {
+          search: vi
+            .fn()
+            .mockResolvedValue({ data: [{ id: 'fileA', fileName: 'Floors.pdf', tags: [] }], hasMore: false, total: 1 }),
+        },
+        fabfilechunks: { findByFabFileId: vi.fn(), findVectorsByFabFileIds: vi.fn(() => Promise.resolve(rows)) },
+        adminSettings: {
+          // Serves the platform-only read path (and the char budget, which is absent from every
+          // fixture here and so stays at its default).
+          getSettingsValue: vi.fn(async (key: string) => platform[key]),
+          findBySettingNames: vi.fn(async (names: string[]) =>
+            names
+              .filter(name => platform[name] != null)
+              .map(name => ({ settingName: name, settingValue: platform[name] }))
+          ),
+          findAll: vi.fn(async () =>
+            Object.entries(platform).map(([settingName, settingValue]) => ({ settingName, settingValue }))
+          ),
+        },
+        ...(opts.withScopedOverlay === false ? {} : { scopedSettings: makeScopedSettings(opts.orgOverride) }),
+      },
+      resolveEntitlementKeys: vi.fn().mockResolvedValue([]),
+      sendStatusUpdate: vi.fn().mockResolvedValue(undefined),
+    };
+  };
+
+  const makeScopedSettings = (orgOverride?: string) => ({
+    findOverrides: vi.fn(async () =>
+      orgOverride == null
+        ? []
+        : [
+            {
+              scopeLevel: SettingScopeLevel.Organization,
+              scopeId: 'org1',
+              settingName: 'forcedRetrievalRelativeFloorPct',
+              settingValue: orgOverride,
+            },
+          ]
+    ),
+  });
+
+  /** Which fixture passages actually reached the model, by index. */
+  const injectedIndices = (content: string) => {
+    const found: number[] = [];
+    for (let i = 0; i < 12; i++) if (content.includes(`PASSAGE_${i}_`)) found.push(i);
+    return found;
+  };
+
+  const run = async (ctx: ReturnType<typeof makeCtx>) => {
+    const feature = new KnowledgeRetrievalFeature(
+      ctx as unknown as ConstructorParameters<typeof KnowledgeRetrievalFeature>[0]
+    );
+    const quest = makeQuest();
+    const messages = await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'stage III NSCLC treatment'
+    );
+    const content = messages.map(m => m.content).join('\n');
+    return { quest, content, injected: injectedIndices(content) };
+  };
+
+  beforeEach(() => {
+    // Both resolvers memoize per scope; without this a value set by one test leaks into the next.
+    invalidateSettingsCache();
+    invalidateScopedSettingsCache();
+  });
+
+  it('rejects candidates that clear the absolute floor but fall outside the top score band', async () => {
+    // THE point of the issue. All four scores clear the 0.75 absolute floor, so the old code
+    // injected all four and the floor made no ranking decision at all. The relative floor cuts at
+    // 85% of 1.0, so the 0.80 and 0.76 tail is dropped while the head is kept.
+    const { injected } = await run(makeCtx({ scores: [1.0, 0.9, 0.8, 0.76] }));
+    expect(injected).toEqual([0, 1]);
+  });
+
+  it('changes nothing at its shipped default on the band this issue was measured against', async () => {
+    // The safety claim the whole default rests on, pinned end to end rather than as arithmetic in
+    // settings.test.ts. Over 166 injected chunks on a production lake the scores spanned 0.8025 to
+    // 0.9140 and the absolute floor rejected NOTHING, so a behavior-preserving default has to admit
+    // that entire band untouched: 85% of 0.9140 is 0.7769, which 0.8025 clears.
+    //
+    // This is the test that fails if someone tunes the default upward without meaning to - the exact
+    // change that would silently cut production recall on the corpus the issue was filed about.
+    const { injected } = await run(makeCtx({ scores: [0.914, 0.85, 0.8025] }));
+    expect(injected).toEqual([0, 1, 2]);
+  });
+
+  it('a relative floor of 0 disables ranking, leaving the absolute floor as the only gate', async () => {
+    // The pre-#2497 behavior, still expressible - this is what makes the change reversible by
+    // configuration rather than by deploy.
+    const { injected } = await run(
+      makeCtx({ scores: [1.0, 0.9, 0.8, 0.76], platform: { forcedRetrievalRelativeFloorPct: '0' } })
+    );
+    expect(injected).toEqual([0, 1, 2, 3]);
+  });
+
+  it('grades a corpus whose whole band sits below the absolute default, instead of taking none of it', async () => {
+    // The failure the absolute floor cannot express: a corpus scoring 0.30-0.50 is uniformly
+    // rejected by a 0.75 line no matter how well-ranked it is internally. Lowering the absolute
+    // floor to a sanity value and letting the relative rule govern keeps the ranking.
+    const lowBand = [0.5, 0.45, 0.3];
+    const collapsed = await run(makeCtx({ scores: lowBand }));
+    expect(collapsed.injected).toEqual([]);
+
+    // The settings cache is process-wide, so the first run above primed it with an EMPTY platform
+    // map. Without clearing it here the second run silently resolves the coded defaults instead of
+    // its own fixture - which reads as "the relative floor did nothing", the exact false negative
+    // this test exists to rule out. beforeEach only covers the gap BETWEEN tests, not within one.
+    invalidateSettingsCache();
+    invalidateScopedSettingsCache();
+
+    const graded = await run(
+      makeCtx({
+        scores: lowBand,
+        platform: { forcedRetrievalMinSimilarityPct: '20', forcedRetrievalRelativeFloorPct: '85' },
+      })
+    );
+    // 85% of the 0.5 top score is 0.425, so the 0.45 near-miss is kept and the 0.30 tail is not.
+    expect(graded.injected).toEqual([0, 1]);
+  });
+
+  it('never starves a turn: the best candidate always clears its own cutoff', async () => {
+    // The invariant that lets the relative floor be applied without adding a new empty-handed exit.
+    // At 100% only the top score itself survives, but something always does.
+    const { injected } = await run(
+      makeCtx({ scores: [0.9, 0.88, 0.8], platform: { forcedRetrievalRelativeFloorPct: '100' } })
+    );
+    expect(injected).toEqual([0]);
+  });
+
+  it('honors an organization override, so the floor is tunable without a deploy', async () => {
+    // Proves the scoped read path is wired, not just the schema metadata: the platform row says 85
+    // and the org row says 95, and the narrower rung is what the turn resolves to.
+    const { injected } = await run(
+      makeCtx({ scores: [1.0, 0.9, 0.8], platform: { forcedRetrievalRelativeFloorPct: '85' }, orgOverride: '95' })
+    );
+    expect(injected).toEqual([0]);
+  });
+
+  it('records the post-floor volume in promptMeta so the change is measurable', async () => {
+    // The issue's sequencing requirement: without this the floor cannot be shown to have done
+    // anything, because a turn that injected two passages and one that injected four were
+    // byte-identical in promptMeta.
+    const { quest } = await run(makeCtx({ scores: [1.0, 0.9, 0.8, 0.76] }));
+    expect(quest.promptMeta?.retrieval?.injected?.chunks).toBe(2);
+    expect(quest.promptMeta?.retrieval?.injected?.topScore).toBeCloseTo(1.0, 5);
+  });
+
+  it('treats an out-of-range floor percent as unusable and keeps the shipped default', async () => {
+    // Defense-in-depth, NOT a production-reachable path - the same standing as positiveIntOr's own
+    // branches in the #1831 suite above. Both read paths run the setting's schema (`max: 100`)
+    // before this code sees a value, so a stored 2000 is sanitized upstream; this mock injects the
+    // raw shape directly to pin the guard's OWN contract, which is what protects the call if that
+    // sanitization is ever bypassed (a new read path, a relaxed bound).
+    //
+    // Worth guarding because the failure is silent and total: both floors are divided by 100 and
+    // compared against a cosine, so 2000 becomes a floor of 20.0 that no similarity can ever clear,
+    // starving every Data-Lake turn. Falling back to the known-good default preserves behavior;
+    // clamping to 100 would admit only a perfect match - the same starvation by another route.
+    //
+    // withScopedOverlay: false to reach the direct getSettingsValue read, whose mock here returns
+    // the stored string unparsed. The scoped resolver would apply the schema and hand back the
+    // default, so the guard would never be exercised.
+    const ctx = makeCtx({
+      scores: [1.0, 0.9, 0.8, 0.76],
+      platform: { forcedRetrievalMinSimilarityPct: '2000' },
+      withScopedOverlay: false,
+    });
+    const { injected } = await run(ctx);
+    // Absolute floor back at its 75 default, so the relative floor still does the ranking.
+    expect(injected).toEqual([0, 1]);
+    expect((ctx.logger as unknown as { warn: ReturnType<typeof vi.fn> }).warn).toHaveBeenCalledWith(
+      expect.stringContaining('forcedRetrievalMinSimilarityPct')
+    );
+  });
+
+  it('applies platform values on a host with no scoped overlay wired', async () => {
+    // The overlay is optional on the db contract, so the floors must still be levers without it -
+    // there is simply no override to find. Without this the no-overlay branch is only ever
+    // exercised incidentally by other suites, where a silent fallback to coded defaults would look
+    // like a pass.
+    // 100 rather than 0 deliberately. A configured 0 yields the same injected set as a build with
+    // no relative floor at all, so it cannot tell "the platform row was read" from "the mechanism
+    // is gone" - and it would also match the coded default's set on some bands. 100 is distinct
+    // from both: the shipped 85 default would keep [0, 1] here, and no floor at all would keep all
+    // four.
+    const { injected } = await run(
+      makeCtx({
+        scores: [1.0, 0.9, 0.8, 0.76],
+        platform: { forcedRetrievalRelativeFloorPct: '100' },
+        withScopedOverlay: false,
+      })
+    );
+    expect(injected).toEqual([0]);
+  });
+
+  it('falls back to the shipped defaults, without throwing, when the settings read fails', async () => {
+    const ctx = makeCtx({ scores: [1.0, 0.9, 0.8, 0.76] });
+    ctx.db.adminSettings.findBySettingNames = vi.fn(async () => {
+      throw new Error('settings store unavailable');
+    });
+    ctx.db.adminSettings.findAll = vi.fn(async () => {
+      throw new Error('settings store unavailable');
+    });
+    const { injected } = await run(ctx);
+    // Degrades to FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT rather than to "no floor" or a throw.
+    expect(FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT).toBe(85);
+    expect(injected).toEqual([0, 1]);
   });
 });
 

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2552,7 +2552,7 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       // turn's FINAL top score, which is not known until the last batch has been scored. This is
       // the floor that ranks - it moves with the turn, so it keeps discriminating whichever band a
       // corpus or an embedding model lands the scores in, where a fixed absolute line either admits
-      // everything or nothing (#2497).
+      // everything or nothing.
       //
       // Skipped when the top score is not positive. `topScore` is not derived from `pool` - it is
       // updated one line BEFORE the absolute-floor `continue`, so it tracks every finite scored

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2069,8 +2069,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
    * `scopeForCaller`).
    *
    * Percent-to-fraction conversion happens here, once, so every comparison below is against a raw
-   * cosine. `nonNegativeIntOr` rather than `positiveIntOr` because `0` is meaningful for both (a
-   * disabled relative floor, an absent absolute one), so it must not be treated as unusable.
+   * cosine. `nonNegativeIntOr` rather than `positiveIntOr` because `0` is meaningful for the
+   * RELATIVE floor (a disabled floor) and both floors share this helper. It is not meaningful for
+   * the absolute one, whose schema bounds it at `min: 1`, so 0 never reaches here for that key -
+   * the reader stays deliberately more permissive than the writer.
    *
    * Never throws, and the catch reaches wider than "no adminSettings adapter": the platform-only
    * path calls `getSettingsValue` unguarded, so a settings or DB outage on an overlay-less host
@@ -2116,8 +2118,14 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
    * scoped overlay is wired. When it is absent there is no override to find and the platform read is
    * byte-identical, so this takes the plain `getSettingsValue` route rather than requiring every host
    * to carry the overlay - the same optionality `scopedSettings` is already documented with on the
-   * db contract above, and the same two-path shape `resolveSearchBudgets` uses, inner guard
-   * included: a scoped failure degrades to the platform read, not to the coded defaults.
+   * db contract above, and the same two-path shape `resolveSearchBudgets` uses.
+   *
+   * The scoped branch is wrapped defensively, NOT because production takes the fallback:
+   * `resolveScopedSettingValues` documents that it never throws and wraps both of its own reads, so
+   * the only thing the catch can realistically see is an argument-evaluation error. The corollary is
+   * worth knowing rather than assuming away - when the resolver's OWN platform read fails it
+   * resolves the coded default internally and returns normally, so a settings outage lands on coded
+   * defaults whether or not this guard is here.
    */
   private async readForcedRetrievalFloorPcts(): Promise<{ relative: unknown; absolute: unknown }> {
     const { db, user } = this.chatCompletion;
@@ -2544,13 +2552,15 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       // corpus or an embedding model lands the scores in, where a fixed absolute line either admits
       // everything or nothing (#2497).
       //
-      // Skipped when the top score is not positive, and that guard is LOAD-BEARING today rather
-      // than written for a future floor. `topScore` is not derived from `pool`: it is updated one
-      // line BEFORE the absolute-floor `continue`, so it tracks every finite scored candidate while
-      // `pool` holds only those that cleared the floor. A turn whose scores are all negative
-      // therefore gets past the `scoredCount === 0` guard, leaves `pool` empty, and arrives here
-      // with `topScore` below zero. That matters because a multiplicative floor inverts across zero
-      // (0.85 * -0.2 = -0.17, ABOVE the score it came from), rejecting even the best candidate.
+      // Skipped when the top score is not positive. `topScore` is not derived from `pool` - it is
+      // updated one line BEFORE the absolute-floor `continue`, so it tracks every finite scored
+      // candidate while `pool` holds only those that cleared the floor - which means the VARIABLE
+      // can be negative here even though the guard is inert. Inert twice over: the absolute floor
+      // is a percent and so never below 0, so a negative `topScore` implies every score was
+      // rejected and `ranked` is empty; and a negative cutoff would fail the `> 0` test below
+      // anyway. Kept as documentation that a multiplicative floor inverts across zero
+      // (0.85 * -0.2 = -0.17, ABOVE the score it came from), which would matter if a future
+      // absolute floor ever admitted negatives.
       //
       // Cannot starve a turn: the fraction is at most 1 (the setting caps at 100) and `topScore`
       // equals the head of `ranked` whenever it is non-empty - the global maximum always clears the

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2070,9 +2070,11 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
    *
    * Percent-to-fraction conversion happens here, once, so every comparison below is against a raw
    * cosine. `nonNegativeIntOr` rather than `positiveIntOr` because `0` is meaningful for the
-   * RELATIVE floor (a disabled floor) and both floors share this helper. It is not meaningful for
-   * the absolute one, whose schema bounds it at `min: 1`, so 0 never reaches here for that key -
-   * the reader stays deliberately more permissive than the writer.
+   * RELATIVE floor (a disabled floor) and both floors share this helper. `0` is not meaningful for
+   * the absolute floor, and what keeps it out is the READ path, not the write boundary - scripts
+   * and migrations write this collection raw, but both readers re-parse through the setting's own
+   * schema (`min: 1`) and substitute the coded default on failure. Same mechanism
+   * `forcedRetrievalFloorFraction` relies on for its range check.
    *
    * Never throws, and the catch reaches wider than "no adminSettings adapter": the platform-only
    * path calls `getSettingsValue` unguarded, so a settings or DB outage on an overlay-less host
@@ -2554,13 +2556,12 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       //
       // Skipped when the top score is not positive. `topScore` is not derived from `pool` - it is
       // updated one line BEFORE the absolute-floor `continue`, so it tracks every finite scored
-      // candidate while `pool` holds only those that cleared the floor - which means the VARIABLE
-      // can be negative here even though the guard is inert. Inert twice over: the absolute floor
-      // is a percent and so never below 0, so a negative `topScore` implies every score was
-      // rejected and `ranked` is empty; and a negative cutoff would fail the `> 0` test below
-      // anyway. Kept as documentation that a multiplicative floor inverts across zero
-      // (0.85 * -0.2 = -0.17, ABOVE the score it came from), which would matter if a future
-      // absolute floor ever admitted negatives.
+      // candidate while `pool` holds only those that cleared the floor, and can therefore be
+      // negative here. The guard is inert either way: a non-positive `topScore` makes the product
+      // non-positive, so the `> 0` test below takes the unfiltered branch with or without it. Kept
+      // as documentation that a multiplicative floor inverts across zero (0.85 * -0.2 = -0.17,
+      // ABOVE the score it came from), which would matter if a future absolute floor admitted
+      // negatives.
       //
       // Cannot starve a turn: the fraction is at most 1 (the setting caps at 100) and `topScore`
       // equals the head of `ranked` whenever it is non-empty - the global maximum always clears the

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -55,7 +55,8 @@ import {
   buildLakeMemoryContext,
   lakeMemoryFacts,
   FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
-  FORCED_RETRIEVAL_MIN_SIMILARITY_DEFAULT,
+  FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+  FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
   LAKE_RECALL_K_DEFAULT,
   DATALAKE_TAG_PREFIX,
   PROMPT_TEXT_MAX,
@@ -71,7 +72,8 @@ import {
   sessionNamesALake,
   type ResolvedLakeAccessSet,
 } from '../dataLakeService/narrowLakeAccessToSession';
-import { positiveIntOr } from '../dataLakeService/resolveSearchBudgets';
+import { nonNegativeIntOr, positiveIntOr } from '../dataLakeService/resolveSearchBudgets';
+import { resolveScopedSettingValues, scopeForCaller } from '../settings/resolveScopedSetting';
 import {
   classifyLoadedChunk,
   partitionFilesByEmbeddingModel,
@@ -1629,21 +1631,65 @@ const FORCED_RETRIEVAL_FILE_BATCH_SIZE = 10;
 const FORCED_RETRIEVAL_BATCH_CHUNK_CAP = 1000;
 // Hard ceiling on chunks scored in one turn, so a few huge documents cannot stall a turn.
 const FORCED_RETRIEVAL_MAX_SCANNED_CHUNKS = 4000;
-// Above-floor candidates retained for the char-budget walk, so resident chunk text stays bounded.
+// Candidates above the ABSOLUTE floor retained for the char-budget walk, so resident chunk text
+// stays bounded. The relative floor narrows this pool further, after the scan (it needs the turn's
+// final top score), so this cap bounds memory on its own and does not depend on either floor.
 // The budget can only fit this many sections while the mean retained chunk exceeds
 // (configured char budget)/256 chars - ~47 at the 12,000-char default, which real chunking always
 // clears. Since the char budget became a setting (see `forcedRetrievalCharBudget` below), a very
 // large configured value could in principle admit more sections than this caps; a corpus of very
 // short chunks could inject fewer than expected regardless of budget.
 const FORCED_RETRIEVAL_MAX_SCORED_CHUNKS = 256;
-// Minimum cosine similarity (ada-002) for a chunk to count as relevant. Below this,
-// no chunk is injected and the turn falls back to forcedRetrievalNoContextPrompt. Not itself a
-// lever - shares its default with the settings schema (`forcedRetrievalCharBudget`'s sibling
-// constant) so the two cannot drift.
-const FORCED_RETRIEVAL_MIN_SIMILARITY = FORCED_RETRIEVAL_MIN_SIMILARITY_DEFAULT;
+// Both relevance floors are levers now (`forcedRetrievalRelativeFloorPct` and
+// `forcedRetrievalMinSimilarityPct`, resolved once per turn by resolveForcedRetrievalFloors below),
+// so neither is a module constant - every former FORCED_RETRIEVAL_MIN_SIMILARITY reference is a
+// resolved local instead. When nothing clears them, no chunk is injected and the turn falls back to
+// forcedRetrievalNoContextPrompt.
 // The char budget is now a lever (`forcedRetrievalCharBudget` setting, resolved once per turn by
 // resolveForcedRetrievalCharBudget below) rather than a module constant - every former reference to
 // a FORCED_RETRIEVAL_CHAR_BUDGET constant is a resolved local variable instead.
+
+/**
+ * One of the two floor settings as a 0-1 cosine fraction, or `fallback` when the stored value is
+ * unusable or outside 0-100.
+ *
+ * The range check is defense-in-depth, not a path normal operation reaches: BOTH read paths run the
+ * setting's own schema (`max: 100`) before this sees a value - `getSettingsValue` safeParses, and the
+ * scoped resolver parses the platform base and skips unparseable overrides - so even a hand-edited
+ * row arrives sanitized. It is here because the failure it prevents is silent and total: both floors
+ * are DIVIDED by 100 and then compared against a cosine, so a 2000 that ever did get through becomes
+ * a floor of 20.0, which no similarity can clear, starving every Data-Lake turn with nothing in the
+ * output to say why. Cheap guard, unbounded downside.
+ *
+ * Falls back rather than clamping to 100, which is where this deliberately diverges from
+ * `resolveRelevancePct`'s handling of the same hazard: clamping a fat-fingered value to "admit only
+ * a perfect match" is itself the retrieval starvation this floor exists to prevent, so the coded
+ * default - known-good, behavior-preserving - is the safer landing place.
+ */
+function forcedRetrievalFloorFraction(raw: unknown, fallbackPct: number, label: string, logger: Logger): number {
+  const pct = nonNegativeIntOr(raw as string | number | null | undefined, fallbackPct, label, logger);
+  if (pct > 100) {
+    logger.warn(`\u{1F512} Forced retrieval: ${label} ${pct} exceeds 100; using ${fallbackPct} instead`);
+    return fallbackPct / 100;
+  }
+  return pct / 100;
+}
+
+/**
+ * The two relevance floors a forced-retrieval turn grades candidates against, as raw cosine
+ * fractions (the settings store whole-number percents; the conversion happens once, in the
+ * resolver). Resolved together because they are read in one query and are only meaningful as a
+ * pair: the relative one ranks, the absolute one rejects.
+ */
+interface ForcedRetrievalFloors {
+  /**
+   * Fraction of the turn's best score a candidate must reach. `0` disables the relative floor,
+   * leaving the absolute one as the only gate - the behavior before this was configurable.
+   */
+  relativeFloor: number;
+  /** Absolute cosine floor a candidate must clear regardless of how the turn's band sits. */
+  minSimilarity: number;
+}
 
 /** An above-floor candidate. The vector is dropped so each batch can be freed after scoring. */
 interface ForcedRetrievalCandidate {
@@ -2011,6 +2057,86 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
     }
   }
 
+  /**
+   * Both relevance floors for this turn, on the CALLER's org/owner scope.
+   *
+   * Read via readForcedRetrievalFloorPcts below, which prefers the scoped-settings resolver over the
+   * plain `getSettingsValue` that resolveForcedRetrievalCharBudget uses: these two declare a
+   * `settableAt` block, and that metadata is only honored on the scoped path - a scoped setting read
+   * directly would silently ignore every override. No Lake rung, deliberately: one turn scans an
+   * uncapped SET of lakes into a single pool with a single top score, so there is no lake for a
+   * narrower rung to key on, the same reason `kbSearchMinRelevancePct` stops at owner (see
+   * `scopeForCaller`).
+   *
+   * Percent-to-fraction conversion happens here, once, so every comparison below is against a raw
+   * cosine. `nonNegativeIntOr` rather than `positiveIntOr` because `0` is meaningful for both (a
+   * disabled relative floor, an absent absolute one), so it must not be treated as unusable.
+   *
+   * Never throws. `resolveScopedSettingValues` already guarantees that for settings failures, so the
+   * catch covers only a host with no adminSettings adapter wired at all - the same fail-open posture
+   * as the char budget, and the defaults it falls back to are behavior-preserving.
+   */
+  private async resolveForcedRetrievalFloors(): Promise<ForcedRetrievalFloors> {
+    const coded: ForcedRetrievalFloors = {
+      relativeFloor: FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT / 100,
+      minSimilarity: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT / 100,
+    };
+    try {
+      const { relative, absolute } = await this.readForcedRetrievalFloorPcts();
+      return {
+        relativeFloor: forcedRetrievalFloorFraction(
+          relative,
+          FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+          'forcedRetrievalRelativeFloorPct',
+          this.logger
+        ),
+        minSimilarity: forcedRetrievalFloorFraction(
+          absolute,
+          FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+          'forcedRetrievalMinSimilarityPct',
+          this.logger
+        ),
+      };
+    } catch (err) {
+      this.logger.warn(
+        `\u{1F512} Forced retrieval: failed to read the relevance floors; falling back to ` +
+          `${FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT}% relative / ${FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT}% absolute`,
+        err
+      );
+      return coded;
+    }
+  }
+
+  /**
+   * The two floor settings as stored (whole-number percents), by whichever read path this host has.
+   *
+   * A `settableAt` block is only honored by the scoped resolver, so that is the path whenever the
+   * scoped overlay is wired. When it is absent there is no override to find and the platform read is
+   * byte-identical, so this takes the plain `getSettingsValue` route rather than requiring every host
+   * to carry the overlay - the same optionality `scopedSettings` is already documented with on the
+   * db contract above, and the same two-path shape `resolveSearchBudgets` uses.
+   */
+  private async readForcedRetrievalFloorPcts(): Promise<{ relative: unknown; absolute: unknown }> {
+    const { db, user } = this.chatCompletion;
+    if (db.scopedSettings) {
+      const values = await resolveScopedSettingValues(
+        ['forcedRetrievalRelativeFloorPct', 'forcedRetrievalMinSimilarityPct'],
+        scopeForCaller({ userId: user.id, organizationId: normalizeId(user.organizationId) }),
+        { adminSettings: db.adminSettings, scopedSettings: db.scopedSettings },
+        { logger: this.logger }
+      );
+      return {
+        relative: values.forcedRetrievalRelativeFloorPct,
+        absolute: values.forcedRetrievalMinSimilarityPct,
+      };
+    }
+    const [relative, absolute] = await Promise.all([
+      db.adminSettings.getSettingsValue('forcedRetrievalRelativeFloorPct'),
+      db.adminSettings.getSettingsValue('forcedRetrievalMinSimilarityPct'),
+    ]);
+    return { relative, absolute };
+  }
+
   private noContextMessages(finding: ForcedRetrievalNoContextFinding): IMessage[] {
     return [{ role: 'system' as const, content: forcedRetrievalNoContextPrompt(finding) }];
   }
@@ -2150,8 +2276,12 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         return this.noContextMessages('unavailable');
       }
 
-      // Resolved ONCE here, before the scan - never re-read per chunk in the accumulation loop below.
-      const forcedRetrievalCharBudget = await this.resolveForcedRetrievalCharBudget();
+      // Resolved ONCE here, before the scan - never re-read per chunk in the accumulation loop
+      // below. In parallel because they are independent reads and this is on every lake-mode turn.
+      const [forcedRetrievalCharBudget, floors] = await Promise.all([
+        this.resolveForcedRetrievalCharBudget(),
+        this.resolveForcedRetrievalFloors(),
+      ]);
 
       // Only a non-lake tag survives: a `datalake:` entry (the shape a lake-created session sets
       // `retrievalTags` to) names the SESSION's lake, which is already applied above via
@@ -2348,7 +2478,7 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
             if (!Number.isFinite(score)) continue;
             scoredCount++;
             if (score > topScore) topScore = score;
-            if (score < FORCED_RETRIEVAL_MIN_SIMILARITY) continue;
+            if (score < floors.minSimilarity) continue;
             pool.push({ id: row.id, fabFileId: row.fabFileId, text: row.text, score });
             if (pool.length > FORCED_RETRIEVAL_MAX_SCORED_CHUNKS) {
               pool.sort(compareForcedRetrievalCandidates);
@@ -2395,9 +2525,35 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         recordRetrieval('not_indexed', dataLakeTags, { chunks: 0, chars: 0 });
         return this.noContextMessages('unavailable');
       }
-      const scored = pool.sort(compareForcedRetrievalCandidates);
+      const ranked = pool.sort(compareForcedRetrievalCandidates);
+      // The relative floor runs HERE rather than inside the scan above: it is a fraction of the
+      // turn's FINAL top score, which is not known until the last batch has been scored. This is
+      // the floor that ranks - it moves with the turn, so it keeps discriminating whichever band a
+      // corpus or an embedding model lands the scores in, where a fixed absolute line either admits
+      // everything or nothing (#2497).
+      //
+      // Skipped when the top score is not positive. The reachable case is a top score of exactly
+      // 0 (an all-orthogonal band), where a fraction of 0 is still 0 and would admit everything
+      // anyway. A NEGATIVE top score cannot reach here today - the absolute floor is a percent, so
+      // it is never below 0, and `pool` therefore only holds non-negative scores - but the guard is
+      // written for it regardless, because a multiplicative floor inverts across zero
+      // (0.85 * -0.2 = -0.17, ABOVE the score it came from) and would reject even the best
+      // candidate if a future absolute floor ever admitted negatives.
+      //
+      // Cannot starve a turn: the fraction is at most 1 (the setting caps at 100) and `topScore`
+      // equals the head of `ranked` whenever it is non-empty - the global maximum always clears the
+      // absolute floor if anything does, and the in-scan trim retains the highest scores - so the
+      // best candidate always survives its own cutoff. No new empty-handed exit is introduced.
+      const relativeCutoff = floors.relativeFloor > 0 && topScore > 0 ? topScore * floors.relativeFloor : 0;
+      const scored = relativeCutoff > 0 ? ranked.filter(c => c.score >= relativeCutoff) : ranked;
+      if (scored.length < ranked.length) {
+        this.logger.log(
+          `\u{1F512} Forced retrieval: relative floor kept ${scored.length}/${ranked.length} candidates ` +
+            `(cutoff ${relativeCutoff.toFixed(3)} = ${(floors.relativeFloor * 100).toFixed(0)}% of ${topScore.toFixed(3)})`
+        );
+      }
 
-      // 4. Inject the most-similar chunks (above the relevance floor) up to the budget.
+      // 4. Inject the most-similar chunks (above both relevance floors) up to the budget.
       //    If nothing clears the floor, inject the abstention block instead of off-topic
       //    content, hedged by whether the scan was complete.
       let used = 0;
@@ -2407,7 +2563,8 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       const sourceFileIds: string[] = [];
       const injectedChunkIds: string[] = [];
       const injectedScores: number[] = [];
-      // `scored` is already floor-filtered during the scan, so the walk only enforces the budget.
+      // `scored` has cleared the absolute floor (in the scan) and the relative floor (just above),
+      // so the walk only enforces the budget.
       for (const candidate of scored) {
         if (used >= forcedRetrievalCharBudget) break;
         injectedChunkIds.push(candidate.id);

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2072,9 +2072,11 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
    * cosine. `nonNegativeIntOr` rather than `positiveIntOr` because `0` is meaningful for both (a
    * disabled relative floor, an absent absolute one), so it must not be treated as unusable.
    *
-   * Never throws. `resolveScopedSettingValues` already guarantees that for settings failures, so the
-   * catch covers only a host with no adminSettings adapter wired at all - the same fail-open posture
-   * as the char budget, and the defaults it falls back to are behavior-preserving.
+   * Never throws, and the catch reaches wider than "no adminSettings adapter": the platform-only
+   * path calls `getSettingsValue` unguarded, so a settings or DB outage on an overlay-less host
+   * lands here too. (On the scoped path a missing adapter is swallowed inside the resolver and
+   * never reaches this catch.) Same fail-open posture as the char budget, and the defaults it
+   * falls back to are behavior-preserving.
    */
   private async resolveForcedRetrievalFloors(): Promise<ForcedRetrievalFloors> {
     const coded: ForcedRetrievalFloors = {
@@ -2114,21 +2116,31 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
    * scoped overlay is wired. When it is absent there is no override to find and the platform read is
    * byte-identical, so this takes the plain `getSettingsValue` route rather than requiring every host
    * to carry the overlay - the same optionality `scopedSettings` is already documented with on the
-   * db contract above, and the same two-path shape `resolveSearchBudgets` uses.
+   * db contract above, and the same two-path shape `resolveSearchBudgets` uses, inner guard
+   * included: a scoped failure degrades to the platform read, not to the coded defaults.
    */
   private async readForcedRetrievalFloorPcts(): Promise<{ relative: unknown; absolute: unknown }> {
     const { db, user } = this.chatCompletion;
     if (db.scopedSettings) {
-      const values = await resolveScopedSettingValues(
-        ['forcedRetrievalRelativeFloorPct', 'forcedRetrievalMinSimilarityPct'],
-        scopeForCaller({ userId: user.id, organizationId: normalizeId(user.organizationId) }),
-        { adminSettings: db.adminSettings, scopedSettings: db.scopedSettings },
-        { logger: this.logger }
-      );
-      return {
-        relative: values.forcedRetrievalRelativeFloorPct,
-        absolute: values.forcedRetrievalMinSimilarityPct,
-      };
+      try {
+        const values = await resolveScopedSettingValues(
+          ['forcedRetrievalRelativeFloorPct', 'forcedRetrievalMinSimilarityPct'],
+          scopeForCaller({ userId: user.id, organizationId: normalizeId(user.organizationId) }),
+          { adminSettings: db.adminSettings, scopedSettings: db.scopedSettings },
+          { logger: this.logger }
+        );
+        return {
+          relative: values.forcedRetrievalRelativeFloorPct,
+          absolute: values.forcedRetrievalMinSimilarityPct,
+        };
+      } catch (err) {
+        // Fall THROUGH rather than rethrow: the outer catch lands on coded defaults, which would
+        // discard a platform-wide override for the duration of a transient scoped-read failure.
+        this.logger.warn(
+          '\u{1F512} Forced retrieval: scoped floor read failed; falling back to the platform values',
+          err
+        );
+      }
     }
     const [relative, absolute] = await Promise.all([
       db.adminSettings.getSettingsValue('forcedRetrievalRelativeFloorPct'),
@@ -2532,13 +2544,13 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       // corpus or an embedding model lands the scores in, where a fixed absolute line either admits
       // everything or nothing (#2497).
       //
-      // Skipped when the top score is not positive. The reachable case is a top score of exactly
-      // 0 (an all-orthogonal band), where a fraction of 0 is still 0 and would admit everything
-      // anyway. A NEGATIVE top score cannot reach here today - the absolute floor is a percent, so
-      // it is never below 0, and `pool` therefore only holds non-negative scores - but the guard is
-      // written for it regardless, because a multiplicative floor inverts across zero
-      // (0.85 * -0.2 = -0.17, ABOVE the score it came from) and would reject even the best
-      // candidate if a future absolute floor ever admitted negatives.
+      // Skipped when the top score is not positive, and that guard is LOAD-BEARING today rather
+      // than written for a future floor. `topScore` is not derived from `pool`: it is updated one
+      // line BEFORE the absolute-floor `continue`, so it tracks every finite scored candidate while
+      // `pool` holds only those that cleared the floor. A turn whose scores are all negative
+      // therefore gets past the `scoredCount === 0` guard, leaves `pool` empty, and arrives here
+      // with `topScore` below zero. That matters because a multiplicative floor inverts across zero
+      // (0.85 * -0.2 = -0.17, ABOVE the score it came from), rejecting even the best candidate.
       //
       // Cannot starve a turn: the fraction is at most 1 (the setting caps at 100) and `topScore`
       // equals the head of `ranked` whenever it is non-empty - the global maximum always clears the

--- a/b4m-core/utils/src/cache/AdminSettingsCache.test.ts
+++ b/b4m-core/utils/src/cache/AdminSettingsCache.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Logger } from '@bike4mind/observability';
+import { AdminSettingsCache } from './AdminSettingsCache';
+
+describe('AdminSettingsCache tolerates a partial logger', () => {
+  /**
+   * The shape callers actually pass. `Logger` declares debug/info/warn/error, but this cache is a
+   * process-wide singleton created with whichever logger reaches `getSettingsCache` first - in
+   * practice often a hand-rolled test double or an adapter carrying only the levels its author
+   * needed. Every caller wraps its settings read in a never-throw guard that degrades to coded
+   * defaults, so a cache that threw while logging turned a good read into a silent wrong value.
+   */
+  const partialLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+
+  it('invalidateAll still clears the cache instead of throwing on a missing log level', () => {
+    const cache = new AdminSettingsCache(partialLogger);
+    expect(() => cache.invalidateAll()).not.toThrow();
+    expect(cache.getStats().totalEntries).toBe(0);
+  });
+
+  it('invalidateSetting does not throw on a missing log level', () => {
+    const cache = new AdminSettingsCache(partialLogger);
+    expect(() => cache.invalidateSetting('forcedRetrievalRelativeFloorPct')).not.toThrow();
+  });
+});

--- a/b4m-core/utils/src/cache/AdminSettingsCache.test.ts
+++ b/b4m-core/utils/src/cache/AdminSettingsCache.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { Logger } from '@bike4mind/observability';
-import { AdminSettingsCache } from './AdminSettingsCache';
+import { AdminSettingsCache, type PartialAdminSettingsLogger } from './AdminSettingsCache';
 
 describe('AdminSettingsCache tolerates a partial logger', () => {
   /**
    * The shape callers actually pass. `Logger` declares debug/info/warn/error, but this cache is a
    * process-wide singleton created with whichever logger reaches `getSettingsCache` first - in
    * practice often a hand-rolled test double or an adapter carrying only the levels its author
-   * needed. Every caller wraps its settings read in a never-throw guard that degrades to coded
-   * defaults, so a cache that threw while logging turned a good read into a silent wrong value.
+   * needed. What callers do with a throw varies - `getSettingsByNames` has no guard at all, the
+   * scoped resolver guards one layer out, `resolveSpendLevers` rethrows to halt spend - so a cache
+   * that threw while logging could surface as a silent wrong value or as an unhandled rejection.
    */
-  const partialLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+  // Typed as the widened parameter, not cast through `Logger`: the cast would pass whether or not
+  // the constructor actually accepts a partial logger, so it would assert nothing about the widening.
+  const partialLogger: PartialAdminSettingsLogger = { warn: vi.fn(), error: vi.fn() };
 
   it('invalidateAll still clears the cache instead of throwing on a missing log level', () => {
     const cache = new AdminSettingsCache(partialLogger);

--- a/b4m-core/utils/src/cache/AdminSettingsCache.test.ts
+++ b/b4m-core/utils/src/cache/AdminSettingsCache.test.ts
@@ -10,9 +10,10 @@ describe('AdminSettingsCache tolerates a partial logger', () => {
    * scoped resolver guards one layer out, `resolveSpendLevers` rethrows to halt spend - so a cache
    * that threw while logging could surface as a silent wrong value or as an unhandled rejection.
    */
-  // Typed as the widened parameter, not cast through `Logger`: the cast would pass whether or not
-  // the constructor actually accepts a partial logger, so it would assert nothing about the widening.
-  const partialLogger: PartialAdminSettingsLogger = { warn: vi.fn(), error: vi.fn() };
+  // Runtime-only by construction: no tsconfig here includes `*.test.ts`, so nothing typechecks this
+  // annotation and it cannot enforce the widening. The compile-time half lives next to the
+  // interface in AdminSettingsCache.ts.
+  const partialLogger: PartialAdminSettingsLogger = { warn: vi.fn() };
 
   it('invalidateAll still clears the cache instead of throwing on a missing log level', () => {
     const cache = new AdminSettingsCache(partialLogger);

--- a/b4m-core/utils/src/cache/AdminSettingsCache.ts
+++ b/b4m-core/utils/src/cache/AdminSettingsCache.ts
@@ -15,7 +15,7 @@ export interface PartialAdminSettingsLogger {
 }
 
 // Compile-time proof of that widening, kept in a file the compiler actually reads: no tsconfig in
-// this repo includes `*.test.ts`, so the sibling test exercises the widening at runtime only and
+// this package includes `*.test.ts`, so the sibling test exercises the widening at runtime only and
 // would keep passing if the parameter were narrowed back to `Logger`. This statement would not.
 ({ warn: () => {} }) satisfies ConstructorParameters<typeof AdminSettingsCache>[0];
 

--- a/b4m-core/utils/src/cache/AdminSettingsCache.ts
+++ b/b4m-core/utils/src/cache/AdminSettingsCache.ts
@@ -1,6 +1,19 @@
 import { IAdminSettingsRepository, IAdminSettings } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
 
+/**
+ * A structural subset of `Logger` with every method optional, matching how this file actually
+ * calls it (`this.logger.debug?.()`, see the comment on `logger` below) rather than the promise
+ * `Logger` itself makes (all three required). A full `Logger` still satisfies this - it is a
+ * superset - so every real construction site is unaffected; this only stops the FIELD from
+ * claiming a guarantee the class deliberately does not rely on.
+ */
+interface PartialAdminSettingsLogger {
+  debug?: Logger['debug'];
+  info?: Logger['info'];
+  warn?: Logger['warn'];
+}
+
 interface CacheEntry {
   data: Record<string, string>;
   timestamp: number;
@@ -20,7 +33,17 @@ interface IndividualSettingCache {
 export class AdminSettingsCache {
   private cache: Map<string, CacheEntry> = new Map();
   private individualCache: Map<string, IndividualSettingCache> = new Map();
-  private logger: Logger;
+  /**
+   * Every call through this field is optional-chained (`this.logger.debug?.()`).
+   *
+   * A cache must not throw because it could not log, and this one is uniquely exposed to that: it is
+   * a process-wide singleton created with whichever logger happens to reach `getSettingsCache`
+   * first, and its callers (`getSettingsByNames`, the scoped-settings resolver) all wrap reads in a
+   * never-throw guard that degrades to coded defaults. So a logger missing a quieter level turned a
+   * successful settings read into a silent fallback - a wrong VALUE, reported nowhere, rather than
+   * an error anyone could see.
+   */
+  private logger: PartialAdminSettingsLogger;
   private cleanupInterval: NodeJS.Timeout | null = null;
   private maxCacheSize: number = 1000; // Prevent memory leaks
 
@@ -40,7 +63,7 @@ export class AdminSettingsCache {
   private startCleanupTimer(): void {
     // Only start cleanup in persistent environments (not serverless)
     if (process.env.NODE_ENV !== 'production' || process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME) {
-      this.logger.debug('Skipping cleanup timer in serverless environment');
+      this.logger.debug?.('Skipping cleanup timer in serverless environment');
       return;
     }
 
@@ -48,7 +71,7 @@ export class AdminSettingsCache {
       this.performCleanup();
     }, AdminSettingsCache.CLEANUP_INTERVAL);
 
-    this.logger.debug('Started cache cleanup timer');
+    this.logger.debug?.('Started cache cleanup timer');
   }
 
   /**
@@ -58,7 +81,7 @@ export class AdminSettingsCache {
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
-      this.logger.debug('Stopped cache cleanup timer');
+      this.logger.debug?.('Stopped cache cleanup timer');
     }
   }
 
@@ -97,11 +120,11 @@ export class AdminSettingsCache {
         removedCount++;
       }
 
-      this.logger.warn(`Emergency cache cleanup: removed ${toRemove} entries due to size limit`);
+      this.logger.warn?.(`Emergency cache cleanup: removed ${toRemove} entries due to size limit`);
     }
 
     if (removedCount > 0) {
-      this.logger.debug(
+      this.logger.debug?.(
         `Cache cleanup removed ${removedCount} expired entries (${beforeSize} → ${this.cache.size + this.individualCache.size})`
       );
     }
@@ -132,7 +155,7 @@ export class AdminSettingsCache {
 
     // Return cached data if valid
     if (cached && this.isValid(cached.timestamp, cached.ttl)) {
-      this.logger.debug('📦 Admin settings cache HIT');
+      this.logger.debug?.('📦 Admin settings cache HIT');
       return cached.data;
     }
 
@@ -142,7 +165,7 @@ export class AdminSettingsCache {
     }
 
     // Cache miss - fetch from database
-    this.logger.debug('🔍 Admin settings cache MISS - fetching from database');
+    this.logger.debug?.('🔍 Admin settings cache MISS - fetching from database');
     const fetchStart = Date.now();
 
     const settings = await db.adminSettings.findAll();
@@ -155,7 +178,7 @@ export class AdminSettingsCache {
     );
 
     const fetchTime = Date.now() - fetchStart;
-    this.logger.info(`📦 Cached ${Object.keys(settingsMap).length} admin settings in ${fetchTime}ms`);
+    this.logger.info?.(`📦 Cached ${Object.keys(settingsMap).length} admin settings in ${fetchTime}ms`);
 
     // Store in cache
     const ttl = this.getTTL();
@@ -190,7 +213,7 @@ export class AdminSettingsCache {
 
     // Return cached data if valid
     if (cached && this.isValid(cached.timestamp, cached.ttl)) {
-      this.logger.debug(`📦 Individual setting '${settingName}' cache HIT`);
+      this.logger.debug?.(`📦 Individual setting '${settingName}' cache HIT`);
       return cached.value;
     }
 
@@ -200,7 +223,7 @@ export class AdminSettingsCache {
     }
 
     // Cache miss - fetch from database
-    this.logger.debug(`🔍 Individual setting '${settingName}' cache MISS - fetching from database`);
+    this.logger.debug?.(`🔍 Individual setting '${settingName}' cache MISS - fetching from database`);
     const fetchStart = Date.now();
 
     const setting = await db.adminSettings.findBySettingName(settingName);
@@ -210,7 +233,7 @@ export class AdminSettingsCache {
     const value = setting?.settingValue ?? null;
 
     const fetchTime = Date.now() - fetchStart;
-    this.logger.debug(`📦 Cached individual setting '${settingName}' in ${fetchTime}ms`);
+    this.logger.debug?.(`📦 Cached individual setting '${settingName}' in ${fetchTime}ms`);
 
     // Store in cache
     this.individualCache.set(settingName, {
@@ -252,7 +275,7 @@ export class AdminSettingsCache {
 
     // Fetch uncached settings from database
     if (uncachedSettings.length > 0) {
-      this.logger.debug(
+      this.logger.debug?.(
         `🔍 Batch fetching ${uncachedSettings.length} uncached settings: ${uncachedSettings.join(', ')}`
       );
       const fetchStart = Date.now();
@@ -260,7 +283,7 @@ export class AdminSettingsCache {
       const settings = await db.adminSettings.findBySettingNames(uncachedSettings);
       const fetchTime = Date.now() - fetchStart;
 
-      this.logger.debug(`📦 Batch fetched ${settings.length} settings in ${fetchTime}ms`);
+      this.logger.debug?.(`📦 Batch fetched ${settings.length} settings in ${fetchTime}ms`);
 
       // Cache and add to result
       const ttl = this.getTTL();
@@ -285,7 +308,7 @@ export class AdminSettingsCache {
       });
     }
 
-    this.logger.debug(
+    this.logger.debug?.(
       `📦 Returned ${Object.keys(result).length} settings (${settingNames.length - uncachedSettings.length} from cache, ${uncachedSettings.length} from DB)`
     );
     return result;
@@ -297,7 +320,7 @@ export class AdminSettingsCache {
   invalidateSetting(settingName: string): void {
     this.individualCache.delete(settingName);
     this.cache.delete('all_settings'); // Invalidate full cache too
-    this.logger.info(`🗑️ Invalidated cache for setting: ${settingName}`);
+    this.logger.info?.(`🗑️ Invalidated cache for setting: ${settingName}`);
   }
 
   /**
@@ -306,7 +329,7 @@ export class AdminSettingsCache {
   invalidateAll(): void {
     this.cache.clear();
     this.individualCache.clear();
-    this.logger.info('🗑️ Invalidated all admin settings cache');
+    this.logger.info?.('🗑️ Invalidated all admin settings cache');
   }
 
   /**
@@ -355,9 +378,9 @@ export class AdminSettingsCache {
    * Warm up the cache by fetching all settings
    */
   async warmUp(db: any): Promise<void> {
-    this.logger.info('🔥 Warming up admin settings cache...');
+    this.logger.info?.('🔥 Warming up admin settings cache...');
     await this.getSettingsMap(db);
-    this.logger.info('✅ Admin settings cache warmed up');
+    this.logger.info?.('✅ Admin settings cache warmed up');
   }
 
   /**
@@ -365,6 +388,6 @@ export class AdminSettingsCache {
    */
   public shutdown(): void {
     this.stopCleanupTimer();
-    this.logger.info('🛑 Admin settings cache shutdown complete');
+    this.logger.info?.('🛑 Admin settings cache shutdown complete');
   }
 }

--- a/b4m-core/utils/src/cache/AdminSettingsCache.ts
+++ b/b4m-core/utils/src/cache/AdminSettingsCache.ts
@@ -14,6 +14,11 @@ export interface PartialAdminSettingsLogger {
   warn?: Logger['warn'];
 }
 
+// Compile-time proof of that widening, kept in a file the compiler actually reads: no tsconfig in
+// this repo includes `*.test.ts`, so the sibling test exercises the widening at runtime only and
+// would keep passing if the parameter were narrowed back to `Logger`. This statement would not.
+({ warn: () => {} }) satisfies ConstructorParameters<typeof AdminSettingsCache>[0];
+
 interface CacheEntry {
   data: Record<string, string>;
   timestamp: number;

--- a/b4m-core/utils/src/cache/AdminSettingsCache.ts
+++ b/b4m-core/utils/src/cache/AdminSettingsCache.ts
@@ -8,7 +8,7 @@ import { Logger } from '@bike4mind/observability';
  * superset - so every real construction site is unaffected; this only stops the FIELD from
  * claiming a guarantee the class deliberately does not rely on.
  */
-interface PartialAdminSettingsLogger {
+export interface PartialAdminSettingsLogger {
   debug?: Logger['debug'];
   info?: Logger['info'];
   warn?: Logger['warn'];
@@ -36,12 +36,14 @@ export class AdminSettingsCache {
   /**
    * Every call through this field is optional-chained (`this.logger.debug?.()`).
    *
-   * A cache must not throw because it could not log, and this one is uniquely exposed to that: it is
-   * a process-wide singleton created with whichever logger happens to reach `getSettingsCache`
-   * first, and its callers (`getSettingsByNames`, the scoped-settings resolver) all wrap reads in a
-   * never-throw guard that degrades to coded defaults. So a logger missing a quieter level turned a
-   * successful settings read into a silent fallback - a wrong VALUE, reported nowhere, rather than
-   * an error anyone could see.
+   * A cache must not throw because it could not log, and this one is exposed to that: it is a
+   * process-wide singleton created with whichever logger happens to reach `getSettingsCache` first.
+   * What each caller then does with a throw varies, and it is mostly NOT a degrade-to-defaults
+   * guard: `getSettingsByNames` has none at all, the scoped resolver guards one layer out in
+   * `resolveAll`, and `resolveSpendLevers` deliberately rethrows to halt spend. So a logger missing
+   * a quieter level could surface as a silent wrong VALUE, as an unhandled rejection, or as a hard
+   * fail-closed, depending on who asked. `ScopedSettingsCache` is built by the same factory pair
+   * and still has one unguarded call - the same hazard, not a solved one.
    */
   private logger: PartialAdminSettingsLogger;
   private cleanupInterval: NodeJS.Timeout | null = null;
@@ -52,7 +54,10 @@ export class AdminSettingsCache {
   private static readonly DEVELOPMENT_TTL = 30 * 1000; // 30 seconds in development
   private static readonly CLEANUP_INTERVAL = 60 * 1000; // Clean up every minute
 
-  constructor(logger: Logger) {
+  // Widened to match the field: a full `Logger` is a superset, so every existing construction site
+  // is unaffected. Note `getSettingsCache`/`getSettingsByNames` above still narrow to `Logger`, so
+  // a partial logger cannot yet reach here through them.
+  constructor(logger: PartialAdminSettingsLogger) {
     this.logger = logger;
     this.startCleanupTimer();
   }

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -8,8 +8,10 @@
  *
  * WHY IT DRIVES THE TOOL RATHER THAN A CHAT TURN. #1831 measured through forced retrieval, and this
  * ticket inherited that wording - but forced retrieval is a different code path with different
- * budgets (`ChatCompletionFeatures.ts:1595` states it is NOT routed through semanticDataLakeSearch;
- * it uses `forcedRetrievalCharBudget` and a hardcoded 0.75 similarity floor). The three kb* knobs
+ * budgets (`ChatCompletionFeatures.ts` states it is NOT routed through semanticDataLakeSearch; it
+ * uses `forcedRetrievalCharBudget` plus its own two relevance floors,
+ * `forcedRetrievalRelativeFloorPct` and `forcedRetrievalMinSimilarityPct`, which this probe does not
+ * sweep). The three kb* knobs
  * are consumed in exactly one file, `knowledgeBaseSearch/index.ts`. A forced-retrieval probe would
  * have returned identical numbers at every configuration. Invoking the tool directly also removes
  * model tool-choice variance entirely, which is the variable forced retrieval was chosen to control,


### PR DESCRIPTION
## Description

Forced retrieval (Data-Lake-mode grounding) accepted a passage only if it cleared a fixed absolute cosine floor of 0.75. Measured over 166 injected chunks on a production lake, that line never once bound: the whole distribution sat between 0.8025 and 0.9140, roughly 0.05 above the floor, so every real ranking decision was already being made by top-K and the char budget while the floor read like a quality gate and did nothing. A corpus whose score band happens to sit lower gets the opposite failure and is rejected wholesale.

This replaces it with a floor expressed as a fraction of the best-scoring passage of the *same turn*, and demotes the absolute floor to a settable sanity gate rather than the ranking rule. A relative floor moves with the turn, so it keeps discriminating whichever band a corpus or an embedding model lands the scores in.

Closes #2497.

Was stacked on #2531, which has merged; this branch is rebased onto main and no longer blocked.

## Changes

- `forcedRetrievalRelativeFloorPct` (default 85) and `forcedRetrievalMinSimilarityPct` (default 75) are new admin settings alongside `forcedRetrievalCharBudget`, settable at organization and owner (no lake rung - one turn scans an uncapped set of lakes into a single pool with a single top score, so there's no one lake for a narrower rung to key on; same call `kbSearchMinRelevancePct` already makes).
- Read through the scoped-settings resolver when the overlay is wired (a `settableAt` block is only honored there); otherwise the byte-identical platform read.
- The relative pass runs *after* the scan, once the turn's top score is final. It can't starve a turn: the fraction is capped at 1 and the top score is the head of the ranked pool, so the best candidate always clears its own cutoff.
- An out-of-range percent falls back to the coded default rather than clamping to 100 - clamping would admit only a perfect match, which is the same starvation by another route.
- Both defaults are **behavior-preserving, not tuned**. The absolute floor's default is unchanged at 75 - this doesn't lower it, it only makes it lowerable. The relative floor defaults to 85%, which admits everything the absolute floor admitted on the measured band (0.8025/0.9140 ~= 0.878), so nothing changes in production until an operator raises it.
- Fixed a related bug found while wiring this in: `AdminSettingsCache` is a process-wide singleton whose logger calls were unguarded, so a logger missing a quieter level turned a *successful* settings read into a silent fallback to coded defaults - a wrong value, surfaced nowhere. All 19 call sites are now optional-chained, and the field's type now says so (`PartialAdminSettingsLogger`) instead of promising a guarantee the class doesn't rely on.

## Guide for Testers

This is a backend/config change with no new UI surface beyond two generic admin-settings fields; there's no new screen to click through end to end.

1. Go to `Admin -> Settings -> AI -> Embedding Service`. Confirm two new fields render: "Forced Retrieval Relative Floor (%)" and "Forced Retrieval Absolute Floor (%)", showing 85 and 75.
2. Change the relative floor to 100 and save. Confirm it persists on reload.
3. Start a Data-Lake-mode conversation against a lake with vectorized files and ask a question the lake can answer. Confirm grounding still works normally (this is the default/no-regression case).
4. Raise the relative floor to ~98 and repeat the same question on the same lake. `promptMeta.retrieval.injected.chunks` for that turn should be lower than or equal to what it was at the 85 default, never higher.

### What NOT to test

No UI/UX changes, no new routes, no changes to any other admin setting's behavior.

### Regression Checks

- A Data-Lake-mode turn at the shipped defaults (85 / 75) must inject exactly the same chunks it would have before this change, for any corpus whose score band resembles the one this was measured against (roughly 0.80-0.91). Nothing should be newly rejected on an unmodified deployment.

## Additional Information

- I have added the new AdminSettings to Staging, prod and the hydration script: **N/A**. This is a plain new numeric setting with a coded default and no pre-existing DB row anywhere - the resolver falls back to the coded default when no row exists, same as `forcedRetrievalCharBudget` (#1860) and `kbSearchMinRelevancePct` (#2009) shipped. Nothing to seed; the preview-sync hydration script (`dataSyncerHandler.ts`) copies whatever collection rows exist, it isn't a per-key allowlist.
- Live verification on local self-host was blocked: this worktree has no real `.env` (no embedding key), and the only running dev server belongs to a different, in-use worktree. The three highest-value checks above (render+save, no-regression, floor-reduces-chunks) are traced through the code and covered by new unit tests, but not exercised against a real embedded lake. Flagging this rather than implying it's been run.

## Developer Notes (Optional)

- `resolveForcedRetrievalFloors` / `readForcedRetrievalFloorPcts` on `KnowledgeRetrievalFeature` is the pattern to follow for any future forced-retrieval lever that needs org/owner scoping: prefer the scoped resolver when `db.scopedSettings` is wired, fall back to the plain `getSettingsValue` read otherwise - same two-path shape `resolveSearchBudgets` already uses.
- `forcedRetrievalFloorFraction` is a reusable "percent setting -> cosine fraction, fail to coded default rather than clamp" helper if another similarity floor gets a setting later.

## Deferred follow-ups (filed)

Found during self-review and deliberately not folded into this PR - mostly pre-existing issues in
shared code this diff doesn't own, or separate scope. Consolidated into four issues rather than one
per finding:

- **#2568** - harden the shared int-coercion helpers in `resolveSearchBudgets.ts`: the
  clamp-to-100% starvation path, the untrimmed whitespace value that silently resolves to `0`, and
  the hardcoded `[semanticSearch]` log prefix that's now wrong for forced-retrieval callers. All
  pre-existing, all in the same three functions.
- **#2571** - no pre-relative-floor candidate count in telemetry, so the floor's own effect isn't
  measurable from stored data (only from a log grep).
- **#2572** - deferred forced-retrieval configuration and tuning: org/owner scoping for
  `forcedRetrievalCharBudget`, sweep-tooling coverage for the new floors, per-lake prerequisites,
  and revisiting both defaults after the embedding migration (#471) / ANN cutover (#2526).
- **#2574** - no write surface exists for any scoped-settings override (`writeScopedOverride` has
  zero callers), so the org/owner rungs this PR declares aren't operator-reachable yet. Affects
  ~6 settings, not just these two.


