### PR TITLE
fix(services): key the ANN rebucket off saturation, not bare absence

### DIFF
--- a/b4m-core/services/src/dataLakeService/alternateModelAnn.test.ts
+++ b/b4m-core/services/src/dataLakeService/alternateModelAnn.test.ts
@@ -238,10 +238,10 @@ describe('runAlternateModelAnn', () => {
     expect(outcome.embedded).toBe(true);
     expect(outcome.failed).toBe(false);
     expect(outcome.filesWithHits).toEqual(new Set(['a']));
-    expect(outcome.filesMissed).toEqual(['b']);
+    expect(outcome.filesUnranked).toEqual(['b']);
   });
 
-  it('populates filesMissed and leaves filesWithHits empty on zero raw hits', async () => {
+  it('populates filesUnranked and leaves filesWithHits empty on zero raw hits', async () => {
     const runAnn = vi
       .fn()
       .mockResolvedValue({ results: [], hitsReturned: 0, hitsSkippedUnknownFile: 0, filesWithHits: new Set() });
@@ -254,7 +254,7 @@ describe('runAlternateModelAnn', () => {
     expect(outcome.embedded).toBe(true);
     expect(outcome.failed).toBe(false);
     expect(outcome.filesWithHits.size).toBe(0);
-    expect(outcome.filesMissed).toEqual(['a', 'b']);
+    expect(outcome.filesUnranked).toEqual(['a', 'b']);
   });
 
   it('makes no ANN call when the embed fails, and never rejects', async () => {
@@ -272,7 +272,7 @@ describe('runAlternateModelAnn', () => {
       hitsReturned: 0,
       hitsSkippedUnknownFile: 0,
       filesWithHits: new Set(),
-      filesMissed: [],
+      filesUnranked: [],
       embedded: false,
       failed: true,
     });

--- a/b4m-core/services/src/dataLakeService/alternateModelAnn.ts
+++ b/b4m-core/services/src/dataLakeService/alternateModelAnn.ts
@@ -212,9 +212,12 @@ export async function runAlternateModelAnn(args: {
   try {
     const fileIds = candidate.annReady.map(f => f.id);
     const result = await runAnn({ fileIds, queryVector, model: candidate.model });
-    // Same "zero raw hits" signal the primary model uses (semanticDataLakeSearch.ts's
-    // missedFiles rebucket): a queryable index does not guarantee this model's chunks are
-    // actually in it yet (indexing lag, or a mid-file re-embed under the wrong model).
+    // Bare absence from `filesWithHits`, which is NOT what the primary model keys off any more:
+    // its rebucket now requires the query to have come back UNDER-saturated before it reads
+    // absence as missing content (see semanticDataLakeSearch.ts's `annSaturated`). The looser
+    // signal is kept here because it is diagnostic only - nothing rebuckets on it, so an absence
+    // that merely means "did not rank" costs an over-reported `filesMissed`, not a wasted scan.
+    // Anything that starts ACTING on this list has to adopt the saturation rule first.
     const filesMissed = candidate.annReady.map(f => f.id).filter(id => !result.filesWithHits.has(id));
     return {
       model: candidate.model,

--- a/b4m-core/services/src/dataLakeService/alternateModelAnn.ts
+++ b/b4m-core/services/src/dataLakeService/alternateModelAnn.ts
@@ -167,8 +167,13 @@ export interface AlternateAnnOutcome {
   hitsSkippedUnknownFile: number;
   /** Files this model's ANN query actually returned a raw hit for - NOT to be reported as excluded. */
   filesWithHits: Set<string>;
-  /** ANN-ready but zero raw hits: still excluded, never scanned (this model has no scan fallback). */
-  filesMissed: string[];
+  /**
+   * ANN-ready but zero raw hits: still excluded, never scanned (this model has no scan fallback).
+   * Named for what it can actually prove - bare absence from a rank-bounded response, so on a
+   * saturated query it also contains files that merely lost on rank. Diagnostic only; read the
+   * note in runAlternateModelAnn before acting on it.
+   */
+  filesUnranked: string[];
   /** The query embed under this model succeeded, i.e. a billable provider call was made. */
   embedded: boolean;
   /** Embed failed, or embed succeeded but the ANN query itself failed - either way, no usable results from this model. */
@@ -181,7 +186,7 @@ const EMPTY_OUTCOME = (model: string, embedded: boolean): AlternateAnnOutcome =>
   hitsReturned: 0,
   hitsSkippedUnknownFile: 0,
   filesWithHits: new Set(),
-  filesMissed: [],
+  filesUnranked: [],
   embedded,
   failed: true,
 });
@@ -216,16 +221,19 @@ export async function runAlternateModelAnn(args: {
     // its rebucket now requires the query to have come back UNDER-saturated before it reads
     // absence as missing content (see semanticDataLakeSearch.ts's `annSaturated`). The looser
     // signal is kept here because it is diagnostic only - nothing rebuckets on it, so an absence
-    // that merely means "did not rank" costs an over-reported `filesMissed`, not a wasted scan.
+    // that merely means "did not rank" costs an over-reported count, not a wasted scan. Mirroring
+    // the saturation rule would mean teaching this module which backend is live (the primary's
+    // rule is Atlas-only), which it deliberately does not know - so the honest fix is the name:
+    // `unranked`, not `missed`, so the number cannot be read as a broken index.
     // Anything that starts ACTING on this list has to adopt the saturation rule first.
-    const filesMissed = candidate.annReady.map(f => f.id).filter(id => !result.filesWithHits.has(id));
+    const filesUnranked = candidate.annReady.map(f => f.id).filter(id => !result.filesWithHits.has(id));
     return {
       model: candidate.model,
       results: result.results,
       hitsReturned: result.hitsReturned,
       hitsSkippedUnknownFile: result.hitsSkippedUnknownFile,
       filesWithHits: result.filesWithHits,
-      filesMissed,
+      filesUnranked,
       embedded: true,
       failed: false,
     };

--- a/b4m-core/services/src/dataLakeService/annVectorSearch.ts
+++ b/b4m-core/services/src/dataLakeService/annVectorSearch.ts
@@ -26,10 +26,13 @@ export interface AnnVectorSearchResult {
   hitsReturned: number;
   hitsSkippedUnknownFile: number;
   /**
-   * fabFileIds that produced at least one raw hit, BEFORE minScore filtering. A file absent here
-   * returned zero indexed chunks for this query - not "nothing scored well enough" - so the
-   * caller can tell "queryable index, no matches" apart from "not actually indexed yet" and
-   * rebucket the latter onto the scan path instead of silently returning zero results for it.
+   * fabFileIds that produced at least one raw hit, BEFORE minScore filtering.
+   *
+   * Absence is NOT on its own evidence that a file is unindexed. `knnSearch` bounds by similarity
+   * RANK, so at most `limit` files can appear here and every other ready file is absent simply
+   * for having not ranked. Read this together with `hitsReturned`: only when the backend returned
+   * FEWER than `limit` has it exhausted its indexed content, which is what makes absence
+   * meaningful. See the rebucket in semanticDataLakeSearch.ts for the rule this feeds.
    */
   filesWithHits: Set<string>;
 }

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
@@ -1234,7 +1234,88 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
       expect(vectorSearch).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining(ALARM),
-        expect.objectContaining({ reason: 'no-ready-files', backend: 'atlas', rankableFiles: 1 })
+        // Zero within the lag is what separates this from the transient case below: nothing here
+        // is waiting on anything, the chunk `embeddingModel` backfill simply never ran.
+        expect.objectContaining({
+          reason: 'no-ready-files',
+          backend: 'atlas',
+          rankableFiles: 1,
+          stampedWithinLagFiles: 0,
+        })
+      );
+    });
+
+    it('reports ready-files-within-lag when the whole lake only just finished vectorizing', async () => {
+      const logger = makeLogger();
+      const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+        files: [annFile('f1', { chunkEmbeddingModelStampedAt: freshStamp })],
+        scanChunks: chunkRows('f1', 2),
+      });
+
+      await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, logger: logger as never }, {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never);
+
+      // Same observable state as no-ready-files (zero eligible files, scan-only retrieval) but the
+      // opposite fix: this one resolves itself within one lag window, so pointing an operator at
+      // the backfill would send them after work that has already run.
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(ALARM),
+        expect.objectContaining({ reason: 'ready-files-within-lag', stampedWithinLagFiles: 1 })
+      );
+    });
+
+    it('keeps no-ready-files when only SOME files are inside the lag, and counts them', async () => {
+      const logger = makeLogger();
+      const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+        files: [
+          annFile('never-stamped', { chunkEmbeddingModelStampedAt: undefined }),
+          annFile('just-stamped', { chunkEmbeddingModelStampedAt: freshStamp }),
+        ],
+        scanChunks: chunkRows('never-stamped', 2),
+      });
+
+      await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, logger: logger as never }, {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never);
+
+      // Waiting would never fix `never-stamped`, so the backfill reason wins - and the count is
+      // what tells the operator part of the lake needs nothing but time.
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(ALARM),
+        expect.objectContaining({ reason: 'no-ready-files', rankableFiles: 2, stampedWithinLagFiles: 1 })
+      );
+    });
+
+    it('still fires when an alternate model was embedded but its ANN query threw', async () => {
+      const ALT_MODEL = 'text-embedding-3-small';
+      const logger = makeLogger();
+      const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+        files: [
+          annFile('primary-unstamped', { chunkEmbeddingModelStampedAt: undefined }),
+          annFile('alt', { embeddingModel: ALT_MODEL }),
+        ],
+        scanChunks: chunkRows('primary-unstamped', 2),
+        queryableModels: ['text-embedding-ada-002', ALT_MODEL],
+      });
+      vectorSearch.mockImplementation((_ids: string[], _vec: number[], _model: string) =>
+        Promise.reject(new Error('alt index down'))
+      );
+
+      const result = await semanticDataLakeSearch(
+        { ...baseParams(), vectorSearchEnabled: true, logger: logger as never },
+        {
+          db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+        } as never
+      );
+
+      // The alternate model's query WAS issued, so it counts in annModelsQueried - but it threw and
+      // served nothing, which is exactly the deployment state this alarm exists to report. Keying
+      // the alarm off that metric would let a broken alternate index mask a scan-only primary.
+      expect(result.scan.annModelsQueried).toBe(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(ALARM),
+        expect.objectContaining({ reason: 'no-ready-files' })
       );
     });
 
@@ -1350,6 +1431,12 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
       expect.stringContaining('returned no hits for ready files'),
       expect.anything()
     );
+    // The failure this replaced was silent, so the scanning it avoided is recorded rather than
+    // merely not happening - a regression back to rescanning would otherwise look identical.
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('saturated its limit'),
+      expect.objectContaining({ fileCount: 1, hitsReturned: 2 })
+    );
   });
 
   it('still rescans an unranked ready file when ANN came back short of its limit', async () => {
@@ -1374,8 +1461,30 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
     expect(result.results.map(r => r.fileId)).toContain('unranked');
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('returned no hits for ready files'),
-      expect.objectContaining({ fileCount: 1, hitsReturned: 1, limit: 2 })
+      expect.objectContaining({ fileCount: 1, hitsReturned: 1, hitsUsable: 1, limit: 2 })
     );
+  });
+
+  it('does not read a full response as saturated when every hit was out of scope', async () => {
+    const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+      files: [annFile('ready')],
+      scanChunks: chunkRows('ready', 3),
+      // A full topK of hits whose parent file is not in this query's scope at all - a deleted
+      // parent, or index content belonging to another lake. Counting them as saturation would
+      // suppress the rescue and return NOTHING, where the scan would have answered: worse than the
+      // behavior this PR replaced, which rescanned unconditionally.
+      annHits: [
+        { id: 'ghost-c0', fabFileId: 'not-in-scope', text: 'orphan hit', score: 0.99 },
+        { id: 'ghost-c1', fabFileId: 'not-in-scope', text: 'orphan hit', score: 0.98 },
+      ],
+    });
+
+    const result = await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, topK: 2 }, {
+      db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+    } as never);
+
+    expect(result.scan.chunksScanned).toBe(3);
+    expect(result.results.map(r => r.fileId)).toEqual(['ready', 'ready']);
   });
 
   describe('mixed-embeddingModel lake (alternate-model ANN cutover)', () => {
@@ -1819,6 +1928,38 @@ describe('semanticDataLakeSearch self-host OpenSearch cutover', () => {
     expect(result.scan.annFilesQueried).toBe(0);
     expect(result.scan.chunksScanned).toBe(2);
     expect(result.results.map(r => r.fileId)).toEqual(['ready', 'ready']);
+  });
+
+  /**
+   * The Atlas saturation rule deliberately does NOT apply here.
+   *
+   * Atlas's argument for it is that mongot indexes the chunk collection itself, so a stamped file's
+   * content is in the index by construction. Self-host has no such guarantee: the documents live in
+   * a separate cluster fed by a fail-open dual-write, files predating the feature were never indexed
+   * and have no backfill, and the readiness stamp knows nothing about any of it. Absence-keyed
+   * rescue is the only thing covering that here, so it stays - at the cost of the topK/fileCount
+   * ceiling on this path. Without a saturating fixture the existing zero-hit test above cannot see
+   * the difference, which is why this one supplies a full topK of hits from the indexed file.
+   */
+  it('rescans a stamped-but-unindexed file even when knnSearch saturated its limit', async () => {
+    enableSelfHostOpenSearch();
+    const { search, findVectorsByFabFileIds, knnSearch } = openSearchAdapters({
+      files: [annFile('indexed'), annFile('never-dual-written')],
+      scanChunks: chunkRows('never-dual-written', 3),
+      annHits: [
+        { id: 'indexed-c0', fabFileId: 'indexed', text: 'ann hit', score: 0.95 },
+        { id: 'indexed-c1', fabFileId: 'indexed', text: 'ann hit', score: 0.94 },
+      ],
+    });
+
+    const result = await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, topK: 2 }, {
+      db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds } },
+      vectorIndex: { knnSearch },
+    } as never);
+
+    expect(result.scan.chunksScanned).toBe(3);
+    expect(result.scan.annFilesQueried).toBe(1);
+    expect(result.results.map(r => r.fileId)).toContain('never-dual-written');
   });
 
   it('never calls knnSearch on an Atlas-backed deployment even if a vectorIndex adapter is (mistakenly) provided', async () => {

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
@@ -1212,6 +1212,172 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
     expect(result.results.map(r => r.fileId).sort()).toEqual(['covered', 'missed']);
   });
 
+  /**
+   * The alarm for the exact way this cutover failed in production: enabled, indexed, and silently
+   * never running because no chunk carried an `embeddingModel`. Every arm asserts the `reason`,
+   * since that is the only part of the log that tells an operator which of three fixes applies.
+   */
+  describe('flag-on-but-idle alarm', () => {
+    const ALARM = 'no ANN query ran';
+
+    it('reports no-ready-files when the index is queryable but nothing passed the readiness gate', async () => {
+      const logger = makeLogger();
+      const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+        files: [annFile('f1', { chunkEmbeddingModelStampedAt: undefined })],
+        scanChunks: chunkRows('f1', 2),
+      });
+
+      await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, logger: logger as never }, {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never);
+
+      expect(vectorSearch).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(ALARM),
+        expect.objectContaining({ reason: 'no-ready-files', backend: 'atlas', rankableFiles: 1 })
+      );
+    });
+
+    it('reports index-not-queryable when the index migrator has not finished', async () => {
+      const logger = makeLogger();
+      const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+        files: [annFile('f1')],
+        scanChunks: chunkRows('f1', 2),
+        indexQueryable: false,
+      });
+
+      await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, logger: logger as never }, {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(ALARM),
+        expect.objectContaining({ reason: 'index-not-queryable' })
+      );
+    });
+
+    it('reports no-backend when the flag is on but the deployment has no ANN backend', async () => {
+      const logger = makeLogger();
+      const { search, findVectorsByFabFileIds } = annAdapters({
+        files: [annFile('f1')],
+        scanChunks: chunkRows('f1', 2),
+      });
+
+      // No vectorSearch/getAtlasIndexStatus adapters and no vectorIndex: DocumentDB, or any
+      // deployment where the flag was flipped on without the backend behind it.
+      await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, logger: logger as never }, {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds } },
+      } as never);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(ALARM),
+        expect.objectContaining({ reason: 'no-backend', backend: 'none' })
+      );
+    });
+
+    it('stays silent on a healthy ANN query and when the caller never opted in', async () => {
+      const healthyLogger = makeLogger();
+      const healthy = annAdapters({
+        files: [annFile('ready')],
+        annHits: [{ id: 'ready-c0', fabFileId: 'ready', text: 'ann hit', score: 0.95 }],
+      });
+      await semanticDataLakeSearch({ ...baseParams(), vectorSearchEnabled: true, logger: healthyLogger as never }, {
+        db: {
+          fabfiles: { search: healthy.search },
+          fabfilechunks: {
+            findVectorsByFabFileIds: healthy.findVectorsByFabFileIds,
+            vectorSearch: healthy.vectorSearch,
+            getAtlasIndexStatus: healthy.getAtlasIndexStatus,
+          },
+        },
+      } as never);
+      expect(healthyLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining(ALARM), expect.anything());
+
+      // Flag off is the default for most deployments - scan-only is correct there, not an alarm.
+      const offLogger = makeLogger();
+      const off = annAdapters({ files: [annFile('f1')], scanChunks: chunkRows('f1', 2) });
+      await semanticDataLakeSearch({ ...baseParams(), logger: offLogger as never }, {
+        db: {
+          fabfiles: { search: off.search },
+          fabfilechunks: {
+            findVectorsByFabFileIds: off.findVectorsByFabFileIds,
+            vectorSearch: off.vectorSearch,
+            getAtlasIndexStatus: off.getAtlasIndexStatus,
+          },
+        },
+      } as never);
+      expect(offLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining(ALARM), expect.anything());
+    });
+  });
+
+  /**
+   * The rebucket keys off SATURATION, not bare absence from `filesWithHits`.
+   *
+   * The ANN query is bounded by similarity rank (`limit: topK`), so at most topK files can appear
+   * in `filesWithHits` and every other ready file is absent for the correct reason that it did not
+   * rank. Rebucketing on absence alone made the ANN path's benefit `topK / fileCount`, shrinking
+   * as a lake grows - backwards from the point of the index. These two tests pin the boundary in
+   * both directions; the pair matters more than either alone, since a fix that simply stopped
+   * rebucketing would pass the first and lose the un-indexed-file safety net the second guards.
+   */
+  it('does not rescan an unranked ready file when ANN saturated its limit', async () => {
+    const logger = makeLogger();
+    const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+      files: [annFile('covered'), annFile('unranked')],
+      // Available to the scan if anything asked for them - the assertion is that nothing does.
+      scanChunks: chunkRows('unranked', 3),
+      annHits: [
+        { id: 'covered-c0', fabFileId: 'covered', text: 'ann hit', score: 0.95 },
+        { id: 'covered-c1', fabFileId: 'covered', text: 'ann hit', score: 0.94 },
+      ],
+    });
+
+    const result = await semanticDataLakeSearch(
+      { ...baseParams(), vectorSearchEnabled: true, topK: 2, logger: logger as never },
+      {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never
+    );
+
+    // The point of the index: a ready file that lost on rank costs nothing.
+    expect(result.scan.chunksScanned).toBe(0);
+    expect(findVectorsByFabFileIds).not.toHaveBeenCalled();
+    // Both ready files stayed on the ANN route, so neither was scanned.
+    expect(result.scan.annFilesQueried).toBe(2);
+    expect(result.scan.annHits).toBe(2);
+    expect(result.results.map(r => r.fileId)).toEqual(['covered', 'covered']);
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('returned no hits for ready files'),
+      expect.anything()
+    );
+  });
+
+  it('still rescans an unranked ready file when ANN came back short of its limit', async () => {
+    const logger = makeLogger();
+    const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+      files: [annFile('covered'), annFile('unranked')],
+      scanChunks: chunkRows('unranked', 3),
+      // One hit against topK 2: the backend exhausted what it has indexed and still came up short,
+      // so absence is real evidence of missing content rather than a ranking outcome.
+      annHits: [{ id: 'covered-c0', fabFileId: 'covered', text: 'ann hit', score: 0.95 }],
+    });
+
+    const result = await semanticDataLakeSearch(
+      { ...baseParams(), vectorSearchEnabled: true, topK: 2, logger: logger as never },
+      {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never
+    );
+
+    expect(result.scan.chunksScanned).toBe(3);
+    expect(result.scan.annFilesQueried).toBe(1);
+    expect(result.results.map(r => r.fileId)).toContain('unranked');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('returned no hits for ready files'),
+      expect.objectContaining({ fileCount: 1, hitsReturned: 1, limit: 2 })
+    );
+  });
+
   describe('mixed-embeddingModel lake (alternate-model ANN cutover)', () => {
     const SMALL_3 = 'text-embedding-3-small';
     const VOYAGE_3 = 'voyage-3';

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
@@ -1218,7 +1218,7 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
    * since that is the only part of the log that tells an operator which of three fixes applies.
    */
   describe('flag-on-but-idle alarm', () => {
-    const ALARM = 'no ANN query ran';
+    const ALARM = 'ANN served nothing';
 
     it('reports no-ready-files when the index is queryable but nothing passed the readiness gate', async () => {
       const logger = makeLogger();
@@ -1319,6 +1319,42 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
       );
     });
 
+    it('still fires when an alternate model queried successfully but returned zero hits', async () => {
+      const ALT_MODEL = 'text-embedding-3-small';
+      const logger = makeLogger();
+      const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+        files: [
+          annFile('primary-unstamped', { chunkEmbeddingModelStampedAt: undefined }),
+          annFile('alt', { embeddingModel: ALT_MODEL }),
+        ],
+        scanChunks: chunkRows('primary-unstamped', 2),
+        // Queryable index, successful query, no hits - the shape a lake takes when its chunk
+        // labels are missing while FabFile.embeddingModel is populated. Nothing threw, so this is
+        // NOT the failure case above.
+        queryableModels: ['text-embedding-ada-002', ALT_MODEL],
+      });
+
+      const result = await semanticDataLakeSearch(
+        { ...baseParams(), vectorSearchEnabled: true, logger: logger as never },
+        {
+          db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+        } as never
+      );
+
+      // `embedded && !failed` is true for this outcome, so keying the alarm on a query having
+      // merely SUCCEEDED silences it in the exact production state it exists to catch: retrieval
+      // is 100% scan and every result came from the scan path. Only "served a file" can gate it.
+      expect(result.scan.annModelsQueried).toBe(1);
+      expect(result.scan.annHits).toBe(0);
+      expect(result.scan.chunksScanned).toBe(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(ALARM),
+        // annModelsQueried in the payload is what tells an operator this was "ran and served
+        // nothing" rather than "never ran" - the reason field only describes the primary model.
+        expect.objectContaining({ reason: 'no-ready-files', annModelsQueried: 1, rankableFiles: 1 })
+      );
+    });
+
     it('reports index-not-queryable when the index migrator has not finished', async () => {
       const logger = makeLogger();
       const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
@@ -1331,9 +1367,11 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
         db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
       } as never);
 
+      // Carried on EVERY arm, not just the no-ready-files one: an operator reading the alarm
+      // should never have to know which arm fired to know whether the lag explains it.
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining(ALARM),
-        expect.objectContaining({ reason: 'index-not-queryable' })
+        expect.objectContaining({ reason: 'index-not-queryable', rankableFiles: 1, stampedWithinLagFiles: 0 })
       );
     });
 
@@ -1352,7 +1390,13 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
 
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining(ALARM),
-        expect.objectContaining({ reason: 'no-backend', backend: 'none' })
+        expect.objectContaining({
+          reason: 'no-backend',
+          backend: 'none',
+          rankableFiles: 1,
+          stampedWithinLagFiles: 0,
+          annModelsQueried: 0,
+        })
       );
     });
 
@@ -1485,6 +1529,61 @@ describe('semanticDataLakeSearch Atlas $vectorSearch cutover', () => {
 
     expect(result.scan.chunksScanned).toBe(3);
     expect(result.results.map(r => r.fileId)).toEqual(['ready', 'ready']);
+  });
+
+  it('subtracts out-of-scope hits in the MIXED shape, where they are what pushes the count to the limit', async () => {
+    const logger = makeLogger();
+    const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+      files: [annFile('ready'), annFile('other')],
+      scanChunks: chunkRows('other', 3),
+      // 3 raw hits against topK 3 reads as saturated on the raw count alone, but one belongs to a
+      // file outside this query's scope, so only 2 are usable: the backend came up SHORT of what
+      // it could rank, which is what makes `other`'s absence real evidence rather than a rank
+      // outcome. The all-out-of-scope case above cannot distinguish this from an empty response.
+      annHits: [
+        { id: 'ready-c0', fabFileId: 'ready', text: 'ann hit', score: 0.95 },
+        { id: 'ready-c1', fabFileId: 'ready', text: 'ann hit', score: 0.94 },
+        { id: 'ghost-c0', fabFileId: 'not-in-scope', text: 'orphan hit', score: 0.99 },
+      ],
+    });
+
+    const result = await semanticDataLakeSearch(
+      { ...baseParams(), vectorSearchEnabled: true, topK: 3, logger: logger as never },
+      {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never
+    );
+
+    expect(result.scan.chunksScanned).toBe(3);
+    expect(result.results.map(r => r.fileId)).toContain('other');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('returned no hits for ready files'),
+      expect.objectContaining({ fileCount: 1, hitsReturned: 3, hitsUsable: 2, limit: 3 })
+    );
+  });
+
+  it('stays quiet about saturation when every ready file actually ranked - nothing was left off', async () => {
+    const logger = makeLogger();
+    const { search, findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } = annAdapters({
+      files: [annFile('a'), annFile('b')],
+      annHits: [
+        { id: 'a-c0', fabFileId: 'a', text: 'ann hit', score: 0.95 },
+        { id: 'b-c0', fabFileId: 'b', text: 'ann hit', score: 0.94 },
+      ],
+    });
+
+    const result = await semanticDataLakeSearch(
+      { ...baseParams(), vectorSearchEnabled: true, topK: 2, logger: logger as never },
+      {
+        db: { fabfiles: { search }, fabfilechunks: { findVectorsByFabFileIds, vectorSearch, getAtlasIndexStatus } },
+      } as never
+    );
+
+    expect(result.scan.chunksScanned).toBe(0);
+    expect(result.scan.annFilesQueried).toBe(2);
+    // The debug line reports scanning the index AVOIDED, so a saturated query that left nothing
+    // off must not emit it - otherwise a healthy lake logs a zero on every request.
+    expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining('saturated its limit'), expect.anything());
   });
 
   describe('mixed-embeddingModel lake (alternate-model ANN cutover)', () => {

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
@@ -164,12 +164,16 @@ export interface SemanticSearchScanAccounting {
    * `filesScoped`; ineligible/not-yet-ready files may be searched by neither if a budget stopped
    * the scan first).
    *
-   * The two models' contributions are counted differently, on purpose. The primary model counts
-   * every file it QUERIED, because a file it queried and left unranked was still covered by the
-   * index (that is what the saturation rebucket above decides). An alternate model counts only the
-   * files that RETURNED hits, because it never rebuckets: its unranked files are excluded from the
-   * search entirely rather than covered by anything, so counting them as searched would overstate
-   * coverage.
+   * Counts the files ANN alone was responsible for - NOT every file an ANN query was issued for.
+   * That is what keeps the sum above honest: a ready file the saturation rebucket hands back to
+   * the scan path drops out of this count and turns up in `filesScanned` instead. So the three
+   * cases differ on purpose:
+   *   - Atlas, saturated: unranked ready files are deliberately not scanned, so they stay counted
+   *     here - the index covered them and they simply lost on rank.
+   *   - Atlas under-saturated, and self-host always: the rebucket moves those files, so this
+   *     narrows to the ones that returned hits.
+   *   - Alternate models: always only the files that returned hits. They have no scan fallback, so
+   *     an unranked file is searched by neither route (the caveat above).
    */
   annFilesQueried: number;
   /** Chunk hits returned by ANN retrieval across all ann-queried files and models, before minScore/scope filtering. */
@@ -991,7 +995,7 @@ async function rankChunksForFiles(args: {
     const isModelQueryable = canUseAtlas
       ? async (m: string) => !!(await args.fabfilechunks.getAtlasIndexStatus!(m))?.queryable
       : // Self-host has no per-model status port. openSearchChunkAdapter already fails closed on
-        // an unregistered model or a missing index (returns [] -> filesMissed, not a throw), and
+        // an unregistered model or a missing index (returns [] -> filesUnranked, not a throw), and
         // that "stay excluded" outcome is already correct - the only cost of an optimistic answer
         // here is one wasted embed per model, bounded by MAX_ALTERNATE_ANN_MODELS.
         async () => true;
@@ -1094,19 +1098,25 @@ async function rankChunksForFiles(args: {
   // operator-facing configuration alarm, and the point is that it fires while results still look
   // perfectly healthy, because they do.
   //
-  // Keyed on a model whose query actually SUCCEEDED, not on `annModelsQueried`: a model whose ANN
-  // call threw still counts there (the query was issued, which is what that metric reports) but it
-  // served nothing, so it must not silence this. `annBlockedReason` is only ever set on a primary
-  // model that never queried, so the alternate models are the whole question here.
-  const annQuerySucceeded = outcomes.some(o => o.embedded && !o.failed);
-  if (annBlockedReason && !annQuerySucceeded && rankable.length > 0) {
+  // Keyed on ANN having actually SERVED a file, not on a query having been issued or even having
+  // returned without throwing. `annModelsQueried` counts a query that threw (it WAS issued, which
+  // is what that metric reports), and `embedded && !failed` additionally counts one that came back
+  // empty; both of those leave retrieval entirely on the scan path, which is the state this alarm
+  // exists to report, so neither can be allowed to silence it. `filesWithHits.size > 0` is the
+  // same definition of "served" the mismatch accounting uses at `servedOutcomes` above.
+  // `annBlockedReason` is only ever set on a primary model that never queried, so whether any
+  // ALTERNATE model served something is the whole question here.
+  if (annBlockedReason && servedByAlternateAnn.size === 0 && rankable.length > 0) {
     logger?.warn?.(
-      '[semanticSearch] vector search is enabled but no ANN query ran - retrieval is entirely brute-force scan',
+      '[semanticSearch] vector search is enabled but ANN served nothing - retrieval is entirely brute-force scan',
       {
         embeddingModel,
         reason: annBlockedReason,
         backend: canUseAtlas ? 'atlas' : canUseOpenSearch ? 'opensearch' : 'none',
         rankableFiles: rankable.length,
+        // `reason` only ever describes the PRIMARY model, so this separates "no ANN query ran at
+        // all" (0) from "one ran and served nothing" - different fixes, same scan-only symptom.
+        annModelsQueried: scan.annModelsQueried,
         // Separates "just vectorized, wait one lag window" from "the backfill never ran" when the
         // reason is no-ready-files, and shows the mixed case the distinct reason cannot express.
         stampedWithinLagFiles,
@@ -1166,7 +1176,7 @@ async function rankChunksForFiles(args: {
   );
   if (outcomes.length > 0) {
     logger?.debug?.(
-      `[semanticSearch] alternate-model ANN: ${outcomes.map(o => `${o.model}=${o.failed ? 'failed' : `${o.hitsReturned}hits/${o.filesWithHits.size}files/${o.filesMissed.length}missed`}`).join(', ')}`
+      `[semanticSearch] alternate-model ANN: ${outcomes.map(o => `${o.model}=${o.failed ? 'failed' : `${o.hitsReturned}hits/${o.filesWithHits.size}files/${o.filesUnranked.length}unranked`}`).join(', ')}`
     );
   }
 

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
@@ -816,20 +816,31 @@ async function rankChunksForFiles(args: {
   const canUseOpenSearch =
     !canUseAtlas && args.vectorSearchEnabled && selfHostOpenSearchEnabled() && !!args.vectorIndex;
 
+  // Why the ANN path did not engage, for the "flag on but nothing is using it" alert below. The
+  // three causes need three different fixes, and none of them is visible from `annModelsQueried`
+  // alone, so the reason has to be captured here where it is actually known.
+  let annBlockedReason: 'no-backend' | 'index-not-queryable' | 'no-ready-files' | null = null;
+
   if (canUseAtlas) {
     const indexStatus = await args.fabfilechunks.getAtlasIndexStatus!(embeddingModel);
     if (indexStatus?.queryable) {
       const split = partitionByVectorSearchReadiness(rankable, new Date());
       annEligible = split.annReady;
       scanEligible = split.scanOnly;
+      if (annEligible.length === 0) annBlockedReason = 'no-ready-files';
+    } else {
+      annBlockedReason = 'index-not-queryable';
     }
   } else if (canUseOpenSearch) {
     // No mongot-style indexing-lag concept to check here - the readiness stamp still applies
     // (same-model chunks must be fully vectorized+stamped), but "is it actually in the index yet"
-    // is instead covered below by the zero-raw-hits rebucket, same as Atlas's missedFiles case.
+    // is instead covered below by the under-saturated rebucket, same as Atlas's missedFiles case.
     const split = partitionByVectorSearchReadiness(rankable, new Date());
     annEligible = split.annReady;
     scanEligible = split.scanOnly;
+    if (annEligible.length === 0) annBlockedReason = 'no-ready-files';
+  } else if (args.vectorSearchEnabled) {
+    annBlockedReason = 'no-backend';
   }
 
   // Shared backend seam for the primary model AND every alternate model - this module never
@@ -886,20 +897,47 @@ async function rankChunksForFiles(args: {
     // Atlas: mongot's indexing lag can exceed VECTOR_SEARCH_READY_LAG_MS during a bulk backfill,
     // or a re-embed mid-file can label chunks under the wrong model so mongot never indexes
     // them. On self-host OpenSearch: the file's chunks may simply predate the feature being
-    // enabled (see selfHostSearchIndex.ts - there is no backfill). Either way the file returns
-    // zero raw hits (not "nothing scored well", since both backends rank by similarity before
-    // minScore is applied) and, with no scan fallback, would silently contribute zero results.
-    // Rebucket per file rather than all-or-nothing, so one un-indexed file in a batch does not
-    // cost the rest their ANN path.
-    const missedFiles = annEligible.filter(f => !annResult.filesWithHits.has(f.id));
+    // enabled (see selfHostSearchIndex.ts - there is no backfill). Such a file returns zero raw
+    // hits and, with no scan fallback, would silently contribute zero results.
+    //
+    // But zero raw hits ALONE cannot mean "not indexed", because the query is bounded by
+    // similarity RANK (`limit: topK`), not by a score threshold. At most `topK` files can appear
+    // in `filesWithHits`, so in any file set larger than topK most ready files are absent from it
+    // for the entirely correct reason that they did not rank. Rebucketing on absence alone
+    // therefore rescans nearly every file and makes the ANN path's benefit `topK / fileCount` -
+    // it shrinks as a lake grows, which is backwards from the point of the index.
+    //
+    // Saturation separates the two cases. If the backend returned a full `topK`, it had at least
+    // that many indexed candidates and handed back its best: absence is a ranking outcome, and
+    // rescanning it would defeat the index. If it returned FEWER than asked, it exhausted what it
+    // has indexed and still came up short, so absence is real evidence of missing content and the
+    // per-file fallback is warranted. A corpus genuinely smaller than topK also lands here, and a
+    // full scan of something that small is the cheap, safe answer.
+    const annSaturated = annResult.hitsReturned >= topK;
+    const missedFiles = annSaturated ? [] : annEligible.filter(f => !annResult.filesWithHits.has(f.id));
     if (missedFiles.length > 0) {
       logger?.warn?.('[semanticSearch] ANN vector search returned no hits for ready files, scanning them instead', {
         embeddingModel,
         backend: canUseAtlas ? 'atlas' : 'opensearch',
         fileCount: missedFiles.length,
+        hitsReturned: annResult.hitsReturned,
+        limit: topK,
       });
       scanEligible = [...scanEligible, ...missedFiles];
       annEligible = annEligible.filter(f => annResult.filesWithHits.has(f.id));
+    } else if (annSaturated) {
+      // The whole point of the index: these ready files are NOT scanned. Logged because the
+      // failure this replaced was silent, and a regression here would be silent again - the
+      // count is how much scanning the ANN path actually avoided on this query.
+      const notRescanned = annEligible.filter(f => !annResult.filesWithHits.has(f.id)).length;
+      if (notRescanned > 0) {
+        logger?.debug?.('[semanticSearch] ANN saturated its limit; unranked ready files left off the scan path', {
+          embeddingModel,
+          backend: canUseAtlas ? 'atlas' : 'opensearch',
+          fileCount: notRescanned,
+          hitsReturned: annResult.hitsReturned,
+        });
+      }
     }
   }
 
@@ -1004,6 +1042,28 @@ async function rankChunksForFiles(args: {
     annModelsQueried: (primaryAnnQueried ? 1 : 0) + alternateModelsQueried,
     budgets: { maxFiles: budgets.maxFiles, maxChunks: budgets.maxChunks },
   };
+
+  // How this cutover failed once already: enabled, every index built, and not one chunk carrying an
+  // `embeddingModel`, so the ann path no-opped on every request and nothing anywhere said so. Zero
+  // is never normal once the caller opted in and there IS same-model content to rank, and the
+  // reason decides the fix - a missing backend, an unfinished index migration, or an unrun chunk
+  // `embeddingModel` backfill.
+  //
+  // Unlike the corpus diagnosis below this is NOT guarded on `mismatchReport.partial`: it is an
+  // operator-facing configuration alarm, and the point is that it fires while results still look
+  // perfectly healthy, because they do.
+  if (annBlockedReason && scan.annModelsQueried === 0 && rankable.length > 0) {
+    logger?.warn?.(
+      '[semanticSearch] vector search is enabled but no ANN query ran - retrieval is entirely brute-force scan',
+      {
+        embeddingModel,
+        reason: annBlockedReason,
+        backend: canUseAtlas ? 'atlas' : canUseOpenSearch ? 'opensearch' : 'none',
+        rankableFiles: rankable.length,
+        chunksScanned: scan.chunksScanned,
+      }
+    );
+  }
 
   if (scan.truncated) {
     logger?.warn?.(

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
@@ -29,7 +29,7 @@ import {
   type EmbeddingMismatchReport,
 } from './embeddingMismatch';
 import { BoundedTopK } from './boundedTopK';
-import { partitionByVectorSearchReadiness } from './vectorSearchEligibility';
+import { isVectorSearchReady, partitionByVectorSearchReadiness } from './vectorSearchEligibility';
 import {
   buildRetrievalUnavailableReport,
   emptyRetrievalUnavailableReport,
@@ -163,6 +163,13 @@ export interface SemanticSearchScanAccounting {
    * `filesScanned + annFilesQueried` is the files actually searched by either route (still <=
    * `filesScoped`; ineligible/not-yet-ready files may be searched by neither if a budget stopped
    * the scan first).
+   *
+   * The two models' contributions are counted differently, on purpose. The primary model counts
+   * every file it QUERIED, because a file it queried and left unranked was still covered by the
+   * index (that is what the saturation rebucket above decides). An alternate model counts only the
+   * files that RETURNED hits, because it never rebuckets: its unranked files are excluded from the
+   * search entirely rather than covered by anything, so counting them as searched would overstate
+   * coverage.
    */
   annFilesQueried: number;
   /** Chunk hits returned by ANN retrieval across all ann-queried files and models, before minScore/scope filtering. */
@@ -816,29 +823,42 @@ async function rankChunksForFiles(args: {
   const canUseOpenSearch =
     !canUseAtlas && args.vectorSearchEnabled && selfHostOpenSearchEnabled() && !!args.vectorIndex;
 
-  // Why the ANN path did not engage, for the "flag on but nothing is using it" alert below. The
-  // three causes need three different fixes, and none of them is visible from `annModelsQueried`
-  // alone, so the reason has to be captured here where it is actually known.
-  let annBlockedReason: 'no-backend' | 'index-not-queryable' | 'no-ready-files' | null = null;
+  // Why the ANN path did not engage, for the "flag on but nothing is using it" alert below. Each
+  // cause needs a different fix and none of them is visible from `annModelsQueried` alone, so the
+  // reason has to be captured here where it is actually known.
+  let annBlockedReason: 'no-backend' | 'index-not-queryable' | 'no-ready-files' | 'ready-files-within-lag' | null =
+    null;
+  // One clock for the readiness partition AND the within-lag diagnosis below, so the alarm can
+  // never disagree with the partition that produced it.
+  const annReadinessNow = new Date();
+  // A stamped file still inside VECTOR_SEARCH_READY_LAG_MS is a lake that JUST finished
+  // vectorizing, not an unrun backfill, and the two want opposite responses (wait vs backfill).
+  // `annEligible.length === 0` cannot separate them, so carry the count either way and report the
+  // distinct reason when the lag explains the whole file set.
+  const stampedWithinLagFiles = rankable.filter(
+    f => !!f.chunkEmbeddingModelStampedAt && !isVectorSearchReady(f, annReadinessNow)
+  ).length;
+  const noAnnReadyFilesReason = () =>
+    rankable.length > 0 && stampedWithinLagFiles === rankable.length ? 'ready-files-within-lag' : 'no-ready-files';
 
   if (canUseAtlas) {
     const indexStatus = await args.fabfilechunks.getAtlasIndexStatus!(embeddingModel);
     if (indexStatus?.queryable) {
-      const split = partitionByVectorSearchReadiness(rankable, new Date());
+      const split = partitionByVectorSearchReadiness(rankable, annReadinessNow);
       annEligible = split.annReady;
       scanEligible = split.scanOnly;
-      if (annEligible.length === 0) annBlockedReason = 'no-ready-files';
+      if (annEligible.length === 0) annBlockedReason = noAnnReadyFilesReason();
     } else {
       annBlockedReason = 'index-not-queryable';
     }
   } else if (canUseOpenSearch) {
-    // No mongot-style indexing-lag concept to check here - the readiness stamp still applies
-    // (same-model chunks must be fully vectorized+stamped), but "is it actually in the index yet"
-    // is instead covered below by the under-saturated rebucket, same as Atlas's missedFiles case.
-    const split = partitionByVectorSearchReadiness(rankable, new Date());
+    // The readiness stamp still applies (same-model chunks must be fully vectorized+stamped), but
+    // it says nothing about whether the SEPARATE OpenSearch cluster actually holds the documents.
+    // That gap is covered below by the absence-keyed rebucket this path deliberately keeps.
+    const split = partitionByVectorSearchReadiness(rankable, annReadinessNow);
     annEligible = split.annReady;
     scanEligible = split.scanOnly;
-    if (annEligible.length === 0) annBlockedReason = 'no-ready-files';
+    if (annEligible.length === 0) annBlockedReason = noAnnReadyFilesReason();
   } else if (args.vectorSearchEnabled) {
     annBlockedReason = 'no-backend';
   }
@@ -913,7 +933,27 @@ async function rankChunksForFiles(args: {
     // has indexed and still came up short, so absence is real evidence of missing content and the
     // per-file fallback is warranted. A corpus genuinely smaller than topK also lands here, and a
     // full scan of something that small is the cheap, safe answer.
-    const annSaturated = annResult.hitsReturned >= topK;
+    //
+    // Out-of-scope hits are subtracted first. A hit whose parent file is not in this query's set
+    // (deleted parent, index content from another lake) proves nothing about how deeply THIS file
+    // set is indexed, and counting it could report saturation on a response whose every usable hit
+    // was discarded - suppressing the rescue and returning nothing where the scan would have
+    // answered. Undercounting is the safe direction: it degrades to the old unconditional rebucket.
+    //
+    // Atlas only, deliberately. On self-host OpenSearch the ANN documents live in a separate
+    // cluster fed by a fail-open dual-write, with no backfill for files that predate the feature,
+    // so a stamped file can be permanently absent from the index and the readiness stamp cannot
+    // see it. `retrievalIndexModel` is not the missing residency signal either: it is written
+    // BEFORE the index call on purpose (see IFabFileChunk.retrievalIndexModel - a removal for an
+    // index holding nothing is a no-op, a missed one orphans documents), so it over-claims in
+    // exactly the indexing-failure case that matters. Absence-keyed rescue is therefore still
+    // load-bearing there and stays, leaving self-host at the old `topK / fileCount` ceiling until
+    // a signal that actually confirms residency exists. Atlas's analogue is transient rather than
+    // permanent - during a bulk backfill mongot's indexing lag can exceed
+    // VECTOR_SEARCH_READY_LAG_MS and the already-indexed files will saturate topK while the
+    // lagging ones wait - which self-heals within one lag window and is accepted.
+    const annUsableHits = annResult.hitsReturned - annResult.hitsSkippedUnknownFile;
+    const annSaturated = canUseAtlas && annUsableHits >= topK;
     const missedFiles = annSaturated ? [] : annEligible.filter(f => !annResult.filesWithHits.has(f.id));
     if (missedFiles.length > 0) {
       logger?.warn?.('[semanticSearch] ANN vector search returned no hits for ready files, scanning them instead', {
@@ -921,6 +961,7 @@ async function rankChunksForFiles(args: {
         backend: canUseAtlas ? 'atlas' : 'opensearch',
         fileCount: missedFiles.length,
         hitsReturned: annResult.hitsReturned,
+        hitsUsable: annUsableHits,
         limit: topK,
       });
       scanEligible = [...scanEligible, ...missedFiles];
@@ -1052,7 +1093,13 @@ async function rankChunksForFiles(args: {
   // Unlike the corpus diagnosis below this is NOT guarded on `mismatchReport.partial`: it is an
   // operator-facing configuration alarm, and the point is that it fires while results still look
   // perfectly healthy, because they do.
-  if (annBlockedReason && scan.annModelsQueried === 0 && rankable.length > 0) {
+  //
+  // Keyed on a model whose query actually SUCCEEDED, not on `annModelsQueried`: a model whose ANN
+  // call threw still counts there (the query was issued, which is what that metric reports) but it
+  // served nothing, so it must not silence this. `annBlockedReason` is only ever set on a primary
+  // model that never queried, so the alternate models are the whole question here.
+  const annQuerySucceeded = outcomes.some(o => o.embedded && !o.failed);
+  if (annBlockedReason && !annQuerySucceeded && rankable.length > 0) {
     logger?.warn?.(
       '[semanticSearch] vector search is enabled but no ANN query ran - retrieval is entirely brute-force scan',
       {
@@ -1060,6 +1107,9 @@ async function rankChunksForFiles(args: {
         reason: annBlockedReason,
         backend: canUseAtlas ? 'atlas' : canUseOpenSearch ? 'opensearch' : 'none',
         rankableFiles: rankable.length,
+        // Separates "just vectorized, wait one lag window" from "the backfill never ran" when the
+        // reason is no-ready-files, and shows the mixed case the distinct reason cannot express.
+        stampedWithinLagFiles,
         chunksScanned: scan.chunksScanned,
       }
     );


### PR DESCRIPTION
## Problem

The Atlas `$vectorSearch` cutover shipped a safety net that swallows almost the entire benefit of
the index it was added to protect.

`semanticDataLakeSearch` splits rankable files into an ANN partition and a scan partition, then
rebuckets any ANN-eligible file that came back with zero raw hits onto the scan path - the guard
against a file whose chunks are not actually in the index yet. But it decided "zero raw hits" from
`filesWithHits` alone:

```ts
const missedFiles = annEligible.filter(f => !annResult.filesWithHits.has(f.id));
```

`filesWithHits` is derived from a **global top-K**. The query is bounded by similarity RANK
(`limit: topK`), not by a score threshold, so at most `topK` files can ever appear in it. Every
other ready file is absent for the entirely correct reason that it did not rank - and got sent
back to the brute-force scan.

That makes the ANN path's benefit `topK / fileCount`:

| ready files | ceiling on work avoided |
|---|---|
| 155 | 6.5% |
| 1,000 | 1.0% |
| 10,000 | 0.1% |

It shrinks as a lake grows, which is backwards from the point of having an index. This is an
architectural inversion, not a tuning knob.

## Measured on staging

I ran the whole 30-question ground-truth set through `semanticDataLakeSearch` twice - flag off,
then flag on, byte-identical otherwise - on `main` and again on this branch. Chunks scanned, summed
across all 30 questions:

| | flag off | flag on | scanning removed |
|---|---|---|---|
| `main` | 19,680 | 17,983 | **8.6%** |
| this branch | 18,720 | 13,560 | **27.6%** |

Files touched by the scan fell from 4,410 to 1,590 in the same run - **64% fewer files** - and
`annFilesQueried` went from 173 to 2,820, which is the rebucket no longer clawing back files the
index had already served.

Read each row against its own flag-off column, not across rows: the corpus moved between the two
runs (the `system-help` lake re-synced in between), which is why the flag-off baseline is not
identical. The within-run comparison is the measurement; both arms of a run see the same corpus by
construction.

27.6% rather than something near-total because the residual scan is files that are not ANN-eligible
at all - unstamped chunks - not the ANN path failing to cover its own. In that run the eligible
files also happened to average ~1.8 chunks each against ~8.5 for the scan-only remainder, so the
64% file reduction converts to a smaller chunk reduction. On a lake whose corpus is fully stamped
the ceiling is far higher; the point of this change is that the ceiling is no longer `topK / N`.

Retrieval quality was **identical in both arms of both runs** - recall, precision, hitRate, MRR,
and `per-question divergence: none`, the same rankings chunk for chunk and score for score.

### On the safety net this narrows

Keying off saturation means a file whose stamp claims ANN readiness but whose chunks are not in the
index is no longer rescued by a rescan. I checked whether that state actually occurs rather than
assuming: across all 10,464 stamped files on staging, 10,392 have chunk rows and **all 10,392 have
at least one chunk carrying `embeddingModel`**. Zero stale stamps. The remaining 72 have no chunk
rows at all, which both paths return nothing for either way, so the outcome is unchanged for them.

The gate is worth naming as a latent risk regardless: `isVectorSearchReady` reads only the
file-level `chunkEmbeddingModelStampedAt` and never re-checks that the chunks still carry the
label, so a write path that replaces chunks without re-stamping would produce a file that is
eligible but invisible. Nothing does that today - `fabFileVectorize` stamps every chunk once the
file completes - and the under-saturated branch still covers the sparse-index case this was
originally written for.

## The fix: key the rebucket off saturation

Saturation separates the two cases that bare absence conflates:

- **usable hits `>= topK`** - the backend had at least `topK` indexed candidates and handed back
  its best. Absence from `filesWithHits` is a ranking outcome. Rescanning would defeat the index,
  so those files are left off the scan path.
- **usable hits `< topK`** - the backend exhausted what it has indexed and still came up short.
  Absence is real evidence of missing content, so the per-file fallback fires exactly as before.
  A corpus genuinely smaller than `topK` also lands here, and a full scan of something that small
  is the cheap, safe answer.

"Usable" is `hitsReturned - hitsSkippedUnknownFile`. Hits whose parent file is not in this query's
scope (a deleted parent, another lake's content) get discarded downstream, so counting them toward
saturation would suppress the rescue and return nothing where the scan would have answered - worse
than the behaviour this replaces. Undercounting is the safe direction: it degrades to the old
unconditional rebucket.

Saturation-keying is **Atlas-only** (`canUseAtlas &&`). Self-host OpenSearch keeps the old
unconditional absence-keyed rebucket, because its documents live in a separate cluster behind a
fail-open dual-write with no backfill for files predating the feature - so a stamped file can be
permanently absent from the index, and no field available today proves otherwise
(`retrievalIndexModel` is written BEFORE the index call on purpose, so it over-claims in exactly
the indexing-failure case). That leaves self-host at the old `topK / fileCount` ceiling, documented
in code and filed as #2592.

The un-indexed-file safety net is fully intact - it is the under-saturated branch. Both directions
are pinned by tests, deliberately as a pair: a "fix" that simply stopped rebucketing would pass the
first and silently lose the second.

Also corrects the `filesWithHits` docblock in `annVectorSearch.ts`, which described it in a way
that invited exactly this misreading, and adds a `debug` line counting the ready files the ANN path
kept off the scan - the failure this replaced was silent, and a regression here would be silent
again.

## Second fix: the flag-on-but-idle alarm

Separately, this adds the alarm whose absence is why the cutover sat inert for months. When
`vectorSearchEnabled` is on and there is same-model content to rank, but ANN served no file at all,
retrieval is 100% brute-force and nothing anywhere said so. The log names which cause applies,
because each one needs a different fix:

- `no-backend` - the flag is on where it cannot work (DocumentDB, or a deployment missing the
  adapters).
- `index-not-queryable` - the index migrator has not finished.
- `no-ready-files` - the chunk `embeddingModel` backfill never ran. **This is the production
  state.**
- `ready-files-within-lag` - the lake only just finished vectorizing and every file is still
  inside `VECTOR_SEARCH_READY_LAG_MS`. Transient: it clears itself within one lag window, so it
  must not send an operator after a backfill that already ran. The payload also carries
  `stampedWithinLagFiles` on every arm, which is what distinguishes the mixed case (some files
  waiting on the lag, some genuinely never stamped) that a single reason cannot express.

Keyed on ANN having actually **served a file**, not on a query having been issued.
`annModelsQueried` counts a query that threw (it was issued, which is what that metric reports),
and "embedded and did not throw" additionally counts one that came back empty - both of those leave
retrieval entirely on the scan path, which is the state being reported, so neither can silence it.
The payload carries `annModelsQueried` so an operator can still separate "never ran" (0) from "ran
and served nothing".

Scope worth stating plainly: the alarm only fires when the primary model had **no** ready files at
all, so a single stamped-and-ready file silences it. It is a "this deployment is not using ANN at
all" alarm, not a coverage metric.

Deliberately not guarded on `embeddingMismatch.partial` the way the neighbouring corpus diagnosis
is: this is an operator-facing configuration alarm, and the whole point is that it fires when
results look perfectly healthy - because they do.

## Guide for Testers

There is no UI surface here; this is retrieval internals. Verify it from the logs and from scan
volume.

1. **Prove the alarm on a lake with unstamped chunks.** Turn `EnableDataLakeVectorSearch` on for a
   stage whose `fabfilechunks` have no `embeddingModel`, then ask a data-lake-grounded question.
   Expect exactly one warn per request:
   `vector search is enabled but ANN served nothing - retrieval is entirely brute-force scan` with
   `reason: 'no-ready-files'`. Results themselves should be unchanged and correct.
2. **Prove it goes quiet.** Run the chunk `embeddingModel` backfill, wait out the 60s readiness
   lag, ask the same question. The alarm must stop firing. It stops as soon as the FIRST file is
   stamped and past the lag, not when the backfill finishes - see the scope note above.
3. **Prove the scan volume drops - on an Atlas stage.** With the flag on and the lake fully
   stamped, compare `scan.chunksScanned` for the same question before and after this branch. On a
   lake with more ready files than `topK` it should fall substantially; the `returned no hits for
   ready files` warn should now be rare instead of near-universal. On self-host OpenSearch the
   opposite is expected and correct - that path keeps the unconditional rebucket, so both the scan
   volume and that warn stay where they were.
4. **Prove answers did not change.** Ask several grounded questions and check the citations are the
   same documents as on `main` with the flag on.

## Regression areas

- Data-lake grounded chat and the knowledge-base tool on any stage with the flag ON - this changes
  which files reach the scan path.
- The multi-model / alternate-embedding-model retrieval path. It does **not** share this rebucket
  and is unchanged by the saturation rule: it still reads bare absence from `filesWithHits`, which
  is diagnostic-only there (nothing rebuckets on it, so an absence that merely means "did not
  rank" costs an over-reported `filesMissed` in one log line, not a wasted scan). Worth exercising
  a mixed-model lake anyway, since the shared `runAnn` seam is touched.
- Self-host OpenSearch retrieval, which is deliberately **excluded** from the saturation rule and
  keeps the unconditional rebucket. Atlas can key off saturation because mongot indexes the chunk
  collection itself, so a stamped file's content is in the index by construction. Self-host has no
  such guarantee - a separate cluster, a fail-open dual-write, and no backfill for pre-feature
  files - and `retrievalIndexModel` is not the missing residency signal either, since it is written
  *before* the index call on purpose (a removal for an index holding nothing is a no-op, a missed
  one orphans documents), so it over-claims in exactly the indexing-failure case that matters.
  Self-host therefore keeps the old `topK / fileCount` ceiling until a signal that actually
  confirms residency exists. Confirm a pre-feature file still returns results.
- Anything reading `scan.annFilesQueried` / `annHits` for reporting.

## What NOT to test

- Deployments with the flag OFF - every gate defaults closed and the scan path is untouched.
- Vectorization, chunking, or embedding generation - not touched.
- `falsePositiveRate` on the retrieval probes. It is 100% in both arms because these surfaces use
  `minScore: 0` with no relevance floor. Pre-existing, and a separate piece of work.
- Prod behaviour of the flag itself. Enabling it is a separate decision and a separate change.

## Residual risk

Saturation trades exact recall for ANN recall on the Atlas path, and that trade is not free. Once
the index returns a full `topK`, an unranked ready file is no longer rescanned, so a chunk the
brute-force scan would have found and ANN ranks just outside its window is now missed. The staging
A/B found zero divergence over 30 questions, but that corpus is roughly 5k chunks - under Atlas's
10k `numCandidates` ceiling, where ANN traversal is effectively exhaustive. It therefore does not
demonstrate recall at corpus sizes where that ceiling actually binds, which is the case worth
watching after the flag goes on in prod.

Where the safety net does still degrade: on Atlas, mongot's indexing lag can exceed
`VECTOR_SEARCH_READY_LAG_MS` during a bulk backfill, and the already-indexed files will saturate
`topK` while the lagging ones wait for a later query. Unlike the self-host case this self-heals
within one lag window, which is why it is accepted rather than gated.

## Refs

Refs #2526 - the dark `EnableDataLakeVectorSearch` cutover. This is the change that makes flipping
that flag worth doing: on `main` the flag removes 8.6% of the brute-force scanning, on this branch
27.6%. The flag-on-but-idle alarm here is also the missing signal that let the cutover sit inert.
Does not close #2526, which needs a recorded decision plus the prod-side backfill and index check.

Follow-ups filed separately: #2592 (self-host residency), #2539 (orphaned `fabFileId` rows).
