### PR TITLE
chore(client): guard the standalone bundle against a tracing sweep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN set -eu; \
     echo "stripped traces: ${before} -> $(du -sb apps/client/.next/standalone | cut -f1) bytes"
 # Then assert what actually ships: anything beyond the five entries a healthy standalone build
 # emits means file tracing swept the app source tree in behind us.
-RUN node scripts/check-standalone-tree.mjs apps/client/.next/standalone/apps/client
+RUN node apps/client/scripts/check-standalone-tree.mjs apps/client/.next/standalone/apps/client
 
 # ── Runner: minimal image, standalone output only ───────────────────────────
 FROM node:${NODE_VERSION}-slim AS runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ RUN set -eu; \
     before=$(du -sb apps/client/.next/standalone | cut -f1); \
     find apps/client/.next/standalone -name '*.nft.json' -type f -delete; \
     echo "stripped traces: ${before} -> $(du -sb apps/client/.next/standalone | cut -f1) bytes"
+# Then assert what actually ships: anything beyond the five entries a healthy standalone build
+# emits means file tracing swept the app source tree in behind us.
+RUN node scripts/check-standalone-tree.mjs apps/client/.next/standalone/apps/client
 
 # ── Runner: minimal image, standalone output only ───────────────────────────
 FROM node:${NODE_VERSION}-slim AS runner

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -108,6 +108,16 @@ const nextConfig = {
     '/api/agents/[id]/missions': [ISOLATED_VM_PREBUILDS],
   },
 
+  // DORMANT under Turbopack, which is what `next build` uses here: Next only applies these in
+  // collect-build-traces, and build/index.js gates that on `bundler !== Turbopack`. Measured -
+  // a swept build with this set still copied 545 *.test.ts into the standalone output. Kept as
+  // the floor for a webpack fallback; the working guards are the postbuild prune and
+  // apps/client/scripts/check-standalone-tree.mjs. Globs resolve against this package.
+  // Deliberately NOT public/**: server/help/retrieval.ts reads public/help-content per request.
+  outputFileTracingExcludes: {
+    '**/*': ['e2e/**', '**/*.test.ts?(x)'],
+  },
+
   transpilePackages: [
     'react-syntax-highlighter',
     '@icons-pack/react-simple-icons',

--- a/apps/client/scripts/check-standalone-tree.mjs
+++ b/apps/client/scripts/check-standalone-tree.mjs
@@ -9,7 +9,8 @@
 // is how tens of MB of apps/client reached the Lambda and the container image at once.
 //
 // Allowlist rather than denylist on purpose: the next regression will sweep in a directory
-// nobody thought to name.
+// nobody thought to name. The allowlist is one level deeper under app/, because that name is
+// the SPA source root and a sweep into it would otherwise land inside an allowed entry.
 //
 // Usage: node apps/client/scripts/check-standalone-tree.mjs <path-to-.next/standalone/<app>>
 
@@ -17,6 +18,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const ALLOWED = new Set(['.next', 'app', 'node_modules', 'package.json', 'server.js']);
+
+// `app` cannot be allowlisted wholesale: in the source tree it is the SPA root, the largest
+// directory in the package, so a sweep landing inside it would sit under an allowed entry and
+// pass. Only one thing under it is read at runtime - server/help/retrieval.ts resolves
+// app/generated/help-embeddings.json and help-index.json against cwd on each request - so the
+// standalone copy is pinned a level deeper here rather than trusted as a unit.
+const ALLOWED_UNDER_APP = new Set(['generated']);
 
 const appDir = process.argv[2];
 if (!appDir) {
@@ -33,6 +41,13 @@ const entrySet = new Set(entries);
 const offenders = entries.filter((entry) => !ALLOWED.has(entry));
 const missing = [...ALLOWED].filter((entry) => !entrySet.has(entry)).sort();
 
+// Reported with an `app/` prefix so the message names a path the reader can go and look at.
+if (entrySet.has('app')) {
+  for (const entry of fs.readdirSync(path.join(appDir, 'app')).sort()) {
+    if (!ALLOWED_UNDER_APP.has(entry)) offenders.push(`app/${entry}`);
+  }
+}
+
 if (offenders.length === 0 && missing.length === 0) {
   console.log(`check-standalone-tree: ${appDir} is clean (${entries.length} allowed entries)`);
   process.exit(0);
@@ -47,7 +62,10 @@ if (offenders.length > 0) {
   }
   console.error(
     'A failure here means file tracing swept the app source tree into the build output; expected only: ' +
-      [...ALLOWED].join(', ')
+      [...ALLOWED].join(', ') +
+      ' (and under app/ only: ' +
+      [...ALLOWED_UNDER_APP].join(', ') +
+      ')'
   );
 }
 

--- a/apps/client/scripts/check-standalone-tree.mjs
+++ b/apps/client/scripts/check-standalone-tree.mjs
@@ -11,7 +11,7 @@
 // Allowlist rather than denylist on purpose: the next regression will sweep in a directory
 // nobody thought to name.
 //
-// Usage: node scripts/check-standalone-tree.mjs <path-to-.next/standalone/<app>>
+// Usage: node apps/client/scripts/check-standalone-tree.mjs <path-to-.next/standalone/<app>>
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -29,21 +29,35 @@ if (!fs.existsSync(appDir)) {
 }
 
 const entries = fs.readdirSync(appDir).sort();
+const entrySet = new Set(entries);
 const offenders = entries.filter((entry) => !ALLOWED.has(entry));
+const missing = [...ALLOWED].filter((entry) => !entrySet.has(entry)).sort();
 
-if (offenders.length === 0) {
+if (offenders.length === 0 && missing.length === 0) {
   console.log(`check-standalone-tree: ${appDir} is clean (${entries.length} allowed entries)`);
   process.exit(0);
 }
 
-console.error(`check-standalone-tree: ${offenders.length} unexpected entries in ${appDir}`);
-for (const offender of offenders) {
-  const full = path.join(appDir, offender);
-  const kind = fs.lstatSync(full).isDirectory() ? 'dir ' : 'file';
-  console.error(`  ${kind} ${offender}`);
+if (offenders.length > 0) {
+  console.error(`check-standalone-tree: ${offenders.length} unexpected entries in ${appDir}`);
+  for (const offender of offenders) {
+    const full = path.join(appDir, offender);
+    const kind = fs.lstatSync(full).isDirectory() ? 'dir ' : 'file';
+    console.error(`  ${kind} ${offender}`);
+  }
+  console.error(
+    'A failure here means file tracing swept the app source tree into the build output; expected only: ' +
+      [...ALLOWED].join(', ')
+  );
 }
-console.error(
-  'A failure here means file tracing swept the app source tree into the build output; expected only: ' +
-    [...ALLOWED].join(', ')
-);
+
+if (missing.length > 0) {
+  // A truncated build (e.g. a build step that died silently) still writes a subset of the
+  // allowed entries, which the offender check alone reports as clean.
+  console.error(`check-standalone-tree: ${missing.length} expected entries missing from ${appDir}`);
+  for (const entry of missing) {
+    console.error(`  missing ${entry}`);
+  }
+}
+
 process.exit(1);

--- a/apps/client/server/utils/spoolRequestToFile.test.ts
+++ b/apps/client/server/utils/spoolRequestToFile.test.ts
@@ -37,6 +37,17 @@ describe('spoolRequestToFile', () => {
     expect(existsSync(leaked!)).toBe(false);
   });
 
+  it('keeps a traversing filename inside the temp directory', async () => {
+    // Today's callers pass literals, so this is defence in depth for the next one.
+    const spooled = await spoolRequestToFile(bodyOf('x'), 1024, { filename: '../../escaped.zip' });
+    try {
+      expect(spooled.path.endsWith('/escaped.zip')).toBe(true);
+      expect(spooled.path).not.toContain('..');
+    } finally {
+      await spooled.cleanup();
+    }
+  });
+
   it('cleanup removes the file and is safe to call twice', async () => {
     const spooled = await spoolRequestToFile(bodyOf('data'), 1024);
     await spooled.cleanup();

--- a/apps/client/server/utils/spoolRequestToFile.test.ts
+++ b/apps/client/server/utils/spoolRequestToFile.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { existsSync, readFileSync } from 'fs';
 import { UploadTooLargeError, spoolRequestToFile } from './spoolRequestToFile';
 
+/** basename() passes a literal ".." through unchanged (it is only two dots, not a separator). */
+const parentOf = (spooledPath: string): string => spooledPath.replace(/\/\.\.$/, '');
+
 /** A request body as the route sees it: an async iterable of Buffers. */
 const bodyOf = (...chunks: string[]): AsyncIterable<Buffer> => ({
   async *[Symbol.asyncIterator]() {
@@ -46,6 +49,17 @@ describe('spoolRequestToFile', () => {
     } finally {
       await spooled.cleanup();
     }
+  });
+
+  it('rejects a filename of exactly ".." instead of writing outside the temp directory', async () => {
+    // basename('..') returns '..' unchanged, unlike '../../escaped.zip' above, so the resulting
+    // path points at the temp directory's parent rather than a file inside it.
+    let attemptedPath: string | undefined;
+    await expect(
+      spoolRequestToFile(bodyOf('x'), 1024, { filename: '..', onPath: p => (attemptedPath = p) })
+    ).rejects.toThrow();
+    expect(attemptedPath, 'test needs the path to check for a leak').toBeDefined();
+    expect(existsSync(parentOf(attemptedPath!))).toBe(false);
   });
 
   it('cleanup removes the file and is safe to call twice', async () => {

--- a/apps/client/server/utils/spoolRequestToFile.ts
+++ b/apps/client/server/utils/spoolRequestToFile.ts
@@ -1,6 +1,7 @@
 import { createWriteStream } from 'fs';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
+import { basename } from 'path';
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
 
@@ -45,11 +46,11 @@ export async function spoolRequestToFile(
   maxBytes: number,
   options: SpoolOptions = {}
 ): Promise<SpooledUpload> {
-  // Template literals, not path.join: @vercel/nft partially evaluates a join() whose arguments it
-  // cannot resolve, gives up on a concrete path, and falls back to globbing the app directory -
-  // which drags all of apps/client into the traced Lambda bundle. Keep these opaque to the tracer.
+  // Template literals, not path.join: a join() chained onto a value known only at runtime
+  // (mkdtemp's return) makes the build's file tracer give up on a concrete path and glob the whole
+  // app directory into the trace. basename() is safe here - it sanitises a name, it builds no path.
   const dir = await mkdtemp(`${tmpdir()}/b4m-upload-`);
-  const path = `${dir}/${options.filename ?? 'upload.bin'}`;
+  const path = `${dir}/${basename(options.filename ?? 'upload.bin')}`;
   options.onPath?.(path);
 
   let removed = false;

--- a/packages/scripts/src/checkLambdaBundleGuards.test.ts
+++ b/packages/scripts/src/checkLambdaBundleGuards.test.ts
@@ -46,8 +46,13 @@ describe('spoolRequestToFile keeps its temp path opaque to the file tracer', () 
 
   it('calls no path-building helper the tracer would have to fold', () => {
     const code = codeOnly(source);
-    expect(code).not.toMatch(/\bjoin\s*\(/);
-    expect(code).not.toMatch(/\bresolve\s*\(/);
+    expect(code, 'this module must build no path at all, so the tracer never has a call to fold').not.toMatch(
+      /\bjoin\s*\(/
+    );
+    expect(
+      code,
+      'the ban is scoped to this one small file, so a Promise resolve() here is a finding too, not a false positive'
+    ).not.toMatch(/\bresolve\s*\(/);
   });
 
   it('still sanitises the caller-supplied filename', () => {

--- a/packages/scripts/src/checkLambdaBundleGuards.test.ts
+++ b/packages/scripts/src/checkLambdaBundleGuards.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Pins the three things that keep the Next server Lambda under its unzipped size cap.
+ *
+ * None of them can be protected by an ordinary unit test. The tracing regression that started
+ * this produced byte-identical runtime behaviour - every existing test passed on the swept
+ * build and on the fixed one - and the only difference was in `next build`'s traced file set,
+ * which no unit test can see. So each invariant is pinned at its declaration site instead:
+ * a revert has to edit one of these literals, and editing it fails here.
+ *
+ * Text-matched rather than executed, deliberately. Executing the real thing means a full
+ * `next build`, which does not belong in a unit shard; the shapes below are what the build
+ * reads, so pinning them is the same assertion at a thousandth of the cost.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const read = (rel: string) => fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+/** Comments here explain the banned shapes by name, so the ban has to be read against code only. */
+const codeOnly = (source: string) => source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+describe('spoolRequestToFile keeps its temp path opaque to the file tracer', () => {
+  /**
+   * Measured, not theorised: with the join() here the build traced all of apps/client into the
+   * bundle, and with the interpolation it does not. The mechanism is the inferred part - the
+   * tracer looks unable to fold a join() chained onto a value known only at runtime (mkdtemp's
+   * return) and appears to fall back to globbing the containing directory - and a standalone
+   * nodeFileTrace over the same shape did not reproduce it, so treat the shape as the trigger
+   * and the explanation as provisional.
+   *
+   * Scoped to this one module on purpose. The broad shape - any join() the tracer cannot fold -
+   * matches roughly twenty other sites in traced server code that demonstrably do not sweep, so
+   * a repo-wide ban would be noise. This is the site where the difference was measured.
+   */
+  const source = read('apps/client/server/utils/spoolRequestToFile.ts');
+
+  it('builds the spooled path by interpolation, not by joining onto the mkdtemp result', () => {
+    expect(source).toMatch(/const dir = await mkdtemp\(/);
+    expect(source, 'the spooled path must be a template literal off the mkdtemp result').toMatch(
+      /const path = `\$\{dir\}\//
+    );
+  });
+
+  it('calls no path-building helper the tracer would have to fold', () => {
+    const code = codeOnly(source);
+    expect(code).not.toMatch(/\bjoin\s*\(/);
+    expect(code).not.toMatch(/\bresolve\s*\(/);
+  });
+
+  it('still sanitises the caller-supplied filename', () => {
+    expect(source).toMatch(/basename\(options\.filename/);
+  });
+});
+
+describe('the container build asserts its output after pruning it', () => {
+  it('prunes compiled test routes and only then checks what it is about to copy', () => {
+    const dockerfile = read('Dockerfile');
+    const pruneAt = dockerfile.indexOf('pruneTestRoutes.mjs');
+    const guardAt = dockerfile.indexOf('check-standalone-tree.mjs');
+    expect(pruneAt, 'Dockerfile must still prune compiled test routes').toBeGreaterThan(-1);
+    expect(guardAt, 'Dockerfile must check the standalone tree').toBeGreaterThan(-1);
+    expect(guardAt, 'the tree check has to run after the prune to describe what ships').toBeGreaterThan(pruneAt);
+  });
+});
+
+/**
+ * The excludes themselves are dormant - Next applies them in collect-build-traces, which it
+ * skips under Turbopack - so what is worth pinning is the carve-out, not the effect. Someone
+ * trimming the bundle later will reach for public/** first, and it is the one directory here
+ * that is read at request time.
+ */
+describe('outputFileTracingExcludes floor', () => {
+  const config = read('apps/client/next.config.mjs');
+
+  it('declares the Playwright suite and unit tests as excludable', () => {
+    expect(config).toMatch(/outputFileTracingExcludes/);
+    expect(config).toMatch(/'e2e\/\*\*'/);
+    expect(config).toMatch(/'\*\*\/\*\.test\.ts\?\(x\)'/);
+  });
+
+  it('does not exclude public/**, which the help retrieval path reads at request time', () => {
+    // server/help/retrieval.ts resolves public/help-content per request, so excluding public/**
+    // would trade a smaller bundle for a runtime ENOENT.
+    const excludes = /outputFileTracingExcludes:\s*\{[\s\S]*?\n {2}\},/.exec(config);
+    expect(excludes, 'outputFileTracingExcludes block not found').not.toBeNull();
+    expect(excludes![0]).not.toContain('public');
+    expect(read('apps/client/server/help/retrieval.ts')).toContain("'public/help-content'");
+  });
+});

--- a/packages/scripts/src/checkStandaloneTree.test.ts
+++ b/packages/scripts/src/checkStandaloneTree.test.ts
@@ -34,6 +34,10 @@ function makeHealthyTree(): void {
     if (entry.includes('.json') || entry.endsWith('.js')) fs.writeFileSync(full, '{}');
     else fs.mkdirSync(full);
   }
+  // The only thing under app/ that a healthy build emits: the help artifacts retrieval.ts
+  // resolves against cwd on each request.
+  fs.mkdirSync(path.join(appDir, 'app', 'generated'));
+  fs.writeFileSync(path.join(appDir, 'app', 'generated', 'help-index.json'), '{}');
 }
 
 /** Run the guard, returning its exit status and combined output. */
@@ -82,6 +86,20 @@ describe('check-standalone-tree', () => {
       expect(output).toContain(swept);
     }
     expect(output).toContain('file tracing swept the app source tree');
+  });
+
+  it('rejects a sweep that lands inside app/, which a top-level allowlist would miss', () => {
+    makeHealthyTree();
+    // app/ is the SPA source root, so this is where a sweep is likeliest to land and the one
+    // place a top-level-only allowlist reports clean while shipping the source tree.
+    fs.mkdirSync(path.join(appDir, 'app', 'components'));
+    fs.writeFileSync(path.join(appDir, 'app', 'router.tsx'), '');
+
+    const { status, output } = runGuard(appDir);
+    expect(status).toBe(1);
+    expect(output).toContain('2 unexpected entries');
+    expect(output).toContain('app/components');
+    expect(output).toContain('app/router.tsx');
   });
 
   it('is an allowlist, so it rejects an entry nobody thought to name', () => {

--- a/packages/scripts/src/checkStandaloneTree.test.ts
+++ b/packages/scripts/src/checkStandaloneTree.test.ts
@@ -6,8 +6,8 @@ import os from 'node:os';
 import path from 'node:path';
 
 /**
- * Exercises scripts/check-standalone-tree.mjs, the last thing the container build runs before
- * the standalone output is copied into the runner image.
+ * Exercises apps/client/scripts/check-standalone-tree.mjs, the last thing the container build
+ * runs before the standalone output is copied into the runner image.
  *
  * The guard exists because a @vercel/nft directory-glob fallback swept all of apps/client into
  * the build output, and nothing failed: the image built, the Lambda deployed, and the only
@@ -20,7 +20,7 @@ import path from 'node:path';
  * offenders it names on stderr, which is exactly what the Dockerfile depends on.
  */
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const GUARD = path.join(REPO_ROOT, 'scripts', 'check-standalone-tree.mjs');
+const GUARD = path.join(REPO_ROOT, 'apps', 'client', 'scripts', 'check-standalone-tree.mjs');
 
 const HEALTHY_ENTRIES = ['.next', 'app', 'node_modules', 'package.json', 'server.js'];
 
@@ -97,5 +97,15 @@ describe('check-standalone-tree', () => {
     const { status, output } = runGuard(path.join(tmpRoot, 'nope'));
     expect(status).toBe(1);
     expect(output).toContain('no standalone app directory');
+  });
+
+  it('fails and names what is missing when a truncated build drops an expected entry', () => {
+    makeHealthyTree();
+    fs.rmSync(path.join(appDir, 'server.js'));
+
+    const { status, output } = runGuard(appDir);
+    expect(status).toBe(1);
+    expect(output).toContain('missing');
+    expect(output).toContain('server.js');
   });
 });

--- a/packages/scripts/src/checkStandaloneTree.test.ts
+++ b/packages/scripts/src/checkStandaloneTree.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Exercises scripts/check-standalone-tree.mjs, the last thing the container build runs before
+ * the standalone output is copied into the runner image.
+ *
+ * The guard exists because a @vercel/nft directory-glob fallback swept all of apps/client into
+ * the build output, and nothing failed: the image built, the Lambda deployed, and the only
+ * symptom was tens of MB of raw source riding along inside a bundle already near Lambda's
+ * 250 MB unzipped cap. A byte budget would not have caught it either - most of the standalone
+ * tree is .nft.json metadata whose size barely moves. What DOES move is the entry list, so
+ * that is what gets pinned.
+ *
+ * Run as a subprocess rather than imported: the script's contract is its exit code and the
+ * offenders it names on stderr, which is exactly what the Dockerfile depends on.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const GUARD = path.join(REPO_ROOT, 'scripts', 'check-standalone-tree.mjs');
+
+const HEALTHY_ENTRIES = ['.next', 'app', 'node_modules', 'package.json', 'server.js'];
+
+let tmpRoot: string;
+let appDir: string;
+
+/** Build a standalone app directory holding exactly the entries a healthy build emits. */
+function makeHealthyTree(): void {
+  for (const entry of HEALTHY_ENTRIES) {
+    const full = path.join(appDir, entry);
+    if (entry.includes('.json') || entry.endsWith('.js')) fs.writeFileSync(full, '{}');
+    else fs.mkdirSync(full);
+  }
+}
+
+/** Run the guard, returning its exit status and combined output. */
+function runGuard(target: string): { status: number; output: string } {
+  try {
+    const stdout = execFileSync('node', [GUARD, target], { encoding: 'utf8', stdio: 'pipe' });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { status: e.status, output: `${e.stdout}${e.stderr}` };
+  }
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'standalone-tree-'));
+  appDir = path.join(tmpRoot, '.next', 'standalone', 'apps', 'client');
+  fs.mkdirSync(appDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('check-standalone-tree', () => {
+  it('passes on a healthy standalone tree', () => {
+    makeHealthyTree();
+    const { status, output } = runGuard(appDir);
+    expect(status, output).toBe(0);
+    expect(output).toContain('is clean');
+  });
+
+  it('fails and names the offenders when file tracing sweeps the app source tree in', () => {
+    makeHealthyTree();
+    // The shape the regression produced: source directories from apps/client landing beside
+    // the five real entries.
+    for (const swept of ['server', 'pages', 'e2e', 'next.config.mjs']) {
+      const full = path.join(appDir, swept);
+      if (swept.endsWith('.mjs')) fs.writeFileSync(full, '');
+      else fs.mkdirSync(full);
+    }
+
+    const { status, output } = runGuard(appDir);
+    expect(status).toBe(1);
+    expect(output).toContain('4 unexpected entries');
+    for (const swept of ['server', 'pages', 'e2e', 'next.config.mjs']) {
+      expect(output).toContain(swept);
+    }
+    expect(output).toContain('file tracing swept the app source tree');
+  });
+
+  it('is an allowlist, so it rejects an entry nobody thought to name', () => {
+    makeHealthyTree();
+    fs.mkdirSync(path.join(appDir, 'some-future-directory'));
+
+    const { status, output } = runGuard(appDir);
+    expect(status).toBe(1);
+    expect(output).toContain('some-future-directory');
+  });
+
+  it('fails loudly rather than passing when the standalone output is missing', () => {
+    const { status, output } = runGuard(path.join(tmpRoot, 'nope'));
+    expect(status).toBe(1);
+    expect(output).toContain('no standalone app directory');
+  });
+});

--- a/scripts/check-standalone-tree.mjs
+++ b/scripts/check-standalone-tree.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Asserts the Next standalone app directory holds nothing but the entries a healthy build
+// emits, so a file-tracing regression cannot quietly ship the source tree.
+//
+// A `next build --output standalone` for this app writes exactly five entries: the compiled
+// .next, the generated help artifacts under app/, the traced node_modules, package.json and
+// server.js. When the file tracer loses a concrete path it falls back to globbing the app
+// directory, and everything it sweeps in lands here as raw source next to those five - which
+// is how tens of MB of apps/client reached the Lambda and the container image at once.
+//
+// Allowlist rather than denylist on purpose: the next regression will sweep in a directory
+// nobody thought to name.
+//
+// Usage: node scripts/check-standalone-tree.mjs <path-to-.next/standalone/<app>>
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ALLOWED = new Set(['.next', 'app', 'node_modules', 'package.json', 'server.js']);
+
+const appDir = process.argv[2];
+if (!appDir) {
+  console.error('usage: check-standalone-tree.mjs <.next/standalone/<app> dir>');
+  process.exit(1);
+}
+if (!fs.existsSync(appDir)) {
+  console.error(`check-standalone-tree: no standalone app directory at ${appDir}`);
+  process.exit(1);
+}
+
+const entries = fs.readdirSync(appDir).sort();
+const offenders = entries.filter((entry) => !ALLOWED.has(entry));
+
+if (offenders.length === 0) {
+  console.log(`check-standalone-tree: ${appDir} is clean (${entries.length} allowed entries)`);
+  process.exit(0);
+}
+
+console.error(`check-standalone-tree: ${offenders.length} unexpected entries in ${appDir}`);
+for (const offender of offenders) {
+  const full = path.join(appDir, offender);
+  const kind = fs.lstatSync(full).isDirectory() ? 'dir ' : 'file';
+  console.error(`  ${kind} ${offender}`);
+}
+console.error(
+  'A failure here means file tracing swept the app source tree into the build output; expected only: ' +
+    [...ALLOWED].join(', ')
+);
+process.exit(1);


### PR DESCRIPTION
## Description

The bundle crossing that blocked staging came from two `path.join()` calls building a temp upload path. A `join()` chained onto a value known only at runtime makes the build's file tracer give up on a concrete path and glob the containing directory into the trace, which swept all of `apps/client` into the Lambda. That shape was fixed in #2551 and reclaimed 43,025,185 bytes, 99.1% of the growth between the last passing deploy and the failure.

Nothing asserts it stays fixed, and no ordinary test can. The swept build and the clean build behave identically at runtime - every existing test passed on both - and the only difference is in `next build`'s traced file set. So this pins the invariants at the build boundary instead, where a regression is visible.

Worth being precise about the mechanism, because it is the part I could not prove. The effect is measured: with the `join()` the build traces the app directory, with the interpolation it does not. The explanation is inferred, and a standalone `nodeFileTrace` over the same shape did not reproduce it. The comments say so rather than asserting tracer internals.

Child of #2549.

## Changes

- `apps/client/scripts/check-standalone-tree.mjs` - allowlists the entries a healthy standalone build emits and fails the container build on anything else, wired into the `Dockerfile` after the existing prune so it describes what is about to be copied. Allowlist rather than denylist, because the next regression will sweep in a directory nobody thought to name. The allowlist goes one level deeper under `app/`, pinned to `generated`: that name is the SPA source root, so a sweep landing inside it would otherwise sit under an allowed entry and report clean. `app/generated` is the only thing under it read at runtime - `server/help/retrieval.ts` resolves the help embeddings and index against cwd per request.
- `apps/client/next.config.mjs` - declares `e2e/**` and unit tests in `outputFileTracingExcludes`. This is **inert today** and the comment says so: Next applies excludes in `collect-build-traces`, which it skips under Turbopack, and this app builds with Turbopack. Measured - a swept build with this set still copied 545 `*.test.ts` into the standalone output. It is kept as a floor for the webpack path, not as the guard. `public/**` is deliberately not excluded, because help retrieval reads `public/help-content` per request.
- `apps/client/server/utils/spoolRequestToFile.ts` - `basename()` on the caller-supplied filename, so the spooled path cannot escape its temp directory. Safe for the tracer: it sanitises a name, it builds no path.
- `packages/scripts/src/checkLambdaBundleGuards.test.ts`, `checkStandaloneTree.test.ts` - pin each invariant at its declaration site. Text-matched rather than executed, because executing the real thing means a full `next build`, which does not belong in a unit shard.

Compiled-test-route pruning is deliberately **not** here. It overlaps #2577, which was already open against the pruner, so I handed my working diff over on that issue rather than landing it twice.

## Guide for Testers

Build-time only. Nothing about request handling changes, and there is no UI surface.

1. Check out this branch and run `pnpm --filter @bike4mind/scripts test`. Expected: all tests pass, including `checkLambdaBundleGuards` and `checkStandaloneTree`.
2. Run `pnpm --filter @bike4mind/client exec vitest run --project node server/utils/spoolRequestToFile.test.ts`. Expected: 6 tests pass.
3. Confirm the guard actually guards. Create a stray directory in a built standalone tree and run the checker against it:
   - `mkdir -p /tmp/fake-standalone/apps/client/pages && touch /tmp/fake-standalone/apps/client/package.json`
   - `node apps/client/scripts/check-standalone-tree.mjs /tmp/fake-standalone/apps/client`
   - Expected: exit code 1, and the output names `pages` as an unexpected entry.
4. Confirm it passes a healthy shape. `mkdir -p /tmp/ok-standalone/{.next,app,node_modules} && touch /tmp/ok-standalone/{package.json,server.js}`, then `node apps/client/scripts/check-standalone-tree.mjs /tmp/ok-standalone`. Expected: exit code 0 and a "clean" line.
5. Confirm the guard reports a missing directory rather than passing silently: `node apps/client/scripts/check-standalone-tree.mjs /tmp/does-not-exist`. Expected: exit code 1. A guard that passes when its target is absent is worse than no guard.
6. Confirm the tests fail when the fix is reverted. Temporarily change the spooled path in `apps/client/server/utils/spoolRequestToFile.ts` back to `join(dir, options.filename ?? 'upload.bin')` and re-run step 1. Expected: three assertions in `checkLambdaBundleGuards` fail. Revert the edit afterwards.
7. Confirm a sweep landing *inside* `app/` is caught, not just one beside it. Take the healthy tree from step 4, add `mkdir -p /tmp/ok-standalone/app/generated && mkdir -p /tmp/ok-standalone/app/components`, then re-run the guard. Expected: exit code 1, naming `app/components` with its path rather than reporting clean.
8. Confirm the filename cannot escape its directory. In `spoolRequestToFile.test.ts` the path-traversal case passes a filename containing parent-directory segments and asserts the resulting path stays inside the temp directory. Expected: it passes.

### Regression Checks

9. **Container build.** Build the self-host image. Expected: the new `check-standalone-tree` step runs after the existing prune step and prints a clean line. A failure here means file tracing swept the source tree, which is the condition this exists to catch.
10. **Hosted build unchanged.** `outputFileTracingExcludes` is inert under Turbopack, so the traced file set should be byte-identical to `main`. If the bundle size *does* move on this branch, that contradicts the measurement above and is worth stopping for.
11. **Upload paths still work.** Exercise a file upload end to end and confirm the file is received intact. `basename()` is the only runtime behaviour change in this PR, and it only strips directory segments from a name that should never have had them.

### What NOT to test

- **Bundle size reduction.** There is none in this PR. #2551 already banked the 43 MB; this only stops it coming back. The number should not move.
- **Test-route pruning.** Not in this PR, see #2577.
- **`outputFileTracingExcludes` having any effect.** It has none under Turbopack. That is the documented state, not a defect to report.
- **Anything in the UI.** No client code changed.

## Additional Information

The preview gate fails on this branch. It matches `infra/`, `sst.config.ts` and the overlay pins, none of which this touches, so there is no preview to attach.

The guard script lives at `apps/client/scripts/check-standalone-tree.mjs` rather than the repo-root `scripts/`, because the container build's `deps` stage copies `apps/`, `b4m-core/`, `packages/` and `patches/` and never the root `scripts/`. The sibling pruner invoked on the line above it is there for the same reason. An earlier revision of this PR had it at the root, where the build could not resolve it.

The `Dockerfile`'s existing explicit prune line is left alone. It predates this change and is unrelated to the guard being added after it.


