### PR TITLE
build(selfhost): drop Next file-tracing metadata from the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,15 @@ RUN NODE_OPTIONS='--max-old-space-size=12288' pnpm --filter @bike4mind/client bu
 # and the standalone server preloads them at boot, running test-only module
 # side effects in production (see the script header for the S3 stub failure).
 RUN node apps/client/scripts/pruneTestRoutes.mjs apps/client/.next/standalone/apps/client/.next
+# Strip Next's file-tracing metadata: .nft.json is ~66% of the tree the runner
+# copies below, and only the bundler reads it (in next 16.2.11 the name resolves
+# solely under next/dist/build/**, never under dist/server/**). Must stay in this
+# builder stage: the hosted OpenNext path reads these same files back out of
+# .next/standalone in copyTracedFiles, and never runs through this image.
+RUN set -eu; \
+    before=$(du -sb apps/client/.next/standalone | cut -f1); \
+    find apps/client/.next/standalone -name '*.nft.json' -type f -delete; \
+    echo "stripped traces: ${before} -> $(du -sb apps/client/.next/standalone | cut -f1) bytes"
 
 # ── Runner: minimal image, standalone output only ───────────────────────────
 FROM node:${NODE_VERSION}-slim AS runner


### PR DESCRIPTION
## Description

`next build` writes a `.nft.json` file-trace beside every compiled route. The self-host image ships all of them and never reads one: they are input to the bundler, not to the server.

In next 16.2.11 the string resolves only under `next/dist/build/**` (`collect-build-traces.js`, `build/utils.js`, `build/index.js`, `build/adapter/build-complete.js`, `webpack/plugins/next-trace-entrypoints-plugin.js`) and its `esm/` mirror. There are zero hits under `dist/server/**`, and the one dynamically-constructed form is a `.replace(/\.nft\.json$/, '')` inside the build adapter, still build-time.

They are also the bulk of the image. Measured in the builder stage: 794 files, 539,042,045 bytes out of a 779,737,353-byte standalone tree, so 69% of what the runner stage copies in.

This deletes them in the builder stage, right after the existing test-route prune.

**The placement is load-bearing.** The hosted OpenNext path reads these same files back out of `.next/standalone` during `copyTracedFiles`, so they must survive there. It does not: OpenNext runs via `sst.aws.Nextjs` in `infra/web.ts`, doing its own `next build` on the deploy runner. The root `Dockerfile` has exactly two consumers, `compose.selfhost.yaml` and `.github/workflows/selfhost-image.yml`, and neither is on the hosted path. Nothing about the Lambda bundle changes.

## Changes

- `Dockerfile`: new builder-stage step after `pruneTestRoutes.mjs` that deletes `*.nft.json` under `apps/client/.next/standalone`.
- The step echoes the tree size before and after. If Next ever renames the extension, the build log shows a zero delta instead of the image quietly regrowing.

### Sizes

| | before | after | delta |
|---|---:|---:|---:|
| standalone tree | 779,737,353 | 240,695,308 | -539,042,045 (-69.1%) |
| `/app` in the runner image | 821,407,726 | 282,349,297 | -539,058,429 (-65.6%) |
| container rootfs | 1,070,266,005 | 531,207,576 | -539,058,429 (-50.4%) |
| **image on disk** | **1.31 GB** | **738 MB** | **-44%** |
| **compressed pull** | **181,721,600** | **148,218,116** | **-33,503,484 (-18.4%)** |

Worth being precise about which number to quote. The 539 MB is real disk and page-cache savings on every self-host host, but it is not what anyone downloads: `.nft.json` is JSON and compresses roughly 16:1, so the registry pull only shrinks 33.5 MB. The honest headline is 1.31 GB to 738 MB on disk.

## Guide for Testers

This is a container-image change with no UI and no API surface. Verification is that the image still boots and still reaches both of its external dependencies.

1. From the repo root, build the image: `docker build -t b4m-selfhost:test .`
2. Confirm the strip step ran. In the build output, find the line beginning `stripped traces:` and check the second number is roughly a third of the first. Expected shape: `stripped traces: 779737353 -> 240695308 bytes`
3. Confirm no traces shipped: `docker run --rm --entrypoint sh b4m-selfhost:test -c 'find /app -name "*.nft.json" | wc -l'`. Expected: `0`
4. Confirm the server entrypoint survived: `docker run --rm --entrypoint sh b4m-selfhost:test -c 'ls /app/apps/client/server.js'`. Expected: the path prints, no error.
5. Create the env file if you do not have one: `cp .env.selfhost.example .env.selfhost`, then replace every `change-me-openssl-rand-hex-32` value with the output of `openssl rand -hex 32`.
6. Start the stack: `B4M_IMAGE=b4m-selfhost:test docker compose -f compose.selfhost.yaml --env-file .env.selfhost up -d`
7. Wait until every service reports healthy: `docker compose -f compose.selfhost.yaml --env-file .env.selfhost ps`. Expected: nine services, none restarting. The app takes about 30 seconds.
8. Boot check: `curl -i http://localhost:3000/api/health`. Expected: HTTP 200 with `"status":"ok"` and `"stage":"selfhost"`.
9. SPA shell: open `http://localhost:3000/` in a browser. Expected: the login page renders, no blank page and no console error about a missing module.

### Regression Checks

The two dependency paths that a broken standalone tree would take down. Run both.

10. Put a probe object into MinIO: `docker run --rm --network <project>_default --entrypoint sh minio/mc -c 'mc alias set local http://minio:9000 minioadmin minioadmin && echo hello-probe | mc pipe local/b4m-app-files/app-config/probe.txt'` (substitute your compose project name, `docker compose ls` shows it).
11. Read it back through the app, which exercises S3/MinIO: `curl -i http://localhost:3000/api/app-files/serve/app-config/probe.txt`. Expected: HTTP 200, body `hello-probe`, and headers `Accept-Ranges: bytes` plus `Content-Security-Policy: default-src 'none'; sandbox`.
12. Range path: `curl -i -r 0-4 http://localhost:3000/api/app-files/serve/app-config/probe.txt`. Expected: HTTP 206 and body `hello`.
13. Allowlist still denies: `curl -i http://localhost:3000/api/app-files/serve/whats-new/x.txt`. Expected: HTTP 404.
14. Write a row directly to Mongo: `docker exec <project>-mongo-1 mongosh --quiet "mongodb://localhost:27017/bike4mind?replicaSet=rs0" --eval 'db.adminsettings.insertOne({settingName:"serverStatus", settingValue:"maintenance", createdAt:new Date(), updatedAt:new Date()})'`
15. Restart the app so the read cannot be served from cache: `docker restart <project>-app-1`, then wait for step 8 to return 200 again.
16. Read it back, which exercises Mongo: `curl http://localhost:3000/api/settings/serverStatus`. Expected: `{"serverStatus":"maintenance"}`. **Step 15 is required.** `getSettingsMap` sits behind a process-local `AdminSettingsCache`, so without the restart this returns the cached `live` and proves nothing.
17. Clean up: delete the row with `deleteMany({settingName:"serverStatus"})`, restart the app, confirm the endpoint returns `{"serverStatus":"live"}`.
18. Tear down: `docker compose -f compose.selfhost.yaml --env-file .env.selfhost down -v`

### What NOT to test

- Anything in the hosted app, staging or prod. This file is not on the deploy path and the Lambda bundle is byte-identical.
- Any UI feature, any model or chat behaviour, any auth flow. Nothing in the request path changed.
- A preview environment. Previews build through OpenNext, not through this Dockerfile, so a preview cannot tell you whether this worked.

## Additional Information

I ran the full nine-service compose stack on the stripped image and exercised steps 8 through 17 above, all passing, including the cold-process Mongo read returning the row I wrote.

I also ran the same eight probes against a build of the unmodified Dockerfile as a control. Status codes were identical on every one: `/api/health` 200, `/api/settings/serverStatus` 200, the MinIO proxy 200, `/` 200, `/login` 200, `/api/settings/publicSettings` 401, `/api/auth/providers` 400, the unallowlisted prefix 404. The change is behaviour-neutral, only smaller.

Both arches of the published GHCR image go through this same file, so `ghcr.io/bike4mind/bike4mind-selfhost` picks the reduction up on the next publish.

## Developer Notes

- The builder stage is now the place where self-host-only output trimming lives, next to `pruneTestRoutes.mjs`. Anything else that is build-input rather than runtime-input belongs in the same window: after `next build`, before the runner `COPY`.
- The before/after echo is the cheap version of a size guard. If this is worth enforcing rather than observing, the natural next step is a threshold check in the same step that fails the build when the tree exceeds a ceiling, which would also catch a dependency that quietly doubles the traced set.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
