### PR TITLE
refactor(data-lakes): pin findAccessible's arm inventory across model and service test fake

### DIFF
--- a/b4m-core/common/src/constants/dataLakes.ts
+++ b/b4m-core/common/src/constants/dataLakes.ts
@@ -680,6 +680,40 @@ export function lakeMatchesAccess(
 }
 
 /**
+ * The names of the access arms `DataLakeModel.findAccessible` ORs together, in the order that
+ * method emits them (`packages/database/src/models/ai/DataLakeModel.ts`, built by
+ * `buildAccessibleQuery`):
+ *
+ * - `owner`    - `createdByUserId` is the caller. Unconditional.
+ * - `public`   - an `isPublic` lake, still AND-ed with the requirement gate. Dropped when
+ *                `includePublic: false` (the archived/deleted MANAGEMENT views).
+ * - `orgGate`  - org membership AND the requirement gate AND the not-private exclusion.
+ * - `orgAdmin` - a lake in an org the caller administers, by those rights alone. Only when
+ *                `administeredOrgIds` is non-empty.
+ * - `grant`    - a lake the caller holds a persisted access grant on. Only when the caller
+ *                passes a non-empty `grantedLakeIds`.
+ * - `orgGrant` - a lake granted to one of the caller's orgs, ANDed with that granting org so the
+ *                grant reaches no further. One disjunct per granting org, so this name can label
+ *                several; dropped with the public arm when `includePublic: false`.
+ *
+ * The `ctx.isAdmin` bypass is deliberately NOT an arm: it replaces the whole `$or` rather than
+ * adding a disjunct, so an admin context yields zero arms.
+ *
+ * This inventory is the seam two suites check themselves against, so adding an arm to the real
+ * query without naming it here (or naming it here without teaching the service-layer fake about
+ * it) fails loudly instead of quietly weakening what those tests claim:
+ *
+ * - `packages/database/src/models/ai/DataLakeModel.accessArms.test.ts` - the built `$or` and this
+ *   list stay parallel, and a maximal context reaches every name.
+ * - `b4m-core/services/src/dataLakeService/dataLakeService.test.ts` - `ARM_COVERAGE` beside the
+ *   in-memory `findAccessible` fake declares a position on every name (that fake is a deliberate
+ *   SUBSET of the real query, so its job is arm awareness, not output equality).
+ */
+export const FIND_ACCESSIBLE_ARMS = ['owner', 'public', 'orgGate', 'orgAdmin', 'grant', 'orgGrant'] as const;
+
+export type FindAccessibleArm = (typeof FIND_ACCESSIBLE_ARMS)[number];
+
+/**
  * Single projection from a persisted lake document to the lightweight DataLakeConfig
  * the access filters operate on. Centralized so the `requiredEntitlement` field (and any
  * future field) cannot be silently dropped at one of the many former inline projections.

--- a/b4m-core/common/src/constants/dataLakes.ts
+++ b/b4m-core/common/src/constants/dataLakes.ts
@@ -681,20 +681,11 @@ export function lakeMatchesAccess(
 
 /**
  * The names of the access arms `DataLakeModel.findAccessible` ORs together, in the order that
- * method emits them (`packages/database/src/models/ai/DataLakeModel.ts`, built by
- * `buildAccessibleQuery`):
- *
- * - `owner`    - `createdByUserId` is the caller. Unconditional.
- * - `public`   - an `isPublic` lake, still AND-ed with the requirement gate. Dropped when
- *                `includePublic: false` (the archived/deleted MANAGEMENT views).
- * - `orgGate`  - org membership AND the requirement gate AND the not-private exclusion.
- * - `orgAdmin` - a lake in an org the caller administers, by those rights alone. Only when
- *                `administeredOrgIds` is non-empty.
- * - `grant`    - a lake the caller holds a persisted access grant on. Only when the caller
- *                passes a non-empty `grantedLakeIds`.
- * - `orgGrant` - a lake granted to one of the caller's orgs, ANDed with that granting org so the
- *                grant reaches no further. One disjunct per granting org, so this name can label
- *                several; dropped with the public arm when `includePublic: false`.
+ * method emits them. What each one admits, and the condition that includes it, lives with the code
+ * that implements it - `buildAccessibleQuery` in
+ * `packages/database/src/models/ai/DataLakeModel.ts` - deliberately NOT restated here, since a
+ * second copy of the semantics is pinned by nothing and would go stale invisibly from another
+ * package. `orgGrant` is the one name that can label several disjuncts (one per granting org).
  *
  * The `ctx.isAdmin` bypass is deliberately NOT an arm: it replaces the whole `$or` rather than
  * adding a disjunct, so an admin context yields zero arms.
@@ -703,8 +694,8 @@ export function lakeMatchesAccess(
  * query without naming it here (or naming it here without teaching the service-layer fake about
  * it) fails loudly instead of quietly weakening what those tests claim:
  *
- * - `packages/database/src/models/ai/DataLakeModel.accessArms.test.ts` - the built `$or` and this
- *   list stay parallel, and a maximal context reaches every name.
+ * - `packages/database/src/models/ai/DataLakeModel.accessArms.test.ts` - every label sits in front
+ *   of the disjunct it names, per context, and a maximal context reaches every name.
  * - `b4m-core/services/src/dataLakeService/dataLakeService.test.ts` - `ARM_COVERAGE` beside the
  *   in-memory `findAccessible` fake declares a position on every name (that fake is a deliberate
  *   SUBSET of the real query, so its job is arm awareness, not output equality).

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -11,6 +11,8 @@ import {
   type DataLakeStatus,
   type IDataLakeDocument,
   type IDataLakeBatchDocument,
+  FIND_ACCESSIBLE_ARMS,
+  type FindAccessibleArm,
 } from '@bike4mind/common';
 import {
   canAccessLake,
@@ -1426,11 +1428,41 @@ describe('management views - the grant reach is manage-scoped, not read-scoped',
  * fields and keep the row, so every lake the reach admits is a lake whose name and slug leave the
  * service, however little the caller may then do with it.
  *
- * findAccessible is faked rather than stubbed here - the four arms these cases turn on (creator,
- * member org, administered org, granted ids), mirroring DataLakeModel.findAccessible. It must stay
- * in sync with that method's arms to keep meaning what it claims.
+ * findAccessible is faked rather than stubbed here, so the fake has to take a position on each arm
+ * of the real DataLakeModel.findAccessible. It deliberately models a SUBSET of them - see
+ * ARM_COVERAGE below, whose keys are pinned to the shared FIND_ACCESSIBLE_ARMS inventory by a test
+ * in this file. What is enforced is arm AWARENESS, not output equality: matching the real query
+ * arm-for-arm would mean re-implementing the requirement gate, the not-private exclusion and the
+ * isAdmin bypass in JS, a second copy that can drift on its own with nothing proving the two agree.
+ * The database side of the same inventory is pinned in DataLakeModel.accessArms.test.ts.
  */
 describe("management views - an org grant on another org's lake discloses nothing", () => {
+  // One line per arm of the real findAccessible, saying how this fake models it or why these
+  // scenarios do not need it. Adding an arm to that method therefore fails HERE, next to the fake
+  // that would otherwise have silently stopped covering it.
+  const ARM_COVERAGE: Record<FindAccessibleArm, string> = {
+    owner: 'modeled: createdByUserId === actor.userId',
+    public:
+      'not modeled - no scenario here uses a public lake, and the management views these ' +
+      'cases exercise pass includePublic:false, which drops the arm from the real query too',
+    orgGate:
+      'modeled as membership only (actor.organizationIds contains the lake org); the real arm is ' +
+      'wider - it also admits an ORG-LESS lake, and ANDs the requirement gate and the not-private ' +
+      'exclusion, none of which these lakes exercise (every lake here is org-scoped and gate-less)',
+    orgAdmin: 'modeled: actor.administeredOrgIds contains the lake org - the arm these cases turn on',
+    grant: 'modeled: opts.grantedLakeIds contains the lake id, which is what the reach under test feeds it',
+    orgGrant:
+      'not modeled, deliberately - the management views under test pass includePublic:false and no ' +
+      'orgGrantedLakes, so the real query drops this arm too. That suppression is the property these ' +
+      'cases assert: an org grant on another org\'s lake must not name it in a restore/cleanup list',
+  };
+
+  it('accounts for every arm of the real findAccessible', () => {
+    // Fails when FIND_ACCESSIBLE_ARMS grows, which is the point: the new arm needs a decision here
+    // before the disclosure cases below can go on claiming what they claim.
+    expect(Object.keys(ARM_COVERAGE).sort()).toEqual([...FIND_ACCESSIBLE_ARMS].sort());
+  });
+
   const findAccessibleFake = (all: IDataLakeDocument[]) =>
     vi
       .fn()

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -662,37 +662,63 @@ describe('listDataLakes - grant-reachable lakes (#2034)', () => {
     expect(result.find(l => l.id === 'granted')).toBeUndefined();
   });
 
-  it.each([
-    ['listDataLakes', listDataLakes] as const,
-    ['listArchivedDataLakes', listArchivedDataLakes] as const,
-    ['listDeletedDataLakes', listDeletedDataLakes] as const,
-  ])('%s hands findAccessible an org grant keyed by the ISSUING org', async (_name, listFn) => {
+  const orgGrantDb = () => {
+    const findAccessible = vi.fn().mockResolvedValue([]);
+    return {
+      findAccessible,
+      db: {
+        dataLakes: { findAccessible, find: vi.fn() },
+        settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+        dataLakeAccessGrants: {
+          listActiveByLakes: vi.fn().mockResolvedValue([]),
+          listByPrincipal: vi.fn(async (type: string, id: string) =>
+            type === 'organization' && id === 'orgA'
+              ? [{ dataLakeId: 'granted', principalType: type, principalId: id, role: 'reader' }]
+              : []
+          ),
+        },
+      },
+    };
+  };
+
+  it('listDataLakes hands findAccessible an org grant keyed by the ISSUING org', async () => {
     // The issuer is the only thing that makes the org half safe: the datastore ANDs each org's ids
     // with `organizationId: <that org>` (DataLakeModel `orgGrantArms`), which is the only place the
     // lake's own org is known. Flattening the map into `grantedLakeIds` on the way here routes it
     // into the unconditional USER arm, and an orgA grant then lifts an orgB lake's gate for a caller
     // who belongs to both. Deep equality on purpose - `objectContaining` on `grantedLakeIds` alone
     // cannot see the org half move.
-    const findAccessible = vi.fn().mockResolvedValue([]);
-    const db = {
-      dataLakes: { findAccessible, find: vi.fn() },
-      settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
-      dataLakeAccessGrants: {
-        listActiveByLakes: vi.fn().mockResolvedValue([]),
-        listByPrincipal: vi.fn(async (type: string, id: string) =>
-          type === 'organization' && id === 'orgA'
-            ? [{ dataLakeId: 'granted', principalType: type, principalId: id, role: 'reader' }]
-            : []
-        ),
-      },
-    };
+    const { findAccessible, db } = orgGrantDb();
 
-    await listFn(ctx({ userId: 'me', organizationIds: ['orgA', 'orgB'] }), { db } as never);
+    await listDataLakes(ctx({ userId: 'me', organizationIds: ['orgA', 'orgB'] }), { db } as never);
 
     expect(findAccessible.mock.calls[0]![1]).toMatchObject({
       grantedLakeIds: [],
       orgGrantedLakes: { orgA: ['granted'] },
     });
+  });
+
+  it.each([
+    ['listArchivedDataLakes', listArchivedDataLakes] as const,
+    ['listDeletedDataLakes', listDeletedDataLakes] as const,
+  ])('%s hands findAccessible no org reach at all, and no reader row', async (_name, listFn) => {
+    // The management views ask the MANAGE reach, which is user-principal owner/curator only. The org
+    // half is not merely empty here, it is never resolved: `findAccessible` drops `orgGrantArms`
+    // under includePublic:false, so passing one would be inert, and an org grant carries no role to
+    // narrow it by. Absence rather than a flattened id list is the point - flattening would route it
+    // into the unconditional USER arm, which is the hazard the sibling test above describes.
+    const { findAccessible, db } = orgGrantDb();
+
+    await listFn(ctx({ userId: 'me', organizationIds: ['orgA', 'orgB'] }), { db } as never);
+
+    const opts = findAccessible.mock.calls[0]![1];
+    expect(opts).toMatchObject({ includePublic: false, grantedLakeIds: [] });
+    expect(opts.orgGrantedLakes).toBeUndefined();
+    expect(db.dataLakeAccessGrants.listByPrincipal).not.toHaveBeenCalledWith(
+      'organization',
+      expect.anything(),
+      expect.anything()
+    );
   });
 
   it('labels a reader-granted lake unmanageable even when another arm returns it', async () => {
@@ -1280,6 +1306,196 @@ describe('redactLakeForActor - editor-only fields on the raw-document exits', ()
     const result = await listDeletedDataLakes(ctx({ userId: 'me', organizationIds: ['orgA'] }), { db });
 
     expect('systemPrompt' in result[0]!).toBe(false);
+  });
+});
+
+/**
+ * The archived/deleted views pass includePublic:false on the stated ground that restore/cleanup is
+ * owner/admin-only, so a stranger must not see someone else's lake there - and then handed
+ * findAccessible the full READ reach, which admits `reader` rows and any-role org rows. A reader
+ * grant therefore did through the grant arm exactly what includePublic:false suppressed through the
+ * public arm. These pin the reach split by ROLE.
+ *
+ * Asserted on the findAccessible spy's `opts`, not on the returned rows: the reach is the thing
+ * under test, and a stub that echoed its input could not tell a narrowed reach from a wide one.
+ */
+describe('management views - the grant reach is manage-scoped, not read-scoped', () => {
+  // Dispatches on the principal so a membership org and an administered org are distinguishable -
+  // a stub returning one row for every call could not tell which arm asked.
+  const grantRepoFor = (rows: Record<string, { dataLakeId: string; role: string }[]>) => ({
+    listByPrincipal: vi
+      .fn()
+      .mockImplementation(
+        async (principalType: string, principalId: string) => rows[`${principalType}:${principalId}`] ?? []
+      ),
+    listActiveByLakes: vi.fn().mockResolvedValue([]),
+  });
+
+  // The cutover setting is ON here to prove the manage reach does not consult it. That is the only
+  // thing it proves at this level: the read reach's reader/org arms are ALSO held back by the
+  // source-level READ_GRANT_ENFORCEMENT_READY interlock, so with it false the two reaches happen to
+  // agree on a reader row here. The reaches are compared where they provably differ in
+  // resolveLakeReadAccess.test.ts; these cases guard the wiring and the role split.
+  const dbFor = (grants: ReturnType<typeof grantRepoFor>) => ({
+    dataLakes: { findAccessible: vi.fn().mockResolvedValue([]), find: vi.fn() },
+    dataLakeAccessGrants: grants,
+    settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+  });
+
+  const reachPassedTo = (db: ReturnType<typeof dbFor>): string[] =>
+    db.dataLakes.findAccessible.mock.calls[0][1].grantedLakeIds;
+
+  it('withholds a reader-granted lake from the archived view even with the cutover ON', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'reader' }] }));
+
+    await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(reachPassedTo(db)).toEqual([]);
+  });
+
+  it('still reaches an owner/curator-granted lake (the reach is narrowed, not closed)', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+
+    await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(reachPassedTo(db)).toEqual(['granted']);
+  });
+
+  it('withholds an ORG-principal grant whatever the caller holds in the granting org', async () => {
+    const orgRows = { 'organization:orgA': [{ dataLakeId: 'granted', role: 'owner' }] };
+
+    // Not by admin rights and not by membership: with no lake document in hand the reach cannot
+    // apply canManageLake's lake-org containment, and these views redact rather than exclude, so an
+    // org grant admitted here would disclose a lake in a DIFFERENT org (see the cross-org case
+    // below). A same-org lake is unaffected - findAccessible's own administeredOrgIds arm carries it.
+    const asAdmin = dbFor(grantRepoFor(orgRows));
+    await listArchivedDataLakes(ctx({ userId: 'me', administeredOrgIds: ['orgA'] }), { db: asAdmin });
+    expect(reachPassedTo(asAdmin)).toEqual([]);
+
+    const asMember = dbFor(grantRepoFor(orgRows));
+    await listDeletedDataLakes(ctx({ userId: 'me', organizationIds: ['orgA'] }), { db: asMember });
+    expect(reachPassedTo(asMember)).toEqual([]);
+  });
+
+  // The deleted view's docblock claims the archived view's rationale, so it must behave the same way.
+  it('applies the same split in the deleted view', async () => {
+    const reader = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'reader' }] }));
+    await listDeletedDataLakes(ctx({ userId: 'me' }), { db: reader });
+    expect(reachPassedTo(reader)).toEqual([]);
+
+    const curator = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+    await listDeletedDataLakes(ctx({ userId: 'me' }), { db: curator });
+    expect(reachPassedTo(curator)).toEqual(['granted']);
+  });
+
+  // The transitional view post-filters on canManageLake, so narrowing its reach cannot change its
+  // output - but it must not go the other way and start withholding a lake the filter would keep.
+  it('keeps a curator-granted lake reachable in the transitional view', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+
+    await listTransitionalDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(reachPassedTo(db)).toEqual(['granted']);
+  });
+
+  it('does not read the read-grant cutover flag at all', async () => {
+    const db = dbFor(grantRepoFor({ 'user:me': [{ dataLakeId: 'granted', role: 'curator' }] }));
+
+    await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    // A flag read here would mean an owner/curator grant - whose producers are live and unflagged -
+    // could be withheld by an operator toggle that has nothing to do with management.
+    expect(db.settings.getSettingsValue).not.toHaveBeenCalled();
+  });
+
+  it('degrades to an empty reach when no grant repo is wired', async () => {
+    const db = {
+      dataLakes: { findAccessible: vi.fn().mockResolvedValue([]), find: vi.fn() },
+      settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+    };
+
+    await listArchivedDataLakes(ctx({ userId: 'me', administeredOrgIds: ['orgA'] }), { db });
+
+    expect(db.dataLakes.findAccessible.mock.calls[0][1].grantedLakeIds).toEqual([]);
+  });
+});
+
+/**
+ * The cases above assert the reach on findAccessible's INPUT. These assert the views' output,
+ * because what the org arm's removal closes is a disclosure: the archived/deleted views redact
+ * fields and keep the row, so every lake the reach admits is a lake whose name and slug leave the
+ * service, however little the caller may then do with it.
+ *
+ * findAccessible is faked rather than stubbed here - the four arms these cases turn on (creator,
+ * member org, administered org, granted ids), mirroring DataLakeModel.findAccessible. It must stay
+ * in sync with that method's arms to keep meaning what it claims.
+ */
+describe("management views - an org grant on another org's lake discloses nothing", () => {
+  const findAccessibleFake = (all: IDataLakeDocument[]) =>
+    vi
+      .fn()
+      .mockImplementation(async (actor: AccessContext, opts: { grantedLakeIds?: string[] }) =>
+        all.filter(
+          l =>
+            l.createdByUserId === actor.userId ||
+            (!!l.organizationId &&
+              ((actor.organizationIds ?? []).includes(l.organizationId) ||
+                (actor.administeredOrgIds ?? []).includes(l.organizationId))) ||
+            (opts.grantedLakeIds ?? []).includes(l.id)
+        )
+      );
+
+  const dbWith = (all: IDataLakeDocument[], rows: Record<string, { dataLakeId: string; role: string }[]>) => ({
+    dataLakes: { findAccessible: findAccessibleFake(all), find: vi.fn() },
+    dataLakeAccessGrants: {
+      listByPrincipal: vi
+        .fn()
+        .mockImplementation(
+          async (principalType: string, principalId: string) => rows[`${principalType}:${principalId}`] ?? []
+        ),
+      listActiveByLakes: vi.fn().mockResolvedValue([]),
+    },
+    settings: { getSettingsValue: vi.fn().mockResolvedValue(true) },
+  });
+
+  // orgB's lake, an orgA owner grant, an orgA admin who has nothing else on it: canManageLake denies
+  // the manage, so the list must not name the lake either.
+  const crossOrg = () => ({
+    lakes: [lake({ id: 'theirs', slug: 'theirs', createdByUserId: 'other', organizationId: 'orgB' })],
+    grants: { 'organization:orgA': [{ dataLakeId: 'theirs', role: 'owner' }] },
+    actor: ctx({ userId: 'me', administeredOrgIds: ['orgA'] }),
+  });
+
+  it('keeps it out of the archived view', async () => {
+    const { lakes, grants, actor } = crossOrg();
+    const db = dbWith(lakes, grants);
+
+    expect(await listArchivedDataLakes(actor, { db })).toEqual([]);
+  });
+
+  it('keeps it out of the deleted view', async () => {
+    const { lakes, grants, actor } = crossOrg();
+    const db = dbWith(lakes, grants);
+
+    expect(await listDeletedDataLakes(actor, { db })).toEqual([]);
+  });
+
+  it("still shows an org MEMBER their own org's archived lake (the membership arm is untouched)", async () => {
+    const theirs = lake({ id: 'ours', slug: 'ours', createdByUserId: 'other', organizationId: 'orgA' });
+    const db = dbWith([theirs], {});
+
+    const result = await listArchivedDataLakes(ctx({ userId: 'me', organizationIds: ['orgA'] }), { db });
+
+    expect(result.map(l => l.id)).toEqual(['ours']);
+  });
+
+  it('still shows a USER owner grant, which carries its own authorization', async () => {
+    const theirs = lake({ id: 'theirs', slug: 'theirs', createdByUserId: 'other', organizationId: 'orgB' });
+    const db = dbWith([theirs], { 'user:me': [{ dataLakeId: 'theirs', role: 'owner' }] });
+
+    const result = await listArchivedDataLakes(ctx({ userId: 'me' }), { db });
+
+    expect(result.map(l => l.id)).toEqual(['theirs']);
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -22,7 +22,12 @@ import {
 } from '@bike4mind/common';
 import { canManageLake, canShredLakeMemory, isEffectiveOwner, type LakeGrant } from './manageRule';
 import { redactLakesForActor, type ReaderDataLake } from './redactLakeForActor';
-import { grantedLakeReachFor, resolveEnforceReadGrants, type LakeAccessLogger } from './resolveLakeReadAccess';
+import {
+  grantedLakeReachFor,
+  manageGrantedLakeIdsFor,
+  resolveEnforceReadGrants,
+  type LakeAccessLogger,
+} from './resolveLakeReadAccess';
 
 /** Grant-repo slice the list labels need: batch-read a set of lakes' grants, and one principal's. */
 type GrantLookup = Pick<IDataLakeAccessGrantRepository, 'listActiveByLakes' | 'listByPrincipal'>;
@@ -517,25 +522,25 @@ export const listAllDataLakes = async (
  * this is a management view (restore is owner/admin-only), so it must NOT surface strangers'
  * public lakes; the owner still sees their own archived public lake via the owner arm.
  *
- * Returns raw documents, and the org arm still yields lakes the caller does not own, so the
- * editor-only fields are redacted per lake before they leave the service.
+ * The grant reach is MANAGE-scoped (`manageGrantedLakeIdsFor`), not the read reach the browse list
+ * uses: a `reader` grant is read access and confers no restore, so admitting one here would have
+ * surfaced a stranger's lake in a cleanup list - the same outcome includePublic:false is set to
+ * prevent, arriving through the grant arm instead of the public one. No cutover flag is read: the
+ * roles this reach admits are live and unflagged (see manageGrantedLakeIdsFor).
+ *
+ * Returns raw documents, and the org-MEMBERSHIP arm still yields lakes the caller cannot manage
+ * (pre-existing and intended - org members see their org's archived lakes), so the editor-only
+ * fields are still redacted per lake before they leave the service.
  */
 export const listArchivedDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
 ): Promise<(IDataLakeDocument | ReaderDataLake)[]> => {
-  const includeReaders = await resolveEnforceReadGrants(db.settings);
-  const { grantedLakeIds, orgGrantedLakes } = await grantedLakeReachFor(
-    ctx.userId,
-    ctx.organizationIds ?? [],
-    db.dataLakeAccessGrants,
-    includeReaders
-  );
+  const grantedLakeIds = await manageGrantedLakeIdsFor(ctx.userId, db.dataLakeAccessGrants);
   const lakes = await db.dataLakes.findAccessible(ctx, {
     statuses: ['archived'],
     includePublic: false,
     grantedLakeIds,
-    orgGrantedLakes,
   });
   const grantsByLake = await grantsByLakeIdFor(lakes, db.dataLakeAccessGrants);
   return redactLakesForActor(lakes, ctx, grantsByLake);
@@ -544,25 +549,15 @@ export const listArchivedDataLakes = async (
 /**
  * Soft-deleted lakes accessible to the user (management view: cleanup / restore). includePublic:
  * false for the same reason as the archived view - a stranger has no management role on someone
- * else's public lake. Editor-only fields are redacted per lake, as in the archived view.
+ * else's public lake. The grant reach is MANAGE-scoped and the editor-only fields are redacted per
+ * lake, both for the archived view's reasons.
  */
 export const listDeletedDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
 ): Promise<(IDataLakeDocument | ReaderDataLake)[]> => {
-  const includeReaders = await resolveEnforceReadGrants(db.settings);
-  const { grantedLakeIds, orgGrantedLakes } = await grantedLakeReachFor(
-    ctx.userId,
-    ctx.organizationIds ?? [],
-    db.dataLakeAccessGrants,
-    includeReaders
-  );
-  const lakes = await db.dataLakes.findAccessible(ctx, {
-    statuses: ['deleted'],
-    includePublic: false,
-    grantedLakeIds,
-    orgGrantedLakes,
-  });
+  const grantedLakeIds = await manageGrantedLakeIdsFor(ctx.userId, db.dataLakeAccessGrants);
+  const lakes = await db.dataLakes.findAccessible(ctx, { statuses: ['deleted'], includePublic: false, grantedLakeIds });
   const grantsByLake = await grantsByLakeIdFor(lakes, db.dataLakeAccessGrants);
   return redactLakesForActor(lakes, ctx, grantsByLake);
 };
@@ -574,9 +569,11 @@ export const listDeletedDataLakes = async (
  * nowhere and can only be found by reading its id out of the datastore.
  *
  * Narrowed three ways against the archived/deleted views it otherwise mirrors:
- * - MANAGE-scoped, not read-scoped. The only action offered is a retry, which each lifecycle
- *   service restricts to owner/admin/org-manager, so a caller who cannot manage the lake could do
- *   nothing with the row. Filtering on `canManageLake` here also means nothing needs redacting.
+ * - MANAGE-scoped, not read-scoped, at BOTH ends: the grant reach is `manageGrantedLakeIdsFor` and
+ *   the rows are then filtered on `canManageLake`. The only action offered is a retry, which each
+ *   lifecycle service restricts to owner/admin/org-manager, so a caller who cannot manage the lake
+ *   could do nothing with the row. The post-filter also means nothing needs redacting, and it makes
+ *   the reach narrowing a no-op here: the rows it drops are rows the filter was already dropping.
  * - includePublic:false, for the same reason the archived view passes it: a stranger holds no
  *   management role on someone else's public lake.
  * - Cutoff-filtered, per status (see strandedCutoffMsFor). A lake that entered 'archiving'
@@ -587,18 +584,11 @@ export const listTransitionalDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
 ): Promise<TransitionalDataLakeSummary[]> => {
-  const includeReaders = await resolveEnforceReadGrants(db.settings);
-  const { grantedLakeIds, orgGrantedLakes } = await grantedLakeReachFor(
-    ctx.userId,
-    ctx.organizationIds ?? [],
-    db.dataLakeAccessGrants,
-    includeReaders
-  );
+  const grantedLakeIds = await manageGrantedLakeIdsFor(ctx.userId, db.dataLakeAccessGrants);
   const lakes = await db.dataLakes.findAccessible(ctx, {
     statuses: [...DATA_LAKE_TRANSITIONAL_STATUSES],
     includePublic: false,
     grantedLakeIds,
-    orgGrantedLakes,
   });
   const grantsByLake = await grantsByLakeIdFor(lakes, db.dataLakeAccessGrants);
   const now = Date.now();

--- a/b4m-core/services/src/dataLakeService/manageRule.test.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.test.ts
@@ -125,6 +125,20 @@ describe('canManageLake', () => {
     ).toBe(false);
   });
 
+  // Rung 5 used to compare the grant's org against the actor's admin rights and NOTHING else, so an
+  // orgX admin holding an org grant managed - and, since canAccessLake calls this first, also read -
+  // a lake belonging to orgY. Rung 4 above always compared; rung 5 did not.
+  it('rung 5: an ORG grant never reaches across orgs', () => {
+    const orgXAdmin = actor({ userId: 'member', administeredOrgIds: ['orgX'] });
+    const orgXGrant = [grant('organization', 'orgX', 'owner')];
+
+    // The hole: a lake owned by a DIFFERENT org.
+    expect(canManageLake(lake('creator', 'orgY'), orgXAdmin, orgXGrant)).toBe(false);
+    // Still granting, for the two shapes the rung exists to serve.
+    expect(canManageLake(lake('creator'), orgXAdmin, orgXGrant)).toBe(true);
+    expect(canManageLake(lake('creator', 'orgX'), orgXAdmin, orgXGrant)).toBe(true);
+  });
+
   it('denies a stranger with no grant and no org rights', () => {
     expect(canManageLake(lake('creator', 'org1'), actor({ userId: 'stranger' }))).toBe(false);
   });
@@ -152,6 +166,19 @@ describe('resolveLakeManageRung', () => {
         grant('organization', 'org-2', 'curator'),
       ])
     ).toBe('org-grant');
+  });
+
+  it('names no rung for a cross-org ORG grant, and still org-grant on the org-less lake', () => {
+    const orgXAdmin = actor({ userId: 'member', administeredOrgIds: ['orgX'] });
+    const orgXGrant = [grant('organization', 'orgX', 'owner')];
+
+    expect(resolveLakeManageRung(lake('creator', 'orgY'), orgXAdmin, orgXGrant)).toBeNull();
+    expect(resolveLakeManageRung(lake('creator'), orgXAdmin, orgXGrant)).toBe('org-grant');
+    // The org-LESS lake is the only shape that reports this rung: on a same-org lake the org-admin
+    // rung above fires first, and cross-org is now denied outright. Which is why the containment
+    // admits the org-less lake rather than demanding strict equality - strict equality would make
+    // rung 5 a subset of rung 4, and this rung (plus its persisted audit value) dead code.
+    expect(resolveLakeManageRung(lake('creator', 'orgX'), orgXAdmin, orgXGrant)).toBe('org-admin');
   });
 
   it('returns null for an actor who cannot manage the lake at all', () => {

--- a/b4m-core/services/src/dataLakeService/manageRule.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.ts
@@ -107,6 +107,23 @@ export function isEffectiveOwner(
 }
 
 /**
+ * Is an ORGANIZATION-principal grant contained to the lake it is granted on? True for an org-less
+ * lake (nothing to cross) or when the granted org IS the lake's own org; false for a lake belonging
+ * to a DIFFERENT org. Both sides are normalized because `lake.organizationId` may arrive as an
+ * ObjectId while `principalId` is always a string.
+ *
+ * Factored out rather than inlined twice: `canManageLake` and `resolveLakeManageRung` must agree on
+ * the org-grant rung, and a shared conjunct cannot drift between them.
+ *
+ * Org membership never crosses orgs (epic decision 12). The read arm enforces that at grant-WRITE
+ * time (see resolveReadGrant's sync note); the MANAGE rung enforces it here, at decision time, so an
+ * admin of orgA holding an org grant cannot manage - and therefore cannot read - an orgB lake.
+ */
+function isGrantOrgContained(grant: LakeGrant, lakeOrg: string | undefined): boolean {
+  return !lakeOrg || normalizeId(grant.principalId) === lakeOrg;
+}
+
+/**
  * The single WRITE/MANAGE decision for a lake, in ascending rungs (none weakens the gate; each only
  * ADDS a manager):
  *   1. platform admin;
@@ -115,7 +132,8 @@ export function isEffectiveOwner(
  *      ownership transfer and the visibility expose gate, which stay effective-owner-only;
  *   4. an admin of the lake's org (`lake.organizationId in actor.administeredOrgIds`) - the
  *      org-manageable rung: org lakes survive their creator because org admins manage them by role;
- *   5. an `owner`/`curator` ORG grant for an org the actor administers.
+ *   5. an `owner`/`curator` ORG grant for an org the actor administers, where that org is the
+ *      lake's OWN org (or the lake has none) - an org grant never reaches across orgs.
  *
  * Deliberately narrower than `canAccessLake` (read): a tag/entitlement/org-READ grant lets a member
  * read a lake but not write into it. `canAccessLake` calls THIS first, so every rung here also
@@ -146,7 +164,8 @@ export function canManageLake(
     g =>
       g.principalType === 'organization' &&
       (g.role === 'owner' || g.role === 'curator') &&
-      administeredOrgIds.includes(g.principalId)
+      administeredOrgIds.includes(g.principalId) &&
+      isGrantOrgContained(g, lakeOrg)
   );
 }
 
@@ -197,7 +216,8 @@ export function resolveLakeManageRung(
     g =>
       g.principalType === 'organization' &&
       (g.role === 'owner' || g.role === 'curator') &&
-      administeredOrgIds.includes(g.principalId)
+      administeredOrgIds.includes(g.principalId) &&
+      isGrantOrgContained(g, lakeOrg)
   );
   if (hasOrgGrant) return 'org-grant';
 

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
@@ -7,6 +7,7 @@ import {
   resolveReadGrant,
   resolveLakeReadAccess,
   resolveEnforceReadGrants,
+  manageGrantedLakeIdsFor,
   ENFORCE_LAKE_READ_GRANTS_KEY,
   READ_GRANT_ENFORCEMENT_READY,
 } from './resolveLakeReadAccess';
@@ -342,5 +343,60 @@ describe('grantedLakeReachFor - the two reach sets earn different bypasses', () 
 
   it('an unwired grant repo reaches nothing', async () => {
     expect(await grantedLakeReachFor('u1', ['orgA'])).toEqual({ grantedLakeIds: [], orgGrantedLakes: {} });
+  });
+});
+
+/**
+ * The two reaches, side by side on the SAME grant rows. The management views (archived/deleted/
+ * transitional) offer only restore/cleanup/retry, so they must ask the manage reach; the browse and
+ * read views ask the wide one. Compared directly rather than only through a list view because a
+ * view also depends on which arms `findAccessible` keeps - this is where the reaches themselves
+ * provably differ.
+ */
+describe('grant reach - read vs manage', () => {
+  const repo = (rows: Record<string, { dataLakeId: string; role: string }[]>) => ({
+    listByPrincipal: vi
+      .fn()
+      .mockImplementation(
+        async (principalType: string, principalId: string) => rows[`${principalType}:${principalId}`] ?? []
+      ),
+  });
+
+  it('the read reach admits a reader row under enforce; the manage reach never does', async () => {
+    const rows = { 'user:me': [{ dataLakeId: 'lake1', role: 'reader' }] };
+
+    // Called with includeReaders=true directly rather than through the setting, so this asserts the
+    // reach's own contract rather than the cutover's current position.
+    expect((await grantedLakeReachFor('me', [], repo(rows) as never, true)).grantedLakeIds).toEqual(['lake1']);
+    expect(await manageGrantedLakeIdsFor('me', repo(rows) as never)).toEqual([]);
+  });
+
+  it('both reaches admit owner and curator rows', async () => {
+    for (const role of ['owner', 'curator']) {
+      const rows = { 'user:me': [{ dataLakeId: 'lake1', role }] };
+      expect((await grantedLakeReachFor('me', [], repo(rows) as never, true)).grantedLakeIds).toEqual(['lake1']);
+      expect(await manageGrantedLakeIdsFor('me', repo(rows) as never)).toEqual(['lake1']);
+    }
+  });
+
+  it('the read reach resolves ORG-principal rows; the manage reach does not ask for them at all', async () => {
+    const rows = { 'organization:orgA': [{ dataLakeId: 'lake1', role: 'owner' }] };
+    const manageRepo = repo(rows);
+
+    // Read reach: membership in the granting org resolves the row, keyed by that org so the repo
+    // can AND it with the lake's own org.
+    expect(await grantedLakeReachFor('me', ['orgA'], repo(rows) as never, true)).toEqual({
+      grantedLakeIds: [],
+      orgGrantedLakes: { orgA: ['lake1'] },
+    });
+    // Manage reach: a bare id list, so it carries no granting org and asks for no org rows. The
+    // management views drop `orgGrantArms` anyway under includePublic:false.
+    expect(await manageGrantedLakeIdsFor('me', manageRepo as never)).toEqual([]);
+    expect(manageRepo.listByPrincipal).not.toHaveBeenCalledWith('organization', expect.anything(), expect.anything());
+  });
+
+  it('both degrade to an empty reach with no repo wired', async () => {
+    expect(await grantedLakeReachFor('me', ['orgA'])).toEqual({ grantedLakeIds: [], orgGrantedLakes: {} });
+    expect(await manageGrantedLakeIdsFor('me', undefined)).toEqual([]);
   });
 });

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
@@ -46,11 +46,16 @@ export interface LakeAccessLogger {
  * reader/curator/owner and to org-shared lakes) and it bypasses Private-by-default. `grants` is
  * pre-filtered to ACTIVE (expiry) by the caller, so a lapsed grant never reaches here.
  *
- * Role is intentionally not inspected here: any grant a principal holds admits a READ. Owner/curator
- * (and org owner/curator for an org ADMIN) already pass the legacy `owner-admin` arm via
- * canManageLake, so the outcomes this newly flips are (a) a user `reader` grant and (b) an org grant
- * of any role reaching a plain member - the gaps #1673 closes. The org read arm keys off MEMBERSHIP
- * (`ctx.organizationIds`), distinct from canManageLake's org-MANAGE arm, which keys off admin rights.
+ * Role is intentionally not inspected here: any grant a principal holds admits a READ. A user
+ * owner/curator grant already passes the legacy `owner-admin` arm via canManageLake, so the outcomes
+ * this newly flips are (a) a user `reader` grant and (b) an org grant of any role reaching a plain
+ * member - the gaps #1673 closes. The org read arm keys off MEMBERSHIP (`ctx.organizationIds`),
+ * distinct from canManageLake's org-MANAGE arm, which keys off admin rights.
+ *
+ * An org owner/curator grant held by an org ADMIN pre-passes that legacy arm only when the grant is
+ * contained to the lake's own org (or the lake has none) - canManageLake's org-grant rung compares
+ * the two. A CROSS-org org grant is denied there, so it arrives un-allowed and this arm would be
+ * what decides it; `containedGrants` strips the row before it gets here, so the two gates agree.
  *
  * THIS ARM never lets an org grant reach a lake outside the granting org. Scoped deliberately: the
  * claim is about the read-grant arm, not about the whole decision - the legacy `canManageLake` org
@@ -267,4 +272,33 @@ export const grantedLakeReachFor = async (
     grantedLakeIds: Array.from(ids),
     orgGrantedLakes: Object.fromEntries(Array.from(byOrg, ([orgId, lakeIds]) => [orgId, Array.from(lakeIds)])),
   };
+};
+
+/**
+ * Lake ids the caller can reach via a MANAGE-conferring active grant - the narrower sibling of
+ * `grantedLakeReachFor`, for the management views (archived / deleted / transitional) whose only
+ * offered action is a restore, cleanup or retry.
+ *
+ * Narrower two ways. By ROLE: owner/curator only, allow-listed rather than excluding `reader`, so a
+ * role added to DATA_LAKE_ACCESS_ROLES (called out there as an additive change) fails closed here
+ * until someone decides it manages. A reader grant is read access and confers no restore - the same
+ * ground these views already pass includePublic:false on.
+ *
+ * By PRINCIPAL: user grants only, so the return type is a bare id list rather than a
+ * `LakeGrantReach`. An org grant carries no role through `orgGrantArms`, so DataLakeModel already
+ * suppresses those arms alongside the public one whenever `includePublic:false` - which is exactly
+ * the three views this feeds. Resolving an org reach here would therefore be dead weight. Given up
+ * with it either way: an org-LESS lake carrying an org grant, which `orgGrantArms` also never
+ * matches. A SAME-org lake is unaffected - it arrives via findAccessible's own administeredOrgIds
+ * arm, which carries the lake-org containment an id list cannot.
+ *
+ * Reads no cutover flag, unlike `grantedLakeReachFor`'s `includeReaders`: owner/curator grants have
+ * live, unflagged producers (createDataLake, transferLakeOwnership) and the rungs that honor them
+ * are live too, so gating this on the read-grant cutover would withhold ids the manage gate accepts.
+ */
+export const manageGrantedLakeIdsFor = async (userId: string, grants?: PrincipalGrantLookup): Promise<string[]> => {
+  if (!grants) return [];
+  const rows = await grants.listByPrincipal('user', userId, { activeAsOf: new Date() });
+  const manageable = rows.filter(row => row.role === 'owner' || row.role === 'curator');
+  return Array.from(new Set(manageable.map(row => row.dataLakeId)));
 };

--- a/packages/database/src/models/ai/DataLakeModel.accessArms.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.accessArms.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FIND_ACCESSIBLE_ARMS } from '@bike4mind/common';
+import type { AccessContext, FindAccessibleArm } from '@bike4mind/common';
+import { DataLakeModel, dataLakeRepository, buildAccessibleQuery } from './DataLakeModel';
+
+/**
+ * `findAccessible`'s access arms are hand-built into a Mongo `$or`, and a second, in-memory
+ * hand-mirror of those same arms lives in the service layer's test fake
+ * (`b4m-core/services/src/dataLakeService/dataLakeService.test.ts`, `ARM_COVERAGE` beside
+ * `findAccessibleFake`). That fake carries the cross-org disclosure cases, which is a job it can
+ * only do while it knows about every arm - and an arm added here would otherwise leave it quietly
+ * asserting less than it claims, with a PASS either way.
+ *
+ * `FIND_ACCESSIBLE_ARMS` is the shared inventory that closes that gap; these are its
+ * database-side teeth. They assert the arm LABELS, not the query semantics: what each arm admits
+ * is pinned behaviorally, against real Mongo, in `DataLakeModel.test.ts` and the two
+ * `*ScopeAgreement.test.ts` files. Nothing here needs a database.
+ *
+ * No frozen byte-for-byte filter matrix on purpose: `buildAccessibleQuery` was extracted out of
+ * `findAccessible` unchanged, and that was verified by capturing the filter reaching
+ * `DataLakeModel.find` for every row of `CONTEXTS` before and after the extraction and diffing
+ * the two (identical). A committed copy of those literals would be a change-detector that fails
+ * on any legitimate edit while the Mongo-backed suites above are what actually catch a behavior
+ * change.
+ */
+
+const ctx = (over: Partial<AccessContext> = {}): AccessContext => ({
+  userId: 'u1',
+  isAdmin: false,
+  userTags: ['alpha'],
+  organizationIds: [],
+  ...over,
+});
+
+type Opts = Parameters<typeof buildAccessibleQuery>[1];
+
+const MAXIMAL = {
+  name: 'the maximal non-admin caller',
+  ctx: ctx({ organizationIds: ['o1'], administeredOrgIds: ['o3'], entitlementKeys: ['e-1'] }),
+  opts: { grantedLakeIds: ['l1'], orgGrantedLakes: { o1: ['l2'] }, includePublic: true } as Opts,
+  arms: [...FIND_ACCESSIBLE_ARMS],
+};
+
+// Each row names the arms the built `$or` should carry, in order. The four conditional arms are
+// each present in exactly one row and absent in another, so a condition inverted or dropped shows
+// up here rather than only in a Mongo-backed behavior test.
+const CONTEXTS: { name: string; ctx: AccessContext; opts?: Opts; arms: FindAccessibleArm[] }[] = [
+  { name: 'a plain caller', ctx: ctx(), arms: ['owner', 'public', 'orgGate'] },
+  {
+    name: 'an org member',
+    ctx: ctx({ organizationIds: ['o1', 'o2'] }),
+    arms: ['owner', 'public', 'orgGate'],
+  },
+  {
+    name: 'an org admin',
+    ctx: ctx({ administeredOrgIds: ['o3'] }),
+    arms: ['owner', 'public', 'orgGate', 'orgAdmin'],
+  },
+  {
+    name: 'a grant holder',
+    ctx: ctx(),
+    opts: { grantedLakeIds: ['l1'] },
+    arms: ['owner', 'public', 'orgGate', 'grant'],
+  },
+  {
+    // One disjunct per granting org, so `orgGrant` is the one name that repeats - the parallelism
+    // assertion below is what keeps the repeat honest.
+    name: 'an org-grant holder in two orgs',
+    ctx: ctx(),
+    opts: { orgGrantedLakes: { o1: ['l1'], o2: ['l2', 'l3'] } },
+    arms: ['owner', 'public', 'orgGate', 'orgGrant', 'orgGrant'],
+  },
+  {
+    name: 'a management view (includePublic: false) drops the public and org-grant arms',
+    ctx: ctx(),
+    opts: { includePublic: false, orgGrantedLakes: { o1: ['l1'] } },
+    arms: ['owner', 'orgGate'],
+  },
+  {
+    name: 'empty administeredOrgIds/grantedLakeIds/orgGrantedLakes add no arm',
+    ctx: ctx({ administeredOrgIds: [] }),
+    opts: { grantedLakeIds: [], orgGrantedLakes: { o1: [] } },
+    arms: ['owner', 'public', 'orgGate'],
+  },
+  MAXIMAL,
+  // The isAdmin bypass replaces the whole $or instead of adding a disjunct, so it labels no arm -
+  // and the parallelism assertion below still has to hold on it (0 arms, no $or).
+  { name: 'an admin', ctx: ctx({ isAdmin: true }), arms: [] },
+];
+
+describe('buildAccessibleQuery - arm labelling', () => {
+  it.each(CONTEXTS)('labels $name with the expected arms', ({ ctx: c, opts, arms }) => {
+    expect(buildAccessibleQuery(c, opts).arms).toEqual(arms);
+  });
+
+  it.each(CONTEXTS)('keeps arms parallel to the $or for $name', ({ ctx: c, opts }) => {
+    const { filter, arms } = buildAccessibleQuery(c, opts);
+    const or = (filter.$or as unknown[] | undefined) ?? [];
+    // An arm pushed into the $or without a label (or labelled without being pushed) lands here.
+    // If this fails, teach `FIND_ACCESSIBLE_ARMS` about the new arm AND give ARM_COVERAGE in
+    // dataLakeService.test.ts a position on it.
+    expect(or.length).toBe(arms.length);
+  });
+
+  it('reaches every declared arm and declares every arm it reaches', () => {
+    const reached = new Set<string>();
+    for (const row of CONTEXTS) for (const arm of buildAccessibleQuery(row.ctx, row.opts).arms) reached.add(arm);
+    expect([...reached].sort()).toEqual([...FIND_ACCESSIBLE_ARMS].sort());
+  });
+
+  it('is what findAccessible actually queries with', async () => {
+    let captured: unknown;
+    const spy = vi.spyOn(DataLakeModel, 'find').mockImplementation(((filter: unknown) => {
+      captured = filter;
+      return { select: () => [] } as never;
+    }) as never);
+
+    await dataLakeRepository.findAccessible(MAXIMAL.ctx, MAXIMAL.opts);
+    spy.mockRestore();
+
+    // Without this, the guards above could hold on a builder the shipped method had stopped using.
+    expect(captured).toEqual(buildAccessibleQuery(MAXIMAL.ctx, MAXIMAL.opts).filter);
+  });
+});

--- a/packages/database/src/models/ai/DataLakeModel.accessArms.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.accessArms.test.ts
@@ -37,7 +37,7 @@ type Opts = Parameters<typeof buildAccessibleQuery>[1];
 const MAXIMAL = {
   name: 'the maximal non-admin caller',
   ctx: ctx({ organizationIds: ['o1'], administeredOrgIds: ['o3'], entitlementKeys: ['e-1'] }),
-  opts: { grantedLakeIds: ['l1'], orgGrantedLakes: { o1: ['l2'] }, includePublic: true } as Opts,
+  opts: { grantedLakeIds: ['l1'], orgGrantedLakes: { o1: ['l2'] }, includePublic: true } satisfies Opts,
   arms: [...FIND_ACCESSIBLE_ARMS],
 };
 
@@ -93,13 +93,29 @@ describe('buildAccessibleQuery - arm labelling', () => {
     expect(buildAccessibleQuery(c, opts).arms).toEqual(arms);
   });
 
-  it.each(CONTEXTS)('keeps arms parallel to the $or for $name', ({ ctx: c, opts }) => {
+  // A count check alone cannot see a label that has drifted off the disjunct it names, and the
+  // labels are the whole product of this builder. One cheap shape probe per arm, each distinct
+  // enough to reject any of the others.
+  type Arm = Record<string, unknown>;
+  const conjuncts = (a: Arm): Arm[] => (a.$and as Arm[] | undefined) ?? [];
+  const SHAPE: Record<FindAccessibleArm, (a: Arm) => boolean> = {
+    owner: a => 'createdByUserId' in a,
+    public: a => conjuncts(a)[0]?.isPublic === true,
+    orgGate: a => conjuncts(a).length === 3,
+    orgAdmin: a => typeof a.organizationId === 'object' && !('_id' in a),
+    grant: a => '_id' in a && !('organizationId' in a),
+    orgGrant: a => '_id' in a && typeof a.organizationId === 'string',
+  };
+
+  it.each(CONTEXTS)('sits every label in front of the disjunct it names for $name', ({ ctx: c, opts }) => {
     const { filter, arms } = buildAccessibleQuery(c, opts);
-    const or = (filter.$or as unknown[] | undefined) ?? [];
-    // An arm pushed into the $or without a label (or labelled without being pushed) lands here.
-    // If this fails, teach `FIND_ACCESSIBLE_ARMS` about the new arm AND give ARM_COVERAGE in
-    // dataLakeService.test.ts a position on it.
+    const or = (filter.$or as Arm[] | undefined) ?? [];
+    // Fails on a disjunct pushed into the $or without a label (or labelled without being pushed),
+    // and on a label/disjunct misalignment the counts agree about. If this fails, teach
+    // `FIND_ACCESSIBLE_ARMS` about the new arm AND give ARM_COVERAGE in dataLakeService.test.ts a
+    // position on it.
     expect(or.length).toBe(arms.length);
+    arms.forEach((name, i) => expect(SHAPE[name](or[i])).toBe(true));
   });
 
   it('reaches every declared arm and declares every arm it reaches', () => {
@@ -115,8 +131,12 @@ describe('buildAccessibleQuery - arm labelling', () => {
       return { select: () => [] } as never;
     }) as never);
 
-    await dataLakeRepository.findAccessible(MAXIMAL.ctx, MAXIMAL.opts);
-    spy.mockRestore();
+    try {
+      await dataLakeRepository.findAccessible(MAXIMAL.ctx, MAXIMAL.opts);
+    } finally {
+      // Without the finally, a throw above leaves the `find` spy installed for the rest of the file.
+      spy.mockRestore();
+    }
 
     // Without this, the guards above could hold on a builder the shipped method had stopped using.
     expect(captured).toEqual(buildAccessibleQuery(MAXIMAL.ctx, MAXIMAL.opts).filter);

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -14,6 +14,7 @@ import type {
   BatchCounterField,
   AccessContext,
   DataLakeStatus,
+  FindAccessibleArm,
   LakeSettleFields,
   TaxonomyStatus,
   IDataLakeBatch,
@@ -319,6 +320,119 @@ const orgGrantArms = (orgGrantedLakes?: Record<string, string[]>): Record<string
 const LIST_PROJECTION = '-inconsistencyReport';
 const LIST_PROJECTION_FIELDS = { inconsistencyReport: 0 } as const;
 
+/**
+ * The pure filter build behind `findAccessible` - see that method's docblock for what the arms
+ * mean and why the unconstrained ones are unconstrained.
+ *
+ * Returns the Mongo `filter` plus `arms`: the names of the disjuncts in `filter.$or`, in the same
+ * order, drawn from `FIND_ACCESSIBLE_ARMS`. The labels exist so a new arm cannot be added here
+ * without being declared in that inventory and taken a position on by the service-layer fake -
+ * `DataLakeModel.accessArms.test.ts` asserts the two stay parallel. An `isAdmin` context emits no
+ * `$or` at all and therefore no arms.
+ */
+export const buildAccessibleQuery = (
+  ctx: AccessContext,
+  opts?: {
+    statuses?: DataLakeStatus[];
+    includePublic?: boolean;
+    grantedLakeIds?: string[];
+    orgGrantedLakes?: Record<string, string[]>;
+  }
+): { filter: Record<string, unknown>; arms: FindAccessibleArm[] } => {
+  const statuses = opts?.statuses ?? (['draft', 'active'] as DataLakeStatus[]);
+
+  // The isAdmin bypass replaces the whole $or rather than adding a disjunct to it, so it labels
+  // no arm.
+  if (ctx.isAdmin) return { filter: { status: { $in: statuses } }, arms: [] };
+
+  // Public lakes belong in the browse/read list, NOT the archived/deleted MANAGEMENT views:
+  // restore/cleanup are owner/admin-only, so a stranger has no role on someone else's public
+  // lake there. Those views pass includePublic:false; the owner still sees their own via the
+  // owner arm, and org members keep org lakes via the org arm (pre-existing, intended).
+  const includePublic = opts?.includePublic ?? true;
+
+  // Org constraint: lake has no org OR the lake's org is one the caller is a MEMBER of.
+  // `?? []`: a runtime belt against a malformed ctx, not a widening of the declared (required)
+  // type - a missing set must deny org-scoped lakes, not throw or vacuously allow them.
+  const memberOrgIds = ctx.organizationIds ?? [];
+  const orgConstraint =
+    memberOrgIds.length > 0
+      ? { $or: [{ organizationId: { $in: [null, ''] } }, { organizationId: { $in: memberOrgIds } }] }
+      : { organizationId: { $in: [null, ''] } };
+
+  const requirement = requirementConstraint(ctx.userTags, ctx.entitlementKeys);
+
+  // Not-private: exclude lakes with no org AND no gate at all. Such a lake grants a
+  // non-owner nothing, so it must stay owner-only rather than read-by-anyone. Uses the
+  // null/'' form + $nor (DocumentDB-safe) consistent with the rest of this model.
+  const notPrivate = {
+    $nor: [
+      {
+        $and: [
+          { $or: [{ organizationId: null }, { organizationId: '' }] },
+          { $or: [{ requiredUserTag: null }, { requiredUserTag: '' }] },
+          { $or: [{ requiredEntitlement: null }, { requiredEntitlement: '' }] },
+        ],
+      },
+    ],
+  };
+
+  // Public arm: an isPublic lake is accessible app-wide - it bypasses the org prerequisite
+  // AND the not-private exclusion (a public gateless lake IS meant to be world-readable). The
+  // requirement constraint is still ANDed as defense in depth, so a gate added after publishing
+  // keeps holding while a normal (gate-less) public lake passes via requirementConstraint's
+  // both-blank arm.
+  const publicArm = { $and: [{ isPublic: true }, requirement] };
+
+  // Non-owner arms: the org/gate arm always applies; the public arm only in browse/read views
+  // (dropped for management views via includePublic - see the note at the top of this method).
+  const nonOwnerArms: [FindAccessibleArm, Record<string, unknown>][] = [
+    ['orgGate', { $and: [orgConstraint, requirement, notPrivate] }],
+  ];
+  if (includePublic) nonOwnerArms.unshift(['public', publicArm]);
+
+  // Org-admin arm (#2005): a lake in an org the caller holds ADMIN rights in, reachable by those
+  // rights alone - the analog of the owner arm, for the same reason (the gate admits them via
+  // canManageLake before it ever reaches the org prerequisite). Keyed off `administeredOrgIds`
+  // (billing owner OR managerId OR adminUserIds), deliberately a DIFFERENT set from the
+  // `organizationIds` membership the org arm above uses: membership also decides what the account
+  // switcher offers as a write target (see `orgMembershipFilter`), so widening membership to fix
+  // this would have handed a team manager the org as somewhere to write as. The two sets are meant
+  // to differ; what was wrong was that only one of them reached this query. Applies to the
+  // management views too (includePublic:false): restore/cleanup are owner/admin-only and an org
+  // admin is in that class - `redactLakesForActor` agrees, keying off the same `canManageLake`.
+  // Served by the existing { organizationId: 1, status: 1 } index.
+  const administeredOrgIds = ctx.administeredOrgIds ?? [];
+  if (administeredOrgIds.length > 0) nonOwnerArms.push(['orgAdmin', { organizationId: { $in: administeredOrgIds } }]);
+
+  // Explicit-grant arm (#1668): a lake the caller holds an active access grant on is reachable by
+  // that grant alone - the grant IS the authorization, so it needs none of the org/gate constraints
+  // (it is the analog of the createdByUserId owner bypass, extended to a transferred/delegated
+  // owner-curator-reader). The ids are pre-resolved by the caller from listByPrincipal (an empty
+  // list adds no arm). This covers ONLY persisted grant rows; the ephemeral tag/entitlement view is
+  // #1673's separate concern.
+  const grantedLakeIds = opts?.grantedLakeIds ?? [];
+  if (grantedLakeIds.length > 0) nonOwnerArms.push(['grant', { _id: { $in: grantedLakeIds } }]);
+
+  // ORG-principal grant arms, one per granting org (see `orgGrantArms`), so this is the one arm
+  // name that can label MORE than one disjunct. Suppressed alongside the public arm in the
+  // archived/deleted MANAGEMENT views: an org grant carries no role here, so a reader-level one
+  // must not surface someone else's lake in a restore/cleanup list.
+  if (includePublic) {
+    for (const arm of orgGrantArms(opts?.orgGrantedLakes)) nonOwnerArms.push(['orgGrant', arm]);
+  }
+
+  const labelled: [FindAccessibleArm, Record<string, unknown>][] = [
+    ['owner', { createdByUserId: ctx.userId }],
+    ...nonOwnerArms,
+  ];
+
+  return {
+    filter: { status: { $in: statuses }, $or: labelled.map(([, arm]) => arm) },
+    arms: labelled.map(([name]) => name),
+  };
+};
+
 class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements IDataLakeRepository {
   constructor(private dataLakeModel: mongoose.Model<IDataLakeDocument>) {
     super(dataLakeModel);
@@ -526,86 +640,7 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
       orgGrantedLakes?: Record<string, string[]>;
     }
   ): Promise<IDataLakeDocument[]> {
-    const statuses = opts?.statuses ?? (['draft', 'active'] as DataLakeStatus[]);
-    // Public lakes belong in the browse/read list, NOT the archived/deleted MANAGEMENT views:
-    // restore/cleanup are owner/admin-only, so a stranger has no role on someone else's public
-    // lake there. Those views pass includePublic:false; the owner still sees their own via the
-    // owner arm, and org members keep org lakes via the org arm (pre-existing, intended).
-    const includePublic = opts?.includePublic ?? true;
-
-    // Org constraint: lake has no org OR the lake's org is one the caller is a MEMBER of.
-    // `?? []`: a runtime belt against a malformed ctx, not a widening of the declared (required)
-    // type - a missing set must deny org-scoped lakes, not throw or vacuously allow them.
-    const memberOrgIds = ctx.organizationIds ?? [];
-    const orgConstraint =
-      memberOrgIds.length > 0
-        ? { $or: [{ organizationId: { $in: [null, ''] } }, { organizationId: { $in: memberOrgIds } }] }
-        : { organizationId: { $in: [null, ''] } };
-
-    const requirement = requirementConstraint(ctx.userTags, ctx.entitlementKeys);
-
-    // Not-private: exclude lakes with no org AND no gate at all. Such a lake grants a
-    // non-owner nothing, so it must stay owner-only rather than read-by-anyone. Uses the
-    // null/'' form + $nor (DocumentDB-safe) consistent with the rest of this model.
-    const notPrivate = {
-      $nor: [
-        {
-          $and: [
-            { $or: [{ organizationId: null }, { organizationId: '' }] },
-            { $or: [{ requiredUserTag: null }, { requiredUserTag: '' }] },
-            { $or: [{ requiredEntitlement: null }, { requiredEntitlement: '' }] },
-          ],
-        },
-      ],
-    };
-
-    // Public arm: an isPublic lake is accessible app-wide - it bypasses the org prerequisite
-    // AND the not-private exclusion (a public gateless lake IS meant to be world-readable). The
-    // requirement constraint is still ANDed as defense in depth, so a gate added after publishing
-    // keeps holding while a normal (gate-less) public lake passes via requirementConstraint's
-    // both-blank arm.
-    const publicArm = { $and: [{ isPublic: true }, requirement] };
-
-    // Non-owner arms: the org/gate arm always applies; the public arm only in browse/read views
-    // (dropped for management views via includePublic - see the note at the top of this method).
-    const nonOwnerArms: Record<string, unknown>[] = [{ $and: [orgConstraint, requirement, notPrivate] }];
-    if (includePublic) nonOwnerArms.unshift(publicArm);
-
-    // Org-admin arm (#2005): a lake in an org the caller holds ADMIN rights in, reachable by those
-    // rights alone - the analog of the owner arm, for the same reason (the gate admits them via
-    // canManageLake before it ever reaches the org prerequisite). Keyed off `administeredOrgIds`
-    // (billing owner OR managerId OR adminUserIds), deliberately a DIFFERENT set from the
-    // `organizationIds` membership the org arm above uses: membership also decides what the account
-    // switcher offers as a write target (see `orgMembershipFilter`), so widening membership to fix
-    // this would have handed a team manager the org as somewhere to write as. The two sets are meant
-    // to differ; what was wrong was that only one of them reached this query. Applies to the
-    // management views too (includePublic:false): restore/cleanup are owner/admin-only and an org
-    // admin is in that class - `redactLakesForActor` agrees, keying off the same `canManageLake`.
-    // Served by the existing { organizationId: 1, status: 1 } index.
-    const administeredOrgIds = ctx.administeredOrgIds ?? [];
-    if (administeredOrgIds.length > 0) nonOwnerArms.push({ organizationId: { $in: administeredOrgIds } });
-
-    // Explicit USER-grant arm (#1668): a lake the caller holds an active user-principal grant on is
-    // reachable by that grant alone - the grant IS the authorization, so it needs none of the
-    // org/gate constraints (it is the analog of the createdByUserId owner bypass, extended to a
-    // transferred/delegated owner-curator-reader, and it is MEANT to cross orgs). The ids are
-    // pre-resolved by the caller from listByPrincipal (an empty list adds no arm). This covers ONLY
-    // persisted grant rows; the ephemeral tag/entitlement view is #1673's separate concern.
-    const grantedLakeIds = opts?.grantedLakeIds ?? [];
-    if (grantedLakeIds.length > 0) nonOwnerArms.push({ _id: { $in: grantedLakeIds } });
-
-    // ORG-principal grant arms, one per granting org (see `orgGrantArms`). Suppressed alongside the
-    // public arm in the archived/deleted MANAGEMENT views: an org grant carries no role here, so a
-    // reader-level one must not surface someone else's lake in a restore/cleanup list.
-    if (includePublic) nonOwnerArms.push(...orgGrantArms(opts?.orgGrantedLakes));
-
-    const filter: Record<string, unknown> = ctx.isAdmin
-      ? { status: { $in: statuses } }
-      : {
-          status: { $in: statuses },
-          $or: [{ createdByUserId: ctx.userId }, ...nonOwnerArms],
-        };
-
+    const { filter } = buildAccessibleQuery(ctx, opts);
     const results = await this.dataLakeModel.find(filter).select(LIST_PROJECTION);
     return results.map(r => r.toJSON() as IDataLakeDocument);
   }


### PR DESCRIPTION
# Pull Request

## Description
`DataLakeModel.findAccessible` builds a Mongo `$or` out of five access arms (owner, public, org-membership, org-admin, explicit grant). The service layer keeps a second, hand-written in-memory mirror of those same arms in a test fake (`findAccessibleFake` in `dataLakeService.test.ts`) so it can drive the cross-org disclosure tests without a database. Nothing enforced that the two stayed in sync: a sixth arm added to the real query would leave the fake silently modeling fewer arms than the real method has, while the disclosure tests kept passing anyway.

This PR adds a shared, named inventory of arm labels and pins both sides against it, so a new arm now fails loudly in whichever suite has not been taught about it yet, instead of degrading a suite's guarantee with no signal.

No behavior change: `findAccessible`'s emitted `$or` is byte-identical before and after.

## Changes
- `b4m-core/common/src/constants/dataLakes.ts`: add `FIND_ACCESSIBLE_ARMS`, the ordered list of arm names, next to the shared `lakeMatchesAccess` predicate both packages already import.
- `packages/database/src/models/ai/DataLakeModel.ts`: extract `findAccessible`'s filter construction into a pure `buildAccessibleQuery(ctx, opts)` that returns `{ filter, arms }`. The `$or` it builds and the order of its disjuncts are unchanged; only the labels are new.
- `packages/database/src/models/ai/DataLakeModel.accessArms.test.ts` (new): asserts the built `$or` and `arms` stay parallel in length across a context matrix, and that the matrix collectively reaches every name in `FIND_ACCESSIBLE_ARMS`.
- `b4m-core/services/src/dataLakeService/dataLakeService.test.ts`: the fake gets an `ARM_COVERAGE` map declaring, per arm, whether and how it's modeled (it deliberately models a subset - no public arm, no requirement gate, no not-private exclusion, no `isAdmin` bypass). A new test pins `ARM_COVERAGE`'s keys to `FIND_ACCESSIBLE_ARMS`.

## Guide for Testers
Backend/test-infrastructure only - no user-facing behavior changed.

**What NOT to test:** there is nothing to exercise in the running app; `findAccessible`'s query output is unchanged. Verification is at the test-suite level only (see below).

**Regression checks (reproduce locally):**
1. Run `pnpm --filter @bike4mind/database test` - passes (195 files, 2519 tests, 1 skipped).
2. Run `pnpm --filter @bike4mind/services test` - passes (390 files, 6474 tests, 12 skipped).
3. Run `pnpm turbo:typecheck` - passes.
4. Run `pnpm lint:check` - passes.
5. To see the guard actually catch something: add a sixth name to `FIND_ACCESSIBLE_ARMS` and rerun `pnpm --filter @bike4mind/services test` - the new `ARM_COVERAGE` pin test fails. Revert that, instead push an unlabeled disjunct into `buildAccessibleQuery`'s `$or` and rerun `pnpm --filter @bike4mind/database test` - the arms/`$or` parallelism test fails.

## Additional Information
Stacked on #2566 (the org-grant containment fix this branch builds on) and cannot merge before it. Raised originally as a P3 on that PR's review and deliberately deferred rather than folded in there, since it restructures a shipped query builder.

Reviewed with 0 P0 / 0 P1. Two items left open, neither blocking:
- P2: consider whether `buildAccessibleQuery`'s pure extraction deserves its own unit beyond the guard tests (deferred - the existing Mongo-backed suites already pin its behavior).
- P2 (and 9 P3s): minor naming/comment suggestions on the new inventory and guard tests.

## Developer Notes (Optional)
- `FIND_ACCESSIBLE_ARMS` (`@bike4mind/common`) and `buildAccessibleQuery` (`@bike4mind/database`) are now the seam for this access model: any future arm added to `findAccessible` should be added there first, which is what forces both test suites to take a position on it.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [ ] If adding/modifying telemetry fields - N/A, no telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
