### PR TITLE
fix(lake-memory): stamp the purge-fence test timestamp at call time, not at setup

### DIFF
--- a/apps/client/server/dataLakes/extractLakeMemoryPurgeFence.test.ts
+++ b/apps/client/server/dataLakes/extractLakeMemoryPurgeFence.test.ts
@@ -97,10 +97,14 @@ const seedLake = (docCount: number, lakeOver: Record<string, unknown> = {}) => {
 const PLENTY_OF_TIME = { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 };
 
 /**
- * A purge that lands AFTER the run claimed its lease - the only kind the fence refuses. Evaluated when
- * the mock is called, so it necessarily post-dates the run's `claimedAt`. A hardcoded past timestamp
- * would describe a purge that PREDATES the run, which the fence deliberately lets through so a rebuild
- * can re-key a lake that was erased once already.
+ * A purge that lands AFTER the run claimed its lease - the only kind the fence refuses. A hardcoded past
+ * timestamp would describe a purge that PREDATES the run, which the fence deliberately lets through so a
+ * rebuild can re-key a lake that was erased once already.
+ *
+ * MUST be called from inside a `mockImplementation`, never passed to `mockResolvedValue`: that argument
+ * is evaluated eagerly at setup, so the stamp would predate the `claimedAt` taken inside
+ * extractLakeMemoryForBatch and the `>=` fence would only trip when both landed in the same millisecond.
+ * That is what made this suite fail under CI scheduling contention while passing locally.
  */
 const purgedNow = () => new Date();
 
@@ -142,7 +146,7 @@ describe('extractLakeMemoryForBatch purge fence', () => {
     // hasMore drives the handler's re-enqueue. A purged lake that still asked for a continuation would
     // keep billing LLM work to rebuild exactly what was just erased.
     seedLake(10);
-    getLakeMemoryFenceMock.mockResolvedValue({ exists: true, purgedAt: purgedNow() });
+    getLakeMemoryFenceMock.mockImplementation(async () => ({ exists: true, purgedAt: purgedNow() }));
 
     const result = await extractLakeMemoryForBatch(PLENTY_OF_TIME, makeLogger() as never);
 
@@ -329,7 +333,7 @@ describe('extractLakeMemoryForBatch purge fence', () => {
     // The lease is deliberately NOT cleared by the purge itself, precisely so this run releases it -
     // otherwise a post-purge rebuild would 409 until the lease aged out.
     seedLake(10);
-    getLakeMemoryFenceMock.mockResolvedValue({ exists: true, purgedAt: purgedNow() });
+    getLakeMemoryFenceMock.mockImplementation(async () => ({ exists: true, purgedAt: purgedNow() }));
 
     await extractLakeMemoryForBatch(PLENTY_OF_TIME, makeLogger() as never);
 


### PR DESCRIPTION
## What

`extractLakeMemoryPurgeFence.test.ts` has been failing intermittently in the `client 3/3` shard on
unrelated PRs. Two of its mocks stamp the purge timestamp a moment too early, so the fence they are
testing only trips when two `new Date()` calls land in the same millisecond.

## Why it fails

The fence in `extractLakeMemory.ts:226` is:

```ts
return !!fence.purgedAt && fence.purgedAt.getTime() >= claimedAt.getTime();
```

`claimedAt` is taken *inside* `extractLakeMemoryForBatch`, at call time. The `>=` is deliberate and
documented - a purge stamped in the same millisecond must fail closed.

Two tests set the mock up like this:

```ts
getLakeMemoryFenceMock.mockResolvedValue({ exists: true, purgedAt: purgedNow() });
```

`mockResolvedValue`'s argument is evaluated **eagerly**, at setup, so `purgedAt` is stamped strictly
before `claimedAt`. If the clock ticks one millisecond between the two - a scheduling gap, which CI
contention makes likely and an idle laptop makes rare - `purgedAt < claimedAt`, the fence reads as
unmoved, the run processes all 10 documents, and the assertion sees `docsProcessed: 10` instead of
`0`.

The `purgedNow` helper's own docblock already claimed the invariant that prevents this - "Evaluated
when the mock is called, so it necessarily post-dates the run's `claimedAt`" - which holds at the
three `mockImplementation` sites in the same file and is simply not true of the two
`mockResolvedValue` ones.

## Fix

Move those two to `mockImplementation`, matching the three sites that already do it, so `purgedAt`
really is stamped at call time and lands after `claimedAt` unconditionally. Then make the docblock
say what actually guarantees it, so the next person does not reintroduce the eager form.

No production code changes. `extractLakeMemory.ts` is untouched.

## Guide for Testers

There is no user-facing surface; this is a test-determinism fix.

1. **Confirm it passes repeatedly.**
   `pnpm --filter @bike4mind/client exec vitest run server/dataLakes/extractLakeMemoryPurgeFence.test.ts --project node`
   run several times in a row - all green.
2. **Confirm the fix is what makes it deterministic.** Temporarily change the fence in
   `extractLakeMemory.ts:226` to `>= claimedAt.getTime() + 1`, which forces the exact
   one-millisecond skew CI hits. On `main` the two tests below fail; on this branch they still pass.
   Revert the edit afterwards.
   - `does not ask for a continuation run, so the chain ends with the purge`
   - `releases the extraction lease when it stops on the fence`
3. **Confirm the shard is green.** `pnpm --filter @bike4mind/client test --shard=3/3`.

## Regression areas

- Lake-memory purge-fence behaviour is unchanged - only the test's mock timing moves. The three
  `mockImplementation` sites, the two hardcoded past-timestamp tests (a purge that predates the run,
  which the fence deliberately lets through), and the lake-deleted arm are all untouched.

## What NOT to test

- Anything about purge semantics in production. No source file changed.
