### PR TITLE
fix(data-lake): attribute key-driven auto-activate rows to the key

### DIFF
--- a/apps/client/pages/api/files/[id]/__tests__/index.put.test.ts
+++ b/apps/client/pages/api/files/[id]/__tests__/index.put.test.ts
@@ -131,13 +131,14 @@ const makeRes = () => {
 // a real 24-hex ObjectId string rather than a readable slug.
 const FILE_ID = '507f1f77bcf86cd799439011';
 
-const req = (body: unknown, id: string = FILE_ID, userId = 'u1') =>
+const req = (body: unknown, id: string = FILE_ID, userId = 'u1', apiKeyInfo?: { keyId: string }) =>
   ({
     method: 'PUT',
     user: { id: userId, isAdmin: false },
     ability: {},
     query: { id },
     body,
+    apiKeyInfo,
     logger: { updateMetadata: vi.fn(), error: vi.fn(), warn: vi.fn() },
   }) as never;
 
@@ -146,6 +147,9 @@ const run = (body: unknown, res: unknown, id?: string) =>
 
 const runAs = (userId: string, body: unknown, res: unknown) =>
   (handler as (req: unknown, res: unknown) => Promise<void>)(req(body, FILE_ID, userId), res);
+
+const runWithKey = (keyId: string, body: unknown, res: unknown) =>
+  (handler as (req: unknown, res: unknown) => Promise<void>)(req(body, FILE_ID, 'u1', { keyId }), res);
 
 const fabFile = (overrides: Record<string, unknown> = {}) => ({
   id: FILE_ID,
@@ -266,6 +270,31 @@ describe('PUT /api/files/[id] - data-lake tags', () => {
         // activateIfDraft checks nothing (see recomputeLakeStats).
         manageRung: 'system',
         changes: [expect.objectContaining({ field: 'status', before: 'draft', after: 'active' })],
+      })
+    );
+  });
+
+  // The API-key half of the case above, on the same real chain. #1964 fixed this misattribution on
+  // the tag-toggle door; the PUT door had the identical gap - the route attached no principal, so
+  // `updateFabFile` built its `reconcileLakeTags` actor without one and the fallback named the
+  // human. Dropping the route's `auditPrincipal` line turns this red while every other case here
+  // stays green.
+  it('names the API key, not the human, when a key-driven join publishes a draft lake', async () => {
+    h.findByDatalakeTag.mockResolvedValue({ ...LAKE, status: 'draft' });
+    h.findUpdateAccessById.mockResolvedValue(fabFile({ tags: [] }));
+    makeStatefulFabFile({ id: FILE_ID, userId: 'u1', tags: [] });
+    h.computeDataLakeStats.mockResolvedValue({ fileCount: 1, totalSizeBytes: 12, totalChunkedChars: 0 });
+    h.activateIfDraft.mockResolvedValue(true);
+    const { res } = makeRes();
+
+    await runWithKey('key-abc', { tags: [{ name: META, strength: 1 }] }, res);
+
+    expect(h.recordConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'auto-activate',
+        principalKind: 'apiKey',
+        principalId: 'key-abc',
+        onBehalfOfUserId: 'u1',
       })
     );
   });

--- a/apps/client/pages/api/files/[id]/index.ts
+++ b/apps/client/pages/api/files/[id]/index.ts
@@ -176,6 +176,9 @@ const handler = baseApi()
             // wide as the prologue gate above - the org rungs of `canManageLake` cannot be derived
             // from the user document this service is handed.
             administeredOrgIds: ctx.administeredOrgIds,
+            // Same reason the DELETE handler below attaches one: a tag write here can flip a draft
+            // lake to active, and this route accepts a `b4m_live_` key.
+            auditPrincipal: lakeConfigAuditPrincipal(req.user, req.apiKeyInfo),
             logger: req.logger,
             storage: {
               upload: (filepath, content, option) => {

--- a/apps/client/pages/api/files/tags/[id].ts
+++ b/apps/client/pages/api/files/tags/[id].ts
@@ -4,6 +4,7 @@ import { BadRequestError, ForbiddenError } from '@server/utils/errors';
 import { tagService } from '@bike4mind/services';
 import { dataLakeRepository, fabFileRepository, fileTagRepository, userRepository } from '@bike4mind/database';
 import { lakeConfigAuditDb } from '@server/dataLakes/lakeConfigAuditDb';
+import { lakeConfigAuditPrincipal } from '@server/dataLakes/lakeConfigAuditPrincipal';
 
 type TagIdQuery = { id?: string | string[] };
 
@@ -53,6 +54,9 @@ const handler = baseApi()
           // Threaded so a failed audit write on that flip is reported through the request logger
           // rather than console.warn, which alerting cannot see.
           logger: req.logger,
+          // This route accepts a `b4m_live_` key, so without this a key-driven rename that flips a
+          // draft lake to active records the human it acts for instead of the key.
+          auditPrincipal: lakeConfigAuditPrincipal(req.user, req.apiKeyInfo),
         }
       );
 
@@ -80,6 +84,7 @@ const handler = baseApi()
           },
           // Same reason as the rename above.
           logger: req.logger,
+          auditPrincipal: lakeConfigAuditPrincipal(req.user, req.apiKeyInfo),
         }
       );
 

--- a/apps/client/pages/api/files/tags/__tests__/[id].test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/[id].test.ts
@@ -102,6 +102,39 @@ describe('PUT /api/files/tags/[id]', () => {
     expect(params).toEqual({ id: 'from-url', name: 'receipts' });
   });
 
+  // Sibling of #1964: a prefix-arm rename can flip a draft lake to active, and this route accepts
+  // a `b4m_live_` key, so without the principal that row named the human it acts for. The service
+  // treats `auditPrincipal` as optional, so dropping the route's line would still compile and
+  // silently misattribute, with no other assertion here going red.
+  it('resolves the caller as the auditPrincipal for a key-authenticated rename', async () => {
+    const { res } = makeRes();
+
+    await call(
+      {
+        method: 'PUT',
+        query: { id: 't1' },
+        body: { id: 't1', name: 'receipts' },
+        user: { id: 'u1' },
+        apiKeyInfo: { keyId: 'key-abc' },
+      },
+      res
+    );
+
+    expect(h.update.mock.calls[0][2].auditPrincipal).toEqual({
+      principalKind: 'apiKey',
+      principalId: 'key-abc',
+      onBehalfOfUserId: 'u1',
+    });
+  });
+
+  it('passes no auditPrincipal for an ordinary session rename', async () => {
+    const { res } = makeRes();
+
+    await call({ method: 'PUT', query: { id: 't1' }, body: { id: 't1', name: 'receipts' }, user: { id: 'u1' } }, res);
+
+    expect(h.update.mock.calls[0][2].auditPrincipal).toBeUndefined();
+  });
+
   it('rejects an unauthenticated request before reaching the service', async () => {
     const { res } = makeRes();
 
@@ -174,5 +207,25 @@ describe('DELETE /api/files/tags/[id]', () => {
 
     const [, params] = h.remove.mock.calls[0];
     expect(params).toEqual({ id: 't1' });
+  });
+
+  it('resolves the caller as the auditPrincipal for a key-authenticated delete', async () => {
+    const { res } = makeRes();
+
+    await call({ method: 'DELETE', query: { id: 't1' }, user: { id: 'u1' }, apiKeyInfo: { keyId: 'key-abc' } }, res);
+
+    expect(h.remove.mock.calls[0][2].auditPrincipal).toEqual({
+      principalKind: 'apiKey',
+      principalId: 'key-abc',
+      onBehalfOfUserId: 'u1',
+    });
+  });
+
+  it('passes no auditPrincipal for an ordinary session delete', async () => {
+    const { res } = makeRes();
+
+    await call({ method: 'DELETE', query: { id: 't1' }, user: { id: 'u1' } }, res);
+
+    expect(h.remove.mock.calls[0][2].auditPrincipal).toBeUndefined();
   });
 });

--- a/apps/client/pages/api/files/tags/__tests__/toggle.lakeAuthz.test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/toggle.lakeAuthz.test.ts
@@ -17,6 +17,8 @@ const h = vi.hoisted(() => ({
   pullTagsByFabFileId: vi.fn(),
   computeDataLakeStats: vi.fn(),
   administeredOrgIds: [] as string[],
+  recordConfigChange: vi.fn(),
+  activateIfDraft: vi.fn(),
 }));
 
 vi.mock('@server/middlewares/baseApi', () => ({
@@ -36,12 +38,12 @@ vi.mock('@server/middlewares/asyncHandler', () => ({
 // `addFileToLake` both have to admit the caller, and only the second of those is what a narrowed
 // actor breaks on this door.
 vi.mock('@bike4mind/database', () => ({
-  lakeConfigChangeEventRepository: { record: vi.fn().mockResolvedValue({}) },
+  lakeConfigChangeEventRepository: { record: h.recordConfigChange },
   dataLakeRepository: {
     findByDatalakeTag: h.findByDatalakeTag,
     find: vi.fn().mockResolvedValue([]),
     setStats: vi.fn().mockResolvedValue(undefined),
-    activateIfDraft: vi.fn().mockResolvedValue(undefined),
+    activateIfDraft: h.activateIfDraft,
   },
   dataLakeAccessGrantRepository: { listByLake: h.listByLake, listActiveByLakes: h.listActiveByLakes },
   fabFileRepository: {
@@ -90,9 +92,15 @@ const makeRes = () => {
   const json = vi.fn();
   return { res: { json, status: vi.fn(() => ({ json })) } as never, json };
 };
-const call = (body: unknown, res: unknown) =>
+const call = (body: unknown, res: unknown, apiKeyInfo?: { keyId: string }) =>
   (handler as (req: unknown, res: unknown) => Promise<void>)(
-    { method: 'POST', body, user: { id: 'u2', isAdmin: false }, logger: { error: vi.fn(), warn: vi.fn() } } as never,
+    {
+      method: 'POST',
+      body,
+      user: { id: 'u2', isAdmin: false },
+      apiKeyInfo,
+      logger: { error: vi.fn(), warn: vi.fn() },
+    } as never,
     res
   );
 
@@ -106,6 +114,8 @@ describe('POST /api/files/tags/toggle - lake write authorization', () => {
     const file = { id: 'f1', userId: 'u2', tags: [] };
     h.findAllUpdateAccessByIds.mockResolvedValue([{ ...file, toJSON: () => file }]);
     h.computeDataLakeStats.mockResolvedValue({ fileCount: 1, totalSizeBytes: 0, totalChunkedChars: 0 });
+    h.recordConfigChange.mockResolvedValue({});
+    h.activateIfDraft.mockResolvedValue(undefined);
   });
 
   it('admits an org admin of the lake org who holds no grant and did not create it', async () => {
@@ -146,5 +156,45 @@ describe('POST /api/files/tags/toggle - lake write authorization', () => {
       /permission to change this data lake's files/
     );
     expect(h.pushTagsByFabFileId).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The end-to-end half of #1964, through the REAL service and recompute to the audit repo - the
+   * shape #2124 established for the file-write doors. toggle.test.ts pins what the ROUTE resolves
+   * and toggleTags.test.ts pins what the SERVICE records; only this one proves the two halves
+   * actually meet on a live draft-lake activation.
+   */
+  it('records the API key on the auto-activate row a key-driven toggle triggers', async () => {
+    h.administeredOrgIds = ['org-1'];
+    h.findByDatalakeTag.mockResolvedValue({ ...LAKE, status: 'draft' });
+    h.activateIfDraft.mockResolvedValue(true);
+    const { res } = makeRes();
+
+    await call({ ids: ['f1'], tags: [META] }, res, { keyId: 'key-abc' });
+
+    expect(h.recordConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'auto-activate',
+        principalKind: 'apiKey',
+        principalId: 'key-abc',
+        onBehalfOfUserId: 'u2',
+        // Unchanged by the principal: activateIfDraft authorizes nothing (see recomputeLakeStats).
+        manageRung: 'system',
+      })
+    );
+  });
+
+  it('records the session user on that same row when no key is involved', async () => {
+    h.administeredOrgIds = ['org-1'];
+    h.findByDatalakeTag.mockResolvedValue({ ...LAKE, status: 'draft' });
+    h.activateIfDraft.mockResolvedValue(true);
+    const { res } = makeRes();
+
+    await call({ ids: ['f1'], tags: [META] }, res);
+
+    expect(h.recordConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'auto-activate', principalKind: 'user', principalId: 'u2' })
+    );
+    expect('onBehalfOfUserId' in h.recordConfigChange.mock.calls[0][0]).toBe(false);
   });
 });

--- a/apps/client/pages/api/files/tags/__tests__/toggle.test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/toggle.test.ts
@@ -71,8 +71,11 @@ const makeRes = () => {
   const json = vi.fn();
   return { res: { json, status: vi.fn(() => ({ json })) } as never, json };
 };
-const req = (body: unknown, user: Record<string, unknown> = { id: 'u1', isAdmin: false }) =>
-  ({ method: 'POST', body, user }) as never;
+const req = (
+  body: unknown,
+  user: Record<string, unknown> = { id: 'u1', isAdmin: false },
+  apiKeyInfo?: { keyId: string }
+) => ({ method: 'POST', body, user, apiKeyInfo }) as never;
 const call = (r: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(r, res);
 
 describe('POST /api/files/tags/toggle', () => {
@@ -155,6 +158,31 @@ describe('POST /api/files/tags/toggle', () => {
       expect.anything()
     );
     expect(h.toggleTags.mock.calls[0][0]).toBe('u1');
+  });
+
+  // #1964: this is the door #1917 wired the other four config-write routes through but not this
+  // one, so a key-driven toggle that auto-activates a draft lake recorded the human instead of the
+  // key. A service-level test alone cannot catch a route that never resolves the principal at
+  // all - see toggleTags.test.ts's "auto-activate audit principal (#1964)" for the service-side
+  // half of this regression.
+  it('resolves the caller as the auditPrincipal for a key-authenticated toggle', async () => {
+    const { res } = makeRes();
+
+    await call(req({ ids: ['f1'], tags: ['datalake:lake'] }, { id: 'u1', isAdmin: false }, { keyId: 'key-abc' }), res);
+
+    expect(h.toggleTags.mock.calls[0][2].auditPrincipal).toEqual({
+      principalKind: 'apiKey',
+      principalId: 'key-abc',
+      onBehalfOfUserId: 'u1',
+    });
+  });
+
+  it('passes no auditPrincipal for an ordinary session toggle', async () => {
+    const { res } = makeRes();
+
+    await call(req({ ids: ['f1'], tags: ['datalake:lake'] }), res);
+
+    expect(h.toggleTags.mock.calls[0][2].auditPrincipal).toBeUndefined();
   });
 
   it('survives a malformed tags payload rather than throwing on the gate', async () => {

--- a/apps/client/pages/api/files/tags/toggle.ts
+++ b/apps/client/pages/api/files/tags/toggle.ts
@@ -66,7 +66,7 @@ const handler = baseApi().post(
       // Matches every other audited config-write door (#1917): undefined for a session caller,
       // the key's principal for a `b4m_live_` caller - so a toggle that auto-activates a draft
       // lake attributes the History row to the key, not the human.
-      auditPrincipal: lakeConfigAuditPrincipal(req.user!, req.apiKeyInfo),
+      auditPrincipal: lakeConfigAuditPrincipal(req.user, req.apiKeyInfo),
       logger: req.logger,
     });
 

--- a/apps/client/pages/api/files/tags/toggle.ts
+++ b/apps/client/pages/api/files/tags/toggle.ts
@@ -12,6 +12,7 @@ import {
 } from '@bike4mind/database';
 import { fileTagRepository } from '@bike4mind/database';
 import { lakeConfigAuditDb } from '@server/dataLakes/lakeConfigAuditDb';
+import { lakeConfigAuditPrincipal } from '@server/dataLakes/lakeConfigAuditPrincipal';
 import { toAccessContext } from '@server/dataLakes/toAccessContext';
 
 const handler = baseApi().post(
@@ -62,6 +63,10 @@ const handler = baseApi().post(
       // wide as the prologue gate above - the org rungs of `canManageLake` cannot be derived from
       // the user document the service is handed.
       administeredOrgIds: ctx.administeredOrgIds,
+      // Matches every other audited config-write door (#1917): undefined for a session caller,
+      // the key's principal for a `b4m_live_` caller - so a toggle that auto-activates a draft
+      // lake attributes the History row to the key, not the human.
+      auditPrincipal: lakeConfigAuditPrincipal(req.user!, req.apiKeyInfo),
       logger: req.logger,
     });
 

--- a/b4m-core/services/src/fabFileService/toggleTags.test.ts
+++ b/b4m-core/services/src/fabFileService/toggleTags.test.ts
@@ -71,14 +71,17 @@ const makeAdapters = (files: ReturnType<typeof file>[], lakeDoc: IDataLakeDocume
         find: vi.fn().mockResolvedValue([]),
       },
       users: { findById: vi.fn().mockResolvedValue({ id: 'owner', isAdmin: false }) },
+      // Wired unconditionally so a test can assert on it without rebuilding the fixture; degrades
+      // to "no event recorded" the same way an absent repo would if a caller genuinely omitted it.
+      lakeConfigChangeEvents: { record: vi.fn().mockResolvedValue({}) },
     },
     store,
   };
 };
 
 // real repositories; the mocks implement only the methods under test.
-const run = (adapters: ReturnType<typeof makeAdapters>, params: unknown) =>
-  toggleTags('owner', params, adapters as any);
+const run = (adapters: ReturnType<typeof makeAdapters>, params: unknown, extra?: Record<string, unknown>) =>
+  toggleTags('owner', params, { ...adapters, ...extra } as any);
 
 describe('toggleTags - ordinary tags', () => {
   it('adds an absent tag with the caller casing intact and counts it', async () => {
@@ -212,6 +215,46 @@ describe('toggleTags - data lake meta-tags', () => {
     await run(adapters, { ids: ['f1'], tags: ['datalake:lake'] });
 
     expect(adapters.db.dataLakes.activateIfDraft).toHaveBeenCalledWith('lake1');
+  });
+
+  // #1964: the one remaining door that could emit an `auto-activate` config-change row without
+  // ever attaching an `auditPrincipal` - the four config-write routes (#1917) and the other
+  // recompute callers (#2124) already do. Mutation-verified: deleting the `auditPrincipal` line
+  // from the actor at toggleTags.ts's actor construction turns the first case red (the fallback
+  // derives `principalKind: 'user'` from `actor.userId` instead).
+  describe('auto-activate audit principal (#1964)', () => {
+    it('names the API key, not the human, when a key-driven toggle activates a draft lake', async () => {
+      const adapters = makeAdapters([file('f1')], lake({ status: 'draft' }));
+      adapters.db.dataLakes.activateIfDraft = vi.fn().mockResolvedValue(true);
+
+      await run(
+        adapters,
+        { ids: ['f1'], tags: ['datalake:lake'] },
+        { auditPrincipal: { principalKind: 'apiKey', principalId: 'key-abc', onBehalfOfUserId: 'owner' } }
+      );
+
+      expect(adapters.db.lakeConfigChangeEvents.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'auto-activate',
+          principalKind: 'apiKey',
+          principalId: 'key-abc',
+          onBehalfOfUserId: 'owner',
+        })
+      );
+    });
+
+    it('still names the session user with no onBehalfOfUserId when no key is involved', async () => {
+      const adapters = makeAdapters([file('f1')], lake({ status: 'draft' }));
+      adapters.db.dataLakes.activateIfDraft = vi.fn().mockResolvedValue(true);
+
+      await run(adapters, { ids: ['f1'], tags: ['datalake:lake'] });
+
+      expect(adapters.db.lakeConfigChangeEvents.record).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'auto-activate', principalKind: 'user', principalId: 'owner' })
+      );
+      const [event] = adapters.db.lakeConfigChangeEvents.record.mock.calls[0];
+      expect('onBehalfOfUserId' in event).toBe(false);
+    });
   });
 
   it('recomputes a lake once for the whole batch, not once per file', async () => {

--- a/b4m-core/services/src/fabFileService/toggleTags.ts
+++ b/b4m-core/services/src/fabFileService/toggleTags.ts
@@ -10,6 +10,7 @@ import {
   IFileTagRepository,
   IScopedSettingsRepository,
   IUserDocument,
+  LakeAuditPrincipal,
 } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 import { assertLakeWritable } from '../dataLakeService/assertLakeAccess';
@@ -59,6 +60,13 @@ interface FabFileToggleTagsAdapters extends LakeConfigAuditAdapters {
    * in front of it. Same adapter, for the same reason, as `createFabFile`'s and `updateFabFile`'s.
    */
   administeredOrgIds?: string[];
+  /**
+   * The resolved audit principal for an API-key caller (undefined for a session caller) - see
+   * `lakeConfigAuditPrincipal`. Attached to the actor below so a toggle that auto-activates a
+   * draft lake attributes the resulting config-change row to the key, not the human it acts for,
+   * matching every other audited config-write door (#1917).
+   */
+  auditPrincipal?: LakeAuditPrincipal;
 }
 
 const storedTagNames = (file: Pick<IFabFileDocument, 'tags'>): string[] =>
@@ -115,7 +123,7 @@ const matchingStoredNames = (storedNames: readonly string[], tag: string): strin
 export const toggleTags = async (
   userId: string,
   params: unknown,
-  { db, logger, administeredOrgIds }: FabFileToggleTagsAdapters
+  { db, logger, administeredOrgIds, auditPrincipal }: FabFileToggleTagsAdapters
 ): Promise<ToggledFabFile[]> => {
   const { ids, tags: requestedTags } = fabFileToggleTagsSchema.parse(params);
 
@@ -145,7 +153,12 @@ export const toggleTags = async (
     throw new BadRequestError('Some files are not accessible or you do not have permission to edit them');
   }
 
-  const actor = { userId, isAdmin: !!user.isAdmin, administeredOrgIds: administeredOrgIds ?? [] };
+  const actor = {
+    userId,
+    isAdmin: !!user.isAdmin,
+    administeredOrgIds: administeredOrgIds ?? [],
+    auditPrincipal,
+  };
   // Grant-aware manage gates below: consult each lake's active grants so a transferred lake's
   // superseded creator does not still pass. Batched + cached across both prefix-arm gate passes.
   // The org rungs fire only when the caller resolved `administeredOrgIds` for us - the route door

--- a/b4m-core/services/src/fabFileService/update.ts
+++ b/b4m-core/services/src/fabFileService/update.ts
@@ -9,6 +9,7 @@ import {
   IScopedSettingsRepository,
   IUserDocument,
   KnowledgeType,
+  LakeAuditPrincipal,
   isImageServeable,
 } from '@bike4mind/common';
 import { NotFoundError, secureParameters } from '@bike4mind/utils';
@@ -78,12 +79,20 @@ interface UpdateFabFileAdapters extends LakeConfigAuditAdapters {
    * the route gate in front of it. Same adapter, for the same reason, as `createFabFile`'s.
    */
   administeredOrgIds?: string[];
+  /**
+   * The resolved audit principal for an API-key caller (undefined for a session caller) - see
+   * `lakeConfigAuditPrincipal`. Rides on the actor into `reconcileLakeTags`' stats recompute, so a
+   * key-driven tag write that flips a draft lake to active attributes the config-change row to the
+   * key rather than to the human it acts for, matching every other audited config-write door
+   * (#1917).
+   */
+  auditPrincipal?: LakeAuditPrincipal;
 }
 
 export const updateFabFile = async (
   user: IUserDocument,
   parameters: UpdateFabFileParameters,
-  { db, logger, storage, administeredOrgIds }: UpdateFabFileAdapters
+  { db, logger, storage, administeredOrgIds, auditPrincipal }: UpdateFabFileAdapters
 ) => {
   const { id, fileContent, ...params } = secureParameters(parameters, updateFabFileSchema);
 
@@ -144,7 +153,7 @@ export const updateFabFile = async (
     params.tags === undefined
       ? undefined
       : await reconcileLakeTags(
-          { userId: user.id, isAdmin: !!user.isAdmin, administeredOrgIds: administeredOrgIds ?? [] },
+          { userId: user.id, isAdmin: !!user.isAdmin, administeredOrgIds: administeredOrgIds ?? [], auditPrincipal },
           id,
           (fabFile.tags ?? []).map(t => t?.name).filter((name): name is string => typeof name === 'string'),
           params.tags,

--- a/b4m-core/services/src/tagService/remove.test.ts
+++ b/b4m-core/services/src/tagService/remove.test.ts
@@ -251,4 +251,59 @@ describe('tagService - remove', () => {
       expect(mockDataLakeRepo.setStats).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * The audit principal on the auto-activate row a prefix-arm delete can emit. Sibling of #1964's
+   * tag-toggle door: this path built its actor with no `auditPrincipal`, so a key-driven delete
+   * that published a draft lake recorded the human instead of the key. Removing `auditPrincipal`
+   * from the actor at remove.ts's recompute call turns the key case red.
+   */
+  describe('auto-activate audit principal', () => {
+    const auditSpy = () => {
+      const record = vi.fn().mockResolvedValue({});
+      return { db: { lakeConfigChangeEvents: { record } }, record };
+    };
+
+    const drivingActivation = (audit: ReturnType<typeof auditSpy>) => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc('lk:invoices'));
+      (mockDataLakeRepo.find as Mock).mockResolvedValueOnce([lake({ status: 'draft' })]);
+      // fileCount > 0 is what makes the flip eligible - a surviving sibling tag kept members.
+      (mockFabFileRepo.computeDataLakeStats as Mock).mockResolvedValue({
+        fileCount: 1,
+        totalSizeBytes: 10,
+        totalChunkedChars: 0,
+      });
+      (mockDataLakeRepo.activateIfDraft as Mock).mockResolvedValue(true);
+      return { db: { ...adapters.db, ...audit.db } };
+    };
+
+    it('names the API key, not the human, when a key-driven delete publishes a draft lake', async () => {
+      const audit = auditSpy();
+      const withAudit = {
+        ...drivingActivation(audit),
+        auditPrincipal: { principalKind: 'apiKey' as const, principalId: 'key-abc', onBehalfOfUserId: userId },
+      };
+
+      await remove(userId, { id: existingTagId }, withAudit);
+
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'auto-activate',
+          principalKind: 'apiKey',
+          principalId: 'key-abc',
+          onBehalfOfUserId: userId,
+        })
+      );
+    });
+
+    it('still names the tag owner when no key is involved', async () => {
+      const audit = auditSpy();
+
+      await remove(userId, { id: existingTagId }, drivingActivation(audit));
+
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'auto-activate', principalKind: 'user', principalId: userId })
+      );
+    });
+  });
 });

--- a/b4m-core/services/src/tagService/remove.ts
+++ b/b4m-core/services/src/tagService/remove.ts
@@ -1,5 +1,5 @@
 import { secureParameters, BadRequestError } from '@bike4mind/utils';
-import { IDataLakeRepository, IFabFileRepository, ITagRepository } from '@bike4mind/common';
+import { IDataLakeRepository, IFabFileRepository, ITagRepository, LakeAuditPrincipal } from '@bike4mind/common';
 import { z } from 'zod';
 import { couldMatchTagPrefixArmLoosely, loadPrefixArmCandidateLakes } from '../dataLakeService/prefixArmMembership';
 import { recomputeLakeStats } from '../dataLakeService/recomputeLakeStats';
@@ -31,6 +31,13 @@ interface TagRemoveAdapters {
    * many callers, and an absent logger degrades to the console fallback rather than failing.
    */
   logger?: LakeConfigAuditAdapters['logger'];
+  /**
+   * The resolved audit principal for an API-key caller (undefined for a session caller) - see
+   * `lakeConfigAuditPrincipal`. Rides on the actor handed to recomputeLakeStats, so a key-driven
+   * delete that flips a draft lake to active names the key rather than the human it acts for,
+   * matching every other audited config-write door (#1917).
+   */
+  auditPrincipal?: LakeAuditPrincipal;
 }
 
 /**
@@ -51,7 +58,7 @@ interface TagRemoveAdapters {
  * the bulk strip below does NOT do on its own is recompute the affected lakes' stats.
  */
 export const remove = async (userId: string, params: TagRemoveParams, adapters: TagRemoveAdapters) => {
-  const { db, logger } = adapters;
+  const { db, logger, auditPrincipal } = adapters;
   const { id } = secureParameters(params, tagRemoveSchema);
 
   const tag = await db.tags.findByIdAndUserId(id, userId);
@@ -84,7 +91,9 @@ export const remove = async (userId: string, params: TagRemoveParams, adapters: 
     // causes should not read as `system`. `isAdmin` is immaterial on this path - recomputeLakeStats
     // forces the rung to `system` because activateIfDraft authorizes nothing.
     await Promise.all(
-      affectedLakes.map(lake => recomputeLakeStats(lake, { db, logger }, { actor: { userId, isAdmin: false } }))
+      affectedLakes.map(lake =>
+        recomputeLakeStats(lake, { db, logger }, { actor: { userId, isAdmin: false, auditPrincipal } })
+      )
     );
   }
 

--- a/b4m-core/services/src/tagService/update.test.ts
+++ b/b4m-core/services/src/tagService/update.test.ts
@@ -510,4 +510,59 @@ describe('tagService - update', () => {
       expect(renameOrder).toBeLessThan(recomputeOrder);
     });
   });
+
+  /**
+   * The audit principal on the auto-activate row a prefix-arm rename can emit. Sibling of #1964's
+   * tag-toggle door: this path built its actor with no `auditPrincipal`, so a key-driven rename
+   * that published a draft lake recorded the human instead of the key. Removing `auditPrincipal`
+   * from the actor at update.ts's recompute call turns the key case red.
+   */
+  describe('auto-activate audit principal', () => {
+    const auditSpy = () => {
+      const record = vi.fn().mockResolvedValue({});
+      return { db: { lakeConfigChangeEvents: { record } }, record };
+    };
+
+    const drivingActivation = (audit: ReturnType<typeof auditSpy>) => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'lk:invoices' }));
+      (mockDataLakeRepo.find as Mock).mockResolvedValueOnce([lake({ status: 'draft' })]);
+      // fileCount > 0 is what makes the flip eligible (see recomputeLakeStats).
+      (mockFabFileRepo.computeDataLakeStats as Mock).mockResolvedValue({
+        fileCount: 1,
+        totalSizeBytes: 10,
+        totalChunkedChars: 0,
+      });
+      (mockDataLakeRepo.activateIfDraft as Mock).mockResolvedValue(true);
+      return { db: { ...adapters.db, ...audit.db } };
+    };
+
+    it('names the API key, not the human, when a key-driven rename publishes a draft lake', async () => {
+      const audit = auditSpy();
+      const withAudit = {
+        ...drivingActivation(audit),
+        auditPrincipal: { principalKind: 'apiKey' as const, principalId: 'key-abc', onBehalfOfUserId: userId },
+      };
+
+      await update(userId, { id: existingTagId, name: 'archived' }, withAudit);
+
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'auto-activate',
+          principalKind: 'apiKey',
+          principalId: 'key-abc',
+          onBehalfOfUserId: userId,
+        })
+      );
+    });
+
+    it('still names the tag owner when no key is involved', async () => {
+      const audit = auditSpy();
+
+      await update(userId, { id: existingTagId, name: 'archived' }, drivingActivation(audit));
+
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'auto-activate', principalKind: 'user', principalId: userId })
+      );
+    });
+  });
 });

--- a/b4m-core/services/src/tagService/update.ts
+++ b/b4m-core/services/src/tagService/update.ts
@@ -1,4 +1,10 @@
-import { IDataLakeRepository, IFabFileRepository, ITagRepository, IUserDocument } from '@bike4mind/common';
+import {
+  IDataLakeRepository,
+  IFabFileRepository,
+  ITagRepository,
+  IUserDocument,
+  LakeAuditPrincipal,
+} from '@bike4mind/common';
 import { secureParameters, BadRequestError } from '@bike4mind/utils';
 import { z } from 'zod';
 import {
@@ -55,6 +61,13 @@ interface TagUpdateAdapters {
    * same reason the audit repos are.
    */
   logger?: LakeConfigAuditAdapters['logger'];
+  /**
+   * The resolved audit principal for an API-key caller (undefined for a session caller) - see
+   * `lakeConfigAuditPrincipal`. Rides on the actor handed to recomputeLakeStats, so a key-driven
+   * rename that flips a draft lake to active names the key rather than the human it acts for,
+   * matching every other audited config-write door (#1917).
+   */
+  auditPrincipal?: LakeAuditPrincipal;
 }
 
 /**
@@ -81,7 +94,7 @@ interface TagUpdateAdapters {
  * lakes' stats.
  */
 export const update = async (userId: string, params: TagUpdateParams, adapters: TagUpdateAdapters) => {
-  const { db, logger } = adapters;
+  const { db, logger, auditPrincipal } = adapters;
   const { id, ...rest } = secureParameters(params, tagUpdateSchema);
 
   const tag = await db.tags.findByIdAndUserId(id, userId);
@@ -165,7 +178,9 @@ export const update = async (userId: string, params: TagUpdateParams, adapters: 
     );
     // See tagService/remove: the tag owner is the principal, and the rung stays `system`.
     await Promise.all(
-      affectedLakes.map(lake => recomputeLakeStats(lake, { db, logger }, { actor: { userId, isAdmin: false } }))
+      affectedLakes.map(lake =>
+        recomputeLakeStats(lake, { db, logger }, { actor: { userId, isAdmin: false, auditPrincipal } })
+      )
     );
   }
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="1456" height="816" alt="01-door1-toggle-key" src="https://github.com/user-attachments/assets/c36dcd2c-cfd5-4a15-946e-b64fd390cf17" />

**Door 1 (Tag Toggle, Key-Driven)**: History row names the API key with the human shown via `onBehalfOfUserId`.

<img width="1456" height="816" alt="02-door1-toggle-session" src="https://github.com/user-attachments/assets/b8f9874d-b2e2-46a6-aee7-e5bd00632cab" />

**Door 1 (Tag Toggle, Browser Session)**: History row names the human plainly, no key attribution.

<img width="1512" height="801" alt="03-door2-fileput-key" src="https://github.com/user-attachments/assets/afb35591-184e-479a-b8b0-8b9d5f994896" />

**Door 2 (Whole-Array Tag PUT, Key-Driven)**: History row names the API key.

<img width="1512" height="801" alt="04-door2-fileput-session" src="https://github.com/user-attachments/assets/ea0ea383-0226-4059-8f6e-b4290c9fe0ee" />

**Door 2 (Whole-Array Tag PUT, Browser Session)**: History row names the human plainly.

<img width="1512" height="801" alt="05-door3-tagrename-key" src="https://github.com/user-attachments/assets/4a143b04-1ed0-43ab-bb1c-ab79642f664a" />

**Door 3 (Tag Rename into `fileTagPrefix`, Key-Driven)**: History row names the API key.

<img width="1512" height="801" alt="06-door3-tagdelete-key" src="https://github.com/user-attachments/assets/5429964a-d777-40d4-9a5f-9a4b1af56dbc" />

**Door 3 (Tag Delete, Key-Driven)**: auto-activate row already correctly attributed to the API key (delete itself emits no separate History row).

## Description

Closes #1964: a data lake's config-change history attributes a write to the API key that made it (`principalKind: apiKey`, with the human preserved in `onBehalfOfUserId`), wired for four config-write routes by PR #1917. `toggleTags` was the door #1964 named - tagging a file with a lake's `datalake:*` meta-tag can auto-activate a draft lake, and that write recorded the human instead of the key when a `b4m_live_` key drove it.

Expert review of this branch found that #1964's own "Blast radius" paragraph was stale: two more live doors had the identical gap. `updateFabFile` -> `reconcileLakeTags` (reached from the `PUT /api/files/{id}` tag-replace route) and `tagService.update`/`remove` (reached from `PUT`/`DELETE /api/files/tags/{id}`, the tag rename and delete routes) both built their recompute actor with no way to carry a key's principal, so a key-driven rename, delete, or whole-array tag write that flipped a draft lake to active also misattributed the row. All three doors are fixed on this branch.

`auditPrincipal` is read only by `recordLakeConfigChange` - no authorization gate (`canManageLake`, `assertCanWriteStaticRegistryTags`, `isEffectiveOwner`, the membership writes) reads it, so this is an audit-attribution fix only and does not change what any caller is allowed to do.

## Changes

- `b4m-core/services/src/fabFileService/toggleTags.ts` - `FabFileToggleTagsAdapters` takes an optional `auditPrincipal` (`:69`) and attaches it to the actor (`:126`, `:160`) that rides into `recomputeLakeStats`.
- `apps/client/pages/api/files/tags/toggle.ts` - resolves `lakeConfigAuditPrincipal(req.user!, req.apiKeyInfo)` and passes it to `toggleTags` (`:69`).
- `b4m-core/services/src/fabFileService/update.ts` - `updateFabFile` takes the same optional `auditPrincipal` (`:89`, `:95`) and attaches it to the actor handed to `reconcileLakeTags` (`:156`), so a whole-array tag write that joins a lake carries it into that lake's stats recompute.
- `apps/client/pages/api/files/[id]/index.ts` - the PUT handler resolves and attaches the principal (`:181`); the DELETE handler already did this from PR #2124 (`:305`, unchanged).
- `b4m-core/services/src/tagService/update.ts` - `update` takes an optional `auditPrincipal` (`:70`, `:97`) and attaches it to the recompute actor for a prefix-arm rename that flips a draft lake active (`:182`).
- `b4m-core/services/src/tagService/remove.ts` - `remove` takes the same field (`:40`, `:61`) and attaches it to the recompute actor for a prefix-arm delete (`:95`).
- `apps/client/pages/api/files/tags/[id].ts` - both the PUT (rename) and DELETE (remove) handlers resolve and attach the principal (`:59`, `:87`).
- Tests, all mutation-verified (each wiring line was temporarily removed and the corresponding test confirmed failing before being restored):
  - `b4m-core/services/src/fabFileService/toggleTags.test.ts` - new `auto-activate audit principal (#1964)` describe.
  - `apps/client/pages/api/files/tags/__tests__/toggle.test.ts` - route resolves and passes the exact `auditPrincipal` object for a key and a session caller.
  - `apps/client/pages/api/files/tags/__tests__/toggle.lakeAuthz.test.ts` - end-to-end through the real route, service, and recompute to the audit-repo spy.
  - `apps/client/pages/api/files/[id]/__tests__/index.put.test.ts` - drives the real `updateFabFile` chain to the audit row.
  - `b4m-core/services/src/tagService/update.test.ts` and `remove.test.ts` - new `auto-activate audit principal` describe in each.
  - `apps/client/pages/api/files/tags/__tests__/[id].test.ts` - both the PUT and DELETE handlers resolve and pass the principal.

## Guide for Testers

Each scenario needs a data lake left in **draft** (create it without uploading through the UI) and a `b4m_live_` API key for an account that can write that lake.

1. Using the key (not a browser session), `POST /api/files/tags/toggle` with `{"ids":["<fileId>"],"tags":["datalake:<lake-tag>"]}` to join a file to the draft lake.
2. Open the lake's **Settings -> History** tab as a manager. Expected: the `Activated automatically` row names the API key (`principalKind: apiKey`), with the human shown beneath it.
3. Repeat step 1 with an ordinary browser session instead of the key. Expected: the resulting row names the human plainly, with no key attribution shown.
4. Create a second draft lake and note its `fileTagPrefix`. Using the key, `PUT /api/files/{id}` on a file that does not yet carry that prefix, with body `{"tags":[{"name":"<fileTagPrefix>example","strength":1}],"fileContent":""}` (a content tag matching the prefix, not the lake's `datalake:` meta-tag - and `tags` entries are objects, not plain strings). Expected: the auto-activate row names the key.
5. Using the key, `PUT /api/files/tags/{tagId}` to rename a tag INTO a draft lake's `fileTagPrefix` (the tag must already belong to the lake creator, and the lake must hold at least one file under that prefix). Expected: the resulting auto-activate row names the key.
6. Using the key, `DELETE /api/files/tags/{tagId}` where deleting a sibling tag leaves the lake's `fileTagPrefix` as the file's only remaining membership signal for a draft lake with other members. Expected: the resulting auto-activate row names the key.
7. Repeat steps 4-6 with an ordinary browser session. Expected: each row still names the human plainly, with no key attribution.

### What NOT to test

- Tag toggles that do not activate a lake - those emit no config-change event by design, unchanged by this PR.
- The rung recorded on these rows (`system`) - unchanged; only the principal identity changes.
- Any UI rendering of the History tab itself - this PR only changes which principal is recorded, not how the tab displays one.

## Additional Information

Scope grew beyond issue #1964 during self-review: a fix-completeness sweep for the same actor-construction shape found two more live, key-reachable doors with the identical gap (see Description). Both are closed on this branch rather than filed as follow-ups, since the split between #1964 and its sibling #1994/PR #2124 is what let this exact premise go stale twice already.

Preview verification (screenshots above) passed all 6 cases across the three doors - every key-driven row names `apiKey (for <human>)`, every session-driven row names the human plainly with no `onBehalfOfUserId`. Two notes from that run: door 2's session case has no direct UI trigger for a literal `PUT /api/files/{id}` with a new tag (every "add a tag" UI action calls the toggle endpoint instead), so its screenshot is a toggle-driven stand-in rather than that exact route - the key case for door 2 was still verified directly against the route. Tag delete emits no dedicated History row of its own (only `auto-activate` is audited), so its screenshot shows the pre-existing correctly-attributed activation row, confirmed via API state that the delete itself succeeded with no incorrectly-attributed row produced.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) (n/a - backend attribution only, no UI change)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc (n/a - no telemetry fields touched)
