### PR TITLE
fix(data-lakes): invalidate the config history after an ownership transfer

### DIFF
--- a/apps/client/app/hooks/data/dataLakes.test.ts
+++ b/apps/client/app/hooks/data/dataLakes.test.ts
@@ -874,17 +874,6 @@ describe('nextRebuildPoll', () => {
 });
 
 /**
- * A config write adds a history row, and the History tab renders in the same modal that submitted
- * it. `useUpdateDataLake` invalidated that key from the start; these two did not, and only got away
- * with it because the history query pairs `staleTime: 0` with an `enabled` toggle that flips on tab
- * switch. That is an incidental refetch, not a guarantee - raising staleTime or dropping the toggle
- * would strand the row the owner just created. These pin the invalidation itself.
- *
- * The key is asserted as the literal `['dataLakeConfigHistory', 'lake1']` prefix rather than through
- * dataLakeKeys.configHistoryOf: building the expectation from the same helper the hook calls would
- * still pass if that helper's shape drifted away from what the query is actually keyed under.
- */
-/**
  * The build door's poll predicate. Same reason nextRebuildPoll is tested here: an inline
  * `refetchInterval` lambda is executed by no test, so a wrong predicate ships green - and the wrong
  * one here is a 5s poll that never terminates.
@@ -906,6 +895,18 @@ describe('lakeMemoryPollInterval', () => {
   });
 });
 
+/**
+ * A config write adds a history row, and the History tab renders in the same modal that submitted
+ * it. `useUpdateDataLake` invalidated that key from the start; the rest of the config-writing doors
+ * did not, and only got away with it because the history query pairs `staleTime: 0` with an
+ * `enabled` toggle that flips on tab switch. That is an incidental refetch, not a guarantee -
+ * raising staleTime or dropping the toggle would strand the row the owner just created. These pin
+ * the invalidation itself.
+ *
+ * The key is asserted as the literal `['dataLakeConfigHistory', 'lake1']` prefix rather than through
+ * dataLakeKeys.configHistoryOf: building the expectation from the same helper the hook calls would
+ * still pass if that helper's shape drifted away from what the query is actually keyed under.
+ */
 describe('config-history invalidation on the non-update config writes', () => {
   const mountWith = () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -952,6 +953,45 @@ describe('config-history invalidation on the non-update config writes', () => {
     const { result } = renderHook(() => useRemoveFileFromDataLake('lake1'), { wrapper });
     await act(async () => {
       await result.current.mutateAsync('f1');
+    });
+
+    expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['dataLakeConfigHistory', 'lake1']));
+  });
+
+  it("useGrantLakeAccess invalidates the shared lake's history", async () => {
+    const { wrapper, invalidate } = mountWith();
+    apiPost.mockResolvedValueOnce({ data: { data: { principalId: 'u1', role: 'reader' } } });
+
+    const { result } = renderHook(() => useGrantLakeAccess(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'lake1', principalType: 'user', principalId: 'u1', role: 'reader' });
+    });
+
+    expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['dataLakeConfigHistory', 'lake1']));
+  });
+
+  it("useRevokeLakeAccess invalidates the lake's history", async () => {
+    const { wrapper, invalidate } = mountWith();
+    apiDelete.mockResolvedValueOnce({ data: { data: { revoked: true } } });
+
+    const { result } = renderHook(() => useRevokeLakeAccess(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'lake1', principalType: 'user', principalId: 'u1' });
+    });
+
+    expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['dataLakeConfigHistory', 'lake1']));
+  });
+
+  // The transfer door moves no document field, so its history row is the ONLY record that the
+  // handover happened - and the manager who just confirmed the transfer is the reader most likely
+  // to open History next.
+  it("useTransferLakeOwnership invalidates the transferred lake's history", async () => {
+    const { wrapper, invalidate } = mountWith();
+    apiPost.mockResolvedValueOnce({ data: { newOwnerUserId: 'u2', demotedUserIds: ['u1'] } });
+
+    const { result } = renderHook(() => useTransferLakeOwnership(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'lake1', newOwnerUserId: 'u2' });
     });
 
     expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['dataLakeConfigHistory', 'lake1']));

--- a/apps/client/app/hooks/data/dataLakes.test.ts
+++ b/apps/client/app/hooks/data/dataLakes.test.ts
@@ -18,6 +18,7 @@ import { toast } from 'sonner';
 const apiGet = vi.fn();
 const apiDelete = vi.fn();
 const apiPost = vi.fn();
+const apiPut = vi.fn();
 
 /**
  * A rejection shaped the way axios actually rejects: `.message` is the generic status line and the
@@ -36,6 +37,7 @@ vi.mock('@client/app/contexts/ApiContext', () => ({
     get: (...args: unknown[]) => apiGet(...args),
     delete: (...args: unknown[]) => apiDelete(...args),
     post: (...args: unknown[]) => apiPost(...args),
+    put: (...args: unknown[]) => apiPut(...args),
   },
 }));
 // dataLakes.ts value-imports these at module load for its OTHER hooks; useBrowsePublicDataLakes
@@ -69,6 +71,7 @@ import {
   useApplyTaxonomySuggestions,
   useRechunkDataLake,
   useSetLakeVisibility,
+  useUpdateFallbackLakeSettings,
   useArchiveDataLake,
   useGetTransitionalDataLakes,
   useRetryLakeLifecycle,
@@ -591,7 +594,13 @@ describe('useCleanupDataLake queued purge', () => {
     expect(result.current.deleted.data).toEqual([deletedLake('lk2')]);
     // Exactly the mount fetch: a second GET would have re-added the still-soft-deleted lk1.
     expect(deletedFetchCount()).toBe(1);
-    expect(invalidate).not.toHaveBeenCalled();
+    // Was a blunt `not.toHaveBeenCalled()`. Its point was "this door refreshes nothing that could
+    // re-add the row", and the config-history key it now invalidates cannot - so the assertion is
+    // narrowed to the exhaustive list rather than dropped, keeping its real value: any FURTHER key
+    // added to this onSuccess still has to be justified here.
+    expect(invalidate.mock.calls.map(call => JSON.stringify(call[0]?.queryKey))).toEqual([
+      JSON.stringify(['dataLakeConfigHistory', 'lk1']),
+    ]);
   });
 
   it('brings the row back on the next fetch when the consumer releases a guard-refused purge (#1744)', async () => {
@@ -992,6 +1001,41 @@ describe('config-history invalidation on the non-update config writes', () => {
     const { result } = renderHook(() => useTransferLakeOwnership(), { wrapper });
     await act(async () => {
       await result.current.mutateAsync({ id: 'lake1', newOwnerUserId: 'u2' });
+    });
+
+    expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['dataLakeConfigHistory', 'lake1']));
+  });
+
+  // The purge door builds its own onSuccess around the pending-purge suppression rather than going
+  // through invalidateAfterLifecycle, which is how it missed this key while the other four
+  // lifecycle actions had it. Inert in today's UI (a purge is accepted from the Deleted section,
+  // History unmounted), so this pins the CONSISTENCY - and `purge` is the action least worth
+  // special-casing, being the only audit record a purge leaves. Not reachable via the retry path
+  // either: TransitionalRetryAction excludes it, so nothing else picks up the slack.
+  it("useCleanupDataLake invalidates the purged lake's history", async () => {
+    const { wrapper, invalidate } = mountWith();
+    apiPost.mockResolvedValueOnce({ data: { success: true } });
+
+    const { result } = renderHook(() => useCleanupDataLake(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync('lake1');
+    });
+    // A purge writes module-scoped suppression state, and this describe has no reset of its own.
+    // Cleared before the assertion so a failure here cannot also strand 'lake1' for later cases.
+    __resetPurgingLakesForTests();
+
+    expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['dataLakeConfigHistory', 'lake1']));
+  });
+
+  // The static/registry lake's admin overlay. A different route and a different service from
+  // useUpdateDataLake, but it records the same `update` action, so it owes the same invalidation.
+  it("useUpdateFallbackLakeSettings invalidates the edited lake's history", async () => {
+    const { wrapper, invalidate } = mountWith();
+    apiPut.mockResolvedValueOnce({ data: { id: 'lake1' } });
+
+    const { result } = renderHook(() => useUpdateFallbackLakeSettings(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'lake1', groundingMode: 'retrieve' });
     });
 
     expect(invalidatedKeys(invalidate)).toContain(JSON.stringify(['dataLakeConfigHistory', 'lake1']));

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -263,7 +263,9 @@ export function useLakeOwnershipCandidates(dataLakeId: string | null, enabled = 
  *
  * Invalidates the lake list as well as the access view: ownership decides `canManage`, so the panel's
  * own controls (Access included) may legitimately disappear for the actor once they are no longer the
- * owner - refetching is what keeps the UI honest about what the actor can still do.
+ * owner - refetching is what keeps the UI honest about what the actor can still do. The config
+ * history goes too: this door records a `transfer-ownership` event, and the History tab that renders
+ * it sits in the same modal that submitted the transfer.
  */
 export function useTransferLakeOwnership() {
   const queryClient = useQueryClient();
@@ -279,6 +281,7 @@ export function useTransferLakeOwnership() {
     onSuccess: (_data, { id }) => {
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.access(id) });
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.ownershipCandidates(id) });
+      queryClient.invalidateQueries({ queryKey: dataLakeKeys.configHistoryOf(id) });
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
       toast.success('Data lake ownership transferred');
     },

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -503,8 +503,12 @@ export function useUpdateFallbackLakeSettings() {
       const response = await api.put<DataLakeConfig>(`/api/data-lakes/${id}/settings`, params);
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (_data, { id }) => {
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
+      // This door records an `update` config-change event too, same as useUpdateDataLake. Inert
+      // while the only caller is FallbackLakeSettingsModal, which does not mount the History
+      // section - kept for the same rule the other config doors follow.
+      queryClient.invalidateQueries({ queryKey: dataLakeKeys.configHistoryOf(id) });
       toast.success('Data lake settings updated');
     },
     onError: (error: Error) => {
@@ -611,9 +615,11 @@ function invalidateAfterLifecycle(queryClient: ReturnType<typeof useQueryClient>
   // lake list and the tag tree disagree - the page's lake rail (sourced from `list`) drops the
   // row while the tree beside it still shows that lake's branches and counts it in the totals.
   queryClient.invalidateQueries({ queryKey: dataLakeKeys.tagCountsRoot });
-  // Every lifecycle action records a config-history row. Invalidated for all five rather than
-  // only the reversible ones: for delete/cleanup the history observer is already unmounted, so
-  // the extra key is inert, and enumerating which actions qualify would rot as actions are added.
+  // Every lifecycle action records a config-history row. Invalidated for all four rather than only
+  // the reversible ones: after a delete the history observer is already unmounted, so the extra key
+  // is inert, and enumerating which actions qualify would rot as actions are added. Four, not five:
+  // `cleanup` never reaches this helper - the purge door builds its own onSuccess around the
+  // pending-purge suppression, and invalidates this same key itself.
   queryClient.invalidateQueries({ queryKey: dataLakeKeys.configHistoryOf(id) });
 }
 
@@ -723,6 +729,15 @@ export function useCleanupDataLake() {
       // ['data-lakes', 'deleted'], so it would refetch the list above and undo the removal. No
       // other catalog changes either - a purgeable lake is already soft-deleted, so it is
       // already absent from the active/archived/public lists.
+      //
+      // The history IS invalidated, and safely: ['dataLakeConfigHistory', id] does not prefix-match
+      // the deleted list, so it cannot undo the removal above. Inert in today's UI - a purge is
+      // accepted from the Deleted section, with the lake's History observer unmounted - and kept
+      // anyway for the rule `invalidateAfterLifecycle` already states: every door whose write can
+      // record a config-history row invalidates that lake's history, rather than each door
+      // re-deciding whether its row is currently observable. `purge` is the entry that rule can
+      // least afford to skip - it is the only audit record a purge leaves behind.
+      queryClient.invalidateQueries({ queryKey: dataLakeKeys.configHistoryOf(id) });
       toast.success('Data lake permanently purged');
     },
     onError: (error: Error) => {


### PR DESCRIPTION
# Pull Request

Closes #2556

## Description

Config-writing doors in `apps/client/app/hooks/data/dataLakes.ts` record `lakeConfigChangeEvent` rows, and those rows are what `LakeConfigHistorySection` renders. Three doors wrote a row without invalidating `dataLakeKeys.configHistoryOf(id)`: `useTransferLakeOwnership` (the one #2556 was filed for), `useCleanupDataLake` (`purge`), and `useUpdateFallbackLakeSettings` (`update`). All three now do.

### Correction: none of these is a live user-visible bug

The first two revisions of this description called the transfer gap a live bug - a manager transferring a lake and then opening History to no row. **Checking the wiring rather than the issue text, that is not reachable today**, and the same reasoning that clears transfer clears the other two:

- `useLakeConfigHistory` is mounted with `enabled: !!lake?.canManage && tab === 'history'` ([`DataLakeSettingsModal.tsx:147`](apps/client/app/components/DataLakeWizard/DataLakeSettingsModal.tsx#L147)) - only while that tab is the active one.
- Transfer is submitted from `DataLakeAccessModal`, a **separate** modal opened from the Access button in [`manager/LakeInfoPanel.tsx:221`](apps/client/app/components/DataLakeWizard/manager/LakeInfoPanel.tsx#L221) - not a tab of the settings modal. So the history query has no observer at the moment of the write.
- The query pairs `staleTime: 0` with that `enabled` toggle, so re-opening the tab refetches regardless of whether anything invalidated.

So #2556's premise - "the config history keeps showing a window that predates the change until something else refetches it" - is overstated: the enabled-toggle remount is that something. The fix is still worth making, for the reason the existing `useSetLakeVisibility` comment already gives about this exact key: that refetch is **incidental, not a guarantee**, and raising `staleTime` or dropping the `enabled` toggle would silently strand the row. Transfer is the door where that would hurt most - a transfer moves no document field, so its history row is the only record the handover happened at all, and it is the one row that could not be reconstructed from the lake document afterwards.

Framing this accurately matters more than it sounds: shipped as a "stale audit trail" fix, it would be the kind of thing someone later points at to explain a symptom it never caused.

### Corrected census

The first revision claimed transfer-ownership was the only gap. **That was wrong**, and @onoya caught it: the census had assumed every lifecycle action reaches `invalidateAfterLifecycle`, but the purge door builds its own `onSuccess` around the pending-purge suppression and never calls that helper.

Redone from the server side, which is the enumerable end. Eleven services call `recordLakeConfigChange`; ten are operator doors with exactly one client mutation each:

| service | action | client door | before |
|---|---|---|---|
| `updateDataLake` | `update` | `useUpdateDataLake` | ✅ |
| `updateFallbackLakeSettings` | `update` | `useUpdateFallbackLakeSettings` | ❌ **fixed here** |
| `setLakeVisibility` | `visibility` | `useSetLakeVisibility` | ✅ |
| `transferLakeOwnership` | `transfer-ownership` | `useTransferLakeOwnership` | ❌ **fixed here** |
| `archiveDataLake` | `archive` | `useArchiveDataLake` (helper) | ✅ |
| `unarchiveDataLake` | `unarchive` | `useUnarchiveDataLake` (helper) | ✅ |
| `deleteDataLake` | `delete` | `usePermanentDeleteDataLake` (helper) | ✅ |
| `restoreDeletedDataLake` | `restore` | `useRestoreDeletedDataLake` (helper) | ✅ |
| `acceptDataLakePurge` | `purge` | `useCleanupDataLake` | ❌ **fixed here** |
| `manageLakeGrant` | `grant-access` / `revoke-access` | `useGrantLakeAccess` / `useRevokeLakeAccess` | ✅ |

Note the two `delete`-ish names, which do not mean what they look like: `usePermanentDeleteDataLake` drives the **recoverable** `delete` action (its toast reads "Data lake deleted (recoverable)"), while the irreversible hard delete is `useCleanupDataLake` / `purge` on the row below.

The eleventh, `recomputeLakeStats` (`auto-activate`), is deliberately **not** claimed as closed. It is reached by many callers - tag edits, file add/remove/purge, batch reconciliation - including server-side paths with no client door at all (`reconcileStuckBatches`, `reconcileLakeTags`), so "every door invalidates" is not a property the client can establish. The lake-scoped client doors that reach it (`useAddFileToDataLake`, `useRemoveFileFromDataLake` via `invalidateLakeFileMembershipQueries`, and `usePurgeDataLakeDocument`) do invalidate, and an existing test covers the file-removal path. **That is best-effort, not a closed set.**

## Changes

- `dataLakes.ts` - add `configHistoryOf(id)` invalidation to `useTransferLakeOwnership`, `useCleanupDataLake` and `useUpdateFallbackLakeSettings`. The latter's `onSuccess` gains the `{ id }` variables argument it previously ignored.
- `dataLakes.ts` - correct `invalidateAfterLifecycle`'s comment, which claimed to invalidate for "all five" lifecycle actions. It only ever sees four; `cleanup` has never reached it, which is precisely how that gap survived.
- `dataLakes.test.ts` - five cases in the existing `config-history invalidation` block: three for the doors fixed here, plus one each pinning `useGrantLakeAccess` and `useRevokeLakeAccess`, which had the behavior but no test guarding it.
- `dataLakes.test.ts` - narrow the purge test's `expect(invalidate).not.toHaveBeenCalled()` to an exhaustive key list. Its point was that this door refreshes nothing that could re-add the removed row; the history key cannot (`['dataLakeConfigHistory', id]` does not prefix-match `['data-lakes','deleted']`). The exhaustive form keeps the guard for any *further* key added later, so it was narrowed rather than deleted.
- `dataLakes.test.ts` - move the block comment documenting these tests onto the `describe` it documents (it had drifted above `lakeMemoryPollInterval`), and add a `put` mock to the ApiContext stub for the file's first PUT caller.

Each of the three fixes was confirmed to fail its test against the unfixed hook and pass with it.

## Guide for Testers

Test on this PR's preview environment: **https://app.pr2609.preview.bike4mind.com** - not staging, which does not carry this branch. Wait for the deploy bot's comment to say the preview has landed before starting; it is replaced the moment it does.

Requires a data lake you own in an organization with at least one other member, and `EnableDataLakes` on.

**What you are checking is that nothing regressed.** Per the correction above, the invalidations this PR adds are guarantees rather than repairs - the History tab already refreshed on re-open by way of `staleTime: 0`, so there is no before/after difference to observe in the UI. Comparing against `main` is not something the preview can show you either, since it only serves this branch - the steps below are a "does it still work" pass, not an A/B.

Note on navigation: **Access and Settings are two separate modals**, both opened from the buttons on the lake's info panel. History is a tab *inside Settings*; there is no Access tab.

1. Go to `app.pr2609.preview.bike4mind.com` and sign in as the owner of an org-owned data lake.
2. Navigate to Sidebar -> Data Lakes and select the lake you own.
3. On the lake's info panel, click **Settings** (`datalake-settings-btn-<id>`), then the **History** tab. Note the newest row and its timestamp. Close the modal.
4. Back on the info panel, click **Access** (`datalake-access-btn-<id>`). A separate access modal opens.

5. Use **Transfer ownership**, pick another member of the organization, and confirm. Expected: a success toast reading `Data lake ownership transferred`. Close the access modal.

    <img width="1507" height="767" alt="transfer-modal" src="https://github.com/user-attachments/assets/de52e2c7-2ad1-4545-860e-eaf919a1e042" />

    <img width="1507" height="767" alt="sucess-toast" src="https://github.com/user-attachments/assets/1f33f4a0-491f-42f7-aadc-d2d4dd0a4bb2" />

6. Click **Settings -> History** again. Expected: a new top row describing the transfer, dated now.

    <img width="727" height="266" alt="history-tab" src="https://github.com/user-attachments/assets/26b1bf50-70e8-4dd6-be91-b365141e7117" />

7. In the access modal, **Grant access** to a teammate's email with role `Reader`, then re-open Settings -> History. Expected: a new `grant-access` row.
8. **Revoke** that grant, re-open History. Expected: a new `revoke-access` row.

### Regression Checks

9. Change the lake's visibility (Settings -> Visibility) and re-open History. Expected: a new row.
10. Archive the lake from the lake list, then re-open its History. Expected: a new row.
11. **The purge path is the one to watch** - this PR adds a cache invalidation to that door, and the risk it must not introduce is the purged row flickering back. Expand the **Deleted** section, purge a soft-deleted lake, and confirm the row disappears **and stays gone** without reloading. Re-expand the section and confirm it is still absent.
12. Confirm History still shows only the acted-on lake's rows - opening a *different* lake's History must not show the transferred lake's events.

### What NOT to test

- Server-side audit content: no service, route, or schema changed. Which fields each row records, and its authority rung, are untouched.
- The transfer's authorization rules and candidate picker - unchanged.
- The fallback/registry lake settings overlay is admin-only and its modal has no History section, so its fix has no observable effect at all.

## Additional Information

Client-only, two files, no API/schema/infra surface. Three one-line `invalidateQueries` additions; the rest is test coverage and comment corrections.

Follow-up filed as #2658: the `scopes the invalidation to that one lake, never the whole history root` assertion - the one guarding against invalidating the bare `['dataLakeConfigHistory']` root - covers only `useSetLakeVisibility`, leaving the other eight doors unguarded against that specific mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


