### PR TITLE
feat(services): alarm on truncated data-lake scans, and report them from every return path

### DIFF
--- a/b4m-core/services/package.json
+++ b/b4m-core/services/package.json
@@ -199,6 +199,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1080.0",
+    "@aws-sdk/client-cloudwatch": "^3.1080.0",
     "@aws-sdk/client-s3": "^3.1080.0",
     "@aws-sdk/client-transcribe": "^3.1080.0",
     "@aws-sdk/credential-provider-node": "^3.972.63",

--- a/b4m-core/services/src/dataLakeService/scanTruncationMetrics.test.ts
+++ b/b4m-core/services/src/dataLakeService/scanTruncationMetrics.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const send = vi.fn();
+// Both are invoked with `new`, so the mocks have to be constructible - an arrow function is not.
+vi.mock('@aws-sdk/client-cloudwatch', () => ({
+  CloudWatchClient: vi.fn(function (this: any) {
+    this.send = send;
+  }),
+  PutMetricDataCommand: vi.fn(function (this: any, input: unknown) {
+    this.input = input;
+  }),
+  StandardUnit: { Count: 'Count' },
+}));
+
+import {
+  DATA_LAKE_RETRIEVAL_NAMESPACE,
+  SCAN_TRUNCATED_METRIC,
+  reportScanTruncation,
+  scanTruncationCause,
+  type ScanTruncationReport,
+} from './scanTruncationMetrics';
+
+const report = (overrides: Partial<ScanTruncationReport> = {}): ScanTruncationReport => ({
+  fileBudgetHit: true,
+  chunkBudgetHit: false,
+  filesScanned: 10,
+  filesMatching: 50,
+  chunksScanned: 100,
+  maxFiles: 10,
+  maxChunks: 1000,
+  ...overrides,
+});
+
+const makeLogger = () => ({ warn: vi.fn() });
+
+describe('scanTruncationMetrics literals', () => {
+  // infra/alarms.ts cannot import from a b4m-core package, so its `dataLakeScanTruncated` alarm
+  // hard-codes these two strings. A rename here that only touched the package would leave that
+  // alarm watching a metric nobody publishes - which is exactly the silent failure the alarm
+  // exists to catch. Pin them.
+  it('pins the namespace and metric name that infra/alarms.ts hard-codes', () => {
+    expect(DATA_LAKE_RETRIEVAL_NAMESPACE).toBe('Lumina5/DataLakeRetrieval');
+    expect(SCAN_TRUNCATED_METRIC).toBe('ScanTruncated');
+  });
+});
+
+describe('scanTruncationCause', () => {
+  it.each([
+    { fileBudgetHit: true, chunkBudgetHit: false, expected: 'files' },
+    { fileBudgetHit: false, chunkBudgetHit: true, expected: 'chunks' },
+    { fileBudgetHit: true, chunkBudgetHit: true, expected: 'files-and-chunks' },
+  ])('maps files=$fileBudgetHit chunks=$chunkBudgetHit to $expected', ({ fileBudgetHit, chunkBudgetHit, expected }) => {
+    expect(scanTruncationCause(fileBudgetHit, chunkBudgetHit)).toBe(expected);
+  });
+});
+
+describe('reportScanTruncation', () => {
+  beforeEach(() => {
+    send.mockReset();
+    send.mockResolvedValue({});
+    delete process.env.SEED_STAGE_NAME;
+  });
+
+  it('publishes nothing outside a deployed stage, but still logs', async () => {
+    const logger = makeLogger();
+
+    await reportScanTruncation('lake-scoped', report(), logger as never);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'), {
+      entrypoint: 'lake-scoped',
+      cause: 'files',
+    });
+  });
+
+  it('publishes a Stage-only datapoint for the alarm plus a wider set for attribution', async () => {
+    process.env.SEED_STAGE_NAME = 'production';
+
+    await reportScanTruncation('file-scoped', report({ chunkBudgetHit: true }), makeLogger() as never);
+
+    const { input } = send.mock.calls[0][0];
+    expect(input.Namespace).toBe('Lumina5/DataLakeRetrieval');
+    expect(input.MetricData).toHaveLength(2);
+    expect(input.MetricData.every((d: { MetricName: string }) => d.MetricName === 'ScanTruncated')).toBe(true);
+
+    // A CloudWatch alarm matches ONE exact dimension set and never rolls up, so the alarm's
+    // datapoint has to carry Stage and nothing else. If a Cause/Entrypoint dimension leaked onto
+    // it the alarm would silently stop matching.
+    expect(input.MetricData[0].Dimensions).toEqual([{ Name: 'Stage', Value: 'production' }]);
+    expect(input.MetricData[1].Dimensions).toEqual([
+      { Name: 'Stage', Value: 'production' },
+      { Name: 'Cause', Value: 'files-and-chunks' },
+      { Name: 'Entrypoint', Value: 'file-scoped' },
+    ]);
+  });
+
+  it('never throws when CloudWatch rejects the publish - the search it reports on must still return', async () => {
+    process.env.SEED_STAGE_NAME = 'production';
+    send.mockRejectedValue(new Error('AccessDenied'));
+    const logger = makeLogger();
+
+    await expect(reportScanTruncation('lake-scoped', report(), logger as never)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to emit ScanTruncated metric'),
+      expect.objectContaining({ error: 'AccessDenied' })
+    );
+  });
+});

--- a/b4m-core/services/src/dataLakeService/scanTruncationMetrics.ts
+++ b/b4m-core/services/src/dataLakeService/scanTruncationMetrics.ts
@@ -1,0 +1,122 @@
+import { CloudWatchClient, PutMetricDataCommand, StandardUnit } from '@aws-sdk/client-cloudwatch';
+import type { Logger } from '@bike4mind/observability';
+
+/**
+ * Telemetry for a retrieval failure that looks like a success.
+ *
+ * When a scan hits `maxFiles` or `maxChunks` the search still returns a well-formed,
+ * plausibly-ranked result set - it just ranks a budgeted PREFIX of the corpus. Nobody files a
+ * ticket for an answer that reads fine, so the first lake to outgrow the budgets degrades
+ * quietly. `scan.truncated` has always recorded it; this publishes it as something alarmable.
+ *
+ * Emitted from the two public search entrypoints rather than from the ranking core, because
+ * truncation is decided on three different return paths (a budgeted scan, an empty query
+ * embedding, and a scope whose every file was retrieval-excluded) and an emitter wired to only
+ * the first would be blind to the other two.
+ *
+ * Keep the names below in sync with infra/alarms.ts (`dataLakeScanTruncated`); the tests pin
+ * the literals, because infra cannot import them.
+ */
+export const DATA_LAKE_RETRIEVAL_NAMESPACE = 'Lumina5/DataLakeRetrieval';
+export const SCAN_TRUNCATED_METRIC = 'ScanTruncated';
+
+/** Which budget stopped the walk - the two need different operator responses. */
+export type ScanTruncationCause = 'files' | 'chunks' | 'files-and-chunks';
+
+/** Which search surface truncated. Dimension value, so keep these stable. */
+export type SearchEntrypoint = 'lake-scoped' | 'file-scoped';
+
+/**
+ * Precondition: at least one flag is set. Guaranteed by `truncated` being their disjunction at
+ * every site that builds it, which is also the only condition under which this is called.
+ */
+export function scanTruncationCause(fileBudgetHit: boolean, chunkBudgetHit: boolean): ScanTruncationCause {
+  if (fileBudgetHit && chunkBudgetHit) return 'files-and-chunks';
+  return fileBudgetHit ? 'files' : 'chunks';
+}
+
+export interface ScanTruncationReport {
+  fileBudgetHit: boolean;
+  chunkBudgetHit: boolean;
+  filesScanned: number;
+  filesMatching: number;
+  chunksScanned: number;
+  maxFiles: number;
+  maxChunks: number;
+}
+
+/**
+ * Reports one truncated search: a warn line naming what was and was not covered, plus the
+ * alarmable metric. Never throws - a CloudWatch failure still leaves the log behind. The caller
+ * awaits it, which only spends latency on a search that is already returning a short corpus;
+ * truncation is rare by construction, so this is not on the hot path.
+ *
+ * Callers must gate on `scan.truncated` rather than on the two budget flags: the flags are the
+ * cause, `truncated` is the signal, and only the caller sees which return path it came from.
+ *
+ * The metric no-ops outside deployed stages (`SEED_STAGE_NAME` comes from
+ * DEFAULT_LAMBDA_ENVIRONMENT in infra/constants.ts) - a CLI, self-host, or test run has no
+ * CloudWatch to publish to. The warn keeps semanticDataLakeSearch's own convention of logging
+ * only through a caller-supplied logger, so relocating it here changed nothing about when it
+ * fires.
+ */
+export async function reportScanTruncation(
+  entrypoint: SearchEntrypoint,
+  report: ScanTruncationReport,
+  logger?: Logger
+): Promise<void> {
+  const cause = scanTruncationCause(report.fileBudgetHit, report.chunkBudgetHit);
+
+  logger?.warn?.(
+    `[semanticSearch] TRUNCATED scan: ranked ${report.chunksScanned} chunks across ` +
+      `${report.filesScanned}/${report.filesMatching} files (maxFiles=${report.maxFiles}, ` +
+      `maxChunks=${report.maxChunks}) - results rank an INCOMPLETE corpus`,
+    { entrypoint, cause }
+  );
+
+  const stage = process.env.SEED_STAGE_NAME;
+  if (!stage) return;
+
+  try {
+    // Fresh client per call: warm Lambda containers outlive their credentials, and a
+    // module-level client captures expired ones (see server/utils/cloudwatch.ts).
+    const client = new CloudWatchClient({ region: process.env.AWS_REGION || 'us-east-2' });
+    const timestamp = new Date();
+
+    await client.send(
+      new PutMetricDataCommand({
+        Namespace: DATA_LAKE_RETRIEVAL_NAMESPACE,
+        MetricData: [
+          // A CloudWatch alarm matches one exact dimension set and never rolls up, so the
+          // Stage-only datapoint is the alarmable one; the wider set exists for attribution
+          // (which budget, which surface). They are separate metrics to CloudWatch, so
+          // neither double-counts the other.
+          {
+            MetricName: SCAN_TRUNCATED_METRIC,
+            Value: 1,
+            Unit: StandardUnit.Count,
+            Timestamp: timestamp,
+            Dimensions: [{ Name: 'Stage', Value: stage }],
+          },
+          {
+            MetricName: SCAN_TRUNCATED_METRIC,
+            Value: 1,
+            Unit: StandardUnit.Count,
+            Timestamp: timestamp,
+            Dimensions: [
+              { Name: 'Stage', Value: stage },
+              { Name: 'Cause', Value: cause },
+              { Name: 'Entrypoint', Value: entrypoint },
+            ],
+          },
+        ],
+      })
+    );
+  } catch (error) {
+    logger?.warn?.(`[semanticSearch] Failed to emit ${SCAN_TRUNCATED_METRIC} metric`, {
+      entrypoint,
+      cause,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.test.ts
@@ -4,9 +4,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // above the floor, which is what the pre-existing exclusion/scoping tests assume.
 // mockCreateEmbeddingService is a spy (not just a stub) so multi-model tests can assert exactly
 // which models were embedded and how many times.
-const { mockCosine, mockCreateEmbeddingService } = vi.hoisted(() => ({
+const { mockCosine, mockCreateEmbeddingService, mockGenerateEmbedding } = vi.hoisted(() => ({
   mockCosine: vi.fn(() => 0.9),
   mockCreateEmbeddingService: vi.fn(),
+  // Defaulted in beforeEach to the model-encoding vector every other test assumes; overridable so
+  // the empty-embedding return path can be exercised.
+  mockGenerateEmbedding: vi.fn(),
 }));
 
 // Mock only the embedding/provider helpers from the utils barrel; keep the real
@@ -26,7 +29,7 @@ vi.mock('@bike4mind/utils', async importOriginal => {
     EmbeddingFactory: class {
       createEmbeddingService(model: string) {
         mockCreateEmbeddingService(model);
-        return { generateEmbedding: async () => [model.length, 0] };
+        return { generateEmbedding: async () => mockGenerateEmbedding(model) };
       }
     },
   };
@@ -44,6 +47,8 @@ beforeEach(() => {
   mockCosine.mockReset();
   mockCosine.mockReturnValue(0.9);
   mockCreateEmbeddingService.mockClear();
+  mockGenerateEmbedding.mockReset();
+  mockGenerateEmbedding.mockImplementation((model: string) => [model.length, 0]);
 });
 
 const baseParams = (): SemanticDataLakeSearchParams => ({
@@ -418,7 +423,7 @@ describe('semanticDataLakeSearch bounded scan + honest accounting', () => {
     expect(result.scan.fileBudgetHit).toBe(true);
     expect(result.scan.truncated).toBe(true);
     expect(result.scan.filesMatching).toBe(50);
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'), expect.any(Object));
   });
 
   it('a corpus that exactly fills the chunk budget is NOT reported as truncated', async () => {
@@ -457,7 +462,7 @@ describe('semanticDataLakeSearch bounded scan + honest accounting', () => {
     expect(result.scan.chunksScanned).toBe(5);
     expect(result.scan.chunkBudgetHit).toBe(true);
     expect(result.scan.truncated).toBe(true);
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'), expect.any(Object));
   });
 
   it('never requests more than one page beyond the page size - the enforceable memory bound', async () => {
@@ -504,6 +509,95 @@ describe('semanticDataLakeSearch bounded scan + honest accounting', () => {
         },
       } as never)
     ).rejects.toThrow('cursor did not advance');
+  });
+});
+
+/**
+ * Truncation is decided on THREE return paths, and until the reporting seam moved to the
+ * entrypoints only the first of them said anything: a budgeted scan warned, while a scope whose
+ * every file was retrieval-excluded and a scope whose query embedding came back empty both
+ * returned a truncated corpus in silence. The metric feeding the `dataLakeScanTruncated` alarm
+ * rides the same seam, so a path that reports nothing is a path the alarm cannot see.
+ */
+describe('semanticDataLakeSearch truncation reporting covers every return path', () => {
+  // Over the file budget with a page still pending, so fileBudgetHit is set before either
+  // downstream return can be reached. The 'MARK - ' prefix only matters to the exclusion test
+  // below; it is inert for the others.
+  const overBudgetPage = () =>
+    filesAdapter([
+      {
+        data: Array.from({ length: 2 }, (_, i) => ({ id: `f${i}`, fileName: `MARK - F${i}.pdf`, tags: [] })),
+        hasMore: true,
+        total: 50,
+      },
+    ]);
+
+  it('reports truncation when the file budget was hit and EVERY scoped file is retrieval-excluded', async () => {
+    const logger = makeLogger();
+    const findVectors = pagingChunkMock([]);
+
+    const result = await semanticDataLakeSearch(
+      {
+        ...baseParams(),
+        logger: logger as never,
+        budgets: { maxFiles: 2, filePageSize: 2 },
+        // Both scoped files carry the marker, so fileIds is empty and the search returns before
+        // any ranking - the path that used to drop the signal entirely. Markers are anchored
+        // leading + word-boundary, hence the 'MARK - ' prefix rather than a bare substring.
+        retrievalFilter: { excludeFilenameMarkers: ['MARK'] },
+      },
+      {
+        db: { fabfiles: { search: overBudgetPage() }, fabfilechunks: { findVectorsByFabFileIds: findVectors } },
+      } as never
+    );
+
+    expect(findVectors).not.toHaveBeenCalled();
+    expect(result.scan.truncated).toBe(true);
+    expect(result.scan.fileBudgetHit).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'), {
+      entrypoint: 'lake-scoped',
+      cause: 'files',
+    });
+  });
+
+  it('reports truncation when the file budget was hit and the query embedding came back empty', async () => {
+    const logger = makeLogger();
+    mockGenerateEmbedding.mockResolvedValue([]);
+
+    const result = await semanticDataLakeSearch(
+      { ...baseParams(), logger: logger as never, budgets: { maxFiles: 2, filePageSize: 2 } },
+      {
+        db: {
+          fabfiles: { search: overBudgetPage() },
+          fabfilechunks: { findVectorsByFabFileIds: pagingChunkMock([]) },
+        },
+      } as never
+    );
+
+    // The scope walk hit its budget BEFORE the embedding failed, so the corpus really is
+    // incomplete - reporting it as complete here is what made this path invisible.
+    expect(result.scan.fileBudgetHit).toBe(true);
+    expect(result.scan.truncated).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'), {
+      entrypoint: 'lake-scoped',
+      cause: 'files',
+    });
+  });
+
+  it('stays silent on a complete scan - an alarm that fires on healthy lakes is worthless', async () => {
+    const logger = makeLogger();
+
+    const result = await semanticDataLakeSearch({ ...baseParams(), logger: logger as never }, {
+      db: {
+        fabfiles: {
+          search: filesAdapter([{ data: [{ id: 'f1', fileName: 'F1.pdf', tags: [] }], hasMore: false, total: 1 }]),
+        },
+        fabfilechunks: { findVectorsByFabFileIds: pagingChunkMock(chunkRows('f1', 2)) },
+      },
+    } as never);
+
+    expect(result.scan.truncated).toBe(false);
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'), expect.anything());
   });
 });
 
@@ -945,6 +1039,32 @@ describe('fileScopedSemanticSearch (allow-list scope)', () => {
     expect(result.scan.fileBudgetHit).toBe(true);
     expect(result.scan.truncated).toBe(true);
     expect(result.scan.filesMatching).toBe(3);
+  });
+
+  /**
+   * The Entrypoint dimension is what tells an operator WHICH surface truncated - a curated agent
+   * kbScope and a lake search have different fixes (recurate vs raise the budget), and the alarm
+   * is otherwise one undifferentiated count.
+   */
+  it('attributes the allow-list surface to its own entrypoint, so a truncating surface is identifiable', async () => {
+    const logger = makeLogger();
+    const { adapters } = scopedAdapters({
+      files: [
+        { id: 'a', fileName: 'A.pdf', tags: [] },
+        { id: 'b', fileName: 'B.pdf', tags: [] },
+      ],
+    });
+
+    const result = await fileScopedSemanticSearch(
+      { ...scopedParams(['a', 'b']), logger: logger as never, budgets: { maxFiles: 1 } },
+      adapters as never
+    );
+
+    expect(result.scan.truncated).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('TRUNCATED'), {
+      entrypoint: 'file-scoped',
+      cause: 'files',
+    });
   });
 
   it('reports a complete allow-list scan as not truncated', async () => {

--- a/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
+++ b/b4m-core/services/src/dataLakeService/semanticDataLakeSearch.ts
@@ -29,6 +29,7 @@ import {
   type EmbeddingMismatchReport,
 } from './embeddingMismatch';
 import { BoundedTopK } from './boundedTopK';
+import { reportScanTruncation, type ScanTruncationReport, type SearchEntrypoint } from './scanTruncationMetrics';
 import { isVectorSearchReady, partitionByVectorSearchReadiness } from './vectorSearchEligibility';
 import {
   buildRetrievalUnavailableReport,
@@ -801,7 +802,14 @@ async function rankChunksForFiles(args: {
     const mismatch = createEmbeddingMismatchAccumulator(excludedForeignFiles(new Set()), embeddingModel);
     mismatch.queryEmbeddingFailed();
     return {
-      ...emptyResult(embeddingModel, budgets, { filesMatching: args.filesMatching, filesScoped: fileIds.length }),
+      // fileBudgetHit rides along deliberately: the scope walk already hit its budget before the
+      // embedding failed, so dropping it here would report a truncated corpus as complete.
+      ...emptyResult(embeddingModel, budgets, {
+        filesMatching: args.filesMatching,
+        filesScoped: fileIds.length,
+        truncated: args.fileBudgetHit,
+        fileBudgetHit: args.fileBudgetHit,
+      }),
       embeddingMismatch: mismatch.report(),
       retrievalUnavailable,
       supersession,
@@ -1125,12 +1133,11 @@ async function rankChunksForFiles(args: {
     );
   }
 
-  if (scan.truncated) {
-    logger?.warn?.(
-      `[semanticSearch] TRUNCATED scan: ranked ${scan.chunksScanned} chunks across ${scan.filesScanned}/${scan.filesMatching} files ` +
-        `(maxFiles=${scan.budgets.maxFiles}, maxChunks=${scan.budgets.maxChunks}) - results rank an INCOMPLETE corpus`
-    );
-  } else if (scan.chunksScanned > 0 && scan.chunksSkippedDimensionMismatch === scan.chunksScanned) {
+  // Truncation is reported by the entrypoint wrappers, not here: this function is only one of
+  // three return paths that can set `scan.truncated`. The suppression the old else-if provided is
+  // kept explicitly - a budgeted prefix that happens to be entirely foreign-model says nothing
+  // about the whole corpus, so the diagnosis below would be guessing.
+  if (!scan.truncated && scan.chunksScanned > 0 && scan.chunksSkippedDimensionMismatch === scan.chunksScanned) {
     // Guarded on ALL chunks mismatching: a few stale chunks mid-revectorize are expected and must
     // stay quiet, but an entire corpus in the wrong vector space can never return anything.
     logger?.warn?.(
@@ -1194,7 +1201,41 @@ async function rankChunksForFiles(args: {
   };
 }
 
+/**
+ * The one place a truncated search is reported. Both public entrypoints are thin wrappers around
+ * their real bodies so that every internal return path - a budgeted scan, an empty query
+ * embedding, a fully retrieval-excluded scope - passes through here. Reporting from the ranking
+ * core instead would see only the first of the three.
+ */
+async function withTruncationReport(
+  entrypoint: SearchEntrypoint,
+  result: SemanticDataLakeSearchResult,
+  logger?: Logger
+): Promise<SemanticDataLakeSearchResult> {
+  const { scan } = result;
+  if (!scan.truncated) return result;
+
+  const report: ScanTruncationReport = {
+    fileBudgetHit: scan.fileBudgetHit,
+    chunkBudgetHit: scan.chunkBudgetHit,
+    filesScanned: scan.filesScanned,
+    filesMatching: scan.filesMatching,
+    chunksScanned: scan.chunksScanned,
+    maxFiles: scan.budgets.maxFiles,
+    maxChunks: scan.budgets.maxChunks,
+  };
+  await reportScanTruncation(entrypoint, report, logger);
+  return result;
+}
+
 export async function semanticDataLakeSearch(
+  params: SemanticDataLakeSearchParams,
+  adapters: SemanticDataLakeSearchAdapters
+): Promise<SemanticDataLakeSearchResult> {
+  return withTruncationReport('lake-scoped', await lakeScopedSearch(params, adapters), params.logger);
+}
+
+async function lakeScopedSearch(
   params: SemanticDataLakeSearchParams,
   adapters: SemanticDataLakeSearchAdapters
 ): Promise<SemanticDataLakeSearchResult> {
@@ -1339,6 +1380,13 @@ export interface FileScopedSemanticSearchAdapters {
  * deleted/archived files curated into a scope contribute nothing.
  */
 export async function fileScopedSemanticSearch(
+  params: FileScopedSemanticSearchParams,
+  adapters: FileScopedSemanticSearchAdapters
+): Promise<SemanticDataLakeSearchResult> {
+  return withTruncationReport('file-scoped', await fileScopedSearch(params, adapters), params.logger);
+}
+
+async function fileScopedSearch(
   params: FileScopedSemanticSearchParams,
   adapters: FileScopedSemanticSearchAdapters
 ): Promise<SemanticDataLakeSearchResult> {

--- a/infra/alarms.ts
+++ b/infra/alarms.ts
@@ -1161,6 +1161,50 @@ if (isMonitoredStage) {
     },
   });
 
+  /**
+   * Alarm: data-lake retrieval scanned only a budgeted prefix of the corpus
+   *
+   * A truncated scan returns a well-formed, plausibly-ranked result set built from an INCOMPLETE
+   * corpus, so it is invisible from the outside: no error, no empty result, nobody files a
+   * ticket. This is the alarm the $vectorSearch cutover work asked for - the first lake to
+   * outgrow DATA_LAKE_SEARCH_MAX_FILES_DEFAULT (5,000) or DATA_LAKE_SEARCH_MAX_CHUNKS_DEFAULT
+   * (100,000) would otherwise degrade quietly.
+   *
+   * Threshold 0 over one hour: steady state is genuinely zero (the whole production corpus is
+   * well under both budgets today), so a single truncated search is the signal, and waiting for
+   * a sustained rate would just mean more users get short-corpus answers first. The operator
+   * response is to raise the budget or shard the lake, which is not urgent enough to page -
+   * hence Medium, matching deprecatedModelRequest's "silent, needs a human decision" shape.
+   *
+   * Reuses the DataLakeStuckBatches topic, as the taxonomy alarm above already does: it is the
+   * de-facto data-lake ops topic, and topics are not subscribed in IaC anyway.
+   *
+   * Metric emitted by: b4m-core/services/src/dataLakeService/scanTruncationMetrics.ts ->
+   * reportScanTruncation, wired from both public search entrypoints in semanticDataLakeSearch.ts.
+   * Namespace: Lumina5/DataLakeRetrieval / ScanTruncated
+   * Alarms on the Stage-only dimension set; the Cause/Entrypoint set is for attribution only.
+   */
+  new aws.cloudwatch.MetricAlarm('dataLakeScanTruncated', {
+    name: `${$app.name}-${$app.stage}-data-lake-scan-truncated`,
+    alarmDescription:
+      'A data-lake search ranked only a budgeted prefix of the corpus - retrieval is returning incomplete results without erroring',
+    comparisonOperator: 'GreaterThanThreshold',
+    evaluationPeriods: 1,
+    metricName: 'ScanTruncated',
+    namespace: 'Lumina5/DataLakeRetrieval',
+    period: 3600, // 1 hour
+    statistic: 'Sum',
+    threshold: 0,
+    dimensions: { Stage: $app.stage },
+    // No emission means no search truncated, which is the healthy state.
+    treatMissingData: 'notBreaching',
+    alarmActions: [dataLakeStuckBatchesAlarm!.arn],
+    tags: {
+      Application: 'DataLakeRetrieval',
+      Severity: 'Medium',
+    },
+  });
+
   // dlqAlarmTopic is a conditional export from infra/dlqAlarms.ts, gated by that file's OWN copy
   // of the MONITORED_STAGES + ENABLE_MONITORING expression. The two agree today, but asserting
   // `dlqAlarmTopic!` across a file boundary on a value another module owns means a future

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,6 +1298,9 @@ importers:
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1080.0
         version: 3.1080.0
+      '@aws-sdk/client-cloudwatch':
+        specifier: ^3.1080.0
+        version: 3.1080.0
       '@aws-sdk/client-s3':
         specifier: ^3.1080.0
         version: 3.1080.0


### PR DESCRIPTION
## Description

A data-lake scan that hits `maxFiles` (5,000) or `maxChunks` (100,000) still returns a
well-formed, plausibly-ranked result set - it just ranks a budgeted **prefix** of the corpus.
No error, no empty result, nobody files a ticket. `scan.truncated` has always recorded it;
nothing watched it, so the first lake to outgrow the budgets would degrade quietly.

Wiring an alarm to the existing warn would not have been enough. Truncation is decided on
**three** return paths, and only one of them reported anything:

| site | `truncated` | reported? |
|---|---|---|
| `rankChunksForFiles` normal scan (both entrypoints) | `fileBudgetHit \|\| chunkBudgetHit` | warn only |
| `rankChunksForFiles`, query embedding came back empty | **`false` - `fileBudgetHit` was dropped** | no |
| `semanticDataLakeSearch`, every scoped file retrieval-excluded | correct | no |

So an alarm on the existing warn would have been blind to two real truncations, and the middle
row actively reported a truncated corpus as complete. Both are fixed here.

Part of #2526. This PR is only the alerting half of that issue - it does not touch the ANN path
and does not change the `EnableDataLakeVectorSearch` setting.

## Changes

- **`scanTruncationMetrics.ts`** (new) - owns the warn plus the `Lumina5/DataLakeRetrieval /
  ScanTruncated` metric. Same shape as `modelSunsetMetrics.ts`: `SEED_STAGE_NAME` gate, fresh
  client per call, never throws. Publishes a Stage-only datapoint for the alarm plus a
  `Cause`/`Entrypoint` set for attribution, because a CloudWatch alarm matches one exact
  dimension set and never rolls up.
- **Both public entrypoints became thin wrappers** over their real bodies (`lakeScopedSearch` /
  `fileScopedSearch`), so every internal return funnels through one `withTruncationReport` seam.
  `rankChunksForFiles` stays private with exactly those two call sites, which is what makes the
  coverage total rather than merely broad.
- **The dropped `fileBudgetHit`** on the empty-query-embedding return is restored.
- **The `if (truncated) / else if (all-chunks-mismatched)` chain** became an explicit
  `if (!truncated && ...)`. Behavior-preserving: a budgeted prefix that happens to be entirely
  foreign-model still suppresses the mismatch diagnosis, because it says nothing about the whole
  corpus.
- **`infra/alarms.ts`** - `dataLakeScanTruncated`, threshold 0 over 1h, Severity Medium, on the
  existing DataLakeStuckBatches topic (as the taxonomy alarm already does).
- Tests pin the metric-name literals, since `infra/` cannot import them.

## Guide for Testers

**Steady state is zero.** The whole production corpus is well under both budgets today (largest
single lake is ~22k chunks against a 100k budget), so this alarm should never fire on current
data. That is the point - it is insurance for the first lake that crosses. Testing means
**forcing** a truncation by lowering the budget, not by growing a lake.

The budgets are not request parameters - they are resolved server-side from admin settings.

**Change them at the PLATFORM level, not at Lake scope.** Both settings declare
`settableAt: [Organization, Owner, Lake]`, but no retrieval caller ever resolves budgets at a Lake
rung - `data-lakes/semantic-search.ts` passes no scoped settings at all, and the knowledge-base
tool passes only an Organization/Owner scope. A Lake-scoped override on either budget is silently
inert, so scoping the change to one lake makes the test pass for the wrong reason. That gap is
pre-existing; this PR neither causes nor fixes it.

Because the change is platform-wide it lowers the budget for everyone on that stage while it is
set, so keep the window short and reset it in step 11. On a PR preview, which has its own
database, the change is contained to that preview.

### Setup

1. Go to `https://app.staging.bike4mind.com` and log in.
2. Create a data lake with **at least 3 files** in it (Files -> Upload Files -> Data Lakes).
   Wait for all files to finish vectorizing.
3. Ask a question against that lake in a chat session. Expect a normal grounded answer with
   citations. This is your baseline - keep the answer.

### Forced truncation, lake-scoped entrypoint

4. Go to Admin -> General Ops -> Admin Settings. Search for `Data Lake Search Max Files` (search
   matches the setting NAME, not the key `dataLakeSearchMaxFiles`; if you get "N results" with an
   empty list, flip the **All Tabs** view toggle - this setting is in the `AI` category).
5. Set it to one less than the lake's file count (e.g. `3` for a 4-file lake), at platform level.
   Prefer that over `1`: a budget of `1` scans a single file that may hold no vectors at all, so
   you can get zero hits for reasons unrelated to truncation.
6. Re-ask the same question from step 3. Expect HTTP 200 and a normal-looking answer - the
   request must NOT error, and the UI must not show a failure. Note that a low enough budget can
   legitimately return **zero** hits while still reporting success; that silent degradation is
   exactly what this alarm exists to catch.
7. In CloudWatch Logs for the staging web function, expect a line containing
   `[semanticSearch] TRUNCATED scan:` with context `{ entrypoint: 'lake-scoped', cause: 'files' }`.
8. Now reset max files to its default and set `Data Lake Search Max Chunks` to just under the
   lake's total chunk count, at platform level. Re-ask. Expect the same log line with
   `cause: 'chunks'`. Setting both low at once yields `cause: 'files-and-chunks'`.

### The metric and the alarm

9. In CloudWatch -> Metrics, open namespace `Lumina5/DataLakeRetrieval`, metric `ScanTruncated`.
   Expect a datapoint on the `Stage` dimension **alone**, and a separate one on
   `Stage + Cause + Entrypoint`. The Stage-only one is what the alarm reads.
10. In CloudWatch -> Alarms, confirm `bike4mind-dev-data-lake-scan-truncated` exists and moves to
    ALARM within roughly an hour of step 6 (period 3600s, threshold 0, so one datapoint is enough).
11. **Reset both settings to their defaults** when done, and confirm the alarm returns to OK.

### Regression Checks

This refactors the two entrypoints that EVERY data-lake retrieval passes through, so the
regression surface is wider than the feature. With both budgets back at their defaults:

12. **Normal chat retrieval.** Re-ask the step-3 question. Expect the same quality of grounded
    answer with citations, and **no** `TRUNCATED` log line.
13. **Agent kbScope retrieval** - this exercises the `file-scoped` entrypoint, which is a separate
    wrapper. Run an agent with a curated knowledge-base scope and confirm it still retrieves and
    cites correctly.
14. **The RLM data-lake REPL path.** Run a data-lake REPL/agent question that ends in "not found"
    territory. The agent prompt branches on `scan.truncated` (see Additional Information), so
    confirm it still concludes absence normally rather than looping on `listArticles` /
    `keywordSearch`.
15. **No added cost on the healthy path.** Confirm NO `ScanTruncated` datapoint appears for any of
    steps 12-14. A non-truncated search must emit nothing at all.
16. **The all-chunks-mismatched warning still fires** when it should - on a lake whose corpus is
    entirely in the wrong vector space, expect the `needs re-vectorizing` warn. Then lower the
    file budget (platform level, as above), re-ask against that same lake, and confirm the
    mismatch warning is **suppressed** while truncated (that suppression is deliberate and was
    preserved from the old else-if).

### Verified

I ran the whole matrix on a PR preview against a seeded 6-file lake, through the real
`POST /api/data-lakes/semantic-search` endpoint (not a test harness):

| Budgets | scan flags | results |
|---|---|---|
| defaults | `truncated=false` | 6 of 6 |
| `maxFiles=3` | `truncated=true`, `file_budget_hit=true`, `chunk_budget_hit=false` | 3, still returned |
| `maxChunks=3` | `truncated=true`, `file_budget_hit=false`, `chunk_budget_hit=true` | 3, still returned |
| both low | both flags true | 2, still returned |
| restored | `truncated=false`, no warn, no metric | 6 of 6 |

- **CloudWatch received four distinct dimension sets**: the `Stage`-only series (what the alarm
  evaluates, confirmed carrying no `Cause`/`Entrypoint`), plus `files`, `chunks` and
  `files-and-chunks` attribution series. `Sum = 1.0` at `period=3600`, which is above the
  alarm's threshold of 0, so the datapoint the alarm reads does breach.
- The `PutMetricData` call succeeded under the web function's real IAM role, and the namespace and
  metric-name literals match what `infra/alarms.ts` hard-codes.
- The warn line appeared in the preview's web function logs with the right structured context and
  counts (`ranked 3 chunks across 3/6 files`).
- Normal chat retrieval still grounds: the model quoted the seeded file text verbatim.
- A budget sweep confirmed truncation never discards ranked results - as the chunk budget tightens,
  hits drop off monotonically (4 -> 3 -> 2 -> 1 -> 0) and every surviving hit keeps its exact score.

Locally, against a real Mongo and real embeddings, 21 assertions cover the same ground plus two
things a deployment cannot easily reach: that a CloudWatch rejection is caught and warned rather
than thrown (exercised with a real client and invalid credentials), and that nothing is emitted
when `SEED_STAGE_NAME` is unset.

- The **`file-scoped`** entrypoint is verified live as well, through `POST /api/embed/chat` (the
  only caller that sets a `kbScope`). With `maxFiles=3` against the same 6-file lake it logged
  `entrypoint: 'file-scoped'`, `cause: 'files'`, `ranked 3 chunks across 3/6 files`, and emitted a
  `Cause=files` + `Entrypoint=file-scoped` series **plus** the same `Stage`-only alarmable
  datapoint - so the alarm reacts to this entrypoint too. The answer still quoted the seeded file
  text verbatim: truncation degraded coverage without breaking grounding.

Not covered by either run, and unit-tested only: the empty-query-embedding return path. The alarm
**resource** itself is created only on monitored stages, so it is verifiable after this merges, not
before.

### What NOT to test

- Do not expect the alarm to fire on organic traffic. Nothing on staging or production is near
  either budget; that is why the budget has to be lowered by hand.
- Do not test the ALARM on a **PR preview**. Alarms are created only in monitored stages
  (dev / production) via `isMonitoredStage`, so a preview creates no alarm resource at all -
  step 10 is not verifiable there. A preview CAN still verify the metric is published (the
  `SEED_STAGE_NAME` gate is satisfied) plus every log and response behavior, so steps 4-9 and
  all the regression checks work fine on one.
- No UI changed. There is nothing to click beyond the admin setting.
- `partial_results` / the "partial results" warning banner is NOT driven by `scan.truncated`
  (it comes from `isPartialSearch`, which reads only the embedding-mismatch and
  retrieval-unavailable reports), so it is out of scope here.

## Additional Information

**The one genuinely user-observable change.** Restoring the dropped `fileBudgetHit` means a
search that both blew its file budget *and* failed to embed its query now reports
`truncated: true` where it previously said `false`. That is the honest answer - the scope walk
really did hit its budget - but it is not purely telemetry, because one consumer branches on it:

`apps/client/server/tavern/rlm/dataLakeReplPrompts.ts:30-31` instructs the model that *"If
scan.truncated is true the search covered only part of the lake, so widen with listArticles or
keywordSearch before concluding something is absent."* So in this narrow case an RLM agent will
now widen its search instead of concluding absence. I think that is the better behavior (nothing
was ranked, and the corpus genuinely was budget-limited), but it is a behavior change and it is
the thing to watch on staging - hence regression check 14.

Two things I checked and can rule out:

- **`partial_results` and the `warning` string are unaffected.** Both come from
  `isPartialSearch` / `describeSearchLimitations`, which compose only `embeddingMismatch.partial`,
  `retrievalUnavailable.partial` and `supersession` - neither ever reads `scan.truncated`.
- **The knowledge-base tool's `NOTE:` injection is unreachable from the changed path.**
  `formatSemanticResults` does inject a truncation note into the tool result the model sees
  (`knowledgeBaseSearch/index.ts:147-149`), but it sits behind a `results.length === 0` early
  return, and the empty-embedding path always has zero results.

`packages/scripts/retrieval/vector-search-ab.ts` also aggregates a truncation counter, so its
offline truncation-rate number now counts this case. Dev-only script, no shipped impact.

**Why no leading indicator.** An "approaching the budget" metric would need a `PutMetricData`
call on every search - real latency on the hot path for a signal that fires never at current
scale. The report is awaited, but only on the truncated branch.

**Verification.** `turbo:typecheck`, `lint:check`, `typecheck:infra` and the full
`@bike4mind/services` suite (397 files, 6641 tests) all pass. Note that `infra/` is not a turbo
workspace package and `typecheck:infra:local` self-skips without `.sst/platform/config.d.ts`, so
`infra/alarms.ts` needed `npx sst install` plus a direct `pnpm typecheck:infra` to actually get
checked locally.

The new tests were mutation-checked rather than assumed load-bearing - dropping the restored
`fileBudgetHit` fails 1, making an entrypoint a passthrough fails 4, renaming the metric literal
fails 3, and leaking a `Cause` dimension onto the alarm datapoint fails 1.

## Developer Notes

- `scanTruncationMetrics.ts` is the third instance of the b4m-core CloudWatch emitter pattern
  (after `modelSunsetMetrics.ts` and `replSandboxMetrics.ts`). Packages in `b4m-core` cannot
  import `apps/client/server/utils/cloudwatch.ts`, so the pattern is copied deliberately; each
  package needs its own `@aws-sdk/client-cloudwatch` dependency.
- `withTruncationReport` is a reusable shape for this class of problem: when a derived flag is
  assigned on several return paths, report it once at the public boundary rather than at the one
  site that happened to log. Grep every site that **assigns** the flag, not the sites that read it.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, that doc does not exist in this repo and no CloudWatch metric is documented in markdown today


