### PR TITLE
feat(retrieval): record the relative-floor candidate pair in promptMeta

### DIFF
--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -515,12 +515,23 @@ export const RetrievalSummarySchema = z.object({
    *
    * Date-bound any rollup, the same caveat `mode` documents on itself: turns recorded before this
    * landed carry no volume, and no backfill is possible - the volume of a past turn is gone.
+   *
+   * `preRelativeFloorCandidates` is the ONE field here that is not "what reached the model": it is
+   * `ranked.length` in KnowledgeRetrievalFeature, the candidate count AFTER the absolute similarity
+   * floor but BEFORE the relative floor (PR #2567) trims it to what `chunks` counts. It exists so a
+   * low `chunks` count is diagnosable - a small corpus and a relative floor that trimmed a large
+   * pool both end in the same `chunks` number, and only this field tells them apart. Optional
+   * because only forced retrieval computes a ranked pool to trim; a surface with no relative-floor
+   * concept of its own (lake memory, the knowledge tools) never writes it, and its absence must not
+   * read as zero candidates. SUMMED across surfaces/turns like `chunks`, for the same
+   * sum-of-completions reason, with the same absent-is-not-zero handling as `topScore`.
    */
   injected: z
     .object({
       chunks: z.number(),
       chars: z.number(),
       topScore: z.number().optional(),
+      preRelativeFloorCandidates: z.number().optional(),
     })
     .optional(),
   /**

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -516,15 +516,34 @@ export const RetrievalSummarySchema = z.object({
    * Date-bound any rollup, the same caveat `mode` documents on itself: turns recorded before this
    * landed carry no volume, and no backfill is possible - the volume of a past turn is gone.
    *
-   * `preRelativeFloorCandidates` is the ONE field here that is not "what reached the model": it is
-   * `ranked.length` in KnowledgeRetrievalFeature, the candidate count AFTER the absolute similarity
-   * floor but BEFORE the relative floor (PR #2567) trims it to what `chunks` counts. It exists so a
-   * low `chunks` count is diagnosable - a small corpus and a relative floor that trimmed a large
-   * pool both end in the same `chunks` number, and only this field tells them apart. Optional
-   * because only forced retrieval computes a ranked pool to trim; a surface with no relative-floor
-   * concept of its own (lake memory, the knowledge tools) never writes it, and its absence must not
-   * read as zero candidates. SUMMED across surfaces/turns like `chunks`, for the same
-   * sum-of-completions reason, with the same absent-is-not-zero handling as `topScore`.
+   * `preRelativeFloorCandidates` and `postRelativeFloorCandidates` are the ONE pair here that is
+   * not "what reached the model": `ranked.length` and `scored.length` in KnowledgeRetrievalFeature
+   * - the candidates left after the absolute similarity floor, and after the relative floor
+   * (PR #2567) trims them. `chunks` is what survived the char budget on top of that, so the three
+   * numbers bracket two independent trimmers:
+   *
+   *   pre -> [relative floor] -> post -> [char budget] -> chunks
+   *
+   * They exist so a low `chunks` is diagnosable - a small corpus and a floor that trimmed a large
+   * pool end in the same `chunks`. `pre - post` is the floor's own effect and nothing else;
+   * `pre - chunks` is NOT, because the budget trims the same walk. Both optional: only forced
+   * retrieval computes a ranked pool, a surface without one (lake memory, the knowledge tools)
+   * never writes either, and absence must not read as zero candidates. SUMMED like `chunks`, with
+   * the same absent-is-not-zero handling as `topScore`.
+   *
+   * COMPARE THE PAIR ONLY TO ITSELF, never to `chunks`, unless `surfaces` is forced retrieval
+   * alone. `chunks` and `chars` sum across ALL surfaces while this pair is forced-only, so a mixed
+   * turn can store `chunks` above `pre` - inverting the relationship the pair exposes. Lake memory
+   * is the common case, not the exotic one: it is enabled inside the same forced-retrieval gate,
+   * so on a lake-memory lake it writes on nearly every forced turn. Its chunks can be backed out
+   * via `context.lakeMemory.beliefCount` (approximately - that count is pre-sanitization); its
+   * CHARS are recorded nowhere, so `chars` cannot be decontaminated at all. `pre - post` needs
+   * neither, which is the point of storing both.
+   *
+   * BOTH SATURATE, so `pre` counts what the SCAN REACHED, not what the corpus holds: `pool` is
+   * truncated in-scan at FORCED_RETRIEVAL_MAX_SCORED_CHUNKS (256), over a scan itself bounded by
+   * FORCED_RETRIEVAL_MAX_SCANNED_CHUNKS (4000) across FORCED_RETRIEVAL_MAX_CANDIDATE_FILES (100).
+   * 2000 qualifying chunks and 300 both record 256; above the cap a rollup is a plateau.
    */
   injected: z
     .object({
@@ -532,6 +551,7 @@ export const RetrievalSummarySchema = z.object({
       chars: z.number(),
       topScore: z.number().optional(),
       preRelativeFloorCandidates: z.number().optional(),
+      postRelativeFloorCandidates: z.number().optional(),
     })
     .optional(),
   /**

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -519,7 +519,7 @@ export const RetrievalSummarySchema = z.object({
    * `preRelativeFloorCandidates` and `postRelativeFloorCandidates` are the ONE pair here that is
    * not "what reached the model": `ranked.length` and `scored.length` in KnowledgeRetrievalFeature
    * - the candidates left after the absolute similarity floor, and after the relative floor
-   * (PR #2567) trims them. `chunks` is what survived the char budget on top of that, so the three
+   * trims them. `chunks` is what survived the char budget on top of that, so the three
    * numbers bracket two independent trimmers:
    *
    *   pre -> [relative floor] -> post -> [char budget] -> chunks
@@ -537,8 +537,9 @@ export const RetrievalSummarySchema = z.object({
    * is the common case, not the exotic one: it is enabled inside the same forced-retrieval gate,
    * so on a lake-memory lake it writes on nearly every forced turn. Its chunks can be backed out
    * via `context.lakeMemory.beliefCount` (approximately - that count is pre-sanitization); its
-   * CHARS are recorded nowhere, so `chars` cannot be decontaminated at all. `pre - post` needs
-   * neither, which is the point of storing both.
+   * CHARS land only inside the shared sum, with no per-surface field to subtract them back out, so
+   * `chars` cannot be decontaminated at all. `pre - post` needs neither, which is the point of
+   * storing both.
    *
    * BOTH SATURATE, so `pre` counts what the SCAN REACHED, not what the corpus holds: `pool` is
    * truncated in-scan at FORCED_RETRIEVAL_MAX_SCORED_CHUNKS (256), over a scan itself bounded by

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -2339,6 +2339,15 @@ describe('KnowledgeRetrievalFeature relative relevance floor (#2497)', () => {
     expect(quest.promptMeta?.retrieval?.injected?.topScore).toBeCloseTo(1.0, 5);
   });
 
+  it('records the pre-floor candidate count so the relative floor own effect is measurable (#2571)', async () => {
+    // All four scores clear the 0.75 absolute floor and enter the ranked pool, but the relative
+    // floor at its shipped default (85% of top score) keeps only two of them (chunks: 2 above).
+    // Without this field, that turn is byte-identical in promptMeta to a corpus that only ever
+    // HAD two candidates to begin with - which is exactly the ambiguity #2571 was filed about.
+    const { quest } = await run(makeCtx({ scores: [1.0, 0.9, 0.8, 0.76] }));
+    expect(quest.promptMeta?.retrieval?.injected?.preRelativeFloorCandidates).toBe(4);
+  });
+
   it('treats an out-of-range floor percent as unusable and keeps the shipped default', async () => {
     // Defense-in-depth, NOT a production-reachable path - the same standing as positiveIntOr's own
     // branches in the #1831 suite above. Both read paths run the setting's schema (`max: 100`)
@@ -3058,7 +3067,7 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
           forcedSkipReason?: string;
           surfaces: string[];
           dataLakeTags: string[];
-          injected?: { chunks: number; chars: number; topScore?: number };
+          injected?: { chunks: number; chars: number; topScore?: number; preRelativeFloorCandidates?: number };
         };
       }
     )?.retrieval;
@@ -3108,7 +3117,8 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
     // A recorded zero, not an unknown: the scan ran to completion, so nothing was injected and
     // that is a fact. `topScore` must be ABSENT - it is still the -1 sentinel here, and persisting
     // it would read as a real (terrible) similarity rather than as no comparison at all.
-    expect(retrieval?.injected).toEqual({ chunks: 0, chars: 0 });
+    // preRelativeFloorCandidates: 0 too - nothing was ever scored, so nothing entered the pool.
+    expect(retrieval?.injected).toEqual({ chunks: 0, chars: 0, preRelativeFloorCandidates: 0 });
   });
 
   it('records ok when the library was scanned and nothing cleared the similarity floor', async () => {
@@ -3122,7 +3132,9 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
     // THE case this field exists for: 'ok' alone made a fully-starved turn byte-identical to one
     // that injected its whole budget. `topScore: 0` is the diagnostic - the best candidate was
     // compared and scored 0, i.e. it missed the floor rather than never being looked at.
-    expect(retrieval?.injected).toEqual({ chunks: 0, chars: 0, topScore: 0 });
+    // preRelativeFloorCandidates: 0 - the score missed the ABSOLUTE floor, so it never reached the
+    // ranked pool at all; the relative floor never got a candidate to trim.
+    expect(retrieval?.injected).toEqual({ chunks: 0, chars: 0, topScore: 0, preRelativeFloorCandidates: 0 });
     // Still abstains to the user; 'ok' describes the retrieval, not the answer.
     expect(messages[0]?.content).toContain('does not cover this');
   });
@@ -3138,7 +3150,14 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
     // The other half of the pair: a grounded turn reports the volume it grounded on. `chars` is
     // the chunk text only ('text fileA'), never the heading, so it is comparable to the knowledge
     // tools' number. Query and chunk vectors are identical here, hence a topScore of 1.
-    expect(retrieval?.injected).toEqual({ chunks: 1, chars: 'text fileA'.length, topScore: 1 });
+    // preRelativeFloorCandidates: 1 - the single candidate cleared both floors, so nothing was
+    // trimmed and the pre- and post-floor counts agree.
+    expect(retrieval?.injected).toEqual({
+      chunks: 1,
+      chars: 'text fileA'.length,
+      topScore: 1,
+      preRelativeFloorCandidates: 1,
+    });
     expect(messages[0]?.content).toContain('### A.pdf (ID: fileA)');
   });
 

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -2339,13 +2339,13 @@ describe('KnowledgeRetrievalFeature relative relevance floor (#2497)', () => {
     expect(quest.promptMeta?.retrieval?.injected?.topScore).toBeCloseTo(1.0, 5);
   });
 
-  it('records the pre/post floor candidate counts so the floor own effect is measurable (#2571)', async () => {
+  it('records the pre/post floor candidate counts so the floor own effect is measurable', async () => {
     // All four scores clear the 0.75 absolute floor and enter the ranked pool; the relative floor
     // at its shipped default (85% of top score) keeps two. Without these, the turn is byte-
-    // identical in promptMeta to a corpus that only ever HAD two candidates - the ambiguity #2571
-    // was filed about. Asserted as a pair, and alongside `chunks`, because the whole point is that
-    // `pre - post` is the floor alone while `pre - chunks` also carries the char budget: here the
-    // budget does not bind, so post === chunks and the two happen to agree.
+    // identical in promptMeta to a corpus that only ever HAD two candidates - the ambiguity this
+    // pair exists to remove. Asserted as a pair, and alongside `chunks`, because the whole point
+    // is that `pre - post` is the floor alone while `pre - chunks` also carries the char budget:
+    // here the budget does not bind, so post === chunks and the two happen to agree.
     const { quest } = await run(makeCtx({ scores: [1.0, 0.9, 0.8, 0.76] }));
     expect(quest.promptMeta?.retrieval?.injected?.preRelativeFloorCandidates).toBe(4);
     expect(quest.promptMeta?.retrieval?.injected?.postRelativeFloorCandidates).toBe(2);

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -2339,13 +2339,17 @@ describe('KnowledgeRetrievalFeature relative relevance floor (#2497)', () => {
     expect(quest.promptMeta?.retrieval?.injected?.topScore).toBeCloseTo(1.0, 5);
   });
 
-  it('records the pre-floor candidate count so the relative floor own effect is measurable (#2571)', async () => {
-    // All four scores clear the 0.75 absolute floor and enter the ranked pool, but the relative
-    // floor at its shipped default (85% of top score) keeps only two of them (chunks: 2 above).
-    // Without this field, that turn is byte-identical in promptMeta to a corpus that only ever
-    // HAD two candidates to begin with - which is exactly the ambiguity #2571 was filed about.
+  it('records the pre/post floor candidate counts so the floor own effect is measurable (#2571)', async () => {
+    // All four scores clear the 0.75 absolute floor and enter the ranked pool; the relative floor
+    // at its shipped default (85% of top score) keeps two. Without these, the turn is byte-
+    // identical in promptMeta to a corpus that only ever HAD two candidates - the ambiguity #2571
+    // was filed about. Asserted as a pair, and alongside `chunks`, because the whole point is that
+    // `pre - post` is the floor alone while `pre - chunks` also carries the char budget: here the
+    // budget does not bind, so post === chunks and the two happen to agree.
     const { quest } = await run(makeCtx({ scores: [1.0, 0.9, 0.8, 0.76] }));
     expect(quest.promptMeta?.retrieval?.injected?.preRelativeFloorCandidates).toBe(4);
+    expect(quest.promptMeta?.retrieval?.injected?.postRelativeFloorCandidates).toBe(2);
+    expect(quest.promptMeta?.retrieval?.injected?.chunks).toBe(2);
   });
 
   it('treats an out-of-range floor percent as unusable and keeps the shipped default', async () => {
@@ -3067,7 +3071,13 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
           forcedSkipReason?: string;
           surfaces: string[];
           dataLakeTags: string[];
-          injected?: { chunks: number; chars: number; topScore?: number; preRelativeFloorCandidates?: number };
+          injected?: {
+            chunks: number;
+            chars: number;
+            topScore?: number;
+            preRelativeFloorCandidates?: number;
+            postRelativeFloorCandidates?: number;
+          };
         };
       }
     )?.retrieval;
@@ -3117,8 +3127,14 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
     // A recorded zero, not an unknown: the scan ran to completion, so nothing was injected and
     // that is a fact. `topScore` must be ABSENT - it is still the -1 sentinel here, and persisting
     // it would read as a real (terrible) similarity rather than as no comparison at all.
-    // preRelativeFloorCandidates: 0 too - nothing was ever scored, so nothing entered the pool.
-    expect(retrieval?.injected).toEqual({ chunks: 0, chars: 0, preRelativeFloorCandidates: 0 });
+    // Both candidate counts are 0 too - nothing was ever scored, so nothing entered the pool, and
+    // a relative floor over an empty pool leaves it empty.
+    expect(retrieval?.injected).toEqual({
+      chunks: 0,
+      chars: 0,
+      preRelativeFloorCandidates: 0,
+      postRelativeFloorCandidates: 0,
+    });
   });
 
   it('records ok when the library was scanned and nothing cleared the similarity floor', async () => {
@@ -3132,9 +3148,16 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
     // THE case this field exists for: 'ok' alone made a fully-starved turn byte-identical to one
     // that injected its whole budget. `topScore: 0` is the diagnostic - the best candidate was
     // compared and scored 0, i.e. it missed the floor rather than never being looked at.
-    // preRelativeFloorCandidates: 0 - the score missed the ABSOLUTE floor, so it never reached the
-    // ranked pool at all; the relative floor never got a candidate to trim.
-    expect(retrieval?.injected).toEqual({ chunks: 0, chars: 0, topScore: 0, preRelativeFloorCandidates: 0 });
+    // Both counts 0 - the score missed the ABSOLUTE floor, so it never reached the ranked pool at
+    // all and the relative floor never got a candidate to trim. This is the exit whose comment
+    // used to claim it was the trimmed-pool case; a zero pre-count is what proves it is not.
+    expect(retrieval?.injected).toEqual({
+      chunks: 0,
+      chars: 0,
+      topScore: 0,
+      preRelativeFloorCandidates: 0,
+      postRelativeFloorCandidates: 0,
+    });
     // Still abstains to the user; 'ok' describes the retrieval, not the answer.
     expect(messages[0]?.content).toContain('does not cover this');
   });
@@ -3150,13 +3173,14 @@ describe('KnowledgeRetrievalFeature per-turn retrieval summary', () => {
     // The other half of the pair: a grounded turn reports the volume it grounded on. `chars` is
     // the chunk text only ('text fileA'), never the heading, so it is comparable to the knowledge
     // tools' number. Query and chunk vectors are identical here, hence a topScore of 1.
-    // preRelativeFloorCandidates: 1 - the single candidate cleared both floors, so nothing was
-    // trimmed and the pre- and post-floor counts agree.
+    // Both counts 1 - the single candidate cleared both floors, so nothing was trimmed and the
+    // pre-count, post-count and `chunks` all agree.
     expect(retrieval?.injected).toEqual({
       chunks: 1,
       chars: 'text fileA'.length,
       topScore: 1,
       preRelativeFloorCandidates: 1,
+      postRelativeFloorCandidates: 1,
     });
     expect(messages[0]?.content).toContain('### A.pdf (ID: fileA)');
   });

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2544,9 +2544,17 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         // the remedy is re-vectorizing, which the lake owner can do, and a retry never helps.
         // No topScore: nothing was scored, so `topScore` is still its -1 sentinel and persisting
         // that would read as a real (very poor) similarity rather than as an absent one.
-        // pool.length is 0 here too (scoredCount === 0 means nothing ever cleared into it), but
-        // read off pool rather than hardcoded so this stays true if the guard above it ever moves.
-        recordRetrieval('not_indexed', dataLakeTags, { chunks: 0, chars: 0, preRelativeFloorCandidates: pool.length });
+        // Both counts are 0 here (scoredCount === 0 means nothing ever cleared into the pool, and
+        // a relative floor over an empty pool leaves it empty), but read off pool rather than
+        // hardcoded so this stays true if the guard above it ever moves. Written as a PAIR even
+        // though `scored` does not exist yet, because the two must be present on the same turns:
+        // a rollup over one has to cover the same population as a rollup over the other.
+        recordRetrieval('not_indexed', dataLakeTags, {
+          chunks: 0,
+          chars: 0,
+          preRelativeFloorCandidates: pool.length,
+          postRelativeFloorCandidates: pool.length,
+        });
         return this.noContextMessages('unavailable');
       }
       const ranked = pool.sort(compareForcedRetrievalCandidates);
@@ -2651,10 +2659,14 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
           chunks: 0,
           chars: 0,
           ...(scoredCount > 0 ? { topScore } : {}),
-          // The turn the field exists for: candidates cleared the absolute floor (ranked.length)
-          // but the relative floor (or a non-positive char budget) let none of them through as
-          // `chunks` - the loop below breaks before its first push whenever the budget is <= 0.
+          // Necessarily 0, both of them - this is a recorded zero, NOT the trimmed-pool case the
+          // pair exists to expose. The exit is reached only when `sections` came out empty; the
+          // push into it in the loop above is unconditional, so an empty `sections` means an empty
+          // `scored`; and the top candidate always survives its own relative cutoff, so an empty
+          // `scored` means an empty `ranked`. Nothing cleared the ABSOLUTE floor, which is exactly
+          // what the `chunks: 0` beside it says.
           preRelativeFloorCandidates: ranked.length,
+          postRelativeFloorCandidates: scored.length,
         });
         this.logger.log(`🔒 Forced retrieval: no chunk cleared the similarity floor (top=${topScore.toFixed(3)})`);
         return this.noContextMessages(partial ? 'no_match_partial' : 'no_match');
@@ -2668,9 +2680,11 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         chunks: sections.length,
         chars: used,
         ...(scoredCount > 0 ? { topScore } : {}),
-        // ranked.length vs sections.length is the relative floor's own effect: the gap between them
-        // is candidates the floor (or the char budget) trimmed, not candidates the corpus lacked.
+        // `pre - post` is the relative floor's own effect and nothing else. Do NOT read
+        // `pre - chunks` as the floor: the char budget trims the same walk, so that gap is the two
+        // trimmers summed - and `chunks` sums across surfaces while this pair is forced-only.
         preRelativeFloorCandidates: ranked.length,
+        postRelativeFloorCandidates: scored.length,
       });
 
       // Emit citation chips for the distinct source files so the UI shows "Sources (N)".

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2660,11 +2660,13 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
           chars: 0,
           ...(scoredCount > 0 ? { topScore } : {}),
           // Necessarily 0, both of them - this is a recorded zero, NOT the trimmed-pool case the
-          // pair exists to expose. The exit is reached only when `sections` came out empty; the
-          // push into it in the loop above is unconditional, so an empty `sections` means an empty
-          // `scored`; and the top candidate always survives its own relative cutoff, so an empty
+          // pair exists to expose. The exit is reached only when `sections` came out empty. The
+          // walk above skips a candidate only via its budget `break`, and `used` starts at 0
+          // against a budget positiveIntOr floors at 1, so the FIRST candidate is always pushed:
+          // an empty `sections` means an empty `scored`. And the top candidate always survives its
+          // own relative cutoff (`>=` against `topScore * fraction`, fraction <= 1), so an empty
           // `scored` means an empty `ranked`. Nothing cleared the ABSOLUTE floor, which is exactly
-          // what the `chunks: 0` beside it says.
+          // what the `chunks: 0` beside it says. If that budget ever admits 0, this breaks.
           preRelativeFloorCandidates: ranked.length,
           postRelativeFloorCandidates: scored.length,
         });

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2544,7 +2544,9 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         // the remedy is re-vectorizing, which the lake owner can do, and a retry never helps.
         // No topScore: nothing was scored, so `topScore` is still its -1 sentinel and persisting
         // that would read as a real (very poor) similarity rather than as an absent one.
-        recordRetrieval('not_indexed', dataLakeTags, { chunks: 0, chars: 0 });
+        // pool.length is 0 here too (scoredCount === 0 means nothing ever cleared into it), but
+        // read off pool rather than hardcoded so this stays true if the guard above it ever moves.
+        recordRetrieval('not_indexed', dataLakeTags, { chunks: 0, chars: 0, preRelativeFloorCandidates: pool.length });
         return this.noContextMessages('unavailable');
       }
       const ranked = pool.sort(compareForcedRetrievalCandidates);
@@ -2649,6 +2651,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
           chunks: 0,
           chars: 0,
           ...(scoredCount > 0 ? { topScore } : {}),
+          // The turn the field exists for: candidates cleared the absolute floor (ranked.length)
+          // but the relative floor (or a non-positive char budget) let none of them through as
+          // `chunks` - the loop below breaks before its first push whenever the budget is <= 0.
+          preRelativeFloorCandidates: ranked.length,
         });
         this.logger.log(`🔒 Forced retrieval: no chunk cleared the similarity floor (top=${topScore.toFixed(3)})`);
         return this.noContextMessages(partial ? 'no_match_partial' : 'no_match');
@@ -2662,6 +2668,9 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         chunks: sections.length,
         chars: used,
         ...(scoredCount > 0 ? { topScore } : {}),
+        // ranked.length vs sections.length is the relative floor's own effect: the gap between them
+        // is candidates the floor (or the char budget) trimmed, not candidates the corpus lacked.
+        preRelativeFloorCandidates: ranked.length,
       });
 
       // Emit citation chips for the distinct source files so the UI shows "Sources (N)".

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
@@ -213,37 +213,65 @@ describe('mergeRetrievalSummary', () => {
       expect(merged?.injected && 'topScore' in merged.injected).toBe(false);
     });
 
-    describe('preRelativeFloorCandidates', () => {
-      it('sums across surfaces, same as chunks', () => {
+    describe('relative-floor candidate counts', () => {
+      it('sums both counts across surfaces, same as chunks', () => {
         const merged = mergeRetrievalSummary(
-          base({ injected: { chunks: 2, chars: 400, preRelativeFloorCandidates: 4 } }),
-          base({ injected: { chunks: 1, chars: 200, preRelativeFloorCandidates: 3 } })
+          base({ injected: { chunks: 2, chars: 400, preRelativeFloorCandidates: 4, postRelativeFloorCandidates: 3 } }),
+          base({ injected: { chunks: 1, chars: 200, preRelativeFloorCandidates: 3, postRelativeFloorCandidates: 1 } })
         );
         expect(merged?.injected?.preRelativeFloorCandidates).toBe(7);
+        expect(merged?.injected?.postRelativeFloorCandidates).toBe(4);
       });
 
       it('passes a one-sided count through without treating the other side as zero', () => {
-        // Only forced retrieval ever writes this field - a knowledge-tool surface reporting volume
+        // Only forced retrieval ever writes these - a knowledge-tool surface reporting volume
         // alongside it must not turn the absent side into a recorded 0.
         const merged = mergeRetrievalSummary(
-          base({ injected: { chunks: 2, chars: 400, preRelativeFloorCandidates: 4 } }),
+          base({ injected: { chunks: 2, chars: 400, preRelativeFloorCandidates: 4, postRelativeFloorCandidates: 3 } }),
           base({ injected: { chunks: 1, chars: 200 } })
         );
-        expect(merged?.injected).toEqual({ chunks: 3, chars: 600, preRelativeFloorCandidates: 4 });
+        expect(merged?.injected).toEqual({
+          chunks: 3,
+          chars: 600,
+          preRelativeFloorCandidates: 4,
+          postRelativeFloorCandidates: 3,
+        });
       });
 
-      it('omits the field entirely when neither side reports one', () => {
-        const merged = mergeRetrievalSummary(base({ injected: { chunks: 1, chars: 100 } }), base());
+      it('omits both fields entirely when neither side reports one', () => {
+        // The incoming side must carry an `injected` of its own, or mergeInjected returns at its
+        // `!incoming` guard and the branch under test never runs - the mistake this test is the
+        // fixed version of. Mirrors the `omits topScore` sibling above for the same reason.
+        const merged = mergeRetrievalSummary(
+          base({ injected: { chunks: 1, chars: 100 } }),
+          base({ injected: { chunks: 0, chars: 0 } })
+        );
         expect(merged?.injected).toEqual({ chunks: 1, chars: 100 });
         expect(merged?.injected && 'preRelativeFloorCandidates' in merged.injected).toBe(false);
+        expect(merged?.injected && 'postRelativeFloorCandidates' in merged.injected).toBe(false);
       });
 
-      it('sums a recorded zero rather than treating it as absent', () => {
+      it('keeps a recorded zero on BOTH sides as a recorded zero, not an absence', () => {
+        // The discriminating fixture: zero on one side only cannot tell summing from a truthy
+        // filter, because dropping a 0 and adding it reach the same number. Both sides zero is
+        // where the two diverge - summing emits the key with 0, a truthy filter omits it.
         const merged = mergeRetrievalSummary(
-          base({ injected: { chunks: 0, chars: 0, preRelativeFloorCandidates: 0 } }),
-          base({ injected: { chunks: 1, chars: 100, preRelativeFloorCandidates: 2 } })
+          base({ injected: { chunks: 0, chars: 0, preRelativeFloorCandidates: 0, postRelativeFloorCandidates: 0 } }),
+          base({ injected: { chunks: 0, chars: 0, preRelativeFloorCandidates: 0, postRelativeFloorCandidates: 0 } })
+        );
+        expect(merged?.injected?.preRelativeFloorCandidates).toBe(0);
+        expect(merged?.injected?.postRelativeFloorCandidates).toBe(0);
+        expect(merged?.injected && 'preRelativeFloorCandidates' in merged.injected).toBe(true);
+        expect(merged?.injected && 'postRelativeFloorCandidates' in merged.injected).toBe(true);
+      });
+
+      it('sums a recorded zero into a real count rather than dropping it', () => {
+        const merged = mergeRetrievalSummary(
+          base({ injected: { chunks: 0, chars: 0, preRelativeFloorCandidates: 0, postRelativeFloorCandidates: 0 } }),
+          base({ injected: { chunks: 1, chars: 100, preRelativeFloorCandidates: 2, postRelativeFloorCandidates: 2 } })
         );
         expect(merged?.injected?.preRelativeFloorCandidates).toBe(2);
+        expect(merged?.injected?.postRelativeFloorCandidates).toBe(2);
       });
     });
 

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
@@ -213,6 +213,40 @@ describe('mergeRetrievalSummary', () => {
       expect(merged?.injected && 'topScore' in merged.injected).toBe(false);
     });
 
+    describe('preRelativeFloorCandidates', () => {
+      it('sums across surfaces, same as chunks', () => {
+        const merged = mergeRetrievalSummary(
+          base({ injected: { chunks: 2, chars: 400, preRelativeFloorCandidates: 4 } }),
+          base({ injected: { chunks: 1, chars: 200, preRelativeFloorCandidates: 3 } })
+        );
+        expect(merged?.injected?.preRelativeFloorCandidates).toBe(7);
+      });
+
+      it('passes a one-sided count through without treating the other side as zero', () => {
+        // Only forced retrieval ever writes this field - a knowledge-tool surface reporting volume
+        // alongside it must not turn the absent side into a recorded 0.
+        const merged = mergeRetrievalSummary(
+          base({ injected: { chunks: 2, chars: 400, preRelativeFloorCandidates: 4 } }),
+          base({ injected: { chunks: 1, chars: 200 } })
+        );
+        expect(merged?.injected).toEqual({ chunks: 3, chars: 600, preRelativeFloorCandidates: 4 });
+      });
+
+      it('omits the field entirely when neither side reports one', () => {
+        const merged = mergeRetrievalSummary(base({ injected: { chunks: 1, chars: 100 } }), base());
+        expect(merged?.injected).toEqual({ chunks: 1, chars: 100 });
+        expect(merged?.injected && 'preRelativeFloorCandidates' in merged.injected).toBe(false);
+      });
+
+      it('sums a recorded zero rather than treating it as absent', () => {
+        const merged = mergeRetrievalSummary(
+          base({ injected: { chunks: 0, chars: 0, preRelativeFloorCandidates: 0 } }),
+          base({ injected: { chunks: 1, chars: 100, preRelativeFloorCandidates: 2 } })
+        );
+        expect(merged?.injected?.preRelativeFloorCandidates).toBe(2);
+      });
+    });
+
     it('keeps volume alongside a worse outcome from another surface', () => {
       const merged = mergeRetrievalSummary(
         base({ outcome: 'ok', surfaces: ['forced-retrieval'], injected: { chunks: 12, chars: 4000 } }),

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
@@ -42,10 +42,18 @@ function mergeInjected(
   // Max over only the sides that HAVE a score: an absent topScore means "this surface has no
   // comparable similarity to contribute", not zero.
   const scores = [existing.topScore, incoming.topScore].filter((v): v is number => v !== undefined);
+  // Sum over only the sides that HAVE a count, same reasoning as topScore: only forced retrieval's
+  // ranked pool has one to report, and an absent side must not turn a real count into a smaller sum.
+  const preFloorCandidates = [existing.preRelativeFloorCandidates, incoming.preRelativeFloorCandidates].filter(
+    (v): v is number => v !== undefined
+  );
   return {
     chunks: existing.chunks + incoming.chunks,
     chars: existing.chars + incoming.chars,
     ...(scores.length ? { topScore: Math.max(...scores) } : {}),
+    ...(preFloorCandidates.length
+      ? { preRelativeFloorCandidates: preFloorCandidates.reduce((sum, v) => sum + v, 0) }
+      : {}),
   };
 }
 
@@ -77,13 +85,15 @@ function mergeInjected(
  * - surfaces / dataLakeTags / injectedLakePromptIds / preauthorizedLakeIdsUsed: union, deduped.
  *   injectedLakePromptCount is derived from the merged injectedLakePromptIds, not merged
  *   independently, so a two-sided merge can never leave the two disagreeing.
- * - injected: chunks and chars SUM, topScore is the max. The only NON-IDEMPOTENT rule here, and
- *   safe only because every write site emits a delta once per completed search - merging the same
- *   delta twice would double the volume, so a new writer must not re-emit an accumulated value.
- *   Summing is what the field means: total volume the model received this turn, across surfaces
- *   and across repeat knowledge-tool calls. An absent side contributes NOTHING rather than a
- *   zero, so a surface with no volume to report cannot turn another's real number into a starve,
- *   and an absent topScore never defaults to 0 - that would outrank a real negative cosine.
+ * - injected: chunks and chars SUM, topScore is the max, preRelativeFloorCandidates SUMS like
+ *   chunks (only over the sides that have one - see mergeInjected). The only NON-IDEMPOTENT rule
+ *   here, and safe only because every write site emits a delta once per completed search - merging
+ *   the same delta twice would double the volume, so a new writer must not re-emit an accumulated
+ *   value. Summing is what the field means: total volume the model received this turn, across
+ *   surfaces and across repeat knowledge-tool calls. An absent side contributes NOTHING rather than
+ *   a zero, so a surface with no volume to report cannot turn another's real number into a starve,
+ *   and an absent topScore or preRelativeFloorCandidates never defaults to 0 - that would outrank a
+ *   real negative cosine, or claim a surface with no ranked pool of its own ranked zero candidates.
  *
  * The one-sided returns below are a verbatim passthrough, and both injection sites emit a PARTIAL
  * summary (ids with no count; `attempted` with no `outcome`) meant only as a merge delta. So a

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
@@ -43,17 +43,22 @@ function mergeInjected(
   // comparable similarity to contribute", not zero.
   const scores = [existing.topScore, incoming.topScore].filter((v): v is number => v !== undefined);
   // Sum over only the sides that HAVE a count, same reasoning as topScore: only forced retrieval's
-  // ranked pool has one to report, and an absent side must not turn a real count into a smaller sum.
-  const preFloorCandidates = [existing.preRelativeFloorCandidates, incoming.preRelativeFloorCandidates].filter(
-    (v): v is number => v !== undefined
-  );
+  // ranked pool has one to report, and an absent side must not turn a real count into a smaller
+  // sum. Returns undefined for absent-on-both, which is DIFFERENT from a summed 0 - a real 0 is
+  // "the pool was empty", and collapsing the two is what a truthy filter here would silently do.
+  const sumDefined = (a: number | undefined, b: number | undefined): number | undefined => {
+    const present = [a, b].filter((v): v is number => v !== undefined);
+    return present.length ? present.reduce((sum, v) => sum + v, 0) : undefined;
+  };
+  // The pre/post pair is written and absent together at every write site, so they merge identically.
+  const preFloor = sumDefined(existing.preRelativeFloorCandidates, incoming.preRelativeFloorCandidates);
+  const postFloor = sumDefined(existing.postRelativeFloorCandidates, incoming.postRelativeFloorCandidates);
   return {
     chunks: existing.chunks + incoming.chunks,
     chars: existing.chars + incoming.chars,
     ...(scores.length ? { topScore: Math.max(...scores) } : {}),
-    ...(preFloorCandidates.length
-      ? { preRelativeFloorCandidates: preFloorCandidates.reduce((sum, v) => sum + v, 0) }
-      : {}),
+    ...(preFloor !== undefined ? { preRelativeFloorCandidates: preFloor } : {}),
+    ...(postFloor !== undefined ? { postRelativeFloorCandidates: postFloor } : {}),
   };
 }
 
@@ -85,15 +90,18 @@ function mergeInjected(
  * - surfaces / dataLakeTags / injectedLakePromptIds / preauthorizedLakeIdsUsed: union, deduped.
  *   injectedLakePromptCount is derived from the merged injectedLakePromptIds, not merged
  *   independently, so a two-sided merge can never leave the two disagreeing.
- * - injected: chunks and chars SUM, topScore is the max, preRelativeFloorCandidates SUMS like
- *   chunks (only over the sides that have one - see mergeInjected). The only NON-IDEMPOTENT rule
+ * - injected: chunks and chars SUM, topScore is the max, and the pre/post relative-floor candidate
+ *   counts SUM like chunks (only over the sides that have one - see mergeInjected). NOTE that the
+ *   pair is forced-retrieval-only while chunks/chars sum across every surface, so on a mixed turn
+ *   chunks can exceed preRelativeFloorCandidates - compare the pair to itself, never to chunks.
+ *   See the pair's comment on RetrievalSummarySchema. The only NON-IDEMPOTENT rule
  *   here, and safe only because every write site emits a delta once per completed search - merging
  *   the same delta twice would double the volume, so a new writer must not re-emit an accumulated
  *   value. Summing is what the field means: total volume the model received this turn, across
  *   surfaces and across repeat knowledge-tool calls. An absent side contributes NOTHING rather than
  *   a zero, so a surface with no volume to report cannot turn another's real number into a starve,
- *   and an absent topScore or preRelativeFloorCandidates never defaults to 0 - that would outrank a
- *   real negative cosine, or claim a surface with no ranked pool of its own ranked zero candidates.
+ *   and an absent topScore or candidate count never defaults to 0 - that would outrank a real
+ *   negative cosine, or claim a surface with no ranked pool of its own ranked zero candidates.
  *
  * The one-sided returns below are a verbatim passthrough, and both injection sites emit a PARTIAL
  * summary (ids with no count; `attempted` with no `outcome`) meant only as a merge delta. So a

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -57,10 +57,15 @@ const LakeMemorySchema = subSchema({
 // is load-bearing: it means the volume is unknown, which `{ chunks: 0 }` explicitly does not.
 // `default: undefined` on the path below is inert for a single nested subdocument (nothing
 // vivifies it) and kept only for symmetry with the siblings, where it does work.
+//
+// preRelativeFloorCandidates: optional like topScore, and for the same reason - only forced
+// retrieval's ranked pool has a relative floor to trim, so no other surface ever writes it. See
+// the field's own comment in promptMeta.ts.
 const InjectedVolumeSchema = subSchema({
   chunks: { type: Number, required: true },
   chars: { type: Number, required: true },
   topScore: { type: Number, required: false },
+  preRelativeFloorCandidates: { type: Number, required: false },
 });
 
 // Same rationale as LakeMemorySchema above (subSchema + default:undefined to suppress

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -58,14 +58,17 @@ const LakeMemorySchema = subSchema({
 // `default: undefined` on the path below is inert for a single nested subdocument (nothing
 // vivifies it) and kept only for symmetry with the siblings, where it does work.
 //
-// preRelativeFloorCandidates: optional like topScore, and for the same reason - only forced
-// retrieval's ranked pool has a relative floor to trim, so no other surface ever writes it. See
-// the field's own comment in promptMeta.ts.
+// pre/postRelativeFloorCandidates: optional like topScore, and for the same reason - only forced
+// retrieval's ranked pool has a relative floor to trim, so no other surface ever writes them. They
+// are written and absent together, so a rollup over one is a rollup over the same turns as the
+// other. See the pair's own comment in promptMeta.ts for why they are only ever compared to each
+// other and never to `chunks`.
 const InjectedVolumeSchema = subSchema({
   chunks: { type: Number, required: true },
   chars: { type: Number, required: true },
   topScore: { type: Number, required: false },
   preRelativeFloorCandidates: { type: Number, required: false },
+  postRelativeFloorCandidates: { type: Number, required: false },
 });
 
 // Same rationale as LakeMemorySchema above (subSchema + default:undefined to suppress

--- a/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
+++ b/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
@@ -120,9 +120,9 @@ const FULL_PROMPT_META = {
     surfaces: ['knowledgeBaseSearch', 'lake-memory'],
     dataLakeTags: ['datalake:x'],
     // The parity test only checks that a Zod path has a Mongoose declaration; this round trip is
-    // what covers the BSON-type half, so a Number-vs-String slip on any of these three fails here
+    // what covers the BSON-type half, so a Number-vs-String slip on any of these four fails here
     // rather than shipping as a field that saves and then fails its Zod re-parse on read.
-    injected: { chunks: 5, chars: 1300, topScore: 0.88 },
+    injected: { chunks: 5, chars: 1300, topScore: 0.88, preRelativeFloorCandidates: 8 },
     // Deliberately `false`, not `true`: a falsy leaf is where a Mongoose/Zod mismatch silently
     // drops a value, and `false` is this field's load-bearing case (the A/B's control arm).
     knowledgeBaseGuidanceInjected: false,

--- a/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
+++ b/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
@@ -120,9 +120,9 @@ const FULL_PROMPT_META = {
     surfaces: ['knowledgeBaseSearch', 'lake-memory'],
     dataLakeTags: ['datalake:x'],
     // The parity test only checks that a Zod path has a Mongoose declaration; this round trip is
-    // what covers the BSON-type half, so a Number-vs-String slip on any of these four fails here
+    // what covers the BSON-type half, so a Number-vs-String slip on any of these five fails here
     // rather than shipping as a field that saves and then fails its Zod re-parse on read.
-    injected: { chunks: 5, chars: 1300, topScore: 0.88, preRelativeFloorCandidates: 8 },
+    injected: { chunks: 5, chars: 1300, topScore: 0.88, preRelativeFloorCandidates: 8, postRelativeFloorCandidates: 6 },
     // Deliberately `false`, not `true`: a falsy leaf is where a Mongoose/Zod mismatch silently
     // drops a value, and `false` is this field's load-bearing case (the A/B's control arm).
     knowledgeBaseGuidanceInjected: false,


### PR DESCRIPTION
## What
`promptMeta.retrieval.injected` recorded only the post-floor chunk count. After the relative floor (#2567) became a tunable lever, a low `injected.chunks` count was ambiguous between "small corpus" and "the relative floor trimmed a larger candidate pool" - there was no way to measure the floor's own effect from stored telemetry.

Adds `injected.preRelativeFloorCandidates`: `ranked.length` in `KnowledgeRetrievalFeature`, the candidate count after the absolute similarity floor but before the relative floor trims it down to what `chunks` counts. Optional (like `topScore`) - only forced retrieval computes a ranked pool with a relative floor to trim, so lake memory and the knowledge tools never write it.

Touches the three places the issue named:
- `promptMeta.ts` Zod schema (`injected` object)
- `QuestModel.ts` Mongoose model (`InjectedVolumeSchema`), kept in parity via `PromptMetaSchema.parity.test.ts`
- `retrievalSummaryMerge.ts`'s `mergeInjected` - sums like `chunks`, with the same absent-is-not-zero handling as `topScore`

Closes #2571

## Testing
- `PromptMetaSchema.parity.test.ts` (5/5) - Zod/Mongoose path parity
- `QuestModel.promptMetaPersistence.test.ts` (round-trip, extended fixture) - BSON-type parity through save + Zod re-parse
- `retrievalSummaryMerge.test.ts` (36/36, incl. 4 new cases for the new field's merge/sum/absent behavior)
- `ChatCompletionFeatures.test.ts` (157/157, incl. 1 new case pinning the exact motivating scenario: 4 candidates cleared the absolute floor, the relative floor kept 2, `preRelativeFloorCandidates` records 4)
- `pnpm turbo:typecheck` - all 40 packages pass
- Pre-push `typecheck:fast` - all 37 tasks pass

### Guide for testers
This is telemetry-only - nothing user-visible changes. To see it: run a forced-retrieval turn against a Data Lake with a spread of similarity scores, then inspect `promptMeta.retrieval.injected` on the resulting quest document - `preRelativeFloorCandidates` should be >= `chunks`, and equal to it whenever nothing got trimmed.

### Regression risk
Purely additive (new optional field, no existing key changed or removed) - low risk. No behavior change to what gets injected or returned to the model.

### What this does NOT do
Does not add a dashboard or UI for this telemetry - it's a stored field for engineers running retrieval-tuning analysis directly against `promptMeta`, per the issue's own scope. Does not instrument `retrieve_knowledge_content` or the knowledge tools' semantic/keyword arms, which have no relative-floor concept of their own.
