### PR TITLE
fix(api): URL path params win over body spreads on PUT/revoke routes

### DIFF
--- a/apps/client/pages/api/[type]/[id]/__tests__/revokeSharing.test.ts
+++ b/apps/client/pages/api/[type]/[id]/__tests__/revokeSharing.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * Route-layer coverage for /api/[type]/[id]/revokeSharing.
+ * Pins that the URL id and type are authoritative (not overridable by the body),
+ * and that a missing or array-valued id is rejected before the service is called.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  useHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => ({
+    use: (fn: any) => {
+      mockRefs.useHandler = fn;
+      return { use: () => ({}) };
+    },
+  }),
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  BadRequestError: class BadRequestError extends Error {},
+}));
+
+const mockRevoke = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'doc1' }));
+vi.mock('@bike4mind/services', () => ({
+  sharingService: { revoke: (...a: unknown[]) => mockRevoke(...a) },
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  sessionRepository: {},
+  fabFileRepository: {},
+  projectRepository: {},
+  userRepository: {},
+}));
+
+import '../revokeSharing';
+import { BadRequestError } from '@server/utils/errors';
+
+function request(query: Record<string, unknown>, body: Record<string, unknown> = {}) {
+  const { req, res } = createMocks({ method: 'DELETE', query, body });
+  (req as any).user = { id: 'caller' };
+  return { req, res };
+}
+
+describe('/api/[type]/[id]/revokeSharing - URL params win', () => {
+  beforeEach(() => mockRevoke.mockClear());
+
+  it('takes the document id from the URL, not from any body field', async () => {
+    const { req, res } = request(
+      { type: 'sessions', id: 'url-doc-id' },
+      { userId: 'u2', id: 'body-doc-id' }
+    );
+    await mockRefs.useHandler!(req, res);
+    const [, params] = mockRevoke.mock.calls[0];
+    expect(params.id).toBe('url-doc-id');
+  });
+
+  it('takes the document type from the URL, not from any body field', async () => {
+    const { req, res } = request(
+      { type: 'sessions', id: 'doc1' },
+      { userId: 'u2', type: 'files' }
+    );
+    await mockRefs.useHandler!(req, res);
+    const [, params] = mockRevoke.mock.calls[0];
+    expect(params.type).toBe('sessions');
+  });
+
+  it('forwards userId from the body (it is the revocation target, not the caller)', async () => {
+    const { req, res } = request(
+      { type: 'sessions', id: 'doc1' },
+      { userId: 'target-user' }
+    );
+    await mockRefs.useHandler!(req, res);
+    const [callerId, params] = mockRevoke.mock.calls[0];
+    expect(callerId).toBe('caller');
+    expect(params.userId).toBe('target-user');
+  });
+
+  it('rejects a missing id with BadRequestError before reaching the service', async () => {
+    const { req, res } = request({ type: 'sessions' }, { userId: 'u2' });
+    await expect(mockRefs.useHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockRevoke).not.toHaveBeenCalled();
+  });
+
+  it('rejects an array-valued id with BadRequestError before reaching the service', async () => {
+    const { req, res } = request({ type: 'sessions', id: ['a', 'b'] }, { userId: 'u2' });
+    await expect(mockRefs.useHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockRevoke).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/[type]/[id]/__tests__/revokeSharing.test.ts
+++ b/apps/client/pages/api/[type]/[id]/__tests__/revokeSharing.test.ts
@@ -3,8 +3,12 @@ import { createMocks } from 'node-mocks-http';
 
 /**
  * Route-layer coverage for /api/[type]/[id]/revokeSharing.
- * Pins that the URL id and type are authoritative (not overridable by the body),
- * and that a missing or array-valued id is rejected before the service is called.
+ *
+ * The real protection against body-override attacks is that revokeBodySchema is a
+ * plain z.object({ userId, projectId }) with no .passthrough(): Zod strips any id
+ * or type field from req.body before the spread is evaluated. The 'URL params win'
+ * tests document that intent and verify the URL values reach the service; the
+ * BadRequestError tests are load-bearing (they fail without the explicit guard).
  */
 
 const mockRefs = vi.hoisted(() => ({

--- a/apps/client/pages/api/[type]/[id]/revokeSharing.ts
+++ b/apps/client/pages/api/[type]/[id]/revokeSharing.ts
@@ -3,6 +3,7 @@ import { IShareableDocument } from '@bike4mind/common';
 import { fabFileRepository, projectRepository, sessionRepository, userRepository } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
 import { baseApi } from '@server/middlewares/baseApi';
+import { BadRequestError } from '@server/utils/errors';
 import { Request, Response } from 'express';
 
 const revokeBodySchema = z.object({
@@ -19,11 +20,15 @@ interface SharingParams {
 const handler = baseApi().use(
   async (req: Request<unknown, {}, IShareableDocument, SharingParams>, res: Response<IShareableDocument>) => {
     const { type, id } = req.query;
+    if (typeof id !== 'string' || !id) {
+      throw new BadRequestError('Invalid document id');
+    }
     const body = revokeBodySchema.parse(req.body);
 
+    // id and type come after the body spread so URL params win over any body field with the same name.
     const document = await sharingService.revoke(
       req.user.id,
-      { id, type: type as 'files' | 'sessions', ...body },
+      { ...body, id, type: type as 'files' | 'sessions' },
       {
         db: {
           sessions: sessionRepository,

--- a/apps/client/pages/api/[type]/[id]/revokeSharing.ts
+++ b/apps/client/pages/api/[type]/[id]/revokeSharing.ts
@@ -11,9 +11,11 @@ const revokeBodySchema = z.object({
   projectId: z.string().optional(),
 });
 
+// Next.js passes query params as string | string[]; widen the interface so the
+// typeof guard below is honest rather than dead per the declared type.
 interface SharingParams {
-  id: string;
-  type: string;
+  id: string | string[];
+  type: string | string[];
 }
 
 // This endpoint is dispatched at different paths depending on the document type.

--- a/apps/client/pages/api/organizations/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/index.test.ts
@@ -88,6 +88,19 @@ describe('GET /api/organizations/[id] - safe serialization', () => {
   });
 });
 
+describe('PUT /api/organizations/[id] - URL id wins', () => {
+  beforeEach(() => update.mockClear());
+
+  it('takes the org id from the URL, not from any id field in the body', async () => {
+    const { req, res } = mocks({ id: 'caller', isAdmin: true }, 'PUT');
+    (req as any).body = { id: 'from-body', name: 'renamed' };
+    await mockRefs.putHandler!(req, res);
+    const [, params] = update.mock.calls[0];
+    expect(params.id).toBe('org1');
+    expect(params.name).toBe('renamed');
+  });
+});
+
 describe('PUT /api/organizations/[id] - safe serialization', () => {
   beforeEach(() => update.mockClear());
 

--- a/apps/client/pages/api/organizations/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/index.test.ts
@@ -57,7 +57,7 @@ const update = vi.hoisted(() =>
     stripeCustomerId: 'cus_SECRET',
   }))
 );
-vi.mock('@bike4mind/utils', () => ({
+vi.mock('@server/utils/errors', () => ({
   BadRequestError: class BadRequestError extends Error {},
 }));
 vi.mock('@bike4mind/services', () => ({ organizationService: { get, update } }));
@@ -66,7 +66,7 @@ vi.mock('@server/models/Subscription', () => ({ subscriptionRepository: {} }));
 vi.mock('@client/lib/subscriptions/types', () => ({ SubscriptionOwnerType: { Organization: 'organization' } }));
 
 import '@pages/api/organizations/[id]/index';
-import { BadRequestError } from '@bike4mind/utils';
+import { BadRequestError } from '@server/utils/errors';
 
 function mocks(user: unknown, method: 'GET' | 'PUT' = 'GET') {
   const { req, res } = createMocks({ method, query: { id: 'org1' } });

--- a/apps/client/pages/api/organizations/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/index.test.ts
@@ -8,6 +8,11 @@ import { createMocks } from 'node-mocks-http';
  * userDetails) are preserved so member UIs keep working. The PUT (update) response
  * is routed through the same serializer so a manager updating org settings never
  * gets billing identifiers echoed back.
+ *
+ * The real protection against body-override of the org id is that updateOrgBodySchema
+ * is a plain z.object() with no .passthrough(): Zod strips any id field from
+ * req.body before the spread. The 'URL id wins' test documents that intent;
+ * the BadRequestError test is load-bearing.
  */
 
 const mockRefs = vi.hoisted(() => ({
@@ -52,12 +57,16 @@ const update = vi.hoisted(() =>
     stripeCustomerId: 'cus_SECRET',
   }))
 );
+vi.mock('@bike4mind/utils', () => ({
+  BadRequestError: class BadRequestError extends Error {},
+}));
 vi.mock('@bike4mind/services', () => ({ organizationService: { get, update } }));
 vi.mock('@bike4mind/database/infra', () => ({ organizationRepository: {} }));
 vi.mock('@server/models/Subscription', () => ({ subscriptionRepository: {} }));
 vi.mock('@client/lib/subscriptions/types', () => ({ SubscriptionOwnerType: { Organization: 'organization' } }));
 
 import '@pages/api/organizations/[id]/index';
+import { BadRequestError } from '@bike4mind/utils';
 
 function mocks(user: unknown, method: 'GET' | 'PUT' = 'GET') {
   const { req, res } = createMocks({ method, query: { id: 'org1' } });
@@ -98,6 +107,13 @@ describe('PUT /api/organizations/[id] - URL id wins', () => {
     const [, params] = update.mock.calls[0];
     expect(params.id).toBe('org1');
     expect(params.name).toBe('renamed');
+  });
+
+  it('rejects a missing id with BadRequestError before reaching the service', async () => {
+    const { req, res } = createMocks({ method: 'PUT', query: {} });
+    (req as any).user = { id: 'caller', isAdmin: true };
+    await expect(mockRefs.putHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/pages/api/organizations/[id]/index.ts
+++ b/apps/client/pages/api/organizations/[id]/index.ts
@@ -6,6 +6,7 @@ import { partnerSignupRuleRepository, userRepository, withTransaction } from '@b
 import { groupRepository } from '@bike4mind/database/social';
 import { invalidatePartnerRuleCache } from '@server/entitlements/partnerRules';
 import { organizationService } from '@bike4mind/services';
+import { BadRequestError } from '@bike4mind/utils';
 import { toSafeOrganization } from '@bike4mind/common';
 import { Request } from 'express';
 import { subscriptionRepository } from '@server/models/Subscription';
@@ -42,7 +43,10 @@ const handler = baseApi()
   )
   .put(
     asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
-      const orgId = req.query.id!;
+      const orgId = req.query.id;
+      if (typeof orgId !== 'string' || !orgId) {
+        throw new BadRequestError('Invalid organization id');
+      }
 
       const body = updateOrgBodySchema.parse(req.body);
       const updatedOrganization = await organizationService.update(

--- a/apps/client/pages/api/organizations/[id]/index.ts
+++ b/apps/client/pages/api/organizations/[id]/index.ts
@@ -6,8 +6,8 @@ import { partnerSignupRuleRepository, userRepository, withTransaction } from '@b
 import { groupRepository } from '@bike4mind/database/social';
 import { invalidatePartnerRuleCache } from '@server/entitlements/partnerRules';
 import { organizationService } from '@bike4mind/services';
-import { BadRequestError } from '@bike4mind/utils';
 import { toSafeOrganization } from '@bike4mind/common';
+import { BadRequestError } from '@server/utils/errors';
 import { Request } from 'express';
 import { subscriptionRepository } from '@server/models/Subscription';
 import { SubscriptionOwnerType } from '@client/lib/subscriptions/types';

--- a/apps/client/pages/api/organizations/[id]/index.ts
+++ b/apps/client/pages/api/organizations/[id]/index.ts
@@ -47,7 +47,7 @@ const handler = baseApi()
       const body = updateOrgBodySchema.parse(req.body);
       const updatedOrganization = await organizationService.update(
         req.user!,
-        { id: orgId, ...body },
+        { ...body, id: orgId },
         {
           db: {
             organizations: organizationRepository,

--- a/apps/client/pages/api/projects/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/projects/[id]/__tests__/index.test.ts
@@ -3,8 +3,11 @@ import { createMocks } from 'node-mocks-http';
 
 /**
  * Route-layer coverage for PUT /api/projects/[id].
- * Pins that the URL id is authoritative over any body field, and that a missing
- * or array-valued id is rejected before the service is reached.
+ *
+ * The real protection against body-override attacks is that updateProjectBodySchema
+ * is a plain z.object() with no .passthrough(): Zod strips any id field from
+ * req.body before the spread is evaluated. The 'URL id wins' test documents that
+ * intent; the BadRequestError tests are load-bearing.
  */
 
 const mockRefs = vi.hoisted(() => ({

--- a/apps/client/pages/api/projects/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/projects/[id]/__tests__/index.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * Route-layer coverage for PUT /api/projects/[id].
+ * Pins that the URL id is authoritative over any body field, and that a missing
+ * or array-valued id is rejected before the service is reached.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  putHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    put: (fn: any) => {
+      mockRefs.putHandler = fn;
+      return chain;
+    },
+    delete: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@bike4mind/utils', () => ({
+  BadRequestError: class BadRequestError extends Error {},
+  UnprocessableEntityError: class UnprocessableEntityError extends Error {},
+}));
+
+const mockUpdate = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'p1', name: 'updated' }));
+vi.mock('@bike4mind/services', () => ({
+  projectService: { update: (...a: unknown[]) => mockUpdate(...a), get: vi.fn() },
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  projectRepository: {},
+  userRepository: {},
+}));
+
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@server/utils/isDuplicateKeyError', () => ({ isDuplicateKeyError: () => false }));
+vi.mock('@bike4mind/common', () => ({ ProjectEvents: { UPDATE_PROJECT: 'update_project' } }));
+
+import '@pages/api/projects/[id]/index';
+import { BadRequestError } from '@bike4mind/utils';
+
+function put(query: Record<string, unknown>, body: Record<string, unknown> = {}) {
+  const { req, res } = createMocks({ method: 'PUT', query, body });
+  (req as any).user = { id: 'u1' };
+  (req as any).ability = {};
+  return { req, res };
+}
+
+describe('PUT /api/projects/[id] - URL id wins', () => {
+  beforeEach(() => mockUpdate.mockClear());
+
+  it('takes the project id from the URL, not from any body field', async () => {
+    const { req, res } = put({ id: 'url-project-id' }, { id: 'body-project-id', name: 'renamed' });
+    await mockRefs.putHandler!(req, res);
+    const [, params] = mockUpdate.mock.calls[0];
+    expect(params.id).toBe('url-project-id');
+    expect(params.name).toBe('renamed');
+  });
+
+  it('rejects a missing id with BadRequestError before reaching the service', async () => {
+    const { req, res } = put({}, { name: 'renamed' });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an array-valued id with BadRequestError before reaching the service', async () => {
+    const { req, res } = put({ id: ['a', 'b'] }, { name: 'renamed' });
+    await expect(mockRefs.putHandler!(req, res)).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('passes a valid update through to the service with only validated body fields', async () => {
+    const { req, res } = put({ id: 'p1' }, { name: 'new name', description: 'desc' });
+    await mockRefs.putHandler!(req, res);
+    const [userId, params] = mockUpdate.mock.calls[0];
+    expect(userId).toBe('u1');
+    expect(params).toEqual({ id: 'p1', name: 'new name', description: 'desc' });
+  });
+});

--- a/apps/client/pages/api/projects/[id]/index.ts
+++ b/apps/client/pages/api/projects/[id]/index.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ProjectEvents } from '@bike4mind/common';
 import { projectRepository, userRepository } from '@bike4mind/database';
 import { projectService } from '@bike4mind/services';
-import { UnprocessableEntityError } from '@bike4mind/utils';
+import { BadRequestError, UnprocessableEntityError } from '@bike4mind/utils';
 import { baseApi } from '@server/middlewares/baseApi';
 import { isDuplicateKeyError } from '@server/utils/isDuplicateKeyError';
 import { logEvent } from '@server/utils/analyticsLog';
@@ -23,15 +23,17 @@ const handler = baseApi()
     return res.json(project);
   })
   .put(async (req, res) => {
+    const { id } = req.query as { id?: string | string[] };
+    if (typeof id !== 'string' || !id) {
+      throw new BadRequestError('Invalid project id');
+    }
     let project;
     const body = updateProjectBodySchema.parse(req.body);
     try {
       project = await projectService.update(
         req.user.id,
-        {
-          ...(req.query as any),
-          ...body,
-        },
+        // id comes after the body spread so the URL param wins over any body field.
+        { ...body, id },
         {
           db: {
             projects: projectRepository,

--- a/apps/client/pages/api/research/agents/[id]/index.ts
+++ b/apps/client/pages/api/research/agents/[id]/index.ts
@@ -33,7 +33,7 @@ const handler = baseApi({ auth: true })
       const body = updateBodySchema.parse(req.body);
       const result = await researchAgentService.update(
         req.user as any,
-        { id, ...body },
+        { ...body, id },
         {
           db: {
             researchAgents: researchAgentRepository,
@@ -50,7 +50,7 @@ const handler = baseApi({ auth: true })
       const body = updateBodySchema.parse(req.body);
       const result = await researchAgentService.update(
         req.user as any,
-        { id, ...body },
+        { ...body, id },
         {
           db: {
             researchAgents: researchAgentRepository,

--- a/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/__tests__/index.test.ts
+++ b/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/__tests__/index.test.ts
@@ -3,7 +3,11 @@ import { createMocks } from 'node-mocks-http';
 
 /**
  * Route-layer coverage for PUT /api/research/agents/[id]/tasks/[taskId].
- * Pins that the URL taskId is authoritative over any id field in the body.
+ *
+ * The real protection against body-override attacks is that taskUpdateBodySchema
+ * is a plain z.object() with no .passthrough(): Zod strips any id field from
+ * req.body before the spread is evaluated. The 'URL id wins' test documents that
+ * intent and verifies the URL taskId reaches the service correctly.
  */
 
 const mockRefs = vi.hoisted(() => ({

--- a/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/__tests__/index.test.ts
+++ b/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/__tests__/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * Route-layer coverage for PUT /api/research/agents/[id]/tasks/[taskId].
+ * Pins that the URL taskId is authoritative over any id field in the body.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  putHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    put: (fn: any) => {
+      mockRefs.putHandler = fn;
+      return chain;
+    },
+    delete: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: any) => fn,
+}));
+
+const mockUpdate = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'task1', title: 'updated' }));
+vi.mock('@bike4mind/services', () => ({
+  researchTaskService: { update: (...a: unknown[]) => mockUpdate(...a), get: vi.fn(), remove: vi.fn() },
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  researchTaskRepository: {},
+  researchDataRepository: {},
+}));
+
+vi.mock('@bike4mind/common', () => ({
+  ResearchTaskType: ['web', 'document'],
+}));
+
+import '@pages/api/research/agents/[id]/tasks/[taskId]/index';
+
+function put(query: Record<string, unknown>, body: Record<string, unknown> = {}) {
+  const { req, res } = createMocks({ method: 'PUT', query, body });
+  (req as any).user = { id: 'u1' };
+  return { req, res };
+}
+
+describe('PUT /api/research/agents/[id]/tasks/[taskId] - URL id wins', () => {
+  beforeEach(() => mockUpdate.mockClear());
+
+  it('takes the task id from the URL taskId param, not from any id field in the body', async () => {
+    const { req, res } = put(
+      { id: 'agent-1', taskId: 'url-task-id' },
+      { id: 'body-task-id', title: 'fix bug', description: 'desc', type: 'web' }
+    );
+    await mockRefs.putHandler!(req, res);
+    const [, params] = mockUpdate.mock.calls[0];
+    expect(params.id).toBe('url-task-id');
+    expect(params.title).toBe('fix bug');
+  });
+
+  it('passes a valid update through with only validated body fields plus the URL id', async () => {
+    const { req, res } = put(
+      { id: 'agent-1', taskId: 'task-42' },
+      { title: 'research task', description: 'do research', type: 'web' }
+    );
+    await mockRefs.putHandler!(req, res);
+    const [, params] = mockUpdate.mock.calls[0];
+    expect(params.id).toBe('task-42');
+    expect(params.title).toBe('research task');
+  });
+});

--- a/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/index.ts
+++ b/apps/client/pages/api/research/agents/[id]/tasks/[taskId]/index.ts
@@ -39,7 +39,7 @@ const handler = baseApi({ auth: true })
       const body = taskUpdateBodySchema.parse(req.body);
       const result = await researchTaskService.update(
         req.user as any,
-        { id: taskId, ...body },
+        { ...body, id: taskId },
         {
           db: {
             researchTasks: researchTaskRepository,


### PR DESCRIPTION
## Summary

Part of #1569. Six API route handlers were building service call params by placing URL path params (\`id\`, \`type\`) *before* spreading \`req.body\`, meaning a caller could send \`{ \"id\": \"attacker-id\" }\` in the body and override the URL param. The services authorize against the same id they act on so there is no currently exploitable path (all body schemas are plain \`z.object()\` with no \`.passthrough()\`, so Zod strips any \`id\`/\`type\` field before the spread is evaluated). The ordering is fixed here as a hygiene/future-proofing change: a future route-level auth guard must be able to trust that URL params are authoritative.

- Reorder spreads in all affected PUT/POST/revoke handlers so URL params always win: \`{ ...body, id }\` instead of \`{ id, ...body }\`
- Add \`BadRequestError\` guards for missing or array-valued URL segments where not already present
- Widen \`SharingParams\` interface in \`revokeSharing.ts\` so the \`typeof id !== 'string'\` guard is honest (not dead per the declared type)
- Add unit tests for each fixed handler; docblocks explain that the Zod schema strip is the real load-bearing protection and the ordering tests document intent

**Remaining routes with the same \`{ id, ...body }\` shape not covered by this PR** (all inert today for the same Zod-strip reason; #1569 stays open to track them):
- \`apps/client/pages/api/prompts/[id]/update.ts:33\`
- \`apps/client/pages/api/admin/partner-signup-rules/[id].ts:36\`
- \`apps/client/pages/api/artifacts/[id]/index.ts:140\`

## Files changed

**Source fixes:**
- \`apps/client/pages/api/organizations/[id]/index.ts\` -- PUT handler
- \`apps/client/pages/api/projects/[id]/index.ts\` -- PUT handler. Note: the old spread was \`{ ...(req.query as any), ...body }\`, so \`PUT /api/projects/:id?name=X\` with an empty body used to rename the project. The new spread \`{ ...body, id }\` drops that query-string path (a silent no-op rather than an error). The only in-repo caller sends a body and no query string, so blast radius is out-of-tree clients using the query-string form.
- \`apps/client/pages/api/[type]/[id]/revokeSharing.ts\` -- all methods + SharingParams widened
- \`apps/client/pages/api/research/agents/[id]/tasks/[taskId]/index.ts\` -- PUT handler
- \`apps/client/pages/api/research/agents/[id]/index.ts\` -- PUT and POST handlers

**Tests (new or extended):**
- \`apps/client/pages/api/organizations/[id]/__tests__/index.test.ts\` -- extended with URL-wins and BadRequestError blocks
- \`apps/client/pages/api/[type]/[id]/__tests__/revokeSharing.test.ts\` -- new
- \`apps/client/pages/api/projects/[id]/__tests__/index.test.ts\` -- new
- \`apps/client/pages/api/research/agents/[id]/tasks/[taskId]/__tests__/index.test.ts\` -- new

Note: \`[type]/[id]/invites/index.ts\` POST and \`projects/[id]/invites.ts\` POST were confirmed already correct -- URL params placed last.

## Test plan

- [ ] \`pnpm --filter @bike4mind/client test\` passes (new tests cover URL-wins and BadRequestError cases)
- [ ] \`pnpm turbo:typecheck\` clean
- [ ] \`pnpm lint:check\` clean
- [ ] Manual smoke: PUT /api/organizations/:id with \`{ \"id\": \"other-id\" }\` in body -- service receives URL id, not body id

🤖 Generated with [Claude Code](https://claude.com/claude-code)