### PR TITLE
fix(websocket): constrain subscribe_query filters and redact organization fields

### DIFF
--- a/apps/client/app/hooks/useCollection.ts
+++ b/apps/client/app/hooks/useCollection.ts
@@ -21,8 +21,7 @@ type QueryableType =
   | { $lte: IndexableType }
   | { $in: IndexableType[] }
   | { $nin: IndexableType[] }
-  | { $exists: boolean }
-  | { $regex: string };
+  | { $exists: boolean };
 
 type QueryBuilderFn<T> = (
   table: Dexie.Table<T, IndexableType>,
@@ -310,8 +309,6 @@ const convertQuery = <T>(
       return table.where(key).noneOf(normalizedOperand);
     case '$exists':
       return table.where(key).notEqual(Math.random().toString(36).substring(2, 9));
-    case '$regex':
-      return table.where(key).startsWith(normalizedOperand);
     default:
       throw new Error(`Unsupported operator ${operator}`);
   }

--- a/apps/client/app/utils/react-query.ts
+++ b/apps/client/app/utils/react-query.ts
@@ -271,8 +271,7 @@ type QueryableType =
   | { $lte: IndexableType }
   | { $in: IndexableType[] }
   | { $nin: IndexableType[] }
-  | { $exists: boolean }
-  | { $regex: string };
+  | { $exists: boolean };
 
 /**
  * Recursively serialize a value with object keys sorted, so two distinct-but-equal

--- a/apps/client/server/websocket/__tests__/dataSubscribeRequest.test.ts
+++ b/apps/client/server/websocket/__tests__/dataSubscribeRequest.test.ts
@@ -34,7 +34,7 @@ vi.mock('@bike4mind/database', () => ({
   Inbox: {},
   Invite: {},
   mongoose: {},
-  Organization: {},
+  Organization: { collection: { collectionName: 'organizations' } },
   Project: {},
   QuerySubscription: { findOneAndUpdate: (...args: unknown[]) => mockQuerySubscriptionFindOneAndUpdate(...args) },
   Quest: { collection: { collectionName: 'quests' } },
@@ -59,6 +59,7 @@ vi.mock('@server/models/Subscription', () => ({
 
 vi.mock('@server/websocket/subscriptionScopes', () => ({
   questMasterPlanSubscriptionScope: vi.fn(),
+  inviteSubscriptionScope: vi.fn(),
 }));
 
 vi.mock('@server/utils/errors', () => ({

--- a/apps/client/server/websocket/dataSubscribeFieldLimits.test.ts
+++ b/apps/client/server/websocket/dataSubscribeFieldLimits.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { resolveFieldLimits } from './dataSubscribeFieldLimits';
+import { resolveFieldLimits, type FieldLimitOptions } from './dataSubscribeFieldLimits';
+
+const opts = (overrides: Partial<FieldLimitOptions> = {}): FieldLimitOptions => ({
+  questCollectionName: 'quests',
+  organizationCollectionName: 'organizations',
+  ...overrides,
+});
 
 describe('resolveFieldLimits', () => {
   it('excludes functionCalls.returnValue/error for the quests collection', () => {
-    const limits = resolveFieldLimits('quests', 'quests');
+    const limits = resolveFieldLimits('quests', opts());
     expect(limits).toEqual({
       'promptMeta.functionCalls.returnValue': false,
       'promptMeta.functionCalls.error': false,
@@ -11,17 +17,17 @@ describe('resolveFieldLimits', () => {
   });
 
   it('excludes password/stripeCustomerId/resetPasswordToken for the users collection', () => {
-    const limits = resolveFieldLimits('users', 'quests');
+    const limits = resolveFieldLimits('users', opts());
     expect(limits).toEqual({ password: false, stripeCustomerId: false, resetPasswordToken: false });
   });
 
   it('returns undefined for a collection with no configured limits', () => {
-    expect(resolveFieldLimits('projects', 'quests')).toBeUndefined();
+    expect(resolveFieldLimits('projects', opts())).toBeUndefined();
   });
 
   it('uses the passed-in quest collection name rather than a hardcoded literal', () => {
     // Guards against a future rename of the Quest collection silently breaking this exclusion.
-    const limits = resolveFieldLimits('chathistoryitems', 'chathistoryitems');
+    const limits = resolveFieldLimits('chathistoryitems', opts({ questCollectionName: 'chathistoryitems' }));
     expect(limits).toBeDefined();
   });
 
@@ -29,14 +35,36 @@ describe('resolveFieldLimits', () => {
     // A caller-owned quest subscription must not lose returnValue - the client cache merges a WS
     // update as a top-level spread, so ANY exclusion here replaces the owner's own cached tool
     // output the moment a live update lands, not just a sharee's.
-    expect(resolveFieldLimits('quests', 'quests', true)).toBeUndefined();
+    expect(resolveFieldLimits('quests', opts({ isQuestOwner: true }))).toBeUndefined();
   });
 
   it('still excludes functionCalls.returnValue/error for the quests collection when the caller is a sharee', () => {
-    const limits = resolveFieldLimits('quests', 'quests', false);
+    const limits = resolveFieldLimits('quests', opts({ isQuestOwner: false }));
     expect(limits).toEqual({
       'promptMeta.functionCalls.returnValue': false,
       'promptMeta.functionCalls.error': false,
+    });
+  });
+
+  it('excludes stripeCustomerId and billingContact for a non-admin organizations subscriber', () => {
+    expect(resolveFieldLimits('organizations', opts())).toEqual({
+      stripeCustomerId: false,
+      billingContact: false,
+    });
+  });
+
+  it('still excludes stripeCustomerId for a platform admin, who keeps billingContact', () => {
+    // Mirrors toSafeOrganization: stripeCustomerId has no client consumer at all, billingContact
+    // is privileged. Owners are NOT privileged here - see the projection note in the source.
+    expect(resolveFieldLimits('organizations', opts({ isPlatformAdmin: true }))).toEqual({
+      stripeCustomerId: false,
+    });
+  });
+
+  it('uses the passed-in organization collection name rather than a hardcoded literal', () => {
+    expect(resolveFieldLimits('orgs_v2', opts({ organizationCollectionName: 'orgs_v2' }))).toEqual({
+      stripeCustomerId: false,
+      billingContact: false,
     });
   });
 });

--- a/apps/client/server/websocket/dataSubscribeFieldLimits.ts
+++ b/apps/client/server/websocket/dataSubscribeFieldLimits.ts
@@ -1,3 +1,5 @@
+import { ORGANIZATION_OWNER_ONLY_FIELDS, ORGANIZATION_SECRET_FIELDS } from '@bike4mind/common';
+
 /**
  * Per-collection Mongo projection exclusions for the WS data-subscribe handler.
  *
@@ -9,17 +11,38 @@
  * the exclusion for the session's own owner: the client cache merges a WS quest update as a
  * top-level spread (react-query.ts), so an unconditional exclusion replaced the owner's own
  * cached returnValue with nothing the moment any live update landed, not just a sharee's.
+ *
+ * organizations: the subscription streams raw org documents, so it has to reproduce what
+ * `toSafeOrganization` applies on every REST path - it reads the same two field lists so the
+ * transports cannot drift. `stripeCustomerId` is dropped for everyone. `billingContact` is kept
+ * only for a platform admin, NOT for an org owner as the REST serializer does: a Mongo projection
+ * is per-query, not per-document, so an owner-keyed keep would also hand over the billing contact
+ * of every co-member org the same subscription happens to match. An owner's own billing contact
+ * still reaches them through the access-gated REST GET.
  */
+export type FieldLimitOptions = {
+  /** Passed in rather than hardcoded so a collection rename can't silently drop the exclusion. */
+  questCollectionName: string;
+  organizationCollectionName: string;
+  /** The subscribed session belongs to the caller (see the quests note above). */
+  isQuestOwner?: boolean;
+  /** Caller is a platform admin, the only viewer a per-query projection can safely privilege. */
+  isPlatformAdmin?: boolean;
+};
+
 export function resolveFieldLimits(
   collectionName: string,
-  questCollectionName: string,
-  isQuestOwner = false
+  { questCollectionName, organizationCollectionName, isQuestOwner = false, isPlatformAdmin = false }: FieldLimitOptions
 ): Record<string, boolean> | undefined {
   if (collectionName === 'users') {
     return { password: false, stripeCustomerId: false, resetPasswordToken: false };
   }
   if (collectionName === questCollectionName && !isQuestOwner) {
     return { 'promptMeta.functionCalls.returnValue': false, 'promptMeta.functionCalls.error': false };
+  }
+  if (collectionName === organizationCollectionName) {
+    const excluded = [...ORGANIZATION_SECRET_FIELDS, ...(isPlatformAdmin ? [] : ORGANIZATION_OWNER_ONLY_FIELDS)];
+    return Object.fromEntries(excluded.map(field => [field, false]));
   }
   return undefined;
 }

--- a/apps/client/server/websocket/dataSubscribeRequest.ts
+++ b/apps/client/server/websocket/dataSubscribeRequest.ts
@@ -1,5 +1,6 @@
 import { GoneException } from '@aws-sdk/client-apigatewaymanagementapi';
 import { DataSubscribeRequestAction, Permission } from '@bike4mind/common';
+import { z } from 'zod';
 import {
   AdminSettings,
   ApiKey,
@@ -40,12 +41,57 @@ const HARD_LIMIT = 200;
 // whole Lambda timeout.
 const INITIAL_FETCH_MAX_TIME_MS = 5_000;
 
+/** Best-effort extraction, for the notifySubscribeError call on a frame that failed to parse. */
+function extractRawSubscriptionId(rawBody: unknown): string | undefined {
+  if (typeof rawBody !== 'object' || rawBody === null) return undefined;
+  const subscriptionId = (rawBody as Record<string, unknown>).subscriptionId;
+  return typeof subscriptionId === 'string' ? subscriptionId : undefined;
+}
+
+/**
+ * Notifies the client that its `subscribe_query` frame was refused or its initial fetch was
+ * aborted - the two failure modes on this path that are content-dependent rather than auth- or
+ * infra-dependent, so they can fire for a caller whose frame is otherwise well-formed. Neither
+ * throws an UnauthorizedError/JsonWebTokenError, so withWebSocketContext's status code never
+ * reaches the client as a frame; without this, the caller sees silence and the surface just
+ * never updates. Deliberately not used for auth failures - those keep their existing behavior.
+ * Best-effort: a failure here must not mask the original error from withWebSocketContext's log.
+ */
+async function notifySubscribeError(
+  connectionId: string,
+  endpoint: string,
+  subscriptionId: string | undefined,
+  error: unknown
+): Promise<void> {
+  if (!subscriptionId) return;
+  const message =
+    error instanceof z.ZodError
+      ? error.issues.map(issue => issue.message).join('; ')
+      : error instanceof Error
+        ? error.message
+        : 'Internal server error';
+  try {
+    await sendToConnection(connectionId, endpoint, { action: 'data_subscribe_error', subscriptionId, error: message });
+  } catch {
+    // Best-effort notification only.
+  }
+}
+
 // Adds a subscription for the given collection/query; the subscriber-fanout package
 // handles the actual change-stream delivery. Query is scoped to the user's ability here
 // so subscriber-fanout doesn't need to re-check access.
 export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async (event, context, logger) => {
   const endpoint = Resource.websocket.managementEndpoint;
   const connectionId = event.requestContext.connectionId;
+  const rawBody: unknown = JSON.parse(event.body ?? '');
+
+  let parsedRequest;
+  try {
+    parsedRequest = DataSubscribeRequestAction.parse(rawBody);
+  } catch (error) {
+    await notifySubscribeError(connectionId, endpoint, extractRawSubscriptionId(rawBody), error);
+    throw error;
+  }
 
   const {
     accessToken,
@@ -54,7 +100,7 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
     query,
     fields,
     fetchInitialData,
-  } = DataSubscribeRequestAction.parse(JSON.parse(event.body ?? ''));
+  } = parsedRequest;
 
   const user = await verifyWsAccessToken(accessToken);
   const userAbility = ability(user);
@@ -181,7 +227,13 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
   const subscriber = { endpoint, connectionId, clientId: clientSubscriberId, attempts: 0 };
 
   if (fetchInitialData) {
-    const results = await findPromise;
+    let results;
+    try {
+      results = await findPromise;
+    } catch (error) {
+      await notifySubscribeError(connectionId, endpoint, clientSubscriberId, error);
+      throw error;
+    }
     const limit = pLimit(50);
     const sendingOutcomes = await Promise.allSettled(
       results.map(r =>

--- a/apps/client/server/websocket/dataSubscribeRequest.ts
+++ b/apps/client/server/websocket/dataSubscribeRequest.ts
@@ -1,5 +1,5 @@
 import { GoneException } from '@aws-sdk/client-apigatewaymanagementapi';
-import { DataSubscribeRequestAction, InviteType, Permission } from '@bike4mind/common';
+import { DataSubscribeRequestAction, Permission } from '@bike4mind/common';
 import {
   AdminSettings,
   ApiKey,
@@ -21,7 +21,7 @@ import {
 import { Session as SessionModel } from '@bike4mind/database/auth';
 import { accessibleBy } from '@casl/mongoose';
 import { Subscription } from '@server/models/Subscription';
-import { questMasterPlanSubscriptionScope } from '@server/websocket/subscriptionScopes';
+import { inviteSubscriptionScope, questMasterPlanSubscriptionScope } from '@server/websocket/subscriptionScopes';
 import { sendToConnection, withWebSocketContext } from '@server/websocket/utils';
 import { verifyWsAccessToken } from '@server/websocket/verifyWsAccessToken';
 import crypto from 'crypto';
@@ -33,6 +33,12 @@ import { Resource } from 'sst';
 import { resolveFieldLimits } from './dataSubscribeFieldLimits';
 
 const HARD_LIMIT = 200;
+
+// Server-side ceiling (ms) on the one-time initial fetch. The filter is client-authored, so even
+// with the operator allow-list on DataSubscribeRequestAction a badly-shaped-but-legal filter can
+// be slow; this makes the database abort it instead of letting it pin a pooled connection for the
+// whole Lambda timeout.
+const INITIAL_FETCH_MAX_TIME_MS = 5_000;
 
 // Adds a subscription for the given collection/query; the subscriber-fanout package
 // handles the actual change-stream delivery. Query is scoped to the user's ability here
@@ -83,14 +89,10 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
   } else if (collectionName === Invite.collection.collectionName) {
     const canShareProjectsQuery = accessibleBy(userAbility, Permission.share).ofType(Project);
     const shareableProjectIds = await Project.find(canShareProjectsQuery).distinct('_id');
-    scope = {
-      $or: [
-        { 'recipients.pending': { $in: [user.email] } },
-        {
-          $and: [{ type: InviteType.Project }, { documentId: { $in: shareableProjectIds.map(id => id.toString()) } }],
-        },
-      ],
-    };
+    scope = inviteSubscriptionScope(
+      user.email,
+      shareableProjectIds.map(id => id.toString())
+    );
   } else {
     // To make a collection subscribeable, add it to this scope mapping:
     scope = {
@@ -120,7 +122,12 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
   // as `fields`, which is what the separate subscriber-fanout service reads to build its own
   // change-stream projection - so this exclusion applies to live update/insert events fanout
   // relays, not just the one-time fetchInitialData query above.
-  const fieldLimits = resolveFieldLimits(collectionName, Quest.collection.collectionName, isOwnQuestSession);
+  const fieldLimits = resolveFieldLimits(collectionName, {
+    questCollectionName: Quest.collection.collectionName,
+    organizationCollectionName: Organization.collection.collectionName,
+    isQuestOwner: isOwnQuestSession,
+    isPlatformAdmin: !!user.isAdmin,
+  });
 
   let scopedFields: undefined | Record<string, boolean | number> =
     (fields || fieldLimits) &&
@@ -169,7 +176,7 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
   const scopedQuery = { $and: [query, scope] };
   const findPromise = collection
     .find(scopedQuery, scopedFields ?? undefined)
-    .setOptions({ includeDeleted: true, limit: HARD_LIMIT });
+    .setOptions({ includeDeleted: true, limit: HARD_LIMIT, maxTimeMS: INITIAL_FETCH_MAX_TIME_MS });
   const normalizedQuery = findPromise.getQuery();
   const subscriber = { endpoint, connectionId, clientId: clientSubscriberId, attempts: 0 };
 

--- a/apps/client/server/websocket/subscriptionScopes.test.ts
+++ b/apps/client/server/websocket/subscriptionScopes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Types } from 'mongoose';
-import { questMasterPlanSubscriptionScope } from './subscriptionScopes';
+import { InviteType } from '@bike4mind/common';
+import { inviteSubscriptionScope, questMasterPlanSubscriptionScope } from './subscriptionScopes';
 
 describe('questMasterPlanSubscriptionScope', () => {
   const userId = new Types.ObjectId().toString();
@@ -43,5 +44,33 @@ describe('questMasterPlanSubscriptionScope', () => {
 
     expect(scope.$or).not.toContainEqual({ userId: otherUser });
     expect(scope.$or).not.toContainEqual({ sharedWith: otherUser });
+  });
+});
+
+describe('inviteSubscriptionScope', () => {
+  const projectIds = [new Types.ObjectId().toString()];
+  const projectArm = { $and: [{ type: InviteType.Project }, { documentId: { $in: projectIds } }] };
+
+  it('matches invites addressed to the caller plus the shareable-project arm', () => {
+    expect(inviteSubscriptionScope('user@example.com', projectIds).$or).toEqual([
+      { 'recipients.pending': { $in: ['user@example.com'] } },
+      projectArm,
+    ]);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['blank', '   '],
+  ])('drops the pending arm entirely for a %s email', (_label, email) => {
+    // `$in: [undefined]` is read by Mongo as "field missing or null", so an emailless account
+    // would otherwise match every invite whose recipients.pending path is absent.
+    expect(inviteSubscriptionScope(email, projectIds).$or).toEqual([projectArm]);
+  });
+
+  it('trims the email before matching', () => {
+    expect(inviteSubscriptionScope('  user@example.com  ', projectIds).$or?.[0]).toEqual({
+      'recipients.pending': { $in: ['user@example.com'] },
+    });
   });
 });

--- a/apps/client/server/websocket/subscriptionScopes.ts
+++ b/apps/client/server/websocket/subscriptionScopes.ts
@@ -38,8 +38,10 @@ export function questMasterPlanSubscriptionScope(
  * emailless account can have no invites addressed to it - and passing `undefined` through to
  * `$in: [undefined]` makes Mongo read the arm as "field missing or null", which over-matches
  * every invite that has no pending array at all, i.e. other tenants' invites. A blank email
- * therefore drops the arm entirely rather than widening it. Mirrors InviteModel's own
- * pendingEmailMatch guard.
+ * therefore drops the arm entirely rather than widening it - this mirrors the emailless guard in
+ * InviteModel's own pendingEmailMatch, but NOT its matching semantics: pendingEmailMatch also ORs
+ * in a case-insensitive `$regex` arm that this exact-`$in` match does not, a pre-existing
+ * divergence this function doesn't change.
  */
 export function inviteSubscriptionScope(
   pendingEmail: string | null | undefined,

--- a/apps/client/server/websocket/subscriptionScopes.ts
+++ b/apps/client/server/websocket/subscriptionScopes.ts
@@ -1,3 +1,4 @@
+import { InviteType } from '@bike4mind/common';
 import type { mongoose } from '@bike4mind/database';
 
 /**
@@ -25,6 +26,30 @@ export function questMasterPlanSubscriptionScope(
       // Legacy plans (no userId) and session-visibility plans remain
       // reachable through the sessions the user can access
       { notebookId: { $in: accessibleSessionIds } },
+    ],
+  };
+}
+
+/**
+ * Fan-out scope for Invite change-stream subscriptions: invites addressed to the caller's own
+ * email, plus project invites for projects the caller may share.
+ *
+ * `pendingEmail` MUST be a real address. `recipients.pending` holds invitee emails, so an
+ * emailless account can have no invites addressed to it - and passing `undefined` through to
+ * `$in: [undefined]` makes Mongo read the arm as "field missing or null", which over-matches
+ * every invite that has no pending array at all, i.e. other tenants' invites. A blank email
+ * therefore drops the arm entirely rather than widening it. Mirrors InviteModel's own
+ * pendingEmailMatch guard.
+ */
+export function inviteSubscriptionScope(
+  pendingEmail: string | null | undefined,
+  shareableProjectIds: string[]
+): mongoose.FilterQuery<unknown> {
+  const normalizedEmail = typeof pendingEmail === 'string' ? pendingEmail.trim() : '';
+  return {
+    $or: [
+      ...(normalizedEmail ? [{ 'recipients.pending': { $in: [normalizedEmail] } }] : []),
+      { $and: [{ type: InviteType.Project }, { documentId: { $in: shareableProjectIds } }] },
     ],
   };
 }

--- a/b4m-core/common/src/schemas/actions.subscribeQuery.test.ts
+++ b/b4m-core/common/src/schemas/actions.subscribeQuery.test.ts
@@ -22,13 +22,13 @@ describe('DataSubscribeRequestAction query filter gate', () => {
 
   it('refuses a filter that asks the database to run JavaScript', () => {
     expect(() => DataSubscribeRequestAction.parse(frame({ $where: 'while(true){}' }))).toThrow(
-      /Disallowed subscription filter operator/
+      /Disallowed subscription filter/
     );
   });
 
   it('refuses a disallowed operator nested inside an allowed combinator', () => {
     expect(() =>
       DataSubscribeRequestAction.parse(frame({ $and: [{ userId: 'u1' }, { $expr: { $function: { body: 'x' } } }] }))
-    ).toThrow(/Disallowed subscription filter operator/);
+    ).toThrow(/Disallowed subscription filter/);
   });
 });

--- a/b4m-core/common/src/schemas/actions.subscribeQuery.test.ts
+++ b/b4m-core/common/src/schemas/actions.subscribeQuery.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { DataSubscribeRequestAction } from './actions';
+
+/**
+ * Pins the WIRING, not the allow-list itself (subscriptionQueryFilter.test.ts covers that):
+ * the refusal has to happen at `DataSubscribeRequestAction.parse`, because that is the only
+ * point in the WS data-subscribe path that runs before both the initial `Model.find` and the
+ * `QuerySubscription` write the fanout service replays.
+ */
+const frame = (query: Record<string, unknown>) => ({
+  action: 'subscribe_query',
+  subscriptionId: 'sub-1',
+  collectionName: 'users',
+  query,
+  fields: {},
+});
+
+describe('DataSubscribeRequestAction query filter gate', () => {
+  it('accepts an ordinary equality filter', () => {
+    expect(DataSubscribeRequestAction.parse(frame({ sessionId: 'abc' })).query).toEqual({ sessionId: 'abc' });
+  });
+
+  it('refuses a filter that asks the database to run JavaScript', () => {
+    expect(() => DataSubscribeRequestAction.parse(frame({ $where: 'while(true){}' }))).toThrow(
+      /Disallowed subscription filter operator/
+    );
+  });
+
+  it('refuses a disallowed operator nested inside an allowed combinator', () => {
+    expect(() =>
+      DataSubscribeRequestAction.parse(frame({ $and: [{ userId: 'u1' }, { $expr: { $function: { body: 'x' } } }] }))
+    ).toThrow(/Disallowed subscription filter operator/);
+  });
+});

--- a/b4m-core/common/src/schemas/actions.ts
+++ b/b4m-core/common/src/schemas/actions.ts
@@ -26,10 +26,18 @@ export const DataSubscribeRequestAction = z.object({
   // QuerySubscription is written. See subscriptionQueryFilter.ts for what it refuses and why.
   query: z.looseObject({}).superRefine((filter, ctx) => {
     for (const key of findDisallowedSubscriptionFilterKeys(filter)) {
-      ctx.addIssue({ code: 'custom', message: `Disallowed subscription filter operator: ${key}` });
+      // `key` also carries non-operator violations (a RegExp operand, excess nesting depth) with
+      // their own "(... )" suffix, so this prefix stays neutral rather than calling all three an
+      // "operator" - see findDisallowedSubscriptionFilterKeys' own doc comment for the three shapes.
+      ctx.addIssue({ code: 'custom', message: `Disallowed subscription filter: ${key}` });
     }
   }),
-  fields: z.looseObject({}),
+  // Same two sinks (Model.find projection, persisted QuerySubscription) as `query`. A Mongo
+  // projection can't run server-side JavaScript the way `$where` can, but it is still
+  // client-chosen, so this is constrained to the boolean/number projection flags the handler
+  // already assumes it is (see the cast in dataSubscribeRequest.ts) rather than left as
+  // z.looseObject({}).
+  fields: z.record(z.string(), z.union([z.boolean(), z.number()])),
   fetchInitialData: z.boolean().prefault(true).optional(),
   clientId: z.string().optional(),
 });
@@ -144,6 +152,19 @@ export const DataSubscriptionUpdateAction = z.object({
   }),
 });
 export type IDataSubscriptionUpdateAction = z.infer<typeof DataSubscriptionUpdateAction>;
+
+/**
+ * Server -> Client: a `subscribe_query` frame was refused (the operator allow-list, `fields`
+ * validation) or its initial fetch was aborted (`maxTimeMS`). Neither failure throws an
+ * UnauthorizedError/JsonWebTokenError, so withWebSocketContext's status code never reaches the
+ * client as a frame - this is the only signal the caller gets that the subscription never took.
+ */
+export const DataSubscribeErrorAction = z.object({
+  action: z.literal('data_subscribe_error'),
+  subscriptionId: z.string(),
+  error: z.string(),
+});
+export type IDataSubscribeErrorAction = z.infer<typeof DataSubscribeErrorAction>;
 
 export const LLMStatusUpdateAction = z.object({
   action: z.literal('llm_status_update'),
@@ -1501,6 +1522,7 @@ export type IOptiHashiRunUpdatedAction = z.infer<typeof OptiHashiRunUpdatedActio
 
 export const MessageDataToClient = z.discriminatedUnion('action', [
   DataSubscriptionUpdateAction,
+  DataSubscribeErrorAction,
   InboxRefetchAction,
   LLMStatusUpdateAction,
   InvitesRefetchAction,

--- a/b4m-core/common/src/schemas/actions.ts
+++ b/b4m-core/common/src/schemas/actions.ts
@@ -10,6 +10,7 @@ import { FallbackInfoSchema } from './llm';
 import { supportedChatModels } from '../models';
 import { shareableDocumentSchema, QUEST_ERROR_CODES } from '../types';
 import { AGENT_EXECUTION_STATUSES, type AgentExecutionStatus } from '../constants/agentExecutionStatus';
+import { findDisallowedSubscriptionFilterKeys } from './subscriptionQueryFilter';
 
 // Schemas for actions sent over the WebSocket connection.
 
@@ -20,7 +21,14 @@ export const DataSubscribeRequestAction = z.object({
   accessToken: z.string().optional(),
   subscriptionId: z.string(),
   collectionName: z.string(),
-  query: z.looseObject({}),
+  // The server forwards this filter to Mongo and persists it for subscriber-fanout to replay, so
+  // the operator allow-list is enforced at parse time - before any query runs or any
+  // QuerySubscription is written. See subscriptionQueryFilter.ts for what it refuses and why.
+  query: z.looseObject({}).superRefine((filter, ctx) => {
+    for (const key of findDisallowedSubscriptionFilterKeys(filter)) {
+      ctx.addIssue({ code: 'custom', message: `Disallowed subscription filter operator: ${key}` });
+    }
+  }),
   fields: z.looseObject({}),
   fetchInitialData: z.boolean().prefault(true).optional(),
   clientId: z.string().optional(),

--- a/b4m-core/common/src/schemas/index.ts
+++ b/b4m-core/common/src/schemas/index.ts
@@ -9,6 +9,7 @@ export * from './openai';
 export * from './password';
 export * from './partnerSignupRule';
 export * from './query';
+export * from './subscriptionQueryFilter';
 export * from './session';
 export * from './user';
 export * from './settings';

--- a/b4m-core/common/src/schemas/subscriptionQueryFilter.test.ts
+++ b/b4m-core/common/src/schemas/subscriptionQueryFilter.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { SUBSCRIPTION_FILTER_MAX_DEPTH, findDisallowedSubscriptionFilterKeys } from './subscriptionQueryFilter';
+
+describe('findDisallowedSubscriptionFilterKeys', () => {
+  it('accepts the filter shapes real subscriptions send', () => {
+    expect(findDisallowedSubscriptionFilterKeys({})).toEqual([]);
+    expect(findDisallowedSubscriptionFilterKeys({ sessionId: 'abc123' })).toEqual([]);
+    expect(findDisallowedSubscriptionFilterKeys({ _id: { $in: ['a', 'b'] } })).toEqual([]);
+    expect(
+      findDisallowedSubscriptionFilterKeys({
+        $or: [{ userId: 'u1' }, { createdAt: { $gte: '2026-01-01', $lt: '2026-02-01' } }],
+      })
+    ).toEqual([]);
+  });
+
+  it('rejects the server-side JavaScript operators', () => {
+    expect(findDisallowedSubscriptionFilterKeys({ $where: 'while(true){}' })).toEqual(['$where']);
+    expect(findDisallowedSubscriptionFilterKeys({ $expr: { $function: { body: 'x' } } })).toEqual(['$expr']);
+  });
+
+  it('rejects unbounded matching operators', () => {
+    expect(findDisallowedSubscriptionFilterKeys({ email: { $regex: '(a+)+$', $options: 'i' } })).toEqual([
+      'email.$regex',
+      'email.$options',
+    ]);
+    expect(findDisallowedSubscriptionFilterKeys({ $text: { $search: 'x' } })).toEqual(['$text']);
+    expect(findDisallowedSubscriptionFilterKeys({ $jsonSchema: {} })).toEqual(['$jsonSchema']);
+  });
+
+  it('finds a disallowed operator nested inside an allowed combinator', () => {
+    // The dangerous key is reachable through any allow-listed operand, so the scan must recurse
+    // rather than only inspecting top-level keys.
+    expect(findDisallowedSubscriptionFilterKeys({ $and: [{ userId: 'u1' }, { $where: 'sleep(9e9)' }] })).toEqual([
+      '$and[1].$where',
+    ]);
+    expect(findDisallowedSubscriptionFilterKeys({ tags: { $elemMatch: { $where: '1' } } })).toEqual([
+      'tags.$elemMatch.$where',
+    ]);
+  });
+
+  it('rejects a RegExp operand a same-process caller could construct', () => {
+    expect(findDisallowedSubscriptionFilterKeys({ name: /(a+)+$/ })).toEqual(['name (regular expression)']);
+  });
+
+  it('rejects nesting past the depth bound instead of recursing on it', () => {
+    let deep: Record<string, unknown> = { userId: 'u1' };
+    for (let i = 0; i <= SUBSCRIPTION_FILTER_MAX_DEPTH; i++) deep = { $and: [deep] };
+    expect(findDisallowedSubscriptionFilterKeys(deep).length).toBeGreaterThan(0);
+  });
+
+  it('reports every violation, not just the first', () => {
+    expect(findDisallowedSubscriptionFilterKeys({ $where: 'a', $expr: 'b' })).toEqual(['$where', '$expr']);
+  });
+});

--- a/b4m-core/common/src/schemas/subscriptionQueryFilter.ts
+++ b/b4m-core/common/src/schemas/subscriptionQueryFilter.ts
@@ -1,0 +1,88 @@
+/**
+ * Operator allow-list for the client-authored Mongo filter carried on a `subscribe_query` frame.
+ *
+ * The WS data-subscribe handler forwards that filter to `Model.find` and persists it on the
+ * QuerySubscription the separate subscriber-fanout service replays, so an unconstrained
+ * `$`-prefixed key lets any authenticated socket ask the database to run server-side JavaScript
+ * (`$where`, `$expr` + `$function`) or an unbounded `$regex` - either of which pins a pooled
+ * connection for as long as it runs.
+ *
+ * Live subscriptions only ever need equality, membership and range matching, so anything outside
+ * this list is REFUSED rather than stripped: silently dropping an operator would quietly widen the
+ * document set the caller ends up subscribed to.
+ *
+ * The scan is deliberately structural rather than a model of Mongo's grammar - it flags any
+ * `$`-prefixed key anywhere in the tree that isn't allow-listed. It can therefore accept an
+ * allow-listed operator in a position Mongo would treat as a literal sub-document field name, but
+ * that is inert; what matters is that no disallowed operator can reach the driver.
+ */
+
+/** Combinators whose operands are themselves filters. */
+export const SUBSCRIPTION_FILTER_LOGICAL_OPERATORS = ['$and', '$or', '$nor', '$not'] as const;
+
+/** Value-level operators a subscription filter may use. */
+export const SUBSCRIPTION_FILTER_VALUE_OPERATORS = [
+  '$eq',
+  '$ne',
+  '$gt',
+  '$gte',
+  '$lt',
+  '$lte',
+  '$in',
+  '$nin',
+  '$exists',
+  '$type',
+  '$size',
+  '$all',
+  '$elemMatch',
+] as const;
+
+const ALLOWED_OPERATORS: ReadonlySet<string> = new Set<string>([
+  ...SUBSCRIPTION_FILTER_LOGICAL_OPERATORS,
+  ...SUBSCRIPTION_FILTER_VALUE_OPERATORS,
+]);
+
+/**
+ * Bounds the recursion and the query planner's work. Well below MongoDB's own BSON nesting limit;
+ * no in-repo subscription filter nests more than two levels.
+ */
+export const SUBSCRIPTION_FILTER_MAX_DEPTH = 12;
+
+/**
+ * Returns a dotted path for every part of `filter` a subscription may not send: a disallowed
+ * `$`-prefixed key, a `RegExp` operand, or nesting past {@link SUBSCRIPTION_FILTER_MAX_DEPTH}.
+ * An empty array means the filter is safe to forward to the database.
+ */
+export function findDisallowedSubscriptionFilterKeys(filter: unknown): string[] {
+  const violations: string[] = [];
+
+  const walk = (node: unknown, path: string, depth: number): void => {
+    if (depth > SUBSCRIPTION_FILTER_MAX_DEPTH) {
+      violations.push(`${path} (nested deeper than ${SUBSCRIPTION_FILTER_MAX_DEPTH})`);
+      return;
+    }
+    if (node instanceof RegExp) {
+      // Unreachable for a JSON frame, but a same-process TS caller can construct one, and a
+      // catastrophically backtracking pattern is the same denial of service as `$regex`.
+      violations.push(`${path} (regular expression)`);
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach((entry, i) => walk(entry, `${path}[${i}]`, depth + 1));
+      return;
+    }
+    if (node === null || typeof node !== 'object') return;
+
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (key.startsWith('$') && !ALLOWED_OPERATORS.has(key)) {
+        violations.push(childPath);
+        continue;
+      }
+      walk(value, childPath, depth + 1);
+    }
+  };
+
+  walk(filter, '', 0);
+  return violations;
+}


### PR DESCRIPTION
## Description

The WebSocket `subscribe_query` path hands the client-authored Mongo filter straight to
`Model.find` and then persists it on the `QuerySubscription` row that the separate
subscriber-fanout service replays. `query` was typed `z.looseObject({})`, so a caller could name
any operator MongoDB understands - including `$where`/`$expr` + `$function`, which run
server-side JavaScript, and `$regex`, which can be made to backtrack indefinitely. Either one
holds a pooled connection for as long as it runs.

Two narrower scope gaps in the same handler travel with it: the `organizations` subscription
streamed raw org documents (so `stripeCustomerId` and `billingContact` crossed the wire, which
`toSafeOrganization` strips on every REST path), and the `invites` subscription built its
pending-recipient arm as `$in: [user.email]` with no guard, so an account with no email produced
`$in: [undefined]` - which Mongo reads as "field missing or null" and matches every invite that
has no `recipients.pending` path at all.

## Changes

- **`b4m-core/common/src/schemas/subscriptionQueryFilter.ts` (new)** - a structural scan that
  flags any `$`-prefixed key outside an equality / membership / range allow-list, any `RegExp`
  operand, and nesting past a depth bound. It reports every violation with a dotted path rather
  than stopping at the first.
- **`DataSubscribeRequestAction.query`** now runs that scan in a `superRefine`, so a filter is
  refused at parse time - before the initial fetch runs and before any `QuerySubscription` is
  written. `withWebSocketContext` logs the throw.
- **`dataSubscribeRequest.ts`** sets `maxTimeMS: 5000` on the initial fetch, so a filter that is
  legal but slow is aborted by the database instead of pinning a pooled connection for the whole
  Lambda timeout.
- **`dataSubscribeFieldLimits.ts`** gains an `organizations` arm that reuses
  `ORGANIZATION_SECRET_FIELDS` / `ORGANIZATION_OWNER_ONLY_FIELDS` from `toSafeOrganization`, so
  the two transports cannot drift. Its third positional argument became an options object; the
  signature had already grown past what positional booleans read well as.
- **`subscriptionScopes.ts`** gains `inviteSubscriptionScope`, moved out of the handler so the
  emailless guard has a direct test next to `questMasterPlanSubscriptionScope`. A blank or
  non-string email drops the pending arm entirely rather than widening it.

### Addressed in review (`56bdebdb4`)

- **`useCollection.ts`** and **`react-query.ts`** drop `{ $regex: string }` from their
  `QueryableType` (and the matching `convertQuery` arm) - the server refuses `$regex` at parse
  time now, so the client contract shouldn't advertise a shape it will reject.
- **`DataSubscribeRequestAction.fields`** is now `z.record(z.string(), z.union([z.boolean(),
  z.number()]))` instead of `z.looseObject({})` - it rides the same two sinks (`Model.find`
  projection, persisted `QuerySubscription`) as `query`.
- **New `data_subscribe_error` frame** (`DataSubscribeErrorAction` on `MessageDataToClient`):
  `dataSubscribeRequest.ts` sends it, carrying `subscriptionId`, when a filter is refused or the
  `maxTimeMS` fetch aborts - both used to surface to the caller as silence. Auth failures are
  untouched.
- The refusal message is now `Disallowed subscription filter: ...` (was `... filter operator:
  ...`) so a `RegExp`/depth violation doesn't read as a named operator.
- `subscriptionScopes.ts`'s `inviteSubscriptionScope` docblock now scopes its "mirrors
  pendingEmailMatch" claim to the emailless guard specifically; the case-insensitive `$regex` arm
  isn't mirrored (a pre-existing divergence, unchanged here).

## Notes on two judgment calls

**`billingContact` is kept for a platform admin only, not for an org owner.** `toSafeOrganization`
keeps it for either, but it works per document. A Mongo projection is per *query*, so an
owner-keyed keep would also hand over the billing contact of every co-member org that the same
subscription happens to match. An owner's own billing contact still reaches them through the
access-gated REST GET. Nothing in `apps/client/app` subscribes to `organizations` today (there
is no Dexie table for it either), so this degrades no existing surface - it closes the hole
before something starts using the subscription.

**Subscriptions persisted before this deploy are not retro-scrubbed.** `scopedFields` feeds the
`queryId` hash and the `fields` write is `$setOnInsert`, so a pre-deploy row is never mutated in
place - a reconnecting client lands on a new document instead. API Gateway forcibly closes a
WebSocket after 10 minutes idle / 2 hours total, so every pre-deploy subscriber re-hashes well
inside a couple of hours. This is the same reasoning the existing comment in
`dataSubscribeRequest.ts` sets out for the quests exclusion.

## Guide for Testers

This is a backend/transport-only change with no UI. It is verified by unit tests and by a
WebSocket client, not by clicking through the app.

**Regression checks (the ones that matter - these paths all ride `subscribe_query`):**

1. Sign in at `app.staging.bike4mind.com` and open any notebook with existing chat history.
   Expected: the conversation loads and streams as before, with no console errors.
2. Send a message and watch it stream in. Expected: the reply appears live (this is the `quests`
   subscription; the field-limit code path changed shape, so this is the key regression).
3. Open Files. Expected: the file list loads and a newly uploaded file appears without a manual
   refresh (`fabfiles` subscription).
4. Open the Artifacts panel on a session that has artifacts. Expected: they list and update live.
5. Open Inbox / notifications. Expected: pending invites are listed exactly as before
   (`invites` subscription - the arm that changed).
6. Open Admin -> Organizations as a site admin and open one org. Expected: the billing contact
   still renders. (It comes from `GET /api/organizations`, not from a subscription - this
   confirms the REST path is untouched.)

**Direct verification of the fix, for a reviewer with a WS client:**

7. Open a socket with a valid access token and send a `subscribe_query` frame for `users` with
   `query: {"$where": "while(true){}"}`. Expected: the frame is refused, the handler logs
   `Disallowed subscription filter: $where`, no query runs, and no `QuerySubscription` document
   is created for it. The socket should also receive a `data_subscribe_error` frame carrying the
   same `subscriptionId` and that message - that frame is new since the last review round.
8. Repeat with `query: {"$and": [{"userId": "x"}, {"$expr": {}}]}`. Expected: also refused - the
   scan recurses, it is not a top-level check.
9. Send an ordinary filter such as `query: {"sessionId": "<a real id>"}`. Expected: accepted and
   `data_update` frames arrive as before.

**What NOT to test:** there is no new UI, no new setting, no migration and no new admin surface.
Do not look for a visible change anywhere in the app - a correct result here is that everything
listed above behaves exactly as it did before.

## Security Testing

- [ ] Reproduced on staging with a WS client - **not run.** Doing so means executing an
      unbounded `$where` against the staging database, which is the denial of service itself.
      A reviewer who wants a live BEFORE should use a bounded-but-slow filter rather than
      `while(true)`.
- [ ] Verified on a PR preview - **not run**; needs a maintainer-triggered preview deploy. Steps
      7-9 above are the exact check to run once one exists.

Covered by unit tests in the meantime: `subscriptionQueryFilter.test.ts` (what the allow-list
refuses), `actions.subscribeQuery.test.ts` (that the refusal is wired into the parse, which is
what makes it happen before the fetch and before the persisted subscription),
`dataSubscribeFieldLimits.test.ts` (the organizations projection) and `subscriptionScopes.test.ts`
(the emailless invite arm).

