### PR TITLE
fix(data-lakes): correct two comments that misstate their mechanism

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/rechunk.ts
+++ b/apps/client/pages/api/data-lakes/[id]/rechunk.ts
@@ -121,10 +121,11 @@ const handler = baseApi()
       // land is left in the reset state (chunked:false, chunkCount:0), which is exactly what the
       // rescue sweep selects on, so it self-heals on the next pass rather than needing an undo.
       // The cost of routing recovery that way, since the reset above covers the whole wave before
-      // any send: such a file stays unsearchable until REBUILD_PENDING_STALE_MS (2h) has elapsed
-      // AND the next daily 05:00 UTC reconcile runs. On a registry lake its owner may never have
-      // joined the lake, so nobody is watching for it. Resetting each file immediately before its
-      // own send would close the window.
+      // any send: the file stays unsearchable until the chunk rescue sweep re-enqueues it - daily
+      // 05:00 UTC hosted (infra/cron.ts), ~60s self-host, and only while `enableAutoChunk` is on,
+      // which is the one condition that can hold it indefinitely. REBUILD_PENDING_STALE_MS (2h) does
+      // not gate that sweep; it gates this door's own stale-pending re-detection
+      // (findConvergencePausedFilesByScope).
       //
       // NO `chunkSize` on purpose, unlike /converge which sends `policy.requiredTarget`. This door
       // restores RETRIEVABILITY and is deliberately policy-independent: it has to work on a lake with

--- a/b4m-core/services/src/dataLakeService/resolveIngestSpendScope.ts
+++ b/b4m-core/services/src/dataLakeService/resolveIngestSpendScope.ts
@@ -72,7 +72,7 @@ export async function resolveIngestSpendScope(
     // findMemberLakesForFile is built to discard (see the doc comment above).
     const tagNames = (file.tags ?? []).map(t => t?.name);
     const staticTag = extractDataLakeMetaTags(tagNames).filter(isStaticRegistryDatalakeTag)[0];
-    // The prefix arm, matched against the COMPILE-TIME registry so this costs no lakes read and the
+    // The prefix arm, matched against the in-process registry so this costs no lakes read and the
     // zero-reads property above survives. No ownership conjunct, mirroring `registryMembershipScope`
     // - a registry prefix is config rather than a user-chosen tag, so there is no creator to anchor
     // to. Reaching this arm is what keeps the rebuild door's members metered now that it selects


### PR DESCRIPTION
# Pull Request

## Description

Two code comments describe mechanisms the code does not implement. Both were flagged in a round-2 review on #2481 that was posted before a different approver merged, so neither was acted on. Comment-only: no behavior change, no product bug, no user impact.

**`rechunk.ts`** - the note appended to the `allSettled` wave claimed that a file whose send failed stays unsearchable until `REBUILD_PENDING_STALE_MS` (2h) has elapsed *AND* the next daily 05:00 UTC reconcile runs. Those are two independent paths, and the recovery that actually picks the file up consults neither threshold:

- Recovery is `runChunkRescueSweep`. Its selection filter (`buildFabFileChunkScanFilter`) has exactly one age clause: `createdAt: { $lt: now - CHUNK_SCAN_MIN_AGE_MS }`, where that constant is 2 **minutes**. It guards against racing a fresh upload's webhook and keys on `createdAt`, so for an already-uploaded file that /rechunk just reset it imposes no wait at all - the file is eligible on the next pass.
- `chunkRebuildRequestedAt` reaches that filter only inside the media-exclusion `$or`, with no age bound on it.
- `REBUILD_PENDING_STALE_MS` has one functional use: the stale-pending arm of `findConvergencePausedFilesByScope`. That is this door's own re-detection, not the sweep's selection.
- Cadence is per-deployment rather than "daily": hosted drives the sweep from the `dataLakeBatchReconcile` cron (`cron(0 5 * * ? *)`), while self-host runs it every ~60s (`CHUNK_SCAN_INTERVAL_MS`).
- The condition that genuinely can hold recovery indefinitely went unmentioned: `runChunkRescueSweep` returns early unless the `enableAutoChunk` admin setting is on.

The old text also contradicted the "self-heals on the next pass" sentence directly above it, and closed by proposing a per-file reset to shut a window the sweep already closes on its next pass. The error ran in the pessimistic direction - it overstated the outage - so nothing operational was hidden by it.

**`resolveIngestSpendScope.ts`** - the registry is not compile-time. `DATA_LAKES` spreads `PREMIUM_DATA_LAKES`, which is an IIFE over `JSON.parse(process.env.NEXT_PUBLIC_PREMIUM_DATA_LAKES)` evaluated at module init - deploy-time, in-process config. The property the comment actually rests on (no lakes read, so the zero-reads path for a personal upload survives) is true and unaffected; only the label is wrong. Worth correcting because "compile-time" invites wrong inferences about validation and test determinism on a spend-gate path.

Every mechanism claim above was re-verified against `origin/main` at the tip this branch is cut from, not against the review. `chunkScan.ts` changed after the review was written (#2482), so the line references in the original notes had drifted; the structure they describe still holds.

## Changes

- `apps/client/pages/api/data-lakes/[id]/rechunk.ts` - rewrite the 5-line recovery note to name the chunk rescue sweep, give both cadences, and call out the `enableAutoChunk` gate; drop the `REBUILD_PENDING_STALE_MS` claim and point that constant at the door it actually gates.
- `b4m-core/services/src/dataLakeService/resolveIngestSpendScope.ts` - "COMPILE-TIME registry" becomes "in-process registry" (one word, one line). The no-lakes-read claim is preserved verbatim.

Deliberately out of scope:

- `convergeLakePolicy.ts` is untouched. The review's item 2 asked to rewrite the comment there on the grounds that `requiredPassageTokenTarget` is a declared field on `DataLakeConfig`. That is a misread: the field is declared on `ManageableDataLakeConfig extends DataLakeConfig`, a separate interface, and the base `DataLakeConfig` does not declare it. The shipped comment there is correct as written.
- The five pre-existing sites that use "compile-time" for this same registry (`lakeMembershipScope.ts`, `lakeMembership.ts`, two in `dataLakes.ts`, `articles.ts`). Those use it to mean "config rather than user input", which stays true for an env-injected entry; only the line changed here used it to justify "no DB read". Sweeping them would turn a two-line fix into a cross-package diff. The resulting idiom inconsistency is known and accepted.

## Guide for Testers

Nothing to test. This PR changes two comment bodies and no executable code - the compiled output is byte-identical. Reviewing the two diffs against the sources they cite is the whole verification.

**What NOT to test:** any /rechunk or spend-gate runtime behavior. Neither is affected.

## Additional Information

**No test accompanies this PR.** The repo's failing-test-first convention does not apply to a comment-only change: there is no behavior to assert, and a test that pinned comment text would be a test of the comment rather than of the code. `pnpm turbo:typecheck` (40/40) and `pnpm lint:check` are green, as are the `check-no-smart-punctuation.sh` and `check-no-control-bytes.sh` guards on the added lines.

One pre-existing issue found while verifying, filed separately rather than fixed here: `changeShare` and `requiresBulkChangeConfirmation` are computed over the truncated member set (`MEMBER_SCAN_LIMIT = 25_000`), and the converge POST branches on `report.refusal || (report.requiresConfirmation && !confirm)` but never on `scanTruncated`, so a partial scan can skip the owner confirmation. Reachable on a registry lake only with an entry declaring a target and more than 25,000 prefix-arm members, with the wave capped at 200/call and 20/hour. Recorded so it is not rediscovered as new.

Closes #2616

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
