### PR TITLE
test(client): pin the groups[] share strip and tighten the extraData assertions

### DIFF
--- a/apps/client/pages/api/__tests__/updateBodyCastGuards.test.ts
+++ b/apps/client/pages/api/__tests__/updateBodyCastGuards.test.ts
@@ -375,6 +375,10 @@ describe('update-payload cast guards - a wrong-typed body value is a client erro
   // The canonical `extraData` is a closed object, so the key is stripped before the `$set` rather
   // than reaching the cast -- these pin that, since a `z.record` would forward it.
   describe('agents/[id] share arrays', () => {
+    // `toEqual({})` rather than `not.toHaveProperty(key)`: the stripped key leaves `extraData`
+    // PRESENT and empty rather than absent (measured, not assumed), and only the exact form tells
+    // those two apart. Which one it is matters, because this is a `$set` of the whole array: an
+    // `extraData: {}` in the payload overwrites whatever was stored, where an absent key leaves it.
     it.each([
       ['a Map key containing a dot', 'a.b'],
       ['a Map key starting with a dollar', '$x'],
@@ -386,7 +390,7 @@ describe('update-payload cast guards - a wrong-typed body value is a client erro
       expect(outcome).toBeNull();
       expect(wrote).toBe(true);
       const written = (payload as { users?: { extraData?: Record<string, unknown> }[] })?.users;
-      expect(written?.[0]?.extraData ?? {}).not.toHaveProperty(key);
+      expect(written?.[0]?.extraData).toEqual({});
     });
 
     it.each([
@@ -422,6 +426,7 @@ describe('update-payload cast guards - a wrong-typed body value is a client erro
     // nothing into it: an undeclared key is stripped, and the declared one only accepts a form JSON
     // cannot carry. That is the accepted cost of reusing the canonical schema (nothing on Agent
     // reads `extraData` today), pinned here so it stays a deliberate tradeoff rather than a surprise.
+    // The key itself does still reach the `$set`, as `{}`, so such a body clears any stored value.
     it('strips even a legal key from users[].extraData, so a JSON body writes nothing into it', async () => {
       const { outcome, payload, wrote } = await run(byRoute('agents/[id]'), {
         users: [{ userId: 'u1', permissions: ['read'], extraData: { foo: 1 } }],
@@ -430,7 +435,7 @@ describe('update-payload cast guards - a wrong-typed body value is a client erro
       expect(outcome).toBeNull();
       expect(wrote).toBe(true);
       const written = (payload as { users?: { extraData?: Record<string, unknown> }[] })?.users;
-      expect(written?.[0]?.extraData ?? {}).not.toHaveProperty('foo');
+      expect(written?.[0]?.extraData).toEqual({});
     });
 
     it('rejects users[].extraData.lastExportDate as an ISO string, the only form JSON can send', async () => {
@@ -442,6 +447,24 @@ describe('update-payload cast guards - a wrong-typed body value is a client erro
       const sent400 = status.mock.calls.some(call => call[0] === 400);
       expect(threw400 || sent400).toBe(true);
       expect(wrote).toBe(false);
+    });
+
+    // Every strip above is on `users[]`; `groups[]` had no payload assertion at all, and its strip
+    // is load-bearing the same way. An `_id` that survived validation reaches `findOneAndUpdate`'s
+    // `_castUpdate` as `CastError path='groups' kind='embedded'` (verified on 8.24.1), and that
+    // path is not `_id`, so `errorHandler` does not answer 404 for it -- it is a 500 at `error`
+    // level on a caller-supplied key. `toEqual` on the whole entry rather than a `not.toHaveProperty`,
+    // because the `$set` replaces the array outright: anything left in the written entry is a value
+    // that reaches mongoose uncast.
+    it('strips a junk _id from a groups[] entry instead of forwarding it to the $set', async () => {
+      const { outcome, payload, wrote } = await run(byRoute('agents/[id]'), {
+        groups: [{ groupId: 'g1', permissions: ['read'], _id: 'junk' }],
+      });
+
+      expect(outcome).toBeNull();
+      expect(wrote).toBe(true);
+      const written = (payload as { groups?: Record<string, unknown>[] })?.groups;
+      expect(written?.[0]).toEqual({ groupId: 'g1', permissions: ['read'] });
     });
 
     it('still accepts a well-formed share pair', async () => {


### PR DESCRIPTION
# Pull Request

## Description

Closes #2615. Two test-only follow-ups raised in review of #2179 and deliberately deferred out of it. **No production code changes, no behaviour changes** -- both guards already work correctly today; what was missing is coverage pinning them.

**1. Nothing pinned that a junk `groups[]._id` is stripped.** The agents PUT route validates `groups[]` with the canonical `groupShareSchema` from `@bike4mind/common`, a closed `z.object({ groupId, permissions })`, so zod strips an unknown `_id` before the payload reaches the `$set`. Its `users[]` twin had three payload-strip assertions; `groups[]` had zero -- it appeared only in a reject case and in the accept case, neither of which looks at the payload.

That strip is load-bearing rather than cosmetic. Measured against the pinned mongoose 8.24.1, an `_id` that survived validation reaches `findOneAndUpdate`'s `_castUpdate` and throws `CastError path='groups' kind='embedded'`. The path is `'groups'`, **not** `'_id'`, so `errorHandler`'s narrowed mapping does not answer 404 for it: it falls to the `else` branch and becomes a 500 at `error` level (which alarms) on a caller-supplied key. That is the same mechanism as the round-17 blocker on #2179 (a dotted `extraData` Map key throwing `CastError path='users' kind='embedded'`), one array over.

**2. Two assertions hedged with `?? {}`.** `expect(written?.[0]?.extraData ?? {}).not.toHaveProperty(key)` passes whether the field is absent or an empty object, so it cannot distinguish the two and a change from one to the other goes unnoticed. Rather than assume which one the payload carries, I measured it through the route harness: when the body carries an `extraData` key whose contents are all stripped, the payload carries `extraData` as **present and empty**, and when the body omits the key the payload omits it too. So both assertions are now `toEqual({})`, which pins that the write is a full replacement clearing any stored value rather than a merge into it.

## Changes

- `apps/client/pages/api/__tests__/updateBodyCastGuards.test.ts` -- new case in the `agents/[id] share arrays` describe asserting a junk `groups[]._id` is stripped from the payload the repository receives, via `toEqual({ groupId, permissions })` on the whole written entry (pins strictly more than `not.toHaveProperty('_id')`: the `$set` replaces the array outright, so anything left in the entry is a value that reaches mongoose uncast).
- `apps/client/pages/api/__tests__/updateBodyCastGuards.test.ts` -- both `?? {}` assertions tightened to `toEqual({})`, with short comments recording that the present-vs-absent question was resolved by measurement and why the distinction matters.

## Guide for Testers

Backend test-only change with no runtime surface. Nothing to click.

1. Check out this branch and run `pnpm --filter @bike4mind/client exec vitest run --project node pages/api/__tests__/updateBodyCastGuards.test.ts`. Expected: 45 passed (44 before this PR, plus the one new case).

**What NOT to test:** there is no UI, API, or behaviour change here. `PUT /api/agents/[id]` responds exactly as it did before; only the test file changed.

**Regression checks:** none needed beyond CI. No production file is touched by this PR.

## Additional Information

Each new assertion was mutation-verified with its **own narrow mutant** rather than one broad revert, so each case is shown to discriminate on its own:

- **Item 1** -- loosening the canonical schema at the route to `groupShareSchema.extend({ _id: z.string().optional() })`: the new case fails, and running the **entire** `apps/client` node project under that mutant gives `1 failed | 7719 passed` across 667 files. Exactly the new test, nothing else.
- **Item 2** -- a mutant deleting an empty `extraData` after parse (flipping present-`{}` to absent): the three tightened assertions fail. Restoring the old `?? {}` form with the same mutant still applied gives 45/45 passing, which is the direct proof that the tightening added discrimination the previous form did not have.

Gates run locally, all clean: `pnpm exec turbo typecheck:fast` (37/37), `pnpm lint:check`, `pnpm exec prettier --check` on the file, and both ASCII guards (`check-no-smart-punctuation.sh`, `check-no-control-bytes.sh`) with the file staged.

One correction worth recording for future readers: `errorHandler.ts` carries a comment noting that a cast inside a subdocument *schema* reports `path` as the leaf name, so `subs._id` arrives as `_id` and still becomes a 404. That is true for a leaf-level cast, but it does not apply here -- casting a whole embedded document fails on the array path itself. I verified this directly against mongoose 8.24.1 through `_castUpdate` rather than relying on the earlier note: `path='groups'`, `kind='embedded'`, so this case does take the 500 branch. (`Model.castObject` raises a `ValidationError` instead, so it is the wrong probe for this route.)

## Developer Notes (Optional)

- The `agents/[id] share arrays` describe now covers both share arrays symmetrically: `users[]` and `groups[]` each have a payload-strip assertion, so the next schema swap on either one has a guard rather than only a code review.
- `toEqual` on a whole written entry is the stronger default over `not.toHaveProperty` anywhere the write is a `$set` replacement -- it pins the full shape, so an unexpected extra key fails rather than passing unnoticed.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
