### PR TITLE
fix(client): apply the nested business-links filters the UI sends

### DIFF
--- a/apps/client/pages/api/business-links/__tests__/index.test.ts
+++ b/apps/client/pages/api/business-links/__tests__/index.test.ts
@@ -122,3 +122,70 @@ describe('GET /api/business-links - categoryId validation', () => {
     expect(mockRefs.findQuery).toMatchObject({ categoryId });
   });
 });
+
+/**
+ * The shape the app actually sends. `apiClient` serializes the hook's nested
+ * `filters` through `qs` into bracket keys, and Next.js hands those to `req.query`
+ * unexpanded - so a route reading `req.query.categoryId` sees nothing and returns
+ * every link, unfiltered. These drive the handler with those literal bracket keys.
+ */
+describe('GET /api/business-links - nested filters from the client', () => {
+  beforeEach(() => {
+    mockRefs.findQuery = undefined;
+    mockRefs.countQuery = undefined;
+  });
+
+  it('applies filters[categoryId] to the query', async () => {
+    const categoryId = new Types.ObjectId().toString();
+    const { req, res } = invokeGet({ 'filters[categoryId]': categoryId });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockRefs.findQuery).toMatchObject({ categoryId });
+    expect(mockRefs.countQuery).toMatchObject({ categoryId });
+  });
+
+  it('escapes filters[search] before it reaches $regex', async () => {
+    const { req, res } = invokeGet({ 'filters[search]': REDOS_PAYLOAD });
+    await mockRefs.getHandler!(req, res);
+
+    const orConditions = (mockRefs.findQuery as { $or?: Array<Record<string, { $regex: string }>> })?.$or;
+    expect(orConditions, 'nested search should build a $or query').toBeInstanceOf(Array);
+
+    const escaped = escapeRegex(REDOS_PAYLOAD);
+    for (const condition of orConditions!) {
+      const [{ $regex }] = Object.values(condition);
+      expect($regex).toBe(escaped);
+      expect($regex).not.toBe(REDOS_PAYLOAD);
+    }
+  });
+
+  it('applies filters[categoryId] and filters[search] together', async () => {
+    const categoryId = new Types.ObjectId().toString();
+    const { req, res } = invokeGet({ 'filters[categoryId]': categoryId, 'filters[search]': 'acme' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(mockRefs.findQuery).toMatchObject({ categoryId });
+    expect((mockRefs.findQuery as { $or?: unknown[] })?.$or).toBeInstanceOf(Array);
+  });
+
+  it('rejects a malformed filters[categoryId] with 400', async () => {
+    const { req, res } = invokeGet({ 'filters[categoryId]': 'not-an-object-id' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: 'Invalid category ID format' });
+    expect(mockRefs.findQuery).toBeUndefined();
+  });
+
+  it('ignores a filter value that bracket-nests into a non-string', async () => {
+    // `filters[search][x]=1` parses to an object; it must be treated as absent
+    // rather than reaching escapeRegex, which would throw on a non-string.
+    const { req, res } = invokeGet({ 'filters[search][x]': '1', 'filters[categoryId][y]': '2' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect((mockRefs.findQuery as { $or?: unknown })?.$or).toBeUndefined();
+    expect((mockRefs.findQuery as { categoryId?: unknown })?.categoryId).toBeUndefined();
+  });
+});

--- a/apps/client/pages/api/business-links/index.ts
+++ b/apps/client/pages/api/business-links/index.ts
@@ -7,6 +7,7 @@ import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ensureAdmin } from '@server/utils/errors';
 import { isValidObjectId } from '@server/utils/objectId';
+import qs from 'qs';
 
 interface IQuery {
   pageSize?: string;
@@ -15,14 +16,32 @@ interface IQuery {
   categoryId?: string;
 }
 
+// The nested shape the app sends, recovered from the bracket keys in `req.query`.
+interface IParsedQuery extends IQuery {
+  filters?: {
+    search?: unknown;
+    categoryId?: unknown;
+  };
+}
+
+// Bracket keys nest arbitrarily (`filters[search][x]=1` parses to an object) and a
+// repeated key parses to an array, so only a plain string is a usable filter value.
+// Anything else is treated as absent rather than reaching `escapeRegex`, which throws
+// on a non-string.
+const filterString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
 const handler = baseApi()
   .get(
     asyncHandler<{}, unknown, IQuery>(async (req, res) => {
-      const queryParams = req.query as IQuery;
+      // The client serializes the filters nested (`filters[search]=...`) through qs, and
+      // Next.js leaves those bracket keys unexpanded in `req.query` - so re-parse before
+      // reading them, the way `pages/api/organizations/index.ts` does. The flat
+      // `searchTerm`/`categoryId` params stay supported for existing API-key callers.
+      const queryParams = qs.parse(req.query as Record<string, string>) as IParsedQuery;
       const pageSize = parseInt(queryParams.pageSize || '10');
       const pageNumber = parseInt(queryParams.pageNumber || '1');
-      const searchTerm = queryParams.searchTerm || '';
-      const categoryId = queryParams.categoryId;
+      const searchTerm = filterString(queryParams.filters?.search) ?? filterString(queryParams.searchTerm) ?? '';
+      const categoryId = filterString(queryParams.filters?.categoryId) ?? filterString(queryParams.categoryId);
 
       const query: any = {};
 


### PR DESCRIPTION
# Pull Request

Closes #2357

## Description

`GET /api/business-links` read its filters as flat top-level query params (`searchTerm`, `categoryId`), but the Popular Targets UI sends them nested. The hook passes `filters: { search, categoryId }`, and the shared axios instance serializes that with `qs.stringify(params, { arrayFormat: 'brackets' })` into `filters[search]=...&filters[categoryId]=...`. Next.js hands those bracket keys to `req.query` unexpanded, so `req.query.searchTerm` and `req.query.categoryId` were both always `undefined` and the route returned every research link, unfiltered, on every request.

There were two independent mismatches: the nesting (`filters[...]` vs top-level) and the naming (the client calls it `search`, the route called it `searchTerm`). Fixing only the nesting would have left search broken.

The symptom read as "search is broken" rather than "search is unwired" because the react-query key does change on every keystroke and category click, so a refetch fires and a spinner flashes; the rows just come back identical. `PAGE_SIZE = 9999` is what hid it completely in dev-sized data, since the unfiltered result set fits in one page and nothing is truncated.

The sibling `pages/api/organizations/index.ts` already solved exactly this with `qs.parse(req.query)` before reading `params.filters`, so this follows that idiom rather than inventing a new one.

The existing tests did not catch it because they drove the handler with the flat shape (`invokeGet({ categoryId })`) - a contract no caller in this repo produces. The suite was green and proved nothing about the live path.

## Changes

- `apps/client/pages/api/business-links/index.ts`: parse the query with `qs` before reading it, and read the nested `filters.search` / `filters.categoryId`, keeping the flat `searchTerm` / `categoryId` names as a fallback. The route runs under `baseApi()` with default `auth: true`, so an API key can call it with the existing flat params; accepting both shapes keeps any external caller working and makes the change strictly additive rather than a hard cutover.
- `apps/client/pages/api/business-links/index.ts`: only accept a plain string as a filter value. This matters because the filters now actually reach the query for the first time, and a bracket key can nest deeper than expected - `filters[search][x]=1` parses to an object and a repeated key parses to an array, either of which would throw inside `escapeRegex` (`input.replace is not a function`) and turn a malformed request into a 500.
- `apps/client/pages/api/business-links/__tests__/index.test.ts`: regression coverage driving the handler with the literal bracket keys the client actually sends.

The `escapeRegex` ReDoS protection and the `isValidObjectId` -> 400 guard are unchanged and stay on the new path; both were previously on a branch no browser request could enter, and now run against real input.

## Guide for Testers

The behavior change is server-side filtering that was previously inert, so the fastest check is the Popular Targets modal.

1. Go to `app.staging.bike4mind.com` and sign in.
2. Open the Research Tasks area and open the **Popular Targets** modal.
3. Confirm the environment has at least two link categories, each holding distinct links. If not, add a couple via the modal's Add action so there is something to filter.
4. Click a category tab. Expected: the list now shows only that category's links. Before this fix it showed every link in every category.
5. Click a different category tab. Expected: the list changes to that category's links.
6. Type a string that matches only some links (for example part of one link's name or ticker) into the search box and wait about 1 second for the debounce. Expected: the list narrows to name / url / ticker / type matches within the selected category.
7. Clear the search box and wait for the debounce. Expected: the full list for the selected category returns.
8. Check the on-screen "sources" / total counters next to the list. Expected: they match the number of rows actually rendered, not the global link count.

### Regression Checks

1. CSV export still works: trigger the export action in the Popular Targets modal and confirm a `business-links-export.csv` downloads and opens. Note that export deliberately still exports the unfiltered first page - see Additional Information.
2. Create, edit, and delete a research link from the modal and confirm each still succeeds. The POST/PUT/DELETE paths were not touched.
3. Admin organization search still filters correctly (`pages/api/organizations` uses the same `qs.parse` idiom and was not modified).

### What NOT to test

- The category-list endpoint (`/api/business-links/category`) is unchanged; see Additional Information.
- No schema, migration, or admin-settings changes are involved.

## Additional Information

Two related items were deliberately left out of scope:

- **CSV export does not respect the active filters.** `useExportCSV` calls `useBusinessLinks({ pageSize: PAGE_SIZE, pageNumber: 1 })` with no `filters` at all, so it exports the first `PAGE_SIZE` rows globally. That behavior is unchanged by this PR - arguably its own bug, but a separate one, and fixing it would change what an existing user-facing action produces.
- **`useBusinessLinkCategories` has the same class of mismatch** (`IResearchLinkCategoriesQuery.filters.name` vs the category route's `searchTerm`), but no caller passes `filters` today, so it is dormant rather than broken.

One behavioral note for reviewers: turning the filters on necessarily changes what the endpoint returns for the same URL. `pagination.total` and `overallTotal` now report the filtered count rather than the global count. Both are still derived from the same `total`, so they remain equal to each other, and the UI reads them into `state.sources` / `state.total`. This is the point of the fix - it is what makes the counters agree with the rendered rows - but it is a response-shape-preserving, value-changing difference worth knowing about.

This route is not an api-contract endpoint (no contract file, absent from `b4m-core/common/src/api-contract/contracts/`), so there is no generated spec or typed client to regenerate.

## Verification

- `pnpm --filter @bike4mind/client test` - 1193 files, 13110 tests passed, 0 failed.
- `pnpm turbo:typecheck` - 40/40 tasks successful.
- `pnpm lint:check` - clean.
- The four new nested-filter assertions were confirmed to FAIL on the pre-fix route (the built query came back as `{}`, and the malformed-id case returned 200 instead of 400) and to pass after. The pre-existing flat-param tests pass unchanged.

The root cause was also confirmed directly against the repo's own `qs@6.15.3`: `qs.stringify` produces the bracket keys, a `URLSearchParams` parse of that string leaves `categoryId` and `searchTerm` `undefined`, and `qs.parse` recovers the nested object.

Not reproduced against a live database - the diagnosis and fix are from the client serializer, the Next.js query shape, and the route, plus that `qs` round-trip. Steps 4-8 above are the parts nobody has watched run in a live app.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - no UI changes; the fix makes the existing UI's filters take effect
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - no telemetry changes
