### PR TITLE
test(data-lakes): pin the expiry-arm request on lake-grant injection

### DIFF
--- a/b4m-core/services/src/dataLakeService/getDataLakePrompts.test.ts
+++ b/b4m-core/services/src/dataLakeService/getDataLakePrompts.test.ts
@@ -303,7 +303,9 @@ describe('getAccessibleDataLakePrompts', () => {
         principalGrants: { 'user:somebody-else': [{ dataLakeId: 'shared', role: 'curator' }] },
       });
       expect(await getAccessibleDataLakePrompts(ctx)).toEqual([]);
-      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledWith('user', CURATOR, expect.anything());
+      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledWith('user', CURATOR, {
+        activeAsOf: expect.any(Date),
+      });
     });
 
     it('feeds the granted ids to the DB pre-filter as its grant arm', async () => {
@@ -340,7 +342,9 @@ describe('getAccessibleDataLakePrompts', () => {
       // pre-wired, and flipping `includeReaders` would activate it with no other edit.
       const ctx = asCurator('curator');
       await getAccessibleDataLakePrompts(ctx);
-      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledWith('user', CURATOR, expect.anything());
+      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledWith('user', CURATOR, {
+        activeAsOf: expect.any(Date),
+      });
       expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledTimes(1);
     });
 

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
@@ -343,4 +343,34 @@ describe('grantedLakeReachFor - the two reach sets earn different bypasses', () 
   it('an unwired grant repo reaches nothing', async () => {
     expect(await grantedLakeReachFor('u1', ['orgA'])).toEqual({ grantedLakeIds: [], orgGrantedLakes: {} });
   });
+
+  /**
+   * The expiry REQUEST, asserted at the call boundary rather than through its consequences. The
+   * repo drops lapsed rows only when handed an `activeAsOf` - `buildActiveGrantFilter` is a no-op
+   * without one - so degrading this argument to `{}` would honor expired grants forever: for read
+   * access here, and through `getAccessibleDataLakePrompts` for system-prompt injection too.
+   *
+   * No consequence test can catch that regression. Every grant-repo double in the tree returns its
+   * fixture rows unfiltered (none reimplements `buildActiveGrantFilter`), so an expired row is
+   * indistinguishable from a live one on this side of the boundary; the DB-layer tests that DO
+   * cover expiry (`DataLakeAccessGrantModel.test.ts`) never see whether their caller asks for it.
+   * This assertion is the only place the two halves are joined. Matched as `any(Date)` because the
+   * value is `new Date()` at call time.
+   *
+   * Both arms are asserted: the org arm carries the same obligation and is reached only under
+   * `includeReaders`, so a fix applied to one arm alone still leaves the other silent.
+   */
+  it('asks the repo for active-only rows on both principal arms', async () => {
+    const grants = repo(
+      rows({ dataLakeId: 'owned', role: 'owner', principalType: 'user', principalId: 'u1' }),
+      rows({ dataLakeId: 'shared', role: 'reader', principalType: 'organization', principalId: 'orgA' })
+    );
+
+    await grantedLakeReachFor('u1', ['orgA'], grants, true);
+
+    expect(grants.listByPrincipal).toHaveBeenCalledWith('user', 'u1', { activeAsOf: expect.any(Date) });
+    expect(grants.listByPrincipal).toHaveBeenCalledWith('organization', 'orgA', {
+      activeAsOf: expect.any(Date),
+    });
+  });
 });


### PR DESCRIPTION
## Description

A test-only hardening PR. The owner/curator grant arm for lake system-prompt injection shipped
earlier in #2506; while verifying it end to end I found one link in its expiry chain that no test
could catch, and this PR pins it.

`grantedLakeReachFor` asks the grant repo for active-only rows by passing an `activeAsOf` argument.
`buildActiveGrantFilter` (`DataLakeAccessGrantModel.ts:58`) is a no-op without one, so degrading
that argument to `{}` would honor EXPIRED grants indefinitely - for lake read access, and through
`getAccessibleDataLakePrompts` for system-prompt injection with it.

Production behavior is correct today. What was missing was anything to stop it changing quietly:

- The DB layer's expiry tests are thorough (17 assertions in `DataLakeAccessGrantModel.test.ts`,
  including the strict `expiresAt <= now` boundary) but they never see whether their CALLER asks
  for the filter.
- Every grant-repo test double in the service tree returns its fixture rows unfiltered - none
  reimplements `buildActiveGrantFilter` - so on that side of the boundary an expired row is
  indistinguishable from a live one, and no consequence test can detect the regression.
- The two existing assertions on that call matched the options object with `expect.anything()`,
  which also matches `{}`.

That call boundary is the only place the two halves are joined, so that is where this asserts.

This matters more now than it did a week ago: #2533 is the first grant producer that can set
`expiresAt` at all (`createDataLake` and `transferLakeOwnership` never did), so time-limited
sharing is a new capability whose expiry was unenforced-by-test on the injection path.

## Changes

- `resolveLakeReadAccess.test.ts`: new test `asks the repo for active-only rows on both principal
  arms`, asserting `grantedLakeReachFor` hands `listByPrincipal` a real `{ activeAsOf: Date }` on
  BOTH the user and organization arms. Both, because the org arm carries the same obligation and is
  reached only under `includeReaders` - fixing one arm alone would leave the other silent.
- `getDataLakePrompts.test.ts`: tightened two existing assertions from `expect.anything()` to
  `{ activeAsOf: expect.any(Date) }`, closing the same hole at the injection path's own boundary.

No source changes. `+36/-2`, both files tests.

## Guide for Testers

This is a test-only, backend PR with no user-facing surface. Verification is by running the suites
and by a mutation check that proves the new assertions actually fail when the behavior regresses.

1. Check out this branch and build the core packages:
   `pnpm turbo:core:build`
   Expected: build succeeds. (Skipping this step causes a misleading typecheck failure - see
   Regression Checks below.)
2. Run the affected suites:
   `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/services exec vitest run src/dataLakeService/getDataLakePrompts.test.ts src/dataLakeService/manageLakeGrant.test.ts src/dataLakeService/resolveLakeReadAccess.test.ts src/dataLakeService/lakeGrantWriteRule.test.ts`
   Expected: 128 tests pass, 0 fail.
3. Confirm the new test is present and passing. In the output, look for:
   `asks the repo for active-only rows on both principal arms`
   Expected: present, passing.
4. MUTATION CHECK - prove the tests are load-bearing. In
   `b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts`, inside `grantedLakeReachFor`,
   change BOTH `listByPrincipal(...)` calls' third argument from `{ activeAsOf }` to `{}`.
5. Re-run step 2's command.
   Expected: exactly 3 tests fail -
   - `resolveLakeReadAccess.test.ts > ... > asks the repo for active-only rows on both principal arms`
   - `getDataLakePrompts.test.ts > ... > passes no membership org ids to the resolver, so a cutover flip cannot widen it silently`
   - `getDataLakePrompts.test.ts > ... > injects a lake the caller holds a curator grant on` (the tightened assertion)
6. Revert the mutation: `git checkout -- b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts`
7. Re-run step 2's command.
   Expected: back to 128 passing, 0 failing.

### Regression Checks

8. Typecheck both ways CI does:
   `pnpm --filter @bike4mind/services typecheck` and, in `b4m-core/services`,
   `pnpm run typecheck:native`
   Expected: both pass with no errors.
   GOTCHA: on a worktree with a stale `b4m-core/common/dist`, `tsc` reports 3 pre-existing-looking
   errors about `'grant-access'` / `'revoke-access'` / `'accessGrant'` not being assignable. Those
   are stale build artifacts, NOT a real type error and NOT from this branch - run
   `pnpm turbo:core:build --force` and they disappear.
9. Lint: `pnpm lint:check`
   Expected: passes.
10. Confirm no source file changed: `git diff --stat main...HEAD`
    Expected: exactly two files, both `*.test.ts`.

### What NOT to test

- No UI, no API route, and no runtime behavior changes in this PR. There is nothing to click and
  no endpoint to exercise.
- Do NOT expect any change to who can read a lake or whose lake prompt is injected. The grant arm
  itself shipped in #2506 and is unchanged here; this PR only adds test coverage around it.
- No admin settings, no migrations, no telemetry fields.

## Additional Information

Separately from this diff, I verified the grant arm's live behavior on a local self-host stack
against a real database, with the grant minted through #2533's real HTTP route by email:

- A user with `org: null`, `isAdmin: false`, who did NOT create the lake - so both pre-#2506 trust
  arms fail by construction - holding a `curator` grant DOES receive the lake's `systemPrompt`,
  with no `preauthorizedLakeIds` passed.
- Downgrading that same user to `reader` through the same route makes the prompt disappear;
  restoring `curator` brings it back. The grant role was the only variable changed, which rules out
  any other arm accounting for the result.

Two incidental findings from that run, neither addressed here:

- Setting a DB lake's `systemPrompt` works through a plain owner-level `PUT /api/data-lakes/:id`
  (`UpdateDataLakeRequestInput` includes the field). #1768's premise that a lake owner cannot
  control these fields appears to hold only for fallback/registry lakes, which are admin-only via a
  different route.
- `addFileToDataLake` skips `activateIfDraft` when the file already carries the lake's tag, so a
  lake seeded by tagging a file at creation time stays `draft` with `fileCount: 0`. Not
  investigated further.

## Developer Notes (Optional)

The pattern worth reusing: when a guarantee spans two layers and each layer's tests can only see
its own half, assert the REQUEST at the call boundary, not the consequence. Here the DB layer
proves it filters expired rows given `activeAsOf`, and this PR proves the caller asks for it -
neither test could have covered the other's half, and no fake in between was faithful enough to
make the composition observable.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
