### PR TITLE
refactor(data-lakes): dedupe lake/grant reads on manage doors

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/__tests__/access.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/access.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { LakeAccessView } from '@bike4mind/common';
 
 const h = vi.hoisted(() => ({
-  assertLakeAccess: vi.fn(),
-  loadActiveLakeGrants: vi.fn(),
+  assertLakeAccessWithGrants: vi.fn(),
   canManageLake: vi.fn(),
   resolveLakeTransferAuthority: vi.fn(),
   resolveEnforceReadGrants: vi.fn(async () => false),
@@ -24,8 +23,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
 vi.mock('@server/middlewares/featureFlag', () => ({ requireFeatureEnabled: () => () => {} }));
 vi.mock('@bike4mind/services', () => ({
   dataLakeService: {
-    assertLakeAccess: h.assertLakeAccess,
-    loadActiveLakeGrants: h.loadActiveLakeGrants,
+    assertLakeAccessWithGrants: h.assertLakeAccessWithGrants,
     canManageLake: h.canManageLake,
     resolveLakeTransferAuthority: h.resolveLakeTransferAuthority,
     resolveEnforceReadGrants: h.resolveEnforceReadGrants,
@@ -87,10 +85,12 @@ describe('GET /api/data-lakes/[id]/access', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.toAccessContext.mockResolvedValue({ userId: 'u1', isAdmin: false, administeredOrgIds: [] });
-    h.assertLakeAccess.mockResolvedValue({ id: 'lake-oid-1', name: 'Sales Intelligence' });
+    h.assertLakeAccessWithGrants.mockResolvedValue({
+      lake: { id: 'lake-oid-1', name: 'Sales Intelligence' },
+      grants: GRANTS,
+    });
     // clearAllMocks keeps implementations, so this must be re-armed or the enforced-true case leaks.
     h.resolveEnforceReadGrants.mockResolvedValue(false);
-    h.loadActiveLakeGrants.mockResolvedValue(GRANTS);
     h.canManageLake.mockReturnValue(true);
     h.resolveLakeTransferAuthority.mockReturnValue({ allowed: false, viaOrgAdminOnly: false });
     h.assembleLakeAccessView.mockResolvedValue(view);
@@ -126,7 +126,7 @@ describe('GET /api/data-lakes/[id]/access', () => {
   });
 
   it('never reaches the manage gate when the lake is not accessible at all', async () => {
-    h.assertLakeAccess.mockRejectedValue(new Error('Data lake not found'));
+    h.assertLakeAccessWithGrants.mockRejectedValue(new Error('Data lake not found'));
     const { res } = makeRes();
     await expect(call(req({ id: 'lake1' }), res)).rejects.toThrow(/not found/i);
     expect(h.canManageLake).not.toHaveBeenCalled();
@@ -176,7 +176,9 @@ describe('GET /api/data-lakes/[id]/access', () => {
   it('decides the manage gate and the transfer capability from ONE grants read', async () => {
     const { res } = makeRes();
     await call(req({ id: 'lake1' }), res);
-    expect(h.loadActiveLakeGrants).toHaveBeenCalledTimes(1);
+    // One read, and it is the ACCESS GATE's own: the route no longer loads a second copy of the
+    // grants the gate already read to decide whether the caller may see the lake at all.
+    expect(h.assertLakeAccessWithGrants).toHaveBeenCalledTimes(1);
     // Both rules must see the SAME grant set: re-reading could decide the two against different
     // snapshots, and offering a transfer control the write path then refuses is the drift to avoid.
     expect(h.canManageLake).toHaveBeenCalledWith(expect.anything(), expect.anything(), GRANTS);

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/grants-single-read.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/grants-single-read.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The read-count guard for the grant door. Unlike the sibling `grants.test.ts`, this drives the REAL
+ * `@bike4mind/services` and mocks only the repositories, because the thing under test is how many
+ * times the route + service pair touch them: the access gate and the manage gate each used to
+ * resolve the lake and its active grants for themselves, so a single grant cost four round-trips.
+ * Counting the repository calls is what makes "two, not four" a measurement rather than a reading of
+ * the call graph - both counts below are 2 if either gate goes back to resolving its own copy.
+ */
+const repos = vi.hoisted(() => ({
+  findById: vi.fn(),
+  findBySlug: vi.fn(),
+  listByLake: vi.fn(),
+  listByPrincipal: vi.fn(),
+  findGrant: vi.fn(),
+  upsertGrant: vi.fn(),
+  removeGrant: vi.fn(),
+  findAllByEmailsOrUsernames: vi.fn(),
+  record: vi.fn(),
+  toAccessContext: vi.fn(),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const routes: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign((req: { method?: string }, res: unknown) => routes[req.method ?? 'POST']?.(req, res), {
+      use: () => chain,
+      post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((routes.POST = fns[fns.length - 1]), chain),
+      delete: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((routes.DELETE = fns[fns.length - 1]), chain),
+    });
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/featureFlag', () => ({ requireFeatureEnabled: () => () => {} }));
+vi.mock('@server/dataLakes/toAccessContext', () => ({ toAccessContext: repos.toAccessContext }));
+vi.mock('@bike4mind/database', () => ({
+  dataLakeRepository: { findById: repos.findById, findBySlug: repos.findBySlug },
+  dataLakeAccessGrantRepository: {
+    listByLake: repos.listByLake,
+    listByPrincipal: repos.listByPrincipal,
+    findGrant: repos.findGrant,
+    upsertGrant: repos.upsertGrant,
+    removeGrant: repos.removeGrant,
+  },
+  userRepository: { findAllByEmailsOrUsernames: repos.findAllByEmailsOrUsernames },
+  lakeConfigChangeEventRepository: { record: repos.record },
+  adminSettingsRepository: {
+    findBySettingNames: vi.fn().mockResolvedValue([]),
+    findAll: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import handler from '../grants';
+
+const OWNER = 'owner-1';
+const LAKE = { id: 'lake-oid-1', slug: 'my-lake', createdByUserId: OWNER, organizationId: undefined };
+
+const makeRes = () => {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  return { res: { json, status } as never, json };
+};
+const call = (req: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(req, res);
+
+describe('/api/data-lakes/[id]/grants read counts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repos.toAccessContext.mockResolvedValue({
+      userId: OWNER,
+      isAdmin: false,
+      organizationIds: [],
+      administeredOrgIds: [],
+      userTags: [],
+      entitlementKeys: [],
+    });
+    repos.findById.mockResolvedValue(LAKE);
+    repos.findBySlug.mockResolvedValue(null);
+    repos.listByLake.mockResolvedValue([]);
+    repos.listByPrincipal.mockResolvedValue([]);
+    repos.findGrant.mockResolvedValue(null);
+    repos.upsertGrant.mockResolvedValue({});
+    repos.removeGrant.mockResolvedValue(true);
+    repos.findAllByEmailsOrUsernames.mockResolvedValue([{ id: 'u2' }]);
+    repos.record.mockResolvedValue({});
+  });
+
+  it('resolves the lake and its grants exactly once on a grant', async () => {
+    const { res } = makeRes();
+    await call(
+      {
+        method: 'POST',
+        query: { id: LAKE.id },
+        body: { principalType: 'user', principalEmail: 'u2@example.com', role: 'reader' },
+        user: { id: OWNER },
+      },
+      res
+    );
+
+    expect(repos.upsertGrant).toHaveBeenCalledTimes(1);
+    expect(repos.findById).toHaveBeenCalledTimes(1);
+    expect(repos.listByLake).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the lake and its grants exactly once on a revoke', async () => {
+    repos.findGrant.mockResolvedValue({ principalType: 'user', principalId: 'u2', role: 'reader' });
+    const { res } = makeRes();
+    await call(
+      {
+        method: 'DELETE',
+        query: { id: LAKE.id, principalType: 'user', principalId: 'u2' },
+        user: { id: OWNER },
+      },
+      res
+    );
+
+    expect(repos.removeGrant).toHaveBeenCalledTimes(1);
+    expect(repos.findById).toHaveBeenCalledTimes(1);
+    expect(repos.listByLake).toHaveBeenCalledTimes(1);
+  });
+
+  // A registry lake resolves to a synthetic document whose id is its slug, so the door's own second
+  // findById used to run against that slug and refuse first - with the wrong refusal. With one read
+  // the request reaches assertLakeGrantable, which is the refusal that names why it cannot be shared.
+  it('refuses a registry lake by saying it is built into the platform', async () => {
+    const { DATA_LAKES } = await import('@bike4mind/common');
+    // Admin, so the registry lake resolves past the fallback's own tag/entitlement gate and the
+    // request reaches the refusal this case is about rather than a not-found.
+    repos.toAccessContext.mockResolvedValue({
+      userId: OWNER,
+      isAdmin: true,
+      organizationIds: [],
+      administeredOrgIds: [],
+      userTags: [],
+      entitlementKeys: [],
+    });
+    repos.findById.mockResolvedValue(null);
+    repos.findBySlug.mockResolvedValue(null);
+    const { res } = makeRes();
+
+    await expect(
+      call(
+        {
+          method: 'POST',
+          query: { id: DATA_LAKES[0].id },
+          body: { principalType: 'user', principalEmail: 'u2@example.com', role: 'reader' },
+          user: { id: OWNER },
+        },
+        res
+      )
+    ).rejects.toThrow(/built into the platform/i);
+    expect(repos.upsertGrant).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/grants-single-read.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/grants-single-read.test.ts
@@ -7,6 +7,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * resolve the lake and its active grants for themselves, so a single grant cost four round-trips.
  * Counting the repository calls is what makes "two, not four" a measurement rather than a reading of
  * the call graph - both counts below are 2 if either gate goes back to resolving its own copy.
+ *
+ * The counts alone would pass on a gate that read the right pair and then handed the door the wrong
+ * one, so each case also pins WHAT was read (`activeAsOf`, without which a lapsed curator or owner
+ * grant becomes live for the manage decision) and the curator case below pins that the grants the
+ * gate read are the ones the door actually decides on.
  */
 const repos = vi.hoisted(() => ({
   findById: vi.fn(),
@@ -54,6 +59,7 @@ vi.mock('@bike4mind/database', () => ({
 import handler from '../grants';
 
 const OWNER = 'owner-1';
+const CURATOR = 'curator-1';
 const LAKE = { id: 'lake-oid-1', slug: 'my-lake', createdByUserId: OWNER, organizationId: undefined };
 
 const makeRes = () => {
@@ -98,8 +104,12 @@ describe('/api/data-lakes/[id]/grants read counts', () => {
     );
 
     expect(repos.upsertGrant).toHaveBeenCalledTimes(1);
+    expect(repos.upsertGrant).toHaveBeenCalledWith(
+      expect.objectContaining({ dataLakeId: LAKE.id, principalId: 'u2', role: 'reader' })
+    );
     expect(repos.findById).toHaveBeenCalledTimes(1);
     expect(repos.listByLake).toHaveBeenCalledTimes(1);
+    expect(repos.listByLake).toHaveBeenCalledWith(LAKE.id, { activeAsOf: expect.any(Date) });
   });
 
   it('resolves the lake and its grants exactly once on a revoke', async () => {
@@ -115,7 +125,41 @@ describe('/api/data-lakes/[id]/grants read counts', () => {
     );
 
     expect(repos.removeGrant).toHaveBeenCalledTimes(1);
+    expect(repos.removeGrant).toHaveBeenCalledWith(LAKE.id, 'user', 'u2');
     expect(repos.findById).toHaveBeenCalledTimes(1);
+    expect(repos.listByLake).toHaveBeenCalledTimes(1);
+    expect(repos.listByLake).toHaveBeenCalledWith(LAKE.id, { activeAsOf: expect.any(Date) });
+  });
+
+  // The seam itself: a curator who is NOT the lake's creator reaches the manage gate ONLY through a
+  // grant row, and the door is now pure over the grants the gate handed it. So a gate that reads the
+  // grants and then returns the wrong set (`[]`, say) still passes every count above while silently
+  // dropping every grant-carried rung - this case is what fails when that happens.
+  it('decides the manage gate on the grants the access gate read', async () => {
+    repos.toAccessContext.mockResolvedValue({
+      userId: CURATOR,
+      isAdmin: false,
+      organizationIds: [],
+      administeredOrgIds: [],
+      userTags: [],
+      entitlementKeys: [],
+    });
+    repos.listByLake.mockResolvedValue([{ principalType: 'user', principalId: CURATOR, role: 'curator' }]);
+    const { res } = makeRes();
+
+    await call(
+      {
+        method: 'POST',
+        query: { id: LAKE.id },
+        body: { principalType: 'user', principalEmail: 'u2@example.com', role: 'reader' },
+        user: { id: CURATOR },
+      },
+      res
+    );
+
+    expect(repos.upsertGrant).toHaveBeenCalledWith(
+      expect.objectContaining({ dataLakeId: LAKE.id, principalId: 'u2', grantedByUserId: CURATOR })
+    );
     expect(repos.listByLake).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/grants.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/grants.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const h = vi.hoisted(() => ({
-  assertLakeAccess: vi.fn(),
+  assertLakeAccessWithGrants: vi.fn(),
   grantLakeAccess: vi.fn(),
   revokeLakeAccess: vi.fn(),
   toAccessContext: vi.fn(async () => ({ userId: 'u1', isAdmin: false, administeredOrgIds: [] })),
@@ -22,7 +22,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
 vi.mock('@server/middlewares/featureFlag', () => ({ requireFeatureEnabled: () => () => {} }));
 vi.mock('@bike4mind/services', () => ({
   dataLakeService: {
-    assertLakeAccess: h.assertLakeAccess,
+    assertLakeAccessWithGrants: h.assertLakeAccessWithGrants,
     grantLakeAccess: h.grantLakeAccess,
     revokeLakeAccess: h.revokeLakeAccess,
   },
@@ -49,17 +49,23 @@ const makeRes = () => {
 };
 const call = (r: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(r, res);
 
+// The gate's own return value, forwarded WHOLE to the service: the resolved document (not the raw
+// id-or-slug from the query) and the active grants the gate read to make its own decision.
+const LAKE = { id: 'lake-oid-1', slug: 'my-lake' };
+const GRANTS = [{ principalType: 'user', principalId: 'u9', role: 'curator' }];
+
 describe('/api/data-lakes/[id]/grants', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.toAccessContext.mockResolvedValue({ userId: 'u1', isAdmin: false, administeredOrgIds: [] });
-    h.assertLakeAccess.mockResolvedValue({ id: 'lake-oid-1', slug: 'my-lake' });
+    h.assertLakeAccessWithGrants.mockResolvedValue({ lake: LAKE, grants: GRANTS });
     h.grantLakeAccess.mockResolvedValue({ principalType: 'user', principalId: 'u2', role: 'reader' });
     h.revokeLakeAccess.mockResolvedValue({ revoked: true });
   });
 
   it('grants against the RESOLVED lake, trimming the principal, and wires the audit repos', async () => {
-    // assertLakeAccess resolves id-or-slug, so the service must get lake.id, not the raw query value.
+    // The gate resolves id-or-slug, so the service must get the resolved lake, not the raw query
+    // value - and the grants the gate already read, so its manage gate does not re-read them.
     const { res, json } = makeRes();
     await call(
       {
@@ -74,7 +80,8 @@ describe('/api/data-lakes/[id]/grants', () => {
 
     expect(h.grantLakeAccess).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'u1', isAdmin: false }),
-      'lake-oid-1',
+      LAKE,
+      GRANTS,
       expect.objectContaining({ principalType: 'organization', principalId: 'org1', role: 'reader' }),
       // Not expect.anything(): the audit repos ride one shared helper, and a route that dropped
       // `adminSettings` would still compile while quietly pinning every event to the floor default.
@@ -97,7 +104,8 @@ describe('/api/data-lakes/[id]/grants', () => {
     );
     expect(h.grantLakeAccess).toHaveBeenCalledWith(
       expect.anything(),
-      'lake-oid-1',
+      LAKE,
+      GRANTS,
       expect.objectContaining({ principalEmail: 'a@b.co', expiresAt: new Date('2027-01-01T00:00:00Z') }),
       expect.anything()
     );
@@ -117,7 +125,8 @@ describe('/api/data-lakes/[id]/grants', () => {
 
     expect(h.revokeLakeAccess).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'u1' }),
-      'lake-oid-1',
+      LAKE,
+      GRANTS,
       { principalType: 'user', principalId: 'u2' },
       // Pinned on THIS door too, not just the grant one: revoking is the single most audit-relevant
       // write on a lake, and dropping the shared helper here compiles and leaves every other suite
@@ -137,7 +146,8 @@ describe('/api/data-lakes/[id]/grants', () => {
     );
     expect(h.revokeLakeAccess).toHaveBeenCalledWith(
       expect.anything(),
-      'lake-oid-1',
+      LAKE,
+      GRANTS,
       { principalType: 'user', principalId: 'u2' },
       expect.anything()
     );
@@ -173,7 +183,8 @@ describe('/api/data-lakes/[id]/grants', () => {
       expect.objectContaining({
         auditPrincipal: { principalKind: 'apiKey', principalId: 'key-abc', onBehalfOfUserId: 'u1' },
       }),
-      'lake-oid-1',
+      LAKE,
+      GRANTS,
       expect.anything(),
       expect.anything()
     );
@@ -196,8 +207,8 @@ describe('/api/data-lakes/[id]/grants', () => {
   });
 
   it('does not reach the service when the caller cannot see the lake', async () => {
-    // assertLakeAccess denies with a not-found-style error, so existence is never disclosed.
-    h.assertLakeAccess.mockRejectedValue(new Error('Data lake not found'));
+    // The gate denies with a not-found-style error, so existence is never disclosed.
+    h.assertLakeAccessWithGrants.mockRejectedValue(new Error('Data lake not found'));
     const { res } = makeRes();
     await expect(
       call(

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/transfer-ownership.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/transfer-ownership.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const h = vi.hoisted(() => ({
   assertLakeAccess: vi.fn(),
+  assertLakeAccessWithGrants: vi.fn(),
   transferLakeOwnership: vi.fn(),
   listLakeOwnershipCandidates: vi.fn(),
   toAccessContext: vi.fn(async () => ({ userId: 'u1', isAdmin: false, administeredOrgIds: [] })),
@@ -23,6 +24,7 @@ vi.mock('@server/middlewares/featureFlag', () => ({ requireFeatureEnabled: () =>
 vi.mock('@bike4mind/services', () => ({
   dataLakeService: {
     assertLakeAccess: h.assertLakeAccess,
+    assertLakeAccessWithGrants: h.assertLakeAccessWithGrants,
     transferLakeOwnership: h.transferLakeOwnership,
     listLakeOwnershipCandidates: h.listLakeOwnershipCandidates,
   },
@@ -52,6 +54,10 @@ const makeRes = () => {
 const req = (query: Record<string, string>, body: unknown) => ({ method: 'POST', query, body }) as never;
 const call = (r: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(r, res);
 
+// The POST gate's return value, forwarded WHOLE to the service.
+const LAKE = { id: 'lake-oid-1', slug: 'my-lake' };
+const GRANTS = [{ principalType: 'user', principalId: 'u9', role: 'owner' }];
+
 describe('POST /api/data-lakes/[id]/transfer-ownership', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -60,15 +66,17 @@ describe('POST /api/data-lakes/[id]/transfer-ownership', () => {
   });
 
   it('transfers against the RESOLVED lake and returns the service result verbatim', async () => {
-    // assertLakeAccess resolves id-or-slug, so the service must get lake.id, not the raw query value.
-    h.assertLakeAccess.mockResolvedValue({ id: 'lake-oid-1', slug: 'my-lake' });
+    // The gate resolves id-or-slug, so the service must get the resolved lake, not the raw query
+    // value - and the grants the gate already read, so its authority check does not re-read them.
+    h.assertLakeAccessWithGrants.mockResolvedValue({ lake: LAKE, grants: GRANTS });
     const { res, json } = makeRes();
 
     await call(req({ id: 'my-lake' }, { newOwnerUserId: 'newOwner' }), res);
 
     expect(h.transferLakeOwnership).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'u1', isAdmin: false }),
-      'lake-oid-1',
+      LAKE,
+      GRANTS,
       'newOwner',
       // Not expect.anything(): the config-audit repos ride one shared helper, and a route that
       // dropped `adminSettings` would still compile (it is optional so the retention read stays
@@ -84,7 +92,7 @@ describe('POST /api/data-lakes/[id]/transfer-ownership', () => {
   });
 
   it('does not transfer when the access gate denies the lake', async () => {
-    h.assertLakeAccess.mockRejectedValue(new Error('Data lake not found'));
+    h.assertLakeAccessWithGrants.mockRejectedValue(new Error('Data lake not found'));
     const { res } = makeRes();
 
     await expect(call(req({ id: 'lake1' }, { newOwnerUserId: 'x' }), res)).rejects.toThrow(/not found/i);
@@ -92,7 +100,7 @@ describe('POST /api/data-lakes/[id]/transfer-ownership', () => {
   });
 
   it('takes the acting principal from the access context, never from the request body', async () => {
-    h.assertLakeAccess.mockResolvedValue({ id: 'lake1' });
+    h.assertLakeAccessWithGrants.mockResolvedValue({ lake: { id: 'lake1' }, grants: [] });
     const { res } = makeRes();
 
     await call(req({ id: 'lake1' }, { newOwnerUserId: 'newOwner', userId: 'attacker', isAdmin: true }), res);
@@ -100,14 +108,15 @@ describe('POST /api/data-lakes/[id]/transfer-ownership', () => {
     // The actor is the ctx, not the body-supplied attacker identity; newOwnerUserId still comes from the body.
     expect(h.transferLakeOwnership).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'u1', isAdmin: false }),
-      'lake1',
+      { id: 'lake1' },
+      [],
       'newOwner',
       expect.anything()
     );
   });
 
   it('rejects a missing newOwnerUserId (schema validation)', async () => {
-    h.assertLakeAccess.mockResolvedValue({ id: 'lake1' });
+    h.assertLakeAccessWithGrants.mockResolvedValue({ lake: { id: 'lake1' }, grants: [] });
     const { res } = makeRes();
 
     await expect(call(req({ id: 'lake1' }, {}), res)).rejects.toThrow();

--- a/apps/client/pages/api/data-lakes/[id]/access.ts
+++ b/apps/client/pages/api/data-lakes/[id]/access.ts
@@ -59,14 +59,11 @@ const handler = baseApi()
     const format = firstQueryValue(req.query.format);
     const ctx = await toAccessContext(req);
 
-    const lake = await dataLakeService.assertLakeAccess(id, ctx, {
+    // Grants read ONCE, by the access gate itself, and applied to both decisions below: the manage
+    // gate and the transfer capability. `resolveCanManageLake` would re-query them for the same
+    // answer, and so would a separate `loadActiveLakeGrants` here.
+    const { lake, grants } = await dataLakeService.assertLakeAccessWithGrants(id, ctx, {
       db: { dataLakes: dataLakeRepository, dataLakeAccessGrants: dataLakeAccessGrantRepository },
-    });
-
-    // Grants read ONCE and applied to both decisions: the manage gate below and the transfer
-    // capability further down. `resolveCanManageLake` would re-query them for the same answer.
-    const grants = await dataLakeService.loadActiveLakeGrants(lake, {
-      db: { dataLakeAccessGrants: dataLakeAccessGrantRepository },
     });
     if (!dataLakeService.canManageLake(lake, ctx, grants)) {
       throw new ForbiddenError('You must be able to manage this data lake to view its access.');

--- a/apps/client/pages/api/data-lakes/[id]/grants.ts
+++ b/apps/client/pages/api/data-lakes/[id]/grants.ts
@@ -59,14 +59,15 @@ const handler = baseApi()
     const input = GrantInput.parse(req.body);
     const ctx = await toAccessContext(req);
 
-    const lake = await dataLakeService.assertLakeAccess(id, ctx, {
+    // The gate hands back the active grants it read to make its own decision, so the manage gate
+    // inside the service is applied to that same set rather than re-reading the lake and its grants.
+    const { lake, grants } = await dataLakeService.assertLakeAccessWithGrants(id, ctx, {
       db: { dataLakes: dataLakeRepository, dataLakeAccessGrants: dataLakeAccessGrantRepository },
     });
 
     const actor = { ...ctx, auditPrincipal: lakeConfigAuditPrincipal(req.user!, req.apiKeyInfo) };
-    const data = await dataLakeService.grantLakeAccess(actor, lake.id, input, {
+    const data = await dataLakeService.grantLakeAccess(actor, lake, grants, input, {
       db: {
-        dataLakes: dataLakeRepository,
         dataLakeAccessGrants: dataLakeAccessGrantRepository,
         users: userRepository,
         ...lakeConfigAuditDb,
@@ -84,14 +85,15 @@ const handler = baseApi()
     });
     const ctx = await toAccessContext(req);
 
-    const lake = await dataLakeService.assertLakeAccess(id, ctx, {
+    // The gate hands back the active grants it read to make its own decision, so the manage gate
+    // inside the service is applied to that same set rather than re-reading the lake and its grants.
+    const { lake, grants } = await dataLakeService.assertLakeAccessWithGrants(id, ctx, {
       db: { dataLakes: dataLakeRepository, dataLakeAccessGrants: dataLakeAccessGrantRepository },
     });
 
     const actor = { ...ctx, auditPrincipal: lakeConfigAuditPrincipal(req.user!, req.apiKeyInfo) };
-    const data = await dataLakeService.revokeLakeAccess(actor, lake.id, input, {
+    const data = await dataLakeService.revokeLakeAccess(actor, lake, grants, input, {
       db: {
-        dataLakes: dataLakeRepository,
         dataLakeAccessGrants: dataLakeAccessGrantRepository,
         users: userRepository,
         ...lakeConfigAuditDb,

--- a/apps/client/pages/api/data-lakes/[id]/transfer-ownership.ts
+++ b/apps/client/pages/api/data-lakes/[id]/transfer-ownership.ts
@@ -60,13 +60,14 @@ const handler = baseApi()
     const ctx = await toAccessContext(req);
 
     // Resolve + access-gate the lake first, so a caller who can't even see it gets a not-found
-    // (no existence leak). The service then applies the stricter transfer authorization.
-    const lake = await dataLakeService.assertLakeAccess(id, ctx, {
+    // (no existence leak). The service then applies the stricter transfer authorization, to the
+    // grants this gate already read rather than a second copy of them.
+    const { lake, grants } = await dataLakeService.assertLakeAccessWithGrants(id, ctx, {
       db: { dataLakes: dataLakeRepository, dataLakeAccessGrants: dataLakeAccessGrantRepository },
     });
 
     const actor = { ...ctx, auditPrincipal: lakeConfigAuditPrincipal(req.user!, req.apiKeyInfo) };
-    const result = await dataLakeService.transferLakeOwnership(actor, lake.id, newOwnerUserId, {
+    const result = await dataLakeService.transferLakeOwnership(actor, lake, grants, newOwnerUserId, {
       db: {
         dataLakes: dataLakeRepository,
         dataLakeAccessGrants: dataLakeAccessGrantRepository,

--- a/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
+++ b/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
@@ -41,6 +41,18 @@ interface AssertLakeAccessAdapters {
 }
 
 /**
+ * The manage-door variant of the adapters: `dataLakeAccessGrants` is REQUIRED. The read shape above
+ * makes it optional for the ~57 callers that only need the lake, and that optionality must not be
+ * spent here: a manage caller that omitted the repo would receive `grants: []`, indistinguishable
+ * from "this lake has no grants", and every grant-carried rung (a curator, a transferred owner)
+ * would silently vanish from the decision the door then makes. Required turns that into a compile
+ * error, the same reason `TransferLakeOwnershipAdapters` narrows its own audit repo.
+ */
+type AssertLakeAccessWithGrantsAdapters = AssertLakeAccessAdapters & {
+  db: { dataLakeAccessGrants: NonNullable<AssertLakeAccessAdapters['db']['dataLakeAccessGrants']> };
+};
+
+/**
  * Pure access decision for a lake the caller already holds. Bypass-then-constraints:
  * owner or admin is granted immediately; otherwise a non-owner must satisfy the org
  * constraint (if the lake is org-scoped) AND the requirement constraint - the requirement
@@ -200,9 +212,10 @@ const resolveGrantHeldLakeBySlug = async (
  *
  * Returns the lake AND the grants the gate itself read, so a caller that goes on to make a manage
  * decision does not re-query them - the identical set `loadActiveLakeGrants` would return, active
- * as of this call. `grants` is `[]` for a fallback lake and, importantly, ALSO `[]` when no
- * `dataLakeAccessGrants` repo is wired: a caller building a manage decision on it must wire the
- * repo, or every grant-carried rung silently disappears.
+ * as of this call. `grants` is `[]` for a fallback lake (there is no document to hang a grant row
+ * on) and also `[]` when no `dataLakeAccessGrants` repo is wired, which is why the manage entry
+ * point `assertLakeAccessWithGrants` requires that repo - only the lake-only `assertLakeAccess`
+ * wrapper may reach this with it absent.
  *
  * Slug resolution (#2425): findBySlug's own-org/org-less arms miss a lake in an org the
  * caller isn't a member of, even when they hold a real owner/curator grant on it (e.g. a
@@ -213,7 +226,7 @@ const resolveGrantHeldLakeBySlug = async (
  * extra grants query only ever runs on a miss, matching the prior lazy-thunk design, but the
  * decision now lives here rather than inside the repository method.
  */
-export const assertLakeAccessWithGrants = async (
+const resolveLakeAccessWithGrants = async (
   lakeIdOrSlug: string,
   ctx: AccessContext,
   { db, logger }: AssertLakeAccessAdapters
@@ -262,12 +275,25 @@ export const assertLakeAccessWithGrants = async (
 };
 
 /**
- * The access gate, for the callers that need only the lake. See `assertLakeAccessWithGrants` for
- * the contract; a caller that goes on to make a MANAGE decision should use that instead of
- * re-reading the same grants.
+ * The access gate for a caller that goes on to make a MANAGE decision: same gate, and it hands back
+ * the grants it read so the door does not re-query them. See `resolveLakeAccessWithGrants` above for
+ * the contract. This entry point exists only to REQUIRE the grants repo (see
+ * `AssertLakeAccessWithGrantsAdapters`), which the lake-only wrapper below cannot.
+ */
+export const assertLakeAccessWithGrants = (
+  lakeIdOrSlug: string,
+  ctx: AccessContext,
+  adapters: AssertLakeAccessWithGrantsAdapters
+): Promise<{ lake: IDataLakeDocument; grants: LakeGrant[] }> =>
+  resolveLakeAccessWithGrants(lakeIdOrSlug, ctx, adapters);
+
+/**
+ * The access gate, for the callers that need only the lake. See `resolveLakeAccessWithGrants` for
+ * the contract; a caller that goes on to make a MANAGE decision should use
+ * `assertLakeAccessWithGrants` instead of re-reading the same grants.
  */
 export const assertLakeAccess = async (
   lakeIdOrSlug: string,
   ctx: AccessContext,
   adapters: AssertLakeAccessAdapters
-): Promise<IDataLakeDocument> => (await assertLakeAccessWithGrants(lakeIdOrSlug, ctx, adapters)).lake;
+): Promise<IDataLakeDocument> => (await resolveLakeAccessWithGrants(lakeIdOrSlug, ctx, adapters)).lake;

--- a/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
+++ b/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
@@ -196,7 +196,13 @@ const resolveGrantHeldLakeBySlug = async (
  * real lake that shadows a fallback slug resolves to the DB lake, and its denial is
  * final (no fallback retry). Denies with a NOT-FOUND-style error so a user who can't
  * see a lake can't confirm it exists. Every single-lake read and every batch/file
- * operation calls this first. Returns the lake on grant.
+ * operation calls this first (most through the `assertLakeAccess` wrapper below).
+ *
+ * Returns the lake AND the grants the gate itself read, so a caller that goes on to make a manage
+ * decision does not re-query them - the identical set `loadActiveLakeGrants` would return, active
+ * as of this call. `grants` is `[]` for a fallback lake and, importantly, ALSO `[]` when no
+ * `dataLakeAccessGrants` repo is wired: a caller building a manage decision on it must wire the
+ * repo, or every grant-carried rung silently disappears.
  *
  * Slug resolution (#2425): findBySlug's own-org/org-less arms miss a lake in an org the
  * caller isn't a member of, even when they hold a real owner/curator grant on it (e.g. a
@@ -207,11 +213,11 @@ const resolveGrantHeldLakeBySlug = async (
  * extra grants query only ever runs on a miss, matching the prior lazy-thunk design, but the
  * decision now lives here rather than inside the repository method.
  */
-export const assertLakeAccess = async (
+export const assertLakeAccessWithGrants = async (
   lakeIdOrSlug: string,
   ctx: AccessContext,
   { db, logger }: AssertLakeAccessAdapters
-): Promise<IDataLakeDocument> => {
+): Promise<{ lake: IDataLakeDocument; grants: LakeGrant[] }> => {
   const lake =
     (await db.dataLakes.findById(lakeIdOrSlug).catch(() => null)) ??
     (await db.dataLakes.findBySlug(lakeIdOrSlug, ctx.organizationIds)) ??
@@ -248,9 +254,20 @@ export const assertLakeAccess = async (
       });
     }
     if (!decision.allowed) throw new NotFoundError('Data lake not found');
-    return lake;
+    return { lake, grants };
   }
   const fallback = await resolveFallbackLake(lakeIdOrSlug, ctx, db.fallbackLakeSettings, logger);
   if (!fallback) throw new NotFoundError('Data lake not found');
-  return fallback;
+  return { lake: fallback, grants: [] };
 };
+
+/**
+ * The access gate, for the callers that need only the lake. See `assertLakeAccessWithGrants` for
+ * the contract; a caller that goes on to make a MANAGE decision should use that instead of
+ * re-reading the same grants.
+ */
+export const assertLakeAccess = async (
+  lakeIdOrSlug: string,
+  ctx: AccessContext,
+  adapters: AssertLakeAccessAdapters
+): Promise<IDataLakeDocument> => (await assertLakeAccessWithGrants(lakeIdOrSlug, ctx, adapters)).lake;

--- a/b4m-core/services/src/dataLakeService/lakeConfigChangeWiring.test.ts
+++ b/b4m-core/services/src/dataLakeService/lakeConfigChangeWiring.test.ts
@@ -460,8 +460,8 @@ describe('transferLakeOwnership', () => {
   const orgLake = () => lake({ organizationId: 'org1' });
   const orgOwner = { ...owner, organizationIds: ['org1'] };
   const transferDb = (existing: IDataLakeDocument) => ({
-    dataLakes: { findById: vi.fn().mockResolvedValue(existing), update: echoUpdate(existing) },
-    dataLakeAccessGrants: { listByLake: vi.fn().mockResolvedValue([]), upsertGrant: vi.fn().mockResolvedValue({}) },
+    dataLakes: { update: echoUpdate(existing) },
+    dataLakeAccessGrants: { upsertGrant: vi.fn().mockResolvedValue({}) },
     users: { findById: vi.fn().mockResolvedValue({ id: 'newOwner' }) },
     organizations: {
       findById: vi.fn().mockResolvedValue({
@@ -477,7 +477,7 @@ describe('transferLakeOwnership', () => {
   it('records the ownership move on the derived field', async () => {
     const existing = orgLake();
     const audit = auditSpy();
-    await transferLakeOwnership(orgOwner, 'lake1', 'newOwner', { db: { ...transferDb(existing), ...audit.db } });
+    await transferLakeOwnership(orgOwner, existing, [], 'newOwner', { db: { ...transferDb(existing), ...audit.db } });
 
     expect(audit.only()).toMatchObject({
       action: 'transfer-ownership',
@@ -495,15 +495,13 @@ describe('transferLakeOwnership', () => {
     const existing = lake({ organizationId: 'org-1' });
     const audit = auditSpy();
     const db = transferDb(existing);
-    db.dataLakeAccessGrants.listByLake = vi
-      .fn()
-      .mockResolvedValue([{ principalType: 'user', principalId: 'orgAdmin', role: 'curator', status: 'active' }]);
     // An org-owned lake requires the incoming owner to be a member of that org.
     db.organizations.findById = vi.fn().mockResolvedValue({ id: 'org-1', users: [{ userId: 'newOwner' }] });
 
     await transferLakeOwnership(
       { userId: 'orgAdmin', isAdmin: false, administeredOrgIds: ['org-1'] },
-      'lake1',
+      existing,
+      [{ principalType: 'user', principalId: 'orgAdmin', role: 'curator' }],
       'newOwner',
       { db: { ...db, ...audit.db } }
     );
@@ -517,7 +515,7 @@ describe('transferLakeOwnership', () => {
   it('records ownership, not platform-admin, when an admin transfers a lake they own', async () => {
     const existing = lake();
     const audit = auditSpy();
-    await transferLakeOwnership({ userId: 'owner', isAdmin: true }, 'lake1', 'newOwner', {
+    await transferLakeOwnership({ userId: 'owner', isAdmin: true }, existing, [], 'newOwner', {
       db: { ...transferDb(existing), ...audit.db },
     });
 
@@ -527,7 +525,7 @@ describe('transferLakeOwnership', () => {
   it('records platform-admin when an admin transfers a lake they do NOT own', async () => {
     const existing = lake();
     const audit = auditSpy();
-    await transferLakeOwnership({ userId: 'root', isAdmin: true }, 'lake1', 'newOwner', {
+    await transferLakeOwnership({ userId: 'root', isAdmin: true }, existing, [], 'newOwner', {
       db: { ...transferDb(existing), ...audit.db },
     });
 
@@ -537,7 +535,7 @@ describe('transferLakeOwnership', () => {
   it('records nothing when the named owner already solely owns the lake', async () => {
     const existing = orgLake();
     const audit = auditSpy();
-    await transferLakeOwnership(orgOwner, 'lake1', 'owner', { db: { ...transferDb(existing), ...audit.db } });
+    await transferLakeOwnership(orgOwner, existing, [], 'owner', { db: { ...transferDb(existing), ...audit.db } });
     expect(audit.record).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/dataLakeService/manageLakeGrant.test.ts
+++ b/b4m-core/services/src/dataLakeService/manageLakeGrant.test.ts
@@ -36,11 +36,15 @@ const makeAdapters = (
     upsertGrant,
     removeGrant,
     record,
+    // The resolved (lake, grants) pair the API route reads from its access gate and hands to the
+    // door, spread into each call below so the real argument order stays visible at the call site.
+    lakeArgs: [
+      over.lakeDoc === undefined ? lake() : over.lakeDoc,
+      (over.grants ?? []).map(g => ({ principalType: g.principalType, principalId: g.principalId, role: g.role })),
+    ] as const,
     adapters: {
       db: {
-        dataLakes: { findById: vi.fn(async () => (over.lakeDoc === undefined ? lake() : over.lakeDoc)) },
         dataLakeAccessGrants: {
-          listByLake: vi.fn(async () => over.grants ?? []),
           findGrant: vi.fn(async () => over.existing ?? null),
           upsertGrant,
           removeGrant,
@@ -58,31 +62,21 @@ const curatorGrants = [grantRow({ principalId: 'cur', role: 'curator' })];
 
 describe('grantLakeAccess', () => {
   it('refuses a fallback (registry) lake before any write', async () => {
-    const { adapters, upsertGrant } = makeAdapters({ lakeDoc: lake({ id: DATA_LAKES[0].id }) });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ lakeDoc: lake({ id: DATA_LAKES[0].id }) });
     await expect(
-      grantLakeAccess(
-        owner,
-        DATA_LAKES[0].id,
-        { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' },
-        adapters
-      )
+      grantLakeAccess(owner, ...lakeArgs, { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' }, adapters)
     ).rejects.toThrow(/built into the platform/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
 
-  it('refuses a lake that does not exist', async () => {
-    const { adapters } = makeAdapters({ lakeDoc: null });
-    await expect(
-      grantLakeAccess(owner, 'ghost', { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' }, adapters)
-    ).rejects.toThrow(/not found/i);
-  });
-
   it('refuses a plain reader before any write', async () => {
-    const { adapters, upsertGrant } = makeAdapters({ grants: [grantRow({ principalId: 'rdr', role: 'reader' })] });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
+      grants: [grantRow({ principalId: 'rdr', role: 'reader' })],
+    });
     await expect(
       grantLakeAccess(
         { userId: 'rdr', isAdmin: false },
-        'lake1',
+        ...lakeArgs,
         { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' },
         adapters
       )
@@ -91,10 +85,10 @@ describe('grantLakeAccess', () => {
   });
 
   it('lets a curator grant a reader, attributing the grant to the actor', async () => {
-    const { adapters, upsertGrant, record } = makeAdapters({ grants: curatorGrants });
+    const { adapters, lakeArgs, upsertGrant, record } = makeAdapters({ grants: curatorGrants });
     const result = await grantLakeAccess(
       curator,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' },
       adapters
     );
@@ -119,9 +113,14 @@ describe('grantLakeAccess', () => {
   });
 
   it('refuses an owner grant, so a curator cannot escalate past the transfer gate', async () => {
-    const { adapters, upsertGrant } = makeAdapters({ grants: curatorGrants });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ grants: curatorGrants });
     await expect(
-      grantLakeAccess(curator, 'lake1', { principalType: 'user', principalEmail: 'cur@b.c', role: 'owner' }, adapters)
+      grantLakeAccess(
+        curator,
+        ...lakeArgs,
+        { principalType: 'user', principalEmail: 'cur@b.c', role: 'owner' },
+        adapters
+      )
     ).rejects.toThrow(/transfer ownership/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
@@ -129,7 +128,7 @@ describe('grantLakeAccess', () => {
   it('refuses re-roling an existing owner grant down, which would un-transfer the lake', async () => {
     // The requested role is a legal 'curator', so only the check against the EXISTING row catches
     // this. Without it a curator could demote the owner through the routine sharing door.
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       grants: curatorGrants,
       existing: grantRow({ principalId: 'theOwner', role: 'owner' }),
       userByEmail: { id: 'theOwner' },
@@ -137,7 +136,7 @@ describe('grantLakeAccess', () => {
     await expect(
       grantLakeAccess(
         curator,
-        'lake1',
+        ...lakeArgs,
         { principalType: 'user', principalEmail: 'owner@b.c', role: 'curator' },
         adapters
       )
@@ -148,17 +147,22 @@ describe('grantLakeAccess', () => {
   it('refuses naming a user by id, which the door cannot resolve to an account', async () => {
     // An id is taken at face value, so a typo becomes a permanent unresolvable row and a padded or
     // recased variant a second row for the same person. Email is the only checkable input.
-    const { adapters, upsertGrant } = makeAdapters();
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters();
     await expect(
-      grantLakeAccess(owner, 'lake1', { principalType: 'user', principalId: 'u1', role: 'reader' }, adapters)
+      grantLakeAccess(owner, ...lakeArgs, { principalType: 'user', principalId: 'u1', role: 'reader' }, adapters)
     ).rejects.toThrow(/by email address/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
 
   it('refuses an org curator grant, which could confer management on nobody', async () => {
-    const { adapters, upsertGrant } = makeAdapters();
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters();
     await expect(
-      grantLakeAccess(owner, 'lake1', { principalType: 'organization', principalId: 'org1', role: 'curator' }, adapters)
+      grantLakeAccess(
+        owner,
+        ...lakeArgs,
+        { principalType: 'organization', principalId: 'org1', role: 'curator' },
+        adapters
+      )
     ).rejects.toThrow(/only be granted reader access/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
@@ -166,12 +170,12 @@ describe('grantLakeAccess', () => {
   it('clears a lapsed expiry on re-grant, and audits the restore as a fresh grant', async () => {
     // Without the clear, upsertGrant leaves the past date alone: the write lands, the caller is told
     // access was granted, and loadActiveLakeGrants still filters the row out.
-    const { adapters, upsertGrant, record } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant, record } = makeAdapters({
       existing: grantRow({ principalId: 'u1', role: 'reader', expiresAt: new Date(Date.now() - 86_400_000) }),
     });
     const result = await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' },
       adapters
     );
@@ -190,12 +194,12 @@ describe('grantLakeAccess', () => {
   it('audits a SAME-role re-grant over a lapsed row, which restores access', async () => {
     // The role did not move, so this is the one case where an unchanged role is still a change -
     // treating the lapsed row as `before` would make grantChange return null and lose the event.
-    const { adapters, record } = makeAdapters({
+    const { adapters, lakeArgs, record } = makeAdapters({
       existing: grantRow({ principalId: 'u1', role: 'reader', expiresAt: new Date(Date.now() - 1000) }),
     });
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' },
       adapters
     );
@@ -207,12 +211,12 @@ describe('grantLakeAccess', () => {
   });
 
   it('leaves a still-current expiry alone', async () => {
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       existing: grantRow({ principalId: 'u1', role: 'reader', expiresAt: new Date(Date.now() + 86_400_000) }),
     });
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' },
       adapters
     );
@@ -220,7 +224,7 @@ describe('grantLakeAccess', () => {
   });
 
   it('refuses re-roling a LAPSED owner grant: an expiry says nothing about who owns the lake', async () => {
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       grants: curatorGrants,
       existing: grantRow({ principalId: 'theOwner', role: 'owner', expiresAt: new Date(Date.now() - 1000) }),
       userByEmail: { id: 'theOwner' },
@@ -228,7 +232,7 @@ describe('grantLakeAccess', () => {
     await expect(
       grantLakeAccess(
         curator,
-        'lake1',
+        ...lakeArgs,
         { principalType: 'user', principalEmail: 'owner@b.c', role: 'curator' },
         adapters
       )
@@ -237,20 +241,25 @@ describe('grantLakeAccess', () => {
   });
 
   it('refuses an org grant naming another org', async () => {
-    const { adapters, upsertGrant } = makeAdapters();
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters();
     await expect(
-      grantLakeAccess(owner, 'lake1', { principalType: 'organization', principalId: 'org2', role: 'reader' }, adapters)
+      grantLakeAccess(
+        owner,
+        ...lakeArgs,
+        { principalType: 'organization', principalId: 'org2', role: 'reader' },
+        adapters
+      )
     ).rejects.toThrow(/organization that owns it/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
 
   it('records nothing when the principal already holds that role', async () => {
-    const { adapters, upsertGrant, record } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant, record } = makeAdapters({
       existing: grantRow({ principalId: 'u1', role: 'reader' }),
     });
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' },
       adapters
     );
@@ -261,10 +270,10 @@ describe('grantLakeAccess', () => {
   });
 
   it('records a re-role as before -> after', async () => {
-    const { adapters, record } = makeAdapters({ existing: grantRow({ principalId: 'u1', role: 'reader' }) });
+    const { adapters, lakeArgs, record } = makeAdapters({ existing: grantRow({ principalId: 'u1', role: 'reader' }) });
     const result = await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' },
       adapters
     );
@@ -277,15 +286,25 @@ describe('grantLakeAccess', () => {
   });
 
   it('resolves a user principal by exact email', async () => {
-    const { adapters, upsertGrant } = makeAdapters({ userByEmail: { id: 'u9' } });
-    await grantLakeAccess(owner, 'lake1', { principalType: 'user', principalEmail: 'a@b.c', role: 'reader' }, adapters);
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ userByEmail: { id: 'u9' } });
+    await grantLakeAccess(
+      owner,
+      ...lakeArgs,
+      { principalType: 'user', principalEmail: 'a@b.c', role: 'reader' },
+      adapters
+    );
     expect(upsertGrant).toHaveBeenCalledWith(expect.objectContaining({ principalId: 'u9' }));
   });
 
   it('refuses an unknown email without writing', async () => {
-    const { adapters, upsertGrant } = makeAdapters({ userByEmail: null });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ userByEmail: null });
     await expect(
-      grantLakeAccess(owner, 'lake1', { principalType: 'user', principalEmail: 'ghost@b.c', role: 'reader' }, adapters)
+      grantLakeAccess(
+        owner,
+        ...lakeArgs,
+        { principalType: 'user', principalEmail: 'ghost@b.c', role: 'reader' },
+        adapters
+      )
     ).rejects.toThrow(/no account was found/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
@@ -294,17 +313,22 @@ describe('grantLakeAccess', () => {
     // Email uniqueness is case-SENSITIVE while the lookup collates case-insensitively, so `a@b.c`
     // and `A@b.c` are two real accounts one typed address matches. Picking one silently is how a
     // grant lands on the wrong person; a findOne-shaped lookup cannot even see the second match.
-    const { adapters, upsertGrant } = makeAdapters({ usersByEmail: [{ id: 'u1' }, { id: 'u2' }] });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ usersByEmail: [{ id: 'u1' }, { id: 'u2' }] });
     await expect(
-      grantLakeAccess(owner, 'lake1', { principalType: 'user', principalEmail: 'a@b.c', role: 'reader' }, adapters)
+      grantLakeAccess(owner, ...lakeArgs, { principalType: 'user', principalEmail: 'a@b.c', role: 'reader' }, adapters)
     ).rejects.toThrow(/more than one account/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
 
   it('refuses a CURATOR granting curator, so curatorship cannot propagate itself', async () => {
-    const { adapters, upsertGrant } = makeAdapters({ grants: curatorGrants });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ grants: curatorGrants });
     await expect(
-      grantLakeAccess(curator, 'lake1', { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' }, adapters)
+      grantLakeAccess(
+        curator,
+        ...lakeArgs,
+        { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' },
+        adapters
+      )
     ).rejects.toThrow(/curators cannot grant curator access/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
@@ -321,10 +345,10 @@ describe('grantLakeAccess', () => {
     { who: 'an ORG ADMIN of the lake own org', actor: { userId: 'cur', isAdmin: false, administeredOrgIds: ['org1'] } },
     { who: 'a PLATFORM ADMIN', actor: { userId: 'cur', isAdmin: true } },
   ])('lets $who who ALSO holds a curator grant grant curator', async ({ actor }) => {
-    const { adapters, upsertGrant } = makeAdapters({ grants: curatorGrants });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ grants: curatorGrants });
     await grantLakeAccess(
       actor as ManageActor,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' },
       adapters
     );
@@ -334,11 +358,11 @@ describe('grantLakeAccess', () => {
   it('still refuses an org admin of some OTHER org who holds only a curator grant here', async () => {
     // The anti-cheat for the pair above: exempting on "has administeredOrgIds at all" would pass
     // them. The org rung has to actually apply to THIS lake.
-    const { adapters, upsertGrant } = makeAdapters({ grants: curatorGrants });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ grants: curatorGrants });
     await expect(
       grantLakeAccess(
         { userId: 'cur', isAdmin: false, administeredOrgIds: ['org-other'] },
-        'lake1',
+        ...lakeArgs,
         { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' },
         adapters
       )
@@ -348,10 +372,10 @@ describe('grantLakeAccess', () => {
 
   it('lets an OWNER grant curator - the refusal is the rung, not the role', async () => {
     // The anti-cheat for the test above: a blanket refusal of `curator` would pass it too.
-    const { adapters, upsertGrant } = makeAdapters();
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters();
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'curator' },
       adapters
     );
@@ -362,10 +386,10 @@ describe('grantLakeAccess', () => {
     // The expiry is part of what the grant confers: shortening one is an access change, and with the
     // role alone in the audited value it landed as a write nothing recorded.
     const expiresAt = new Date(Date.now() + 86_400_000);
-    const { adapters, record } = makeAdapters({ existing: grantRow({ principalId: 'u1', role: 'reader' }) });
+    const { adapters, lakeArgs, record } = makeAdapters({ existing: grantRow({ principalId: 'u1', role: 'reader' }) });
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader', expiresAt },
       adapters
     );
@@ -387,12 +411,12 @@ describe('grantLakeAccess', () => {
     // The anti-cheat for the test above: `expiresAt` omitted means "leave it alone", so the audit
     // has to resolve the after side against the ROW - reading the omission as a clear would record
     // a phantom "expiry removed" on every routine same-role re-grant of an expiring row.
-    const { adapters, record } = makeAdapters({
+    const { adapters, lakeArgs, record } = makeAdapters({
       existing: grantRow({ principalId: 'u1', role: 'reader', expiresAt: new Date(Date.now() + 86_400_000) }),
     });
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' },
       adapters
     );
@@ -404,7 +428,7 @@ describe('grantLakeAccess', () => {
     const withExpiry = makeAdapters();
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...withExpiry.lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader', expiresAt },
       withExpiry.adapters
     );
@@ -415,7 +439,7 @@ describe('grantLakeAccess', () => {
     const without = makeAdapters();
     await grantLakeAccess(
       owner,
-      'lake1',
+      ...without.lakeArgs,
       { principalType: 'user', principalEmail: 'u1@b.c', role: 'reader' },
       without.adapters
     );
@@ -425,11 +449,13 @@ describe('grantLakeAccess', () => {
 
 describe('revokeLakeAccess', () => {
   it('refuses a plain reader before any write', async () => {
-    const { adapters, removeGrant } = makeAdapters({ grants: [grantRow({ principalId: 'rdr', role: 'reader' })] });
+    const { adapters, lakeArgs, removeGrant } = makeAdapters({
+      grants: [grantRow({ principalId: 'rdr', role: 'reader' })],
+    });
     await expect(
       revokeLakeAccess(
         { userId: 'rdr', isAdmin: false },
-        'lake1',
+        ...lakeArgs,
         { principalType: 'user', principalId: 'u1' },
         adapters
       )
@@ -438,18 +464,20 @@ describe('revokeLakeAccess', () => {
   });
 
   it('refuses revoking an ownership grant', async () => {
-    const { adapters, removeGrant } = makeAdapters({ existing: grantRow({ principalId: 'u1', role: 'owner' }) });
+    const { adapters, lakeArgs, removeGrant } = makeAdapters({
+      existing: grantRow({ principalId: 'u1', role: 'owner' }),
+    });
     await expect(
-      revokeLakeAccess(owner, 'lake1', { principalType: 'user', principalId: 'u1' }, adapters)
+      revokeLakeAccess(owner, ...lakeArgs, { principalType: 'user', principalId: 'u1' }, adapters)
     ).rejects.toThrow(/transfer ownership/i);
     expect(removeGrant).not.toHaveBeenCalled();
   });
 
   it('revokes a reader and records one audit row', async () => {
-    const { adapters, removeGrant, record } = makeAdapters({
+    const { adapters, lakeArgs, removeGrant, record } = makeAdapters({
       existing: grantRow({ principalId: 'u1', role: 'reader' }),
     });
-    const result = await revokeLakeAccess(owner, 'lake1', { principalType: 'user', principalId: 'u1' }, adapters);
+    const result = await revokeLakeAccess(owner, ...lakeArgs, { principalType: 'user', principalId: 'u1' }, adapters);
 
     expect(result).toEqual({ revoked: true });
     expect(removeGrant).toHaveBeenCalledWith('lake1', 'user', 'u1');
@@ -466,8 +494,10 @@ describe('revokeLakeAccess', () => {
     // conferred nothing. The role cannot simply be dropped the way the grant door drops a lapsed
     // `previousRole`: with no `after` side that returns null and loses the event entirely.
     const expiresAt = new Date(Date.now() - 86_400_000);
-    const { adapters, record } = makeAdapters({ existing: grantRow({ principalId: 'u1', role: 'reader', expiresAt }) });
-    await revokeLakeAccess(owner, 'lake1', { principalType: 'user', principalId: 'u1' }, adapters);
+    const { adapters, lakeArgs, record } = makeAdapters({
+      existing: grantRow({ principalId: 'u1', role: 'reader', expiresAt }),
+    });
+    await revokeLakeAccess(owner, ...lakeArgs, { principalType: 'user', principalId: 'u1' }, adapters);
     expect(record).toHaveBeenCalledWith(
       expect.objectContaining({
         changes: [{ field: 'accessGrant', kind: 'literal', before: `user:u1=reader until ${expiresAt.toISOString()}` }],
@@ -476,9 +506,9 @@ describe('revokeLakeAccess', () => {
   });
 
   it('is a no-op for a principal with no grant', async () => {
-    const { adapters, removeGrant, record } = makeAdapters({ existing: null });
+    const { adapters, lakeArgs, removeGrant, record } = makeAdapters({ existing: null });
     await expect(
-      revokeLakeAccess(owner, 'lake1', { principalType: 'user', principalId: 'u1' }, adapters)
+      revokeLakeAccess(owner, ...lakeArgs, { principalType: 'user', principalId: 'u1' }, adapters)
     ).resolves.toEqual({ revoked: false });
     expect(removeGrant).not.toHaveBeenCalled();
     expect(record).not.toHaveBeenCalled();

--- a/b4m-core/services/src/dataLakeService/manageLakeGrant.ts
+++ b/b4m-core/services/src/dataLakeService/manageLakeGrant.ts
@@ -3,13 +3,11 @@ import type {
   DataLakePrincipalType,
   IDataLakeAccessGrantRepository,
   IDataLakeDocument,
-  IDataLakeRepository,
   IUserRepository,
 } from '@bike4mind/common';
-import { BadRequestError, ForbiddenError, NotFoundError } from '@bike4mind/utils';
-import { canManageLake, type ManageActor } from './manageRule';
+import { BadRequestError, ForbiddenError } from '@bike4mind/utils';
+import { canManageLake, type LakeGrant, type ManageActor } from './manageRule';
 import { assertLakeGrantable } from './assertLakeAccess';
-import { loadActiveLakeGrants } from './authorizeLakeManage';
 import { grantChange } from './diffLakeConfig';
 import { refuseGrantWrite, refuseOwnerGrantChange } from './lakeGrantWriteRule';
 import { recordLakeConfigChange, type LakeConfigAuditAdapters } from './recordLakeConfigChange';
@@ -23,11 +21,7 @@ import { recordLakeConfigChange, type LakeConfigAuditAdapters } from './recordLa
 interface ManageLakeGrantAdapters extends LakeConfigAuditAdapters {
   db: LakeConfigAuditAdapters['db'] & {
     lakeConfigChangeEvents: NonNullable<LakeConfigAuditAdapters['db']['lakeConfigChangeEvents']>;
-    dataLakes: Pick<IDataLakeRepository, 'findById'>;
-    dataLakeAccessGrants: Pick<
-      IDataLakeAccessGrantRepository,
-      'listByLake' | 'findGrant' | 'upsertGrant' | 'removeGrant'
-    >;
+    dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'findGrant' | 'upsertGrant' | 'removeGrant'>;
     users: Pick<IUserRepository, 'findAllByEmailsOrUsernames'>;
   };
 }
@@ -68,27 +62,22 @@ export interface RevokeLakeAccessResult {
   revoked: boolean;
 }
 
-/** The shared prologue: load, refuse a fallback lake, and apply the manage gate once. */
-async function loadManageableLake(
-  actor: ManageActor,
-  dataLakeId: string,
-  { db }: ManageLakeGrantAdapters
-): Promise<{ lake: IDataLakeDocument; grants: Awaited<ReturnType<typeof loadActiveLakeGrants>> }> {
-  const lake = await db.dataLakes.findById(dataLakeId);
-  if (!lake) {
-    throw new NotFoundError('Data lake not found');
-  }
+/**
+ * The shared prologue: refuse a fallback lake, then apply the manage gate once. Pure over an
+ * already-resolved lake and its ACTIVE grants - both doors below are reached through the route's
+ * `assertLakeAccessWithGrants`, which read exactly this pair, so neither is re-fetched here. The
+ * missing-lake refusal lives in that gate too, as a not-found-style denial.
+ */
+function assertManageableLake(lake: IDataLakeDocument, actor: ManageActor, grants: LakeGrant[]): void {
   // A hardcoded registry lake has no document to hang a grant row on.
   assertLakeGrantable(lake);
 
-  const grants = await loadActiveLakeGrants(lake, { db });
   if (!canManageLake(lake, actor, grants)) {
     // Forbidden, not BadRequest: the route access-gates first, so a caller reaching here can already
     // see the lake and nothing is disclosed by saying they may not manage it. Same call the access
     // view's own manage gate makes.
     throw new ForbiddenError('You do not have permission to manage access to this data lake');
   }
-  return { lake, grants };
 }
 
 /**
@@ -128,12 +117,13 @@ async function loadManageableLake(
  */
 export async function grantLakeAccess(
   actor: ManageActor,
-  dataLakeId: string,
+  lake: IDataLakeDocument,
+  grants: LakeGrant[],
   input: GrantLakeAccessInput,
   adapters: ManageLakeGrantAdapters
 ): Promise<GrantLakeAccessResult> {
   const { db, logger } = adapters;
-  const { lake, grants } = await loadManageableLake(actor, dataLakeId, adapters);
+  assertManageableLake(lake, actor, grants);
 
   const principalId = await resolvePrincipalId(input, db);
   const refusal = refuseGrantWrite(lake, { ...input, principalId });
@@ -220,12 +210,13 @@ export async function grantLakeAccess(
  */
 export async function revokeLakeAccess(
   actor: ManageActor,
-  dataLakeId: string,
+  lake: IDataLakeDocument,
+  grants: LakeGrant[],
   input: RevokeLakeAccessInput,
   adapters: ManageLakeGrantAdapters
 ): Promise<RevokeLakeAccessResult> {
   const { db, logger } = adapters;
-  const { lake, grants } = await loadManageableLake(actor, dataLakeId, adapters);
+  assertManageableLake(lake, actor, grants);
 
   const existing = await db.dataLakeAccessGrants.findGrant(lake.id, input.principalType, input.principalId);
   if (!existing) return { revoked: false };

--- a/b4m-core/services/src/dataLakeService/transferLakeOwnership.test.ts
+++ b/b4m-core/services/src/dataLakeService/transferLakeOwnership.test.ts
@@ -33,13 +33,16 @@ const makeAdapters = (
   return {
     upsertGrant,
     update,
+    // The resolved (lake, grants) pair the API route reads from its access gate and hands to the
+    // service, spread into each call below so the real argument order stays visible at the call site.
+    lakeArgs: [
+      over.lakeDoc === undefined ? lake() : over.lakeDoc,
+      (over.grants ?? []).map(g => ({ principalType: g.principalType, principalId: g.principalId, role: g.role })),
+    ] as const,
     adapters: {
       db: {
-        dataLakes: { findById: vi.fn(async () => (over.lakeDoc === undefined ? lake() : over.lakeDoc)), update },
-        dataLakeAccessGrants: {
-          listByLake: vi.fn(async () => over.grants ?? []),
-          upsertGrant,
-        },
+        dataLakes: { update },
+        dataLakeAccessGrants: { upsertGrant },
         users: { findById: vi.fn(async () => (over.userExists === false ? null : ({ id: 'newOwner' } as never))) },
         organizations: {
           // Default roster carries every principal the tests below hand a lake to, so the org
@@ -61,16 +64,21 @@ const owner: LakeTransferActor = { userId: 'creator', isAdmin: false, organizati
 
 describe('transferLakeOwnership', () => {
   it('refuses a fallback (registry) lake - it has no document to hang a grant on', async () => {
-    const { adapters } = makeAdapters({ lakeDoc: lake({ id: DATA_LAKES[0].id }) });
-    await expect(transferLakeOwnership(owner, DATA_LAKES[0].id, 'newOwner', adapters)).rejects.toThrow(
+    const { adapters, lakeArgs } = makeAdapters({ lakeDoc: lake({ id: DATA_LAKES[0].id }) });
+    await expect(transferLakeOwnership(owner, ...lakeArgs, 'newOwner', adapters)).rejects.toThrow(
       /built into the platform/i
     );
   });
 
   it('rejects an actor who is neither admin, effective owner, nor an admin of the lake org', async () => {
-    const { adapters, upsertGrant } = makeAdapters();
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters();
     await expect(
-      transferLakeOwnership({ userId: 'stranger', isAdmin: false, organizationIds: [] }, 'lake1', 'newOwner', adapters)
+      transferLakeOwnership(
+        { userId: 'stranger', isAdmin: false, organizationIds: [] },
+        ...lakeArgs,
+        'newOwner',
+        adapters
+      )
     ).rejects.toThrow(/do not have permission to transfer/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
@@ -79,18 +87,18 @@ describe('transferLakeOwnership', () => {
     // The picker offers no candidates for an org-less lake, so the write path must not stay broader:
     // otherwise anyone holding a user id could hand that user a lake - and with it, since #2495, the
     // lake's systemPrompt into their system messages on any turn that retrieves from it.
-    const { adapters, upsertGrant } = makeAdapters({ lakeDoc: lake({ organizationId: undefined }) });
-    await expect(transferLakeOwnership(owner, 'lake1', 'newOwner', adapters)).rejects.toThrow(
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ lakeDoc: lake({ organizationId: undefined }) });
+    await expect(transferLakeOwnership(owner, ...lakeArgs, 'newOwner', adapters)).rejects.toThrow(
       /personal data lake cannot be transferred/i
     );
     expect(upsertGrant).not.toHaveBeenCalled();
   });
 
   it('personal lake: a platform admin may still transfer it', async () => {
-    const { adapters, upsertGrant } = makeAdapters({ lakeDoc: lake({ organizationId: undefined }) });
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({ lakeDoc: lake({ organizationId: undefined }) });
     const result = await transferLakeOwnership(
       { userId: 'root', isAdmin: true, organizationIds: [] },
-      'lake1',
+      ...lakeArgs,
       'newOwner',
       adapters
     );
@@ -99,13 +107,13 @@ describe('transferLakeOwnership', () => {
   });
 
   it('rejects a new owner that does not exist', async () => {
-    const { adapters } = makeAdapters({ userExists: false });
-    await expect(transferLakeOwnership(owner, 'lake1', 'ghost', adapters)).rejects.toThrow(/could not be found/i);
+    const { adapters, lakeArgs } = makeAdapters({ userExists: false });
+    await expect(transferLakeOwnership(owner, ...lakeArgs, 'ghost', adapters)).rejects.toThrow(/could not be found/i);
   });
 
   it('transfers by granting the new owner and demoting the prior (fallback) creator to curator', async () => {
-    const { adapters, upsertGrant, update } = makeAdapters();
-    const result = await transferLakeOwnership(owner, 'lake1', 'newOwner', adapters);
+    const { adapters, lakeArgs, upsertGrant, update } = makeAdapters();
+    const result = await transferLakeOwnership(owner, ...lakeArgs, 'newOwner', adapters);
 
     expect(upsertGrant).toHaveBeenCalledWith(
       expect.objectContaining({ principalType: 'user', principalId: 'newOwner', role: 'owner' })
@@ -127,11 +135,13 @@ describe('transferLakeOwnership', () => {
     // The grants above have already moved ownership, so throwing here would report a failure that
     // did not happen and invite a retry of a finished operation - but a silent swallow would leave
     // the stamp quietly naming an older, smaller edit.
-    const { adapters, update } = makeAdapters();
+    const { adapters, lakeArgs, update } = makeAdapters();
     update.mockRejectedValueOnce(new Error('mongo down'));
     const logger = { warn: vi.fn() };
 
-    await expect(transferLakeOwnership(owner, 'lake1', 'newOwner', { ...adapters, logger } as never)).resolves.toEqual({
+    await expect(
+      transferLakeOwnership(owner, ...lakeArgs, 'newOwner', { ...adapters, logger } as never)
+    ).resolves.toEqual({
       newOwnerUserId: 'newOwner',
       demotedUserIds: ['creator'],
     });
@@ -142,14 +152,16 @@ describe('transferLakeOwnership', () => {
   });
 
   it('reports a stamp that matched no document, which resolves null instead of throwing', async () => {
-    // `BaseModel.update` is a findOneAndUpdate: a lake deleted between this function's opening
-    // findById and the final stamp write resolves NULL rather than throwing, so the catch never sees
-    // it. Without the result check that failure is completely silent.
-    const { adapters, update } = makeAdapters();
+    // `BaseModel.update` is a findOneAndUpdate: a lake deleted between the route's access gate,
+    // where this lake was resolved, and the final stamp write resolves NULL rather than throwing, so
+    // the catch never sees it. Without the result check that failure is completely silent.
+    const { adapters, lakeArgs, update } = makeAdapters();
     update.mockResolvedValueOnce(null as never);
     const logger = { warn: vi.fn() };
 
-    await expect(transferLakeOwnership(owner, 'lake1', 'newOwner', { ...adapters, logger } as never)).resolves.toEqual({
+    await expect(
+      transferLakeOwnership(owner, ...lakeArgs, 'newOwner', { ...adapters, logger } as never)
+    ).resolves.toEqual({
       newOwnerUserId: 'newOwner',
       demotedUserIds: ['creator'],
     });
@@ -162,12 +174,12 @@ describe('transferLakeOwnership', () => {
   it('still reports the failed stamp when no logger is wired, rather than going silent', async () => {
     // `logger` is optional on the adapters, so a caller that omits it must not turn a swallowed
     // failure into no output at all - the only other symptom is a stamp naming an older, smaller edit.
-    const { adapters, update } = makeAdapters();
+    const { adapters, lakeArgs, update } = makeAdapters();
     update.mockRejectedValueOnce(new Error('mongo down'));
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     try {
-      await expect(transferLakeOwnership(owner, 'lake1', 'newOwner', adapters)).resolves.toEqual({
+      await expect(transferLakeOwnership(owner, ...lakeArgs, 'newOwner', adapters)).resolves.toEqual({
         newOwnerUserId: 'newOwner',
         demotedUserIds: ['creator'],
       });
@@ -183,20 +195,20 @@ describe('transferLakeOwnership', () => {
   it('does not write the lake at all when the actor has no id to attribute', async () => {
     // The stamp write exists only to record WHO; with nobody to record it must not cost a round
     // trip, and it must not clear a prior stamp that WAS attributable.
-    const { adapters, update } = makeAdapters();
-    await transferLakeOwnership({ userId: '', isAdmin: true, organizationIds: [] }, 'lake1', 'newOwner', adapters);
+    const { adapters, lakeArgs, update } = makeAdapters();
+    await transferLakeOwnership({ userId: '', isAdmin: true, organizationIds: [] }, ...lakeArgs, 'newOwner', adapters);
 
     expect(update).not.toHaveBeenCalled();
   });
 
   it('demotes a PRIOR owner-grant holder (not the creator) when ownership was already transferred once', async () => {
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       grants: [activeGrant({ principalId: 'prevOwner', role: 'owner' })],
     });
     // prevOwner is the current effective owner and may transfer onward.
     const result = await transferLakeOwnership(
       { userId: 'prevOwner', isAdmin: false, organizationIds: ['org1'] },
-      'lake1',
+      ...lakeArgs,
       'newOwner',
       adapters
     );
@@ -205,8 +217,8 @@ describe('transferLakeOwnership', () => {
   });
 
   it('is a no-op demotion when transferring to the current sole owner', async () => {
-    const { adapters, upsertGrant } = makeAdapters();
-    const result = await transferLakeOwnership(owner, 'lake1', 'creator', adapters);
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters();
+    const result = await transferLakeOwnership(owner, ...lakeArgs, 'creator', adapters);
     expect(result.demotedUserIds).toEqual([]);
     // Only the owner upsert runs; nobody is demoted to curator.
     expect(upsertGrant).toHaveBeenCalledTimes(1);
@@ -214,17 +226,17 @@ describe('transferLakeOwnership', () => {
   });
 
   it('org lake: refuses a new owner who is not a member of the owning org', async () => {
-    const { adapters } = makeAdapters({
+    const { adapters, lakeArgs } = makeAdapters({
       lakeDoc: lake({ organizationId: 'org1' }),
       org: { userId: 'billing', adminUserIds: [], users: [{ userId: 'creator' }] },
     });
-    await expect(transferLakeOwnership(owner, 'lake1', 'newOwner', adapters)).rejects.toThrow(
+    await expect(transferLakeOwnership(owner, ...lakeArgs, 'newOwner', adapters)).rejects.toThrow(
       /must belong to the organization/i
     );
   });
 
   it('org lake: allows an org admin to transfer to an org member (orphaned-creator succession)', async () => {
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       lakeDoc: lake({ organizationId: 'org1', createdByUserId: 'departed' }),
       org: { userId: 'billing', adminUserIds: [], users: [{ userId: 'newOwner' }] },
     });
@@ -234,13 +246,13 @@ describe('transferLakeOwnership', () => {
       administeredOrgIds: ['org1'],
       organizationIds: ['org1'],
     };
-    const result = await transferLakeOwnership(orgAdmin, 'lake1', 'newOwner', adapters);
+    const result = await transferLakeOwnership(orgAdmin, ...lakeArgs, 'newOwner', adapters);
     expect(result.newOwnerUserId).toBe('newOwner');
     expect(upsertGrant).toHaveBeenCalledWith(expect.objectContaining({ principalId: 'newOwner', role: 'owner' }));
   });
 
   it('consent guard (B4): forbids an org admin from transferring the lake to THEMSELVES', async () => {
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       lakeDoc: lake({ organizationId: 'org1', createdByUserId: 'departed' }),
       org: { userId: 'billing', adminUserIds: ['orgAdmin'], users: [{ userId: 'orgAdmin' }] },
     });
@@ -250,7 +262,7 @@ describe('transferLakeOwnership', () => {
       administeredOrgIds: ['org1'],
       organizationIds: ['org1'],
     };
-    await expect(transferLakeOwnership(orgAdmin, 'lake1', 'orgAdmin', adapters)).rejects.toThrow(
+    await expect(transferLakeOwnership(orgAdmin, ...lakeArgs, 'orgAdmin', adapters)).rejects.toThrow(
       /cannot transfer a data lake to themselves/i
     );
     expect(upsertGrant).not.toHaveBeenCalled();
@@ -259,12 +271,17 @@ describe('transferLakeOwnership', () => {
   it('org lake: refuses an owner who has left the owning org, even holding the owner grant', async () => {
     // Lake grants are not revoked on org departure, so the grant alone must not authorize a write
     // that hands the lake on (and, through the picker, discloses the org's roster).
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       lakeDoc: lake({ organizationId: 'org1' }),
       org: { userId: 'billing', adminUserIds: [], users: [{ userId: 'newOwner' }] },
     });
     await expect(
-      transferLakeOwnership({ userId: 'creator', isAdmin: false, organizationIds: [] }, 'lake1', 'newOwner', adapters)
+      transferLakeOwnership(
+        { userId: 'creator', isAdmin: false, organizationIds: [] },
+        ...lakeArgs,
+        'newOwner',
+        adapters
+      )
     ).rejects.toThrow(/do not have permission to transfer/i);
     expect(upsertGrant).not.toHaveBeenCalled();
   });
@@ -272,12 +289,12 @@ describe('transferLakeOwnership', () => {
   it('a platform admin MAY transfer a lake to themselves (superuser, exempt from the consent guard)', async () => {
     // A personal lake, which only a platform admin may transfer at all - so this covers the consent
     // guard's admin exemption without also dragging in the org roster check on the recipient.
-    const { adapters, upsertGrant } = makeAdapters({
+    const { adapters, lakeArgs, upsertGrant } = makeAdapters({
       lakeDoc: lake({ createdByUserId: 'someoneElse', organizationId: undefined }),
     });
     const result = await transferLakeOwnership(
       { userId: 'root', isAdmin: true, organizationIds: [] },
-      'lake1',
+      ...lakeArgs,
       'root',
       adapters
     );
@@ -287,11 +304,11 @@ describe('transferLakeOwnership', () => {
 
   it('the current owner MAY transfer to themselves (no-op-ish; exempt from the consent guard)', async () => {
     // Owner authorized as effective owner, not via the org-admin rung, so the guard does not apply.
-    const { adapters } = makeAdapters({
+    const { adapters, lakeArgs } = makeAdapters({
       lakeDoc: lake({ organizationId: 'org1', createdByUserId: 'creator' }),
       org: { users: [{ userId: 'creator' }] },
     });
-    const result = await transferLakeOwnership(owner, 'lake1', 'creator', adapters);
+    const result = await transferLakeOwnership(owner, ...lakeArgs, 'creator', adapters);
     expect(result.newOwnerUserId).toBe('creator');
   });
 });

--- a/b4m-core/services/src/dataLakeService/transferLakeOwnership.ts
+++ b/b4m-core/services/src/dataLakeService/transferLakeOwnership.ts
@@ -183,8 +183,8 @@ export const transferLakeOwnership = async (
       // gate (where this lake was resolved) and this final write - several awaits apart: grant
       // upserts, user and org lookups - would no-op with no exception for the catch to see. The
       // window is one round-trip wider than when this function resolved the lake itself. Checking
-      // the result is what
-      // makes "never fails silently" true for BOTH shapes, not just the throwing one.
+      // the result is what makes "never fails silently" true for BOTH shapes, not just the
+      // throwing one.
       const stamped = await db.dataLakes.update({ id: lake.id, ...stamp });
       if (!stamped) {
         warn('[dataLakes] ownership transferred but the lake was not found for the actor stamp', {

--- a/b4m-core/services/src/dataLakeService/transferLakeOwnership.ts
+++ b/b4m-core/services/src/dataLakeService/transferLakeOwnership.ts
@@ -1,13 +1,13 @@
 import type {
   IDataLakeAccessGrantRepository,
+  IDataLakeDocument,
   IDataLakeRepository,
   IOrganizationRepository,
   IUserRepository,
 } from '@bike4mind/common';
-import { BadRequestError, NotFoundError, normalizeId } from '@bike4mind/utils';
-import { resolveEffectiveOwnerIds } from './manageRule';
+import { BadRequestError, normalizeId } from '@bike4mind/utils';
+import { resolveEffectiveOwnerIds, type LakeGrant } from './manageRule';
 import { assertLakeGrantable } from './assertLakeAccess';
-import { loadActiveLakeGrants } from './authorizeLakeManage';
 import {
   isOrgOwnershipCandidate,
   resolveLakeTransferAuthority,
@@ -25,8 +25,8 @@ interface TransferLakeOwnershipAdapters extends LakeConfigAuditAdapters {
   // that into a compile error.
   db: LakeConfigAuditAdapters['db'] & {
     lakeConfigChangeEvents: NonNullable<LakeConfigAuditAdapters['db']['lakeConfigChangeEvents']>;
-    dataLakes: Pick<IDataLakeRepository, 'findById' | 'update'>;
-    dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'listByLake' | 'upsertGrant'>;
+    dataLakes: Pick<IDataLakeRepository, 'update'>;
+    dataLakeAccessGrants: Pick<IDataLakeAccessGrantRepository, 'upsertGrant'>;
     users: Pick<IUserRepository, 'findById'>;
     organizations: Pick<IOrganizationRepository, 'findById'>;
   };
@@ -84,18 +84,14 @@ export interface TransferLakeOwnershipResult {
  */
 export const transferLakeOwnership = async (
   actor: LakeTransferActor,
-  dataLakeId: string,
+  lake: IDataLakeDocument,
+  grants: LakeGrant[],
   newOwnerUserId: string,
   { db, logger }: TransferLakeOwnershipAdapters
 ): Promise<TransferLakeOwnershipResult> => {
-  const lake = await db.dataLakes.findById(dataLakeId);
-  if (!lake) {
-    throw new NotFoundError('Data lake not found');
-  }
   // Fallback lakes have no document and no createdByUserId to seed from - grants are refused.
   assertLakeGrantable(lake);
 
-  const grants = await loadActiveLakeGrants(lake, { db });
   const lakeOrg = normalizeId(lake.organizationId);
   // Shared with the candidate listing behind the transfer picker, so the option set a manager is
   // offered and the gate this write applies can never drift apart.
@@ -183,9 +179,11 @@ export const transferLakeOwnership = async (
     const warn = (msg: string, meta: unknown) => (logger ? logger.warn(msg, meta) : console.warn(msg, meta));
     try {
       // The return value matters as much as the throw: `BaseModel.update` is a `findOneAndUpdate`
-      // that RESOLVES `null` when no document matches, so a lake deleted between this function's
-      // opening `findById` and this final write (several awaits apart - grant upserts, user and org
-      // lookups) would no-op with no exception for the catch to see. Checking the result is what
+      // that RESOLVES `null` when no document matches, so a lake deleted between the route's access
+      // gate (where this lake was resolved) and this final write - several awaits apart: grant
+      // upserts, user and org lookups - would no-op with no exception for the catch to see. The
+      // window is one round-trip wider than when this function resolved the lake itself. Checking
+      // the result is what
       // makes "never fails silently" true for BOTH shapes, not just the throwing one.
       const stamped = await db.dataLakes.update({ id: lake.id, ...stamp });
       if (!stamped) {


### PR DESCRIPTION
## Description
The grant, revoke and transfer-ownership doors each resolved the target lake and its active grants twice per request: once in the access gate that decides whether the caller may act, and again inside the service call that does the write. This PR makes each door pass through what the gate already read instead of re-querying.

## Changes
- `assertLakeAccess.ts`: new `assertLakeAccessWithGrants` returns `{ lake, grants }` alongside the existing `assertLakeAccess`, which stays a thin wrapper so its ~57 existing callers are untouched.
- `manageLakeGrant.ts`: `loadManageableLake` splits into a pure `assertManageableLake`; `grantLakeAccess` / `revokeLakeAccess` now take an already-resolved lake and grant list instead of re-fetching them.
- `transferLakeOwnership.ts`: same shape, same fix.
- `apps/client/pages/api/data-lakes/[id]/{grants,transfer-ownership,access}.ts`: routes now forward the lake and grants the access gate already loaded instead of discarding them.
- No change to who may grant, revoke or transfer, or to any refusal message - only the read count changed.

## Guide for Testers
This is a backend-only refactor with no UI surface and no behavior change for callers.

**What NOT to test:** there is nothing to click through in the app - the grant/revoke/transfer-ownership flows behave identically from a user's perspective. Verification is via the automated test suite below.

**Regression checks (for a reviewer running locally):**
1. `pnpm --filter @bike4mind/services test` - all data-lake grant/revoke/transfer suites pass.
2. `pnpm --filter @bike4mind/client exec vitest run --project node data-lakes` - route-level tests pass, including a new test asserting `dataLakes.findById` and `dataLakeAccessGrants.listByLake` are each called exactly once per POST/DELETE `/grants` request (both were called twice before this change).

## Additional Information
Verified before opening this PR:
- `pnpm --filter @bike4mind/services test` - 6693 passed, 12 skipped.
- `pnpm turbo:typecheck` - 40/40 tasks passed.
- `pnpm lint:check` - clean.
- `apps/client` node-lane data-lake route tests - 439 passed.

This branch went through an internal design + review pass before this PR. Three non-blocking follow-ups were identified and are being carried forward as future work rather than blocking this change (the shipped behavior is correct today):

- [ ] Give `assertLakeAccessWithGrants` its own adapter type with `dataLakeAccessGrants` required, instead of reusing the adapter type whose optionality exists for the higher-fan-in read callers - restores a compile-time guarantee that a caller can't silently pass `grants: []`.
- [ ] Add a route test proving the gate-to-door seam is load-bearing (a non-creator curator's grant should actually reach the write), not just that read counts are low.
- [ ] Tighten the new read-count assertions to check call arguments (e.g. `activeAsOf`), not just call count, so a correctness regression in what's read can't hide behind a passing count check.

## Developer Notes (Optional)
- `assertLakeAccessWithGrants` is a new seam alongside `assertLakeAccess` - a natural next step (out of scope here) is migrating other high-fan-in callers that currently re-read grants after calling `assertLakeAccess`.
- `listLakeOwnershipCandidates` (the transfer route's GET) has the same double-read shape and was intentionally left out of this change as a separate slice.

## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, backend-only
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2559
