### PR TITLE
fix(websocket): re-check scope and ownership in Connection-only handlers

### DIFF
--- a/apps/client/pages/api/jupyter/execute.ts
+++ b/apps/client/pages/api/jupyter/execute.ts
@@ -88,9 +88,11 @@ const handler = baseApi({ auth: true }).post(async (req, res) => {
         return source.trim().length > 0;
       }).length;
 
-      // Use findOneAndUpdate with userId filter to prevent unauthorized quest modification
+      // Owner-scoped so a caller cannot drive execution on someone else's quest.
+      // `promptMeta.session.userId` is the Quest's owner field - the schema declares no top-level
+      // `userId`, so the filter this used to carry could never match and the route always 403'd.
       const updatedQuest = await Quest.findOneAndUpdate(
-        { _id: questId, userId },
+        { _id: questId, 'promptMeta.session.userId': userId },
         {
           $set: {
             'jupyterNotebook.status': 'executing',

--- a/apps/client/pages/api/jupyter/progress.ts
+++ b/apps/client/pages/api/jupyter/progress.ts
@@ -65,7 +65,13 @@ const handler = baseApi({ auth: true }).post(async (req, res) => {
     }
   }
 
-  const updated = await Quest.findOneAndUpdate({ _id: questId, userId }, { $set: updateData }, { new: true });
+  // `promptMeta.session.userId`, not `userId`: the Quest schema declares no top-level owner
+  // field, so the filter this used to carry could never match and the route always 403'd.
+  const updated = await Quest.findOneAndUpdate(
+    { _id: questId, 'promptMeta.session.userId': userId },
+    { $set: updateData },
+    { new: true }
+  );
 
   if (!updated) {
     return res.status(403).json({ error: 'Quest not found or access denied' });

--- a/apps/client/server/api/jupyter/__tests__/execute.test.ts
+++ b/apps/client/server/api/jupyter/__tests__/execute.test.ts
@@ -233,9 +233,11 @@ describe('/api/jupyter/execute', () => {
       const { default: handler } = await import('@client/pages/api/jupyter/execute');
       await handler(mockReq as any, mockRes as any);
 
-      // Uses findOneAndUpdate with userId filter for ownership check
+      // Ownership predicate is `promptMeta.session.userId` - the Quest schema declares no
+      // top-level `userId`, so the filter this used to assert could never match a real document
+      // and the route 403'd every caller. The mock made it look correct.
       expect(Quest.findOneAndUpdate).toHaveBeenCalledWith(
-        { _id: 'quest-456', userId: 'user-123' },
+        { _id: 'quest-456', 'promptMeta.session.userId': 'user-123' },
         expect.objectContaining({
           $set: expect.objectContaining({
             'jupyterNotebook.status': 'executing',

--- a/apps/client/server/websocket/__tests__/jupyterNotebookProgress.test.ts
+++ b/apps/client/server/websocket/__tests__/jupyterNotebookProgress.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 vi.mock('@bike4mind/database/content', () => ({
   Quest: {
     findOne: vi.fn(),
-    findByIdAndUpdate: vi.fn(),
+    findOneAndUpdate: vi.fn(),
   },
 }));
 
@@ -111,6 +111,28 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
     });
   });
 
+  describe('scope validation', () => {
+    it('drops the frame when the socket was opened with a bridge-only key', async () => {
+      // cc-bridge:connect is enough to pass $connect, so this socket is authenticated - it just
+      // has no authority to mutate notebook execution state.
+      mockEvent.body = createCellOutputBody();
+      (Connection.findOne as Mock).mockResolvedValue({
+        connectionId: 'conn-123',
+        userId: 'user-456',
+        scopes: ['cc-bridge:connect'],
+      });
+
+      const { func } = await import('../jupyterNotebookProgress');
+      const result = await func(mockEvent as any, mockContext as any, mockLogger as any);
+
+      expect(result).toEqual({ statusCode: 200 });
+      expect(Quest.findOne).not.toHaveBeenCalled();
+      expect(Quest.findOneAndUpdate).not.toHaveBeenCalled();
+      expect(sendToClient).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('notebooks:write'));
+    });
+  });
+
   describe('progress handling', () => {
     beforeEach(() => {
       (Connection.findOne as Mock).mockResolvedValue({
@@ -135,7 +157,7 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
           cellCount: 5,
         },
       });
-      (Quest.findByIdAndUpdate as Mock).mockResolvedValue({});
+      (Quest.findOneAndUpdate as Mock).mockResolvedValue({});
 
       const { func } = await import('../jupyterNotebookProgress');
       const result = await func(mockEvent as any, mockContext as any, mockLogger as any);
@@ -143,8 +165,8 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
       expect(result).toEqual({ statusCode: 200 });
 
       // Should update Quest with progress
-      expect(Quest.findByIdAndUpdate).toHaveBeenCalledWith(
-        'quest-789',
+      expect(Quest.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: 'quest-789', 'promptMeta.session.userId': 'user-456' },
         expect.objectContaining({
           $set: expect.objectContaining({
             'jupyterNotebook.executedCells': 3, // cellIndex + 1 for complete
@@ -184,14 +206,14 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
         _id: 'quest-789',
         jupyterNotebook: { status: 'executing', cellCount: 3 },
       });
-      (Quest.findByIdAndUpdate as Mock).mockResolvedValue({});
+      (Quest.findOneAndUpdate as Mock).mockResolvedValue({});
 
       const { func } = await import('../jupyterNotebookProgress');
       await func(mockEvent as any, mockContext as any, mockLogger as any);
 
       // Should record error in Quest and set status to 'failed'
-      expect(Quest.findByIdAndUpdate).toHaveBeenCalledWith(
-        'quest-789',
+      expect(Quest.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: 'quest-789', 'promptMeta.session.userId': 'user-456' },
         expect.objectContaining({
           $set: expect.objectContaining({
             'jupyterNotebook.lastError': "NameError: name 'x' is not defined",
@@ -224,14 +246,14 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
         _id: 'quest-789',
         jupyterNotebook: { status: 'executing', cellCount: 3 },
       });
-      (Quest.findByIdAndUpdate as Mock).mockResolvedValue({});
+      (Quest.findOneAndUpdate as Mock).mockResolvedValue({});
 
       const { func } = await import('../jupyterNotebookProgress');
       await func(mockEvent as any, mockContext as any, mockLogger as any);
 
       // Should set status to completed
-      expect(Quest.findByIdAndUpdate).toHaveBeenCalledWith(
-        'quest-789',
+      expect(Quest.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: 'quest-789', 'promptMeta.session.userId': 'user-456' },
         expect.objectContaining({
           $set: expect.objectContaining({
             'jupyterNotebook.status': 'completed',
@@ -253,14 +275,14 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
         _id: 'quest-789',
         jupyterNotebook: { status: 'executing', cellCount: 3 },
       });
-      (Quest.findByIdAndUpdate as Mock).mockResolvedValue({});
+      (Quest.findOneAndUpdate as Mock).mockResolvedValue({});
 
       const { func } = await import('../jupyterNotebookProgress');
       await func(mockEvent as any, mockContext as any, mockLogger as any);
 
       // Should update executedCells without incrementing (isComplete=false)
-      expect(Quest.findByIdAndUpdate).toHaveBeenCalledWith(
-        'quest-789',
+      expect(Quest.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: 'quest-789', 'promptMeta.session.userId': 'user-456' },
         expect.objectContaining({
           $set: expect.objectContaining({
             'jupyterNotebook.executedCells': 0, // cellIndex + 0 because not complete
@@ -279,6 +301,25 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
       );
     });
 
+    it('scopes the Quest lookup to the connection owner', async () => {
+      // sessionId is caller-supplied; without the owner predicate this frame drives another
+      // user's notebook execution state.
+      mockEvent.body = createCellOutputBody();
+      (Quest.findOne as Mock).mockResolvedValue(null);
+
+      const { func } = await import('../jupyterNotebookProgress');
+      await func(mockEvent as any, mockContext as any, mockLogger as any);
+
+      expect(Quest.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'session-456',
+          'promptMeta.session.userId': 'user-456',
+        }),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
     it('should handle case when no Quest is found', async () => {
       mockEvent.body = createCellOutputBody();
       (Quest.findOne as Mock).mockResolvedValue(null);
@@ -289,7 +330,7 @@ describe('jupyterNotebookProgress WebSocket handler', () => {
       expect(result).toEqual({ statusCode: 200 });
 
       // Should not update Quest
-      expect(Quest.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(Quest.findOneAndUpdate).not.toHaveBeenCalled();
 
       // Should still relay to web clients with empty questId
       expect(sendToClient).toHaveBeenCalledWith(

--- a/apps/client/server/websocket/__tests__/keepCommandResponse.test.ts
+++ b/apps/client/server/websocket/__tests__/keepCommandResponse.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+vi.mock('@bike4mind/database/social', () => ({
+  Connection: { findOne: vi.fn() },
+}));
+
+vi.mock('@server/websocket/utils', () => ({
+  withWebSocketContext: vi.fn(
+    (handler: (event: unknown, context: unknown, logger: unknown) => Promise<unknown>) => handler
+  ),
+  sendToConnection: vi.fn(),
+}));
+
+import { Connection } from '@bike4mind/database/social';
+import { sendToConnection } from '@server/websocket/utils';
+import { func } from '../keepCommandResponse';
+
+/**
+ * `originConnectionId` is client-supplied. The sender's own Connection row proves who is
+ * SPEAKING, never who may be spoken TO, so the destination has to be resolved and matched.
+ */
+describe('keepCommandResponse relay target', () => {
+  const event = {
+    requestContext: { connectionId: 'cli-conn', domainName: 'ws.example.com', stage: 'dev' },
+    body: JSON.stringify({
+      action: 'keep_command_response',
+      requestId: 'req-1',
+      originConnectionId: 'hud-conn',
+      success: true,
+      result: { ok: true },
+    }),
+  };
+  const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+
+  const connectionsByIdReturning = (rows: Record<string, { userId: string } | null>) =>
+    (Connection.findOne as Mock).mockImplementation(
+      async ({ connectionId }: { connectionId: string }) => rows[connectionId] ?? null
+    );
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('relays to an origin connection owned by the same user', async () => {
+    connectionsByIdReturning({ 'cli-conn': { userId: 'user-1' }, 'hud-conn': { userId: 'user-1' } });
+
+    expect(await func(event as never, {} as never, logger as never)).toEqual({ statusCode: 200 });
+    expect(sendToConnection).toHaveBeenCalledWith(
+      'hud-conn',
+      'https://ws.example.com/dev',
+      expect.objectContaining({ action: 'keep_command_result', requestId: 'req-1', success: true })
+    );
+  });
+
+  it('drops a relay aimed at a connection owned by another user', async () => {
+    connectionsByIdReturning({ 'cli-conn': { userId: 'user-1' }, 'hud-conn': { userId: 'victim' } });
+
+    expect(await func(event as never, {} as never, logger as never)).toEqual({ statusCode: 200 });
+    expect(sendToConnection).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('belongs to another user'));
+  });
+
+  it('drops a relay aimed at an unknown connection', async () => {
+    connectionsByIdReturning({ 'cli-conn': { userId: 'user-1' } });
+
+    expect(await func(event as never, {} as never, logger as never)).toEqual({ statusCode: 200 });
+    expect(sendToConnection).not.toHaveBeenCalled();
+  });
+
+  it('drops the frame when the sender itself has no connection row', async () => {
+    connectionsByIdReturning({ 'hud-conn': { userId: 'user-1' } });
+
+    expect(await func(event as never, {} as never, logger as never)).toEqual({ statusCode: 200 });
+    expect(sendToConnection).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/server/websocket/__tests__/voiceSessionSendTranscript.test.ts
+++ b/apps/client/server/websocket/__tests__/voiceSessionSendTranscript.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  connectionFindOne: vi.fn(),
+  sessionFindOne: vi.fn(),
+  userFindById: vi.fn(),
+  upsertVoiceTranscriptTurn: vi.fn(),
+  ofType: vi.fn(),
+  accessibleBy: vi.fn(),
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  Connection: { findOne: mocks.connectionFindOne },
+  questRepository: { upsertVoiceTranscriptTurn: mocks.upsertVoiceTranscriptTurn },
+  userRepository: { findById: mocks.userFindById },
+}));
+
+vi.mock('@bike4mind/database/auth', () => ({
+  Session: { findOne: mocks.sessionFindOne },
+}));
+
+vi.mock('@casl/mongoose', () => ({
+  accessibleBy: (...args: unknown[]) => {
+    mocks.accessibleBy(...args);
+    return { ofType: mocks.ofType };
+  },
+}));
+
+vi.mock('@server/auth/ability', () => ({ default: vi.fn(() => ({})) }));
+
+vi.mock('@server/utils/errors', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+}));
+
+vi.mock('@server/websocket/utils', () => ({
+  withWebSocketContext: vi.fn(
+    (handler: (event: unknown, context: unknown, logger: unknown) => Promise<unknown>) => handler
+  ),
+}));
+
+import { Permission } from '@bike4mind/common';
+import { func } from '../voiceSessionSendTranscript';
+
+/**
+ * The transcript write is the one Connection-only handler that both authorizes a WRITE and picks
+ * the row it writes, so its two gaps are covered here: read-accessibility standing in for update
+ * permission, and a socket's key scope never being consulted at all.
+ */
+describe('voiceSessionSendTranscript authorization', () => {
+  const event = {
+    requestContext: { connectionId: 'conn-1' },
+    body: JSON.stringify({
+      action: 'voice_session_send_transcript',
+      userId: 'user-1',
+      sessionId: 'session-1',
+      transcript: 'hello there',
+      type: 'input',
+      conversationItemId: 'item-1',
+    }),
+  };
+  const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connectionFindOne.mockResolvedValue({ connectionId: 'conn-1', userId: 'user-1' });
+    mocks.userFindById.mockResolvedValue({ id: 'user-1' });
+    mocks.ofType.mockReturnValue({ scopeMarker: 'update-scope' });
+    mocks.sessionFindOne.mockResolvedValue({ _id: 'session-1' });
+    mocks.upsertVoiceTranscriptTurn.mockResolvedValue({});
+  });
+
+  const run = () => func(event as never, {} as never, logger as never);
+
+  it('gates the write on update permission, not read accessibility', async () => {
+    await run();
+
+    expect(mocks.accessibleBy).toHaveBeenCalledWith(expect.anything(), Permission.update);
+    expect(mocks.sessionFindOne).toHaveBeenCalledWith({ _id: 'session-1', scopeMarker: 'update-scope' });
+  });
+
+  it('binds the upsert to the caller so it cannot land on another user turn', async () => {
+    await run();
+
+    expect(mocks.upsertVoiceTranscriptTurn).toHaveBeenCalledWith(
+      'session-1',
+      'item-1',
+      'user-1',
+      expect.objectContaining({ prompt: 'hello there', type: 'voice_transcript' })
+    );
+  });
+
+  it('writes nothing when the session is readable but not writable by the caller', async () => {
+    // A sharee holding only [read, share] falls out of the accessibleBy(update) filter.
+    mocks.sessionFindOne.mockResolvedValue(null);
+
+    expect(await run()).toEqual({ statusCode: 200 });
+    expect(mocks.upsertVoiceTranscriptTurn).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing when the socket was opened with a bridge-only key', async () => {
+    mocks.connectionFindOne.mockResolvedValue({
+      connectionId: 'conn-1',
+      userId: 'user-1',
+      scopes: ['cc-bridge:connect'],
+    });
+
+    expect(await run()).toEqual({ statusCode: 200 });
+    expect(mocks.sessionFindOne).not.toHaveBeenCalled();
+    expect(mocks.upsertVoiceTranscriptTurn).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('ai:chat'), expect.anything());
+  });
+
+  it('writes nothing when the frame claims a different user than the socket owner', async () => {
+    mocks.connectionFindOne.mockResolvedValue({ connectionId: 'conn-1', userId: 'someone-else' });
+
+    expect(await run()).toEqual({ statusCode: 200 });
+    expect(mocks.upsertVoiceTranscriptTurn as Mock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/server/websocket/ccAgentRegister.ts
+++ b/apps/client/server/websocket/ccAgentRegister.ts
@@ -150,6 +150,17 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
     return { statusCode: 403 };
   }
 
+  // A register naming an instanceId that already belongs to someone else would otherwise rewrite
+  // that record's owner, device and connection - taking over a live session. This is the same
+  // ownership check cc_agent_event and cc_agent_disconnect already make; `findByInstanceId` rather
+  // than the user-scoped lookup because "not registered yet" and "registered to someone else" have
+  // to be told apart here, and only the second is a rejection.
+  const existing = await activeCodeAgentRepository.findByInstanceId(instanceId);
+  if (existing && existing.userId !== userId) {
+    logger.warn(`[CC_AGENT_REGISTER] Instance ${instanceId} is already registered to another user - rejecting`);
+    return { statusCode: 403 };
+  }
+
   const spriteId = pickSprite(instanceId);
   const position = pickSpawnPosition();
 

--- a/apps/client/server/websocket/connectionScope.test.ts
+++ b/apps/client/server/websocket/connectionScope.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { ApiKeyScope } from '@bike4mind/common';
+import { connectionHoldsScope } from './connectionScope';
+
+describe('connectionHoldsScope', () => {
+  it('passes a JWT socket, which records no scopes at all', () => {
+    expect(connectionHoldsScope({}, [ApiKeyScope.AI_CHAT])).toBe(true);
+    expect(connectionHoldsScope({ scopes: undefined }, [ApiKeyScope.AI_CHAT])).toBe(true);
+    // Mongoose materialises an unset array path as [], so absent and empty must behave alike.
+    expect(connectionHoldsScope({ scopes: [] }, [ApiKeyScope.AI_CHAT])).toBe(true);
+  });
+
+  it('refuses a bridge-only key for an action it was not minted for', () => {
+    // The whole point: $connect admits cc-bridge:connect, so this socket exists and is
+    // authenticated - it just has no authority over voice billing or notebook state.
+    expect(connectionHoldsScope({ scopes: [ApiKeyScope.CC_BRIDGE] }, [ApiKeyScope.AI_CHAT])).toBe(false);
+    expect(connectionHoldsScope({ scopes: [ApiKeyScope.CC_BRIDGE] }, [ApiKeyScope.WRITE_NOTEBOOKS])).toBe(false);
+  });
+
+  it('passes a key holding any one of the required scopes', () => {
+    expect(connectionHoldsScope({ scopes: [ApiKeyScope.AI_CHAT] }, [ApiKeyScope.AI_CHAT])).toBe(true);
+    expect(
+      connectionHoldsScope({ scopes: [ApiKeyScope.CC_BRIDGE, ApiKeyScope.AI_CHAT] }, [
+        ApiKeyScope.AI_GENERATE,
+        ApiKeyScope.AI_CHAT,
+      ])
+    ).toBe(true);
+  });
+
+  it('does not treat admin:* as a wildcard', () => {
+    // decideScopeGate uses a plain `includes`, and this gate must not be more permissive than it.
+    expect(connectionHoldsScope({ scopes: [ApiKeyScope.ADMIN] }, [ApiKeyScope.AI_CHAT])).toBe(false);
+  });
+
+  it("says nothing about a missing connection - that is the caller's check", () => {
+    // Every caller rejects an unknown connectionId before reaching this gate; the null tolerance
+    // exists so a future caller cannot crash here, NOT so a missing row can authorize anything.
+    expect(connectionHoldsScope(null, [ApiKeyScope.AI_CHAT])).toBe(true);
+  });
+});

--- a/apps/client/server/websocket/connectionScope.ts
+++ b/apps/client/server/websocket/connectionScope.ts
@@ -1,0 +1,30 @@
+import { ApiKeyScope } from '@bike4mind/common';
+
+/**
+ * Per-action scope gate for the WebSocket handlers that authorize on the Connection row alone.
+ *
+ * `$connect` (connect.ts) admits an API key holding ANY ONE of `ai:generate` / `ai:chat` /
+ * `cc-bridge:connect` and persists that key's whole scope list on the Connection row. Nothing
+ * downstream read it back, so a socket opened with a bridge-only key could then send any frame
+ * the transport accepts. Each Connection-only handler names the scope its own action needs and
+ * calls this before acting - the comment at connect.ts anticipated exactly this check.
+ *
+ * An empty or absent scope list passes. That is not a hole: it means no delegated credential is
+ * recorded on the row, which is a JWT socket - a full user session, not a narrowed key - and
+ * `resolveIdentity` will not admit an API key holding none of the three connect scopes, so a
+ * scopeless key cannot reach a handler in the first place. Absent and empty are treated alike
+ * because Mongoose materialises an unset array path as `[]`.
+ *
+ * OR semantics over `required`, matching `decideScopeGate` (apiKeyScopeGate.ts) so the two gates
+ * cannot come to read differently. There is deliberately no staging escape hatch, for the reason
+ * that file gives for `verifyApiKey`: every sender of these actions today is a browser or the CLI
+ * on a JWT socket, so there is no grandfathered API-key population a grace period could rescue.
+ */
+export function connectionHoldsScope(
+  connection: { scopes?: string[] | null } | null | undefined,
+  required: ApiKeyScope[]
+): boolean {
+  const held = connection?.scopes;
+  if (!held?.length) return true;
+  return required.some(scope => held.includes(scope));
+}

--- a/apps/client/server/websocket/jupyterNotebookProgress.ts
+++ b/apps/client/server/websocket/jupyterNotebookProgress.ts
@@ -1,6 +1,7 @@
-import { JupyterCellOutputAction } from '@bike4mind/common';
+import { ApiKeyScope, JupyterCellOutputAction } from '@bike4mind/common';
 import { Quest } from '@bike4mind/database/content';
 import { Connection } from '@bike4mind/database/social';
+import { connectionHoldsScope } from '@server/websocket/connectionScope';
 import { withWebSocketContext, sendToClient } from '@server/websocket/utils';
 import { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
 
@@ -34,13 +35,27 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
     return { statusCode: 200 };
   }
 
+  // This frame mutates notebook execution state, which notebooks:write is the scope for. A socket
+  // opened with a narrower key has no authority here - notably cc-bridge:connect, which is enough
+  // to pass $connect on its own. A key holding notebooks:write alongside one of the three connect
+  // scopes still passes, which is the intended shape: the gate narrows the credential, it does not
+  // ban API keys from the action.
+  if (!connectionHoldsScope(connection, [ApiKeyScope.WRITE_NOTEBOOKS])) {
+    logger.warn(`[JUPYTER_OUTPUT] Connection ${connectionId} lacks notebooks:write - dropping cell output`);
+    return { statusCode: 200 };
+  }
+
   const userId = connection.userId;
   logger.info(`[JUPYTER_OUTPUT] Cell ${cellIndex} output (type: ${outputType}, complete: ${isComplete})`);
 
-  // Find the most recent quest in this session with jupyterNotebook state
+  // Owner-scoped: sessionId is caller-supplied, so without this predicate any authenticated
+  // socket could drive another user's notebook execution state. `promptMeta.session.userId` is
+  // the quest's owner field - the Quest schema has no top-level `userId` (see the note in
+  // pages/api/jupyter/execute.ts).
   const quest = await Quest.findOne(
     {
       sessionId,
+      'promptMeta.session.userId': userId,
       'jupyterNotebook.status': { $in: ['generating', 'executing'] },
     },
     {},
@@ -75,7 +90,9 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
       }
     }
 
-    await Quest.findByIdAndUpdate(quest._id, { $set: updateData });
+    // Re-assert ownership on the write, not just the read: the quest was selected under the
+    // caller's own predicate, so this only closes the gap between the two queries.
+    await Quest.findOneAndUpdate({ _id: quest._id, 'promptMeta.session.userId': userId }, { $set: updateData });
   }
 
   // Relay the cell output to web clients only for real-time display

--- a/apps/client/server/websocket/keepCommandResponse.ts
+++ b/apps/client/server/websocket/keepCommandResponse.ts
@@ -12,6 +12,12 @@ import { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
  *
  * Authentication: The CLI's connection was verified during $connect, so we
  * validate the sender by checking the Connection model for the connectionId.
+ *
+ * `originConnectionId` is client-supplied, so the destination is resolved back to a Connection
+ * row and must belong to the SAME user as the sender. keepCommandRequest only ever hands the
+ * value to that user's own sockets (it fans out via sendToClient), so the legitimate flow always
+ * satisfies this; anything else is a caller naming a stranger's socket to push a forged
+ * keep_command_result into their HUD.
  */
 export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async (event, _context, logger) => {
   const { connectionId, domainName, stage } = event.requestContext;
@@ -31,6 +37,14 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
   const connection = await Connection.findOne({ connectionId });
   if (!connection) {
     logger.error(`[KEEP_CMD_RESP] Unknown connectionId: ${connectionId}`);
+    return { statusCode: 200 };
+  }
+
+  const destination = await Connection.findOne({ connectionId: originConnectionId });
+  if (!destination || destination.userId !== connection.userId) {
+    logger.warn(
+      `[KEEP_CMD_RESP] Dropping relay for request ${requestId}: originConnectionId ${originConnectionId} is unknown or belongs to another user`
+    );
     return { statusCode: 200 };
   }
 

--- a/apps/client/server/websocket/voiceSessionEnded.ts
+++ b/apps/client/server/websocket/voiceSessionEnded.ts
@@ -1,7 +1,13 @@
 import { withWebSocketContext, sendToClient } from '@server/websocket/utils';
 import { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
 import { pickRealtimeVoiceTier } from '@server/voice/realtimeVoicePricing';
-import { CreditHolderType, IModelPrice, VoiceSessionEndedAction, computeRealtimeVoiceUsd } from '@bike4mind/common';
+import {
+  ApiKeyScope,
+  CreditHolderType,
+  IModelPrice,
+  VoiceSessionEndedAction,
+  computeRealtimeVoiceUsd,
+} from '@bike4mind/common';
 import { getSettingsMap, getSettingsValue, NotFoundError, usdToCreditsStochastic } from '@bike4mind/utils';
 import {
   adminSettingsRepository,
@@ -13,6 +19,7 @@ import {
   userRepository,
 } from '@bike4mind/database';
 import { sessionService, creditService } from '@bike4mind/services';
+import { connectionHoldsScope } from '@server/websocket/connectionScope';
 
 export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async (event, context, logger) => {
   const { userId, sessionId, model, usage } = VoiceSessionEndedAction.parse(JSON.parse(event.body ?? ''));
@@ -24,6 +31,16 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
   const connection = await Connection.findOne({ connectionId });
   if (!connection || connection.userId !== userId) {
     logger.warn('voiceSessionEnded userId mismatch or unknown connection - rejecting', {
+      connectionId,
+      claimedUserId: userId,
+    });
+    return { statusCode: 200 };
+  }
+
+  // This frame settles credits. Owning the socket is not enough authority for that: a key minted
+  // only to run the cc-bridge can open one, and must not be able to move its owner's balance.
+  if (!connectionHoldsScope(connection, [ApiKeyScope.AI_CHAT])) {
+    logger.warn('voiceSessionEnded from a connection without ai:chat scope - rejecting', {
       connectionId,
       claimedUserId: userId,
     });

--- a/apps/client/server/websocket/voiceSessionSendTranscript.ts
+++ b/apps/client/server/websocket/voiceSessionSendTranscript.ts
@@ -1,7 +1,10 @@
-import { Connection, questRepository, sessionRepository, userRepository } from '@bike4mind/database';
-import { VoiceSessionSendTranscriptAction } from '@bike4mind/common';
-import { sessionService } from '@bike4mind/services';
+import { Connection, questRepository, userRepository } from '@bike4mind/database';
+import { Session as SessionModel } from '@bike4mind/database/auth';
+import { ApiKeyScope, Permission, VoiceSessionSendTranscriptAction } from '@bike4mind/common';
+import { accessibleBy } from '@casl/mongoose';
+import ability from '@server/auth/ability';
 import { NotFoundError } from '@server/utils/errors';
+import { connectionHoldsScope } from '@server/websocket/connectionScope';
 import { withWebSocketContext } from '@server/websocket/utils';
 import { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
 
@@ -16,7 +19,17 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
   const connectionId = event.requestContext.connectionId;
   const connection = await Connection.findOne({ connectionId });
   if (!connection || connection.userId !== userId) {
-    logger.warn('voiceSessionSendTranscript userId mismatch or unknown connection — rejecting', {
+    logger.warn('voiceSessionSendTranscript userId mismatch or unknown connection - rejecting', {
+      connectionId,
+      claimedUserId: userId,
+    });
+    return { statusCode: 200 };
+  }
+
+  // This frame writes conversation history. A key minted only to run the cc-bridge can open a
+  // socket, and must not be able to author turns in its owner's notebooks.
+  if (!connectionHoldsScope(connection, [ApiKeyScope.AI_CHAT])) {
+    logger.warn('voiceSessionSendTranscript from a connection without ai:chat scope - rejecting', {
       connectionId,
       claimedUserId: userId,
     });
@@ -25,36 +38,28 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
 
   const user = await userRepository.findById(userId);
   if (!user) throw new NotFoundError('User not found');
-  const session = await sessionService.getSession(
-    user.id,
-    { id: sessionId },
-    {
-      db: {
-        sessions: sessionRepository,
-        users: userRepository,
-      },
-    }
-  );
-  if (!session) {
-    logger.warn(`Session not found for sessionId ${sessionId}`);
+
+  // Write access, not read access. Read-accessibility admits a sharee holding only [read, share],
+  // and this handler inserts and overwrites turns in the notebook - the same `Permission.update`
+  // predicate every HTTP session-write path applies (sessionCrud.ts, sessionOperations.ts).
+  const writableSession = await SessionModel.findOne({
+    _id: sessionId,
+    ...accessibleBy(ability(user), Permission.update).ofType(SessionModel),
+  });
+  if (!writableSession) {
+    logger.warn(`voiceSessionSendTranscript: session ${sessionId} not found or not writable by ${userId}`);
     return { statusCode: 200 };
   }
 
-  if (type === 'input') {
-    await questRepository.upsertBySessionIdAndConversationItemId(sessionId, conversationItemId, {
-      prompt: transcript,
-      status: 'done',
-      type: 'voice_transcript',
-      ...(timestamp ? { timestamp } : {}),
-    });
-  } else {
-    await questRepository.upsertBySessionIdAndConversationItemId(sessionId, conversationItemId, {
-      replies: [transcript],
-      status: 'done',
-      type: 'voice_transcript',
-      ...(timestamp ? { timestamp } : {}),
-    });
-  }
+  const turn =
+    type === 'input'
+      ? { prompt: transcript, status: 'done' as const, type: 'voice_transcript' as const }
+      : { replies: [transcript], status: 'done' as const, type: 'voice_transcript' as const };
+
+  await questRepository.upsertVoiceTranscriptTurn(sessionId, conversationItemId, userId, {
+    ...turn,
+    ...(timestamp ? { timestamp } : {}),
+  });
 
   return { statusCode: 200 };
 });

--- a/packages/database/src/__test__/questPromptMetaSessionPersistence.test.ts
+++ b/packages/database/src/__test__/questPromptMetaSessionPersistence.test.ts
@@ -98,7 +98,7 @@ describe('Quest promptMeta.session write-path asymmetry', () => {
 /**
  * Same asymmetry, one field over. `ChatHistoryItemSchema.prompt` was `required: true`, but the
  * writes that can create a quest without one bypass validators entirely:
- * `upsertBySessionIdAndConversationItemId` (a bare upsert, used by the voice transcript handler,
+ * `upsertVoiceTranscriptTurn` (a bare upsert, used by the voice transcript handler,
  * whose assistant branch only ever sets replies/status/type/timestamp) and `update()`. Prompt-less
  * quests are therefore normal on disk - 17 of 55 in one local database - and a copy of one died on
  * `prompt: Path 'prompt' is required.` before the promptMeta rebind could matter.
@@ -110,7 +110,7 @@ describe('Quest prompt write-path asymmetry', () => {
   setupMongoTest();
 
   it('lets the unvalidated upsert create a quest with no prompt', async () => {
-    const upserted = await questRepository.upsertBySessionIdAndConversationItemId('session1', 'item-1', {
+    const upserted = await questRepository.upsertVoiceTranscriptTurn('session1', 'item-1', 'user1', {
       replies: ['assistant said this'],
       status: 'done',
       type: 'voice_transcript',

--- a/packages/database/src/__test__/websocketWriteOwnership.test.ts
+++ b/packages/database/src/__test__/websocketWriteOwnership.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { ActiveCodeAgent, activeCodeAgentRepository } from '../models/ai/ActiveCodeAgentModel';
+import { Quest, questRepository } from '../models/content/QuestModel';
+import { setupMongoTest } from './utils';
+
+/**
+ * The two WebSocket write paths whose upsert key used to omit the owner. Both are exercised
+ * against a real database because the property being pinned is the FILTER Mongo matches on -
+ * a mocked repository would assert the code we wrote rather than what the driver does with it.
+ */
+describe('activeCodeAgentRepository.upsertOnRegister ownership', () => {
+  setupMongoTest();
+
+  const register = (userId: string, overrides: Record<string, unknown> = {}) =>
+    activeCodeAgentRepository.upsertOnRegister({
+      userId,
+      deviceId: `device-${userId}`,
+      instanceId: 'shared-instance',
+      connectionId: `conn-${userId}`,
+      workspaceName: `ws-${userId}`,
+      workspacePath: `/home/${userId}/ws`,
+      spriteId: 'knight',
+      position: { x: 1, y: 2 },
+      startedAt: new Date(),
+      ...overrides,
+    });
+
+  it('is idempotent for the owner, as bridge reconnects rely on', async () => {
+    await register('owner');
+    const again = await register('owner', { connectionId: 'conn-owner-2' });
+
+    expect(again.connectionId).toBe('conn-owner-2');
+    expect(await ActiveCodeAgent.countDocuments({ instanceId: 'shared-instance' })).toBe(1);
+  });
+
+  it('does not let a second user take over a live session record', async () => {
+    const original = await register('owner');
+
+    await expect(register('attacker')).rejects.toThrow(/registered to another user/);
+
+    // Not merely "unchanged": no second row either. An earlier draft of this fix leaned on the
+    // unique index to reject the attacker's insert, and this assertion is what showed that the
+    // index is not built in time to be load-bearing.
+    expect(await ActiveCodeAgent.countDocuments({ instanceId: 'shared-instance' })).toBe(1);
+    const after = await ActiveCodeAgent.findOne({ instanceId: 'shared-instance' }).lean();
+    expect(after?.userId).toBe('owner');
+    expect(after?.deviceId).toBe(original.deviceId);
+    expect(after?.connectionId).toBe(original.connectionId);
+  });
+});
+
+describe('questRepository.upsertVoiceTranscriptTurn ownership', () => {
+  setupMongoTest();
+
+  const turn = (userId: string, text: string) =>
+    questRepository.upsertVoiceTranscriptTurn('session-1', 'item-1', userId, {
+      prompt: text,
+      status: 'done',
+      type: 'voice_transcript',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the voice handler's exact partial write
+    } as any);
+
+  it('stamps the owner onto the row it inserts', async () => {
+    const inserted = await turn('owner', 'hello');
+
+    expect(inserted?.promptMeta?.session?.userId).toBe('owner');
+    expect(inserted?.promptMeta?.session?.id).toBe('session-1');
+  });
+
+  it('updates the owner own turn in place rather than duplicating it', async () => {
+    await turn('owner', 'first');
+    await turn('owner', 'corrected');
+
+    const rows = await Quest.find({ sessionId: 'session-1', conversationItemId: 'item-1' }).lean();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].prompt).toBe('corrected');
+  });
+
+  it('does not let a co-editor overwrite another user turn by reusing its conversationItemId', async () => {
+    await turn('owner', 'what the owner said');
+    await turn('attacker', 'what the attacker wants it to say');
+
+    const ownerRow = await Quest.findOne({
+      sessionId: 'session-1',
+      conversationItemId: 'item-1',
+      'promptMeta.session.userId': 'owner',
+    }).lean();
+    expect(ownerRow?.prompt).toBe('what the owner said');
+  });
+});

--- a/packages/database/src/models/ai/ActiveCodeAgentModel.ts
+++ b/packages/database/src/models/ai/ActiveCodeAgentModel.ts
@@ -110,7 +110,19 @@ export const ActiveCodeAgent: IActiveCodeAgentModel =
 export type SweptCodeAgent = Pick<IActiveCodeAgentDoc, 'instanceId' | 'deviceId' | 'workspaceName' | 'source'>;
 
 export const activeCodeAgentRepository = {
-  /** Upsert a session record on register. Idempotent: bridge reconnects call this again. */
+  /**
+   * Upsert a session record on register. Idempotent: bridge reconnects call this again.
+   *
+   * Refuses outright when `instanceId` is already registered to a DIFFERENT user: keying the
+   * upsert on instanceId alone let such a register rewrite the victim's userId, deviceId and
+   * connectionId, taking over their live session. The explicit read-then-refuse is what carries
+   * the guarantee - the unique index on instanceId is not: it turns the fallback insert into an
+   * E11000 rather than a takeover, but index build is not synchronous with the first write, so it
+   * cannot be the only thing standing between two users.
+   *
+   * `userId` is also in the FILTER so a register racing this check cannot match the victim's row
+   * either. ccAgentRegister.ts makes the same check first, to answer 403 rather than 500.
+   */
   async upsertOnRegister(
     doc: Pick<
       IActiveCodeAgentDoc,
@@ -129,9 +141,14 @@ export const activeCodeAgentRepository = {
       capabilities?: ICcAgentCapability[];
     }
   ): Promise<IActiveCodeAgentDoc> {
+    const existing = await ActiveCodeAgent.findOne({ instanceId: doc.instanceId }, { userId: 1 }).lean();
+    if (existing && existing.userId !== doc.userId) {
+      throw new Error(`ActiveCodeAgent instanceId=${doc.instanceId} is registered to another user`);
+    }
+
     const now = new Date();
     const result = await ActiveCodeAgent.findOneAndUpdate(
-      { instanceId: doc.instanceId },
+      { instanceId: doc.instanceId, userId: doc.userId },
       {
         $set: {
           userId: doc.userId,

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -418,7 +418,7 @@ export const ChatHistoryItemSchema = new Schema<IChatHistoryItemDocument>(
     timestamp: { type: Date, required: true },
     type: { type: String, required: true },
     // NOT required, despite the TS type being `prompt: string`. An assistant-side voice turn is
-    // created by upsertBySessionIdAndConversationItemId (a bare upsert - no validators) which sets
+    // created by upsertVoiceTranscriptTurn (a bare upsert - no validators) which sets
     // only replies/status/type/timestamp, so prompt-less quests are normal on disk. `required: true`
     // could therefore never protect the write that omits it; it only fired on create(), the copy
     // path, turning someone else's prompt-less turn into a failed fork/snip/clone of a whole
@@ -791,12 +791,32 @@ class QuestRepository extends BaseRepository<IChatHistoryItemDocument> implement
     return { ...result.toObject(), id: result._id.toString() } as Pick<IChatHistoryItemDocument, 'id' | 'status'>;
   }
 
-  async upsertBySessionIdAndConversationItemId(
+  /**
+   * Upsert the quest row for one voice-transcript turn.
+   *
+   * Keyed on (sessionId, conversationItemId, OWNER) - not on the first two alone. The
+   * conversationItemId is minted by the voice client, so on a session shared with write access a
+   * second user could otherwise reuse another user's item id and overwrite their turn in place.
+   * With the owner in the key a reused id creates that caller's own row instead of taking one
+   * over.
+   *
+   * `promptMeta.session.id` is written on insert because Mongo seeds an upserted document only
+   * from the equality filter, which supplies the owner but not the session id its sub-schema
+   * also requires. Rows written before this owner binding existed carry no promptMeta at all and
+   * so will no longer be matched - a voice session live across the deploy inserts a fresh row
+   * rather than updating its earlier one.
+   */
+  async upsertVoiceTranscriptTurn(
     sessionId: string,
     conversationItemId: string,
+    ownerUserId: string,
     data: Partial<IChatHistoryItemDocument>
   ) {
-    return this.model.findOneAndUpdate({ sessionId, conversationItemId }, { $set: data }, { upsert: true, new: true });
+    return this.model.findOneAndUpdate(
+      { sessionId, conversationItemId, 'promptMeta.session.userId': ownerUserId },
+      { $set: data, $setOnInsert: { 'promptMeta.session.id': sessionId } },
+      { upsert: true, new: true }
+    );
   }
 
   // Flag a quest as stopped so an in-flight ChatCompletionProcess cancellation


### PR DESCRIPTION
## Description

A cluster of WebSocket action handlers authorize a frame by loading the `Connection` row created at
`$connect` and going no further. That row proves *who is speaking*; several of these handlers were
also treating it as proof of *what the speaker may do* and *whose rows they may touch*, and it is
neither.

Two things follow from that.

**The persisted key scopes were never read back.** `$connect` admits an API key holding any one of
`ai:generate` / `ai:chat` / `cc-bridge:connect` and stores that key's whole scope list on the
Connection row - but nothing downstream consulted it, so a socket opened with a bridge-only key
could send frames that settle voice billing, author conversation turns, or flip notebook execution
state. The comment in `connect.ts` already anticipated the check ("`connection.userId` can also gate
on `connection.scopes`"); nothing had consumed it yet.

**Several handlers pick the row they mutate from a client-supplied id with no owner predicate.**
`jupyter_cell_output` finds a Quest by `sessionId` alone, `voice_session_send_transcript` upserts by
`(sessionId, conversationItemId)` alone after checking only that the session is *readable*,
`cc_agent_register` upserts an ActiveCodeAgent by `instanceId` alone, and `keep_command_response`
relays to whatever `originConnectionId` the sender names.

## Changes

**A scope gate the Connection-only handlers can call** - `connectionScope.ts`. An empty or absent
scope list passes: that means no delegated credential is recorded on the row (a JWT socket, i.e. a
full user session), and `resolveIdentity` will not admit an API key holding none of the three
connect scopes. Absent and empty are treated alike because Mongoose materialises an unset array path
as `[]`. OR semantics over the required list, matching `decideScopeGate`, so the two gates cannot
come to read differently.

- `voice_session_ended` and `voice_session_send_transcript` now require `ai:chat` - they settle
  credits and author conversation history respectively.
- `jupyter_cell_output` now requires `notebooks:write`.

**Owner predicates on the writes:**

- `jupyter_cell_output` scopes both the Quest lookup and the update to the connection's own user
  (`Quest.findByIdAndUpdate` becomes `findOneAndUpdate` with an owner filter, so the ownership check
  cannot be lost between read and write).
- `voice_session_send_transcript` now requires `Permission.update` on the session rather than mere
  read-accessibility - a sharee holding `[read, share]` could insert and overwrite turns - and the
  upsert is keyed on the caller as well as `(sessionId, conversationItemId)`, so reusing another
  user's `conversationItemId` creates the caller's own row instead of overwriting theirs.
  `upsertBySessionIdAndConversationItemId` is renamed `upsertVoiceTranscriptTurn`: the old name
  enumerated a key that is no longer sufficient. Its `$setOnInsert` now seeds
  `promptMeta.session.id`, because Mongo seeds an upsert from the equality filter only, and the
  filter supplies the owner but not the session id the sub-schema also requires.
- `cc_agent_register` refuses an `instanceId` already registered to another user - the same
  ownership check `cc_agent_event` and `cc_agent_disconnect` already make. The refusal lives in the
  repository so it holds for every caller, with the handler checking first so the answer is a 403
  rather than a 500.
- `keep_command_response` resolves `originConnectionId` back to a Connection row and relays only if
  it belongs to the same user as the sender. The legitimate flow always satisfies this:
  `keep_command_request` only ever hands that value to the requesting user's own sockets.

**An adjacent bug this turned up - please look at this one.** The two jupyter HTTP routes were the
ownership filter I set out to copy. They filter `Quest.findOneAndUpdate({ _id: questId, userId })` -
but the Quest schema declares no top-level `userId` at all. The owner field is
`promptMeta.session.userId`, and those two lines were the only places in the repo filtering a Quest
on a root `userId`. So the filter could never match: `progress.ts` answered 403 for every caller,
and `execute.ts` did the same whenever a `questId` was supplied (it skips the block entirely when
one is not). I corrected the field in both. **That is a behaviour change beyond the transport
work** - it takes those paths from always-403 to actually working - and I could not exercise them
live. If you would rather ship the WebSocket changes alone, say so and I will split those two lines
out.

## What I deliberately did NOT change

`updateStatus` / `touch` / `removeByInstanceId` on the ActiveCodeAgent repository still key on
`instanceId` alone. Their only callers, `cc_agent_event` and `cc_agent_disconnect`, verify ownership
before calling, so they are gated - just at the handler rather than structurally. (`updatePosition`
keys on instanceId too, but has no production caller at all.) Worth a follow-up pass; widening this
PR into the repository's whole surface would bury the changes above.

## Guide for Testers

Backend/transport only - no UI, no new setting, no migration.

**Regression checks (all of these ride handlers that changed):**

1. Sign in at `app.staging.bike4mind.com` and start a voice session on any notebook. Speak a
   sentence, wait for the reply, then end the session. Expected: your words and the reply both
   appear as turns in the notebook history, and your credit balance drops by the usual amount. This
   is the whole voice path - `voice_session_send_transcript` for the turns, `voice_session_ended`
   for the settlement - and it is the main regression risk in this PR.
2. Reload that notebook. Expected: both transcript turns are still there, and not duplicated.
3. Share a notebook with a second account **with edit permission** and run a voice session there as
   that second account. Expected: transcript turns still save - update permission is what is
   required now, and an editor has it.
4. Share a notebook with a third account **view-only**. Expected: that account cannot write
   transcript turns, and the owner's history is unchanged afterwards.
5. Open the Tavern and confirm your Claude Code agents still appear, move, and disappear when a
   session ends. Expected: unchanged.
6. Restart a bridge session while the Tavern is open. Expected: the same agent re-registers and does
   not duplicate - register is still idempotent for its own owner.
7. If you have the Keep/CLI HUD wired up, run a command from the web HUD. Expected: the result comes
   back to the HUD as before.

**Regression checks for the two HTTP routes I corrected:**

8. `POST /api/jupyter/progress` on a quest you own, and `POST /api/jupyter/execute` with a `questId`
   you own. Expected: 200, not 403. Before this PR these returned 403 for everyone, so the success
   path here is new - please confirm the 200 is what you expect rather than assuming it.
9. Both routes naming a quest you do not own. Expected: still 403.

**What NOT to test:** there is no visible UI change anywhere. Do not look for a new admin toggle,
setting or panel - there is none.

## Security Testing

- [ ] Reproduced on staging - **not run.** Reproducing these needs a socket opened with a
      deliberately narrow API key plus a second test account holding a view-only share; I did not
      have a staging key minted with `cc-bridge:connect` alone to do it with.
- [ ] Verified on a PR preview - **not run**; needs a maintainer-triggered preview deploy.

What the tests cover in the meantime, and what each one actually pins:

- `connectionScope.test.ts` - the gate itself, including that `admin:*` is not a wildcard and that an
  absent scope list means a JWT socket rather than an empty allow-list.
- `voiceSessionSendTranscript.test.ts` - that the handler asks for `Permission.update` and not read,
  that a bridge-scoped socket writes nothing, and that the upsert carries the caller's id.
- `jupyterNotebookProgress.test.ts` - that the Quest lookup and update both carry the owner
  predicate, and that a bridge-scoped socket touches neither the Quest nor the relay.
- `keepCommandResponse.test.ts` - that a relay aimed at another user's connection is dropped.
- `websocketWriteOwnership.test.ts` - against a real database rather than mocks, because the property
  being pinned is the filter Mongo matches on: that a second user cannot take over a live
  ActiveCodeAgent record, that register stays idempotent for its owner, and that reusing another
  user's `conversationItemId` cannot overwrite their transcript turn.

Two notes on the tests themselves, because they are the same lesson twice.

`execute.test.ts` carried an assertion pinning the old `{ _id, userId }` filter, and it passed on
main - against a mock. The test made a filter that could never match a real document look verified.

And my first draft of the `cc_agent_register` fix leaned on the unique index on `instanceId` to
reject the attacker's insert. The database-backed test showed it does not: the index is not built in
time to be load-bearing, and the attacker got a second row. That is why the refusal is now an
explicit read-then-throw in the repository, with the index demoted to a race backstop, and why that
test asserts a document count rather than only "the victim's row is unchanged".
