### PR TITLE
test(session): cover the chat panel layout menu

### DIFF
--- a/apps/client/app/components/Session/ChatPanelControls.test.tsx
+++ b/apps/client/app/components/Session/ChatPanelControls.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
+import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
+import ChatPanelControls from './ChatPanelControls';
+
+// The copy button's hook reaches SessionsContext and react-query, neither of which the
+// header's own wiring depends on. `copyState` is mutable so a test can render the
+// post-copy state without driving the hook's 2s reset timer.
+const { copyMarkdown, copyState } = vi.hoisted(() => ({
+  copyMarkdown: vi.fn(),
+  copyState: { copied: false },
+}));
+vi.mock('./useCopySessionMarkdown', () => ({
+  useCopySessionMarkdown: () => ({ copyMarkdown, copied: copyState.copied }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const PREFIX = 'docked-chat';
+
+const renderControls = (props: Partial<React.ComponentProps<typeof ChatPanelControls>> = {}) =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <ChatPanelControls testIdPrefix={PREFIX} {...props} />
+    </CssVarsProvider>
+  );
+
+const trigger = () => screen.getByTestId(`${PREFIX}-layout-select-btn`);
+const openMenu = () => fireEvent.click(trigger());
+const openOptionLabels = () =>
+  within(screen.getByTestId(`${PREFIX}-layout-listbox`))
+    .getAllByRole('option')
+    .map(option => option.textContent);
+
+beforeEach(() => {
+  copyMarkdown.mockClear();
+  copyState.copied = false;
+  // Distinct from every value the menu can write, so each assertion below fails if the
+  // selection never reaches the store.
+  setSessionLayout({ layout: 'hide' });
+});
+
+describe('ChatPanelControls layout menu', () => {
+  it('writes the picked dock direction to the session layout', () => {
+    renderControls({ activeLayout: 'dockRight' });
+
+    openMenu();
+    fireEvent.click(screen.getByRole('option', { name: 'Dock bottom' }));
+
+    expect(useSessionLayout.getState().layout).toBe('dockBottom');
+  });
+
+  // The label and the persisted name deliberately disagree (see LAYOUT_LABELS), so this is
+  // the assertion that catches the mapping silently inverting.
+  it('maps the "Dock left" label onto the dockRight layout name', () => {
+    renderControls({ activeLayout: 'dockBottom' });
+
+    openMenu();
+    fireEvent.click(screen.getByRole('option', { name: 'Dock left' }));
+
+    expect(useSessionLayout.getState().layout).toBe('dockRight');
+  });
+
+  it('writes floatingChat when Float is offered and picked', () => {
+    renderControls({ activeLayout: 'dockRight', showFloat: true });
+
+    openMenu();
+    fireEvent.click(screen.getByRole('option', { name: 'Float' }));
+
+    expect(useSessionLayout.getState().layout).toBe('floatingChat');
+  });
+
+  it('offers only the dock directions without showFloat', () => {
+    renderControls({ activeLayout: 'dockRight' });
+
+    openMenu();
+
+    expect(openOptionLabels()).toEqual(['Dock left', 'Dock bottom']);
+  });
+
+  it('offers Float alongside the dock directions with showFloat', () => {
+    renderControls({ activeLayout: 'dockRight', showFloat: true });
+
+    openMenu();
+
+    expect(openOptionLabels()).toEqual(['Dock left', 'Dock bottom', 'Float']);
+  });
+
+  // The floating window passes no activeLayout, so no Option matches and Joy would otherwise
+  // leave the trigger blank.
+  it('falls back to the "Layout" placeholder when no layout is active', () => {
+    renderControls();
+
+    expect(trigger()).toHaveTextContent('Layout');
+  });
+
+  it('names the active layout on the trigger', () => {
+    renderControls({ activeLayout: 'dockBottom' });
+
+    expect(trigger()).toHaveTextContent('Dock bottom');
+  });
+
+  // Two panels mount this cluster under different prefixes, so every testid the rest of
+  // this suite reads is only meaningful if the prop actually reaches them.
+  it("prefixes its testids with the caller's prefix", () => {
+    renderControls({ testIdPrefix: 'floating-chat' });
+
+    fireEvent.click(screen.getByTestId('floating-chat-layout-select-btn'));
+
+    expect(screen.getByTestId('floating-chat-layout-listbox')).toBeInTheDocument();
+    expect(screen.getByTestId('floating-chat-copy-markdown')).toBeInTheDocument();
+  });
+});
+
+describe('ChatPanelControls copy button', () => {
+  it('copies the chat as Markdown on click', () => {
+    renderControls({ activeLayout: 'dockRight' });
+
+    fireEvent.click(screen.getByTestId(`${PREFIX}-copy-markdown`));
+
+    expect(copyMarkdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('swaps the copy icon for a tick once a copy has landed', () => {
+    copyState.copied = true;
+    renderControls({ activeLayout: 'dockRight' });
+
+    expect(screen.getByTestId('CheckIcon')).toBeInTheDocument();
+    expect(screen.queryByTestId('ContentCopyIcon')).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/Session/ChatPanelControls.tsx
+++ b/apps/client/app/components/Session/ChatPanelControls.tsx
@@ -38,7 +38,7 @@ interface ChatPanelControlsProps {
   /** data-testid prefix, e.g. 'docked-chat' or 'floating-chat' */
   testIdPrefix: string;
   /** Current docked layout; preselected in the menu. Omit in the floating window. */
-  activeLayout?: 'dockRight' | 'dockBottom';
+  activeLayout?: Exclude<LayoutChoice, 'floatingChat'>;
   /** Offer "Float" in the menu (docked panels only - the floating window is already there). */
   showFloat?: boolean;
 }
@@ -53,7 +53,7 @@ const ChatPanelControls: React.FC<ChatPanelControlsProps> = ({ testIdPrefix, act
 
   return (
     <>
-      <Select
+      <Select<LayoutChoice>
         size="sm"
         variant="outlined"
         color="neutral"
@@ -65,7 +65,7 @@ const ChatPanelControls: React.FC<ChatPanelControlsProps> = ({ testIdPrefix, act
         indicator={<ExpandMoreIcon sx={{ fontSize: 18 }} />}
         renderValue={option => (
           <Typography noWrap level="body-sm" textColor="inherit" sx={{ minWidth: 0 }}>
-            {option ? LAYOUT_LABELS[option.value as LayoutChoice] : 'Layout'}
+            {option ? LAYOUT_LABELS[option.value] : 'Layout'}
           </Typography>
         )}
         slotProps={{


### PR DESCRIPTION
## Description

Closes #2289

`apps/client/app/components/Session/ChatPanelControls.tsx` - the layout Select and copy-as-Markdown button in the chat panel header - had no test coverage. The only suite that mounts a component containing it (`DockedChatPanel.test.tsx`) mocks it away, so nothing pinned its behaviour. This adds a co-located unit suite, and fixes the type hole the coverage work surfaced.

The type hole: the `<Select>` inferred its value type from `value={activeLayout ?? null}`, i.e. `'dockRight' | 'dockBottom' | null`. The menu's third `Option` emits `'floatingChat'`, so `onChange`'s value was typed narrower than what the control can actually produce, and `renderValue` needed an `as LayoutChoice` cast to paper over it. It worked at runtime only because Joy does not tie `Option` children to the parent's generic. Naming the generic explicitly closes the gap and makes the cast unnecessary.

## Changes

- `ChatPanelControls.tsx`: `<Select>` -> `<Select<LayoutChoice>>`; drop the now-redundant `option.value as LayoutChoice` cast in `renderValue`; derive `activeLayout?: 'dockRight' | 'dockBottom'` from `Exclude<LayoutChoice, 'floatingChat'>` so the prop and the union stay in step. Type-only - no runtime change.
- New `ChatPanelControls.test.tsx`, 10 tests, co-located per CLAUDE.md. Covers the label-to-layout mapping for all three values (including the deliberate "Dock left" -> `dockRight` disagreement), the `showFloat` gate asserted as the exact option list in both states, the "Layout" placeholder when no `activeLayout` is set, the trigger tracking the active layout, `testIdPrefix` propagation, and the copy button's click wiring plus its copied-state icon swap.

Layout assertions read the real `useSessionLayout` store rather than mocking `setSessionLayout`, matching `DockedChatPanel.test.tsx` and `FloatingChatWindow.test.tsx` - it pins the user-visible outcome rather than the call shape.

Deliberately not asserted: the listbox `sx` block (presentation, and asserting it would mean matching MUI/Emotion generated class names, which CLAUDE.md forbids), Joy's own keyboard/a11y behaviour, and the `value &&` guard in `onChange` (single-select Joy offers no deselect affordance, so a null value is unreachable from the UI).

## Guide for Testers

No user-visible behaviour changes: this is test coverage plus a type-only fix, so there is nothing new to click through.

1. Confirm CI is green, in particular the three `Run Tests (client i/3)` shard legs and `typecheck`.

### Regression Checks

The layout menu is unchanged, so this is a spot-check that nothing regressed:

1. Sign in at `app.staging.bike4mind.com` and open any session with at least one message in it.
2. In the chat panel header, click the layout dropdown. Expect exactly three options: `Dock left`, `Dock bottom`, `Float`.
3. Click `Dock bottom`. Expect the chat panel to move to the bottom of the window and the dropdown trigger to read `Dock bottom`.
4. Reopen the dropdown and click `Dock left`. Expect the chat panel to move to the right-hand side (the label and the layout deliberately disagree - pre-existing, not changed here) and the trigger to read `Dock left`.
5. Reopen the dropdown and click `Float`. Expect the floating chat window to appear.
6. In the floating chat window's header, open the layout dropdown. Expect exactly two options - `Dock left` and `Dock bottom` - with no `Float`, and the trigger reading `Layout` rather than a layout name.
7. Back in a docked panel, click the copy button in the header. Expect the copy icon to swap to a tick for about two seconds, and the session's Markdown to be on your clipboard.

### What NOT to test

Nothing else. No API, schema, migration, or infra surface is touched.

## Additional Information

Titled `test(...)` rather than `fix(...)` on purpose: the type change has no runtime effect, and a `fix` title would drive a patch version bump for it.

Every new assertion was mutation-tested - the source was broken, the suite confirmed to fail, then reverted:

| Mutation | Tests that failed |
|---|---|
| swap the two dock labels in `LAYOUT_LABELS` | 5 |
| drop the `showFloat &&` gate | 1 |
| drop `placeholder` + the `renderValue` fallback | 1 |
| `onChange` -> no-op | 3 |
| always render `ContentCopyIcon`, never the tick | 1 |
| `value={activeLayout ?? null}` -> `value={null}` | 1 |
| hardcode `'docked-chat-'` into a testid | 1 |

The type fix was verified the same way: with `Select<LayoutChoice>`, assigning `onChange`'s value to `'dockRight' | 'dockBottom' | null` is a TS2322 error; without it, that assignment compiles - confirming the old type was narrower than what the control emits.

Verified locally at this HEAD: `pnpm turbo:typecheck` 40/40 pass, `pnpm lint:check` clean, `pnpm --filter @bike4mind/client test` 13095 passed / 101 skipped. Two node-project files (`server/utils/__tests__/dataLakeSpendGateIntegration.test.ts`, `pages/api/users/__tests__/counterLogs.test.ts`) timed out in their `mongodb-memory-server` startup hook under a full-parallel local run and pass in isolation; neither is touched by this branch.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
