### PR TITLE
fix(fab-files): prevent cleared MaxFileSize from blocking all uploads

### DIFF
--- a/apps/client/app/components/Session/FilePond.test.tsx
+++ b/apps/client/app/components/Session/FilePond.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+// Capture the props FilePond receives so the test can assert on the derived
+// `maxFileSize` string without mounting the real widget.
+let capturedProps: Record<string, unknown> | null = null;
+
+vi.mock('react-filepond', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub stands in for the FilePond component
+  FilePond: (props: any) => {
+    capturedProps = props;
+    return null;
+  },
+  registerPlugin: vi.fn(),
+}));
+
+vi.mock('@client/app/utils/filesAPICalls', () => ({
+  createFabFileOnServerWithUpload: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+let mockServerSettings: Array<{ settingName: string; settingValue: string }> = [];
+vi.mock('@client/app/contexts/UserSettingsContext', () => ({
+  useServerSettings: () => ({ serverSettings: mockServerSettings }),
+}));
+
+import FilePondModal from './FilePond';
+
+describe('FilePondModal MaxFileSize derivation (#2456)', () => {
+  beforeEach(() => {
+    capturedProps = null;
+    mockServerSettings = [];
+  });
+
+  it('reads .settingValue off the found row, not the row object itself', () => {
+    mockServerSettings = [{ settingName: 'MaxFileSize', settingValue: '50' }];
+
+    render(<FilePondModal onFileProcessComplete={vi.fn()} />);
+
+    // Regression guard for the `[object Object]MB` bug: `.find(...)` returns the
+    // whole IAdminSettings row, so a naive `${row}MB` template would render the
+    // row's own toString(), not its numeric settingValue.
+    expect(capturedProps?.maxFileSize).toBe('50MB');
+  });
+
+  it('falls back to the server default (30MB) when MaxFileSize is cleared', () => {
+    mockServerSettings = [{ settingName: 'MaxFileSize', settingValue: '' }];
+
+    render(<FilePondModal onFileProcessComplete={vi.fn()} />);
+
+    expect(capturedProps?.maxFileSize).toBe('30MB');
+  });
+
+  it('falls back to the server default (30MB) when no MaxFileSize row exists', () => {
+    mockServerSettings = [];
+
+    render(<FilePondModal onFileProcessComplete={vi.fn()} />);
+
+    expect(capturedProps?.maxFileSize).toBe('30MB');
+  });
+});

--- a/apps/client/app/components/Session/FilePond.tsx
+++ b/apps/client/app/components/Session/FilePond.tsx
@@ -24,7 +24,9 @@ const FilePondModal: React.FC<FilePondModalProps> = ({ onFileProcessComplete }) 
   const [files] = useState<any[]>([]);
   const pond = useRef(null);
   const { serverSettings } = useServerSettings();
-  const maxFileSize = serverSettings.find(setting => setting.settingName === 'MaxFileSize') || 100;
+  // `.find(...)` returns the whole IAdminSettings row, not its value - read `.settingValue`
+  // (matches the server default of 30MB, not the old unrelated 100MB fallback).
+  const maxFileSize = Number(serverSettings.find(setting => setting.settingName === 'MaxFileSize')?.settingValue) || 30;
   // FilePond expects the max file size as a string in MB, e.g. '100MB'
   const maxFileSizeForFilePond = `${maxFileSize}MB`;
 

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.maxFileSize.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.maxFileSize.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Regression guard (#2456): `useGetSettingsValue('MaxFileSize') || 30` doesn't coerce
+// first, so a stored '0' string (truthy) survives the `||` unchanged and reproduces the
+// zero-cap upload bug. A source-level assertion is used here (not a render test) because
+// SessionBottom requires a large web of context providers that adds little signal beyond
+// locking this invariant - see SessionBottom.dedup.test.ts for the same tradeoff.
+describe('SessionBottom - MaxFileSize coerces before falling back (regression)', () => {
+  const sessionBottom = readFileSync(resolve(__dirname, 'SessionBottom.tsx'), 'utf8');
+
+  it("wraps useGetSettingsValue('MaxFileSize') in Number(...) before the || fallback", () => {
+    expect(sessionBottom).toMatch(/const maxFileSize = Number\(useGetSettingsValue\('MaxFileSize'\)\) \|\| 30;/);
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -237,7 +237,9 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
       };
 
   const pond = useNotebookFilepond();
-  const maxFileSize = useGetSettingsValue('MaxFileSize') || 100;
+  // Fallback matches the server default of 30MB (`MaxFileSize`'s schema default), not the old
+  // unrelated 100MB.
+  const maxFileSize = useGetSettingsValue('MaxFileSize') || 30;
   const enforceCredits = !!useGetSettingsValue('enforceCredits');
 
   // Credit warning conditions - extracted for readability

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -237,9 +237,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
       };
 
   const pond = useNotebookFilepond();
-  // Fallback matches the server default of 30MB (`MaxFileSize`'s schema default), not the old
-  // unrelated 100MB.
-  const maxFileSize = useGetSettingsValue('MaxFileSize') || 30;
+  // Number(...) first so a stored '0' string (truthy) still falls through to the default -
+  // `|| 30` alone only catches the empty-string case. Fallback matches the server default of
+  // 30MB (`MaxFileSize`'s schema default), not the old unrelated 100MB.
+  const maxFileSize = Number(useGetSettingsValue('MaxFileSize')) || 30;
   const enforceCredits = !!useGetSettingsValue('enforceCredits');
 
   // Credit warning conditions - extracted for readability

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -845,6 +845,26 @@ describe('LakeAccessAuditRetentionDays cannot be configured below the floor', ()
   });
 });
 
+describe('MaxFileSize cannot coerce a cleared field to a real 0', () => {
+  // A cleared admin field is stored as '', which z.coerce.number() reads as 0 - a value that
+  // PASSES validation, so the schema's own `.prefault(30)` (undefined-only) never fires and
+  // every caller sees a real 0MB limit instead of the intended default. The `min: 1` floor
+  // makes that coerced 0 fail validation instead, so callers (getSettingsValue's safeParse
+  // fallback) land on the default the way an unset row already does.
+  it('rejects both a cleared field and an explicit 0, unlike prefault-only defaulting', () => {
+    expect(() => settingsMap.MaxFileSize.schema.parse('')).toThrow();
+    expect(() => settingsMap.MaxFileSize.schema.parse(0)).toThrow();
+  });
+
+  it('still prefaults an unset row to 30', () => {
+    expect(settingsMap.MaxFileSize.schema.parse(undefined)).toBe(30);
+  });
+
+  it('accepts a genuinely configured value', () => {
+    expect(settingsMap.MaxFileSize.schema.parse('50')).toBe(50);
+  });
+});
+
 describe('AbstentionPrompt default carries the anti-invention licence', () => {
   // The always-on backstop is the ONLY anti-invention text on a normal turn that answers WITHOUT
   // searching the knowledge base. (A promptMode session strips it like any authored prompt, so that

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -2820,6 +2820,8 @@ export const settingsMap = {
     key: 'MaxFileSize',
     name: 'Max File Size',
     defaultValue: 30,
+    min: 1, // clearing the field stores '', which z.coerce.number() reads as 0 - without a floor
+    // that 0 passes validation as a real limit and every upload gets refused
     description: 'The maximum file size allowed for uploads in MB.',
     category: 'Knowledge',
     group: API_SERVICE_GROUPS.KNOWLEDGE.id,

--- a/b4m-core/services/src/fabFileService/create.test.ts
+++ b/b4m-core/services/src/fabFileService/create.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, vi, Mock } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
 import { FabFileSourceType, KnowledgeType } from '@bike4mind/common';
+import { invalidateSettingsCache } from '@bike4mind/utils';
 import { createFabFile, type CreateFabFileAdapters } from './create';
 
 // Unsupported file-type gating on ingest. The rejection throws right
@@ -163,6 +164,60 @@ describe('createFabFile (upload moderation gate root cause)', () => {
     expect(persistedData.mimeType).toBe('audio/mpeg');
     // Stored under the generated-audio prefix with an .mp3 extension.
     expect(persistedData.filePath).toMatch(/^generated-audio\/.+\.mp3$/);
+  });
+});
+
+describe('createFabFile MaxFileSize enforcement - cleared setting no longer blocks every upload (#2456)', () => {
+  const mockUserId = 'user-123';
+
+  let mockAdapters: CreateFabFileAdapters;
+  let fabFilesCreate: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The admin-settings cache key is process-wide ('all_settings'), not scoped to this test's
+    // db mock - without invalidating it, whichever test in this file populates it first would
+    // leak its findAll() result into every later test in this file.
+    invalidateSettingsCache();
+
+    fabFilesCreate = vi.fn().mockImplementation(async data => ({ id: 'fab-1', ...data }));
+    mockAdapters = {
+      db: {
+        fabFiles: { create: fabFilesCreate },
+        adminSettings: {
+          findAll: vi.fn().mockResolvedValue([{ settingName: 'MaxFileSize', settingValue: '' }]),
+          findBySettingNames: vi.fn().mockResolvedValue([]),
+        },
+        users: {
+          findById: vi.fn().mockResolvedValue({ id: mockUserId, storageLimit: 1000, currentStorageSize: 0 }),
+        },
+      },
+      storage: {
+        generateSignedUrl: vi.fn().mockResolvedValue('https://s3.example.com/signed-url'),
+        upload: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as CreateFabFileAdapters;
+  });
+
+  // Undo this block's own beforeEach fetch (`MaxFileSize: ''`), so it doesn't leak forward into
+  // every describe block that runs after this one in the same file.
+  afterEach(() => {
+    invalidateSettingsCache();
+  });
+
+  it('accepts a normal-sized upload when MaxFileSize is stored as a cleared empty string', async () => {
+    await expect(
+      createFabFile(
+        mockUserId,
+        {
+          fileName: 'notes.txt',
+          mimeType: 'text/plain',
+          fileSize: 10 * 1024 * 1024, // 10MB - well under the 30MB default, well over a stray 0
+          type: KnowledgeType.FILE,
+        },
+        mockAdapters
+      )
+    ).resolves.toBeDefined();
   });
 });
 

--- a/b4m-core/services/src/fabFileService/create.test.ts
+++ b/b4m-core/services/src/fabFileService/create.test.ts
@@ -199,8 +199,10 @@ describe('createFabFile MaxFileSize enforcement - cleared setting no longer bloc
     } as unknown as CreateFabFileAdapters;
   });
 
-  // Undo this block's own beforeEach fetch (`MaxFileSize: ''`), so it doesn't leak forward into
-  // every describe block that runs after this one in the same file.
+  // Not undoing our own beforeEach - guarding the NEXT describe block in this file from it.
+  // The admin-settings cache this block populates (`MaxFileSize: ''`) is process-wide, so
+  // without this it would leak forward and feed every describe block that runs after this
+  // one, not just the tests inside it.
   afterEach(() => {
     invalidateSettingsCache();
   });

--- a/b4m-core/services/src/fabFileService/create.ts
+++ b/b4m-core/services/src/fabFileService/create.ts
@@ -108,10 +108,11 @@ export interface CreateFabFileAdapters {
   administeredOrgIds?: string[];
 }
 
-// Only reached when the `MaxFileSize` settings row exists but fails the schema's `z.coerce`
-// (e.g. a non-numeric stored value) - a missing row never gets here, since the schema's own
-// `.prefault(30)` already resolves `getSettingsValue` to 30 before this default arg is
-// consulted. Matches that prefault value so the two cases can't diverge if the schema changes.
+// Only reached when the `MaxFileSize` settings row exists but fails the schema (a non-numeric
+// stored value, or a cleared field - stored as '', which coerces to 0 and fails the schema's
+// `min: 1`) - a missing row never gets here, since the schema's own `.prefault(30)` already
+// resolves `getSettingsValue` to 30 before this default arg is consulted. Matches that prefault
+// value so the two cases can't diverge if the schema changes.
 const DEFAULT_MAX_FILE_SIZE = 30;
 const DEFAULT_EXPIRE_IN_SECONDS = 3600 * 24 * 5; // 5 days
 

--- a/packages/database/src/models/infra/ops/AdminSettingsModel.getSettingsValue.test.ts
+++ b/packages/database/src/models/infra/ops/AdminSettingsModel.getSettingsValue.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { setupMongoTest } from '../../../__test__/utils';
+import { AdminSettings, adminSettingsRepository } from './AdminSettingsModel';
+
+describe('AdminSettingsRepository.getSettingsValue - MaxFileSize coercion (#2456)', () => {
+  setupMongoTest();
+
+  // This is the exact call the Slack attachment path (CommandHandler.ts) makes: a cleared
+  // field is stored as '', which z.coerce.number() reads as a real 0 unless the schema's
+  // `min: 1` rejects it - safeParse then fails and this repository falls back to the
+  // setting's own defaultValue (30) instead of returning the coerced 0.
+  it('falls back to the default when MaxFileSize is stored as a cleared empty string', async () => {
+    await AdminSettings.create({ settingName: 'MaxFileSize', settingValue: '' });
+    const value = await adminSettingsRepository.getSettingsValue('MaxFileSize');
+    expect(value).toBe(30);
+  });
+
+  it('returns the configured value when MaxFileSize is set normally', async () => {
+    await AdminSettings.create({ settingName: 'MaxFileSize', settingValue: '50' });
+    const value = await adminSettingsRepository.getSettingsValue('MaxFileSize');
+    expect(value).toBe(50);
+  });
+
+  it('falls back to the default when no MaxFileSize row exists at all', async () => {
+    const value = await adminSettingsRepository.getSettingsValue('MaxFileSize');
+    expect(value).toBe(30);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="1566" height="193" alt="maxfilesize-cleared-validation" src="https://github.com/user-attachments/assets/e57ce53b-2700-491e-a038-fa91199e31b6" />

**Cleared Field Blocked**: the Max File Size field in Admin Settings after clearing it - shows the "Enter a number of 1 or more." helper text and the disabled Save button.

<img width="1456" height="816" alt="maxfilesize-upload-success" src="https://github.com/user-attachments/assets/a98b8a51-b4d7-4e6d-9e98-97c65c083ba9" />

**Upload Succeeds**: a small file attached successfully in a session/notebook after saving Max File Size back to a valid value.

## Description

The `MaxFileSize` admin setting is defined as `z.coerce.number()` with no lower bound
(`b4m-core/common/src/schemas/settings.ts:2819`). Clearing the field in the admin UI
stores it as `''`, which `z.coerce.number()` reads as a real `0` - a value that PASSES
validation, so the schema's own `.prefault(30)` (which only fires on `undefined`) never
applies. Every caller then sees a genuine `0` byte limit and refuses every upload:
`b4m-core/services/src/fabFileService/create.ts:168` for the web upload path, and (via
`AdminSettingsRepository.getSettingsValue`) the Slack attachment path.

Adding a `min: 1` floor to the schema (`b4m-core/common/src/schemas/settings.ts:2823`)
makes that coerced `0` fail validation instead, so `getSettingsValue`'s existing
safeParse-fails-then-return-default fallback (`b4m-core/utils/src/settings.ts`, and
separately `packages/database/src/models/infra/ops/AdminSettingsModel.ts`) resolves it
to the setting's own default (30) - the same way an unset row already does. No changes
were needed at either call site: this is a schema-only fix.

Also fixes a second, independent bug found while reconciling the client-side fallback:
`apps/client/app/components/Session/FilePond.tsx:29` was reading the whole
`IAdminSettings` row via `.find(...)` instead of its `.settingValue`, so the FilePond
size cap rendered as literally `[object Object]MB` whenever a `MaxFileSize` row existed
at all. Both client fallbacks now default to 30MB (was 100MB, which never matched the
server's actual default).

Closes #2456.

## Changes

- `b4m-core/common/src/schemas/settings.ts` - add a `min: 1` floor to the `MaxFileSize`
  setting so a cleared field (coerced to `0`) fails validation instead of passing
  through as a real 0MB limit.
- `b4m-core/common/src/schemas/settings.test.ts` - new tests: a cleared field and an
  explicit `0` both fail validation; an unset row still prefaults to 30; a genuinely
  configured value still parses correctly.
- `b4m-core/services/src/fabFileService/create.ts` - comment-only update: the
  fallback-default constant's comment now also names a cleared field (not just a
  non-numeric value) as a case that reaches it.
- `b4m-core/services/src/fabFileService/create.test.ts` - new test: `createFabFile`
  accepts a normal-sized upload when `MaxFileSize` is stored as a cleared empty string.
- `packages/database/src/models/infra/ops/AdminSettingsModel.getSettingsValue.test.ts` -
  new test file: `AdminSettingsRepository.getSettingsValue` (the exact call the Slack
  attachment path makes) falls back to 30 for a cleared field, returns a genuinely
  configured value normally, and falls back to 30 when no row exists at all.
- `apps/client/app/components/Session/FilePond.tsx` - read `.settingValue` off the
  found settings row instead of the row object itself; fallback changed from 100 to 30
  to match the server default.
- `apps/client/app/components/Session/SessionBottom/SessionBottom.tsx` - fallback
  changed from 100 to 30 to match the server default.

## Guide for Testers

1. Sign in as an admin user on the preview link.
2. Go to Sidebar -> Admin -> General Ops -> Admin Settings, and find "Max File Size"
   under the Knowledge category.
3. Clear the input field completely (delete every digit).
   Expected: the field's helper text shows "Enter a number of 1 or more." and the Save
   button becomes disabled - the browser will not let you save the cleared value.
4. Type `30` back into the field and click Save.
   Expected: Save succeeds with no error.
5. As any user, open a session/notebook, click the file-attach button, and upload a
   file well under 30MB (e.g. a small `.txt` file).
   Expected: the file uploads successfully.
6. In Slack, attach a similarly small file to a message in a channel where Bike4Mind is
   installed.
   Expected: the attachment is accepted (no "exceeds file size limit" error).

**What NOT to test:** reproducing the original bug (an empty `MaxFileSize` value
blocking every upload) through the admin UI. The fix makes the UI itself refuse to save
that state (step 3 above), so the broken state can only occur from a row already stored
before this fix shipped. That case is covered by the automated tests in this PR
(`AdminSettingsModel.getSettingsValue.test.ts`, `create.test.ts`), not by manual QA.

## Additional Information

Automated test results observed in this session (per-package, not the full monorepo
suite):

- `@bike4mind/common`: 2282/2282 passed
- `@bike4mind/services`: 6709/6709 passed
- `@bike4mind/slack`: 21/21 passed (unaffected - confirms no code change was needed at
  the Slack call site)
- `@bike4mind/database`: 2574/2574 passed, 1 skipped (pre-existing, unrelated to this
  change)

Typecheck and lint were run and are clean on every touched package. A typecheck failure
in `@bike4mind/premium-overwatch` exists on `main` already (confirmed via
git-stash-and-rerun) and is unrelated to this change.

Manual QA was also run on the PR preview (chael_admin) and passed 4/4: Max File Size
found under Knowledge showing `30`; clearing the field showed "Enter a number of 1 or
more." with Save disabled; saving a real value succeeded and persisted across a
reload; a small file attached in a session with no size-refusal error. Slack
attachment was not covered by this pass - that path is exercised by
`AdminSettingsModel.getSettingsValue.test.ts` instead.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new setting was added; an existing setting's schema was tightened
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no new UI; the only user-visible change is validation text on an existing field
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no docs reference this setting's bounds
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry fields touched
