### PR TITLE
fix(api-keys): hide revoked keys behind a toggle and allow deleting them

### DIFF
--- a/apps/client/app/components/profile/UserApiKeysTab.test.tsx
+++ b/apps/client/app/components/profile/UserApiKeysTab.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { ApiKeyScope } from '@bike4mind/common';
+import UserApiKeysTab from './UserApiKeysTab';
+
+/**
+ * The revoked-key hygiene half of the table: revoked rows are hidden behind a
+ * default-off toggle, and delete is reachable only once a key is revoked (the
+ * UI half of the delete route's revoked-only rule).
+ */
+
+const activeKey = {
+  id: 'key-1',
+  name: 'CI key',
+  scopes: [ApiKeyScope.AI_CHAT],
+  status: 'active',
+  keyPrefix: 'b4m_live_abc',
+  createdAt: new Date('2026-01-01'),
+};
+const revokedKey = {
+  id: 'key-2',
+  name: 'Old CI key',
+  scopes: [ApiKeyScope.AI_CHAT],
+  status: 'disabled',
+  keyPrefix: 'b4m_live_xyz',
+  createdAt: new Date('2026-01-02'),
+  revokedAt: new Date('2026-02-01'),
+};
+
+const h = vi.hoisted(() => ({
+  keys: [] as any[],
+  deleteMutate: vi.fn(),
+}));
+
+vi.mock('@client/app/hooks/data/userApiKeys', () => ({
+  useGetUserApiKeys: () => ({ data: h.keys, isLoading: false, error: null, refetch: vi.fn() }),
+  useCreateUserApiKey: () => ({ mutate: vi.fn(), isPending: false }),
+  useRotateUserApiKey: () => ({ mutate: vi.fn(), isPending: false }),
+  useRevokeUserApiKey: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteUserApiKey: () => ({ mutate: h.deleteMutate, isPending: false }),
+  useBillingOrganizations: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@client/app/hooks/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ copied: false, handleCopyToClipboard: vi.fn() }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const renderTab = () =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <UserApiKeysTab />
+    </CssVarsProvider>
+  );
+
+describe('UserApiKeysTab - revoked keys', () => {
+  beforeEach(() => {
+    h.keys = [];
+    h.deleteMutate.mockClear();
+  });
+
+  it('hides revoked rows by default and counts them on the toggle', () => {
+    h.keys = [activeKey, revokedKey];
+    renderTab();
+
+    expect(screen.getByText('CI key')).toBeInTheDocument();
+    expect(screen.queryByText('Old CI key')).not.toBeInTheDocument();
+    expect(screen.getByText('Show revoked (1)')).toBeInTheDocument();
+  });
+
+  it('reveals revoked rows when the toggle is turned on', () => {
+    h.keys = [activeKey, revokedKey];
+    renderTab();
+
+    fireEvent.click(screen.getByTestId('api-keys-show-revoked'));
+
+    expect(screen.getByText('Old CI key')).toBeInTheDocument();
+    expect(screen.getByText('Revoked')).toBeInTheDocument();
+  });
+
+  it('offers no toggle when nothing is revoked', () => {
+    h.keys = [activeKey];
+    renderTab();
+
+    expect(screen.queryByTestId('api-keys-show-revoked')).not.toBeInTheDocument();
+  });
+
+  // Hiding every row would otherwise read as "you have no keys", which is the
+  // one thing the empty state must not say while keys still exist.
+  it('explains an all-revoked list instead of rendering an empty table', () => {
+    h.keys = [revokedKey];
+    renderTab();
+
+    expect(screen.getByTestId('api-keys-all-revoked')).toBeInTheDocument();
+    expect(screen.queryByText('Old CI key')).not.toBeInTheDocument();
+    expect(screen.getByTestId('api-keys-show-revoked')).toBeInTheDocument();
+  });
+
+  it('keeps delete disabled for an active key', () => {
+    h.keys = [activeKey];
+    renderTab();
+
+    expect(screen.getByTestId('api-key-delete-key-1')).toBeDisabled();
+  });
+
+  it('deletes a revoked key only after the confirmation is accepted', () => {
+    h.keys = [activeKey, revokedKey];
+    renderTab();
+    fireEvent.click(screen.getByTestId('api-keys-show-revoked'));
+
+    fireEvent.click(screen.getByTestId('api-key-delete-key-2'));
+    expect(h.deleteMutate).not.toHaveBeenCalled();
+    // The dialog names the key, so a mis-wired row can't confirm the wrong one.
+    expect(screen.getByTestId('confirmation-dialog')).toHaveTextContent('Old CI key');
+
+    fireEvent.click(screen.getByTestId('confirmation-confirm-btn'));
+    expect(h.deleteMutate).toHaveBeenCalledWith('key-2');
+  });
+});

--- a/apps/client/app/components/profile/UserApiKeysTab.tsx
+++ b/apps/client/app/components/profile/UserApiKeysTab.tsx
@@ -3,12 +3,14 @@ import {
   useCreateUserApiKey,
   useRotateUserApiKey,
   useRevokeUserApiKey,
+  useDeleteUserApiKey,
   useBillingOrganizations,
   CreateUserApiKeyRequest,
 } from '@client/app/hooks/data/userApiKeys';
 import { useTheme } from '@mui/joy';
 import {
   Box,
+  Checkbox,
   CircularProgress,
   Table,
   Typography,
@@ -43,6 +45,7 @@ import { cardSurfaceSx, hairlineBorderColor, tableHeaderSx } from '@client/app/c
 import AddIcon from '@mui/icons-material/Add';
 import RotateLeftIcon from '@mui/icons-material/RotateLeft';
 import BlockIcon from '@mui/icons-material/Block';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import CopyIcon from '@mui/icons-material/ContentCopy';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
@@ -51,6 +54,8 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { IUserApiKeyDocument, ApiKeyScope } from '@bike4mind/common';
 import { GENERIC_MODAL_API_KEY_SCOPES } from '@client/app/constants/apiKeyScopes';
 import { revocationTooltip } from '@client/app/utils/apiKeyRevocation';
+import ConfirmationModal from '@client/app/components/common/ConfirmationModal';
+import { toast } from 'sonner';
 import { useState } from 'react';
 import { useCopyToClipboard } from '@client/app/hooks/useCopyToClipboard';
 import dayjs from 'dayjs';
@@ -1709,6 +1714,14 @@ ai_response = response.json()`,
   );
 }
 
+/**
+ * `disabled` is the only state any revoke path writes (revokeUserApiKey, the
+ * bulk deactivation, the cc-bridge device revoke all stamp revokedAt with it),
+ * so it reads as "revoked" everywhere - and it is the only state the delete
+ * route accepts.
+ */
+const isRevoked = (key: IUserApiKeyDocument) => key.status === 'disabled';
+
 export default function UserApiKeysTab() {
   const { data, isLoading, error, refetch } = useGetUserApiKeys();
   const { data: billingOrgs } = useBillingOrganizations();
@@ -1717,6 +1730,11 @@ export default function UserApiKeysTab() {
   const [showKeyCreatedModal, setShowKeyCreatedModal] = useState(false);
   const [newlyCreatedKey, setNewlyCreatedKey] = useState('');
   const [mainTab, setMainTab] = useState(0);
+  // Off by default: revoked rows accumulate forever (scopes are write-once, so
+  // every scope change mints a replacement and leaves one behind) and their
+  // audit value is served by the toggle, not by permanent screen space.
+  const [showRevoked, setShowRevoked] = useState(false);
+  const [keyPendingDelete, setKeyPendingDelete] = useState<IUserApiKeyDocument | null>(null);
 
   const rotateMutation = useRotateUserApiKey({
     onSuccess: result => {
@@ -1725,7 +1743,16 @@ export default function UserApiKeysTab() {
     },
   });
 
-  const revokeMutation = useRevokeUserApiKey();
+  // With revoked rows hidden, revoking makes the row leave the list - so say so,
+  // rather than leaving a silent disappearance as the only feedback.
+  const revokeMutation = useRevokeUserApiKey({ onSuccess: () => toast.success('API key revoked') });
+
+  const deleteMutation = useDeleteUserApiKey({
+    onSuccess: () => {
+      toast.success('API key deleted');
+      setKeyPendingDelete(null);
+    },
+  });
 
   const handleNewKeySuccess = (key: string) => {
     setNewlyCreatedKey(key);
@@ -1733,16 +1760,20 @@ export default function UserApiKeysTab() {
   };
 
   const getStatusColor = (key: IUserApiKeyDocument) => {
-    if (key.status === 'disabled') return 'danger';
+    if (isRevoked(key)) return 'danger';
     if (key.expiresAt && dayjs(key.expiresAt).isBefore(dayjs())) return 'warning';
     return 'success';
   };
 
   const getStatusText = (key: IUserApiKeyDocument) => {
-    if (key.status === 'disabled') return 'Disabled';
+    if (isRevoked(key)) return 'Revoked';
     if (key.expiresAt && dayjs(key.expiresAt).isBefore(dayjs())) return 'Expired';
     return 'Active';
   };
+
+  const keys = data ?? [];
+  const revokedCount = keys.filter(isRevoked).length;
+  const visibleKeys = showRevoked ? keys : keys.filter(key => !isRevoked(key));
 
   return (
     <Box
@@ -1767,7 +1798,17 @@ export default function UserApiKeysTab() {
             <Typography level="title-md" sx={{ color: 'text.primary' }}>
               Manage Your API Keys
             </Typography>
-            <Box display="flex" gap={1} flexShrink={0}>
+            <Box display="flex" gap={1} flexShrink={0} alignItems="center">
+              {revokedCount > 0 && (
+                <Checkbox
+                  size="sm"
+                  label={`Show revoked (${revokedCount})`}
+                  checked={showRevoked}
+                  onChange={event => setShowRevoked(event.target.checked)}
+                  slotProps={{ input: { 'data-testid': 'api-keys-show-revoked' } }}
+                  sx={{ mr: 1, whiteSpace: 'nowrap' }}
+                />
+              )}
               <Tooltip title="Refresh">
                 <IconButton onClick={() => refetch()} variant="outlined">
                   <RefreshIcon />
@@ -1790,11 +1831,17 @@ export default function UserApiKeysTab() {
                 Retry
               </Button>
             </Box>
-          ) : data?.length === 0 ? (
+          ) : keys.length === 0 ? (
             <Alert color="neutral" startDecorator={<InfoOutlinedIcon />}>
               <Typography>
                 You don&apos;t have any API keys yet. Create one to get started with programmatic access to your
                 account.
+              </Typography>
+            </Alert>
+          ) : visibleKeys.length === 0 ? (
+            <Alert color="neutral" startDecorator={<InfoOutlinedIcon />}>
+              <Typography data-testid="api-keys-all-revoked">
+                All of your API keys are revoked. Turn on Show revoked to see or delete them.
               </Typography>
             </Alert>
           ) : (
@@ -1823,7 +1870,7 @@ export default function UserApiKeysTab() {
                   </tr>
                 </thead>
                 <tbody>
-                  {data?.map(key => (
+                  {visibleKeys.map(key => (
                     <tr key={key.id}>
                       <td>
                         <Typography fontWeight="lg">{key.name}</Typography>
@@ -1895,7 +1942,7 @@ export default function UserApiKeysTab() {
                               variant="outlined"
                               onClick={() => rotateMutation.mutate(key.id)}
                               loading={rotateMutation.isPending}
-                              disabled={key.status === 'disabled'}
+                              disabled={isRevoked(key)}
                             >
                               <RotateLeftIcon />
                             </IconButton>
@@ -1907,10 +1954,27 @@ export default function UserApiKeysTab() {
                               color="danger"
                               onClick={() => revokeMutation.mutate({ keyId: key.id, reason: 'Revoked by user' })}
                               loading={revokeMutation.isPending}
-                              disabled={key.status === 'disabled'}
+                              disabled={isRevoked(key)}
                             >
                               <BlockIcon />
                             </IconButton>
+                          </Tooltip>
+                          {/* span wrapper: a disabled button emits no pointer events, and the
+                              disabled-state tooltip is the one carrying the instruction. */}
+                          <Tooltip title={isRevoked(key) ? 'Delete permanently' : 'Revoke this key before deleting it'}>
+                            <span>
+                              <IconButton
+                                size="sm"
+                                variant="outlined"
+                                color="danger"
+                                onClick={() => setKeyPendingDelete(key)}
+                                disabled={!isRevoked(key)}
+                                aria-label={`Delete ${key.name}`}
+                                data-testid={`api-key-delete-${key.id}`}
+                              >
+                                <DeleteOutlineIcon />
+                              </IconButton>
+                            </span>
                           </Tooltip>
                         </Box>
                       </td>
@@ -1933,6 +1997,20 @@ export default function UserApiKeysTab() {
         open={showKeyCreatedModal}
         onClose={() => setShowKeyCreatedModal(false)}
         apiKey={newlyCreatedKey}
+      />
+
+      <ConfirmationModal
+        open={keyPendingDelete !== null}
+        onClose={() => setKeyPendingDelete(null)}
+        onConfirm={() => {
+          if (keyPendingDelete) deleteMutation.mutate(keyPendingDelete.id);
+        }}
+        loading={deleteMutation.isPending}
+        title="Delete API key"
+        description={`Remove "${keyPendingDelete?.name}" from your list for good. It is already revoked, so nothing can authenticate with it either way - but usage recorded while it was active will no longer show its name.`}
+        confirmText="Delete"
+        confirmColor="danger"
+        showWarningIcon
       />
     </Box>
   );

--- a/apps/client/app/components/profile/UserApiKeysTab.tsx
+++ b/apps/client/app/components/profile/UserApiKeysTab.tsx
@@ -1961,7 +1961,11 @@ export default function UserApiKeysTab() {
                           </Tooltip>
                           {/* span wrapper: a disabled button emits no pointer events, and the
                               disabled-state tooltip is the one carrying the instruction. */}
-                          <Tooltip title={isRevoked(key) ? 'Delete permanently' : 'Revoke this key before deleting it'}>
+                          {/* Must stay identical to the ConflictError in userApiKeyService/delete.ts,
+                              which is what surfaces if this guard is ever bypassed. */}
+                          <Tooltip
+                            title={isRevoked(key) ? 'Delete permanently' : 'Revoke this API key before deleting it'}
+                          >
                             <span>
                               <IconButton
                                 size="sm"

--- a/apps/client/app/hooks/data/userApiKeys.ts
+++ b/apps/client/app/hooks/data/userApiKeys.ts
@@ -83,7 +83,11 @@ export interface RotateUserApiKeyResponse {
 /**
  * Includes revoked (`disabled`) keys - the management tables render them as a
  * `Revoked` row with the actions disabled, so revocation stays visible instead
- * of the key silently dropping out of the list.
+ * of the key silently dropping out of the list. Hiding them is a per-table
+ * client-side filter (see UserApiKeysTab's Show revoked toggle), deliberately
+ * NOT a narrower fetch: every mutation here invalidates the single
+ * `['user-api-keys']` entry, so two tables asking for different slices under
+ * one key would clobber each other's cache.
  */
 export function useGetUserApiKeys() {
   return useQuery<IUserApiKeyDocument[]>({
@@ -207,6 +211,28 @@ export function useAdminResetApiKeyRateLimit({ onSuccess }: { onSuccess?: () => 
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'user-api-keys'] });
+      if (onSuccess) onSuccess();
+    },
+    onError: (error: Error) => {
+      toast.error(parseValidationError(error));
+    },
+  });
+}
+
+/**
+ * Permanently remove an already-revoked key's row. The route refuses a key that
+ * is still active (409), so the table's delete action stays disabled until the
+ * key is revoked - same rule, enforced on both sides.
+ */
+export function useDeleteUserApiKey({ onSuccess }: { onSuccess?: () => void } = {}) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async keyId => {
+      await api.delete(`/api/user-api-keys/${keyId}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-api-keys'] });
       if (onSuccess) onSuccess();
     },
     onError: (error: Error) => {

--- a/apps/client/pages/api/user-api-keys/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/__tests__/index.test.ts
@@ -5,8 +5,10 @@ import { createMocks } from 'node-mocks-http';
  * PATCH /api/user-api-keys/[id] (embed-key configure, Phase E): the "nothing to
  * update" guard, the host-aware origin screen (validateEmbedKeyOrigins, run for
  * real here), and the analytics `updatedFields` that reflects only the fields
- * actually sent. The service is mocked - these assertions are about what the
- * route screens, forwards, and logs, not the service's own invariants.
+ * actually sent. Plus DELETE on the same route: the id guard, the adapters it
+ * threads, and the DELETED event. The services are mocked - these assertions are
+ * about what the route screens, forwards, and logs, not the services' own
+ * invariants (the revoked-only rule is covered in delete.test.ts).
  */
 
 // PUBLISH_HOST is read from SERVER_DOMAIN at module load, so set it before imports.
@@ -14,7 +16,10 @@ vi.hoisted(() => {
   process.env.SERVER_DOMAIN = 'bike4mind.com';
 });
 
-const mockRefs = vi.hoisted(() => ({ patchHandler: null as null | ((req: any, res: any) => unknown) }));
+const mockRefs = vi.hoisted(() => ({
+  patchHandler: null as null | ((req: any, res: any) => unknown),
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
+}));
 
 vi.mock('@server/middlewares/baseApi', () => {
   const chain: any = {
@@ -22,6 +27,10 @@ vi.mock('@server/middlewares/baseApi', () => {
     post: () => chain,
     patch: (fn: any) => {
       mockRefs.patchHandler = fn;
+      return chain;
+    },
+    delete: (fn: any) => {
+      mockRefs.deleteHandler = fn;
       return chain;
     },
   };
@@ -41,11 +50,13 @@ const updateEmbedKey = vi.hoisted(() =>
 // forwards), but resolveOwnedApiKey is the REAL one: the branding-owner read is
 // the site that must not drift from the service's resolution, so stubbing it
 // here would make the org-admin assertions below vacuous.
+const deleteUserApiKey = vi.hoisted(() => vi.fn().mockResolvedValue({ name: 'widget' }));
 vi.mock('@bike4mind/services', async importOriginal => {
   const actual = await importOriginal<typeof import('@bike4mind/services')>();
   return {
     userApiKeyService: {
       updateEmbedKey,
+      deleteUserApiKey,
       resolveOwnedApiKey: actual.userApiKeyService.resolveOwnedApiKey,
     },
   };
@@ -77,7 +88,7 @@ const organizationRepository = vi.hoisted(() => ({
 }));
 vi.mock('@bike4mind/database', () => ({ organizationRepository, userRepository }));
 
-import { CreditHolderType } from '@bike4mind/common';
+import { ConflictError, CreditHolderType } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
 import '@pages/api/user-api-keys/[id]/index';
 
@@ -86,6 +97,51 @@ function patch(id: string | undefined, body: unknown) {
   (req as any).user = { id: 'u1', isAdmin: false };
   return { req, res };
 }
+
+function del(id: string | undefined) {
+  const { req, res } = createMocks({ method: 'DELETE', query: id === undefined ? {} : { id } });
+  (req as any).user = { id: 'u1', isAdmin: false };
+  return { req, res };
+}
+
+describe('DELETE /api/user-api-keys/[id] - remove a revoked key', () => {
+  beforeEach(() => {
+    deleteUserApiKey.mockClear();
+    logEvent.mockClear();
+  });
+
+  it('forwards the key id with both adapters and logs the DELETED event', async () => {
+    const { req, res } = del('key-1');
+    await mockRefs.deleteHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(deleteUserApiKey).toHaveBeenCalledWith(
+      'u1',
+      { keyId: 'key-1' },
+      // The org adapter must be threaded or the service's org-admin fallback
+      // would have no dependency to resolve with.
+      { db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository } }
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { keyId: 'key-1', name: 'widget' } }),
+      expect.anything()
+    );
+  });
+
+  it('rejects a missing key id with 400 and never calls the service', async () => {
+    const { req, res } = del(undefined);
+    await expect(mockRefs.deleteHandler!(req, res)).rejects.toThrow(/Invalid key ID/i);
+    expect(deleteUserApiKey).not.toHaveBeenCalled();
+  });
+
+  it('propagates a service refusal without logging a deletion', async () => {
+    deleteUserApiKey.mockRejectedValueOnce(new ConflictError('Revoke this API key before deleting it'));
+    const { req, res } = del('key-1');
+
+    await expect(mockRefs.deleteHandler!(req, res)).rejects.toThrow(/Revoke this API key/i);
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+});
 
 describe('PATCH /api/user-api-keys/[id] - embed-key configure', () => {
   beforeEach(() => {

--- a/apps/client/pages/api/user-api-keys/[id]/index.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/index.ts
@@ -16,92 +16,121 @@ interface UpdateEmbedKeyRequest {
   branding?: IEmbedBranding;
 }
 
-// Not admin-gated at the route: `updateEmbedKey` resolves the key by ownership -
-// the minter, or an admin of the org the key is billed to (mirroring the
-// org-admin-aware LIST route). A caller who is neither gets a not-found.
-const handler = baseApi().patch(
-  asyncHandler<{}, unknown, UpdateEmbedKeyRequest, { id: string }>(async (req, res) => {
-    const userId = req.user?.id;
-    const keyId = req.query.id;
-    const { agentId, allowedOrigins, branding } = req.body;
+// Neither method is admin-gated at the route: the services resolve the key by
+// ownership - the minter, or an admin of the org the key is billed to (mirroring
+// the org-admin-aware LIST route). A caller who is neither gets a not-found.
+const handler = baseApi()
+  .patch(
+    asyncHandler<{}, unknown, UpdateEmbedKeyRequest, { id: string }>(async (req, res) => {
+      const userId = req.user?.id;
+      const keyId = req.query.id;
+      const { agentId, allowedOrigins, branding } = req.body;
 
-    if (!keyId) throw new BadRequestError('Invalid key ID');
-    if (agentId === undefined && allowedOrigins === undefined && branding === undefined) {
-      throw new BadRequestError('Nothing to update');
-    }
-
-    // Host-aware origin screen lives here (needs the runtime app host); the
-    // service re-validates format/dedup/cap and the embed-scope invariant.
-    let embedOrigins = allowedOrigins;
-    if (allowedOrigins !== undefined) {
-      const originsCheck = validateEmbedKeyOrigins(allowedOrigins);
-      if (!originsCheck.ok) {
-        throw new BadRequestError(originsCheck.error);
+      if (!keyId) throw new BadRequestError('Invalid key ID');
+      if (agentId === undefined && allowedOrigins === undefined && branding === undefined) {
+        throw new BadRequestError('Nothing to update');
       }
-      embedOrigins = originsCheck.value;
-    }
 
-    // Branding format screen (hex color, https logo, caps); the service
-    // re-validates with the same shared schema. The whitelabel write gate then
-    // blocks only an unentitled hideBranding *elevation* against the key OWNER's
-    // plan (same rule as the authoritative read gate); pass the stored value so
-    // an unentitled member editing an unrelated branding field cannot clobber
-    // white-label the org already earned.
-    const brandingCheck = validateEmbedBranding(branding);
-    if (!brandingCheck.ok) {
-      throw new BadRequestError(brandingCheck.error);
-    }
-    // The stored value + owner only matter for an incoming hideBranding
-    // elevation; skip the extra read on the common color/logo/name-only edit
-    // (the gate is a no-op there anyway, and updateEmbedKey re-fetches the doc).
-    let gatedBranding = brandingCheck.value;
-    if (brandingCheck.value?.hideBranding === true) {
-      // Resolve the elevation against the key's billing owner, not the caller.
-      // Same minter-then-org-admin resolution as updateEmbedKey (shared via
-      // resolveOwnedApiKey, so the two can no longer drift), so an org admin
-      // editing a teammate's org key gates against the org's owner (matching the
-      // ownerHasWhitelabel flag the LIST route computes). A key the caller neither
-      // minted nor administers stays unresolved and fails closed to stripped;
-      // updateEmbedKey then throws not-found regardless.
-      const existing = await userApiKeyService.resolveOwnedApiKey(userId, keyId, {
-        db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository },
-      });
-      gatedBranding = existing
-        ? await gateEmbedBrandingWrite(
-            existing,
-            brandingCheck.value,
-            existing.branding?.hideBranding === true,
-            existing.id
-          )
-        : { ...brandingCheck.value, hideBranding: false };
-    }
+      // Host-aware origin screen lives here (needs the runtime app host); the
+      // service re-validates format/dedup/cap and the embed-scope invariant.
+      let embedOrigins = allowedOrigins;
+      if (allowedOrigins !== undefined) {
+        const originsCheck = validateEmbedKeyOrigins(allowedOrigins);
+        if (!originsCheck.ok) {
+          throw new BadRequestError(originsCheck.error);
+        }
+        embedOrigins = originsCheck.value;
+      }
 
-    const updated = await userApiKeyService.updateEmbedKey(
-      userId,
-      { keyId, agentId, allowedOrigins: embedOrigins, branding: gatedBranding },
-      { db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository } }
-    );
+      // Branding format screen (hex color, https logo, caps); the service
+      // re-validates with the same shared schema. The whitelabel write gate then
+      // blocks only an unentitled hideBranding *elevation* against the key OWNER's
+      // plan (same rule as the authoritative read gate); pass the stored value so
+      // an unentitled member editing an unrelated branding field cannot clobber
+      // white-label the org already earned.
+      const brandingCheck = validateEmbedBranding(branding);
+      if (!brandingCheck.ok) {
+        throw new BadRequestError(brandingCheck.error);
+      }
+      // The stored value + owner only matter for an incoming hideBranding
+      // elevation; skip the extra read on the common color/logo/name-only edit
+      // (the gate is a no-op there anyway, and updateEmbedKey re-fetches the doc).
+      let gatedBranding = brandingCheck.value;
+      if (brandingCheck.value?.hideBranding === true) {
+        // Resolve the elevation against the key's billing owner, not the caller.
+        // Same minter-then-org-admin resolution as updateEmbedKey (shared via
+        // resolveOwnedApiKey, so the two can no longer drift), so an org admin
+        // editing a teammate's org key gates against the org's owner (matching the
+        // ownerHasWhitelabel flag the LIST route computes). A key the caller neither
+        // minted nor administers stays unresolved and fails closed to stripped;
+        // updateEmbedKey then throws not-found regardless.
+        const existing = await userApiKeyService.resolveOwnedApiKey(userId, keyId, {
+          db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository },
+        });
+        gatedBranding = existing
+          ? await gateEmbedBrandingWrite(
+              existing,
+              brandingCheck.value,
+              existing.branding?.hideBranding === true,
+              existing.id
+            )
+          : { ...brandingCheck.value, hideBranding: false };
+      }
 
-    await logEvent(
-      {
+      const updated = await userApiKeyService.updateEmbedKey(
         userId,
-        type: UserApiKeyEvents.UPDATED,
-        metadata: {
-          keyId,
-          name: updated.name,
-          updatedFields: [
-            ...(agentId !== undefined ? ['agentId'] : []),
-            ...(allowedOrigins !== undefined ? ['allowedOrigins'] : []),
-            ...(branding !== undefined ? ['branding'] : []),
-          ],
-        },
-      },
-      { ability: req.ability }
-    );
+        { keyId, agentId, allowedOrigins: embedOrigins, branding: gatedBranding },
+        { db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository } }
+      );
 
-    return res.status(200).json(updated);
-  })
-);
+      await logEvent(
+        {
+          userId,
+          type: UserApiKeyEvents.UPDATED,
+          metadata: {
+            keyId,
+            name: updated.name,
+            updatedFields: [
+              ...(agentId !== undefined ? ['agentId'] : []),
+              ...(allowedOrigins !== undefined ? ['allowedOrigins'] : []),
+              ...(branding !== undefined ? ['branding'] : []),
+            ],
+          },
+        },
+        { ability: req.ability }
+      );
+
+      return res.status(200).json(updated);
+    })
+  )
+  // Removal is list hygiene, not a security control: `deleteUserApiKey` refuses
+  // anything but an already-revoked key (409), so the revocation that actually
+  // kills the credential - and stamps its audit trail - always came first.
+  .delete(
+    asyncHandler<{}, unknown, unknown, { id: string }>(async (req, res) => {
+      const userId = req.user?.id;
+      const keyId = req.query.id;
+
+      if (!keyId) throw new BadRequestError('Invalid key ID');
+
+      const { name } = await userApiKeyService.deleteUserApiKey(
+        userId,
+        { keyId },
+        { db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository } }
+      );
+
+      await logEvent(
+        {
+          userId,
+          type: UserApiKeyEvents.DELETED,
+          metadata: { keyId, name },
+        },
+        { ability: req.ability }
+      );
+
+      return res.status(200).json({ success: true });
+    })
+  );
 
 export const config = {
   api: {

--- a/b4m-core/services/src/userApiKeyService/__tests__/delete.test.ts
+++ b/b4m-core/services/src/userApiKeyService/__tests__/delete.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { deleteUserApiKey } from '../delete';
+import { ApiKeyStatus } from '@bike4mind/common';
+import type { IUserApiKeyDocument } from '@bike4mind/common';
+
+const keyDoc = (overrides: Partial<IUserApiKeyDocument> = {}) =>
+  ({
+    id: 'key-1',
+    name: 'CI key',
+    userId: 'user1',
+    status: ApiKeyStatus.DISABLED,
+    ...overrides,
+  }) as unknown as IUserApiKeyDocument;
+
+function makeAdapters(stored: IUserApiKeyDocument | null, administeredOrgIds: string[] = []) {
+  const repo = {
+    findByUserIdAndId: vi.fn().mockResolvedValue(stored?.userId === 'user1' ? stored : null),
+    findByOrganizationIdsAndId: vi.fn().mockResolvedValue(stored?.userId === 'user1' ? null : stored),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  const orgs = { findIdsAdministeredBy: vi.fn().mockResolvedValue(administeredOrgIds) };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { repo, orgs, adapters: { db: { userApiKeys: repo as any, organizations: orgs as any } } };
+}
+
+describe('deleteUserApiKey', () => {
+  it('deletes a revoked key the caller minted and returns its name', async () => {
+    const { repo, adapters } = makeAdapters(keyDoc());
+
+    const result = await deleteUserApiKey('user1', { keyId: 'key-1' }, adapters);
+
+    expect(result.name).toBe('CI key');
+    expect(repo.delete).toHaveBeenCalledWith('key-1');
+  });
+
+  it('refuses to delete an active key so revocation always precedes removal', async () => {
+    const { repo, adapters } = makeAdapters(keyDoc({ status: ApiKeyStatus.ACTIVE }));
+
+    await expect(deleteUserApiKey('user1', { keyId: 'key-1' }, adapters)).rejects.toThrow(/Revoke this API key/);
+    expect(repo.delete).not.toHaveBeenCalled();
+  });
+
+  // An expired key stays ACTIVE until something revokes it (status is not
+  // clock-derived), so it too must be revoked first - no clock in this guard.
+  it('refuses to delete an expired-but-active key', async () => {
+    const { repo, adapters } = makeAdapters(keyDoc({ status: ApiKeyStatus.ACTIVE, expiresAt: new Date('2020-01-01') }));
+
+    await expect(deleteUserApiKey('user1', { keyId: 'key-1' }, adapters)).rejects.toThrow(/Revoke this API key/);
+    expect(repo.delete).not.toHaveBeenCalled();
+  });
+
+  it('lets an org admin delete a revoked key billed to an org they administer', async () => {
+    const { repo, orgs, adapters } = makeAdapters(keyDoc({ userId: 'minter', name: 'Org key' }), ['org-1']);
+
+    const result = await deleteUserApiKey('admin-user', { keyId: 'key-1' }, adapters);
+
+    expect(result.name).toBe('Org key');
+    expect(orgs.findIdsAdministeredBy).toHaveBeenCalledWith('admin-user');
+    expect(repo.findByOrganizationIdsAndId).toHaveBeenCalledWith(['org-1'], 'key-1');
+    expect(repo.delete).toHaveBeenCalledWith('key-1');
+  });
+
+  it('throws NotFound when the caller neither minted nor administers the key', async () => {
+    const { repo, adapters } = makeAdapters(null);
+
+    await expect(deleteUserApiKey('other-user', { keyId: 'key-1' }, adapters)).rejects.toThrow(/not found/);
+    expect(repo.delete).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/userApiKeyService/delete.ts
+++ b/b4m-core/services/src/userApiKeyService/delete.ts
@@ -1,0 +1,65 @@
+import {
+  ApiKeyStatus,
+  ConflictError,
+  IOrganizationRepository,
+  IUserApiKeyRepository,
+  NotFoundError,
+} from '@bike4mind/common';
+import { secureParameters } from '@bike4mind/utils';
+import { z } from 'zod';
+import { resolveOwnedApiKey } from './resolveOwnedApiKey';
+
+const deleteUserApiKeySchema = z.object({
+  keyId: z.string(),
+});
+
+export type DeleteUserApiKeyParameters = z.infer<typeof deleteUserApiKeySchema>;
+
+interface DeleteUserApiKeyAdapters {
+  db: {
+    userApiKeys: IUserApiKeyRepository;
+    organizations: Pick<IOrganizationRepository, 'findIdsAdministeredBy'>;
+  };
+}
+
+export interface DeleteUserApiKeyResult {
+  /** The deleted key's name, so callers can log a real name instead of a placeholder. */
+  name: string;
+}
+
+/**
+ * Remove a revoked key's record, scoped by resolveOwnedApiKey (the key's minter,
+ * or an admin of the org it is billed to). This is list hygiene, never a
+ * security control: only a key already DISABLED may go, so revocation - the
+ * write that actually kills the credential and stamps revokedAt/revokedBy - has
+ * always happened first and is always recorded. An active key gets a 409, so
+ * there is no path to drop a live credential without leaving that trail.
+ *
+ * `db.userApiKeys.delete` is a soft delete (UserApiKeySchema carries
+ * softDeletePlugin): the document stays in the collection with its audit fields
+ * but every finder excludes it, so the key leaves the user's list and can never
+ * validate again. Historical usage rows keep the raw key id and so lose their
+ * name in the usage dashboard ('Unknown key'); the analytics DELETED event and
+ * the soft-deleted document are what an operator reads instead.
+ */
+export const deleteUserApiKey = async (
+  userId: string,
+  parameters: DeleteUserApiKeyParameters,
+  adapters: DeleteUserApiKeyAdapters
+): Promise<DeleteUserApiKeyResult> => {
+  const { db } = adapters;
+  const params = secureParameters(parameters, deleteUserApiKeySchema);
+
+  const apiKey = await resolveOwnedApiKey(userId, params.keyId, { db });
+  if (!apiKey) {
+    throw new NotFoundError('API key not found');
+  }
+
+  if (apiKey.status !== ApiKeyStatus.DISABLED) {
+    throw new ConflictError('Revoke this API key before deleting it');
+  }
+
+  await db.userApiKeys.delete(apiKey.id);
+
+  return { name: apiKey.name };
+};

--- a/b4m-core/services/src/userApiKeyService/index.ts
+++ b/b4m-core/services/src/userApiKeyService/index.ts
@@ -1,4 +1,5 @@
 export * from './create';
+export * from './delete';
 export * from './getSystemUser';
 export * from './list';
 export * from './rateLimit';


### PR DESCRIPTION
# Pull Request

## Description

Closes #2403

Revoked API keys accumulated in the user's key list permanently: `revokeUserApiKey` sets `status: disabled`, the list hook pins `includeDisabled=true`, and there was no hard-delete method in `userApiKeyService` and no `DELETE` route under `/api/user-api-keys`. Since scopes are write-once, every scope adjustment means minting a new key and revoking the old one, so the list only ever grows.

This lands both of the issue's concrete suggestions: a **Show revoked** toggle in the key table (default off) and a **delete** action for keys that are already revoked. The issue's third suggestion - making scopes editable on an active key - is deliberately not here; the issue itself asks for that to be decided on its own merits rather than folded into this fix.

The old behaviour was not an accident: the list hook's docblock explains that revocation stays visible "instead of the key silently dropping out of the list." That audit intent is preserved rather than dropped - revoked rows are one checkbox away, the checkbox shows how many are hidden, and revoking now raises a toast so the row leaving the list is confirmed rather than silent.

## Changes

**Server - `DELETE /api/user-api-keys/:id`**

- `b4m-core/services/src/userApiKeyService/delete.ts` (new): `deleteUserApiKey` resolves ownership through `resolveOwnedApiKey` - the same resolver `revoke`/`rotate`/`updateEmbedKey` use, so an unauthorized caller gets a 404 rather than a 403. Refuses any key that is not already `disabled` with a 409.
- `apps/client/pages/api/user-api-keys/[id]/index.ts`: `DELETE` chained onto the existing PATCH handler, emitting `UserApiKeyEvents.DELETED`. That event type was already declared in `b4m-core/common/src/schemas/analytics/events/userApiKey.ts` with no producer; now it has one.
- `db.userApiKeys.delete` is a soft delete - `UserApiKeySchema` carries `softDeletePlugin`, so the document survives with its audit fields while the `pre('find')`/`pre('findOne')` hooks exclude it from every finder. The row leaves the list, the credential can never validate again, and an operator can still recover it with `includeDeleted`.

**Client - hide and delete**

- `apps/client/app/hooks/data/userApiKeys.ts`: `useDeleteUserApiKey`, invalidating `['user-api-keys']` like its siblings.
- `apps/client/app/components/profile/UserApiKeysTab.tsx`: a `Show revoked (N)` checkbox next to Refresh, off by default, with rows filtered client-side; a per-row delete button, enabled only on a revoked key, behind a `ConfirmationModal` that names the key; a dedicated empty state for an all-revoked list; a success toast on revoke.
- The status chip now reads `Revoked` instead of `Disabled`, matching the revocation tooltip, the embed-key table and the new toggle. Every path that writes `disabled` also stamps `revokedAt` (`revokeUserApiKey`, `deactivateAllByUserId`, the cc-bridge device revoke), so the rename is accurate rather than cosmetic.

**Tests**

- `b4m-core/services/src/userApiKeyService/__tests__/delete.test.ts` (new, 5 cases)
- 3 new DELETE cases in `apps/client/pages/api/user-api-keys/[id]/__tests__/index.test.ts`
- `apps/client/app/components/profile/UserApiKeysTab.test.tsx` (new, 6 cases)

## Guide for Testers

Setup: sign in as any normal user at `app.staging.bike4mind.com` (no admin role needed).

1. Navigate to `app.staging.bike4mind.com/profile?tab=api-keys`. **Expected:** the "User API Keys" section renders with your key list (or the "You don't have any API keys yet" empty state).
2. Click **Create API Key**, type `tester-keep` as the name, pick any scope, and submit. **Expected:** the key is created, its secret is shown once, and a row named `tester-keep` appears with status `Active`.
3. Repeat step 2 with the name `tester-revoke`. **Expected:** two rows, both `Active`.
4. On the `tester-revoke` row, look at the trash icon. **Expected:** it is greyed out/disabled, and hovering it shows the tooltip `Revoke this key before deleting it`.
5. Click the revoke (block) icon on the `tester-revoke` row and confirm the revoke. **Expected:** a toast reads `API key revoked`, the `tester-revoke` row **disappears** from the table, and a checkbox labelled `Show revoked (1)` appears next to the Refresh button.
6. Tick the `Show revoked (1)` checkbox. **Expected:** the `tester-revoke` row reappears with status `Revoked`; its rotate and revoke actions are greyed out, and its trash icon is now enabled.
7. Hover the now-enabled trash icon on the `tester-revoke` row. **Expected:** tooltip reads `Delete permanently`.
8. Click that trash icon. **Expected:** a confirmation dialog titled `Delete API key` opens and names `tester-revoke` in its body, warning that usage recorded while the key was active will no longer show its name.
9. Click **Cancel** in the dialog. **Expected:** the dialog closes and the `tester-revoke` row is still present.
10. Click the trash icon again and click **Delete**. **Expected:** a toast reads `API key deleted`, the `tester-revoke` row is gone, and the `Show revoked` checkbox disappears (0 revoked keys remain).
11. Click **Refresh**, then reload the page. **Expected:** `tester-revoke` does not come back. `tester-keep` is still listed as `Active`.
12. Revoke `tester-keep` too, then tick `Show revoked (1)`, delete it, and untick nothing. **Expected:** with every key revoked and the toggle off, the table shows the message `All of your API keys are revoked. Turn on Show revoked to see or delete them.` - not the "no API keys yet" empty state. (To see this state, revoke a key without deleting it and untick the checkbox.)
13. Confirm the deleted key's credential is dead: if you saved the secret from step 3, call any API endpoint with it. **Expected:** the request is rejected (it was already rejected from step 5 onward - revocation, not deletion, is what kills the credential).

### Regression Checks

14. With no revoked keys in the list, confirm the `Show revoked` checkbox is **not** rendered at all.
15. Confirm creating, rotating, and revoking a key all still work exactly as before, and that rotate on an active key still returns a new secret.
16. Go to `/profile?tab=usage` and confirm the usage dashboard still renders. A deleted key's historical usage rows now show `Unknown key` instead of the key name - that is expected and called out in the confirm dialog.
17. Admin only: open Admin -> Embed Keys. **Expected:** unchanged - that table still shows revoked keys unconditionally and has no delete button.

### What NOT to test

- Editing scopes on an existing key: still not possible, and intentionally out of scope for this PR.
- Restoring a deleted key from the UI: there is no such path. The document is soft-deleted server-side and is only recoverable by an operator query.

## Additional Information

**Why delete requires a prior revoke (409 otherwise).** Removal here is list hygiene, not a security control. Requiring `disabled` first means the write that actually kills the credential and stamps `revokedAt`/`revokedBy` has always happened and is always recorded, so there is no path to drop a live credential without leaving that trail. One consequence: status is not clock-derived, so an *expired* key is still `active` and must also be revoked before it can be deleted - two clicks. That was chosen deliberately over a clock-dependent guard, and is covered by a test.

**Why the toggle filters client-side rather than fetching narrower.** The hook keeps `includeDisabled=true`. Every mutation in that hook invalidates the single `['user-api-keys']` cache entry, so two tables asking for different slices under one key would clobber each other's cache. Fetching wide is also what gives the toggle its `(N)` count.

**Auth posture.** The route is `baseApi()` with no `requiredScopes`, matching its siblings `revoke.ts`/`rotate.ts` and the existing PATCH - so an API key can call it, exactly as an API key can already revoke. A key cannot delete itself, since a `disabled` key cannot authenticate. No new privilege class; flagging it because it is a deliberate match rather than an oversight.

**Reviewing the route diff.** `apps/client/pages/api/user-api-keys/[id]/index.ts` shows ~183 changed lines but only ~30 are new: turning `baseApi().patch(...)` into a two-call chain makes prettier reflow the whole PATCH body by two spaces. `git diff -w` on that file shows the real change. The chain was kept over a diff-friendlier shape because it is the repo idiom, and `DELETE /api/user-api-keys/:id` is the right home for the verb (the sibling `revoke.ts`/`rotate.ts` files exist only because revoke and rotate are not HTTP verbs).

**Not touched.** `EmbedKeysTab` has the same accumulation problem and could adopt the identical toggle, but the issue's repro is the scoped-key table, and `EmbedKeysTab.test.tsx` explicitly asserts that a revoked row renders - a signal that visible-revoked is intentional there. `AdminApiKeysModal` (an admin viewing another user's keys) reads a different hook and was left alone. The new DELETE route is surface-agnostic, so wiring either up later is UI-only.

**Telemetry.** No new telemetry field: `UserApiKeyEvents.DELETED` was already declared and simply had no producer until now. The classification doc the checklist points at does not exist in this repo.

### Verification

| Command | Result |
| --- | --- |
| `pnpm turbo:typecheck` | pass (40/40 tasks) |
| `pnpm lint:check` | pass, clean |
| `pnpm --filter @bike4mind/services test` (userApiKeyService) | 12 files, 113/113 pass |
| client `--project node`, `pages/api/user-api-keys` | 4 files, 58/58 pass |
| client `--project jsdom`, `UserApiKeysTab.test.tsx` | 6/6 pass |
| `pnpm --filter @bike4mind/database test` | 176 files, 2214 pass / 1 skipped |

A full `pnpm turbo:test` run also showed `@bike4mind/scripts` migration integration tests failing on `Hook timed out in 30000ms` - the parallel-`mongod` contention CLAUDE.md warns about. Re-running that package alone left one failure, which then passed 10/10 in isolation. Contention flake, not a regression: this diff touches no file in `packages/scripts` and no DB model.

## Developer Notes

- **New extension point:** `DELETE /api/user-api-keys/:id` + `deleteUserApiKey` is surface-agnostic, so any other key table (embed keys, the admin key modal) can adopt delete as a UI-only change.
- **Reusable pattern:** the `Show revoked (N)` toggle - fetch wide, filter client-side, put the hidden count in the label, and give the all-hidden case its own empty state - applies to any list that keeps soft-retired rows for audit value.
- **Soft-delete as the removal primitive:** `db.userApiKeys.delete` going through `softDeletePlugin` is what lets "delete" be both final from the user's side and recoverable by an operator. Worth knowing before anyone reaches for a hard delete here.
- **Guard placement:** the `disabled`-only precondition lives in the service (`delete.ts`), not the route, so any future caller inherits it.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
