### PR TITLE
feat(client): let a mounted host claim in-place family navigation

### DIFF
--- a/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
+++ b/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
@@ -18,11 +18,14 @@ interface SurfaceBreadcrumbProps {
   /** Left margin (spacing units or a raw CSS length). Default 0; used to sit the breadcrumb a
    *  fixed distance from a sibling control in a header row. */
   ml?: number | string;
+  /** Vertical padding (spacing units or a raw CSS length). Omitted keeps Joy's own 0.5rem;
+   *  pass 0 inside a header row that already spaces its lines. */
+  py?: number | string;
 }
 
-export function SurfaceBreadcrumb({ segments, mb = 2, ml = 0 }: SurfaceBreadcrumbProps) {
+export function SurfaceBreadcrumb({ segments, mb = 2, ml = 0, py }: SurfaceBreadcrumbProps) {
   return (
-    <Breadcrumbs size="sm" sx={{ px: 0, mb, ml }}>
+    <Breadcrumbs size="sm" sx={{ px: 0, py, mb, ml }}>
       {segments.map((seg, i) => {
         const isLast = i === segments.length - 1;
         if (isLast || !seg.onClick) {

--- a/apps/client/app/hooks/useNavigationExecutor.test.ts
+++ b/apps/client/app/hooks/useNavigationExecutor.test.ts
@@ -30,6 +30,7 @@ describe('useNavigationExecutor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useOptiNavigation.getState().clearPending();
+    useOptiNavigation.getState().setHostHandlesFamilyInPlace(false);
   });
 
   it('marks an Opti click as user-initiated so the surface does not drop it as a replay', () => {
@@ -58,5 +59,31 @@ describe('useNavigationExecutor', () => {
       session: 'abc',
       article: 'xyz',
     });
+  });
+
+  // A host that shows the console inside its own pane is already the view the
+  // user is looking at, and it owns the way back out. Naming the standalone view
+  // here would unmount that host mid-click and strand them there.
+  it('leaves the view alone when a host has claimed the console in place', () => {
+    useOptiNavigation.getState().setHostHandlesFamilyInPlace(true);
+    const { result } = renderHook(() => useNavigationExecutor());
+    result.current(optiIntent('assignment.solvers'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    const { pendingFamily, pendingSubTab, pendingUserInitiated } = useOptiNavigation.getState();
+    expect(pendingFamily).toBe('assignment');
+    expect(pendingSubTab).toBe('solvers');
+    expect(pendingUserInitiated).toBe(true);
+  });
+
+  // The claim covers family consoles only; a route intent is a real page change.
+  it('still navigates a route intent while a host holds the console claim', () => {
+    useOptiNavigation.getState().setHostHandlesFamilyInPlace(true);
+    const { result } = renderHook(() => useNavigationExecutor());
+    result.current({ navigationType: 'route', target: '/new' } as Parameters<
+      ReturnType<typeof useNavigationExecutor>
+    >[0]);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/new' });
   });
 });

--- a/apps/client/app/hooks/useNavigationExecutor.ts
+++ b/apps/client/app/hooks/useNavigationExecutor.ts
@@ -20,6 +20,7 @@ export function useNavigationExecutor() {
   const navigate = useNavigate();
   const setActiveTab = useAdminModal(state => state.setActiveTab);
   const requestFamily = useOptiNavigation(state => state.requestFamily);
+  const hostHandlesFamilyInPlace = useOptiNavigation(state => state.hostHandlesFamilyInPlace);
   const setFileBrowserOpen = useFileBrowser(state => state.setOpen);
 
   const execute = useCallback(
@@ -56,6 +57,9 @@ export function useNavigationExecutor() {
           } else {
             requestFamily(intent.target, undefined, { userInitiated: true });
           }
+          // A host showing the console in its own pane is already on screen and owns
+          // its own way back, so the request above is the whole navigation.
+          if (hostHandlesFamilyInPlace) break;
           // Name the target view in the search params rather than leaving the route to
           // its default, which would render the wrong view for a frame before the
           // consumer switches. The updater form is required: router-core passes a plain
@@ -66,7 +70,7 @@ export function useNavigationExecutor() {
         }
       }
     },
-    [navigate, setActiveTab, requestFamily, setFileBrowserOpen]
+    [navigate, setActiveTab, requestFamily, setFileBrowserOpen, hostHandlesFamilyInPlace]
   );
 
   return execute;

--- a/apps/client/app/hooks/useOptiNavigation.test.ts
+++ b/apps/client/app/hooks/useOptiNavigation.test.ts
@@ -8,6 +8,7 @@ import { useOptiNavigation } from './useOptiNavigation';
 describe('useOptiNavigation', () => {
   beforeEach(() => {
     useOptiNavigation.getState().clearPending();
+    useOptiNavigation.getState().setHostHandlesFamilyInPlace(false);
   });
 
   it('defaults a request to not user-initiated', () => {
@@ -30,5 +31,28 @@ describe('useOptiNavigation', () => {
     expect(pendingFamily).toBeNull();
     expect(pendingSubTab).toBeNull();
     expect(pendingUserInitiated).toBe(false);
+  });
+
+  // Read off the initial state, not the live one: the suite's own reset would
+  // mask a default that shipped as true, which would route every click into a
+  // surface that is not mounted.
+  it('claims nothing in place until a host registers', () => {
+    expect(useOptiNavigation.getInitialState().hostHandlesFamilyInPlace).toBe(false);
+  });
+
+  // The claim is a registration by whichever surface is mounted, not part of a
+  // request - clearing it with the request would drop the claim on the first
+  // dispatch and send the next one off to the standalone view.
+  it('keeps a host claim across a consumed request', () => {
+    useOptiNavigation.getState().setHostHandlesFamilyInPlace(true);
+    useOptiNavigation.getState().requestFamily('assignment', undefined, { userInitiated: true });
+    useOptiNavigation.getState().clearPending();
+    expect(useOptiNavigation.getState().hostHandlesFamilyInPlace).toBe(true);
+  });
+
+  it('drops the claim when the host unregisters', () => {
+    useOptiNavigation.getState().setHostHandlesFamilyInPlace(true);
+    useOptiNavigation.getState().setHostHandlesFamilyInPlace(false);
+    expect(useOptiNavigation.getState().hostHandlesFamilyInPlace).toBe(false);
   });
 });

--- a/apps/client/app/hooks/useOptiNavigation.ts
+++ b/apps/client/app/hooks/useOptiNavigation.ts
@@ -32,6 +32,19 @@ interface OptiNavigationState {
    * silently dropped in that state (its consumers gate on a live session).
    */
   pendingPrompt: string | null;
+  /**
+   * Set by a surface that renders the requested family console INSIDE its own
+   * pane and owns the way back out of it. While it holds, the executor dispatches
+   * the request and leaves `?mode=` alone - naming the standalone console view
+   * would unmount that surface mid-click, which is how the user ends up somewhere
+   * with no route back to what they were looking at.
+   *
+   * A registration, not part of a request: `clearPending` leaves it standing, and
+   * the surface clears it when it unmounts.
+   */
+  hostHandlesFamilyInPlace: boolean;
+  /** Register (or clear, with false) the host's in-place console claim. */
+  setHostHandlesFamilyInPlace: (handles: boolean) => void;
   /** Request navigation to a specific opti family, optionally with a sub-tab */
   requestFamily: (familyId: string, subTab?: string, opts?: { userInitiated?: boolean }) => void;
   /** Ask OptiHashiPage to send a prompt to the chat, creating a session if needed */
@@ -47,6 +60,8 @@ export const useOptiNavigation = create<OptiNavigationState>(set => ({
   pendingSubTab: null,
   pendingUserInitiated: false,
   pendingPrompt: null,
+  hostHandlesFamilyInPlace: false,
+  setHostHandlesFamilyInPlace: (handles: boolean) => set({ hostHandlesFamilyInPlace: handles }),
   requestFamily: (familyId: string, subTab?: string, opts?: { userInitiated?: boolean }) =>
     set({ pendingFamily: familyId, pendingSubTab: subTab ?? null, pendingUserInitiated: opts?.userInitiated === true }),
   requestChatPrompt: (prompt: string) => set({ pendingPrompt: prompt }),


### PR DESCRIPTION
## Description

The `/opti` family-navigation executor always named `?mode=optimize` alongside the request it dispatched. That is right for a surface the user is being taken *to*, and wrong for one that shows the requested console inside its own pane: it unmounts that surface mid-click, and the user lands on a view with no route back to what they had been looking at. This PR adds the seam that lets a mounted surface say "I am showing this here" and keep its own view, plus a spacing passthrough on `SurfaceBreadcrumb` for a caller that draws its trail inside a header row.

Nothing in this repo registers the new claim, so every surface here behaves exactly as before. The pattern mirrors the existing `useSessionRouter.setHostCreateSession` registration.

## Changes

- `useOptiNavigation`: new `hostHandlesFamilyInPlace` + `setHostHandlesFamilyInPlace`. It is a **registration**, not part of a request: `clearPending()` deliberately leaves it standing (clearing it with the request would drop the claim on the first dispatch), and the mounted surface clears it on unmount. Defaults to `false`.
- `useNavigationExecutor`: an `action` intent still dispatches `requestFamily(..., { userInitiated: true })` exactly as before; only the follow-up `navigate({ to: '/opti', search: ... mode: 'optimize' })` is skipped while a claim holds. `route`, `tab` and the file-browser intents are untouched.
- `SurfaceBreadcrumb`: optional `py` passthrough. `px` was already pinned to `0`; omitting `py` keeps Joy's own `0.5rem`, so existing callers render identically.
- Tests: 5 new cases across `useOptiNavigation.test.ts` and `useNavigationExecutor.test.ts` — the default (read off `getInitialState()`, so the suite's own reset cannot mask a default that shipped as `true`), claim survival across `clearPending`, unregistration, the skipped navigation, and a `route` intent still navigating while a claim holds.

## Guide for Testers

This is a no-op for this repo: nothing here registers a claim, so the only thing to check is that the existing navigation path did not move.

1. Open the preview app and sign in.
2. Send a chat message that gets a reply carrying a **Suggested Navigation** button (any reply with the navigation buttons block under it).
3. Click a navigation button. Expected: the same view opens as before this PR, and the address bar keeps every other search param it had (`?session=`, `?article=`) with `mode` updated.
4. Click any ordinary in-reply link/button that navigates to a route (for example one that goes to `/new`). Expected: it navigates normally.

### Regression Checks

1. Reload a conversation whose last reply carries navigation buttons. Expected: no automatic jump on load - the replayed navigation is dropped exactly as before.
2. Open a Data Lake sub-view that shows a breadcrumb trail (`Data Lakes / ...`). Expected: unchanged spacing and unchanged clickable parent crumbs.

### What NOT to test

- The behaviour the new claim enables: the only caller is outside this repo, so there is nothing here that can exercise the claimed path.

## Additional Information

The claim is a single slot on purpose - one surface is on screen at a time, and a set of registrations would need an ownership rule this seam does not have a use for yet.

## Developer Notes (Optional)

- **New Extension Point**: `useOptiNavigation` now carries a runtime host registration next to its pub/sub fields, the same shape as `useSessionRouter.setHostCreateSession` - a mounted route can intercept a dispatch that would otherwise navigate. The docblock spells out the registration-vs-request distinction, which is the part that is easy to get wrong.
- **Reusable Pattern**: `SurfaceBreadcrumb` keeps its spacing API additive (`mb`, `ml`, now `py`), with defaults chosen so a new prop cannot move existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
