### PR TITLE
fix(client): confirm a data lake access revoke before sending it

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.test.tsx
@@ -17,6 +17,7 @@ let viewState: {
 let candidatesState: { data?: LakeOwnershipCandidateList; isLoading: boolean; isError?: boolean };
 const transferMutate = vi.fn();
 const grantMutate = vi.fn();
+/** `mutateAsync`, because the confirm dialog awaits the DELETE to decide whether to close. */
 const revokeMutate = vi.fn();
 let revokePending = false;
 /** The in-flight DELETE's own input, which is what scopes the pending state to one row. */
@@ -27,12 +28,18 @@ vi.mock('@client/app/hooks/data/dataLakes', () => ({
   useLakeOwnershipCandidates: () => candidatesState,
   useTransferLakeOwnership: () => ({ mutateAsync: transferMutate, isPending: false }),
   useGrantLakeAccess: () => ({ mutateAsync: grantMutate, isPending: false }),
-  useRevokeLakeAccess: () => ({ mutate: revokeMutate, isPending: revokePending, variables: revokeVariables }),
+  useRevokeLakeAccess: () => ({ mutateAsync: revokeMutate, isPending: revokePending, variables: revokeVariables }),
   downloadLakeAccessCsv: (...args: unknown[]) => downloadCsv(...args),
 }));
 
 const toastError = vi.fn();
 vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastError(...a) } }));
+
+/** Open the confirmation for one grant row, which is now the only path to a DELETE. */
+const openRevokeConfirm = async (principalTestId: string) => {
+  await userEvent.click(screen.getByTestId(`datalake-access-revoke-${principalTestId}`));
+  return screen.getByTestId('datalake-revoke-modal');
+};
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const Wrapper = ({ children }: { children: ReactNode }) => (
@@ -341,8 +348,71 @@ describe('DataLakeAccessModal grant writes', () => {
     render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
 
     expect(screen.queryByTestId('datalake-access-revoke-user-owner1')).not.toBeInTheDocument();
-    await userEvent.click(screen.getByTestId('datalake-access-revoke-user-cur1'));
+    await openRevokeConfirm('user-cur1');
+    // The control opens the confirmation; nothing reaches the door until it is accepted.
+    expect(revokeMutate).not.toHaveBeenCalled();
+  });
+
+  it('sends the DELETE only once the revoke is confirmed, and nothing at all on cancel', async () => {
+    viewState = loaded({ ...fullView, grants: [{ ...fullView.grants[0]!, principalId: 'cur1', role: 'curator' }] });
+    render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+
+    await openRevokeConfirm('user-cur1');
+    await userEvent.click(screen.getByTestId('datalake-revoke-cancel-btn'));
+    expect(revokeMutate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('datalake-revoke-modal')).not.toBeInTheDocument();
+
+    await openRevokeConfirm('user-cur1');
+    await userEvent.click(screen.getByTestId('datalake-revoke-confirm-btn'));
     expect(revokeMutate).toHaveBeenCalledWith({ id: 'lake1', principalType: 'user', principalId: 'cur1' });
+    // Closed on success, so the second click of a double-click has no confirm left to hit.
+    expect(screen.queryByTestId('datalake-revoke-modal')).not.toBeInTheDocument();
+  });
+
+  it('keeps the confirmation open when the door refuses, so the toast can be acted on', async () => {
+    revokeMutate.mockRejectedValueOnce(new Error('nope'));
+    viewState = loaded({ ...fullView, grants: [{ ...fullView.grants[0]!, principalId: 'cur1', role: 'curator' }] });
+    render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+
+    await openRevokeConfirm('user-cur1');
+    await userEvent.click(screen.getByTestId('datalake-revoke-confirm-btn'));
+    expect(screen.getByTestId('datalake-revoke-modal')).toBeInTheDocument();
+  });
+
+  it('locks its own confirm while the DELETE is in flight, so one confirmation cannot send two', async () => {
+    viewState = loaded({ ...fullView, grants: [{ ...fullView.grants[0]!, principalId: 'cur1', role: 'curator' }] });
+    const { rerender } = render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+    await openRevokeConfirm('user-cur1');
+
+    revokePending = true;
+    revokeVariables = { principalType: 'user', principalId: 'cur1' };
+    rerender(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />);
+    expect(screen.getByTestId('datalake-revoke-confirm-btn')).toBeDisabled();
+  });
+
+  it('names what an organization grant and a curator grant take away, and flags an already-lapsed one', async () => {
+    viewState = loaded({
+      ...fullView,
+      grants: [
+        { ...fullView.grants[0]!, principalType: 'organization', principalId: 'orgA', principalName: 'Acme' },
+        { ...fullView.grants[0]!, principalId: 'cur1', role: 'curator', status: 'active', expiresAt: null },
+      ],
+    });
+    render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+
+    // An org row is the one whose blast radius is invisible from the name on it.
+    await openRevokeConfirm('organization-orgA');
+    expect(screen.getByTestId('datalake-revoke-org-warning')).toHaveTextContent(/everyone in Acme/i);
+    // The seeded row is expired, so the copy must not promise it is cutting off live access.
+    expect(screen.getByTestId('datalake-revoke-expired-note')).toHaveTextContent(/already lapsed/i);
+    expect(screen.queryByTestId('datalake-revoke-effect-note')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('datalake-revoke-cancel-btn'));
+
+    await openRevokeConfirm('user-cur1');
+    // Mirror of the grant form's disclosure: the role carried injection trust, so revoking says so.
+    expect(screen.getByTestId('datalake-revoke-curator-warning')).toHaveTextContent(/system-prompt trust/i);
+    expect(screen.getByTestId('datalake-revoke-effect-note')).toHaveTextContent(/ends immediately/i);
+    expect(screen.queryByTestId('datalake-revoke-org-warning')).not.toBeInTheDocument();
   });
 
   it('grants a reader by email, closing the form on success', async () => {

--- a/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.tsx
@@ -131,10 +131,10 @@ function GrantRow({
             variant="plain"
             color="danger"
             onClick={onRevoke}
-            // Guards the double-click - a second DELETE names a row that is already gone, so the
-            // reply reports "no longer had access" for an action that in fact worked - but only on
-            // the row being revoked: one shared flag greyed out every row, and Joy's `loading`
-            // forces `disabled`, so a slow request read as a frozen panel.
+            // The confirm dialog is what closes the double-DELETE path (a second click lands on its
+            // disabled Revoke, not on a second request); this keeps the in-flight state visible on
+            // the row it belongs to. Scoped to that one row because a shared flag greyed out every
+            // row, and Joy's `loading` forces `disabled`, so a slow request read as a frozen panel.
             loading={revoking}
             disabled={revoking}
             data-testid={`datalake-access-revoke-${grant.principalType}-${grant.principalId}`}
@@ -306,6 +306,99 @@ function TransferOwnershipDialog({ lakeId, onClose }: { lakeId: string; onClose:
             Transfer
           </Button>
           <Button variant="plain" color="neutral" onClick={onClose} data-testid="datalake-transfer-cancel-btn">
+            Cancel
+          </Button>
+        </DialogActions>
+      </ModalDialog>
+    </Modal>
+  );
+}
+
+/**
+ * Confirm removing one grant.
+ *
+ * Confirm-gated for the same reason as transfer: the write is immediate, has no undo, and is silent
+ * from the actor's side - an accidental revoke surfaces only when the affected person reports losing
+ * access. It also closes the double-DELETE the bare button allowed, since the second click lands on
+ * a disabled confirm rather than on a second request that reports "no longer had access" for an
+ * action which in fact worked.
+ *
+ * The copy deliberately says what revoking does NOT do: a grant is one of several ways into a lake,
+ * so removing it is not the same as locking the principal out (see `resolveLakeReadAccess`).
+ */
+function RevokeAccessDialog({
+  lakeId,
+  lakeName,
+  grant,
+  revoke,
+  onClose,
+}: {
+  lakeId: string;
+  lakeName: string;
+  grant: LakeAccessGrantView;
+  /** Owned by the table so the row being revoked can show the same in-flight state. */
+  revoke: ReturnType<typeof useRevokeLakeAccess>;
+  onClose: () => void;
+}) {
+  const principal = grant.principalName ?? grant.principalId;
+
+  const handleConfirm = async () => {
+    try {
+      await revoke.mutateAsync({ id: lakeId, principalType: grant.principalType, principalId: grant.principalId });
+      onClose();
+    } catch {
+      // The mutation's onError already surfaced the server's refusal; keep the dialog open so the
+      // manager can read it and retry rather than losing their place in the table.
+    }
+  };
+
+  return (
+    <Modal open onClose={onClose}>
+      <ModalDialog data-testid="datalake-revoke-modal" sx={{ width: { xs: '95%', sm: '26rem' } }}>
+        <ModalClose data-testid="datalake-revoke-close" />
+        <DialogTitle>Revoke access</DialogTitle>
+        <DialogContent>
+          <Stack gap={2} sx={{ pt: 1 }}>
+            <Typography level="body-sm" data-testid="datalake-revoke-summary">
+              Remove the {grant.role} grant on {lakeName} from {principal}?
+            </Typography>
+            {/* An org grant is the one row whose blast radius is not visible from the name on it. */}
+            {grant.principalType === 'organization' && (
+              <Alert color="warning" variant="soft" data-testid="datalake-revoke-org-warning">
+                This grant covers everyone in {principal}, so every member loses the access it gives them.
+              </Alert>
+            )}
+            {/* Mirror of the grant form's curator disclosure - what the role carried is what revoking
+                takes back. Keep in step with isTrustedForInjection (resolveLakeReadAccess.ts). */}
+            {grant.role === 'curator' && (
+              <Alert color="warning" variant="soft" data-testid="datalake-revoke-curator-warning">
+                A curator manages this lake. Revoking also removes their ability to change its files and settings, and
+                the system-prompt trust that comes with the role.
+              </Alert>
+            )}
+            {grant.status === 'expired' ? (
+              <Typography level="body-xs" textColor="text.tertiary" data-testid="datalake-revoke-expired-note">
+                This grant has already lapsed, so it admits no one today - revoking removes the record of it.
+              </Typography>
+            ) : (
+              <Typography level="body-xs" textColor="text.tertiary" data-testid="datalake-revoke-effect-note">
+                Access through this grant ends immediately, and granting it again starts with no expiry. Other ways in
+                are untouched: anyone who also reaches this lake through an access channel, or through their own grant,
+                keeps that access.
+              </Typography>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="danger"
+            loading={revoke.isPending}
+            onClick={handleConfirm}
+            data-testid="datalake-revoke-confirm-btn"
+          >
+            Revoke access
+          </Button>
+          <Button variant="plain" color="neutral" onClick={onClose} data-testid="datalake-revoke-cancel-btn">
             Cancel
           </Button>
         </DialogActions>
@@ -555,6 +648,9 @@ function AccessViewBody({
 }) {
   const [transferring, setTransferring] = useState(false);
   const [granting, setGranting] = useState(false);
+  // The row whose Revoke was clicked, awaiting confirmation. Holds the row itself, not just its
+  // principal pair, so the dialog can describe what is being removed without a second lookup.
+  const [revokeTarget, setRevokeTarget] = useState<LakeAccessGrantView | null>(null);
   const revoke = useRevokeLakeAccess();
   return (
     <Stack gap={3} data-testid="datalake-access-body">
@@ -589,6 +685,15 @@ function AccessViewBody({
         </Box>
         {granting && <GrantAccessForm view={view} onClose={() => setGranting(false)} />}
         {transferring && <TransferOwnershipDialog lakeId={view.lakeId} onClose={() => setTransferring(false)} />}
+        {revokeTarget && (
+          <RevokeAccessDialog
+            lakeId={view.lakeId}
+            lakeName={view.lakeName}
+            grant={revokeTarget}
+            revoke={revoke}
+            onClose={() => setRevokeTarget(null)}
+          />
+        )}
         {view.grants.length === 0 ? (
           <Typography level="body-sm" textColor="text.tertiary" data-testid="datalake-access-grants-empty">
             No explicit grants. Access follows the channels below.
@@ -612,16 +717,7 @@ function AccessViewBody({
                   <GrantRow
                     key={`${g.principalType}:${g.principalId}`}
                     grant={g}
-                    onRevoke={
-                      g.role === 'owner'
-                        ? undefined
-                        : () =>
-                            revoke.mutate({
-                              id: view.lakeId,
-                              principalType: g.principalType,
-                              principalId: g.principalId,
-                            })
-                    }
+                    onRevoke={g.role === 'owner' ? undefined : () => setRevokeTarget(g)}
                     // `variables` is the in-flight request's own input, so the pending state lands
                     // on the row that was clicked rather than on all of them.
                     revoking={

--- a/apps/client/app/hooks/data/dataLakes.test.ts
+++ b/apps/client/app/hooks/data/dataLakes.test.ts
@@ -1515,7 +1515,8 @@ describe('the sharing doors on success', () => {
   });
 
   // `revoked: false` is the outcome the caller asked for, so not an error - but saying "revoked"
-  // would claim this call did something it did not. The honest copy is the whole point of the flag.
+  // would claim this call did something it did not. The honest copy is the whole point of the flag,
+  // and it names the race, because the caller's own double-click can no longer reach this arm.
   it('revoke says the grant was already gone rather than claiming it removed one', async () => {
     apiDelete.mockResolvedValueOnce({ data: { data: { revoked: false } } });
     const { result } = mountWith(() => useRevokeLakeAccess());
@@ -1524,7 +1525,9 @@ describe('the sharing doors on success', () => {
       await result.current.mutateAsync({ id: 'lake1', principalType: 'user', principalId: 'u2' });
     });
 
-    expect(toast.success).toHaveBeenCalledWith('That principal no longer had access');
+    expect(toast.success).toHaveBeenCalledWith(
+      'That principal already had no access - someone else may have revoked it'
+    );
   });
 });
 

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -364,8 +364,12 @@ export function useRevokeLakeAccess() {
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.configHistoryOf(id) });
       queryClient.invalidateQueries({ queryKey: dataLakeKeys.list });
       // `revoked: false` means the grant was already gone - the outcome asked for, so not an error,
-      // but saying "revoked" would claim this call did something it did not.
-      toast.success(data.revoked ? 'Access revoked' : 'That principal no longer had access');
+      // but saying "revoked" would claim this call did something it did not. Naming the race is what
+      // keeps it from reading as "your revoke failed": the caller's own double-click can no longer
+      // land here (the confirm dialog disables while in flight), so another manager got there first.
+      toast.success(
+        data.revoked ? 'Access revoked' : 'That principal already had no access - someone else may have revoked it'
+      );
     },
     onError: (error: Error) => {
       const refusal = isAxiosError(error) ? (error.response?.data as { error?: string } | undefined)?.error : undefined;


### PR DESCRIPTION
# Pull Request

## Description

Fixes #2557.

Revoking a data lake access grant was one click from the row's `Revoke` button straight into `revoke.mutate(...)`, with no undo. An accidental revoke is silent from the actor's side - it surfaces only when the affected person reports losing access - and Transfer Ownership, a comparable access change on the same screen, already gets a full confirmation dialog.

Of the three defects the issue lists, **the pending state was already fixed**: `GrantRow` carries `loading={revoking}` / `disabled={revoking}`, scoped to the row being revoked via the mutation's own `variables`. So this PR is the confirmation step, plus a decision on the third point.

**The `revoked: false` toast.** The issue asked whether it should stay a success at all. It should: with the confirm dialog in place, the caller's own double-click can no longer reach that arm (the dialog awaits the DELETE, disables its own confirm while in flight, and closes only on success), so the only remaining path to `revoked: false` is a genuine race with another manager - which is not an error. What was wrong was the copy, which read as "your revoke failed". It now names the race instead.

## Changes

- New `RevokeAccessDialog` in `DataLakeAccessModal.tsx`, shaped like the `TransferOwnershipDialog` beside it. The row's `Revoke` sets a `revokeTarget` instead of firing the DELETE.
- The dialog names the grant being removed, and states the consequences that are not visible from the row:
  - an **organization** grant takes access from every member of that org (the one row whose blast radius the principal name hides)
  - a **curator** grant carried this lake's system-prompt injection trust, so revoking takes that back too - a mirror of the disclosure the grant form already shows when handing the role out
  - what revoking does **not** do: a grant is one of several ways into a lake, so anyone who also reaches it through an access channel, or their own grant, keeps that access
  - an already-lapsed grant admits no one today, so revoking it removes a record rather than cutting off live access
- The dialog `await`s `mutateAsync`: it closes on success, and stays open on a refusal so the server's toast text is still actionable and the manager keeps their place in the table.
- The mutation stays owned by the grants table and is passed into the dialog, so the per-row in-flight state is preserved.
- `useRevokeLakeAccess`: the `revoked: false` toast now reads `That principal already had no access - someone else may have revoked it`.

## Guide for Testers

Preconditions: an account that can **manage** a data lake (owner, or a curator), and a lake that has at least one non-owner grant on it. If it has none, use step 3 to add one.

1. Go to `app.staging.bike4mind.com` and sign in.
2. Open a data lake you manage and open its **Access and members** modal. Expected: a `Members and grants` table listing the owner row plus any grants.
3. (Only if the table has no non-owner row.) Click **Grant access**, choose `A person`, type the email of another account you control, leave the role as `Reader - can read this lake`, and click **Grant**. Expected: a `Access granted` toast, and a new `reader` row in the table.
4. On the owner row, look for a `Revoke` button. Expected: **there is none** - the server refuses to revoke an ownership grant, so the control is not offered.
5. On a non-owner row, click **Revoke**. Expected: a `Revoke access` dialog opens. It reads `Remove the reader grant on <lake name> from <person>?`, and below it, in small grey text, that access ends immediately, that re-granting starts with no expiry, and that other ways into the lake are untouched. **The grant is still in the table behind the dialog - nothing has been sent yet.**

    <img width="481" height="317" alt="image" src="https://github.com/user-attachments/assets/2db9211d-5567-4b1a-85b4-e3e96449d0d3" />
    
6. Click **Cancel**. Expected: the dialog closes and the row is still there, unchanged. No toast.
7. Click **Revoke** on the same row again, then click **Revoke access** in the dialog. Expected: the dialog closes, an `Access revoked` toast appears, and the row disappears from the table.
8. Repeat steps 3 and 5, and this time double-click **Revoke access** in the dialog as fast as you can. Expected: exactly one `Access revoked` toast. You should **not** see a second toast saying the principal had no access.
9. Grant a **curator** to another account you control (step 3, but pick `Curator - can also manage its files and settings`), then click **Revoke** on that row. Expected: an amber warning saying a curator manages this lake and that revoking removes their ability to change its files and settings, and the system-prompt trust that comes with the role. Confirm it and check the row disappears.

   <img width="481" height="400" alt="image" src="https://github.com/user-attachments/assets/8b3b560c-4ebf-449c-aeed-15c43fc4fdfa" />

10. If the lake belongs to an organization: click **Grant access**, choose `Everyone in <org>`, and grant it. Then click **Revoke** on that organization row. Expected: an amber warning that the grant covers everyone in `<org>`, so every member loses the access it gives them. Confirm it and check the row disappears.

    <img width="481" height="400" alt="image" src="https://github.com/user-attachments/assets/27165bf6-b3b6-4e55-a2da-9d506fa06470" />

11. Optional two-manager race check: with a second manager account, open the same lake's Access modal in another browser. In window A, open the confirm dialog for a row. In window B, revoke that same row. Now confirm in window A. Expected: a toast reading `That principal already had no access - someone else may have revoked it` - not an error, and not a claim that window A removed anything.

### Regression Checks

12. **Transfer ownership** still works: open the Access modal on a lake you own inside an organization, click **Transfer ownership**, pick a member, and confirm. Expected: unchanged behavior - a `Data lake ownership transferred` toast, and the table re-renders with the new owner.
13. **Grant access** still works in all its forms: a person by email, the owning organization, and each of the three expiry choices (`Keep any existing expiry`, `Never expires`, `Expires on a date`). Expected: unchanged behavior.
14. **Export CSV** in the Access modal still downloads the access artifact.
15. The **Access channels** and **Access history** sections of the modal are unchanged - the chips, the lower-bound caveat, the candidate-cap line, and the truncation warning should all read as before.

### What NOT to test

- The revoke API itself is untouched: the route, its query-param contract, its refusal of ownership grants, and the audit event it records are all unchanged. This PR only changes what the client does before calling it, and the wording of one toast.

## Additional Information

Verified locally:

- `pnpm --filter @bike4mind/client exec vitest run app/components/DataLakeWizard` - 465 tests pass, including 4 new ones covering confirm-before-send, cancel-sends-nothing, dialog-stays-open-on-refusal, confirm-locks-while-pending, and the org / curator / expired copy.
- `pnpm --filter @bike4mind/client exec vitest run app/hooks/data/dataLakes.test.ts` - 81 pass.
- `pnpm --filter @bike4mind/client typecheck` - clean.
- prettier, the control-byte guard and the smart-punctuation guard - clean on the changed files.

## Developer Notes

- **Reusable pattern**: `RevokeAccessDialog` follows the same shape as `TransferOwnershipDialog` - own the mutation at the table level, pass it into the confirm dialog, `await mutateAsync` and close only on success. That keeps the per-row in-flight state and the confirm's own lock reading from one source, and is the shape to copy for the next destructive per-row control on this surface.
- **Copy decision worth keeping**: the dialog states what the action does *not* do. Lake access is a union of grants and gate channels, so "revoked" is routinely mistaken for "locked out". Any future access-removal surface should say the same thing.
- The curator warning is a second copy of the injection-trust disclosure the grant form shows. Both point at `isTrustedForInjection` in `resolveLakeReadAccess.ts`; if that rule changes, both need to change.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [ ] If adding/modifying telemetry fields - n/a, no telemetry change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
