### PR TITLE
docs(api): model the error envelope's name footprint on thrown-vs-written

### DIFF
--- a/b4m-core/common/src/api-contract/CONVENTIONS.md
+++ b/b4m-core/common/src/api-contract/CONVENTIONS.md
@@ -109,9 +109,17 @@ serves every *thrown* error body regardless of which schema the contract declare
 status, so a bespoke error schema (`InsufficientCreditsErrorSchema`,
 `ttsErrorResponseSchema`) would omit a field the wire carries. Those derive from
 `ApiErrorSchema` via `.extend()` rather than re-declaring `error`/`request_id`, which is
-also what makes the sunset a single edit. Write a bespoke error schema from scratch only
-when the body is `res.status(...).json(...)`-ed rather than thrown and so never passes
-through the middleware - `ttsResponseTooLargeSchema` is the one such case, and says so.
+also what makes the sunset a single edit.
+
+**The predicate is per body, not per status.** Write a bespoke error schema from scratch
+only when *no* body for that status is thrown; a status reachable both ways keeps the
+envelope, because the fields errorHandler adds (`request_id`, and `name` until its
+sunset) are then genuinely optional rather than absent. Directly written
+bodies are ordinary, not exceptional: `/api/ai/tts` writes a body for every error status
+it declares - and, through its upstream-4xx passthrough, for several it does not - while
+only three of them (`401`, `422`, `429`) can also be reached by a throw.
+`ttsResponseTooLargeSchema` is the current example of a status no throw can reach, and
+says so; `ttsErrorResponseSchema` documents the mixed case.
 
 **[gated]** Now that the runtime and the spec agree, the middleware is pinned to the
 envelope: `errorHandler.test.ts` asserts every key `errorHandler` adds is one
@@ -313,6 +321,7 @@ mistakes "CI passed" for "conventions met":
 
 | Rule | Why it is not gated |
 |---|---|
+| A bespoke error schema is used only where no body is thrown | Whether a body is thrown or `res.status(...).json(...)`-ed lives in handler control flow, not the contract, exactly like the status-condition rule below. So nothing catches a bespoke schema on a status a throw can reach, which then omits whatever errorHandler adds to that body. |
 | A condition maps to the status this guide gives it | The gate checks only that a status is in the allowed *set*. Nothing checks that "no provider key configured" is the `503` the table says - and `/api/ai/tts` returns `401` for it today. Not structurally derivable: the condition lives in handler control flow, not the contract. |
 | `emitsRateLimitHeaders` matches the handler's middleware chain | Half of this **is** now gated - the flag is rejected on any auth mode but `apiKeyOrJwt`, since `baseApi` mounts `apiKeyRateLimit` only on the api-key chain. What remains ungated is whether an `apiKeyOrJwt` handler actually mounts `baseApi`. Closing it needs the adapters to assert at runtime in non-prod, the way they already assert response schemas. |
 | Wire fields are `snake_case` | Requires walking Zod shapes, and today's schemas deliberately accept camelCase aliases, so the check would fail on arrival. Needs the alias metadata to exist first. |

--- a/b4m-core/common/src/openapi/document.test.ts
+++ b/b4m-core/common/src/openapi/document.test.ts
@@ -189,10 +189,19 @@ describe('buildOpenApiDocument', () => {
   // ApiErrorSchema inherits `name` - and it has to inherit the sunset notice with it, or
   // the deprecation is visible on the shared component and nowhere else. See
   // CONVENTIONS.md section 1.
+  //
+  // Each status below is one a THROW can reach - 401 from apiKeyAuth, 422 from request
+  // validation, 429 from apiKeyRateLimit - even though the TTS handler also writes a body
+  // of its own for all three. That mix is why the envelope belongs on them, and pinning
+  // them is what would fail if someone later split them onto a bespoke schema on the
+  // assumption that the handler is the only producer. 502 shares the schema today but is
+  // only ever written, so it is left out rather than pinned into place.
   it('carries the `name` deprecation into error schemas that extend the envelope', () => {
-    const inherited = doc.components.schemas.synthesizeSpeechResponse422.properties.name;
-    expect(inherited.deprecated).toBe(true);
-    expect(inherited.description).toContain('2026-12-01');
+    for (const status of [401, 422, 429]) {
+      const inherited = doc.components.schemas[`synthesizeSpeechResponse${status}`].properties.name;
+      expect(inherited.deprecated).toBe(true);
+      expect(inherited.description).toContain('2026-12-01');
+    }
 
     // The 413 body is written directly rather than thrown, so it never gets `name` at all.
     expect(doc.components.schemas.synthesizeSpeechResponse413.properties.name).toBeUndefined();

--- a/b4m-core/common/src/voiceGeneration.ts
+++ b/b4m-core/common/src/voiceGeneration.ts
@@ -148,9 +148,29 @@ export const TTS_ERROR_CODES = [
 ] as const satisfies readonly ApiErrorCode[];
 
 /**
- * Error body for `POST /api/ai/tts`, shared by every error status the route
- * declares. `errorCode` is present only on the conditions that carry a
- * classifier; an ordinary validation 422 has none.
+ * Error body for `POST /api/ai/tts`, shared by the 401, 422, 429 and 502; the 413
+ * has a shape of its own (`ttsResponseTooLargeSchema`). `errorCode` is present only
+ * on the conditions that carry a classifier; an ordinary validation 422 has none.
+ *
+ * Extends `ApiErrorSchema` because what decides whether a body carries the fields
+ * errorHandler adds - `request_id`, and `name` until its 2026-12-01 sunset - is
+ * whether the body was THROWN, not which status it wears, and three of these four
+ * statuses are reachable both ways:
+ *
+ * - 401: thrown by apiKeyAuth on a rejected key; written by `auth` when no
+ *   credential was presented at all, and by the handler for
+ *   `provider_not_configured` and for an upstream credential rejection
+ *   (`provider_rejected`).
+ * - 422: thrown by request validation and by the char-limit / format guards;
+ *   written by the handler for `insufficient_credits` and for an upstream 422.
+ * - 429: thrown by apiKeyRateLimit; written by the handler on an upstream 429.
+ * - 502: only ever written.
+ *
+ * So those two are genuinely optional here, and splitting this per status would be
+ * wrong for the first three. The 502 does advertise both without ever sending them;
+ * that is not worth a fourth error schema on one route, and `request_id` missing from
+ * this handler's written bodies is a gap in the handler rather than something to
+ * enshrine in a schema.
  */
 export const ttsErrorResponseSchema = ApiErrorSchema.extend({
   provider: supportedVoiceGenerationVendor.optional(),
@@ -162,9 +182,14 @@ export const ttsErrorResponseSchema = ApiErrorSchema.extend({
  * response-size cap. When a browsable copy was saved, `fileUrl` is how the caller
  * retrieves the audio it paid for.
  *
- * Not derived from `ApiErrorSchema`, unlike `ttsErrorResponseSchema`: this body is
- * written directly (pages/api/ai/tts.ts, the exceedsTtsResponseLimit guard) rather
- * than thrown, so errorHandler never sees it and never adds `name` here.
+ * Not derived from `ApiErrorSchema`: every 413 on this route is written, never
+ * thrown, so errorHandler never serves one and `name` is genuinely absent rather than
+ * optional - a stronger claim than `ttsErrorResponseSchema` can make for its own
+ * statuses, see the note there. Two writers, and only the first matches the paragraph
+ * above: the exceedsTtsResponseLimit guard, and the upstream-4xx passthrough relaying
+ * a provider 413, where nothing was generated or billed and there is no `fileUrl`. An
+ * oversized *request* body is a third 413 that never reaches this schema at all -
+ * Next's own body parser answers it in plain text before the router runs.
  */
 export const ttsResponseTooLargeSchema = z.object({
   error: z.string(),


### PR DESCRIPTION
## Description

Closes #2008

`name` is added to an error body in exactly one place - `errorHandler`, the `onError` of the next-connect router `baseApi` builds - so a body carries it if and only if it was **thrown**. The docs modelled that per contract *status* instead, and on `/api/ai/tts` the two do not line up the way the comments claimed.

The issue's premise turned out to be stale in two ways, so this takes the second option the issue offers (keep the single schema, correct the rationale) rather than the first (split the schema):

1. **There is no `402` any more.** #1999 retired the credits exemption; insufficient-credits is now a directly-written `422`. The contract declares `401`, `413`, `422`, `429`, `502`.
2. **Three of the four statuses that share `ttsErrorResponseSchema` are reachable both ways.** `401` is thrown by `apiKeyAuth` on a rejected key, and written by `auth` for a *missing* credential and by the handler for both provider classifiers. `422` is thrown by request validation and by the char-limit / format guards, and written for insufficient credits. `429` is thrown by `apiKeyRateLimit`, and written on an upstream `429`. Only the `502` is write-only.

So `name` is genuinely *optional* on those three, and a per-status split would be wrong for them - the issue's "advertises a `name` the runtime never sends" holds only for the `502`.

No production code path changed. This is doc comments, one `CONVENTIONS.md` rule, and one widened test; `apps/client` is untouched and the generated `openapi.json` is byte-identical.

**One over-declaration is deliberately left standing, and wants a follow-up issue rather than this one.** The `502` still advertises `name`/`request_id` without ever sending them. Splitting it off would mean a fourth error schema on one route to remove two optional fields, one of which (`request_id`) is missing because the handler's written bodies never add it, not by design. The right fix is on the runtime side - have the written bodies carry `request_id`, and have the credit `422` throw `insufficientCreditsError(...)` the way `music.ts` and `sound-effects.ts` already do - which is a behaviour change on a live public endpoint, out of scope for the doc work this P2 asked for. See **Additional Information** for that and the other deferred items.

## Changes

- `b4m-core/common/src/voiceGeneration.ts` - rewrote the `ttsErrorResponseSchema` doc comment: it now names the four statuses it covers and gives the per-status thrown/written map above as the reason it extends `ApiErrorSchema`, plus an explicit note that the `502` advertises `name`/`request_id` without sending them and why that was not split off.
- `b4m-core/common/src/voiceGeneration.ts` - rewrote `ttsResponseTooLargeSchema`'s comment, whose "unlike `ttsErrorResponseSchema`" contrast implied the other statuses were all thrown. It now makes the stronger claim that is actually true (every `413` here is written, none thrown), names both of its writers rather than one, and points out that an oversized *request* body is answered by Next's own body parser before this router runs, so no schema here models that one.
- `b4m-core/common/src/api-contract/CONVENTIONS.md` - replaced the sentence asserting `ttsResponseTooLargeSchema` "is the one such case" of a directly-written error body with the rule it was reaching for: **the predicate is per body, not per status**; a status reachable both ways keeps the envelope. Names the real scale (tts writes a body for every error status it declares, and for several it does not) instead of a count that was wrong.
- `b4m-core/common/src/api-contract/CONVENTIONS.md` - added the missing row to **What is not gated yet**: "A bespoke error schema is used only where no body is thrown", carrying the same reason as the status-condition row below it - it lives in handler control flow, not the contract, so no gate can see it.
- `b4m-core/common/src/openapi/document.test.ts` - the `name`-deprecation test pinned only the `422`; it now loops `401`/`422`/`429`, i.e. exactly the statuses a throw can reach, with a comment saying why the `502` is deliberately not pinned. This is what would fail if someone later "cleaned up" those statuses on the model the issue described.

Wording in both files is phrased around "the fields errorHandler adds (`request_id`, and `name` until its sunset)" so the rule survives #1938's removal of `name`.

## Guide for Testers

This is a documentation + test change with no runtime behaviour, so the guide is command-based rather than click-based. Run everything from the repo root.

1. Check out the branch `refactor/tts-error-schema-thrown-vs-written` and run `pnpm install --frozen-lockfile`. Expected: completes with no errors.
2. Run `pnpm turbo:core:build`. Expected: `18 successful, 18 total`.
3. Run `pnpm --filter @bike4mind/common test`. Expected: `Test Files 119 passed (119)`, `Tests 1946 passed (1946)`. The widened assertion is in `b4m-core/common/src/openapi/document.test.ts`, test name "carries the `name` deprecation into error schemas that extend the envelope".
4. Confirm the published spec did not drift: run `pnpm turbo:openapi:generate` then `git status --short`. Expected: `git status --short` prints **nothing**. No schema changed, so `apps/client/public/openapi.json` is byte-identical.
5. Run `pnpm turbo:typecheck`. Expected: `40 successful, 40 total`.
6. Run `pnpm lint:check`. Expected: no output (clean).
7. Run `bash scripts/check-no-smart-punctuation.sh` and `bash scripts/check-no-control-bytes.sh`. Expected: both exit 0 with no output.
8. Open `b4m-core/common/src/voiceGeneration.ts` and read the `ttsErrorResponseSchema` doc comment, then check its per-status thrown/written map against `apps/client/pages/api/ai/tts.ts`, `apps/client/server/middlewares/apiKeyAuth.ts`, `apps/client/server/auth/auth.ts` (line 75 is the missing-credential `401`) and `apps/client/server/middlewares/apiKeyRateLimit.ts`. Expected: each bullet's claim matches the code. This is the substance of the PR and the part that most wants a human read.

### Regression Checks

9. Confirm the generated spec really carries what the widened test asserts, independently of the test. From the repo root run:

```
python3 -c "
import json
s = json.load(open('apps/client/public/openapi.json'))['components']['schemas']
for k in sorted(s):
    if k.startswith('synthesizeSpeechResponse'):
        n = s[k].get('properties', {}).get('name')
        print(k, '| name:', 'absent' if n is None else f\"deprecated={n.get('deprecated')} sunset={'2026-12-01' in n.get('description','')}\")
"
```

Expected, exactly: `200` and `413` report `name: absent`; `401`, `422`, `429` and `502` each report `deprecated=True sunset=True`. Note the `502` carries it too - it shares the schema - and is deliberately not pinned by the test; that is the residual over-declaration described in the Description.

10. Confirm the `413` boundary still holds: in `b4m-core/common/src/openapi/document.test.ts`, temporarily add `413` to the `[401, 422, 429]` loop and re-run step 3. Expected: the test **fails**, because the `413` uses `ttsResponseTooLargeSchema`, which has no `name` at all. Revert the edit.

### What NOT to test

- **No UI change.** Nothing to click, no screenshots, no preview deploy needed.
- **No runtime behaviour change on `/api/ai/tts`.** Request and response bodies, status codes and error classifiers are all exactly as before. Calling the endpoint will not behave differently, so do not go looking for a difference.
- **No published-schema change.** `openapi.json` is byte-identical, so generated clients need no regeneration and no version bump is warranted (hence `docs:` rather than `fix:`/`feat:`).

## Additional Information

Deliberately **not** done, all of it flagged rather than silently skipped:

- **Did not split off a bespoke `502` schema.** Reasoning in the Description. It is the one status where the spec genuinely over-declares.
- **Did not make the tts credit-exhausted `422` throw.** Every other credit-metered endpoint throws `insufficientCreditsError(...)` (`music.ts`, `sound-effects.ts`), so their credit `422` carries `name`/`request_id` and tts's does not. Converting tts's direct write to a throw would make the status uniformly thrown and align the surface, but it is a runtime change on a live public endpoint, not the doc/schema work this P2 asked for.
- **Did not add `request_id` to the directly-written bodies.** Same reason; it is the real cause of the residual `502` over-declaration.

Three unrelated gaps turned up while verifying the map. None are touched here and each wants its own issue:

1. The handler's upstream-4xx passthrough does `res.status(status).json(...)` for *any* upstream 4xx, so the route can emit statuses its contract never declares (`400`, `403`, `404`, `409`, `415`...). The non-prod drift check in `defineNextRoute.ts` does `spec?.schema?.safeParse` and silently skips a status with no spec, so nothing flags it. Real divergence.
2. That same passthrough can relay an upstream `413`, producing a body that satisfies `ttsResponseTooLargeSchema` structurally while contradicting everything the schema and the contract's `413` description say about it (audio "was generated (and billed)", retrievable from `fileUrl`) - in that case nothing was generated, nothing was billed, and there is no `fileUrl`.
3. `baseApi`'s request-entity-too-large `413` is dead code on any route that takes the default 1MB cap, `/api/ai/tts` included: `DEFAULT_MAX_BODY_SIZE` is exactly `1048576` and Next's own body parser rejects at the same `'1mb'` default *before* the router runs, answering in plain text rather than JSON. baseApi's JSON `413` can only fire where `maxBodySize` is set below 1MB. Worth knowing before anyone documents that body.

## Developer Notes (Optional)

- **The rule is now written down where it can be applied.** "A bespoke error schema only where *no* body for that status is thrown; a status reachable both ways keeps the envelope" was previously implicit in a single example, and the example was miscounted. It is now stated as a rule in `CONVENTIONS.md` and listed under **What is not gated yet**, so the next person adding an error schema has something to check against and knows CI will not check it for them.
- **`voiceGeneration.ts` now mentions `name` in two doc comments.** #1938's file list does not include it - and did not before this change either, since `ttsResponseTooLargeSchema` already mentioned it. Both mentions carry the `2026-12-01` sunset date so they stay greppable; worth adding a line to #1938 when it is actioned. The sunset itself is unaffected: no bespoke schema was added and `name` still reaches `ttsErrorResponseSchema` via `.extend()`, so it stays a three-place edit.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no settings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry fields
