### PR TITLE
refactor(client): replace dead Material UI palette tokens and guard against new ones

### DIFF
--- a/apps/client/app/components/Agent/ImageBrowserModal.tsx
+++ b/apps/client/app/components/Agent/ImageBrowserModal.tsx
@@ -98,10 +98,10 @@ const ImageBrowserModal: React.FC<ImageBrowserModalProps> = ({
                   cursor: 'pointer',
                   p: 1,
                   transition: 'all 0.2s',
-                  '&:hover': { borderColor: 'primary.main' },
+                  '&:hover': { borderColor: 'primary.plainColor' },
                   ...(selectedImage?.id === file.id
                     ? {
-                        borderColor: 'primary.main',
+                        borderColor: 'primary.plainColor',
                         borderWidth: 2,
                       }
                     : {}),

--- a/apps/client/app/components/Agent/ImportModal.tsx
+++ b/apps/client/app/components/Agent/ImportModal.tsx
@@ -67,7 +67,7 @@ const ImportModal: React.FC<ImportModalProps> = ({
               bgcolor: 'danger.softBg',
               color: 'danger.softColor',
               border: '1px solid',
-              borderColor: 'danger.softBorder',
+              borderColor: 'danger.outlinedBorder',
               mb: 2,
             }}
           >

--- a/apps/client/app/components/Agent/MainInformationSection.tsx
+++ b/apps/client/app/components/Agent/MainInformationSection.tsx
@@ -170,7 +170,7 @@ const MainInformationSection: React.FC<MainInformationSectionProps> = ({
                       borderColor: 'divider',
                       borderRadius: '4px',
                       zIndex: 3,
-                      '&:hover': { backgroundColor: 'primary.dark' },
+                      '&:hover': { backgroundColor: 'primary.solidHoverBg' },
                     }}
                   >
                     <AddAPhotoIcon sx={{ fontSize: 10, color: 'text.tertiary' }} />
@@ -359,7 +359,7 @@ const MainInformationSection: React.FC<MainInformationSectionProps> = ({
                         border: '1px solid',
                         borderColor: 'divider',
                         borderRadius: '4px',
-                        '&:hover': { backgroundColor: 'primary.dark' },
+                        '&:hover': { backgroundColor: 'primary.solidHoverBg' },
                         zIndex: 3,
                       }}
                     >

--- a/apps/client/app/components/Agent/MainInformationSection.tsx
+++ b/apps/client/app/components/Agent/MainInformationSection.tsx
@@ -170,7 +170,7 @@ const MainInformationSection: React.FC<MainInformationSectionProps> = ({
                       borderColor: 'divider',
                       borderRadius: '4px',
                       zIndex: 3,
-                      '&:hover': { backgroundColor: 'primary.solidHoverBg' },
+                      '&:hover': { backgroundColor: 'primary.softHoverBg' },
                     }}
                   >
                     <AddAPhotoIcon sx={{ fontSize: 10, color: 'text.tertiary' }} />
@@ -359,7 +359,7 @@ const MainInformationSection: React.FC<MainInformationSectionProps> = ({
                         border: '1px solid',
                         borderColor: 'divider',
                         borderRadius: '4px',
-                        '&:hover': { backgroundColor: 'primary.solidHoverBg' },
+                        '&:hover': { backgroundColor: 'primary.softHoverBg' },
                         zIndex: 3,
                       }}
                     >

--- a/apps/client/app/components/CreditsModal/CreditsModal.tsx
+++ b/apps/client/app/components/CreditsModal/CreditsModal.tsx
@@ -181,7 +181,7 @@ const CreditsModal = () => {
                         alignItems: 'center',
                         gap: 1,
                         height: '60vh',
-                        borderColor: 'error.500',
+                        borderColor: 'danger.outlinedBorder',
                       }}
                     >
                       <Typography level="h2">{t('Payment Issues')}</Typography>

--- a/apps/client/app/components/EmailVerificationModal.tsx
+++ b/apps/client/app/components/EmailVerificationModal.tsx
@@ -52,14 +52,14 @@ const EmailVerificationModal: React.FC<EmailVerificationModalProps> = ({
     >
       <ModalDialog sx={{ maxWidth: 500, zIndex: 99999 }}>
         <DialogTitle>
-          <EmailIcon sx={{ mr: 1, color: 'primary.main' }} />
+          <EmailIcon sx={{ mr: 1, color: 'primary.plainColor' }} />
           <span data-testid="email-verification-title">Verify Your Email Address</span>
         </DialogTitle>
         <DialogContent>
           <Typography level="body-md" sx={{ mb: 2 }}>
             We&apos;ve sent a verification email to:
           </Typography>
-          <Typography level="body-md" sx={{ fontWeight: 'bold', mb: 2, color: 'primary.main' }}>
+          <Typography level="body-md" sx={{ fontWeight: 'bold', mb: 2, color: 'primary.plainColor' }}>
             {userEmail}
           </Typography>
           <Typography level="body-sm" sx={{ mb: 2 }}>

--- a/apps/client/app/components/GenAI/QuestMasterReply.tsx
+++ b/apps/client/app/components/GenAI/QuestMasterReply.tsx
@@ -174,7 +174,7 @@ const SubQuestCard: React.FC<SubQuestCardProps> = React.memo(
                 ? 'warning.softHoverBg'
                 : isInProgress
                   ? 'warning.softHoverBg'
-                  : 'background.level4',
+                  : 'background.level2',
             transform: 'translateY(-2px)',
           },
         }}

--- a/apps/client/app/components/Knowledge/AddKnowledgeModal.tsx
+++ b/apps/client/app/components/Knowledge/AddKnowledgeModal.tsx
@@ -114,7 +114,7 @@ const AddKnowledgeModal: React.FC<AddKnowledgeModalProps> = ({ open, onClose }) 
         <Box
           sx={theme => ({
             border: '1px solid',
-            borderColor: isDragging ? 'primary.main' : 'divider',
+            borderColor: isDragging ? 'primary.plainColor' : 'divider',
             borderRadius: '8px',
             p: 3,
             mb: 2,

--- a/apps/client/app/components/Knowledge/AddKnowledgeModal.tsx
+++ b/apps/client/app/components/Knowledge/AddKnowledgeModal.tsx
@@ -122,7 +122,7 @@ const AddKnowledgeModal: React.FC<AddKnowledgeModalProps> = ({ open, onClose }) 
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            bgcolor: isDragging ? 'action.hover' : theme.palette.background.panel,
+            bgcolor: isDragging ? 'neutral.softBg' : theme.palette.background.panel,
             transition: 'all 0.3s',
             minHeight: '100px',
           })}

--- a/apps/client/app/components/Knowledge/DragDropInput.tsx
+++ b/apps/client/app/components/Knowledge/DragDropInput.tsx
@@ -81,7 +81,7 @@ const KnowledgeDragDropInput: FC<KnowledgeDragDropInputProps> = ({ onSuccess, la
         sx ||
         (theme => ({
           border: '1px solid',
-          borderColor: isDragging ? 'primary.main' : 'divider',
+          borderColor: isDragging ? 'primary.plainColor' : 'divider',
           borderRadius: '8px',
           p: { xs: '40px', sm: '140px' },
           display: 'flex',

--- a/apps/client/app/components/Knowledge/PythonArtifactViewer.tsx
+++ b/apps/client/app/components/Knowledge/PythonArtifactViewer.tsx
@@ -528,22 +528,22 @@ const PythonArtifactViewer: React.FC<PythonArtifactViewerProps> = ({ artifact, o
             >
               <Stack direction="row" spacing={2} alignItems="center" sx={{ flex: 1 }}>
                 {!isPersisted && (
-                  <Typography level="body-xs" sx={{ color: 'warning.main' }}>
+                  <Typography level="body-xs" sx={{ color: 'warning.plainColor' }}>
                     Not saved to database
                   </Typography>
                 )}
                 {hasChanges && isPersisted && (
-                  <Typography level="body-xs" sx={{ color: 'warning.main' }}>
+                  <Typography level="body-xs" sx={{ color: 'warning.plainColor' }}>
                     Unsaved changes
                   </Typography>
                 )}
                 {isViewingDifferentVersion && (
-                  <Typography level="body-xs" sx={{ color: 'primary.main', fontStyle: 'italic' }}>
+                  <Typography level="body-xs" sx={{ color: 'primary.plainColor', fontStyle: 'italic' }}>
                     Viewing version {currentVersion}
                   </Typography>
                 )}
                 {isEditMode && (
-                  <Typography level="body-xs" sx={{ color: 'danger.main', fontWeight: 'bold' }}>
+                  <Typography level="body-xs" sx={{ color: 'danger.plainColor', fontWeight: 'bold' }}>
                     Edit mode active
                   </Typography>
                 )}

--- a/apps/client/app/components/Knowledge/ReactArtifactViewer.tsx
+++ b/apps/client/app/components/Knowledge/ReactArtifactViewer.tsx
@@ -613,22 +613,22 @@ const ReactArtifactViewer: React.FC<ReactArtifactViewerProps> = ({ artifact, onE
             >
               <Stack direction="row" spacing={2} alignItems="center" sx={{ flex: 1 }}>
                 {!isPersisted && (
-                  <Typography level="body-xs" sx={{ color: 'warning.main' }}>
+                  <Typography level="body-xs" sx={{ color: 'warning.plainColor' }}>
                     ⚠️ Not saved to database
                   </Typography>
                 )}
                 {hasChanges && isPersisted && (
-                  <Typography level="body-xs" sx={{ color: 'warning.main' }}>
+                  <Typography level="body-xs" sx={{ color: 'warning.plainColor' }}>
                     ● Unsaved changes
                   </Typography>
                 )}
                 {isViewingDifferentVersion && (
-                  <Typography level="body-xs" sx={{ color: 'info.main', fontStyle: 'italic' }}>
+                  <Typography level="body-xs" sx={{ color: 'primary.plainColor', fontStyle: 'italic' }}>
                     📌 Viewing version {currentVersion}
                   </Typography>
                 )}
                 {isEditMode && (
-                  <Typography level="body-xs" sx={{ color: 'danger.main', fontWeight: 'bold' }}>
+                  <Typography level="body-xs" sx={{ color: 'danger.plainColor', fontWeight: 'bold' }}>
                     🔓 Edit mode active
                   </Typography>
                 )}

--- a/apps/client/app/components/ProfileModal/ContentPublishingModal.tsx
+++ b/apps/client/app/components/ProfileModal/ContentPublishingModal.tsx
@@ -99,7 +99,7 @@ const ContentPublishingModal: React.FC<ContentPublishingModalProps> = ({ open, o
                     cursor: 'pointer',
                     transition: 'all 0.2s ease',
                     '&:hover': {
-                      borderColor: outputFormat === 'blog' ? 'primary.600' : 'neutral.outlinedHoverBorder',
+                      borderColor: outputFormat === 'blog' ? 'primary.600' : 'neutral.outlinedBorder',
                     },
                   }}
                 >

--- a/apps/client/app/components/ProfileModal/NotebookCurationModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookCurationModal.tsx
@@ -703,7 +703,7 @@ const NotebookCurationModal: React.FC<NotebookCurationModalProps> = ({ open, onC
                           cursor: 'pointer',
                           '&:hover': {
                             borderColor:
-                              curationType === CurationType.TRANSCRIPT ? 'success.600' : 'neutral.outlinedHoverBorder',
+                              curationType === CurationType.TRANSCRIPT ? 'success.600' : 'neutral.outlinedBorder',
                           },
                         }}
                       >
@@ -754,7 +754,7 @@ const NotebookCurationModal: React.FC<NotebookCurationModalProps> = ({ open, onC
                             borderColor:
                               curationType === CurationType.EXECUTIVE_SUMMARY
                                 ? 'success.600'
-                                : 'neutral.outlinedHoverBorder',
+                                : 'neutral.outlinedBorder',
                           },
                         }}
                       >

--- a/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
@@ -232,7 +232,7 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
                     <Stack
                       sx={{
                         border: '2px dashed',
-                        borderColor: selectedFile ? 'success.outlinedBorder' : 'neutral.outlinedBorder',
+                        borderColor: selectedFile ? 'success.plainColor' : 'neutral.outlinedBorder',
                         borderRadius: 'md',
                         p: 3,
                         textAlign: 'center',

--- a/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookImportModal.tsx
@@ -232,13 +232,13 @@ const NotebookImportModal: React.FC<NotebookImportModalProps> = ({ open, onClose
                     <Stack
                       sx={{
                         border: '2px dashed',
-                        borderColor: selectedFile ? 'success.main' : 'neutral.outlinedBorder',
+                        borderColor: selectedFile ? 'success.outlinedBorder' : 'neutral.outlinedBorder',
                         borderRadius: 'md',
                         p: 3,
                         textAlign: 'center',
                         cursor: 'pointer',
                         '&:hover': {
-                          borderColor: 'primary.main',
+                          borderColor: 'primary.plainColor',
                           bgcolor: 'background.level1',
                         },
                       }}

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/ApiKeysSection.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/ApiKeysSection.tsx
@@ -151,7 +151,7 @@ const SpeechTabContent = () => {
                           minHeight: '28px !important',
                           '&:hover': {
                             backgroundColor: 'neutral.outlinedHoverBg',
-                            borderColor: 'neutral.outlinedHoverBorder',
+                            borderColor: 'neutral.outlinedBorder',
                           },
                         }}
                         slots={{ root: IconButton }}
@@ -437,7 +437,7 @@ const ProviderContainer = ({
                               minHeight: '28px !important',
                               '&:hover': {
                                 backgroundColor: 'neutral.outlinedHoverBg',
-                                borderColor: 'neutral.outlinedHoverBorder',
+                                borderColor: 'neutral.outlinedBorder',
                               },
                             }}
                             slots={{ root: IconButton }}

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
@@ -361,7 +361,7 @@ const GeneralSettingsTab = () => {
                       minHeight: '28px !important',
                       '&:hover': {
                         backgroundColor: 'neutral.outlinedHoverBg',
-                        borderColor: 'neutral.outlinedHoverBorder',
+                        borderColor: 'neutral.outlinedBorder',
                       },
                     }}
                     slots={{ root: IconButton }}
@@ -445,7 +445,7 @@ const GeneralSettingsTab = () => {
                       minHeight: '28px !important',
                       '&:hover': {
                         backgroundColor: 'neutral.outlinedHoverBg',
-                        borderColor: 'neutral.outlinedHoverBorder',
+                        borderColor: 'neutral.outlinedBorder',
                       },
                     }}
                     slots={{ root: IconButton }}

--- a/apps/client/app/components/ProfileModal/SystemPromptsTab.tsx
+++ b/apps/client/app/components/ProfileModal/SystemPromptsTab.tsx
@@ -632,7 +632,7 @@ export function SystemPromptsTab({ user }: SystemPromptsTabProps) {
                       sx={{
                         flex: 1,
                         fontWeight: isAdding ? 'md' : 'sm',
-                        color: isAdding ? 'primary.main' : 'text.primary',
+                        color: isAdding ? 'primary.plainColor' : 'text.primary',
                       }}
                     >
                       {file.fileName}

--- a/apps/client/app/components/ProfileModal/UploadImportHistoryModal.tsx
+++ b/apps/client/app/components/ProfileModal/UploadImportHistoryModal.tsx
@@ -298,7 +298,7 @@ const UploadImportHistoryModal: FC<IUploadImportHistoryModalProps> = ({
                 textAlign: 'center',
                 transition: 'border-color 0.3s, background-color 0.3s',
                 '&:hover': {
-                  bgcolor: 'neutral.plainHoverBg',
+                  bgcolor: 'neutral.softBg',
                 },
                 bgcolor: isDragging ? 'neutral.softBg' : 'background.surface',
               }}

--- a/apps/client/app/components/ProfileModal/UploadImportHistoryModal.tsx
+++ b/apps/client/app/components/ProfileModal/UploadImportHistoryModal.tsx
@@ -292,7 +292,7 @@ const UploadImportHistoryModal: FC<IUploadImportHistoryModalProps> = ({
               onDrop={handleDrop}
               sx={{
                 border: '2px dashed',
-                borderColor: isDragging ? 'primary.main' : 'neutral.outlinedBorder',
+                borderColor: isDragging ? 'primary.plainColor' : 'neutral.outlinedBorder',
                 borderRadius: 'sm',
                 p: 2,
                 textAlign: 'center',

--- a/apps/client/app/components/ProfileModal/UploadImportHistoryModal.tsx
+++ b/apps/client/app/components/ProfileModal/UploadImportHistoryModal.tsx
@@ -298,9 +298,9 @@ const UploadImportHistoryModal: FC<IUploadImportHistoryModalProps> = ({
                 textAlign: 'center',
                 transition: 'border-color 0.3s, background-color 0.3s',
                 '&:hover': {
-                  bgcolor: 'action.hover',
+                  bgcolor: 'neutral.plainHoverBg',
                 },
-                bgcolor: isDragging ? 'action.hover' : 'background.surface',
+                bgcolor: isDragging ? 'neutral.softBg' : 'background.surface',
               }}
             >
               <Button

--- a/apps/client/app/components/Project/Files.tsx
+++ b/apps/client/app/components/Project/Files.tsx
@@ -1,5 +1,6 @@
 import { FC, useCallback, useMemo, useState, useRef } from 'react';
 import { debounce } from 'lodash';
+import { alpha } from '@mui/system';
 import SearchIcon from '@mui/icons-material/Search';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { brand, brandAlpha } from '@client/app/utils/themes/colors';
@@ -413,7 +414,7 @@ const ProjectFiles: FC<{
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
-                  bgcolor: 'background.backdrop',
+                  bgcolor: theme => alpha(theme.palette.background.surface, 0.85),
                   zIndex: 1000,
                   borderRadius: 'inherit',
                 }}

--- a/apps/client/app/components/Project/Files.tsx
+++ b/apps/client/app/components/Project/Files.tsx
@@ -413,7 +413,7 @@ const ProjectFiles: FC<{
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
-                  bgcolor: 'action.hover',
+                  bgcolor: 'background.backdrop',
                   zIndex: 1000,
                   borderRadius: 'inherit',
                 }}

--- a/apps/client/app/components/Project/Files.tsx
+++ b/apps/client/app/components/Project/Files.tsx
@@ -418,7 +418,7 @@ const ProjectFiles: FC<{
                   borderRadius: 'inherit',
                 }}
               >
-                <Typography className="project-files-drag-text" level="h4" sx={{ color: 'primary.main' }}>
+                <Typography className="project-files-drag-text" level="h4" sx={{ color: 'primary.plainColor' }}>
                   {t('file_browser.drop_files_here')}
                 </Typography>
               </Box>

--- a/apps/client/app/components/ResearchTasks/Detail/Info.tsx
+++ b/apps/client/app/components/ResearchTasks/Detail/Info.tsx
@@ -82,7 +82,7 @@ const ResearchTaskDetailInfo: FC<ResearchTaskDetailInfoProps> = ({ task }) => {
             >
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
-                  <Avatar variant="soft" sx={{ bgcolor: 'primary.softBg', color: 'primary.softColor' }}>
+                  <Avatar variant="soft" sx={{ color: 'primary.plainColor' }}>
                     <Description sx={{ fontSize: 20 }} />
                   </Avatar>
                   <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/apps/client/app/components/ResearchTasks/Detail/Info.tsx
+++ b/apps/client/app/components/ResearchTasks/Detail/Info.tsx
@@ -74,7 +74,7 @@ const ResearchTaskDetailInfo: FC<ResearchTaskDetailInfoProps> = ({ task }) => {
                 gridColumn: { xs: '1', md: '1 / -1' },
                 transition: 'all 0.2s ease',
                 '&:hover': {
-                  borderColor: 'info.300',
+                  borderColor: 'primary.plainColor',
                   boxShadow: `0 4px 20px ${brandAlpha[500][15]}`,
                   transform: 'translateY(-2px)',
                 },
@@ -82,7 +82,7 @@ const ResearchTaskDetailInfo: FC<ResearchTaskDetailInfoProps> = ({ task }) => {
             >
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
-                  <Avatar variant="soft" sx={{ bgcolor: 'info.50', color: 'info.600' }}>
+                  <Avatar variant="soft" sx={{ bgcolor: 'primary.softBg', color: 'primary.softColor' }}>
                     <Description sx={{ fontSize: 20 }} />
                   </Avatar>
                   <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/apps/client/app/components/ResearchTasks/Form.tsx
+++ b/apps/client/app/components/ResearchTasks/Form.tsx
@@ -1139,14 +1139,14 @@ const ResearchTaskForm: FC<ResearchTaskFormProps> = ({ onSubmit, onCancel, taskI
                 sx={{
                   textTransform: 'uppercase',
                   letterSpacing: '0.1em',
-                  color: mode === 'dark' ? 'secondary.400' : 'secondary.700',
+                  color: mode === 'dark' ? 'neutral.400' : 'neutral.700',
                   fontWeight: 700,
                   display: 'flex',
                   alignItems: 'center',
                   gap: 0.5,
                 }}
               >
-                <Box sx={{ width: 4, height: 4, borderRadius: '50%', bgcolor: 'secondary.500' }} />
+                <Box sx={{ width: 4, height: 4, borderRadius: '50%', bgcolor: 'neutral.500' }} />
                 Step 4: Schedule Execution
               </Typography>
             </Box>

--- a/apps/client/app/components/ResearchTasks/Form.tsx
+++ b/apps/client/app/components/ResearchTasks/Form.tsx
@@ -623,7 +623,7 @@ const ResearchTaskForm: FC<ResearchTaskFormProps> = ({ onSubmit, onCancel, taskI
                                 transition: 'all 0.2s ease',
                                 '&:hover': {
                                   borderColor: field.value === option.value ? 'primary.600' : 'primary.400',
-                                  bgcolor: field.value === option.value ? 'primary.100' : 'primary.25',
+                                  bgcolor: field.value === option.value ? 'primary.100' : 'primary.50',
                                   transform: 'translateY(-2px)',
                                   boxShadow: `0 4px 12px ${blackAlpha[0][10]}`,
                                 },
@@ -1239,7 +1239,7 @@ const ResearchTaskForm: FC<ResearchTaskFormProps> = ({ onSubmit, onCancel, taskI
                                   transition: 'all 0.2s ease',
                                   '&:hover': {
                                     borderColor: field.value === option.value ? 'primary.600' : 'primary.400',
-                                    bgcolor: field.value === option.value ? 'primary.100' : 'primary.25',
+                                    bgcolor: field.value === option.value ? 'primary.100' : 'primary.50',
                                     transform: 'translateY(-2px)',
                                     boxShadow: `0 4px 12px ${blackAlpha[0][10]}`,
                                   },

--- a/apps/client/app/components/ResearchTasks/TaskListItem.tsx
+++ b/apps/client/app/components/ResearchTasks/TaskListItem.tsx
@@ -67,7 +67,7 @@ const TaskListItem: FC<TaskListItemProps> = ({ task, isSelected, onClick, onEdit
           borderColor: 'divider',
           '&:hover': {
             bgcolor: 'background.level1',
-            borderColor: 'neutral.outlinedHoverBorder',
+            borderColor: 'neutral.outlinedBorder',
             '& .actions': {
               opacity: 1,
             },

--- a/apps/client/app/components/Session/AISettings/AdvancedAIModal.tsx
+++ b/apps/client/app/components/Session/AISettings/AdvancedAIModal.tsx
@@ -146,7 +146,7 @@ const commonInputStyles = (_mode: string) => ({
   // state, which Temperature uses on fixed-temperature models and which must not look clickable.
   '&:not(.Mui-disabled):hover': {
     backgroundColor: 'primary.softHoverBg',
-    borderColor: 'primary.main',
+    borderColor: 'primary.plainColor',
   },
 });
 
@@ -538,7 +538,7 @@ const ResetButton: React.FC<{
           borderColor: 'var(--joy-palette-border-light)',
           '&:hover': {
             backgroundColor: 'primary.softHoverBg',
-            borderColor: 'primary.main',
+            borderColor: 'primary.plainColor',
           },
         }}
       >
@@ -736,7 +736,7 @@ const SelectedModelDetails: React.FC<SelectedModelDetailsProps> = ({
             label: 'Stream',
             control: (
               <Checkbox
-                checkedIcon={<CheckIcon sx={{ color: 'success.main' }} />}
+                checkedIcon={<CheckIcon sx={{ color: 'success.plainColor' }} />}
                 checked={stream}
                 onChange={() => setStream(!stream)}
                 disabled={voiceOver}
@@ -1079,11 +1079,11 @@ const SelectedModelDetails: React.FC<SelectedModelDetailsProps> = ({
                       // The filled bar carries the value, so it goes inert with everything else -
                       // primary blue on a dimmed row still read as the one live control.
                       '& .MuiSlider-track': {
-                        backgroundColor: readOnly ? 'text.tertiary' : 'primary.main',
+                        backgroundColor: readOnly ? 'text.tertiary' : 'primary.solidBg',
                       },
                       // No handle while previewing: there is nothing to drag, and a handle reads as
                       // grabbable however it is coloured. The filled bar still shows the value.
-                      '& .MuiSlider-thumb': readOnly ? { display: 'none' } : { backgroundColor: 'primary.main' },
+                      '& .MuiSlider-thumb': readOnly ? { display: 'none' } : { backgroundColor: 'primary.solidBg' },
                     }}
                   />
                 </Box>

--- a/apps/client/app/components/Session/AISettings/ResearchModeIndicator.tsx
+++ b/apps/client/app/components/Session/AISettings/ResearchModeIndicator.tsx
@@ -163,7 +163,7 @@ const ResearchModeIndicator: FC = () => {
           ...fixedHeight,
           '&:hover': {
             backgroundColor: theme => theme.palette.primary.softHoverBg,
-            borderColor: 'primary.dark',
+            borderColor: 'primary.plainColor',
           },
         }}
         onClick={() => openModal('research-mode')}

--- a/apps/client/app/components/Session/GoogleDoc.tsx
+++ b/apps/client/app/components/Session/GoogleDoc.tsx
@@ -474,13 +474,13 @@ const GoogleDrive: React.FC<GoogleDriveProps> = ({ onFileProcessed, existingAcce
         sx={{
           width: '100%',
           textAlign: 'center',
-          backgroundColor: isSignedIn ? 'neutral.main' : 'transparent',
-          color: isSignedIn ? 'success.main' : 'neutral.main',
+          backgroundColor: isSignedIn ? 'neutral.solidBg' : 'transparent',
+          color: isSignedIn ? 'success.plainColor' : 'neutral.plainColor',
           border: '1px solid',
-          borderColor: isSignedIn ? 'success.main' : 'transparent',
+          borderColor: isSignedIn ? 'success.outlinedBorder' : 'transparent',
           '&:hover': {
-            backgroundColor: isSignedIn ? 'neutral.light' : 'transparent',
-            borderColor: isSignedIn ? 'success.main' : 'neutral.main',
+            backgroundColor: isSignedIn ? 'neutral.softBg' : 'transparent',
+            borderColor: isSignedIn ? 'success.outlinedBorder' : 'neutral.outlinedBorder',
           },
         }}
       >

--- a/apps/client/app/components/Session/GoogleDoc.tsx
+++ b/apps/client/app/components/Session/GoogleDoc.tsx
@@ -477,14 +477,14 @@ const GoogleDrive: React.FC<GoogleDriveProps> = ({ onFileProcessed, existingAcce
           backgroundColor: isSignedIn ? 'neutral.solidBg' : 'transparent',
           color: isSignedIn ? 'success.plainColor' : 'neutral.plainColor',
           border: '1px solid',
-          borderColor: isSignedIn ? 'success.outlinedBorder' : 'transparent',
+          borderColor: isSignedIn ? 'success.plainColor' : 'transparent',
           '&:hover': {
             backgroundColor: isSignedIn ? 'neutral.softBg' : 'transparent',
-            borderColor: isSignedIn ? 'success.outlinedBorder' : 'neutral.outlinedBorder',
+            borderColor: isSignedIn ? 'success.plainColor' : 'neutral.outlinedBorder',
           },
         }}
       >
-        <GoogleIcon sx={{ marginRight: '0.5vw' }} color={isSignedIn ? 'success' : 'secondary'} />
+        <GoogleIcon sx={{ marginRight: '0.5vw', color: isSignedIn ? 'success.plainColor' : 'inherit' }} />
         {isSignedIn ? 'Sign Out' : 'Sign In with Google'}
       </Button>
       {isSignedIn && (

--- a/apps/client/app/components/Session/ImageDisplay.tsx
+++ b/apps/client/app/components/Session/ImageDisplay.tsx
@@ -25,9 +25,9 @@ const ImageDisplay: FC<ImageDisplayProps> = ({ imageUrl, error }) => {
           sx={{
             p: 2,
             border: '1px solid',
-            borderColor: 'error.main',
+            borderColor: 'danger.outlinedBorder',
             borderRadius: '8px',
-            bgcolor: 'error.softBg',
+            bgcolor: 'danger.softBg',
           }}
         >
           <Typography color="danger">{error.message}</Typography>

--- a/apps/client/app/components/Session/ImageMaskerFlux.tsx
+++ b/apps/client/app/components/Session/ImageMaskerFlux.tsx
@@ -173,7 +173,7 @@ const ImageMaskerFlux: React.FC<ImageMaskerProps> = ({ imageUrl, onSave, open, o
               maxWidth: '90vw',
               maxHeight: '90vh',
               overflow: 'auto',
-              backgroundColor: 'background.paper',
+              backgroundColor: 'background.surface',
             }}
           >
             <Typography level="h2" data-testid="image-edit-dialog-title">
@@ -254,11 +254,6 @@ const ImageMaskerFlux: React.FC<ImageMaskerProps> = ({ imageUrl, onSave, open, o
                 value={promptMessage}
                 onChange={e => setPromptMessage(e.target.value)}
                 data-testid="image-edit-prompt"
-                sx={{
-                  '& .MuiOutlinedInput-root': {
-                    backgroundColor: 'background.paper',
-                  },
-                }}
               />
             </Box>
 

--- a/apps/client/app/components/Session/ImageMaskerOpenAi.tsx
+++ b/apps/client/app/components/Session/ImageMaskerOpenAi.tsx
@@ -210,7 +210,7 @@ const ImageMaskerOpenAi: React.FC<ImageMaskerProps> = ({ imageUrl, onSave, open,
         <ModalDialog>
           <Box
             sx={{
-              backgroundColor: 'background.paper',
+              backgroundColor: 'background.surface',
               padding: 2,
               borderRadius: 2,
               maxWidth: '90vw',
@@ -281,11 +281,6 @@ const ImageMaskerOpenAi: React.FC<ImageMaskerProps> = ({ imageUrl, onSave, open,
                 value={promptMessage}
                 onChange={e => setPromptMessage(e.target.value)}
                 data-testid="image-edit-prompt"
-                sx={{
-                  '& .MuiOutlinedInput-root': {
-                    backgroundColor: 'background.paper',
-                  },
-                }}
               />
             </Box>
 

--- a/apps/client/app/components/Session/NotebookExecutionButtons.tsx
+++ b/apps/client/app/components/Session/NotebookExecutionButtons.tsx
@@ -324,7 +324,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   if (status === 'completed') {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'success.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'success.main', display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'success.softColor', display: 'flex', alignItems: 'center', gap: 1 }}>
           <CheckCircleOutline sx={{ fontSize: 16 }} />
           Notebook executed successfully ({executedCells}/{cellCount} cells)
         </Typography>
@@ -336,7 +336,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   if (status === 'failed') {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'danger.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'danger.main', display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'danger.softColor', display: 'flex', alignItems: 'center', gap: 1 }}>
           <ErrorOutline sx={{ fontSize: 16 }} />
           Notebook execution failed: {lastError || 'Unknown error'}
         </Typography>
@@ -359,12 +359,12 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
     const progress = cellCount > 0 ? Math.round((executedCells / cellCount) * 100) : 0;
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'primary.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'primary.softColor', display: 'flex', alignItems: 'center', gap: 1 }}>
           <CircularProgress size="sm" sx={{ '--CircularProgress-size': '16px' }} />
           Executing notebook... ({executedCells}/{cellCount || '?'} cells, {progress}%)
         </Typography>
         {lastError && (
-          <Typography level="body-xs" sx={{ mt: 0.5, color: 'warning.main' }}>
+          <Typography level="body-xs" sx={{ mt: 0.5, color: 'warning.plainColor' }}>
             Last error: {lastError}
           </Typography>
         )}
@@ -376,7 +376,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   if (error) {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'danger.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'danger.main', mb: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'danger.softColor', mb: 1 }}>
           {error}
         </Typography>
         <Button size="sm" variant="outlined" color="danger" onClick={handleExecute} disabled={isExecuting}>

--- a/apps/client/app/components/Session/NotebookExecutionButtons.tsx
+++ b/apps/client/app/components/Session/NotebookExecutionButtons.tsx
@@ -324,7 +324,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   if (status === 'completed') {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'success.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'success.softColor', display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'success.plainColor', display: 'flex', alignItems: 'center', gap: 1 }}>
           <CheckCircleOutline sx={{ fontSize: 16 }} />
           Notebook executed successfully ({executedCells}/{cellCount} cells)
         </Typography>
@@ -336,7 +336,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   if (status === 'failed') {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'danger.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'danger.softColor', display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'danger.plainColor', display: 'flex', alignItems: 'center', gap: 1 }}>
           <ErrorOutline sx={{ fontSize: 16 }} />
           Notebook execution failed: {lastError || 'Unknown error'}
         </Typography>
@@ -359,7 +359,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
     const progress = cellCount > 0 ? Math.round((executedCells / cellCount) * 100) : 0;
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'primary.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'primary.softColor', display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'primary.plainColor', display: 'flex', alignItems: 'center', gap: 1 }}>
           <CircularProgress size="sm" sx={{ '--CircularProgress-size': '16px' }} />
           Executing notebook... ({executedCells}/{cellCount || '?'} cells, {progress}%)
         </Typography>
@@ -376,7 +376,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   if (error) {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'danger.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'danger.softColor', mb: 1 }}>
+        <Typography level="body-sm" sx={{ color: 'danger.plainColor', mb: 1 }}>
           {error}
         </Typography>
         <Button size="sm" variant="outlined" color="danger" onClick={handleExecute} disabled={isExecuting}>

--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -790,7 +790,7 @@ const PendingActionButtons: FC<PendingActionButtonsProps> = ({ pendingAction, me
   if (isExpired) {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'warning.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'warning.softColor' }}>
+        <Typography level="body-sm" sx={{ color: 'warning.plainColor' }}>
           This confirmation has expired. Please request the action again.
         </Typography>
       </Box>

--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -773,7 +773,7 @@ const PendingActionButtons: FC<PendingActionButtonsProps> = ({ pendingAction, me
   if (isConfirmed || isCancelled) {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'background.level1' }}>
-        <Typography level="body-sm" sx={{ color: result?.success ? 'success.main' : 'danger.main' }}>
+        <Typography level="body-sm" sx={{ color: result?.success ? 'success.plainColor' : 'danger.plainColor' }}>
           {result?.message || (isConfirmed ? 'Action completed' : 'Action cancelled')}
         </Typography>
         {result?.url && (
@@ -790,7 +790,7 @@ const PendingActionButtons: FC<PendingActionButtonsProps> = ({ pendingAction, me
   if (isExpired) {
     return (
       <Box sx={{ mt: 2, p: 1.5, borderRadius: 'sm', bgcolor: 'warning.softBg' }}>
-        <Typography level="body-sm" sx={{ color: 'warning.main' }}>
+        <Typography level="body-sm" sx={{ color: 'warning.softColor' }}>
           This confirmation has expired. Please request the action again.
         </Typography>
       </Box>
@@ -1036,7 +1036,7 @@ const AttachmentDownloadButtons: FC<AttachmentDownloadButtonsProps> = ({ attachm
                   {!isDeleted && att.author && ` • by ${att.author}`}
                 </Typography>
                 {errors[att.id] && (
-                  <Typography level="body-xs" sx={{ color: 'danger.main' }}>
+                  <Typography level="body-xs" sx={{ color: 'danger.plainColor' }}>
                     {errors[att.id]}
                   </Typography>
                 )}

--- a/apps/client/app/components/Session/SidenavItem.tsx
+++ b/apps/client/app/components/Session/SidenavItem.tsx
@@ -762,8 +762,6 @@ const SessionSidenavItem: FC<{
               alignItems: 'center',
               justifyContent: 'center',
               borderRadius: '50%',
-              backgroundColor: 'success.main',
-              color: 'success.contrastText',
               fontSize: '12px',
             }}
           >

--- a/apps/client/app/components/Session/SidenavItem.tsx
+++ b/apps/client/app/components/Session/SidenavItem.tsx
@@ -761,7 +761,6 @@ const SessionSidenavItem: FC<{
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              borderRadius: '50%',
               fontSize: '12px',
             }}
           >

--- a/apps/client/app/components/admin/AdminOperationsModelSetting.tsx
+++ b/apps/client/app/components/admin/AdminOperationsModelSetting.tsx
@@ -178,7 +178,7 @@ export const AdminOperationsModelSetting: React.FC = () => {
   return (
     <Card variant="outlined" sx={{ mb: 2, p: 3 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-        <SmartToyIcon sx={{ mr: 1, color: 'primary.main' }} />
+        <SmartToyIcon sx={{ mr: 1, color: 'primary.plainColor' }} />
         <Typography level="h4">Operations Model</Typography>
       </Box>
 

--- a/apps/client/app/components/admin/SubscribersTab.tsx
+++ b/apps/client/app/components/admin/SubscribersTab.tsx
@@ -348,7 +348,7 @@ const SubscribersTab = () => {
             <Alert
               color="warning"
               variant="soft"
-              sx={{ mb: 2, backgroundColor: isDarkMode ? 'warning.550' : 'warning.100' }}
+              sx={{ mb: 2 }}
               endDecorator={
                 <IconButton
                   size="sm"

--- a/apps/client/app/components/admin/Users/LoginDetailsModal.tsx
+++ b/apps/client/app/components/admin/Users/LoginDetailsModal.tsx
@@ -41,7 +41,7 @@ const LoginDetailsModal: React.FC<LoginDetailsModalProps> = ({ open, onClose, us
           <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 1 }}>
             <Card variant="outlined" sx={{ flex: { sm: '1 1 30%' } }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, p: 2 }}>
-                <Avatar variant="solid" size="sm" sx={{ bgcolor: 'primary.main' }}>
+                <Avatar variant="solid" size="sm" sx={{ bgcolor: 'primary.solidBg' }}>
                   <PersonIcon />
                 </Avatar>
                 <Box>

--- a/apps/client/app/components/artifacts/ArtifactVersionDropdown.tsx
+++ b/apps/client/app/components/artifacts/ArtifactVersionDropdown.tsx
@@ -178,7 +178,7 @@ export const ArtifactVersionDropdown: React.FC<ArtifactVersionDropdownProps> = (
                             Latest
                           </Chip>
                         )}
-                        {isSelected && <LatestIcon sx={{ fontSize: 16, color: 'primary.main' }} />}
+                        {isSelected && <LatestIcon sx={{ fontSize: 16, color: 'primary.plainColor' }} />}
                       </Stack>
                     </Stack>
                     {version.versionTag && (

--- a/apps/client/app/components/b4m/ComingSoon.tsx
+++ b/apps/client/app/components/b4m/ComingSoon.tsx
@@ -73,12 +73,7 @@ const ComingSoon = () => {
           onChange={handleEmailChange}
           sx={{ width: '100%', maxWidth: '400px' }}
         />
-        <Button
-          data-testid="coming-soon-submit-btn"
-          type="submit"
-          disabled={isSubmitting}
-          sx={{ mt: 2, backgroundColor: 'primary', '&:hover': { backgroundColor: 'primary.dark' } }}
-        >
+        <Button data-testid="coming-soon-submit-btn" type="submit" disabled={isSubmitting} sx={{ mt: 2 }}>
           Notify Me
         </Button>
       </Box>

--- a/apps/client/app/components/modals/WhatsNewSliderModal.tsx
+++ b/apps/client/app/components/modals/WhatsNewSliderModal.tsx
@@ -48,7 +48,7 @@ const navButtonSx = {
   '--IconButton-size': { xs: '32px' },
   '&:hover': {
     backgroundColor: 'neutral.outlinedHoverBg',
-    borderColor: 'neutral.outlinedHoverBorder',
+    borderColor: 'neutral.outlinedBorder',
   },
 } as const;
 

--- a/apps/client/app/components/profile/ChangeEmailCard.tsx
+++ b/apps/client/app/components/profile/ChangeEmailCard.tsx
@@ -282,7 +282,7 @@ const ChangeEmailCard = () => {
             p: 2,
           }}
         >
-          <EmailIcon sx={{ fontSize: 32, color: 'primary.main', flexShrink: 0 }} />
+          <EmailIcon sx={{ fontSize: 32, color: 'primary.plainColor', flexShrink: 0 }} />
 
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <Typography level="title-md" sx={{ mb: 0.5 }}>

--- a/apps/client/app/routes/quests.tsx
+++ b/apps/client/app/routes/quests.tsx
@@ -891,7 +891,7 @@ function QuestsPage() {
           aria-describedby="archive-confirm-description"
         >
           <DialogTitle id="archive-confirm-title">
-            <WarningIcon sx={{ mr: 1, color: 'warning.main' }} />
+            <WarningIcon sx={{ mr: 1, color: 'warning.plainColor' }} />
             Archive Quest?
           </DialogTitle>
           <Divider />

--- a/apps/client/app/utils/themes/palette.test.ts
+++ b/apps/client/app/utils/themes/palette.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from './themePrimitives';
+
+/**
+ * Guards the Material-UI-vs-Joy palette-shape mismatch that lets a whole `sx` declaration
+ * disappear at runtime with no error: Joy has no `main`/`light`/`dark`/`contrastText` keys
+ * and no `error`/`info`/`secondary`/`action` families, so `sx={{ color: 'primary.main' }}`
+ * resolves to nothing, the browser rejects the literal, and the rule is dropped silently.
+ *
+ * The eslint `no-restricted-syntax` guard in eslint.config.mjs stops new ones being written;
+ * this locks the theme half of the contract - that the tokens we replaced them with exist.
+ */
+const theme = extendTheme({ ...getThemeConfig() });
+const MODES = ['light', 'dark'] as const;
+const JOY_COLOR_FAMILIES = ['primary', 'neutral', 'danger', 'success', 'warning'] as const;
+
+// Every palette token reachable from an `sx` string in apps/client/app. Keep in sync when a new
+// one is introduced - a typo'd token fails here instead of silently rendering nothing.
+const TOKENS_IN_USE: Record<(typeof JOY_COLOR_FAMILIES)[number], string[]> = {
+  primary: ['500', 'plainColor', 'softColor', 'softBg', 'softHoverBg', 'solidBg', 'solidHoverBg'],
+  neutral: ['plainColor', 'plainHoverBg', 'softBg', 'solidBg', 'outlinedBorder'],
+  danger: ['plainColor', 'softColor', 'softBg', 'outlinedBorder'],
+  success: ['plainColor', 'softColor', 'softBg', 'outlinedBorder'],
+  warning: ['plainColor', 'softColor', 'softBg'],
+};
+
+describe('Joy palette shape', () => {
+  it.each(MODES)('%s: has no Material UI shade keys on any colour family', mode => {
+    for (const family of JOY_COLOR_FAMILIES) {
+      const palette = theme.colorSchemes[mode].palette[family] as Record<string, unknown>;
+      for (const key of ['main', 'light', 'dark', 'contrastText']) {
+        expect(`${family}.${key}=${palette[key]}`).toBe(`${family}.${key}=undefined`);
+      }
+    }
+  });
+
+  it.each(MODES)('%s: has no Material-UI-only colour families', mode => {
+    const palette = theme.colorSchemes[mode].palette as Record<string, unknown>;
+    for (const family of ['error', 'info', 'secondary', 'action']) {
+      expect(`${family}=${palette[family]}`).toBe(`${family}=undefined`);
+    }
+  });
+
+  it.each(MODES)('%s: resolves every token the app uses', mode => {
+    for (const [family, tokens] of Object.entries(TOKENS_IN_USE)) {
+      const palette = theme.colorSchemes[mode].palette[family as (typeof JOY_COLOR_FAMILIES)[number]] as Record<
+        string,
+        unknown
+      >;
+      for (const token of tokens) {
+        expect(`${family}.${token}=${typeof palette[token]}`).toBe(`${family}.${token}=string`);
+      }
+    }
+  });
+});

--- a/apps/client/app/utils/themes/palette.test.ts
+++ b/apps/client/app/utils/themes/palette.test.ts
@@ -19,7 +19,7 @@ const JOY_COLOR_FAMILIES = ['primary', 'neutral', 'danger', 'success', 'warning'
 // one is introduced - a typo'd token fails here instead of silently rendering nothing.
 const TOKENS_IN_USE: Record<(typeof JOY_COLOR_FAMILIES)[number], string[]> = {
   primary: ['500', 'plainColor', 'softColor', 'softBg', 'softHoverBg', 'solidBg', 'solidHoverBg'],
-  neutral: ['plainColor', 'plainHoverBg', 'softBg', 'solidBg', 'outlinedBorder'],
+  neutral: ['400', '500', '700', 'plainColor', 'plainHoverBg', 'softBg', 'solidBg', 'outlinedBorder'],
   danger: ['plainColor', 'softColor', 'softBg', 'outlinedBorder'],
   success: ['plainColor', 'softColor', 'softBg', 'outlinedBorder'],
   warning: ['plainColor', 'softColor', 'softBg'],
@@ -40,6 +40,14 @@ describe('Joy palette shape', () => {
     for (const family of ['error', 'info', 'secondary', 'action']) {
       expect(`${family}=${palette[family]}`).toBe(`${family}=undefined`);
     }
+  });
+
+  // The project drag overlay covers content, so it needs the translucent scrim rather than one of
+  // the opaque surface tokens.
+  it.each(MODES)('%s: background.backdrop is translucent', mode => {
+    const backdrop = theme.colorSchemes[mode].palette.background.backdrop;
+    expect(typeof backdrop).toBe('string');
+    expect(backdrop).toContain('rgba');
   });
 
   it.each(MODES)('%s: resolves every token the app uses', mode => {

--- a/apps/client/app/utils/themes/palette.test.ts
+++ b/apps/client/app/utils/themes/palette.test.ts
@@ -1,33 +1,56 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from './themePrimitives';
 
 /**
- * Guards the Material-UI-vs-Joy palette-shape mismatch that lets a whole `sx` declaration
- * disappear at runtime with no error: Joy has no `main`/`light`/`dark`/`contrastText` keys
- * and no `error`/`info`/`secondary`/`action` families, so `sx={{ color: 'primary.main' }}`
- * resolves to nothing, the browser rejects the literal, and the rule is dropped silently.
+ * Guards the palette-shape mismatch that lets a whole `sx` declaration disappear at runtime with
+ * no error. Joy has no `main`/`light`/`dark`/`contrastText` key and no `error`/`info`/`secondary`/
+ * `action` family, so `sx={{ color: 'primary.main' }}` resolves to nothing, the browser rejects the
+ * leftover literal as a CSS value, and the declaration is dropped silently.
  *
- * The eslint `no-restricted-syntax` guard in eslint.config.mjs stops new ones being written;
- * this locks the theme half of the contract - that the tokens we replaced them with exist.
+ * The eslint guard in eslint.config.mjs catches the Material-shaped ones by regex. It cannot catch
+ * a shade that simply does not exist (`primary.25`, `warning.550`) or a Joy key that was removed
+ * between versions (`neutral.outlinedHoverBorder`) - only the theme knows those. So this resolves
+ * every palette string the SPA actually contains against the built theme, rather than against a
+ * hand-kept list that drifts.
  */
 const theme = extendTheme({ ...getThemeConfig() });
 const MODES = ['light', 'dark'] as const;
-const JOY_COLOR_FAMILIES = ['primary', 'neutral', 'danger', 'success', 'warning'] as const;
+const APP_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
-// Every palette token reachable from an `sx` string in apps/client/app. Keep in sync when a new
-// one is introduced - a typo'd token fails here instead of silently rendering nothing.
-const TOKENS_IN_USE: Record<(typeof JOY_COLOR_FAMILIES)[number], string[]> = {
-  primary: ['500', 'plainColor', 'softColor', 'softBg', 'softHoverBg', 'solidBg', 'solidHoverBg'],
-  neutral: ['400', '500', '700', 'plainColor', 'plainHoverBg', 'softBg', 'solidBg', 'outlinedBorder'],
-  danger: ['plainColor', 'softColor', 'softBg', 'outlinedBorder'],
-  success: ['plainColor', 'softColor', 'softBg', 'outlinedBorder'],
-  warning: ['plainColor', 'softColor', 'softBg'],
+// `common` is deliberately absent: this app's i18n keys are shaped the same way (`t('common.close')`)
+// and there is no way to tell them apart from a palette lookup by shape alone.
+const SCANNED_FAMILIES = ['primary', 'neutral', 'danger', 'success', 'warning', 'text', 'background'] as const;
+const TOKEN_RE = new RegExp(`'((?:${SCANNED_FAMILIES.join('|')})\\.[A-Za-z0-9]+)'`, 'g');
+
+const collectTokens = () => {
+  const found = new Map<string, string>();
+  for (const entry of fs.readdirSync(APP_DIR, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile() || !/\.tsx?$/.test(entry.name)) continue;
+    const file = path.join(entry.parentPath, entry.name);
+    // This file quotes dead tokens on purpose, to assert they are dead.
+    if (file === fileURLToPath(import.meta.url)) continue;
+    const source = fs.readFileSync(file, 'utf8');
+    for (const [, token] of source.matchAll(TOKEN_RE)) {
+      if (!found.has(token)) found.set(token, path.relative(APP_DIR, file));
+    }
+  }
+  return found;
 };
 
+const TOKENS_IN_SOURCE = collectTokens();
+
 describe('Joy palette shape', () => {
+  it('finds palette strings to check at all, so a broken scan cannot pass vacuously', () => {
+    expect(TOKENS_IN_SOURCE.size).toBeGreaterThan(30);
+    expect(TOKENS_IN_SOURCE.has('primary.plainColor')).toBe(true);
+  });
+
   it.each(MODES)('%s: has no Material UI shade keys on any colour family', mode => {
-    for (const family of JOY_COLOR_FAMILIES) {
+    for (const family of ['primary', 'neutral', 'danger', 'success', 'warning'] as const) {
       const palette = theme.colorSchemes[mode].palette[family] as Record<string, unknown>;
       for (const key of ['main', 'light', 'dark', 'contrastText']) {
         expect(`${family}.${key}=${palette[key]}`).toBe(`${family}.${key}=undefined`);
@@ -42,23 +65,14 @@ describe('Joy palette shape', () => {
     }
   });
 
-  // The project drag overlay covers content, so it needs the translucent scrim rather than one of
-  // the opaque surface tokens.
-  it.each(MODES)('%s: background.backdrop is translucent', mode => {
-    const backdrop = theme.colorSchemes[mode].palette.background.backdrop;
-    expect(typeof backdrop).toBe('string');
-    expect(backdrop).toContain('rgba');
-  });
-
-  it.each(MODES)('%s: resolves every token the app uses', mode => {
-    for (const [family, tokens] of Object.entries(TOKENS_IN_USE)) {
-      const palette = theme.colorSchemes[mode].palette[family as (typeof JOY_COLOR_FAMILIES)[number]] as Record<
-        string,
-        unknown
-      >;
-      for (const token of tokens) {
-        expect(`${family}.${token}=${typeof palette[token]}`).toBe(`${family}.${token}=string`);
-      }
-    }
+  it.each(MODES)('%s: every palette string in app/ resolves', mode => {
+    const palette = theme.colorSchemes[mode].palette as Record<string, Record<string, unknown>>;
+    const dead = [...TOKENS_IN_SOURCE]
+      .filter(([token]) => {
+        const [family, key] = token.split('.');
+        return palette[family]?.[key] === undefined;
+      })
+      .map(([token, file]) => `${token} (${file})`);
+    expect(dead).toEqual([]);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -201,6 +201,55 @@ const noWindowOpenInClientUi = [
     message: WINDOW_OPEN_MESSAGE,
   },
 ];
+// Material UI palette tokens are inert under Joy, and fail silently. Joy's palette has no
+// `main`/`light`/`dark`/`contrastText` key on any colour family, and no `error`/`info`/`secondary`/
+// `action`/`grey` family at all, so `sx={{ color: 'primary.main' }}` resolves to nothing, the
+// browser rejects the leftover literal as a CSS value, and the entire declaration is dropped. No
+// error, no warning - the rule simply never applies, and it reads as working code in review.
+//
+// This rule exists because 52 of them had accumulated across 21 files before one was noticed:
+// `primary.main` is what every Material UI example on the internet shows, and nothing in the
+// toolchain distinguishes it from a token that works.
+//
+// Scoped to apps/client/app/** - the Joy SPA. apps/client/pages/** is the API backend, and the
+// `border.light` / `inbox.border.light` tokens this codebase really does define are excluded by
+// anchoring on the palette FAMILY name rather than on the `.light` suffix alone.
+//
+// Only plain string literals are matched, which is how these are written in practice
+// (`sx={{ color: 'primary.main' }}`). A computed `${family}.main` template would slip through;
+// that is accepted, since matching template parts would false-flag any string ending in `.dark`.
+//
+// `[.]` rather than `\.`: these selectors are ordinary JS strings, and `'\.'` collapses to `'.'`
+// there, which would silently widen the dot to "any character". Same hazard the fs selectors below
+// spell around.
+const JOY_PALETTE_FAMILIES = 'primary|neutral|danger|success|warning|common|text|background';
+const MUI_ONLY_FAMILIES = 'error|info|secondary|action|grey';
+const MUI_SHADE_KEYS = 'main|light|dark|contrastText';
+// Keys a Material palette family is actually addressed by. Deliberately enumerated rather than
+// `[a-zA-Z]+`, so a legitimate non-palette string such as 'error.message' stays unflagged.
+// The shade keys are omitted here on purpose: the first selector already covers them for these
+// families, and listing them twice makes a single 'error.main' report the same error twice.
+const MUI_ONLY_FAMILY_KEYS =
+  '[0-9]{2,3}|hover|selected|active|focus|disabled|plainColor|softColor|softBg|solidBg|solidColor|outlinedColor|outlinedBorder';
+const DEAD_PALETTE_MESSAGE =
+  'Material UI palette token: Joy has no main/light/dark/contrastText key, and no ' +
+  'error/info/secondary/action/grey family, so this value resolves to nothing and the whole CSS ' +
+  'declaration is silently dropped. Use the Joy token for the role - text/icon: ' +
+  '<family>.plainColor (<family>.softColor on a matching softBg); border: <family>.outlinedBorder; ' +
+  'fill: <family>.solidBg; hover fill: <family>.solidHoverBg. For the dead families: error -> ' +
+  'danger, info -> primary, secondary -> neutral, action.hover -> neutral.plainHoverBg.';
+const noDeadPaletteTokens = [
+  // A Joy family (or a Material-only one) carrying a Material shade key: 'primary.main', 'error.main'.
+  {
+    selector: `Literal[value=/^(${JOY_PALETTE_FAMILIES}|${MUI_ONLY_FAMILIES})[.](${MUI_SHADE_KEYS})$/]`,
+    message: DEAD_PALETTE_MESSAGE,
+  },
+  // A Material-only family, whatever the key: 'info.300', 'secondary.500', 'action.hover'.
+  {
+    selector: `Literal[value=/^(${MUI_ONLY_FAMILIES})[.](${MUI_ONLY_FAMILY_KEYS})$/]`,
+    message: DEAD_PALETTE_MESSAGE,
+  },
+];
 const noTreeWalkInPagesTests = [
   // bare call: `readdirSync(dir)` (named/destructured import)
   { selector: `CallExpression[callee.name=/${TREE_WALK_NAMES}/]`, message: WALK_MESSAGE },
@@ -551,13 +600,15 @@ export default defineConfig([
     },
   },
 
-  // Ban window.open in the SPA's UI code - see noWindowOpenInClientUi above for the Safari
-  // popup-window rationale. Glob is disjoint from the pages-tests block above, so flat-config
-  // last-rule-wins on no-restricted-syntax leaves that rule intact.
+  // Ban window.open and dead Material UI palette tokens in the SPA's UI code - see
+  // noWindowOpenInClientUi and noDeadPaletteTokens above for the rationale behind each. Both sets
+  // must be spread into this one rule: flat-config last-rule-wins means a second block declaring
+  // no-restricted-syntax for these files would replace them, not add to them. The glob is disjoint
+  // from the pages-tests block above, so that rule is left intact.
   {
     files: ['apps/client/app/**/*.{ts,tsx}'],
     rules: {
-      'no-restricted-syntax': ['error', ...noWindowOpenInClientUi],
+      'no-restricted-syntax': ['error', ...noWindowOpenInClientUi, ...noDeadPaletteTokens],
       // Catches the bare `open(url)` form the selectors above cannot safely match. Scope-aware,
       // so a local/parameter named `open` is untouched.
       'no-restricted-globals': ['error', { name: 'open', message: WINDOW_OPEN_MESSAGE }],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -225,12 +225,19 @@ const noWindowOpenInClientUi = [
 const JOY_PALETTE_FAMILIES = 'primary|neutral|danger|success|warning|common|text|background';
 const MUI_ONLY_FAMILIES = 'error|info|secondary|action|grey';
 const MUI_SHADE_KEYS = 'main|light|dark|contrastText';
+// Material keys that exist on no Joy family, so they are dead even on a family Joy does have.
+const MUI_ONLY_JOY_FAMILY_KEYS = 'background[.](default|paper)|text[.]disabled';
 // Keys a Material palette family is actually addressed by. Deliberately enumerated rather than
 // `[a-zA-Z]+`, so a legitimate non-palette string such as 'error.message' stays unflagged.
 // The shade keys are omitted here on purpose: the first selector already covers them for these
 // families, and listing them twice makes a single 'error.main' report the same error twice.
+// Caveat worth knowing before extending: `[0-9]{2,3}` would also match a dotted i18n or
+// HTTP-status key shaped 'error.404'. None exist in this tree today; if one appears, drop the
+// numeric alternative and enumerate the shades instead of loosening the family list.
 const MUI_ONLY_FAMILY_KEYS =
-  '[0-9]{2,3}|hover|selected|active|focus|disabled|plainColor|softColor|softBg|solidBg|solidColor|outlinedColor|outlinedBorder';
+  '[0-9]{2,3}|A[0-9]{3}|hover|selected|active|focus|disabled|disabledBackground|' +
+  '(?:hover|selected|disabled|focus|activated)Opacity|(?:main|light|dark)Channel|' +
+  'plainColor|softColor|softBg|solidBg|solidColor|outlinedColor|outlinedBorder';
 const DEAD_PALETTE_MESSAGE =
   'Material UI palette token: Joy has no main/light/dark/contrastText key, and no ' +
   'error/info/secondary/action/grey family, so this value resolves to nothing and the whole CSS ' +
@@ -249,7 +256,18 @@ const noDeadPaletteTokens = [
     selector: `Literal[value=/^(${MUI_ONLY_FAMILIES})[.](${MUI_ONLY_FAMILY_KEYS})$/]`,
     message: DEAD_PALETTE_MESSAGE,
   },
+  // A Material-only key on a family Joy does have: 'background.paper', 'text.disabled'.
+  {
+    selector: `Literal[value=/^(${MUI_ONLY_JOY_FAMILY_KEYS})$/]`,
+    message: DEAD_PALETTE_MESSAGE,
+  },
 ];
+
+// A regex can only recognise a token shape. It cannot know that `primary.25` or `warning.550` name
+// a shade this palette does not have, or that `neutral.outlinedHoverBorder` was a Joy key that a
+// version bump removed - those are just as dead, and only the built theme can tell. That half is
+// apps/client/app/utils/themes/palette.test.ts, which resolves every palette string in the SPA
+// against the theme. Keep the two together: neither is sufficient alone.
 const noTreeWalkInPagesTests = [
   // bare call: `readdirSync(dir)` (named/destructured import)
   { selector: `CallExpression[callee.name=/${TREE_WALK_NAMES}/]`, message: WALK_MESSAGE },

--- a/packages/scripts/src/checkDeadPaletteTokenGuard.test.ts
+++ b/packages/scripts/src/checkDeadPaletteTokenGuard.test.ts
@@ -1,40 +1,37 @@
 import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 /**
  * Guards the `no-restricted-syntax` rule that bans Material UI palette tokens in the Joy SPA.
  *
- * The rule is a pair of regexes embedded in esquery selector strings, and both halves of it are
- * easy to break in a way nothing else notices: widen it and it starts flagging `border.light` /
- * `inbox.border.light`, which this theme really does define; narrow it and `primary.main` sails
- * through again. Neither shows up as a test failure anywhere else, because a dead token throws
- * nothing at runtime - it just silently renders no CSS.
+ * Both halves of the rule are easy to break unnoticed: widen it and it starts flagging
+ * `border.light` / `inbox.border.light`, which this theme really does define; narrow it and
+ * `primary.main` sails through again. Neither shows up anywhere else, because a dead token throws
+ * nothing at runtime - it just renders no CSS.
  *
- * So this pulls the selectors out of the real config and exercises the real regexes, rather than
- * restating them. It also pins that they live in the SAME rule entry as the window.open selectors:
- * flat config is last-rule-wins per rule id, so a well-meaning "separate concerns" block declaring
- * its own no-restricted-syntax for apps/client/app/** would silently delete the other guard.
+ * So this runs the real config through eslint's Linter over fixture sources, rather than
+ * re-implementing the selectors. That also covers the two things a regex check could not: that the
+ * strings are valid *esquery* selectors at all, and that the rule still reaches every file under
+ * apps/client/app - including its test files, which a later config block with a narrower glob
+ * would silently exempt, flat config being last-rule-wins per rule id.
  */
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const config = (await import(path.join(REPO_ROOT, 'eslint.config.mjs'))).default;
+// cwd matters: flat-config `files` globs resolve against it, and this package's vitest runs from
+// packages/scripts, where `apps/client/app/**` would match nothing and every fixture would come
+// back clean.
+const linter = new Linter({ configType: 'flat', cwd: REPO_ROOT });
 
-const clientUiBlock = config.find(
-  (block: { files?: string[] }) => block.files?.length === 1 && block.files[0] === 'apps/client/app/**/*.{ts,tsx}'
-);
+/** Rule ids reported for `source` when linted as `filename`. */
+const lint = (source: string, filename = 'apps/client/app/components/Fixture.tsx') =>
+  linter.verify(source, config, path.join(REPO_ROOT, filename)).map(message => message.ruleId);
 
-type Entry = { selector: string; message: string };
-const selectors: Entry[] = (clientUiBlock?.rules?.['no-restricted-syntax'] ?? []).slice(1);
-const paletteSelectors = selectors.filter(entry => entry.message.startsWith('Material UI palette token'));
+const flags = (token: string, filename?: string) =>
+  lint(`export const sx = { color: '${token}' };\n`, filename).includes('no-restricted-syntax');
 
-/** The union of the palette selectors: what the rule flags, as a single testable predicate. */
-const flags = (value: string) =>
-  paletteSelectors.some(entry => {
-    const pattern = entry.selector.match(/^Literal\[value=\/(.+)\/\]$/)?.[1];
-    if (!pattern) throw new Error(`selector is not a Literal value regex: ${entry.selector}`);
-    return new RegExp(pattern).test(value);
-  });
-
+// Dead: resolves to nothing, so the whole declaration is dropped.
 const DEAD = [
   'primary.main',
   'danger.main',
@@ -50,7 +47,14 @@ const DEAD = [
   'info.300',
   'secondary.500',
   'action.hover',
+  'action.disabledBackground',
+  'action.hoverOpacity',
   'grey.700',
+  'grey.A400',
+  'error.mainChannel',
+  'background.paper',
+  'background.default',
+  'text.disabled',
 ];
 
 // Tokens this theme really defines, plus the near-misses that make a lazier regex wrong.
@@ -58,30 +62,29 @@ const LIVE = [
   'primary.plainColor',
   'primary.500',
   'primary.solidHoverBg',
-  'success.softColor',
+  'primary.softHoverBg',
+  'success.plainColor',
   'danger.outlinedBorder',
-  'neutral.plainHoverBg',
+  'neutral.outlinedBorder',
+  'neutral.softBg',
   'success.mainChannel',
   'common.white',
   'text.primary',
+  'text.tertiary',
   'background.surface',
-  'background.backdrop',
+  'background.level2',
   'border.light',
   'border.solid',
   'inbox.border.light',
-  // Not a palette lookup at all - a shape a future non-style string could plausibly take.
+  // Not palette lookups at all - shapes a future non-style string could plausibly take.
   'error.message',
   'logo.dark',
 ];
 
 describe('dead Material UI palette token guard', () => {
-  it('is wired into the apps/client/app block', () => {
-    expect(clientUiBlock, 'expected an eslint block scoped to apps/client/app/**/*.{ts,tsx}').toBeDefined();
-    expect(paletteSelectors.length).toBeGreaterThan(0);
-  });
-
-  it('shares the rule entry with the window.open guard, which last-rule-wins would otherwise drop', () => {
-    expect(selectors.some(entry => entry.message.includes('openInNewTab()'))).toBe(true);
+  it('lints the fixture at all, so a misconfigured Linter cannot pass vacuously', () => {
+    expect(lint(`export const a = 'primary.main';\n`)).toContain('no-restricted-syntax');
+    expect(lint(`export const a = 'primary.plainColor';\n`)).toEqual([]);
   });
 
   it.each(DEAD)('flags %s', token => {
@@ -92,12 +95,19 @@ describe('dead Material UI palette token guard', () => {
     expect(flags(token)).toBe(false);
   });
 
-  it('reports each dead token exactly once', () => {
+  it('reports a dead token once, not once per selector', () => {
     for (const token of DEAD) {
-      const hits = paletteSelectors.filter(entry =>
-        new RegExp(entry.selector.match(/^Literal\[value=\/(.+)\/\]$/)![1]).test(token)
-      );
-      expect(`${token} matched by ${hits.length} selector(s)`).toBe(`${token} matched by 1 selector(s)`);
+      const hits = lint(`export const sx = { color: '${token}' };\n`).filter(id => id === 'no-restricted-syntax');
+      expect(`${token} reported ${hits.length}x`).toBe(`${token} reported 1x`);
     }
+  });
+
+  it('still covers test files under apps/client/app', () => {
+    expect(flags('primary.main', 'apps/client/app/components/Fixture.test.tsx')).toBe(true);
+  });
+
+  it('still bans window.open in the same block, which last-rule-wins would otherwise drop', () => {
+    expect(lint(`window.open('https://example.com');\n`)).toContain('no-restricted-syntax');
+    expect(lint(`open('https://example.com');\n`)).toContain('no-restricted-globals');
   });
 });

--- a/packages/scripts/src/checkDeadPaletteTokenGuard.test.ts
+++ b/packages/scripts/src/checkDeadPaletteTokenGuard.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * Guards the `no-restricted-syntax` rule that bans Material UI palette tokens in the Joy SPA.
+ *
+ * The rule is a pair of regexes embedded in esquery selector strings, and both halves of it are
+ * easy to break in a way nothing else notices: widen it and it starts flagging `border.light` /
+ * `inbox.border.light`, which this theme really does define; narrow it and `primary.main` sails
+ * through again. Neither shows up as a test failure anywhere else, because a dead token throws
+ * nothing at runtime - it just silently renders no CSS.
+ *
+ * So this pulls the selectors out of the real config and exercises the real regexes, rather than
+ * restating them. It also pins that they live in the SAME rule entry as the window.open selectors:
+ * flat config is last-rule-wins per rule id, so a well-meaning "separate concerns" block declaring
+ * its own no-restricted-syntax for apps/client/app/** would silently delete the other guard.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const config = (await import(path.join(REPO_ROOT, 'eslint.config.mjs'))).default;
+
+const clientUiBlock = config.find(
+  (block: { files?: string[] }) => block.files?.length === 1 && block.files[0] === 'apps/client/app/**/*.{ts,tsx}'
+);
+
+type Entry = { selector: string; message: string };
+const selectors: Entry[] = (clientUiBlock?.rules?.['no-restricted-syntax'] ?? []).slice(1);
+const paletteSelectors = selectors.filter(entry => entry.message.startsWith('Material UI palette token'));
+
+/** The union of the palette selectors: what the rule flags, as a single testable predicate. */
+const flags = (value: string) =>
+  paletteSelectors.some(entry => {
+    const pattern = entry.selector.match(/^Literal\[value=\/(.+)\/\]$/)?.[1];
+    if (!pattern) throw new Error(`selector is not a Literal value regex: ${entry.selector}`);
+    return new RegExp(pattern).test(value);
+  });
+
+const DEAD = [
+  'primary.main',
+  'danger.main',
+  'success.main',
+  'warning.main',
+  'neutral.main',
+  'error.main',
+  'info.main',
+  'primary.light',
+  'neutral.light',
+  'primary.dark',
+  'success.contrastText',
+  'info.300',
+  'secondary.500',
+  'action.hover',
+  'grey.700',
+];
+
+// Tokens this theme really defines, plus the near-misses that make a lazier regex wrong.
+const LIVE = [
+  'primary.plainColor',
+  'primary.500',
+  'primary.solidHoverBg',
+  'success.softColor',
+  'danger.outlinedBorder',
+  'neutral.plainHoverBg',
+  'success.mainChannel',
+  'common.white',
+  'text.primary',
+  'background.surface',
+  'background.backdrop',
+  'border.light',
+  'border.solid',
+  'inbox.border.light',
+  // Not a palette lookup at all - a shape a future non-style string could plausibly take.
+  'error.message',
+  'logo.dark',
+];
+
+describe('dead Material UI palette token guard', () => {
+  it('is wired into the apps/client/app block', () => {
+    expect(clientUiBlock, 'expected an eslint block scoped to apps/client/app/**/*.{ts,tsx}').toBeDefined();
+    expect(paletteSelectors.length).toBeGreaterThan(0);
+  });
+
+  it('shares the rule entry with the window.open guard, which last-rule-wins would otherwise drop', () => {
+    expect(selectors.some(entry => entry.message.includes('openInNewTab()'))).toBe(true);
+  });
+
+  it.each(DEAD)('flags %s', token => {
+    expect(flags(token)).toBe(true);
+  });
+
+  it.each(LIVE)('leaves %s alone', token => {
+    expect(flags(token)).toBe(false);
+  });
+
+  it('reports each dead token exactly once', () => {
+    for (const token of DEAD) {
+      const hits = paletteSelectors.filter(entry =>
+        new RegExp(entry.selector.match(/^Literal\[value=\/(.+)\/\]$/)![1]).test(token)
+      );
+      expect(`${token} matched by ${hits.length} selector(s)`).toBe(`${token} matched by 1 selector(s)`);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Closes #2290

`primary.main` is a Material UI palette token. Joy's palette has no `main` key, so `sx={{ color: 'primary.main' }}` never resolves - the string falls through as a literal CSS value, the browser rejects it, and the declaration is dropped. Each one is a design intention that never shipped: a drag target that never highlights, an icon that never takes the brand colour, a slider thumb that stays default. They read as working code in review, which is how they accumulate.

The issue listed 21 sites. Sweeping for the full Material shade shape (`main` / `light` / `dark` / `contrastText` on any palette family) found **52 occurrences across 21 files** - also `success.main`, `warning.main`, `danger.main`, `primary.dark`, `neutral.main`, `neutral.light`, `success.contrastText` and `info.main`. A further 10 sites referenced Material-only *families* that Joy does not have at all (`error.*`, `info.*`, `secondary.*`, `action.hover`). All are translated or removed here.

The durable half is two complementary build guards, so the next one fails CI instead of shipping inert.

Two findings worth a reviewer's attention:

- **The lint regex suggested in the issue would have been a trap.** `/\.(main|light|dark|contrastText)$/` also matches `border.light` and `inbox.border.light`, which this theme genuinely defines and which have roughly 20 live call sites. The guard anchors on the palette *family* name instead, so those stay untouched.
- **Everything here renders for the first time.** Nothing in this PR changes a colour that was already visible; it turns on colours that were being dropped. Every regression found while doing this was light-mode-only, so please review in light mode.

## Changes

- Replaced 52 dead Material shade tokens with Joy equivalents across 38 client components.
- Replaced 10 Material-only family references (`error.500`, `info.300/50/600`, `secondary.400/500/700`, four `action.hover`) with `danger.*` / `primary.*` / `neutral.*`.
- Fixed 18 further palette strings that no regex can catch - shades that do not exist (`primary.25`, `warning.550`) and Joy keys removed by a version bump (`neutral.outlinedHoverBorder`) - surfaced by the new theme-resolution test.
- **New eslint rule** (`noDeadPaletteTokens` in `eslint.config.mjs`): fails the build on any palette family carrying a Material shade key, on any Material-only family, and on `background.paper` / `text.disabled`. Spread into the existing `apps/client/app/**` entry rather than added as a new block - flat config is last-rule-wins per rule id, so a separate block would have silently deleted the existing `window.open` guard.
- **New `apps/client/app/utils/themes/palette.test.ts`**: scans every `.ts`/`.tsx` under `apps/client/app` and resolves each palette string against `extendTheme(getThemeConfig())` in both colour schemes. This catches what a regex cannot - a shade that does not exist, or a Joy key a version bump removed. The `common` family is excluded because this app's i18n keys are shaped identically (`t('common.close')`).
- **New `packages/scripts/src/checkDeadPaletteTokenGuard.test.ts`**: runs the real eslint config through `Linter` over fixtures, pinning that the selectors work as esquery rather than merely as regexes, that `border.light` stays unflagged, that the rule reaches test files, and that the `window.open` guard still shares the entry.

Both guards were verified to fail when their guard is broken, not merely to pass.

Mapping used:

| role | token |
|---|---|
| text / icon / accent border | `<family>.plainColor` |
| solid fill | `<family>.solidBg` |
| hover fill | `<family>.solidHoverBg`, or `softHoverBg` off a neutral surface |
| resting neutral stroke | `neutral.outlinedBorder` |
| `error.*` | `danger.*` (Joy has no `error` family) |
| `info.*` / `secondary.*` | `primary.*` / `neutral.*` |
| `action.hover` | `neutral.softBg` |

`plainColor` is used for every foreground rather than the variant-matched `softColor`. This theme copies its dark `warning.softColor` (`#FFA500`) into light, so `softColor` on `softBg` lands at 1.65:1 there. `plainColor` is the one foreground group still at Joy's defaults and clears AA in both schemes for every family.

Four sites were **removed rather than translated**, because enabling them would have been a regression, not a fix:

- `Session/SidenavItem.tsx` - `success.main` + `success.contrastText` on the full-height, 50%-rounded wrapper around the row menu button would paint a green blob over the right edge of every sidenav row, permanently, not only while processing. Its now-pointless `borderRadius: '50%'` went with it.
- `b4m/ComingSoon.tsx` - `backgroundColor: 'primary'` (a family, so also inert) plus a `primary.dark` hover only restated what a Joy solid Button already paints.
- `Session/ImageMasker{Flux,OpenAi}.tsx` - two `background.paper` rules behind a `& .MuiOutlinedInput-root` selector, a Material class a Joy Textarea never emits. Doubly inert, so there was nothing to preserve.
- `admin/SubscribersTab.tsx` - a hand-rolled per-mode background on a soft warning Alert that already paints `warning.softBg` per scheme.

## Guide for Testers

Use the PR preview URL (`pr<N>.preview.bike4mind.com`) once a maintainer deploys one, or `app.staging.bike4mind.com`.

**Do the whole pass in LIGHT mode.** Every regression found while writing this was light-mode-only; a dark-mode pass will miss them.

Every navigation path below has now been traced in code. An earlier revision of this guide inferred several of them from component directory names and got them wrong: there is no "Settings -> API Keys" (API Keys is a top-level `/profile` tab), no `/knowledge` route (the artifact viewer is a panel inside a session), and no notebooks list route. If a path here still does not match the deploy, treat that as a bug in this guide, not in the build.

1. Sign in. At the **bottom of the left sidenav**, click the account card to open the account menu, find the **Theme** row, and click the **sun (Light)** icon. Expected: the app switches to the light colour scheme. (If the Theme row is absent, this deploy has `branding.modeToggleEnabled` off; use your OS light/dark setting instead.)
2. Open the left sidenav and look at the list of chat sessions. Expected: each row looks exactly as it does on `main` - in particular there is **no green circle or green blob** on the right-hand edge of any row, whether idle or processing. This is the highest-value regression check in the PR.
3. Hover each sidenav row. Expected: the hover highlight is unchanged from `main`.
4. Open a session and send a message that returns an image, or open any existing session containing a generated image. Expected: the image renders normally. If an image fails, the error box shows a red-bordered panel on a soft red background with readable red text.
5. In a session, click the AI settings / Advanced AI control to open the **Advanced AI** modal. Expected: the modal opens.
6. In that modal, find the Temperature slider (or any slider) on a model that allows editing. Expected: the filled track and the round thumb are **brand blue**, not the default grey. Drag the thumb. Expected: it moves and the value updates.
7. Still in Advanced AI, pick a model with a fixed temperature so the slider goes read-only. Expected: the track turns grey and the thumb disappears entirely - no draggable-looking handle on an inert control.
8. Hover the numeric input boxes and the Reset button in the same modal. Expected: on hover the background tints light blue and the border turns brand blue. Nothing should flash an unstyled or black border.
9. Still in Advanced AI, find the **Stream** checkbox and tick it. Expected: the checkmark is green.
10. Open the sidenav account menu -> **API Keys** (this lands on `/profile?tab=api-keys`; API Keys is a top-level tab, not a Settings sub-tab). Hover the small copy/edit icon buttons next to a key. Expected: the button background tints and the border stays a light grey - it must not vanish or turn black on hover.
11. From `/profile`, open the **Settings** tab, then its **General** sub-tab, and hover the equivalent small icon buttons there. Expected: same as step 10.
12. Open a project, go to its **Files** area, and drag a file from your desktop over the file list without dropping it. Expected: a translucent light overlay covers the list and the words "Drop files here" appear in **brand blue** and stay readable against the overlay. Drop the file. Expected: the overlay clears and the upload starts.
13. Open the Knowledge / Add Knowledge modal and drag a file over its drop zone without dropping. Expected: the dashed/solid border turns brand blue and the zone background tints light grey. Move the file away. Expected: the border returns to the default divider grey.
14. Go to `/profile` -> **Settings** tab -> **General** sub-tab and click the **Import** button to open the notebook import modal, then click the dashed drop area to pick a `.ipynb` file. Expected: **before** selecting, the dashed border is grey; **after** selecting, the dashed border turns green and the filename is shown. Hover the area. Expected: the border turns brand blue and the background lightens.
15. Open the Upload / Import History modal and drag a file over its drop zone. Expected: the dashed border turns brand blue and the background tints light grey; on release it returns to the surface colour.
16. Go to `/profile` and stay on the default **Profile** tab. Expected: the "Email Address" card at the top shows a large **brand blue** envelope icon. No flow needed - the card always renders. (The other two `primary.main` sites fixed in this area live in `EmailVerificationModal.tsx`, which has **no importers anywhere in the app** - it is dead code and cannot be reached in a browser. The tokens there were still corrected so the new guards pass repo-wide, but there is nothing to look at.)
17. Go to `/profile` -> **Settings** tab -> **Custom Instructions** sub-tab (this is what the old "System Prompts" tab was renamed to; `?tab=system-prompts` still redirects here) and add a file to a prompt. Expected: while a file is being added, its filename is shown in **brand blue** and slightly bolder; other filenames stay the default text colour.
18. Sign in as an admin, go to `/admin` -> **Settings** tab -> the **AI** category. Expected: the "Operations Model" card shows a **brand blue** robot icon to the left of the heading.
19. Still at `/admin`, open the **Subscribers** tab. If a warning banner appears at the top, expected: it is a soft yellow Joy alert that looks correct in **both** light and dark mode (toggle the theme once here to confirm). It previously had a hand-rolled per-mode background that has been deleted.
20. Open a session, attach a Google Doc via the Google Drive control, and sign in to Google. Expected: **before** signing in, the button has a transparent background and grey text with a grey Google icon on hover; **after** signing in, the button has a dark neutral fill, a green border, and green "Sign Out" text with a green Google icon.
21. In a session, get an assistant reply that contains a notebook and click its **Execute** button (the execution buttons render inline on the reply, not on a notebooks page - there is no notebooks list route). Expected: while running, a blue "Executing notebook..." line on a soft blue panel; on success a green "Notebook executed successfully" line on a soft green panel; on failure a red line on a soft red panel. Each line's text must be clearly readable against its panel.
22. Open a session containing a React or Python artifact and open it in the artifact viewer. The viewer is the **Knowledge side panel inside a session** (`KnowledgeViewer`, rendered by `SessionContainer`) - there is no `/knowledge` route. Make an edit without saving. Expected: an "Unsaved changes" line appears. **Check its colour carefully** - it is now a dark yellow-brown (`#9A5B13`), not the app's usual orange. It must be readable; whether the brown reads as on-brand is the open design question in this PR.
23. In the same artifact viewer, switch to an older version. Expected: an italic "Viewing version N" line in **brand blue**.
24. In the same artifact viewer, enter edit mode. Expected: a bold "Edit mode active" line in **red**.
25. Open the Quests page (`/quests`). Expected: the warning icon renders in the same dark yellow-brown as step 22 - readable, but noticeably browner than the app's orange.
26. Open an agent's edit form (Agents -> select an agent -> Main Information) and hover the small camera / avatar-upload button on the avatar. Expected: on hover the button background tints light blue. It must not turn dark navy.
27. If the Research Engine feature flag (`enableResearchEngine`) is on for your account, open the **Files browser** -> **Research Engine**, pick or create a research agent, then start a new research task. Expected: the form's "Step 4: Schedule Execution" heading and its small leading dot are **grey**, where steps 1-3 use coloured families. Confirm grey reads as intentional and not as disabled.
28. In the same research task form, hover an unselected option card in steps 1-3. Expected: the card background tints a very light blue and lifts slightly. It must not go white or transparent.
29. Open a completed research task's detail view. Expected: the prompt card's leading avatar disc shows a **brand blue** document icon, and hovering the card turns its border brand blue.
30. In any session, trigger a tool confirmation and let it expire (or find an expired one in history). Expected: the "This confirmation has expired" line is dark yellow-brown text on a soft yellow panel and is clearly readable.

### Regression Checks

- **No sidenav green blob** (step 2). This is the one place where a naive translation would have introduced a permanent visual bug.
- Every drag-and-drop target in the app still accepts a drop and still uploads: Project Files (step 12), Add Knowledge (step 13), Notebook Import (step 14), Upload Import History (step 15).
- Every small icon button that got `neutral.outlinedBorder` still has a visible border on hover and does not collapse (steps 10, 11).
- The "Coming Soon" panel (wherever it appears) still renders as a normal solid Joy button/panel with a working hover, despite two rules being deleted from it.
- The image-edit / masking dialogs (Flux and OpenAI variants) still open, the prompt textarea still accepts typing, and neither the dialog nor the textarea has a transparent or wrong-coloured background.
- Toggle the theme to **dark** once at the end and spot-check steps 2, 12, 20, 21 and 22. Expected: no text becomes unreadable against its panel in either scheme.

### What NOT to test

- No behaviour, data, API, routing or state changes. Nothing here alters what a control does, only what colour it paints.
- No new components, props or user-facing copy. Any text you see is pre-existing.
- The eslint rule and the two guard test files are build-time only and have no runtime effect.

## Additional Information

**Deliberately out of scope:**

- **No theme changes.** Two root causes live in `themePrimitives.ts` and deserve a follow-up: light `warning.softColor` is set to the dark value (`#FFA500`), and `success.outlinedBorder` is overridden in dark only. Both are worked around at the call site here; fixing them properly changes pre-existing consumers and belongs in its own PR.
- **`warning.plainColor` is Joy's `yellow.500` = `#9A5B13`, a brown.** This theme's warning identity is `#FFA500`, which fails contrast on a light background, so the accessible choice drifts off-brand. It affects the quests warning icon and the four artifact-viewer status badges (steps 22, 25, 30). If the brown reads wrong, the fix is a `warning.plainColor` override in `themePrimitives.ts` - deliberately not done here, since it is a theme-wide change touching pre-existing `color="warning"` consumers.
- **The guard is scoped to `apps/client/app/**`**, the only Joy UI in this repo. Any other package adopting Joy needs the glob widened.
- **JSX props are out of reach of both guards.** `<GoogleIcon color="secondary">` was the one instance found and is fixed (step 20), but a Material `color` prop on an icon is the same bug class and no selector here catches it.
- `Session/ResizableSplitter.tsx` still uses `primary.500` from the earlier fix in #2281. Left alone - `plainColor` would be more consistent, but it works and it is not this issue's file.

**Verification run locally from a clean tree:**

- `pnpm turbo:typecheck` - 40/40 successful
- `pnpm lint:check` - clean repo-wide, so the new rule fires on nothing left in the tree
- `pnpm --filter @bike4mind/client test` - 1079 files / 11583 tests passed, 10 files / 81 tests skipped
- `pnpm --filter @bike4mind/scripts exec vitest run src/checkDeadPaletteTokenGuard.test.ts` - 45/45 passed

The full `@bike4mind/scripts` suite shows 10 failures locally, all `mongodb-memory-server` migration integration tests timing out at 30s under whole-suite contention; each passes in isolation and none is reachable from this diff, which touches no DB code. Relying on CI for that package.

## Developer Notes

- **`apps/client/app/utils/themes/palette.test.ts` is a reusable pattern:** it resolves every palette string in the source tree against the actually-built theme in both colour schemes. Any future palette key that stops existing - a Joy version bump, a theme refactor, a typo'd shade - now fails a test instead of silently dropping a declaration in the browser. It is the only guard that can catch a *valid-shaped* key that is not *present*.
- **Two guards, deliberately complementary.** The eslint rule catches token *shapes* statically and gives the fast in-editor signal; the theme-resolution test catches *existence* and needs the built theme. Neither subsumes the other, and the mapping table above documents which replacement to reach for when the rule fires.
- **Flat-config gotcha, now pinned by a test:** eslint flat config is last-rule-wins per rule id, so adding a second block with the same rule id silently deletes the earlier one's options. `packages/scripts/src/checkDeadPaletteTokenGuard.test.ts` asserts that both the new palette selectors and the pre-existing `window.open` guard survive in the same entry - worth copying for any future addition to `no-restricted-syntax`.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

