### PR TITLE
perf(data-lakes): memoize the per-turn grant, membership and enforce-flag reads

### DIFF
--- a/b4m-core/services/src/dataLakeService/getDataLakePrompts.test.ts
+++ b/b4m-core/services/src/dataLakeService/getDataLakePrompts.test.ts
@@ -1,19 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DATA_LAKES, type DataLakeConfig, type IDataLakeDocument } from '@bike4mind/common';
 import { getAccessibleDataLakePrompts, datalakeTagsFrom } from './getDataLakePrompts';
-import { grantedLakeReachFor } from './resolveLakeReadAccess';
+import { grantedLakeReachForTurn } from './resolveLakeReadAccess';
 import type { DataLakeAccessContext } from './getDynamicDataLakeTags';
 
 /**
  * A spy that KEEPS the real implementation - every other test in this file depends on the helper
- * actually reading the grant rows. It exists so one test can assert the literal arguments this
- * call site passes, which is the only way the `includeReaders = false` + no-org-ids floor is
- * pinned: threading `organizationIds` alone changes no observable behaviour (`grantedLakeReachFor`
- * reads them only under `includeReaders`), so no outcome assertion can catch that pre-wiring.
+ * actually reading the grant rows, and on its per-turn memo actually collapsing the repeat. It
+ * exists so one test can assert the literal arguments this call site passes, which is the only way
+ * the `includeReaders = false` + no-org-ids floor is pinned: threading `organizationIds` alone
+ * changes no observable behaviour (the reach helper reads them only under `includeReaders`), so no
+ * outcome assertion can catch that pre-wiring.
+ *
+ * Spied on the MEMOIZING wrapper because that is what the call site calls - the wrapper reaches
+ * `grantedLakeReachFor` through the module's own binding, which a spy on that export cannot see.
  */
 vi.mock('./resolveLakeReadAccess', async importOriginal => {
   const actual = await importOriginal<typeof import('./resolveLakeReadAccess')>();
-  return { ...actual, grantedLakeReachFor: vi.fn(actual.grantedLakeReachFor) };
+  return { ...actual, grantedLakeReachForTurn: vi.fn(actual.grantedLakeReachForTurn) };
 });
 
 const OWNER = 'user-owner';
@@ -328,6 +332,10 @@ describe('getAccessibleDataLakePrompts', () => {
         principalGrants: { [`organization:${ORG}`]: [{ dataLakeId: 'shared', role: 'curator' }] },
       });
       expect(await getAccessibleDataLakePrompts(ctx)).toEqual([]);
+      // The positive assertion keeps the negative one honest: with a per-turn memo above the reach
+      // helper, a cache hit would satisfy `not.toHaveBeenCalledWith('organization', ...)` without
+      // the org arm being guarded at all, and the guard would stop guarding without ever failing.
+      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledWith('user', CURATOR, expect.anything());
       expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).not.toHaveBeenCalledWith(
         'organization',
         expect.anything(),
@@ -352,8 +360,55 @@ describe('getAccessibleDataLakePrompts', () => {
      * state the comment at the call site says it prevents. This is the assertion that catches it.
      */
     it('resolves the grant arm with no org ids and readers off (the permanent injection floor)', async () => {
+      const ctx = asCurator('curator');
+      await getAccessibleDataLakePrompts(ctx);
+      // Asserted on the memoizing wrapper, which is what this site calls: the memo keys on these
+      // two arguments precisely so injection and retrieval cannot collide in it, so the floor and
+      // the key are the same assertion.
+      expect(grantedLakeReachForTurn).toHaveBeenCalledWith(ctx, CURATOR, [], expect.anything(), false);
+    });
+
+    /**
+     * The read runs per TOOL CALL, so a grounded turn issued it 2..N times over with byte-identical
+     * arguments (#2589). Both calls here share ONE context object, which is what a turn does: the
+     * `ToolContext` is built once per request and closed over by every tool, so `search` and
+     * `retrieve` hand this resolver the same instance.
+     */
+    it('issues one grant read for two injections in the same turn', async () => {
+      const ctx = asCurator('curator');
+
+      const first = await getAccessibleDataLakePrompts(ctx);
+      const second = await getAccessibleDataLakePrompts(ctx);
+
+      expect(second).toEqual(first);
+      expect(second).toEqual([{ id: 'shared', name: 'Shared Lake', systemPrompt: 'Cite the control number.' }]);
+      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledTimes(1);
+      // The membership read rides the same per-turn memo, for the same reason.
+      expect(ctx.db.organizations.findMembershipOrgIds).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT share the memo between two turns', async () => {
+      // Two contexts are two requests. A hit across them would keep honoring a grant revoked a
+      // request ago - the process-lifetime cache the memo's WeakMap scope exists to avoid being.
       await getAccessibleDataLakePrompts(asCurator('curator'));
-      expect(grantedLakeReachFor).toHaveBeenCalledWith(CURATOR, [], expect.anything(), false);
+      const second = asCurator('curator');
+      await getAccessibleDataLakePrompts(second);
+      expect(second.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-reads after a failed grant read rather than reusing the empty arm', async () => {
+      // A cached rejection would read as "this curator holds no grants" for the rest of the turn -
+      // the same confusion the fail-closed warn exists to end, made sticky.
+      const ctx = asCurator('curator');
+      (ctx.db.dataLakeAccessGrants?.listByPrincipal as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('grants down')
+      );
+
+      expect(await getAccessibleDataLakePrompts(ctx)).toEqual([]);
+      expect(await getAccessibleDataLakePrompts(ctx)).toEqual([
+        { id: 'shared', name: 'Shared Lake', systemPrompt: 'Cite the control number.' },
+      ]);
+      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledTimes(2);
     });
 
     it('drops a granted lake whose datalakeTag is malformed, as retrieval does', async () => {

--- a/b4m-core/services/src/dataLakeService/getDataLakePrompts.ts
+++ b/b4m-core/services/src/dataLakeService/getDataLakePrompts.ts
@@ -3,8 +3,16 @@ import type { DataLakeConfig, IDataLakeDocument } from '@bike4mind/common';
 import { normalizeId } from '@bike4mind/utils/normalizeId';
 import type { DataLakeAccessContext } from './getDynamicDataLakeTags';
 import { filterStillManagedLakes, type ManageRecheckAdapter } from './filterStillManagedLakes';
-import { grantedLakeReachFor } from './resolveLakeReadAccess';
+import { grantedLakeReachForTurn } from './resolveLakeReadAccess';
+import { createScopedAsyncMemo } from './scopedAsyncMemo';
 import { isDatalakeTagWellFormed } from './createDataLake';
+
+/**
+ * Per-turn memo for the membership read below. Keyed on the caller, its only argument, and scoped
+ * to the shared context object so it lives exactly as long as the turn - the same reason and the
+ * same lifetime as the grant read three lines under it (see createScopedAsyncMemo).
+ */
+const membershipOrgIdsByTurn = createScopedAsyncMemo<string[]>();
 
 /**
  * The distinct `datalake:*` provenance tags among a bag of file tag names - i.e. which lakes a set
@@ -186,18 +194,28 @@ export async function getAccessibleDataLakePrompts(
   // may still catch this throw and degrade to an empty scope, which is ALSO fail-closed (it
   // denies, never grants). The placement buys observability into where a failure originated, not
   // a stronger deny guarantee than returning [] outright would have given.
-  const organizationIds = userId ? await context.db.organizations.findMembershipOrgIds(userId) : [];
+  //
+  // Memoized per turn, because this resolver runs per TOOL CALL. That contract is per ATTEMPT, not
+  // per turn: the memo evicts a rejection, so the next tool call re-reads and throws again rather
+  // than inheriting a cached "member of nothing". A membership CHANGE mid-turn is not picked up -
+  // the same per-turn snapshot the grant read below takes, and bounded the same way.
+  const organizationIds = userId
+    ? await membershipOrgIdsByTurn(context, userId, () => context.db.organizations.findMembershipOrgIds(userId))
+    : [];
 
   // The lake ids the caller reaches by an owner/curator grant (see GRANT ARM in the doc comment).
   // Resolved BEFORE the lake read for the same reason as in getDynamicDataLakeAccess: a grant-held
   // lake matches none of that query's tag/org/public arms, so its ids have to go IN as the query's
   // grant arm rather than be filtered out of the result.
   //
-  // Uses the same helper as the retrieval resolver, so the two sides resolve a grant row the same
-  // way - a lake retrieval grounds on but injection distrusts is exactly the gap #2495 closes.
-  // Sharing the helper is not by itself a lockstep guarantee: the two call sites already pass
-  // different arguments, and today's agreement rests on both pinning `includeReaders = false`.
-  // That agreement is MEANT to be broken by the cutover, in the deny direction only - see below.
+  // Uses the same helper as the retrieval resolver - through `grantedLakeReachForTurn`, whose only
+  // addition is the per-turn memo this site needs because it runs per TOOL CALL - so the two sides
+  // resolve a grant row the same way: a lake retrieval grounds on but injection distrusts is
+  // exactly the gap #2495 closes. Sharing the helper is not by itself a lockstep guarantee: the two
+  // call sites already pass different arguments, and today's agreement rests on both pinning
+  // `includeReaders = false`. That agreement is MEANT to be broken by the cutover, in the deny
+  // direction only - see below. The memo keys on those arguments for that reason, so the two sites
+  // cannot collide in it either.
   //
   // But `includeReaders: false` here is a PERMANENT security floor, NOT the cutover default it is
   // at the other call sites. That cutover has HAPPENED: `getDynamicDataLakeAccess` and browse have
@@ -223,7 +241,13 @@ export async function getAccessibleDataLakePrompts(
       // Only the USER-principal reach is consumed. `orgGrantedLakes` is empty by construction
       // here (no membership org ids, `includeReaders` false) and is deliberately not forwarded to
       // the query, so the org-principal arm cannot activate on this path even if that changes.
-      const reach = await grantedLakeReachFor(userId, [], context.db.dataLakeAccessGrants, INCLUDE_READER_GRANTS);
+      const reach = await grantedLakeReachForTurn(
+        context,
+        userId,
+        [],
+        context.db.dataLakeAccessGrants,
+        INCLUDE_READER_GRANTS
+      );
       for (const id of reach.grantedLakeIds) grantedLakeIds.add(id);
     } catch (err) {
       // Fail closed, loudly: the arm contributes nothing, which denies a legitimate curator their

--- a/b4m-core/services/src/dataLakeService/getDataLakePrompts.ts
+++ b/b4m-core/services/src/dataLakeService/getDataLakePrompts.ts
@@ -4,15 +4,8 @@ import { normalizeId } from '@bike4mind/utils/normalizeId';
 import type { DataLakeAccessContext } from './getDynamicDataLakeTags';
 import { filterStillManagedLakes, type ManageRecheckAdapter } from './filterStillManagedLakes';
 import { grantedLakeReachForTurn } from './resolveLakeReadAccess';
-import { createScopedAsyncMemo } from './scopedAsyncMemo';
+import { membershipOrgIdsForTurn } from './membershipOrgIdsForTurn';
 import { isDatalakeTagWellFormed } from './createDataLake';
-
-/**
- * Per-turn memo for the membership read below. Keyed on the caller, its only argument, and scoped
- * to the shared context object so it lives exactly as long as the turn - the same reason and the
- * same lifetime as the grant read three lines under it (see createScopedAsyncMemo).
- */
-const membershipOrgIdsByTurn = createScopedAsyncMemo<string[]>();
 
 /**
  * The distinct `datalake:*` provenance tags among a bag of file tag names - i.e. which lakes a set
@@ -186,7 +179,8 @@ export async function getAccessibleDataLakePrompts(
     );
   }
   // Same membership resolution as getDynamicDataLakeAccess - resolved from `db.organizations`,
-  // never from a selected-org pointer (#1674).
+  // never from a selected-org pointer (#1674) - and now through the same per-turn memo, so the two
+  // resolvers share ONE read per turn rather than one each per tool call.
   //
   // Resolved outside the try/catch below on purpose: within THIS resolver, a transient failure
   // here propagates rather than being silently folded into "no prompts" by the fail-safe catch
@@ -195,13 +189,10 @@ export async function getAccessibleDataLakePrompts(
   // denies, never grants). The placement buys observability into where a failure originated, not
   // a stronger deny guarantee than returning [] outright would have given.
   //
-  // Memoized per turn, because this resolver runs per TOOL CALL. That contract is per ATTEMPT, not
-  // per turn: the memo evicts a rejection, so the next tool call re-reads and throws again rather
-  // than inheriting a cached "member of nothing". A membership CHANGE mid-turn is not picked up -
-  // the same per-turn snapshot the grant read below takes, and bounded the same way.
-  const organizationIds = userId
-    ? await membershipOrgIdsByTurn(context, userId, () => context.db.organizations.findMembershipOrgIds(userId))
-    : [];
+  // That contract is per ATTEMPT, not per turn - the memo evicts a rejection, so the next tool call
+  // re-reads and throws again rather than inheriting a cached "member of nothing". See
+  // membershipOrgIdsForTurn for what the per-turn snapshot does and does not cover.
+  const organizationIds = userId ? await membershipOrgIdsForTurn(context, userId, context.db.organizations) : [];
 
   // The lake ids the caller reaches by an owner/curator grant (see GRANT ARM in the doc comment).
   // Resolved BEFORE the lake read for the same reason as in getDynamicDataLakeAccess: a grant-held

--- a/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.test.ts
+++ b/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.test.ts
@@ -660,4 +660,56 @@ describe('getDynamicDataLakeAccess - the persisted access-grant rung', () => {
     expect(listByPrincipal).not.toHaveBeenCalled();
     expect(res.dataLakeTags).toEqual([]);
   });
+
+  /**
+   * This resolver runs per TOOL CALL - three tool-layer entry points forward the same `ToolContext`
+   * (resolveSessionLakeAccess, resolveAttachmentLakeAccess, knowledgeBaseRetrieve) - so a turn using
+   * two knowledge tools re-issued all three of its reads. Both calls here share ONE context object,
+   * which is what those entry points do.
+   */
+  describe('per-turn read collapse', () => {
+    it('issues one grant, membership and flag read for two resolutions in the same turn', async () => {
+      const ctx = grantCtx([theirGatedLake], [grantRow('theirs', 'owner')], { enforce: true });
+
+      const first = await getDynamicDataLakeAccess(ctx);
+      const second = await getDynamicDataLakeAccess(ctx);
+
+      expect(second.dataLakeTags).toEqual(first.dataLakeTags);
+      expect(second.dataLakeTags).toEqual(['datalake:theirs']);
+      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledTimes(1);
+      expect(ctx.db.organizations.findMembershipOrgIds).toHaveBeenCalledTimes(1);
+      expect(ctx.db.adminSettings?.getSettingsValue).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT share any of the three between two turns', async () => {
+      // Two contexts are two requests. A hit across them would keep honoring a grant, a membership
+      // or an enforcement setting that changed a request ago.
+      await getDynamicDataLakeAccess(grantCtx([theirGatedLake], [grantRow('theirs', 'owner')], { enforce: true }));
+      const second = grantCtx([theirGatedLake], [grantRow('theirs', 'owner')], { enforce: true });
+      await getDynamicDataLakeAccess(second);
+
+      expect(second.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledTimes(1);
+      expect(second.db.organizations.findMembershipOrgIds).toHaveBeenCalledTimes(1);
+      expect(second.db.adminSettings?.getSettingsValue).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-reads the grants after a failure instead of reporting the view complete', async () => {
+      // The fail-closed contract this resolver already had: a failed grant read narrows the view AND
+      // says so via lakeViewComplete. A cached rejection would leave the second call narrowed while
+      // silently reporting complete.
+      const ctx = grantCtx([theirGatedLake], [grantRow('theirs', 'owner')], { enforce: true });
+      (ctx.db.dataLakeAccessGrants?.listByPrincipal as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('grants down')
+      );
+
+      const failed = await getDynamicDataLakeAccess(ctx);
+      expect(failed.dataLakeTags).toEqual([]);
+      expect(failed.lakeViewComplete).toBe(false);
+
+      const recovered = await getDynamicDataLakeAccess(ctx);
+      expect(recovered.dataLakeTags).toEqual(['datalake:theirs']);
+      expect(recovered.lakeViewComplete).toBe(true);
+      expect(ctx.db.dataLakeAccessGrants?.listByPrincipal).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
+++ b/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
@@ -13,7 +13,8 @@ import {
 import type { Logger } from '@bike4mind/observability';
 import { isDatalakeTagWellFormed } from './createDataLake';
 import { lakeMembershipScope, registryMembershipScope } from './lakeMembershipScope';
-import { grantedLakeReachFor, resolveEnforceReadGrants, type LakeGrantReach } from './resolveLakeReadAccess';
+import { grantedLakeReachForTurn, resolveEnforceReadGrants, type LakeGrantReach } from './resolveLakeReadAccess';
+import { membershipOrgIdsForTurn } from './membershipOrgIdsForTurn';
 
 /**
  * The minimal context the data-lake access resolver needs. The knowledge tools
@@ -269,7 +270,10 @@ export async function getDynamicDataLakeAccess(context: DataLakeAccessContext): 
     // this throw and degrade to an empty scope, which is ALSO fail-closed (it denies, never
     // grants). So the placement buys observability into where a failure originated, not a
     // stronger deny guarantee than returning [] outright would have given.
-    const organizationIds = userId ? await context.db.organizations.findMembershipOrgIds(userId) : [];
+    // Memoized per turn (this resolver runs per TOOL CALL), sharing one entry with the injection
+    // resolver - see membershipOrgIdsForTurn. The propagate-not-swallow placement above still holds:
+    // the memo evicts a rejection rather than caching it as "member of nothing".
+    const organizationIds = userId ? await membershipOrgIdsForTurn(context, userId, context.db.organizations) : [];
     // The grant rung, resolved on the SAME terms as browse (`grantedLakeReachFor`) so the two halves
     // of the access model cannot drift: owner/curator always, reader + org principals only under
     // the enforced cutover. Failing closed to no grants rather than propagating - a grant lookup
@@ -277,8 +281,14 @@ export async function getDynamicDataLakeAccess(context: DataLakeAccessContext): 
     let reach: LakeGrantReach = { grantedLakeIds: [], orgGrantedLakes: {} };
     if (userId && context.db.dataLakeAccessGrants) {
       try {
-        const includeReaders = await resolveEnforceReadGrants(context.db.adminSettings, context.logger);
-        reach = await grantedLakeReachFor(userId, organizationIds, context.db.dataLakeAccessGrants, includeReaders);
+        const includeReaders = await resolveEnforceReadGrants(context.db.adminSettings, context.logger, context);
+        reach = await grantedLakeReachForTurn(
+          context,
+          userId,
+          organizationIds,
+          context.db.dataLakeAccessGrants,
+          includeReaders
+        );
       } catch (err) {
         // Same fail-closed contract as the dataLakes read below: a failed grants read narrows the
         // view (the grant arm contributes nothing) and must SAY so, or a consumer would read the

--- a/b4m-core/services/src/dataLakeService/membershipOrgIdsForTurn.test.ts
+++ b/b4m-core/services/src/dataLakeService/membershipOrgIdsForTurn.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { membershipOrgIdsForTurn } from './membershipOrgIdsForTurn';
+
+describe('membershipOrgIdsForTurn', () => {
+  const repo = (orgIds: string[] = ['orgA']) => ({
+    findMembershipOrgIds: vi.fn(async () => orgIds),
+  });
+  const turn = () => ({});
+
+  it('resolves membership once per turn', async () => {
+    const organizations = repo();
+    const scope = turn();
+
+    expect(await membershipOrgIdsForTurn(scope, 'u1', organizations)).toEqual(['orgA']);
+    expect(await membershipOrgIdsForTurn(scope, 'u1', organizations)).toEqual(['orgA']);
+    expect(organizations.findMembershipOrgIds).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The reason this memo is shared rather than one per resolver. Both lake-access resolvers need
+   * membership and BOTH run per tool call, so a turn that retrieves and then injects used to issue
+   * the read once per resolver per call. Passing the same scope is what makes it one read for the
+   * whole turn - and the two resolvers agreeing on "my orgs" by identity rather than by contract is
+   * the property #1674 is about.
+   */
+  it('serves both lake-access resolvers from ONE entry when they share a turn scope', async () => {
+    const organizations = repo(['orgA', 'orgB']);
+    const scope = turn();
+
+    const retrievalSide = await membershipOrgIdsForTurn(scope, 'u1', organizations);
+    const injectionSide = await membershipOrgIdsForTurn(scope, 'u1', organizations);
+
+    expect(injectionSide).toEqual(retrievalSide);
+    expect(organizations.findMembershipOrgIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT share an entry between two turns', async () => {
+    const organizations = repo();
+    await membershipOrgIdsForTurn(turn(), 'u1', organizations);
+    await membershipOrgIdsForTurn(turn(), 'u1', organizations);
+    expect(organizations.findMembershipOrgIds).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT share an entry between two users', async () => {
+    const organizations = { findMembershipOrgIds: vi.fn(async (userId: string) => [`org-of-${userId}`]) };
+    const scope = turn();
+
+    expect(await membershipOrgIdsForTurn(scope, 'u1', organizations)).toEqual(['org-of-u1']);
+    expect(await membershipOrgIdsForTurn(scope, 'u2', organizations)).toEqual(['org-of-u2']);
+  });
+
+  it('resolves against the CALLING user, not whatever the repo was last asked', async () => {
+    const organizations = repo();
+    await membershipOrgIdsForTurn(turn(), 'u1', organizations);
+    expect(organizations.findMembershipOrgIds).toHaveBeenCalledWith('u1');
+  });
+
+  it('does not cache a rejection: both resolvers keep propagating it', async () => {
+    // Both call sites resolve this OUTSIDE their fail-safe catch on purpose, so a transient failure
+    // surfaces instead of being folded into "member of nothing". A cached rejection would make one
+    // failure permanent for the turn - and both resolvers read that absence as a settled deny.
+    const organizations = {
+      findMembershipOrgIds: vi.fn().mockRejectedValueOnce(new Error('mongo down')).mockResolvedValue(['orgA']),
+    };
+    const scope = turn();
+
+    await expect(membershipOrgIdsForTurn(scope, 'u1', organizations)).rejects.toThrow('mongo down');
+    expect(await membershipOrgIdsForTurn(scope, 'u1', organizations)).toEqual(['orgA']);
+    expect(organizations.findMembershipOrgIds).toHaveBeenCalledTimes(2);
+  });
+});

--- a/b4m-core/services/src/dataLakeService/membershipOrgIdsForTurn.ts
+++ b/b4m-core/services/src/dataLakeService/membershipOrgIdsForTurn.ts
@@ -1,0 +1,32 @@
+import type { IOrganizationRepository } from '@bike4mind/common';
+import { createScopedAsyncMemo } from './scopedAsyncMemo';
+
+/** Backing store for `membershipOrgIdsForTurn`. Keyed on the caller, its only varying argument. */
+const membershipByTurn = createScopedAsyncMemo<string[]>();
+
+/**
+ * The caller's authoritative org membership (owner + `users[]` ACL, #1674), resolved at most ONCE
+ * per turn. Both lake-access resolvers need it and BOTH run per TOOL CALL - `getDynamicDataLakeAccess`
+ * for retrieval and `getAccessibleDataLakePrompts` for injection - so a turn that grounds and then
+ * calls two knowledge tools issued this read once per resolver per call. Sharing one memo (rather
+ * than one per resolver) is what makes it a single read for the whole turn: the two resolvers agree
+ * on what "my orgs" means by contract already, and now by identity.
+ *
+ * `turnScope` must be an object whose lifetime IS the turn - the shared `ToolContext`, built once
+ * per request in `generateTools`. The repo is NOT in the key (an object cannot be), so the scope has
+ * to be the object that owns it; every caller passes `context` and reads the repo off `context.db`.
+ *
+ * THE PROPAGATE-NOT-SWALLOW CONTRACT AT BOTH CALL SITES IS PRESERVED, and it is per ATTEMPT: a
+ * rejection is evicted rather than cached, so the next tool call re-reads and throws again instead
+ * of inheriting a "member of nothing" that both resolvers would read as a settled deny. What IS
+ * per-turn is the successful answer - a membership change mid-turn is not picked up, matching the
+ * grant reach snapshot resolved alongside it (see `grantedLakeReachForTurn`).
+ *
+ * Callers keep their own fail-closed check that the projected reader exists: an unwired host must
+ * still get the legible error naming the missing adapter, not a TypeError from inside a memo.
+ */
+export const membershipOrgIdsForTurn = (
+  turnScope: object,
+  userId: string,
+  organizations: Pick<IOrganizationRepository, 'findMembershipOrgIds'>
+): Promise<string[]> => membershipByTurn(turnScope, userId, () => organizations.findMembershipOrgIds(userId));

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
@@ -4,6 +4,7 @@ import { classifyLakeAccess } from './classifyLakeAccess';
 import {
   containedGrants,
   grantedLakeReachFor,
+  grantedLakeReachForTurn,
   resolveReadGrant,
   resolveLakeReadAccess,
   resolveEnforceReadGrants,
@@ -343,6 +344,128 @@ describe('grantedLakeReachFor - the two reach sets earn different bypasses', () 
 
   it('an unwired grant repo reaches nothing', async () => {
     expect(await grantedLakeReachFor('u1', ['orgA'])).toEqual({ grantedLakeIds: [], orgGrantedLakes: {} });
+  });
+});
+
+/**
+ * The memo exists because the knowledge tools resolve lake access per TOOL CALL, so a grounded turn
+ * repeats this read 2..N times with byte-identical arguments. What is under test here is the KEY:
+ * the retrieval and prompt-injection sites pass deliberately different arguments and are meant to
+ * stay diverged permanently, so an entry they shared would be a silent widening, not a saved read.
+ */
+describe('grantedLakeReachForTurn - one read per turn per distinct argument set', () => {
+  const row = (dataLakeId: string, role: string, principalType = 'user', principalId = 'u1') => ({
+    dataLakeId,
+    role,
+    principalType,
+    principalId,
+  });
+  const repo = () => ({
+    listByPrincipal: vi.fn(async (type: string, id: string) =>
+      type === 'user' ? [row('owned', 'owner')] : [row(`lake-${id}`, 'reader', 'organization', id)]
+    ) as never,
+  });
+  const turn = () => ({});
+
+  it('issues ONE read for two calls in the same turn, and returns the same reach', async () => {
+    const grants = repo();
+    const scope = turn();
+
+    const first = await grantedLakeReachForTurn(scope, 'u1', [], grants, false);
+    const second = await grantedLakeReachForTurn(scope, 'u1', [], grants, false);
+
+    expect(first).toEqual({ grantedLakeIds: ['owned'], orgGrantedLakes: {} });
+    expect(second).toEqual(first);
+    expect(grants.listByPrincipal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT share an entry between two turns', async () => {
+    const grants = repo();
+    await grantedLakeReachForTurn(turn(), 'u1', [], grants, false);
+    await grantedLakeReachForTurn(turn(), 'u1', [], grants, false);
+    expect(grants.listByPrincipal).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT share an entry across differing includeReaders, even in one turn', async () => {
+    // Constraint the whole key exists for: injection pins `includeReaders: false` permanently,
+    // retrieval follows the enforced cutover. A user-keyed memo would hand injection retrieval's
+    // wider set - a reader's read access becoming authority to write another user's system prompt.
+    const grants = repo();
+    const scope = turn();
+
+    const pinned = await grantedLakeReachForTurn(scope, 'u1', [], grants, false);
+    const enforced = await grantedLakeReachForTurn(scope, 'u1', ['orgA'], grants, true);
+
+    expect(pinned.orgGrantedLakes).toEqual({});
+    expect(enforced.orgGrantedLakes).toEqual({ orgA: ['lake-orgA'] });
+  });
+
+  it('does NOT share an entry across differing organizationIds', async () => {
+    const grants = repo();
+    const scope = turn();
+
+    const inA = await grantedLakeReachForTurn(scope, 'u1', ['orgA'], grants, true);
+    const inB = await grantedLakeReachForTurn(scope, 'u1', ['orgB'], grants, true);
+
+    expect(inA.orgGrantedLakes).toEqual({ orgA: ['lake-orgA'] });
+    expect(inB.orgGrantedLakes).toEqual({ orgB: ['lake-orgB'] });
+  });
+
+  it('does NOT share an entry between two users in one turn', async () => {
+    // A turn is one caller today, but the key must not rely on that: the scope object is a request
+    // context, and a host that resolved two principals under one would otherwise cross them.
+    const grants = {
+      listByPrincipal: vi.fn(async (_type: string, id: string) => [row(`lake-${id}`, 'owner')]) as never,
+    };
+    const scope = turn();
+
+    expect((await grantedLakeReachForTurn(scope, 'u1', [], grants, false)).grantedLakeIds).toEqual(['lake-u1']);
+    expect((await grantedLakeReachForTurn(scope, 'u2', [], grants, false)).grantedLakeIds).toEqual(['lake-u2']);
+  });
+
+  it('collapses the same org set given in a different order', async () => {
+    // The ids are sorted into the key, so caller-side ordering cannot split one entry in two - the
+    // membership set is a set, and its resolver makes no ordering promise.
+    const grants = repo();
+    const scope = turn();
+
+    await grantedLakeReachForTurn(scope, 'u1', ['orgA', 'orgB'], grants, true);
+    await grantedLakeReachForTurn(scope, 'u1', ['orgB', 'orgA'], grants, true);
+
+    // One user read plus one per membership org - the second call added none of them.
+    expect(grants.listByPrincipal).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not mutate the caller organizationIds while keying them', async () => {
+    const grants = repo();
+    const organizationIds = ['orgB', 'orgA'];
+    await grantedLakeReachForTurn(turn(), 'u1', organizationIds, grants, true);
+    expect(organizationIds).toEqual(['orgB', 'orgA']);
+  });
+
+  it('does not cache a rejected read: the next call re-reads rather than reporting no grants', async () => {
+    // Otherwise one transient failure reads as "this user holds no grants" for the rest of the
+    // turn, which every consumer takes as a settled deny.
+    const grants = {
+      listByPrincipal: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('grants down'))
+        .mockResolvedValue([row('owned', 'owner')]) as never,
+    };
+    const scope = turn();
+
+    await expect(grantedLakeReachForTurn(scope, 'u1', [], grants, false)).rejects.toThrow('grants down');
+    expect(await grantedLakeReachForTurn(scope, 'u1', [], grants, false)).toEqual({
+      grantedLakeIds: ['owned'],
+      orgGrantedLakes: {},
+    });
+  });
+
+  it('an unwired grant repo still reaches nothing', async () => {
+    expect(await grantedLakeReachForTurn(turn(), 'u1', ['orgA'])).toEqual({
+      grantedLakeIds: [],
+      orgGrantedLakes: {},
+    });
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.test.ts
@@ -467,6 +467,80 @@ describe('grantedLakeReachForTurn - one read per turn per distinct argument set'
       orgGrantedLakes: {},
     });
   });
+
+  it('lets the two sites share an entry when their arguments coincide', async () => {
+    // Enforcement off and a caller in no org: retrieval and injection both pass `(false, [])`, so
+    // one read serves both. Correct, not a widening - the floor is the arguments each site passes.
+    const grants = repo();
+    const scope = turn();
+
+    const retrieval = await grantedLakeReachForTurn(scope, 'u1', [], grants, false);
+    const injection = await grantedLakeReachForTurn(scope, 'u1', [], grants, false);
+
+    expect(injection).toEqual(retrieval);
+    expect(grants.listByPrincipal).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('resolveEnforceReadGrants - the flag read collapses per turn only when scoped', () => {
+  // No default for `value`: `settingsRepo(undefined)` must actually serve `undefined` (the
+  // no-row case), which a parameter default would swallow into the default instead.
+  const settingsRepo = (value: unknown) => ({
+    getSettingsValue: vi.fn(async () => value) as never,
+  });
+  const turn = () => ({});
+
+  it('reads the flag once per turn when given a scope', async () => {
+    // AdminSettingsModel caches nothing, so an unscoped resolver running per tool call re-queries
+    // Mongo for this flag every time.
+    const settings = settingsRepo(true);
+    const scope = turn();
+
+    expect(await resolveEnforceReadGrants(settings, undefined, scope)).toBe(true);
+    expect(await resolveEnforceReadGrants(settings, undefined, scope)).toBe(true);
+    expect(settings.getSettingsValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reads per call with no scope, so the once-per-request callers are unchanged', async () => {
+    const settings = settingsRepo(true);
+    await resolveEnforceReadGrants(settings);
+    await resolveEnforceReadGrants(settings);
+    expect(settings.getSettingsValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT share the flag between two turns', async () => {
+    const settings = settingsRepo(true);
+    await resolveEnforceReadGrants(settings, undefined, turn());
+    await resolveEnforceReadGrants(settings, undefined, turn());
+    expect(settings.getSettingsValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache the report-only answer a failed flag read produces', async () => {
+    // The memo wraps the RAW read, so the throw still reaches the fail-safe catch on each attempt
+    // and the rejection is evicted. Memoizing the resolved boolean instead would hold retrieval
+    // narrowed to report-only for the rest of the turn on one transient failure.
+    const settings = {
+      getSettingsValue: vi.fn().mockRejectedValueOnce(new Error('settings down')).mockResolvedValue(true) as never,
+    };
+    const logger = { warn: vi.fn() };
+    const scope = turn();
+
+    expect(await resolveEnforceReadGrants(settings, logger, scope)).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('enforce-flag read failed'), expect.any(Error));
+    expect(await resolveEnforceReadGrants(settings, logger, scope)).toBe(true);
+    expect(settings.getSettingsValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('memoizes a falsy flag too, rather than re-reading it as a miss', async () => {
+    // `undefined` (no row) and `false` are both legitimate settled answers - a memo that only
+    // cached truthy values would leave the read un-collapsed on exactly the report-only install.
+    const settings = settingsRepo(undefined);
+    const scope = turn();
+
+    expect(await resolveEnforceReadGrants(settings, undefined, scope)).toBe(false);
+    expect(await resolveEnforceReadGrants(settings, undefined, scope)).toBe(false);
+    expect(settings.getSettingsValue).toHaveBeenCalledTimes(1);
+  });
 });
 
 /**

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
@@ -30,6 +30,9 @@ export const ENFORCE_LAKE_READ_GRANTS_KEY = 'EnforceLakeReadGrants' as const;
  */
 export const READ_GRANT_ENFORCEMENT_READY = true;
 
+/** Backing store for `resolveEnforceReadGrants`' optional per-turn flag read. */
+const enforceFlagByTurn = createScopedAsyncMemo<boolean>();
+
 /** Minimal diagnostic sink - a structural subset of the app Logger, so no dependency is added here. */
 export interface LakeAccessLogger {
   info?: (message: string, meta?: unknown) => void;
@@ -186,15 +189,29 @@ export function resolveLakeReadAccess(
  * one both resolve to ENFORCE, not to `false`. For the missing row that is the intended cutover
  * default; for a malformed row it is indistinguishable from it here, and the settings layer is where
  * that would have to be told apart.
+ *
+ * Pass `turnScope` from a caller that runs per TOOL CALL to collapse the flag read to one per turn -
+ * see the call site for why the memo wraps the raw read rather than this function's answer.
  */
 export async function resolveEnforceReadGrants(
   settings: Pick<IAdminSettingsRepository, 'getSettingsValue'> | undefined,
-  logger?: LakeAccessLogger
+  logger?: LakeAccessLogger,
+  turnScope?: object
 ): Promise<boolean> {
   if (!settings) return false;
   let intent = false;
   try {
-    intent = (await settings.getSettingsValue(ENFORCE_LAKE_READ_GRANTS_KEY)) === true;
+    // `getSettingsValue` caches nothing (AdminSettingsModel round-trips to Mongo per call), so a
+    // resolver that runs per TOOL CALL re-reads this flag every time. `turnScope` collapses that to
+    // one read per turn; omitting it keeps the read unmemoized, which is what the once-per-request
+    // browse and manage callers want.
+    //
+    // The MEMO SEES THE RAW READ, deliberately, so the throw below still reaches the catch on every
+    // attempt and the rejection is evicted rather than cached. Memoizing this function's own return
+    // instead would cache the report-only `false` a transient failure produces, holding retrieval
+    // narrowed for the rest of the turn with nothing left to say why.
+    const readFlag = () => settings.getSettingsValue(ENFORCE_LAKE_READ_GRANTS_KEY).then(value => value === true);
+    intent = turnScope ? await enforceFlagByTurn(turnScope, ENFORCE_LAKE_READ_GRANTS_KEY, readFlag) : await readFlag();
   } catch (err) {
     logger?.warn?.('[lakeReadGrantCutover] enforce-flag read failed; treating as report-only', err);
     return false;
@@ -318,6 +335,11 @@ const reachByTurn = createScopedAsyncMemo<LakeGrantReach>();
  * because a reader's READ access must not become authority to write instructions into another
  * user's system prompt. A user-keyed memo would silently merge two sets whose separation is
  * exactly the point. Org ids are sorted so caller-side ordering cannot split an entry in two.
+ *
+ * The two sites DO share an entry when their arguments coincide - enforcement off and a caller who
+ * belongs to no org, where both pass `(false, [])`. That is correct rather than a widening: same
+ * function, same arguments, same rows. The floor injection depends on is the arguments it passes,
+ * which the memo cannot change; what the key prevents is one site being handed the OTHER's set.
  *
  * The grant repo is NOT in the key - being an object, it cannot be - so `turnScope` has to be the
  * object that OWNS it (a ToolContext owns `db.dataLakeAccessGrants`). Handing one scope two

--- a/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
+++ b/b4m-core/services/src/dataLakeService/resolveLakeReadAccess.ts
@@ -6,6 +6,7 @@ import type {
 } from '@bike4mind/common';
 import { classifyLakeAccess, type LakeAccessArm } from './classifyLakeAccess';
 import type { LakeGrant } from './manageRule';
+import { createScopedAsyncMemo } from './scopedAsyncMemo';
 
 /** The platform cutover flag governing whether read-grant resolution is enforced or report-only. */
 export const ENFORCE_LAKE_READ_GRANTS_KEY = 'EnforceLakeReadGrants' as const;
@@ -246,6 +247,10 @@ export interface LakeGrantReach {
  *    would 404 on open - listing it would be incoherent, so it is excluded until enforce.
  * The org arm keys off MEMBERSHIP (`organizationIds`), distinct from the org-MANAGE rung (admin
  * rights).
+ *
+ * A NEW PARAMETER HERE MUST BE ADDED TO `grantedLakeReachForTurn`'S MEMO KEY, which is built from
+ * this signature's arguments by hand. An argument the key omits merges two call sites that meant to
+ * differ - and the sites that differ, differ on exactly the security floor (see that key's doc).
  */
 export const grantedLakeReachFor = async (
   userId: string,
@@ -290,6 +295,51 @@ export const grantedLakeReachFor = async (
     orgGrantedLakes: Object.fromEntries(Array.from(byOrg, ([orgId, lakeIds]) => [orgId, Array.from(lakeIds)])),
   };
 };
+
+/** Backing store for `grantedLakeReachForTurn` - see its doc for what the key has to cover. */
+const reachByTurn = createScopedAsyncMemo<LakeGrantReach>();
+
+/**
+ * `grantedLakeReachFor`, resolved at most ONCE per turn per distinct argument set. For the callers
+ * that run it repeatedly inside one request: the knowledge tools resolve lake access per TOOL
+ * CALL, so a turn that grounds through forced retrieval and then calls both `search` and
+ * `retrieve` issues this read four times over. `turnScope` must be an object whose lifetime IS
+ * the turn - the shared `ToolContext`, built once per request in `generateTools` and closed over
+ * by every tool. Callers that read once, and every browse/manage caller, keep calling
+ * `grantedLakeReachFor` directly.
+ *
+ * THE REACH IT RETURNS IS SHARED between every caller that hits the entry, so treat it as
+ * read-only: mutating either half would reach the other calls in the turn. Today's consumers copy
+ * the ids out (`grantedLakeIds` into a Set) or hand the whole reach to a query that only reads it.
+ *
+ * THE KEY COVERS `includeReaders` AND `organizationIds`, not just the user. The retrieval and
+ * prompt-injection sites pass deliberately different arguments and are meant to stay diverged:
+ * retrieval follows the enforced cutover, while injection pins `includeReaders: false` forever,
+ * because a reader's READ access must not become authority to write instructions into another
+ * user's system prompt. A user-keyed memo would silently merge two sets whose separation is
+ * exactly the point. Org ids are sorted so caller-side ordering cannot split an entry in two.
+ *
+ * The grant repo is NOT in the key - being an object, it cannot be - so `turnScope` has to be the
+ * object that OWNS it (a ToolContext owns `db.dataLakeAccessGrants`). Handing one scope two
+ * different grant repos would share one entry between them.
+ *
+ * The reach is a per-turn SNAPSHOT: `activeAsOf` is captured by the first call, and a grant
+ * revoked or lapsed after it stays honored for the rest of that turn. Deliberate - a turn is
+ * seconds long, the alternative is the repeated read this exists to remove, and the retrieval side
+ * already snapshots this way - `knowledgeBaseRetrieve` holds one resolved lake-access set for the
+ * length of a tool call (`dynamicAccessPromise`). The manage re-check on a session's pre-authorized
+ * ids is NOT part of the snapshot: `filterStillManagedLakes` reads `listActiveByLakes` per call.
+ */
+export const grantedLakeReachForTurn = (
+  turnScope: object,
+  userId: string,
+  organizationIds: string[],
+  grants?: PrincipalGrantLookup,
+  includeReaders = false
+): Promise<LakeGrantReach> =>
+  reachByTurn(turnScope, JSON.stringify([userId, includeReaders, [...organizationIds].sort()]), () =>
+    grantedLakeReachFor(userId, organizationIds, grants, includeReaders)
+  );
 
 /**
  * Lake ids the caller can reach via a MANAGE-conferring active grant - the narrower sibling of

--- a/b4m-core/services/src/dataLakeService/scopedAsyncMemo.test.ts
+++ b/b4m-core/services/src/dataLakeService/scopedAsyncMemo.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createScopedAsyncMemo } from './scopedAsyncMemo';
+
+describe('createScopedAsyncMemo', () => {
+  const scope = () => ({});
+
+  it('resolves once per (scope, key) and hands every later caller the same answer', async () => {
+    const read = vi.fn(async () => 'rows');
+    const memo = createScopedAsyncMemo<string>();
+    const turn = scope();
+
+    expect(await memo(turn, 'k', read)).toBe('rows');
+    expect(await memo(turn, 'k', read)).toBe('rows');
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one in-flight read between concurrent callers', async () => {
+    // The point of caching the PROMISE rather than the settled value: the knowledge tools can
+    // reach the same read before the first has resolved, and two reads would both be issued.
+    const read = vi.fn(async () => 'rows');
+    const memo = createScopedAsyncMemo<string>();
+    const turn = scope();
+
+    expect(await Promise.all([memo(turn, 'k', read), memo(turn, 'k', read)])).toEqual(['rows', 'rows']);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT share an entry between two scopes', async () => {
+    // Two turns are two requests. A hit across them is the process-lifetime cache this exists to
+    // avoid being - on an authorization read that means honoring a grant revoked a request ago.
+    const read = vi.fn(async () => 'rows');
+    const memo = createScopedAsyncMemo<string>();
+
+    await memo(scope(), 'k', read);
+    await memo(scope(), 'k', read);
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT share an entry between two keys in one scope', async () => {
+    const read = vi.fn(async (which: string) => which);
+    const memo = createScopedAsyncMemo<string>();
+    const turn = scope();
+
+    expect(await memo(turn, 'a', () => read('a'))).toBe('a');
+    expect(await memo(turn, 'b', () => read('b'))).toBe('b');
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not share entries between two independent memos', async () => {
+    // Each memo owns its own WeakMap, which is why callers never have to namespace their keys.
+    const read = vi.fn(async () => 'rows');
+    const turn = scope();
+
+    await createScopedAsyncMemo<string>()(turn, 'k', read);
+    await createScopedAsyncMemo<string>()(turn, 'k', read);
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts a rejection, so the next caller re-reads instead of inheriting the failure', async () => {
+    // A failed read is not an answer. Cached, one transient failure would read as a settled
+    // "this caller holds nothing" for the rest of the turn.
+    const read = vi.fn().mockRejectedValueOnce(new Error('grants down')).mockResolvedValue('rows');
+    const memo = createScopedAsyncMemo<string>();
+    const turn = scope();
+
+    await expect(memo(turn, 'k', read)).rejects.toThrow('grants down');
+    expect(await memo(turn, 'k', read)).toBe('rows');
+    // The third call proves the RETRY was memoized in turn - an eviction that also dropped the
+    // replacement would leave the read un-collapsed for the rest of the scope.
+    expect(await memo(turn, 'k', read)).toBe('rows');
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects every concurrent caller of a failed read, and caches neither', async () => {
+    const read = vi.fn().mockRejectedValueOnce(new Error('grants down')).mockResolvedValue('rows');
+    const memo = createScopedAsyncMemo<string>();
+    const turn = scope();
+
+    const [first, second] = await Promise.allSettled([memo(turn, 'k', read), memo(turn, 'k', read)]);
+    expect(first.status).toBe('rejected');
+    expect(second.status).toBe('rejected');
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(await memo(turn, 'k', read)).toBe('rows');
+  });
+});

--- a/b4m-core/services/src/dataLakeService/scopedAsyncMemo.ts
+++ b/b4m-core/services/src/dataLakeService/scopedAsyncMemo.ts
@@ -1,0 +1,48 @@
+/**
+ * A per-scope async memo: one in-flight-or-settled read per (scope object, key) pair, living
+ * exactly as long as the scope object does. Built for collapsing a read that ONE request issues N
+ * times with byte-identical arguments - the knowledge tools resolve lake access once per TOOL
+ * CALL, so a turn that calls both `search` and `retrieve` repeats every read behind that
+ * resolution.
+ *
+ * THE SCOPE OBJECT IS THE LIFETIME: entries are held in a WeakMap keyed on it, so they become
+ * unreachable the moment the request's own context object does. That is the whole reason this is
+ * not a module-level `Map` keyed on a user id - these services run in a long-lived Fargate task,
+ * so such a Map would be process-lifetime, and on an authorization read (a grant row IS the
+ * authorization) that means a revoked grant would keep honoring itself until the task recycled.
+ *
+ * REJECTIONS ARE EVICTED. A failed read is not an answer: caching one would turn a single
+ * transient failure into "this caller holds nothing" for the rest of the scope, which every
+ * caller here reads as a settled deny. The caller's own fail-closed handling still runs per
+ * attempt, so a persistent failure keeps warning rather than going quiet after the first.
+ *
+ * THE KEY MUST COVER EVERY ARGUMENT THE MEMOIZED READ VARIES ON - two call sites that pass
+ * deliberately different arguments must never share an entry. Prefer wrapping the memo in a
+ * helper that derives the key from the arguments itself (see `grantedLakeReachForTurn`) over
+ * asking each call site to build one correctly.
+ */
+export type ScopedAsyncMemo<T> = (scope: object, key: string, resolve: () => Promise<T>) => Promise<T>;
+
+/** One independent memo, with its own WeakMap - so callers never have to namespace their keys. */
+export function createScopedAsyncMemo<T>(): ScopedAsyncMemo<T> {
+  const byScope = new WeakMap<object, Map<string, Promise<T>>>();
+
+  return (scope, key, resolve) => {
+    const entries = byScope.get(scope) ?? new Map<string, Promise<T>>();
+    byScope.set(scope, entries);
+
+    const memoized = entries.get(key);
+    if (memoized) return memoized;
+
+    const pending = resolve();
+    entries.set(key, pending);
+    // Eviction lives here rather than at the caller: the caller awaits `pending` and handles the
+    // rejection itself, but only this side can un-cache it. Identity-guarded so a failure can only
+    // ever evict its OWN entry - no caller today can nest or replace one, but a delete keyed on the
+    // string alone would make doing so drop a live read.
+    pending.catch(() => {
+      if (entries.get(key) === pending) entries.delete(key);
+    });
+    return pending;
+  };
+}


### PR DESCRIPTION
# Pull Request

## Description

Both data-lake access resolvers run **once per tool call**, not once per turn, and neither memoized
the reads behind them. A turn that grounds through forced retrieval and then calls both `search` and
`retrieve` re-issued every one of those reads with byte-identical arguments.

- **Injection** (`getAccessibleDataLakePrompts`) repeated the user-principal grant read and the
  membership read. Four grant reads on a grounded turn.
- **Retrieval** (`getDynamicDataLakeAccess`) repeated *three* reads - membership, the
  `EnforceLakeReadGrants` flag, and the grant read. Three tool-layer entry points forward the same
  `ToolContext` (`resolveSessionLakeAccess`, `resolveAttachmentLakeAccess`,
  `knowledgeBaseRetrieve:545`), and only `knowledgeBaseRetrieve` memoized anything, and only within
  its own tool call.

The flag read is the least obvious of these: `AdminSettingsModel.getSettingsValue`
(`packages/database/src/models/infra/ops/AdminSettingsModel.ts:80-89`) caches nothing and does a
fresh `findOne` every call, so an enforcement flag was re-queried on every tool call.

Each read is individually cheap - this is a tidy-up, not a live incident. It became worth doing when
#2506 moved the injection read onto the per-tool-call path.

Closes #2589

## Changes

- **`scopedAsyncMemo.ts` (new)** - a per-scope async memo: one in-flight-or-settled read per
  `(scope object, key)`, held in a `WeakMap` keyed on the scope so entries die with the request.
  That scoping is the design, not an implementation detail: a module-level `Map` keyed on a user id
  would be process-lifetime in a long-lived Fargate task, and on an authorization read (a grant row
  *is* the authorization) that means a revoked curator grant keeps injecting its lake's
  `systemPrompt` until the task recycles. **Rejections are evicted** - a failed read is not an
  answer, and cached it would read as "this caller holds nothing" for the rest of the turn.
- **`grantedLakeReachForTurn`** - `grantedLakeReachFor` plus that memo, keyed on
  `userId + includeReaders + sorted organizationIds`. The keying is the security-critical part:
  retrieval follows the enforced read-grant cutover while injection pins `includeReaders: false`
  **permanently**, because a reader's read access must not become authority to write instructions
  into another user's system prompt. A user-keyed memo would hand injection retrieval's wider set.
- **`membershipOrgIdsForTurn` (new)** - one memo shared by *both* resolvers rather than one each, so
  a turn that retrieves and then injects issues one membership read instead of one per resolver per
  call. The two already had to agree on what "my orgs" means (#1674); now they agree by identity.
- **`resolveEnforceReadGrants`** takes an optional `turnScope`. The memo wraps the **raw** settings
  read, deliberately, so the throw still reaches the existing fail-safe `catch` on every attempt and
  the rejection is evicted. Memoizing this function's *return* instead would cache the report-only
  `false` a transient failure produces and hold retrieval narrowed for the rest of the turn with
  nothing left to say why.

### Measured, base vs branch

Counted on local self-host with `db.setProfilingLevel(2, {slowms: -1})`, one `/api/chat` turn per
row (`wait:true`, `enableTools:true`, `enableQuestMaster:false`), same message and same fixture on
both branches, base built from the merge-base with a forced clean `turbo:core:build`. Counts are
profiler ops on `datalakeaccessgrants` / `organizations` / the `EnforceLakeReadGrants` row in
`adminsettings`, `EnforceLakeReadGrants` ON.

| turn | tool calls | grant | membership | flag | `injectedLakePromptIds` |
|---|---|---|---|---|---|
| base, nothing retrievable | count + search + retrieve | 4 | 4 | 4 | n/a (no grounding) |
| **branch**, same | count + search + retrieve | **2** | **2** | **2** | n/a |
| base, grounded on a lake file, **curator** grant | search + retrieve | 5 | 5 | 4 | `[<lake id>]` |
| **branch**, same | search + retrieve | **3** | **2** | **2** | `[<lake id>]` |
| base, same file, grant flipped to **reader** | search + retrieve | 5 | 5 | 4 | `[]` |
| **branch**, same | search + retrieve | **3** | **2** | **2** | `[]` |

The residue is the design, not a miss. On the grounded turn the branch's 3 grant reads are the
retrieval entry (`includeReaders: true`), the injection entry (`includeReaders: false`) and the
once-per-turn forced-retrieval site that builds a fresh context literal and so is deliberately
unmemoized - see "Deliberately not collapsed" below. That the two memo entries stay separate under
enforcement is the security-critical half of the keying, and here it is visible in the count.

I had estimated 4 -> 1 membership and 2 -> 1 flag before measuring; the real base figures are
higher (5 and 4) and the branch floor is 2, not 1, because of that unmemoized forced-retrieval
read. Measured numbers above supersede the estimate.

**The trust boundary is provably unmoved.** Same user, same file, same message - only the grant role
changes. `curator` injects the lake's operating instructions on both branches; `reader` injects
nothing on both branches (`[]` is present-and-empty: the injection site ran and nothing qualified).
Retrieval still returns the document's content to the reader in every case, which is the point - a
reader keeps read access and never gains injection trust.
### Deliberately not collapsed

The forced-retrieval site (`ChatCompletionFeatures.ts:1990`) builds a fresh context literal per
call, so it never hits a `ToolContext`-keyed memo - and it runs exactly once per turn (single call
site, `:2829`), so there is nothing there to collapse. Same for the other service-layer callers that
build literals (`ChatCompletionFeatures.ts:791`/`:1866`, `resolveRetrievalLakeScope.ts:180`); of
those, `ChatCompletionProcess.ts:958` already memoizes its result per turn one layer up.

The browse and manage callers keep calling `grantedLakeReachFor` and `resolveEnforceReadGrants`
directly, unmemoized, because they read once per request: `assertLakeAccess.ts:182`,
`listDataLakes.ts:398`, `browsePublicDataLakes.ts:74`, `handleDataLakeCommand.ts:228`.

## Guide for Testers

**This is a server-side read-dedup with no UI surface.** Nothing changes visually; the check is that
grounding and prompt injection still behave exactly as before.

**Preview for QA: https://app.pr2643.preview.bike4mind.com** (deployed and returning 200).

> Read this before you start. The KB retrieval path **cannot** be exercised on the preview. There is
> no `OPENAI_API_KEY` on any preview stage or in the shared fallback secret group, so
> `search_knowledge_base` fails at `EmbeddingFactory.createEmbeddingService` and seeded files never
> vectorize. Steps 1-4 below need local self-host or staging. **On the preview, do the Regression
> Checks only** - those exercise the browse/manage doors, which is where a read-dedup bug would
> surface as a lake going missing.
>
> Steps 1-4 have already been run on local self-host against both branches; the counts and the
> curator-vs-reader boundary are in "Measured, base vs branch" above. Re-run them if you want
> independent confirmation, not because they are outstanding.

1. Open a session scoped to a data lake that has a non-empty **Operating Instructions**
   (`systemPrompt`) and at least one vectorized file.
2. Send a message that makes the model use **both** knowledge tools in one turn, e.g.
   `Search the knowledge base for the control number, then retrieve the full document.`
   **Expected:** the reply is grounded in the lake's files, and the lake's operating instructions
   still steer it. In `GET /api/quests/<id>`, `promptMeta.retrieval.injectedLakePromptIds` contains
   the lake's id.
3. Repeat with a user whose **only** claim on the lake is a `curator` grant (not the owner, not an
   org member). **Expected:** identical - the grant arm still carries injection trust.
4. Repeat with a user holding only a **`reader`** grant.
   **Expected:** the lake's files may still be retrieved, but its operating instructions are **not**
   injected. This is the one boundary this PR must not move.

### Regression Checks

1. **Browse / listing** - Sidebar -> Files -> Upload Files -> Data Lakes. Every lake you could see
   before is still listed, including one reached only by a grant.
2. **Open a grant-held lake** - it still opens (no 404).
3. **Transferred lake** - a lake transferred to you still both lists and grounds.
4. **Org-shared lake** - with `EnforceLakeReadGrants` ON, a lake shared to an org you belong to
   still grounds.
5. **Manage re-check still live** - revoke someone's manage rights on a lake their existing session
   was pre-authorized for; their next turn must stop treating it as pre-authorized. This path is
   deliberately **outside** the memo (`filterStillManagedLakes` reads `listActiveByLakes` per call).
6. **Slack** `/datalake` command still resolves the caller's lakes.

### What NOT to test

- Any UI, styling, copy or layout - there is none in this diff.
- Admin settings, schemas, migrations, API shapes - unchanged. `EnforceLakeReadGrants` behaviour is
  not modified, only how often its value is read within one turn.
- Retrieval *ranking* or *scope* - which lakes and files resolve is unchanged; only the number of
  identical reads behind that resolution changed.
- Credit/billing paths - untouched.

## Additional Information

**Accepted trade-off: the reach is now a per-turn snapshot.** A grant revoked or expiring mid-turn
stays honored for the rest of that turn (seconds), and likewise a membership change. Documented at
`grantedLakeReachForTurn`. Two things are deliberately *not* in the snapshot: the manage re-check on
a session's pre-authorized ids (`filterStillManagedLakes`, still per call), and any read on the
browse/manage doors.

**Retrieval and injection can share one grant entry** when their arguments coincide - enforcement
off and a caller who belongs to no org, where both pass `(false, [])`. That is the same function
over the same arguments, not a widening; what the key prevents is either site being handed the
*other's* set. There is a test for it so the behaviour is stated rather than discovered.

**Coordination with #2623** - that PR edits two assertions in `getDataLakePrompts.test.ts`
(`expect.anything()` -> `{ activeAsOf: expect.any(Date) }`) and appends to
`resolveLakeReadAccess.test.ts`. Whichever lands second takes a small test-file conflict; the changes
are compatible in substance.

**Unblocks #2509** (per-arm grant telemetry) - the memo removes the shared return-shape change that
issue was built around, collapsing it to one caller-side intersection per site.

## Developer Notes

- **`createScopedAsyncMemo`** is a reusable request-scoped memo for any read a per-tool-call path
  repeats. Its two non-obvious contracts are worth knowing before reaching for it: the scope object
  *is* the lifetime (pass something per-request, never a module singleton), and the key must cover
  every argument the read varies on - prefer wrapping it in a helper that derives its own key from
  the arguments, as `grantedLakeReachForTurn` does, over asking each call site to build one.
- **Memoize the raw read, not the fail-safe's answer.** `resolveEnforceReadGrants` is the worked
  example: it never throws by design, so memoizing its return would have cached a failure-derived
  default. Wrapping the read underneath keeps the rejection visible to the `catch` on every attempt.
- **`grantedLakeReachFor` now carries a lockstep note**: a new parameter there must be added to the
  memo key, since the key is derived from that signature by hand.

## Security Testing (for security-labeled PRs only)

Not a security-labeled PR. The change touches an authorization read, so the security-relevant
properties are stated above and pinned by tests rather than left implicit: the injection floor
(`includeReaders: false`), no cross-request cache, and no cached deny on a failed read.

The injection floor is additionally verified live, base vs branch, in the table above: flipping one
user's grant between `curator` and `reader` with everything else held constant flips
`injectedLakePromptIds` between `[<lake id>]` and `[]` identically on both branches. The other two
properties have no live probe on this stack (a cross-request cache needs a second request in the
same process to observe, and the failed-read path needs an induced Mongo failure mid-turn) and rest
on the unit tests - stated here rather than implied.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [x] I have performed a self-review of my own code (`code-defect-lenses`; findings folded into this branch)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry changes
