### PR TITLE
refactor(client): drop the unused breadcrumb padding passthrough

### DIFF
--- a/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
+++ b/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
@@ -18,14 +18,11 @@ interface SurfaceBreadcrumbProps {
   /** Left margin (spacing units or a raw CSS length). Default 0; used to sit the breadcrumb a
    *  fixed distance from a sibling control in a header row. */
   ml?: number | string;
-  /** Vertical padding (spacing units or a raw CSS length). Omitted keeps Joy's own 0.5rem;
-   *  pass 0 inside a header row that already spaces its lines. */
-  py?: number | string;
 }
 
-export function SurfaceBreadcrumb({ segments, mb = 2, ml = 0, py }: SurfaceBreadcrumbProps) {
+export function SurfaceBreadcrumb({ segments, mb = 2, ml = 0 }: SurfaceBreadcrumbProps) {
   return (
-    <Breadcrumbs size="sm" sx={{ px: 0, py, mb, ml }}>
+    <Breadcrumbs size="sm" sx={{ px: 0, mb, ml }}>
       {segments.map((seg, i) => {
         const isLast = i === segments.length - 1;
         if (isLast || !seg.onClick) {


### PR DESCRIPTION
# Pull Request

## Description
`SurfaceBreadcrumb` gained a `py` passthrough in #2634 for a caller that ended up not needing it - the header row in question spaces its own lines and no longer draws a breadcrumb at all. Nothing in the repo sets the prop, so this removes it rather than leaving a documented knob that no call site exercises.

## Changes
- Dropped `py` from `SurfaceBreadcrumbProps` and from the `Breadcrumbs` `sx`.
- `px: 0`, `mb` and `ml` are untouched, and omitting `py` was what every caller already did, so `Breadcrumbs` keeps Joy's own vertical padding exactly as before.

## Guide for Testers

No behaviour to test - this is a no-op for every existing render path. Regression checks, if you want one pass over the breadcrumb call sites:

1. Open `app.staging.bike4mind.com` and go to a surface that draws the mode breadcrumb (the /opti mode sub-views are the only in-repo callers, via `OptiModeBreadcrumb`).
2. The crumb row should sit exactly where it did before: same vertical padding, same left offset, same spacing to the hero below it.
3. Click a non-last crumb: it still navigates.

### What NOT to test
Nothing else touches this file; there is no server, API, or data change in this PR.

## Additional Information
Type-level cleanup only. `pnpm --filter @bike4mind/client typecheck` covers the prop removal; no test asserted `py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
