### PR TITLE
style(client): polish the opti surface chrome

### DIFF
--- a/apps/client/app/components/Session/NavigationButtons.tsx
+++ b/apps/client/app/components/Session/NavigationButtons.tsx
@@ -27,7 +27,7 @@ const NavigationButtons: FC<NavigationButtonsProps> = ({ navigationIntents }) =>
         mt: '16px',
         pt: '16px',
         borderTop: '1px solid',
-        borderColor: 'text.tertiary',
+        borderColor: 'divider',
       }}
     >
       {/* display: block because Joy renders body-xs as a span, and a margin on an

--- a/apps/client/app/components/Session/NavigationButtons.tsx
+++ b/apps/client/app/components/Session/NavigationButtons.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { Box, Button, Stack, Tooltip, Typography } from '@mui/joy';
-import { Explore as NavigateIcon } from '@mui/icons-material';
 import { useNavigationExecutor } from '@client/app/hooks/useNavigationExecutor';
+import { compactButtonSx } from '@client/app/utils/buttonStyles';
 import type { NavigationIntent } from '@bike4mind/common';
 
 interface NavigationButtonsProps {
@@ -20,32 +20,35 @@ const NavigationButtons: FC<NavigationButtonsProps> = ({ navigationIntents }) =>
 
   return (
     <Box
+      // A rule, not a card: the block sits at the foot of the reply body now, so it
+      // separates itself from the answer instead of framing itself inside it - and
+      // its own ground would have swallowed the buttons, which carry that colour.
       sx={{
-        mt: 1.5,
-        p: 1.5,
-        borderRadius: 'md',
-        border: '1px solid',
-        borderColor: 'neutral.outlinedBorder',
-        bgcolor: 'background.surface',
+        mt: '16px',
+        pt: '16px',
+        borderTop: '1px solid',
+        borderColor: 'text.tertiary',
       }}
     >
-      <Typography level="body-xs" sx={{ mb: 1, color: 'neutral.500', fontWeight: 600 }}>
+      {/* display: block because Joy renders body-xs as a span, and a margin on an
+          inline element is ignored - the gap below was coming from the line box. */}
+      <Typography level="body-xs" sx={{ display: 'block', mb: '8px', color: 'text.primary', fontWeight: 600 }}>
         Suggested Navigation
       </Typography>
       <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
         {navigationIntents.map(intent => (
+          // The app's secondary action, at the same metrics as the ones in a brief
+          // card: a suggestion is not the reply's own call to action.
           <Tooltip key={intent.viewId} title={intent.reason} placement="top" arrow>
             <Button
               variant="outlined"
-              color="primary"
+              color="neutral"
               size="sm"
-              startDecorator={<NavigateIcon sx={{ fontSize: 16 }} />}
               onClick={() => execute(intent)}
               data-testid={`nav-btn-${intent.viewId}`}
-              sx={{
-                fontWeight: 500,
-                borderRadius: 'lg',
-              }}
+              // The app's surface ground, not the reply bubble's: the buttons are
+              // chrome the answer carries, so they sit on the app's own colour.
+              sx={{ ...compactButtonSx, backgroundColor: 'background.surface' }}
             >
               {intent.label}
             </Button>

--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -1518,6 +1518,11 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
   // every streamed token.
   const mathReadyContent = useMemo(() => promoteInlineLatexDollars(displayContent), [displayContent]);
 
+  // Suggestions belong to the answer that made them, so they render at the foot of
+  // the reply body rather than under it - which also means a reply that is nothing
+  // BUT suggestions still needs the body to exist to hold them.
+  const navSuggestions = completed && navigationIntents && navigationIntents.length > 0 ? navigationIntents : null;
+
   if (questMasterPlanId) {
     return <QuestMasterPreviewCard questMasterPlanId={questMasterPlanId} />;
   }
@@ -1637,7 +1642,8 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
                 images.length > 0 ||
                 generatedFiles.length > 0 ||
                 videos.length > 0 ||
-                audio.length > 0) && (
+                audio.length > 0 ||
+                navSuggestions) && (
                 <Box
                   sx={{
                     position: 'relative',
@@ -1871,6 +1877,8 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
                         )}
                       </>
                     )}
+
+                    {navSuggestions && <NavigationButtons navigationIntents={navSuggestions} />}
                   </Typography>
                 </Box>
               )}
@@ -1910,10 +1918,6 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
 
       {attachmentList && completed && (
         <AttachmentDownloadButtons attachmentList={attachmentList} sessionId={currentSessionId || undefined} />
-      )}
-
-      {navigationIntents && navigationIntents.length > 0 && completed && (
-        <NavigationButtons navigationIntents={navigationIntents} />
       )}
 
       {/* Deliberately not gated on `completed`: a failed attachment is known before the reply

--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -1606,7 +1606,13 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
       )}
 
       {showSyntaxHighlight ? (
-        <SyntaxHighlighter style={oneDark}>{processedContent || cleanReply}</SyntaxHighlighter>
+        <>
+          <SyntaxHighlighter style={oneDark}>{processedContent || cleanReply}</SyntaxHighlighter>
+          {/* Repeated rather than hoisted above the branch: the suggestions read as part of
+              the reply, so they follow whichever body this view rendered. Edit mode is the
+              one body they are deliberately left out of. */}
+          {navSuggestions && <NavigationButtons navigationIntents={navSuggestions} />}
+        </>
       ) : (
         <>
           <ThoughtBubbles content={thought || ''} isStreaming={!completed} defaultFolded={isExpandable} />

--- a/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
+++ b/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
@@ -18,14 +18,11 @@ interface SurfaceBreadcrumbProps {
   /** Left margin (spacing units or a raw CSS length). Default 0; used to sit the breadcrumb a
    *  fixed distance from a sibling control in a header row. */
   ml?: number | string;
-  /** Vertical padding (spacing units or a raw CSS length). Omitted keeps Joy's own 0.5rem;
-   *  pass 0 inside a header row that already spaces its lines. */
-  py?: number | string;
 }
 
-export function SurfaceBreadcrumb({ segments, mb = 2, ml = 0, py }: SurfaceBreadcrumbProps) {
+export function SurfaceBreadcrumb({ segments, mb = 2, ml = 0 }: SurfaceBreadcrumbProps) {
   return (
-    <Breadcrumbs size="sm" sx={{ px: 0, py, mb, ml }}>
+    <Breadcrumbs size="sm" sx={{ px: 0, mb, ml }}>
       {segments.map((seg, i) => {
         const isLast = i === segments.length - 1;
         if (isLast || !seg.onClick) {

--- a/apps/client/app/components/datalake/deckChrome.test.tsx
+++ b/apps/client/app/components/datalake/deckChrome.test.tsx
@@ -10,7 +10,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
 );
 
-const renderCard = () =>
+const renderCard = (props: { fromChat?: boolean } = {}) =>
   render(
     <Wrapper>
       <ActiveBriefCard
@@ -19,6 +19,7 @@ const renderCard = () =>
         stats={['10 stops']}
         objectiveLine="objective: minimize tour length"
         isDark
+        {...props}
       />
     </Wrapper>
   );
@@ -32,5 +33,14 @@ describe('ActiveBriefCard', () => {
     const card = screen.getByTestId('opti-active-brief');
     expect(within(card).getByText('Austin Food Truck Circuit')).toBeInTheDocument();
     expect(within(card).getByText('objective: minimize tour length')).toBeInTheDocument();
+  });
+
+  it('flags a brief the chat formulated, and stays quiet otherwise', () => {
+    renderCard();
+    expect(screen.queryByTestId('opti-brief-from-chat')).toBeNull();
+
+    cleanup();
+    renderCard({ fromChat: true });
+    expect(screen.getByTestId('opti-brief-from-chat')).toHaveTextContent('synced from chat');
   });
 });

--- a/apps/client/app/components/datalake/deckChrome.test.tsx
+++ b/apps/client/app/components/datalake/deckChrome.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { ActiveBriefCard } from './deckChrome';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const renderCard = () =>
+  render(
+    <Wrapper>
+      <ActiveBriefCard
+        name="Austin Food Truck Circuit"
+        description="Shortest nightly loop hitting ten hotspots."
+        stats={['10 stops']}
+        objectiveLine="objective: minimize tour length"
+        isDark
+      />
+    </Wrapper>
+  );
+
+afterEach(cleanup);
+
+describe('ActiveBriefCard', () => {
+  it('states the brief it is showing', () => {
+    renderCard();
+
+    const card = screen.getByTestId('opti-active-brief');
+    expect(within(card).getByText('Austin Food Truck Circuit')).toBeInTheDocument();
+    expect(within(card).getByText('objective: minimize tour length')).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/datalake/deckChrome.tsx
+++ b/apps/client/app/components/datalake/deckChrome.tsx
@@ -13,12 +13,13 @@
  */
 
 import { Box, Card, Chip, Typography } from '@mui/joy';
+import type { Theme } from '@mui/joy/styles';
 import { alpha, keyframes } from '@mui/system';
-import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import { compactButtonSx } from '@client/app/utils/buttonStyles';
 import { memo, type ReactNode } from 'react';
 import {
   SURFACE_HUES as HUES,
+  dataChipSx,
   inkFor,
   surfaceBackground,
   REDUCED_MOTION_OFF,
@@ -31,6 +32,7 @@ export {
   REDUCED_MOTION_OFF,
   cursorBlink,
   driftFloat,
+  dataChipSx,
   /** Historical name for the generic expanding-ring animation. */
   ringPing as sonarPing,
   StatTicker as TelemetryTicker,
@@ -236,15 +238,29 @@ export function DeckSectionHeader({ label, hint }: { label: string; hint?: strin
       >
         {label}
       </Typography>
-      <Box sx={{ flex: 1, height: '1px', bgcolor: 'divider', opacity: 0.6 }} />
+      {/* ml auto rather than a stretching rule between the two: the hint still sits
+          at the far edge, without an empty element drawing a line to it. */}
       {hint && (
-        <Typography level="body-xs" sx={{ color: 'text.tertiary', whiteSpace: 'nowrap' }}>
+        <Typography level="body-xs" sx={{ ml: 'auto', color: 'text.tertiary', whiteSpace: 'nowrap' }}>
           {hint}
         </Typography>
       )}
     </Box>
   );
 }
+
+/* Console frame */
+
+/**
+ * A framed block on the /opti surfaces: hairline box on the panel ground. Shared
+ * so blocks wear the same frame rather than each mixing its own.
+ */
+export const consolePanelSx = (theme: Theme) => ({
+  borderRadius: '12px',
+  border: '1px solid',
+  borderColor: theme.palette.border.input,
+  backgroundColor: theme.palette.background.surface2,
+});
 
 /* Active brief */
 
@@ -263,7 +279,6 @@ export const ActiveBriefCard = memo(function ActiveBriefCard({
   objectiveLine,
   isDark,
   actions,
-  fromChat = false,
 }: {
   name: string;
   description?: string;
@@ -271,76 +286,64 @@ export const ActiveBriefCard = memo(function ActiveBriefCard({
   objectiveLine: string;
   isDark: boolean;
   actions?: ReactNode;
-  /** True when this brief is the one the AI chat last formulated (and hasn't been
-   *  hand-edited since); surfaces a persistent "synced from chat" provenance chip. */
-  fromChat?: boolean;
 }) {
-  const cyan = inkFor(HUES.cyan, isDark);
   return (
-    <Card
-      variant="outlined"
-      data-testid="opti-active-brief"
-      sx={{
-        borderColor: alpha(cyan, 0.55),
-        borderWidth: 2,
-        borderLeft: `5px solid ${cyan}`,
-        backgroundColor: alpha(cyan, isDark ? 0.1 : 0.06),
-        boxShadow: `0 0 22px -10px ${alpha(cyan, isDark ? 0.85 : 0.4)}`,
-      }}
-    >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-        <CenterFocusStrongIcon sx={{ fontSize: 16, color: cyan }} />
+    // No frame, ground or inset of its own: the brief is the first thing in the
+    // console column, and the panel around it already holds it. gap 0 because the
+    // lines inside carry their own spacing, and Joy's card gap stacked on top of
+    // that opened the block to twice the height of its content.
+    <Card variant="plain" data-testid="opti-active-brief" sx={{ gap: 0, '--Card-padding': '12px' }}>
+      {/* The surface's eyebrow: the label states what the block is, so it recedes
+          into a caption rather than announcing itself in a hue. Unspaced and at
+          reading size - tracked-out micro-caps read as decoration, not a word. */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: '8px' }}>
         <Typography
           level="body-xs"
           sx={{
             fontFamily: 'monospace',
-            fontWeight: 800,
-            letterSpacing: '0.14em',
+            fontSize: '12px',
+            fontWeight: 600,
             textTransform: 'uppercase',
-            color: cyan,
+            color: 'text.tertiary',
           }}
         >
           Active Brief — now solving
         </Typography>
-        {fromChat && (
-          <Chip
-            data-testid="opti-brief-from-chat"
-            size="sm"
-            variant="soft"
-            color="success"
-            startDecorator={<AutoAwesomeIcon sx={{ fontSize: 12 }} />}
-            sx={{ fontFamily: 'monospace', fontSize: '10px', fontWeight: 700 }}
-          >
-            synced from chat
-          </Chip>
-        )}
       </Box>
-      <Typography level="title-lg">{name}</Typography>
+      {/* Each line carries its own bottom margin: the card's own gap is off, so a
+          line that does not render (no description) takes no space with it. */}
+      <Typography level="title-lg" sx={{ mb: '16px' }}>
+        {name}
+      </Typography>
       {description && (
-        <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+        <Typography level="body-sm" sx={{ color: 'text.secondary', mb: '16px' }}>
           {description}
         </Typography>
       )}
-      <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mb: '24px' }}>
         {stats.map(stat => (
-          <Chip
-            key={stat}
-            size="sm"
-            variant="outlined"
-            sx={{ fontFamily: 'monospace', fontSize: '10px', color: cyan, borderColor: alpha(cyan, 0.4) }}
-          >
+          <Chip key={stat} size="sm" variant="outlined" sx={dataChipSx(isDark)}>
             {stat}
           </Chip>
         ))}
-        <Chip
-          size="sm"
-          variant="outlined"
-          sx={{ fontFamily: 'monospace', fontSize: '10px', color: 'text.tertiary', borderColor: 'divider' }}
-        >
+        <Chip size="sm" variant="outlined" sx={dataChipSx(isDark)}>
           {objectiveLine}
         </Chip>
       </Box>
-      {actions && <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>{actions}</Box>}
+      {actions && (
+        <Box
+          sx={{
+            display: 'flex',
+            gap: '12px',
+            flexWrap: 'wrap',
+            // The card owns its footer metrics: whichever buttons a caller passes,
+            // the row reads at one size instead of at each caller's own default.
+            '& > button': compactButtonSx,
+          }}
+        >
+          {actions}
+        </Box>
+      )}
     </Card>
   );
 });

--- a/apps/client/app/components/datalake/deckChrome.tsx
+++ b/apps/client/app/components/datalake/deckChrome.tsx
@@ -279,6 +279,7 @@ export const ActiveBriefCard = memo(function ActiveBriefCard({
   objectiveLine,
   isDark,
   actions,
+  fromChat = false,
 }: {
   name: string;
   description?: string;
@@ -286,6 +287,9 @@ export const ActiveBriefCard = memo(function ActiveBriefCard({
   objectiveLine: string;
   isDark: boolean;
   actions?: ReactNode;
+  /** True when this brief is the one the AI chat last formulated (and hasn't been
+   *  hand-edited since); surfaces a persistent "synced from chat" provenance chip. */
+  fromChat?: boolean;
 }) {
   return (
     // No frame, ground or inset of its own: the brief is the first thing in the
@@ -309,6 +313,11 @@ export const ActiveBriefCard = memo(function ActiveBriefCard({
         >
           Active Brief — now solving
         </Typography>
+        {fromChat && (
+          <Chip data-testid="opti-brief-from-chat" size="sm" variant="outlined" sx={dataChipSx(isDark)}>
+            synced from chat
+          </Chip>
+        )}
       </Box>
       {/* Each line carries its own bottom margin: the card's own gap is off, so a
           line that does not render (no description) takes no space with it. */}

--- a/apps/client/app/components/datalake/surfaceChrome.tsx
+++ b/apps/client/app/components/datalake/surfaceChrome.tsx
@@ -66,6 +66,23 @@ export const surfaceBackground = (isDark: boolean, accent: Hue, secondary: Hue) 
     : `radial-gradient(ellipse 80% 45% at 50% -8%, ${alpha(accent.deep, 0.07)}, transparent 65%),
        radial-gradient(ellipse 60% 40% at 88% 108%, ${alpha(secondary.deep, 0.05)}, transparent 60%)`;
 
+/**
+ * Squared-off chip for a value a block states about itself - a count, a size, a
+ * target, the objective it is solving for. One style for all of them: a hairline
+ * and no fill, so a row of them reads as one set of facts rather than as tags
+ * competing for the eye.
+ */
+export const dataChipSx = (isDark: boolean) => ({
+  fontSize: '13px',
+  // Joy sizes a chip through these vars (its root styles read them), so bare
+  // minHeight/padding here would lose to them.
+  '--Chip-minHeight': '24px',
+  '--Chip-paddingInline': '8px',
+  borderRadius: '4px',
+  color: 'text.primary',
+  borderColor: isDark ? 'rgba(209, 228, 244, 0.1)' : 'rgba(22, 34, 43, 0.1)',
+});
+
 export interface TickerStat {
   label: string;
   value: string;

--- a/apps/client/app/components/datalake/surfaceChrome.tsx
+++ b/apps/client/app/components/datalake/surfaceChrome.tsx
@@ -71,6 +71,9 @@ export const surfaceBackground = (isDark: boolean, accent: Hue, secondary: Hue) 
  * target, the objective it is solving for. One style for all of them: a hairline
  * and no fill, so a row of them reads as one set of facts rather than as tags
  * competing for the eye.
+ *
+ * `isDark` is vestigial now that the hairline is a mode-aware token; the signature
+ * stays until the callers still passing it are updated.
  */
 export const dataChipSx = (isDark: boolean) => ({
   fontSize: '13px',
@@ -80,7 +83,7 @@ export const dataChipSx = (isDark: boolean) => ({
   '--Chip-paddingInline': '8px',
   borderRadius: '4px',
   color: 'text.primary',
-  borderColor: isDark ? 'rgba(209, 228, 244, 0.1)' : 'rgba(22, 34, 43, 0.1)',
+  borderColor: 'divider',
 });
 
 export interface TickerStat {

--- a/apps/client/app/utils/buttonStyles.ts
+++ b/apps/client/app/utils/buttonStyles.ts
@@ -1,0 +1,13 @@
+/**
+ * Metrics for a compact action button - the size the app's secondary actions share:
+ * the active-brief card's footer row and the chat's suggested-navigation buttons.
+ *
+ * Height goes through Joy's own var, which its root style reads. The inline padding
+ * is set directly: Joy hardcodes that one per size and offers no var to aim at.
+ */
+export const compactButtonSx = {
+  fontSize: '13px',
+  fontWeight: 500,
+  paddingInline: '12px',
+  '--Button-minHeight': '32px',
+};


### PR DESCRIPTION
# Pull Request

## Description
UI/UX polish on the shared /opti surface chrome and on the chat reply's navigation block, done live against the running app and collected in one PR. No server, API, data, or contract change - but it is not purely cosmetic either, and the first draft of this description wrongly said so. Three things behave differently, all of them intended: the navigation block renders in a different place in the reply tree, every section header loses a rule element, and the active-brief provenance chip is restyled rather than left alone.

## Changes
- **Active-brief block** (`deckChrome.tsx`): it rang itself in a hue border, tinted its own ground, carried a glow and put an icon in front of a label that already said the same thing - which read as an alert beside the neutral cards around it. It now has no frame, ground or icon at all, a 12px inset, and `gap: 0` with each line owning the space under it, so a line that does not render (no description) takes none with it. Its eyebrow recedes to an unspaced caption at reading size.
- **The `fromChat` provenance chip is restyled, not removed.** An earlier revision of this PR deleted the prop as dead - it has no caller in this repo - but a private downstream consumer passes it and typechecks directly against `apps/client`, so removing it here would have broken that package's build with nothing in this repo's CI able to see it. The prop, its default and its `data-testid="opti-brief-from-chat"` chip are all kept; the chip changes from a green soft chip with a sparkle decorator into an outlined `dataChipSx` chip, so it reads as one more fact in the row instead of a badge over it. Retiring the prop for real is a follow-up, once nothing passes it.
- **One chip style** (`surfaceChrome.tsx`): the accent-filled "data" chip and the outlined "meta" chip collapse into `dataChipSx(isDark)` - hairline, no fill, 13px, 24px tall, 8px inline. A count and the objective are both facts the block states about itself, so a row of them now reads as one set instead of two kinds of tag. The hairline takes the theme's `divider` token rather than the two hardcoded `rgba()` literals it started with.
- **Two new shared styles**: `consolePanelSx` (the framed-block base: hairline box on the panel ground) and `compactButtonSx` (`apps/client/app/utils/buttonStyles.ts` - the metrics of the app's compact secondary action, 13px / 500 / 12px inline / 32px tall). The brief block's footer and the chat's navigation buttons both take the latter, so the two cannot drift apart; height goes through Joy's `--Button-minHeight`, inline padding directly, since Joy hardcodes that one per size. `consolePanelSx` has no caller in this repo yet - its first consumer is a private downstream change queued directly behind this PR.
- **`DeckSectionHeader`** loses the 1px rule that stretched between its label and its hint. The hint keeps its position with `ml: auto`, so every section header on these surfaces is one element lighter with no layout change.
- **Suggested navigation** (`NavigationButtons.tsx`, `PromptReplies.tsx`): the block was a bordered card sitting under the reply, so a suggestion looked like a second message rather than the tail of the answer that made it. It now renders as the last thing inside the reply body, separated by a rule drawn from `divider`; the bubble's render condition includes it, so a reply that is nothing but suggestions still has a body to hold them. It renders under **both** arms of the syntax-highlight toggle - the first revision put it in one arm only, which silently dropped suggestions from research-mode replies, since that surface passes `showSyntaxHighlight` unconditionally. Edit mode still suppresses them on purpose: navigation buttons under a textarea you are mid-edit in is not a state worth keeping. The buttons drop the compass glyph and become outlined neutral at the compact metrics.
- **`SurfaceBreadcrumb`**: dropped the `py` passthrough added in #2634. Nothing in either repo sets it, and omitting it is what every caller already did, so `Breadcrumbs` keeps Joy's own vertical padding exactly as before.

## Guide for Testers
1. Open `app.staging.bike4mind.com` and ask the chat something that earns a navigation suggestion (e.g. "how do I schedule these jobs?").
2. When the reply finishes, the **Suggested Navigation** block appears *inside* the reply bubble, at its foot, separated by a thin rule - not as a bordered card below it. The buttons are outlined neutral with no icon.
3. Click one: it still navigates exactly as before.
4. Toggle syntax highlighting on and re-check step 2 - the block is still there.
5. Go to `/opti` and open any optimization console with a brief loaded. The **Active Brief** block has no border, no tint and no glow; its chips are all one style (hairline, no fill); its footer buttons are 32px tall at 13px.
6. Any surface with a section heading (e.g. the pattern-family lists): the heading label sits on the left, its hint at the far right, and there is no rule drawn between them.

### Regression Checks
1. A reply with no navigation suggestions renders exactly as before - same bubble, same spacing, nothing added.
2. Suggestions still appear only after the reply completes (never mid-stream), and are still absent while a reply is being edited.
3. A research-mode reply that carries suggestions still shows them.
4. Any surface that draws the mode breadcrumb: the crumb row sits where it did, same vertical padding and left offset, and a non-last crumb still navigates on click.
5. Light mode: the brief block, its chips and the navigation buttons all stay legible (the chip hairline and the deck grounds are mode-aware).

### What NOT to test
No server, API, database, auth or LLM path is touched. Nothing here changes what a solver does, what a brief contains, or which views the model may suggest.

## Additional Information
`consolePanelSx` and `compactButtonSx` are shared styles for these surfaces rather than local ones on purpose: the same metrics were about to be hand-copied into a third place, which is how the two chip styles drifted apart in the first place. `dataChipSx` keeps its `isDark` parameter even though the `divider` token made it unused, so the signature does not break twice for a consumer that is mid-flight on it; it retires together with `fromChat`.

`deckChrome.test.tsx` covers the brief block's content and both directions of the provenance chip. The rest is style-only (literal `sx` swaps), so it rides on typecheck and lint. **One gap, stated rather than left to be found:** nothing in this repo mounts `NavigationButtons`, which is exactly why the block could move inside a ternary without anything going red; a mount test needs six app contexts stubbed and was judged too large to bolt onto a styling PR.

Verified on the review-follow-up commit: `pnpm turbo:typecheck` 40/40 pass, `pnpm lint:check` clean, `pnpm --filter @bike4mind/client exec tsc --noEmit` clean, `pnpm --filter @bike4mind/client test` 1194 files / 13137 tests pass.
