### PR TITLE
fix(client): gate unverified OAuth email out of new account login identity

### DIFF
--- a/apps/client/server/utils/auth/verifyCallback.test.ts
+++ b/apps/client/server/utils/auth/verifyCallback.test.ts
@@ -671,6 +671,80 @@ describe('verifyCallback - OAuth create: username dedupe on collision', () => {
   });
 });
 
+describe('verifyCallback - OAuth create: unverified provider email is not persisted as login identity', () => {
+  it('does NOT persist the email on create when the provider marks it unverified', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'attacker' });
+
+    const { err, user } = await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-attacker',
+      username: 'attacker',
+      emails: [{ value: 'victim@example.com', verified: false }],
+    });
+
+    // Sign-in still succeeds and the account is created, but WITHOUT the unverified
+    // email as its login identity - so it can't pre-seed a Stage-2 match key that a
+    // later verified sign-in for the same address would be auto-linked into.
+    expect(err).toBeNull();
+    expect(user).toBeDefined();
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate.mock.calls[0][0].email).toBeUndefined();
+  });
+
+  it('does NOT persist the email on create when the provider gives no verification signal', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'nosignal' });
+
+    await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-nosignal',
+      username: 'nosignal',
+      emails: [{ value: 'victim@example.com' }], // no `verified` field
+    });
+
+    expect(mockCreate.mock.calls[0][0].email).toBeUndefined();
+  });
+
+  it('DOES persist the email on create when the provider marks it verified (unchanged behavior)', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', email: 'real@example.com' });
+
+    await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-real',
+      displayName: 'Real User',
+      emails: [{ value: 'real@example.com', verified: true }],
+    });
+
+    expect(mockCreate.mock.calls[0][0].email).toBe('real@example.com');
+  });
+
+  it('SAML create persists the email (IdP-attested, verified:true by construction)', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', email: 'saml-user@example.com' });
+
+    await runStandard(AuthStrategy.SAML, {
+      id: 'saml-nameid',
+      emails: [{ value: 'saml-user@example.com', verified: true }],
+    });
+
+    expect(mockCreate.mock.calls[0][0].email).toBe('saml-user@example.com');
+  });
+
+  it('creates an emailless account with a random username when the email is unverified and no username is given', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'user-abc12345' });
+
+    await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-emailless',
+      emails: [{ value: 'victim@example.com', verified: false }],
+    });
+
+    const createArg = mockCreate.mock.calls[0][0];
+    expect(createArg.email).toBeUndefined();
+    // No username and no usable (verified) email local-part -> random fallback, no crash.
+    expect(createArg.username).toMatch(/^user-[a-f0-9]{8}$/);
+  });
+});
+
 describe('verifyCallback - Google "with params" callback signature', () => {
   it('strips the params arg and forwards profile + done correctly', async () => {
     mockFindOne.mockResolvedValueOnce(null);

--- a/apps/client/server/utils/auth/verifyCallback.ts
+++ b/apps/client/server/utils/auth/verifyCallback.ts
@@ -246,8 +246,16 @@ const authenticateUser = async (
       done(null, linkedUser);
     } else {
       const name = profile?.displayName ?? profile?.name ?? username ?? '';
-      const baseUsername = deriveOAuthUsername(username, name, email);
-      user = await createUniqueOAuthUser({ name, baseUsername, email, oauthCredentials });
+      // Gate the provider-asserted email out of a brand-new account's login
+      // identity unless the provider marked it verified. An unverified email
+      // persisted here becomes a Stage-2 match key (the email $or above) that a
+      // later verified sign-in for the same address would auto-link into (see
+      // decideAutoLink), handing this account to whoever created it. SAML's
+      // wrapper synthesizes verified:true, so IdP-attested logins still persist
+      // their email; sibling OAuth create paths must apply the same gate.
+      const emailForNewAccount = isProviderEmailVerified(profile) ? email : null;
+      const baseUsername = deriveOAuthUsername(username, name, emailForNewAccount);
+      user = await createUniqueOAuthUser({ name, baseUsername, email: emailForNewAccount, oauthCredentials });
       // Transient flag (not persisted), mirroring isNewOAuthLink above: lets
       // the callback endpoint log the registration and forward a one-shot
       // signup signal to the client for ad-conversion tracking.


### PR DESCRIPTION
## What & why

A first-time OAuth sign-in that creates a **brand-new** local account persisted the provider-asserted email as the account's login identity **with no verification check** (`createUniqueOAuthUser`, the create `else` branch in `verifyCallback.ts`). The sibling *link* path already gates through `decideAutoLink`; the *create* path did not.

That unverified stored email is a pre-seeded **Stage-2 match key**, which enables an account-takeover chain:

1. Attacker signs in via a self-serve provider asserting an arbitrary **unverified** `victim@example.com` -> new passwordless account created with `email: victim@example.com`, `emailVerified` unset.
2. The real victim later signs in via a provider carrying **verified** `victim@example.com`. Stage-1 `(strategy, id)` misses; Stage-2 email match hits the **attacker's** pre-seeded doc.
3. `decideAutoLink` sees provider-verified + emails match + `hasUsablePassword:false` + local unverified -> `promote-and-link`: the victim's verified provider is linked **into the attacker's account** and the email promoted to verified.

The existing `hasUsablePassword` guard only protects **password** accounts, so the OAuth-created shell slips past it. `decideAutoLink` behaves correctly given a legitimate account -> the root cause is the unverified-email doc existing at all, so the fix belongs on the **create** path.

## The change

Gate the email write in the create path on `isProviderEmailVerified(profile)`: when the provider has not marked the email verified, create the account with **no stored email**, removing the match key. Reuses the existing helper and the doc builder's already-null-tolerant email handling; no parallel verification path.

Scope predicate is self-scoping: **SAML** routes through the same callback but its wrapper synthesizes `emails: [{ value, verified: true }]`, so `isProviderEmailVerified` returns true for SAML by construction and IdP-attested logins keep persisting their email. No explicit strategy switch needed.

Sign-in still succeeds in every case; an unverified-email account is simply created without that email.

## How to test

The security-relevant behavior only triggers when a provider asserts an **unverified** email. Real Google/GitHub cannot be made to do that (Google always sends `email_verified: true`; GitHub only exposes a verified primary email), so the fix is **not manually reproducible** through those providers. The actual coverage is the unit tests below, which run in CI. Manual environments can only smoke the happy path (no regression).

**Automated (the real coverage, runs in CI):**
- `verifyCallback.test.ts` mocks the provider profile and asserts the create path directly: `verified:false` and no-`verified`-signal -> account created with **no** email; `verified:true` and SAML -> email persisted; unverified + no username -> emailless account with a random `user-xxxx` username. 37 passed (5 new).

**Preview: social login does not work here, so there is nothing OAuth-level to test.** Each PR deploys its own ephemeral stage `pr<N>` (`.github/.../deploy.yml`) served at a unique host `app.pr<N>.preview.<domain>` (`infra/router.ts`), and OAuth callback URLs are built from the request host (`pages/api/auth/[strategy]/callback.ts`) -> a distinct per-PR callback. Google/GitHub/Okta require pre-registered redirect URIs (Google has no wildcard support), and arbitrary per-PR subdomains are not registered, so real Google/GitHub/Okta login on preview fails with `redirect_uri_mismatch`. Consistent with this, the preview/E2E harness authenticates via **email one-time-code**, not social login (`apps/client/e2e/mfa.spec.ts`, `pages/api/test/otc-code.ts`). The only piece not verifiable from the repo is the provider-console redirect-URI list itself; short of an unusual wildcard registration there, previews cannot exercise this change.

**Staging (later):** where the provider OAuth apps have registered callbacks, verify the happy path end-to-end -> a new Google/GitHub/Okta signup creates an account with its email and logs in (no regression from this change), and an existing user still logs in and links normally. The unverified branch still cannot be exercised with real self-serve providers; reproducing it end-to-end would require an IdP you control (a mock OIDC, or an Okta org configured to assert `email_verified:false`), which is out of proportion for a MED finding already unit-covered.

## Regression checks

- Existing verified-email create tests unchanged and still green.
- Auto-link gate behavior (`decideAutoLink`) untouched.
- Username derivation still falls back correctly when the email is dropped.

## What NOT to test

- **Do not** try to reproduce the takeover manually via Google/GitHub - you cannot force an unverified-email assertion from them (see How to test).
- The **SAML/Okta federated** create branch (`okta/callback.ts` has the same unguarded create) is intentionally **out of scope** here and tracked separately; this PR touches only the self-serve `verifyCallback.ts` create path.

## Verification

```
pnpm --filter @bike4mind/client exec vitest run server/utils/auth/verifyCallback.test.ts   # 37 passed (5 new)
pnpm --filter @bike4mind/client typecheck                                                   # clean
```

Added tests: verified:false create (no email persisted), no-verification-signal create (no email), verified:true create (email persisted), SAML create (email persisted), and unverified + no-username -> emailless account with random `user-xxxx` fallback.

## Open decision for review

Providers that never send a `verified` field (e.g. passport-facebook, which reportedly only returns confirmed emails) will now create **emailless** accounts under the strict gate. This PR ships the strict default (security over UX). If preserving those emails is wanted, the follow-up is a small explicit trusted-provider allowlist rather than silently trusting the flag's absence.

## Checklist

- [x] Tests added for the new behavior and the positive/SAML paths
- [x] Typecheck clean
- [x] No secrets / account-tied identifiers (pre-commit hooks green)
- [x] Scoped to the self-serve create path; federated branch left to its own change
