### PR TITLE
fix(data-lakes): delete the file row before its chunks to stop stranding a stale vector count

### DIFF
--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -612,6 +612,14 @@ export interface IFabFileChunkRepository extends IBaseRepository<IFabFileChunkDo
    * repairs the least-retrievable files first. Powers the lake "Rebuild passages" detection.
    */
   findUnderChunkedFabFileIds(fabFileIds: string[], tokenThreshold: number): Promise<string[]>;
+  /**
+   * Of the given ids, which have at least one row in fabfilechunks - one aggregate over the
+   * `{fabFileId:1,_id:1}` index (mirrors `findUnderChunkedFabFileIds`), so a caller checking a
+   * batch of candidates does not pay a per-id round trip. Built for the #2583 detection sweep: a
+   * file whose id is NOT in the returned set, despite `vectorizedChunkCount > 0`, declares chunks
+   * it does not have.
+   */
+  findFabFileIdsWithChunks(fabFileIds: string[]): Promise<Set<string>>;
 }
 
 /**
@@ -1371,6 +1379,15 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    * `maxChunkCharLength`), ascending by `_id` - the health backfill's phase-2 cursor.
    */
   findFileIdsMissingChunkRollups(options?: { limit?: number; afterFileId?: string }): Promise<string[]>;
+  /**
+   * One page of file ids that DECLARE vectorized chunks (`vectorizedChunkCount > 0`), ascending by
+   * `_id` - candidates for the #2583 detection sweep to check against `findFabFileIdsWithChunks`.
+   * A candidate absent from that result has zero chunk rows behind a positive count.
+   */
+  findFileIdsWithPositiveVectorizedCount(options?: {
+    limit?: number;
+    afterFileId?: string;
+  }): Promise<{ id: string; fileName?: string }[]>;
   /** Stamp all four recomputed chunk-derived rollups together - the health backfill's phase-2 write. */
   setChunkRollups(
     id: string,

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -109,6 +109,7 @@ export const createMockFabFileRepository = (): IFabFileRepository => ({
   setChunkedCharCount: vi.fn(),
   findFileIdsMissingChunkRollups: vi.fn(),
   setChunkRollups: vi.fn(),
+  findFileIdsWithPositiveVectorizedCount: vi.fn(),
   findChunkedFilesByScope: vi.fn(),
   findConvergencePausedFilesByScope: vi.fn(),
   resetChunkStateByIds: vi.fn(),

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.test.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.test.ts
@@ -36,7 +36,7 @@ const makeDb = (fileIds: string[] = ['f1', 'f2']) => ({
       .fn()
       .mockResolvedValueOnce(fileIds)
       .mockResolvedValue([] as never),
-    hardDeleteByIds: vi.fn(async (ids: string[]) => ids),
+    hardDeleteOneById: vi.fn(async () => true),
     findById: vi.fn(async () => undefined as never),
     pullTagsByFabFileId: vi.fn(async () => {}),
   },
@@ -45,39 +45,55 @@ const makeDb = (fileIds: string[] = ['f1', 'f2']) => ({
   },
 });
 
+/** Records every row/chunk delete as `<kind>:<id>` so both ORDER and PAIRING are assertable. */
+const traceDeletes = (db: ReturnType<typeof makeDb>) => {
+  const order: string[] = [];
+  db.fabFiles.hardDeleteOneById = vi.fn(async (id: string) => {
+    order.push(`row:${id}`);
+    return true;
+  });
+  db.fabFileChunks.deleteManyByFabFileId = vi.fn(async (id: string) => {
+    order.push(`chunks:${id}`);
+  });
+  return order;
+};
+
 describe('cleanupDeletedDataLake', () => {
-  it('hard-deletes the file rows before deleting their chunks, so an interruption orphans chunks rather than stranding a row (#2583)', async () => {
-    const order: string[] = [];
+  it("hard-deletes each file's row immediately before its own chunks, so an interruption orphans chunks rather than stranding a row (#2583)", async () => {
     const db = makeDb();
-    db.fabFiles.hardDeleteByIds = vi.fn(async (ids: string[]) => {
-      order.push('files');
-      return ids;
-    });
-    db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
-      order.push('chunks');
-    });
+    const order = traceDeletes(db);
 
-    await cleanupDeletedDataLake(ADMIN, 'lake-1', { db });
+    // chunkSize:1 makes the fan-out strictly sequential. At the default size `inChunks` runs the
+    // slice under Promise.all, so the two files' awaits interleave and the recorded order stops
+    // distinguishing pairing from a bulk-then-bulk sweep - which is the exact thing under test.
+    await cleanupDeletedDataLake(ADMIN, 'lake-1', { db, chunkSize: 1 });
 
-    // The rows go first (#2583): a crash between the two steps must strand only orphaned chunks -
-    // unreachable without their file, and already a tracked, separately cleanable class (#2539) -
-    // never a row reporting a stale vectorizedChunkCount over chunks that no longer exist.
-    expect(order).toEqual(['files', 'chunks', 'chunks']);
-    expect(db.fabFiles.hardDeleteByIds).toHaveBeenCalledWith(['f1', 'f2']);
-    expect(db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledWith('f1');
-    expect(db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledWith('f2');
+    // Row-before-its-chunks (#2583): a crash between the two must strand only orphaned chunks -
+    // unreachable without their file - never a row reporting a stale vectorizedChunkCount over
+    // chunks that no longer exist.
+    //
+    // Interleaved, NOT ['row:f1','row:f2','chunks:f1','chunks:f2']: the pairing is the retry
+    // contract, not a style choice. `fileIds` is derived from the rows, so a bulk row delete
+    // followed by a separate chunk fan-out leaves a DLQ replay re-resolving an EMPTY id list and
+    // skipping the chunk sweep for the whole lake. Flattening this back would restore that.
+    expect(order).toEqual(['row:f1', 'chunks:f1', 'row:f2', 'chunks:f2']);
   });
 
-  it('leaves the file rows already gone, not stranded with stale rollups, when the chunk delete is interrupted (#2583)', async () => {
+  it('leaves the ids it has not reached still resolvable when a chunk delete is interrupted, so a DLQ retry resumes (#2583)', async () => {
     const db = makeDb();
-    db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
-      throw new Error('simulated crash');
+    const order = traceDeletes(db);
+    db.fabFileChunks.deleteManyByFabFileId = vi.fn(async (id: string) => {
+      order.push(`chunks:${id}`);
+      if (id === 'f1') throw new Error('simulated crash');
     });
 
-    await expect(cleanupDeletedDataLake(ADMIN, 'lake-1', { db })).rejects.toThrow('simulated crash');
+    await expect(cleanupDeletedDataLake(ADMIN, 'lake-1', { db, chunkSize: 1 })).rejects.toThrow('simulated crash');
 
-    // The hard-delete already committed by the time the chunk delete threw.
-    expect(db.fabFiles.hardDeleteByIds).toHaveBeenCalledWith(['f1', 'f2']);
+    // f1's row committed before its chunk delete threw, so f1 leaks orphaned chunks - the harmless
+    // direction. f2 was never touched at all: its row survives, so the replay's
+    // `findIdsByDataLakeTag` still names it and the sweep resumes there rather than no-opping.
+    expect(order).toEqual(['row:f1', 'chunks:f1']);
+    expect(db.fabFiles.hardDeleteOneById).not.toHaveBeenCalledWith('f2');
   });
 
   it('is a no-op when the lake is already gone', async () => {
@@ -86,6 +102,6 @@ describe('cleanupDeletedDataLake', () => {
 
     await cleanupDeletedDataLake(ADMIN, 'lake-1', { db });
 
-    expect(db.fabFiles.hardDeleteByIds).not.toHaveBeenCalled();
+    expect(db.fabFiles.hardDeleteOneById).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.test.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { cleanupDeletedDataLake } from './cleanupDeletedDataLake';
+
+const LAKE = {
+  id: 'lake-1',
+  datalakeTag: 'datalake:sales',
+  fileTagPrefix: 'sales',
+  createdByUserId: 'owner-1',
+  organizationId: undefined,
+  status: 'purging' as const,
+};
+
+// isAdmin:true short-circuits canManageLake, so the grant lookup below only needs to resolve, not
+// to carry a real grant.
+const ADMIN = { userId: 'admin-1', isAdmin: true };
+
+const makeDb = (fileIds: string[] = ['f1', 'f2']) => ({
+  dataLakes: {
+    findById: vi.fn(async () => ({ ...LAKE })),
+    delete: vi.fn(async () => {}),
+    find: vi.fn(async () => [] as never),
+  },
+  dataLakeAccessGrants: {
+    listByLake: vi.fn(async () => [] as never),
+    removeAllForLake: vi.fn(async () => {}),
+  },
+  batches: {
+    find: vi.fn(async () => [] as never),
+    delete: vi.fn(async () => {}),
+  },
+  fabFiles: {
+    // Called twice: the main sweep, then the mid-sweep-joiner re-check (step 3b). A real DB would
+    // find nothing left the second time once the ids above are hard-deleted; the mock mirrors that
+    // rather than replaying the same ids forever.
+    findIdsByDataLakeTag: vi
+      .fn()
+      .mockResolvedValueOnce(fileIds)
+      .mockResolvedValue([] as never),
+    hardDeleteByIds: vi.fn(async (ids: string[]) => ids),
+    findById: vi.fn(async () => undefined as never),
+    pullTagsByFabFileId: vi.fn(async () => {}),
+  },
+  fabFileChunks: {
+    deleteManyByFabFileId: vi.fn(async () => {}),
+  },
+});
+
+describe('cleanupDeletedDataLake', () => {
+  it('hard-deletes the file rows before deleting their chunks, so an interruption orphans chunks rather than stranding a row (#2583)', async () => {
+    const order: string[] = [];
+    const db = makeDb();
+    db.fabFiles.hardDeleteByIds = vi.fn(async (ids: string[]) => {
+      order.push('files');
+      return ids;
+    });
+    db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
+      order.push('chunks');
+    });
+
+    await cleanupDeletedDataLake(ADMIN, 'lake-1', { db });
+
+    // The rows go first (#2583): a crash between the two steps must strand only orphaned chunks -
+    // unreachable without their file, and already a tracked, separately cleanable class (#2539) -
+    // never a row reporting a stale vectorizedChunkCount over chunks that no longer exist.
+    expect(order).toEqual(['files', 'chunks', 'chunks']);
+    expect(db.fabFiles.hardDeleteByIds).toHaveBeenCalledWith(['f1', 'f2']);
+    expect(db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledWith('f1');
+    expect(db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledWith('f2');
+  });
+
+  it('leaves the file rows already gone, not stranded with stale rollups, when the chunk delete is interrupted (#2583)', async () => {
+    const db = makeDb();
+    db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
+      throw new Error('simulated crash');
+    });
+
+    await expect(cleanupDeletedDataLake(ADMIN, 'lake-1', { db })).rejects.toThrow('simulated crash');
+
+    // The hard-delete already committed by the time the chunk delete threw.
+    expect(db.fabFiles.hardDeleteByIds).toHaveBeenCalledWith(['f1', 'f2']);
+  });
+
+  it('is a no-op when the lake is already gone', async () => {
+    const db = makeDb();
+    db.dataLakes.findById = vi.fn(async () => undefined as never);
+
+    await cleanupDeletedDataLake(ADMIN, 'lake-1', { db });
+
+    expect(db.fabFiles.hardDeleteByIds).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -38,7 +38,10 @@ interface CleanupDeletedDataLakeAdapters {
     dataLakeResearchConfigs?: Pick<IDataLakeResearchConfigRepository, 'deleteForLake'>;
     dataLakeResearchRuns?: Pick<IDataLakeResearchRunRepository, 'deleteForLake'>;
     batches: Pick<IDataLakeBatchRepository, 'find' | 'delete'>;
-    fabFiles: Pick<IFabFileRepository, 'findIdsByDataLakeTag' | 'hardDeleteByIds' | 'findById' | 'pullTagsByFabFileId'>;
+    fabFiles: Pick<
+      IFabFileRepository,
+      'findIdsByDataLakeTag' | 'hardDeleteOneById' | 'findById' | 'pullTagsByFabFileId'
+    >;
     fabFileChunks: Pick<IFabFileChunkRepository, 'deleteManyByFabFileId'>;
   };
   retrievalIndex?: RetrievalIndexPort;
@@ -149,19 +152,32 @@ export const cleanupDeletedDataLake = async (
   // Re-resolving would also destroy anything that became a member since - a file the creator
   // tagged mid-sweep - leaving its chunks behind and its index entry unrequested. It survives
   // this run instead, which is the recoverable direction.
-  await db.fabFiles.hardDeleteByIds(fileIds);
+  //
+  // Each file's row goes first and its own chunks immediately after, in the SAME iteration (#2583).
+  // Rows-then-chunks is the ordering that matters: chunks-then-row used to leave an interruption
+  // between the two stranding a ROW with a stale vectorizedChunkCount over zero real chunks -
+  // unretrievable, but every counter-based health surface reported it vectorized. This order fails
+  // the other, harmless way: an interruption orphans chunk rows, unreachable without their file
+  // (no chunk carries a lake or tag field). Nothing sweeps those yet - #2539 is a different
+  // population, chunks whose `fabFileId` is a serialized document rather than an id.
+  //
+  // PAIRING the two per id is what keeps the sweep retry-safe, and it is why this is not a bulk
+  // `hardDeleteByIds` followed by a separate chunk fan-out. `fileIds` is derived from the rows
+  // themselves, so once they are all gone a DLQ retry re-enters at `findIdsByDataLakeTag` with an
+  // EMPTY list and the chunk sweep becomes a permanent no-op - a whole lake's chunks leaked, with
+  // no id list left anywhere that names them. Paired, the ids this run has not reached yet are
+  // still resolvable on replay, so a run that dies mid-fan-out resumes where it stopped and the
+  // docstring's "a DLQ retry re-runs it" stays true. The irreducible window is one file wide.
+  //
+  // Chunked so a large lake doesn't fan out unbounded (Lambda timeout/memory); both writes are
+  // no-ops on already-purged data, so a replay over a partially-swept lake is harmless. Chunk
+  // deletion covers soft-deleted files too, since the id list is resolved before any hard delete.
+  await inChunks(fileIds, chunkSize, async id => {
+    await db.fabFiles.hardDeleteOneById(id);
+    await db.fabFileChunks.deleteManyByFabFileId(id);
+  });
 
-  // 3. Delete chunks for every member file (covers soft-deleted files too). Chunked so a large
-  // lake doesn't fan out unbounded (Lambda timeout/memory); each delete is a no-op on
-  // already-purged data, so a DLQ retry resumes safely. Runs AFTER the rows are gone (#2583):
-  // chunks-then-rows used to leave an interruption between the two steps stranding a ROW with a
-  // stale vectorizedChunkCount over zero real chunks - unretrievable, but every counter-based
-  // health surface reported it vectorized. This order fails the other, harmless way: an
-  // interruption here only orphans chunk rows, unreachable without their file and already a
-  // tracked, separately cleanable class (#2539).
-  await inChunks(fileIds, chunkSize, id => db.fabFileChunks.deleteManyByFabFileId(id));
-
-  // 3b. Whatever the predicate STILL names is exactly that spared mid-sweep joiner, and sparing it
+  // 2b. Whatever the predicate STILL names is exactly that spared mid-sweep joiner, and sparing it
   // is only half a decision: step 5 deletes the lake, so its prefix tag would outlive the lake it
   // points at. A later lake claiming the same prefix then adopts it silently, because the
   // create-time collision guard (`findCollidingPrefixLakes`) only compares against lakes that

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -145,16 +145,21 @@ export const cleanupDeletedDataLake = async (
     await releaseDriveConnection({ dataLakeId });
   }
 
-  // 2. Delete chunks for every member file (covers soft-deleted files too). Chunked so a large
-  // lake doesn't fan out unbounded (Lambda timeout/memory); each delete is a no-op on
-  // already-purged data, so a DLQ retry resumes safely.
-  await inChunks(fileIds, chunkSize, id => db.fabFileChunks.deleteManyByFabFileId(id));
-
-  // 3. Hard-delete exactly the ids resolved above, NOT by re-running the membership predicate.
+  // 2. Hard-delete exactly the ids resolved above, NOT by re-running the membership predicate.
   // Re-resolving would also destroy anything that became a member since - a file the creator
   // tagged mid-sweep - leaving its chunks behind and its index entry unrequested. It survives
   // this run instead, which is the recoverable direction.
   await db.fabFiles.hardDeleteByIds(fileIds);
+
+  // 3. Delete chunks for every member file (covers soft-deleted files too). Chunked so a large
+  // lake doesn't fan out unbounded (Lambda timeout/memory); each delete is a no-op on
+  // already-purged data, so a DLQ retry resumes safely. Runs AFTER the rows are gone (#2583):
+  // chunks-then-rows used to leave an interruption between the two steps stranding a ROW with a
+  // stale vectorizedChunkCount over zero real chunks - unretrievable, but every counter-based
+  // health surface reported it vectorized. This order fails the other, harmless way: an
+  // interruption here only orphans chunk rows, unreachable without their file and already a
+  // tracked, separately cleanable class (#2539).
+  await inChunks(fileIds, chunkSize, id => db.fabFileChunks.deleteManyByFabFileId(id));
 
   // 3b. Whatever the predicate STILL names is exactly that spared mid-sweep joiner, and sparing it
   // is only half a decision: step 5 deletes the lake, so its prefix tag would outlive the lake it

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -3584,7 +3584,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
       fabFiles: {
         // Second call is the post-purge survivor resolve: nothing joined mid-sweep by default.
         findIdsByDataLakeTag: vi.fn().mockResolvedValueOnce(['f1', 'f2']).mockResolvedValue([]),
-        hardDeleteByIds: vi.fn().mockResolvedValue(['f1', 'f2']),
+        hardDeleteOneById: vi.fn().mockResolvedValue(true),
         findById: vi.fn().mockResolvedValue(null),
         pullTagsByFabFileId: vi.fn().mockResolvedValue(1),
       },
@@ -3622,7 +3622,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     // a HALF-PURGED lake as restorable. Anything failing after the guards must therefore surface as
     // some other error, so the consumer rethrows it to the DLQ rather than releasing.
     const adapters = makeAdapters('purging');
-    adapters.db.fabFiles.hardDeleteByIds = vi.fn().mockRejectedValue(new Error('mongo went away'));
+    adapters.db.fabFiles.hardDeleteOneById = vi.fn().mockRejectedValue(new Error('mongo went away'));
     const err = await cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters).catch(
       (e: unknown) => e
     );
@@ -3636,7 +3636,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     const adapters = makeAdapters('deleted');
     await cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
     expect(adapters.db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledTimes(2);
-    expect(adapters.db.fabFiles.hardDeleteByIds).toHaveBeenCalled();
+    expect(adapters.db.fabFiles.hardDeleteOneById).toHaveBeenCalled();
     expect(adapters.db.batches.delete).toHaveBeenCalledWith('b1');
     expect(adapters.db.dataLakes.delete).toHaveBeenCalledWith('lake1');
   });
@@ -3652,16 +3652,18 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     const releaseDriveConnection = vi.fn(async () => {
       order.push('release-drive');
     });
-    adapters.db.fabFiles.hardDeleteByIds = vi.fn(async () => {
+    adapters.db.fabFiles.hardDeleteOneById = vi.fn(async () => {
       order.push('hard-delete');
-      return [];
+      return true;
     });
     await cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', {
       ...adapters,
       releaseDriveConnection,
     });
     expect(releaseDriveConnection).toHaveBeenCalledWith({ dataLakeId: 'lake1' });
-    expect(order).toEqual(['release-drive', 'hard-delete']);
+    // One hard-delete per member id (the row/chunk writes are paired per file, #2583), so what is
+    // pinned here is that the release precedes ALL of them, not the call count.
+    expect(order).toEqual(['release-drive', 'hard-delete', 'hard-delete']);
   });
 
   it('aborts the sweep when the Drive release fails, rather than purging the lake around it', async () => {
@@ -3707,7 +3709,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     expect(indexRemove).toBeLessThan(
       Math.min(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder)
     );
-    expect(indexRemove).toBeLessThan(adapters.db.fabFiles.hardDeleteByIds.mock.invocationCallOrder[0]);
+    expect(indexRemove).toBeLessThan(adapters.db.fabFiles.hardDeleteOneById.mock.invocationCallOrder[0]);
   });
 
   it('purges exactly the ids it announced, so a mid-sweep joiner is not destroyed unaccounted for', async () => {
@@ -3719,13 +3721,13 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
 
     // By id, never by re-running the predicate: a file tagged into the lake after the resolve
     // would otherwise be hard-deleted with its chunks intact and the index never told.
-    expect(adapters.db.fabFiles.hardDeleteByIds).toHaveBeenCalledWith(memberIds);
+    expect(adapters.db.fabFiles.hardDeleteOneById.mock.calls.map(([id]) => id)).toEqual(memberIds);
     expect(removalInput(retrievalIndex).fabFileIds).toEqual(memberIds);
     // Resolved once for the purge and reused. Re-resolving BEFORE the hard delete would pass the
     // assertions above while reopening the window they exist to close; the only other resolve is
     // the survivor sweep, which runs after.
     const resolves = adapters.db.fabFiles.findIdsByDataLakeTag.mock.invocationCallOrder;
-    const hardDelete = adapters.db.fabFiles.hardDeleteByIds.mock.invocationCallOrder[0];
+    const hardDelete = adapters.db.fabFiles.hardDeleteOneById.mock.invocationCallOrder[0];
     expect(resolves.filter(order => order < hardDelete)).toHaveLength(1);
   });
 
@@ -3739,7 +3741,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
 
     // The survivor keeps its bytes but stops matching a lake that no longer exists, so a later
     // lake claiming 'lk:' cannot adopt it - the create-time guard only sees surviving lakes.
-    expect(adapters.db.fabFiles.hardDeleteByIds).toHaveBeenCalledWith(memberIds);
+    expect(adapters.db.fabFiles.hardDeleteOneById.mock.calls.map(([id]) => id)).toEqual(memberIds);
     expect(adapters.db.fabFiles.pullTagsByFabFileId).toHaveBeenCalledWith('joiner', [lake().datalakeTag, 'lk:late']);
     const pull = adapters.db.fabFiles.pullTagsByFabFileId.mock.invocationCallOrder[0];
     expect(pull).toBeLessThan(adapters.db.dataLakes.delete.mock.invocationCallOrder[0]);
@@ -3770,7 +3772,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     // can never be reconciled. The queue retry re-runs the whole sweep, so leaving it zero-progress
     // is what makes propagating safe.
     expect(adapters.db.fabFileChunks.deleteManyByFabFileId).not.toHaveBeenCalled();
-    expect(adapters.db.fabFiles.hardDeleteByIds).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.hardDeleteOneById).not.toHaveBeenCalled();
     expect(adapters.db.batches.delete).not.toHaveBeenCalled();
     expect(adapters.db.dataLakes.delete).not.toHaveBeenCalled();
   });
@@ -3790,12 +3792,26 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     // Rows before chunks is the #2583 invariant: see cleanupDeletedDataLake.test.ts for why.
     const firstChunk = Math.min(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder);
     const lastChunk = Math.max(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder);
-    const hardDelete = adapters.db.fabFiles.hardDeleteByIds.mock.invocationCallOrder[0];
+    const hardDelete = Math.min(...adapters.db.fabFiles.hardDeleteOneById.mock.invocationCallOrder);
     const firstBatch = Math.min(...adapters.db.batches.delete.mock.invocationCallOrder);
     const lakeDelete = adapters.db.dataLakes.delete.mock.invocationCallOrder[0];
     expect(hardDelete).toBeLessThan(firstChunk);
     expect(lastChunk).toBeLessThan(firstBatch);
     expect(firstBatch).toBeLessThan(lakeDelete);
+    // Per file, not just in aggregate: each row delete precedes ITS OWN chunk delete. The two are
+    // paired inside one iteration so a DLQ retry can still re-derive the ids this run never
+    // reached - a bulk row delete followed by a separate chunk fan-out would satisfy the aggregate
+    // check above while leaving the retry nothing to resolve.
+    const rowOrderById = new Map(
+      adapters.db.fabFiles.hardDeleteOneById.mock.calls.map(([id]: [string], i: number) => [
+        id,
+        adapters.db.fabFiles.hardDeleteOneById.mock.invocationCallOrder[i],
+      ])
+    );
+    adapters.db.fabFileChunks.deleteManyByFabFileId.mock.calls.forEach(([id]: [string], i: number) => {
+      const chunkOrder = adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder[i];
+      expect(rowOrderById.get(id)).toBeLessThan(chunkOrder);
+    });
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1454,7 +1454,7 @@ describe("management views - an org grant on another org's lake discloses nothin
     orgGrant:
       'not modeled, deliberately - the management views under test pass includePublic:false and no ' +
       'orgGrantedLakes, so the real query drops this arm too. That suppression is the property these ' +
-      'cases assert: an org grant on another org\'s lake must not name it in a restore/cleanup list',
+      "cases assert: an org grant on another org's lake must not name it in a restore/cleanup list",
   };
 
   it('accounts for every arm of the real findAccessible', () => {
@@ -3786,13 +3786,15 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     expect(adapters.db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledTimes(3);
     expect(adapters.db.batches.delete).toHaveBeenCalledTimes(3);
 
-    // Ordering contract: last chunk delete -> hard-delete files -> first batch delete -> lake last.
+    // Ordering contract: hard-delete files -> last chunk delete -> first batch delete -> lake last.
+    // Rows before chunks is the #2583 invariant: see cleanupDeletedDataLake.test.ts for why.
+    const firstChunk = Math.min(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder);
     const lastChunk = Math.max(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder);
     const hardDelete = adapters.db.fabFiles.hardDeleteByIds.mock.invocationCallOrder[0];
     const firstBatch = Math.min(...adapters.db.batches.delete.mock.invocationCallOrder);
     const lakeDelete = adapters.db.dataLakes.delete.mock.invocationCallOrder[0];
-    expect(lastChunk).toBeLessThan(hardDelete);
-    expect(hardDelete).toBeLessThan(firstBatch);
+    expect(hardDelete).toBeLessThan(firstChunk);
+    expect(lastChunk).toBeLessThan(firstBatch);
     expect(firstBatch).toBeLessThan(lakeDelete);
   });
 });

--- a/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.test.ts
+++ b/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.test.ts
@@ -55,10 +55,27 @@ const makeDb = (fileOverrides: Record<string, unknown> = {}) => {
 describe('purgeDataLakeDocument', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('destroys chunks then the document and verifies both by reading them back', async () => {
+  it('destroys the document then its chunks, and verifies both by reading them back', async () => {
+    const order: string[] = [];
     const db = makeDb();
+    // Wrap rather than replace: the underlying mocks still mutate makeDb()'s `files`/`chunkCount`
+    // state, which the receipt's read-back (chunksRemaining/documentDeleted/verified) depends on.
+    const originalHardDelete = db.fabFiles.hardDeleteOneById;
+    db.fabFiles.hardDeleteOneById = vi.fn(async (id: string) => {
+      order.push('document');
+      return originalHardDelete(id);
+    });
+    const originalDeleteChunks = db.fabFileChunks.deleteManyByFabFileId;
+    db.fabFileChunks.deleteManyByFabFileId = vi.fn(async (id: string) => {
+      order.push('chunks');
+      return originalDeleteChunks(id);
+    });
+
     const receipt = await purgeDataLakeDocument(OWNER, 'lake-1', 'file-1', { db, storage: makeStorage() });
 
+    // The document goes first (#2583): an interruption between the two must strand orphaned
+    // chunks, never a document reporting a stale vectorizedChunkCount over chunks already gone.
+    expect(order).toEqual(['document', 'chunks']);
     expect(db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledWith('file-1');
     expect(db.fabFiles.hardDeleteOneById).toHaveBeenCalledWith('file-1');
     expect(receipt).toMatchObject({
@@ -72,6 +89,41 @@ describe('purgeDataLakeDocument', () => {
       fileCount: 4,
       totalSizeBytes: 900,
     });
+  });
+
+  it('leaves the document already gone, not stranded with a stale chunk count, when the chunk delete is interrupted (#2583)', async () => {
+    // Simulates a crash/timeout between the two deletes. Because the document goes first, the
+    // interruption strands only orphaned chunks - unreachable without their file, and already a
+    // tracked, separately cleanable class (#2539) - never a document reporting itself vectorized
+    // over chunks that no longer exist.
+    const db = makeDb({ filePath: 'uploads/q3.pdf', fileSize: 27707 });
+    db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
+      throw new Error('simulated crash');
+    });
+    const onPurged = vi.fn(async () => {});
+    const logger = { info: vi.fn(), error: vi.fn() };
+
+    // Once the row is gone there is no retry door left, so this must not throw and skip the
+    // refund below with it - it reports the gap instead, same as any other partial sweep.
+    const receipt = await purgeDataLakeDocument(OWNER, 'lake-1', 'file-1', {
+      db,
+      storage: makeStorage(),
+      onPurged,
+      logger,
+    });
+
+    expect(db.fabFiles.hardDeleteOneById).toHaveBeenCalledWith('file-1');
+    expect(await db.fabFiles.findById('file-1')).toBeUndefined();
+    expect(receipt.documentDeleted).toBe(true);
+    expect(receipt.chunksRemaining).toBe(3);
+    expect(receipt.verified).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('could not finish chunk/session cleanup'),
+      expect.objectContaining({ fabFileId: 'file-1' })
+    );
+    // The refund must still fire: the row really is gone, and there is no retry door to recover it
+    // through otherwise.
+    expect(onPurged).toHaveBeenCalledWith(expect.objectContaining({ fileSize: 27707 }));
   });
 
   it('reports verified:false rather than throwing when the sweep leaves chunks behind', async () => {

--- a/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.test.ts
+++ b/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.test.ts
@@ -93,14 +93,15 @@ describe('purgeDataLakeDocument', () => {
 
   it('leaves the document already gone, not stranded with a stale chunk count, when the chunk delete is interrupted (#2583)', async () => {
     // Simulates a crash/timeout between the two deletes. Because the document goes first, the
-    // interruption strands only orphaned chunks - unreachable without their file, and already a
-    // tracked, separately cleanable class (#2539) - never a document reporting itself vectorized
-    // over chunks that no longer exist.
+    // interruption strands only orphaned chunks - unreachable without their file, costing storage
+    // rather than recall - never a document reporting itself vectorized over chunks that no longer
+    // exist.
     const db = makeDb({ filePath: 'uploads/q3.pdf', fileSize: 27707 });
     db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
       throw new Error('simulated crash');
     });
     const onPurged = vi.fn(async () => {});
+    const shredDocumentMemory = vi.fn(async () => {});
     const logger = { info: vi.fn(), error: vi.fn() };
 
     // Once the row is gone there is no retry door left, so this must not throw and skip the
@@ -109,6 +110,7 @@ describe('purgeDataLakeDocument', () => {
       db,
       storage: makeStorage(),
       onPurged,
+      shredDocumentMemory,
       logger,
     });
 
@@ -118,12 +120,61 @@ describe('purgeDataLakeDocument', () => {
     expect(receipt.chunksRemaining).toBe(3);
     expect(receipt.verified).toBe(false);
     expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('could not finish chunk/session cleanup'),
+      expect.stringContaining('could not delete its chunks'),
       expect.objectContaining({ fabFileId: 'file-1' })
     );
     // The refund must still fire: the row really is gone, and there is no retry door to recover it
     // through otherwise.
     expect(onPurged).toHaveBeenCalledWith(expect.objectContaining({ fileSize: 27707 }));
+    // Same argument, and the reason the shred is gated on `documentDeleted` and not `verified`:
+    // the row is permanently gone, so a shred skipped here is a shred that can never run. The
+    // document would keep speaking through its extracted beliefs forever.
+    expect(shredDocumentMemory).toHaveBeenCalledWith(expect.objectContaining({ fabFileId: 'file-1' }));
+  });
+
+  it('does NOT shred the document memory when the sweep left the row in place', async () => {
+    // The hazard the gate actually guards: shredding the beliefs of a document that SURVIVED the
+    // sweep destroys recall for content still in the lake. A storage-delete refusal never reaches
+    // hardDeleteOneById, so the row stays and the shred must not fire.
+    const db = makeDb({ filePath: 'uploads/q3.pdf', fileSize: 27707 });
+    const storage = { delete: vi.fn(async () => Promise.reject(new Error('s3 down'))) };
+    const shredDocumentMemory = vi.fn(async () => {});
+    const logger = { info: vi.fn(), error: vi.fn() };
+
+    const receipt = await purgeDataLakeDocument(OWNER, 'lake-1', 'file-1', {
+      db,
+      storage,
+      shredDocumentMemory,
+      logger,
+    });
+
+    expect(receipt.documentDeleted).toBe(false);
+    expect(receipt.verified).toBe(false);
+    expect(db.fabFiles.hardDeleteOneById).not.toHaveBeenCalled();
+    expect(shredDocumentMemory).not.toHaveBeenCalled();
+  });
+
+  it('reports verified:false when the session unlink fails, even though the chunks went cleanly (#2583)', async () => {
+    // `verified` is the durable audit claim that the purge converged. Nothing re-reads sessions in
+    // the read-back, so without its own flag an unlink failure is invisible: the receipt would say
+    // verified:true while chats still hold the dead id in `knowledgeIds`.
+    const db = makeDb({ filePath: 'uploads/q3.pdf', fileSize: 27707 });
+    db.sessions.findAllWithKnowledgeId = vi.fn(async () => {
+      throw new Error('sessions unavailable');
+    });
+    const logger = { info: vi.fn(), error: vi.fn() };
+
+    const receipt = await purgeDataLakeDocument(OWNER, 'lake-1', 'file-1', { db, storage: makeStorage(), logger });
+
+    // The chunk delete is in its own try, so an unlink failure does not cost it its attempt.
+    expect(db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledWith('file-1');
+    expect(receipt.documentDeleted).toBe(true);
+    expect(receipt.chunksRemaining).toBe(0);
+    expect(receipt.verified).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('could not unlink it from sessions'),
+      expect.objectContaining({ fabFileId: 'file-1' })
+    );
   });
 
   it('reports verified:false rather than throwing when the sweep leaves chunks behind', async () => {
@@ -635,9 +686,13 @@ describe('purgeDataLakeDocument', () => {
     });
   });
 
-  it('leaves the extracted facts alone when the sweep did not converge', async () => {
-    // Shredding the beliefs of a document that survived would destroy recall for content the lake
-    // still holds.
+  it('still shreds the extracted facts when the row is gone but the chunk sweep left rows behind', async () => {
+    // The gate is `documentDeleted`, not `verified`, and this is the case that separates them: the
+    // row is destroyed, the chunk sweep silently leaves rows, so the receipt files verified:false.
+    // Gating on `verified` would skip the shred here permanently - the row no longer resolves, so a
+    // re-POST 404s and no retry can ever reach it, leaving the document speaking through its
+    // beliefs forever. The hazard the gate DOES guard - shredding a document that survived - is a
+    // documentDeleted:false case, covered by the storage-refusal test above.
     const db = makeDb();
     db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {});
     const shredDocumentMemory = vi.fn(async () => {});
@@ -649,8 +704,9 @@ describe('purgeDataLakeDocument', () => {
       logger: { info: vi.fn(), error: vi.fn() },
     });
 
+    expect(receipt.documentDeleted).toBe(true);
     expect(receipt.verified).toBe(false);
-    expect(shredDocumentMemory).not.toHaveBeenCalled();
+    expect(shredDocumentMemory).toHaveBeenCalledWith(expect.objectContaining({ fabFileId: 'file-1' }));
   });
 
   it('distinguishes collocated vectors from a door left unwired', async () => {

--- a/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.ts
+++ b/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.ts
@@ -262,13 +262,16 @@ export const purgeDataLakeDocument = async (
   // Nothing destructive until the bytes are gone: a refusal costs zero progress, so the row, its
   // chunks and its rollups stay consistent and a retry converges.
   let deletedByThisCall = false;
+  let sessionsUnlinked = true;
   if (storageObjectDeleted) {
     // The row goes FIRST, its chunks after (#2583). Chunks-then-row used to leave an interruption
     // between the two stranding the ROW: a stale vectorizedChunkCount over zero real chunk rows -
     // unretrievable by either read path, while every counter-based health surface reported it
     // vectorized. This order fails the other, harmless way instead: an interruption here orphans
-    // chunk rows, which are unreachable without their file and already a tracked, separately
-    // cleanable class (#2539).
+    // chunk rows, which are unreachable without their file (no chunk carries a lake or tag field;
+    // both read paths filter by a file-derived id list). They cost storage, not recall - and
+    // nothing sweeps them today. #2539 is a DIFFERENT population, chunks whose `fabFileId` is a
+    // serialized document rather than an id; a cleaner written for it would not match these.
     //
     // Atomic, and it answers whether THIS call removed the row. Two concurrent purges both find the
     // gates open and both see the object-store delete succeed (deleting an absent key is a no-op),
@@ -282,10 +285,21 @@ export const purgeDataLakeDocument = async (
     // and verified report the gap truthfully, and onPurged still runs off `deletedByThisCall`.
     try {
       await db.fabFileChunks.deleteManyByFabFileId(file.id);
+    } catch (error) {
+      logger?.error('[dataLake] permanent deletion removed the row but could not delete its chunks', {
+        fabFileId: file.id,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
 
-      // Same unlink `deleteFabFile` performs: a chat holding the id in `knowledgeIds` would
-      // otherwise keep pointing at a row that no longer exists, and the confirmation copy promises
-      // otherwise.
+    // Same unlink `deleteFabFile` performs: a chat holding the id in `knowledgeIds` would
+    // otherwise keep pointing at a row that no longer exists, and the confirmation copy promises
+    // otherwise. Its OWN try, not the chunk delete's: a failure here leaves no trace in the
+    // read-back below (nothing re-reads sessions), so without `sessionsUnlinked` a purge whose
+    // chunks went cleanly would file `verified: true` over chats still holding the dead id.
+    // Separate rather than sequential for the same reason the catch exists at all - a chunk-delete
+    // failure must not cost the unlink its attempt.
+    try {
       const linkedSessions = await db.sessions.findAllWithKnowledgeId(file.id);
       for (const session of linkedSessions) {
         await db.sessions.update({
@@ -294,7 +308,8 @@ export const purgeDataLakeDocument = async (
         });
       }
     } catch (error) {
-      logger?.error('[dataLake] permanent deletion removed the row but could not finish chunk/session cleanup', {
+      sessionsUnlinked = false;
+      logger?.error('[dataLake] permanent deletion removed the row but could not unlink it from sessions', {
         fabFileId: file.id,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
@@ -306,7 +321,7 @@ export const purgeDataLakeDocument = async (
   // `T | null` cast, so an equality check here can never see the row as gone.
   const chunksRemaining = await db.fabFileChunks.countByFabFileId(file.id);
   const documentDeleted = !(await db.fabFiles.findById(file.id));
-  const verified = documentDeleted && chunksRemaining === 0 && storageObjectDeleted;
+  const verified = documentDeleted && chunksRemaining === 0 && storageObjectDeleted && sessionsUnlinked;
 
   // The purged lake only. Every OTHER lake the document belonged to is the caller's to rebuild
   // through `onPurged` - resolving a tag back to its lake needs repositories this service does
@@ -345,9 +360,15 @@ export const purgeDataLakeDocument = async (
 
   await onReceipt?.(receipt);
 
-  // Only once the document is genuinely gone: shredding the beliefs of a document that survived a
-  // failed sweep would destroy recall for content still in the lake.
-  if (verified) {
+  // Gated on `documentDeleted`, NOT `verified`: the hazard this guards against is shredding the
+  // beliefs of a document that SURVIVED a failed sweep, which is exactly `documentDeleted === false`
+  // (a storage-delete refusal never reaches `hardDeleteOneById`, so the row stays and the shred
+  // correctly does not fire). Gating on `verified` instead would tie the shred to the chunk count:
+  // a transient failure in the chunk delete above - likeliest on the large documents where this
+  // matters most - would leave the row permanently gone with its beliefs never shredded, and no
+  // retry could reach it (a re-POST 404s, the row no longer resolves). The document would keep
+  // speaking through those beliefs forever.
+  if (documentDeleted) {
     await shredDocumentMemory?.({
       tagNames,
       fabFileId: file.id,

--- a/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.ts
+++ b/b4m-core/services/src/dataLakeService/purgeDataLakeDocument.ts
@@ -263,20 +263,40 @@ export const purgeDataLakeDocument = async (
   // chunks and its rollups stay consistent and a retry converges.
   let deletedByThisCall = false;
   if (storageObjectDeleted) {
-    await db.fabFileChunks.deleteManyByFabFileId(file.id);
-
+    // The row goes FIRST, its chunks after (#2583). Chunks-then-row used to leave an interruption
+    // between the two stranding the ROW: a stale vectorizedChunkCount over zero real chunk rows -
+    // unretrievable by either read path, while every counter-based health surface reported it
+    // vectorized. This order fails the other, harmless way instead: an interruption here orphans
+    // chunk rows, which are unreachable without their file and already a tracked, separately
+    // cleanable class (#2539).
+    //
     // Atomic, and it answers whether THIS call removed the row. Two concurrent purges both find the
     // gates open and both see the object-store delete succeed (deleting an absent key is a no-op),
     // so without this claim both would refund the owner's quota for the same bytes.
     deletedByThisCall = await db.fabFiles.hardDeleteOneById(file.id);
 
-    // Same unlink `deleteFabFile` performs: a chat holding the id in `knowledgeIds` would otherwise
-    // keep pointing at a row that no longer exists, and the confirmation copy promises otherwise.
-    const linkedSessions = await db.sessions.findAllWithKnowledgeId(file.id);
-    for (const session of linkedSessions) {
-      await db.sessions.update({
-        id: session.id,
-        knowledgeIds: (session.knowledgeIds ?? []).filter(knowledgeId => knowledgeId !== file.id),
+    // Once the row is gone there is no retry door left (the file has already vanished from the
+    // owner's Files list), so this must not throw: an uncaught failure here would skip `onPurged`
+    // below and silently cost the owner their quota refund with no symptom to chase. Log and fall
+    // through to the read-back instead, same as the storage-delete failure above - chunksRemaining
+    // and verified report the gap truthfully, and onPurged still runs off `deletedByThisCall`.
+    try {
+      await db.fabFileChunks.deleteManyByFabFileId(file.id);
+
+      // Same unlink `deleteFabFile` performs: a chat holding the id in `knowledgeIds` would
+      // otherwise keep pointing at a row that no longer exists, and the confirmation copy promises
+      // otherwise.
+      const linkedSessions = await db.sessions.findAllWithKnowledgeId(file.id);
+      for (const session of linkedSessions) {
+        await db.sessions.update({
+          id: session.id,
+          knowledgeIds: (session.knowledgeIds ?? []).filter(knowledgeId => knowledgeId !== file.id),
+        });
+      }
+    } catch (error) {
+      logger?.error('[dataLake] permanent deletion removed the row but could not finish chunk/session cleanup', {
+        fabFileId: file.id,
+        error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
   }

--- a/packages/database/src/models/content/FabFileModel.staleVectorClaims.test.ts
+++ b/packages/database/src/models/content/FabFileModel.staleVectorClaims.test.ts
@@ -23,6 +23,31 @@ describe('stale vector claim detection (#2583)', () => {
     expect(page).toEqual([{ id: String(vectorized._id), fileName: 'vectorized.txt' }]);
   });
 
+  it('findFileIdsWithPositiveVectorizedCount pages forward on afterFileId and terminates', async () => {
+    // The sweep's only loop-exit is an empty page, so `afterFileId` is the sole thing advancing it
+    // (see collectStaleVectorClaims.ts). A cursor that did not move past the last id of a page -
+    // `$gte` instead of `$gt`, or a cast that silently matched nothing - would either spin forever
+    // or stop after one page. Nothing else exercises `limit`/`afterFileId` at all.
+    const created = [];
+    for (const name of ['a.txt', 'b.txt', 'c.txt']) {
+      created.push(await makeFile(name, { chunkCount: 1, vectorizedChunkCount: 1 }));
+    }
+    const idsInOrder = created.map(f => String(f._id)).sort();
+
+    const seen: string[] = [];
+    let afterFileId: string | undefined;
+    for (;;) {
+      const page = await fabFileRepository.findFileIdsWithPositiveVectorizedCount({ limit: 2, afterFileId });
+      if (page.length === 0) break;
+      expect(page.length).toBeLessThanOrEqual(2);
+      afterFileId = page[page.length - 1].id;
+      seen.push(...page.map(f => f.id));
+    }
+
+    // Every candidate exactly once, in id order, and the loop ended.
+    expect(seen).toEqual(idsInOrder);
+  });
+
   it('findFabFileIdsWithChunks returns exactly the candidate ids that have a chunk row', async () => {
     await FabFileChunk.create({ fabFileId: 'has-chunks', text: 't', tokenCount: 1 });
 

--- a/packages/database/src/models/content/FabFileModel.staleVectorClaims.test.ts
+++ b/packages/database/src/models/content/FabFileModel.staleVectorClaims.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { KnowledgeType } from '@bike4mind/common';
+import { FabFile, FabFileChunk, fabFileChunkRepository, fabFileRepository } from './FabFileModel';
+import { setupMongoTest } from '../../__test__/utils';
+
+const makeFile = (fileName: string, extra: Record<string, unknown> = {}) =>
+  FabFile.create({ userId: 'u1', fileName, type: KnowledgeType.TEXT, status: 'complete', ...extra });
+
+/**
+ * The #2583 detection primitives: which files DECLARE vectorized chunks, and which of those have
+ * any chunk rows at all. Pairing the two finds a file whose count is stale - vectorizedChunkCount
+ * counts chunks that are no longer there.
+ */
+describe('stale vector claim detection (#2583)', () => {
+  setupMongoTest();
+
+  it('findFileIdsWithPositiveVectorizedCount selects only files with a positive count', async () => {
+    const vectorized = await makeFile('vectorized.txt', { chunkCount: 2, vectorizedChunkCount: 2 });
+    await makeFile('never-vectorized.txt', { chunkCount: 2, vectorizedChunkCount: 0 });
+    await makeFile('image.txt', {});
+
+    const page = await fabFileRepository.findFileIdsWithPositiveVectorizedCount();
+    expect(page).toEqual([{ id: String(vectorized._id), fileName: 'vectorized.txt' }]);
+  });
+
+  it('findFabFileIdsWithChunks returns exactly the candidate ids that have a chunk row', async () => {
+    await FabFileChunk.create({ fabFileId: 'has-chunks', text: 't', tokenCount: 1 });
+
+    const withChunks = await fabFileChunkRepository.findFabFileIdsWithChunks(['has-chunks', 'chunkless']);
+    expect(withChunks).toEqual(new Set(['has-chunks']));
+    expect(await fabFileChunkRepository.findFabFileIdsWithChunks([])).toEqual(new Set());
+  });
+
+  it('together, flag a file that declares vectorized chunks it does not have', async () => {
+    // Healthy: real chunks back the count.
+    const healthy = await makeFile('healthy.txt', { chunkCount: 1, vectorizedChunkCount: 1 });
+    await FabFileChunk.create({ fabFileId: String(healthy._id), text: 't', tokenCount: 1, vector: [0.1] });
+
+    // Stranded (#2583's mechanism): the count survived a chunk delete that the file row did not.
+    const stranded = await makeFile('stranded.txt', { chunkCount: 3, vectorizedChunkCount: 3 });
+
+    const candidates = await fabFileRepository.findFileIdsWithPositiveVectorizedCount();
+    const withChunks = await fabFileChunkRepository.findFabFileIdsWithChunks(candidates.map(c => c.id));
+    const stale = candidates.filter(c => !withChunks.has(c.id));
+
+    expect(stale).toEqual([{ id: String(stranded._id), fileName: 'stranded.txt' }]);
+  });
+});

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -277,6 +277,17 @@ export class FabFileChunkRepository extends BaseRepository<IFabFileChunkDocument
     return rows.map(r => r._id);
   }
 
+  async findFabFileIdsWithChunks(fabFileIds: string[]): Promise<Set<string>> {
+    if (fabFileIds.length === 0) return new Set();
+    // Same shape as findUnderChunkedFabFileIds: $match on the id set, $group to distinct fabFileId,
+    // both served by the { fabFileId: 1, _id: 1 } index. No chunk content is read.
+    const rows = await this.fabFileChunkModel.aggregate<{ _id: string }>([
+      { $match: { fabFileId: { $in: fabFileIds } } },
+      { $group: { _id: '$fabFileId' } },
+    ]);
+    return new Set(rows.map(r => r._id));
+  }
+
   /**
    * The file's vectorize rollup, computed in ONE pass over its chunks (the fetch is unavoidable -
    * `vector` is in no index - so it must not be paid twice per batch):
@@ -1909,6 +1920,28 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
       .limit(limit)
       .lean();
     return docs.map(d => String(d._id));
+  }
+
+  /**
+   * One page of file ids that DECLARE vectorized chunks (`vectorizedChunkCount > 0`), ascending by
+   * `_id` for cursor paging - the #2583 detection sweep's candidate list. Pair with
+   * `fabFileChunkRepository.findFabFileIdsWithChunks` to find which of these have zero chunk rows
+   * behind that count.
+   */
+  async findFileIdsWithPositiveVectorizedCount(
+    options: { limit?: number; afterFileId?: string } = {}
+  ): Promise<{ id: string; fileName?: string }[]> {
+    const { limit = 500, afterFileId } = options;
+    const docs = await this.fabFileModel
+      .find({
+        vectorizedChunkCount: { $gt: 0 },
+        ...(afterFileId ? { _id: { $gt: afterFileId } } : {}),
+      })
+      .select({ _id: 1, fileName: 1 })
+      .sort({ _id: 1 })
+      .limit(limit)
+      .lean();
+    return docs.map(d => ({ id: String(d._id), fileName: d.fileName }));
   }
 
   /** Stamp all four recomputed chunk-derived rollups together - the health backfill's phase-2 write. */

--- a/packages/scripts/datalake/check-stale-vector-claims.ts
+++ b/packages/scripts/datalake/check-stale-vector-claims.ts
@@ -4,9 +4,9 @@
  * ZERO rows in fabfilechunks. Such a file is unretrievable by both read paths (the ANN index has
  * nothing for it, the brute-force scan finds no vectors to score) while every counter-based health
  * surface reads it as vectorized - a stale count left behind by an interrupted chunk/file delete
- * (see purgeDataLakeDocument.ts, cleanupDeletedDataLake.ts, ingestHelpDatalake.ts, all fixed to
- * order the two writes the other way as of this issue, so this should only ever report pre-existing
- * damage going forward).
+ * (see purgeDataLakeDocument.ts, cleanupDeletedDataLake.ts, ingestHelpDatalake.ts and
+ * retrieval/supersession-probe.ts, all fixed to order the two writes the other way as of this issue,
+ * so this should only ever report pre-existing damage going forward).
  *
  * Deliberately NOT wired into GET /api/data-lakes/:id/health (computeLakeHealth.ts): that endpoint
  * is read-gated for any lake reader and is documented to NEVER scan the chunk collection (#1665 -
@@ -29,6 +29,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { Resource } from 'sst';
 import { connectDB, fabFileChunkRepository, fabFileRepository } from '@bike4mind/database';
+import { collectStaleVectorClaims } from './collectStaleVectorClaims';
 
 interface Options {
   batchSize: number;
@@ -39,24 +40,16 @@ async function main(opts: Options): Promise<number> {
   await connectDB(dbUri);
   console.log(`Connected (stage: ${Resource.App.stage}).`);
 
-  let afterFileId: string | undefined;
-  let scanned = 0;
-  const stale: { id: string; fileName?: string }[] = [];
-
-  for (;;) {
-    const page = await fabFileRepository.findFileIdsWithPositiveVectorizedCount({
-      limit: opts.batchSize,
-      afterFileId,
-    });
-    if (page.length === 0) break;
-    afterFileId = page[page.length - 1].id;
-    scanned += page.length;
-
-    const withChunks = await fabFileChunkRepository.findFabFileIdsWithChunks(page.map(f => f.id));
-    for (const file of page) {
-      if (!withChunks.has(file.id)) stale.push(file);
-    }
-  }
+  // The sweep itself lives in collectStaleVectorClaims.ts so it can be tested without a DB; this
+  // file stays the connection, the argv and the reporting.
+  const { scanned, stale } = await collectStaleVectorClaims(
+    {
+      findFileIdsWithPositiveVectorizedCount: options =>
+        fabFileRepository.findFileIdsWithPositiveVectorizedCount(options),
+      findFabFileIdsWithChunks: ids => fabFileChunkRepository.findFabFileIdsWithChunks(ids),
+    },
+    { batchSize: opts.batchSize }
+  );
 
   console.log(`Scanned ${scanned} file(s) declaring a vectorized chunk count.`);
   if (stale.length === 0) {

--- a/packages/scripts/datalake/check-stale-vector-claims.ts
+++ b/packages/scripts/datalake/check-stale-vector-claims.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env tsx
+/**
+ * Report-only detection sweep for #2583: a file whose `vectorizedChunkCount > 0` but which has
+ * ZERO rows in fabfilechunks. Such a file is unretrievable by both read paths (the ANN index has
+ * nothing for it, the brute-force scan finds no vectors to score) while every counter-based health
+ * surface reads it as vectorized - a stale count left behind by an interrupted chunk/file delete
+ * (see purgeDataLakeDocument.ts, cleanupDeletedDataLake.ts, ingestHelpDatalake.ts, all fixed to
+ * order the two writes the other way as of this issue, so this should only ever report pre-existing
+ * damage going forward).
+ *
+ * Deliberately NOT wired into GET /api/data-lakes/:id/health (computeLakeHealth.ts): that endpoint
+ * is read-gated for any lake reader and is documented to NEVER scan the chunk collection (#1665 -
+ * one staging file alone carries 13k+ chunks). The check here is cheap PER CANDIDATE (an
+ * index-covered $group on `{fabFileId:1,_id:1}`, no chunk content read), but it is still a chunk-
+ * collection read over however many files declare a positive count - fine for an operator-run,
+ * bounded, one-off sweep; not something every page load should pay for. Same posture as
+ * detectLakeInconsistencies, which is also owner/operator-triggered for the same reason.
+ *
+ * Standalone script rather than a queue/migration: bounded, one-time detection over existing data,
+ * not an ongoing pipeline stage. Report-only - repairing the flagged population (re-vectorize the
+ * ones still in a lake, `resetChunkStateByIds` the rest) is deliberately out of scope here.
+ *
+ * Usage (needs DB, provided by `sst shell`):
+ *   npx sst shell --stage dev        -- tsx packages/scripts/datalake/check-stale-vector-claims.ts
+ *   npx sst shell --stage production -- tsx packages/scripts/datalake/check-stale-vector-claims.ts
+ */
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { Resource } from 'sst';
+import { connectDB, fabFileChunkRepository, fabFileRepository } from '@bike4mind/database';
+
+interface Options {
+  batchSize: number;
+}
+
+async function main(opts: Options): Promise<number> {
+  const dbUri = Resource.MONGODB_URI.value.replace('%STAGE%', Resource.App.stage);
+  await connectDB(dbUri);
+  console.log(`Connected (stage: ${Resource.App.stage}).`);
+
+  let afterFileId: string | undefined;
+  let scanned = 0;
+  const stale: { id: string; fileName?: string }[] = [];
+
+  for (;;) {
+    const page = await fabFileRepository.findFileIdsWithPositiveVectorizedCount({
+      limit: opts.batchSize,
+      afterFileId,
+    });
+    if (page.length === 0) break;
+    afterFileId = page[page.length - 1].id;
+    scanned += page.length;
+
+    const withChunks = await fabFileChunkRepository.findFabFileIdsWithChunks(page.map(f => f.id));
+    for (const file of page) {
+      if (!withChunks.has(file.id)) stale.push(file);
+    }
+  }
+
+  console.log(`Scanned ${scanned} file(s) declaring a vectorized chunk count.`);
+  if (stale.length === 0) {
+    console.log('None are stale: every declared count has at least one chunk row behind it.');
+    return 0;
+  }
+
+  console.log(`Found ${stale.length} file(s) declaring vectorized chunks they do not have:`);
+  for (const file of stale) {
+    console.log(`  id=${file.id} fileName=${JSON.stringify(file.fileName ?? '')}`);
+  }
+  console.log(
+    '\nThese are unretrievable by both read paths but read as vectorized by every counter-based ' +
+      'health surface. Repair is a separate, deliberate follow-up - see #2583.'
+  );
+  return 1;
+}
+
+const argv = yargs(hideBin(process.argv))
+  .option('batch-size', { type: 'number', default: 2_000, describe: 'Candidate files read per page' })
+  .parseSync();
+
+main({ batchSize: argv['batch-size'] })
+  .then(code => process.exit(code))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/scripts/datalake/collectStaleVectorClaims.test.ts
+++ b/packages/scripts/datalake/collectStaleVectorClaims.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { collectStaleVectorClaims, type StaleVectorClaimCandidate } from './collectStaleVectorClaims';
+
+/**
+ * Fakes the two repository primitives (proven separately against real Mongo in
+ * FabFileModel.staleVectorClaims.test.ts) so the sweep's own paging and pairing are testable
+ * without a DB - the part `check-stale-vector-claims` would otherwise only exercise in production.
+ */
+const makeDeps = (files: { id: string; fileName?: string; hasChunks: boolean }[]) => {
+  const candidates: StaleVectorClaimCandidate[] = files.map(({ id, fileName }) => ({ id, fileName }));
+  return {
+    findFileIdsWithPositiveVectorizedCount: vi.fn(
+      async ({ limit = 500, afterFileId }: { limit?: number; afterFileId?: string }) => {
+        const start = afterFileId ? candidates.findIndex(c => c.id === afterFileId) + 1 : 0;
+        return candidates.slice(start, start + limit);
+      }
+    ),
+    findFabFileIdsWithChunks: vi.fn(
+      async (ids: string[]) => new Set(ids.filter(id => files.find(f => f.id === id)?.hasChunks))
+    ),
+  };
+};
+
+describe('collectStaleVectorClaims (#2583)', () => {
+  it('flags only the candidates with no chunk row behind their declared count', async () => {
+    const deps = makeDeps([
+      { id: 'f1', fileName: 'healthy.txt', hasChunks: true },
+      { id: 'f2', fileName: 'stranded.txt', hasChunks: false },
+      { id: 'f3', fileName: 'also-healthy.txt', hasChunks: true },
+    ]);
+
+    const report = await collectStaleVectorClaims(deps, { batchSize: 10 });
+
+    expect(report.scanned).toBe(3);
+    expect(report.stale).toEqual([{ id: 'f2', fileName: 'stranded.txt' }]);
+  });
+
+  it('pages with afterFileId until the candidate list is exhausted', async () => {
+    const files = Array.from({ length: 5 }, (_, i) => ({ id: `f${i}`, hasChunks: i % 2 === 0 }));
+    const deps = makeDeps(files);
+
+    const report = await collectStaleVectorClaims(deps, { batchSize: 2 });
+
+    // Three pages of 2/2/1, then the empty page that ends the loop. Every id seen exactly once:
+    // a cursor that failed to advance would spin here rather than return.
+    expect(deps.findFileIdsWithPositiveVectorizedCount).toHaveBeenCalledTimes(4);
+    expect(deps.findFileIdsWithPositiveVectorizedCount.mock.calls.map(([opts]) => opts.afterFileId)).toEqual([
+      undefined,
+      'f1',
+      'f3',
+      'f4',
+    ]);
+    expect(report.scanned).toBe(5);
+    expect(report.stale.map(f => f.id)).toEqual(['f1', 'f3']);
+  });
+
+  it('reports nothing and reads no chunks when no file declares a vectorized count', async () => {
+    const deps = makeDeps([]);
+
+    const report = await collectStaleVectorClaims(deps, { batchSize: 100 });
+
+    expect(report).toEqual({ scanned: 0, stale: [] });
+    expect(deps.findFabFileIdsWithChunks).not.toHaveBeenCalled();
+  });
+});

--- a/packages/scripts/datalake/collectStaleVectorClaims.ts
+++ b/packages/scripts/datalake/collectStaleVectorClaims.ts
@@ -1,0 +1,52 @@
+/**
+ * The pairing behind `check-stale-vector-claims` (#2583), split out from the script so it is
+ * testable without a live DB: the script owns the connection, the argv and the reporting, this owns
+ * the sweep. A file is stale when it DECLARES vectorized chunks (`vectorizedChunkCount > 0`) but has
+ * zero rows in fabfilechunks - unretrievable by both read paths while every counter-based health
+ * surface reads it as vectorized.
+ */
+
+export interface StaleVectorClaimCandidate {
+  id: string;
+  fileName?: string;
+}
+
+export interface StaleVectorClaimDeps {
+  /** Page of files declaring a positive count, ordered by id, strictly after `afterFileId`. */
+  findFileIdsWithPositiveVectorizedCount(options: {
+    limit?: number;
+    afterFileId?: string;
+  }): Promise<StaleVectorClaimCandidate[]>;
+  /** The subset of `fabFileIds` that have at least one chunk row. */
+  findFabFileIdsWithChunks(fabFileIds: string[]): Promise<Set<string>>;
+}
+
+export interface StaleVectorClaimReport {
+  scanned: number;
+  stale: StaleVectorClaimCandidate[];
+}
+
+export async function collectStaleVectorClaims(
+  deps: StaleVectorClaimDeps,
+  { batchSize }: { batchSize: number }
+): Promise<StaleVectorClaimReport> {
+  let afterFileId: string | undefined;
+  let scanned = 0;
+  const stale: StaleVectorClaimCandidate[] = [];
+
+  for (;;) {
+    const page = await deps.findFileIdsWithPositiveVectorizedCount({ limit: batchSize, afterFileId });
+    if (page.length === 0) break;
+    // The ONLY thing advancing the loop: the sole exit is an empty page, so a cursor that fails to
+    // move past the last id of the page re-reads it forever. Pinned by the pagination test.
+    afterFileId = page[page.length - 1].id;
+    scanned += page.length;
+
+    const withChunks = await deps.findFabFileIdsWithChunks(page.map(file => file.id));
+    for (const file of page) {
+      if (!withChunks.has(file.id)) stale.push(file);
+    }
+  }
+
+  return { scanned, stale };
+}

--- a/packages/scripts/help/__tests__/ingestHelpDatalake.test.ts
+++ b/packages/scripts/help/__tests__/ingestHelpDatalake.test.ts
@@ -188,6 +188,55 @@ describe('ingestHelpDatalake', () => {
     expect(h.chunks.every(c => h.files.some(f => f.id === c.fabFileId))).toBe(true);
   });
 
+  it('deletes the file row before its chunks, so an interruption orphans chunks rather than stranding a file (#2583)', async () => {
+    writeCorpus([makeEntry('features/opti'), makeEntry('features/optihashi')], {
+      'features/opti': '## Old\n\nconsolidated away\n',
+      'features/optihashi': '## New\n\nthe survivor\n',
+    });
+    const h = makeHarness();
+    await ingestHelpDatalake(h.deps, opts());
+
+    const order: string[] = [];
+    h.deps.db.fabFiles.deleteManyInIds = vi.fn(async (ids: string[]) => {
+      order.push('files');
+      for (const id of ids) {
+        const i = h.files.findIndex(f => f.id === id);
+        if (i >= 0) h.files.splice(i, 1);
+      }
+    });
+    h.deps.db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
+      order.push('chunks');
+    });
+
+    writeCorpus([makeEntry('features/optihashi')], {});
+    await ingestHelpDatalake(h.deps, opts());
+
+    // The file goes first (#2583): an interruption between the two steps must strand only
+    // orphaned chunks - unreachable without their file, and already a tracked, separately
+    // cleanable class (#2539) - never a file reporting a stale vectorizedChunkCount over chunks
+    // that no longer exist.
+    expect(order).toEqual(['files', 'chunks']);
+  });
+
+  it('leaves the withdrawn member already gone, not stranded with a stale chunk count, when the chunk delete is interrupted (#2583)', async () => {
+    writeCorpus([makeEntry('features/opti'), makeEntry('features/optihashi')], {
+      'features/opti': '## Old\n\nconsolidated away\n',
+      'features/optihashi': '## New\n\nthe survivor\n',
+    });
+    const h = makeHarness();
+    await ingestHelpDatalake(h.deps, opts());
+    const removedId = h.files.find(f => f.tags.some(t => t.name === 'help:features/opti'))?.id;
+
+    h.deps.db.fabFileChunks.deleteManyByFabFileId = vi.fn(async () => {
+      throw new Error('simulated crash');
+    });
+
+    writeCorpus([makeEntry('features/optihashi')], {});
+    await expect(ingestHelpDatalake(h.deps, opts())).rejects.toThrow('simulated crash');
+
+    expect(h.files.some(f => f.id === removedId)).toBe(false);
+  });
+
   it('re-creates every member when the deployment embedding model changed', async () => {
     writeCorpus([makeEntry('features/a')], { 'features/a': '## One\n\nalpha\n' });
     const h = makeHarness();

--- a/packages/scripts/help/__tests__/ingestHelpDatalake.test.ts
+++ b/packages/scripts/help/__tests__/ingestHelpDatalake.test.ts
@@ -212,9 +212,10 @@ describe('ingestHelpDatalake', () => {
     await ingestHelpDatalake(h.deps, opts());
 
     // The file goes first (#2583): an interruption between the two steps must strand only
-    // orphaned chunks - unreachable without their file, and already a tracked, separately
-    // cleanable class (#2539) - never a file reporting a stale vectorizedChunkCount over chunks
-    // that no longer exist.
+    // orphaned chunks - unreachable without their file, costing storage rather than recall -
+    // never a file reporting a stale vectorizedChunkCount over chunks that no longer exist. Note
+    // `deleteManyInIds` tombstones the row rather than removing it; see the site comment for what
+    // that costs the retry story.
     expect(order).toEqual(['files', 'chunks']);
   });
 

--- a/packages/scripts/help/ingestHelpDatalake.ts
+++ b/packages/scripts/help/ingestHelpDatalake.ts
@@ -369,8 +369,16 @@ export async function ingestHelpDatalake(
       // No self-host OpenSearch mirror needed here: both drivers run against an SST-deployed
       // stage, which never sets B4M_SELF_HOST - so selfHostOpenSearchEnabled() can never be
       // true on a path that reaches this line.
-      for (const id of removeIds) await deps.db.fabFileChunks.deleteManyByFabFileId(id);
+      //
+      // Files go first, chunks after (#2583). This cron has no redelivery on a mid-run failure -
+      // it runs directly in a Lambda, not behind a queue - so it is the least protected of the
+      // sites this ordering matters for. Chunks-then-files used to leave an interruption between
+      // the two steps stranding a FILE with a stale vectorizedChunkCount over zero real chunks -
+      // unretrievable, but every counter-based health surface reported it vectorized. This order
+      // fails the other, harmless way: an interruption here only orphans chunk rows, unreachable
+      // without their file and already a tracked, separately cleanable class (#2539).
       await deps.db.fabFiles.deleteManyInIds(removeIds);
+      for (const id of removeIds) await deps.db.fabFileChunks.deleteManyByFabFileId(id);
     }
   }
 

--- a/packages/scripts/help/ingestHelpDatalake.ts
+++ b/packages/scripts/help/ingestHelpDatalake.ts
@@ -374,9 +374,20 @@ export async function ingestHelpDatalake(
       // it runs directly in a Lambda, not behind a queue - so it is the least protected of the
       // sites this ordering matters for. Chunks-then-files used to leave an interruption between
       // the two steps stranding a FILE with a stale vectorizedChunkCount over zero real chunks -
-      // unretrievable, but every counter-based health surface reported it vectorized. This order
-      // fails the other, harmless way: an interruption here only orphans chunk rows, unreachable
-      // without their file and already a tracked, separately cleanable class (#2539).
+      // unretrievable, but every counter-based health surface reported it vectorized.
+      //
+      // `deleteManyInIds` is a SOFT delete (unlike `hardDeleteByIds`, it does not pass
+      // `{ hardDelete: true }`, so the row is tombstoned with `deletedAt`, not removed). That is
+      // deliberate and unchanged here, and it is enough to fix the symptom: a tombstoned row is
+      // filtered out of every read path, so it can no longer report itself vectorized. But it does
+      // change what an interruption costs, and the trade is worth stating plainly. Under
+      // chunks-then-files an interruption was self-healing - the live row re-entered `removable` on
+      // the next run and was re-swept. Under this order the tombstone is final: the next run's
+      // candidate list is plugin-filtered, so the row never re-enters `removable` and its chunks
+      // are never revisited. Those orphans are unreachable without their file and cost storage
+      // rather than recall, and nothing sweeps them today (#2539 is a different population - chunks
+      // whose `fabFileId` is a serialized document, which a cleaner for it would match instead).
+      // A permanently harmless remnant beats a self-healing but actively wrong one.
       await deps.db.fabFiles.deleteManyInIds(removeIds);
       for (const id of removeIds) await deps.db.fabFileChunks.deleteManyByFabFileId(id);
     }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -25,6 +25,7 @@
     "datalake:check-prefix-only-members": "tsx migrate/check-datalake-prefix-only-members.ts",
     "datalake:ingest-pdfs": "tsx datalake/ingest-pdf-datalake.ts",
     "datalake:check-stranded-drive-connections": "tsx datalake/check-stranded-drive-connections.ts",
+    "datalake:check-stale-vector-claims": "tsx datalake/check-stale-vector-claims.ts",
     "datalake:seed-stranded-member": "tsx datalake/seed-stranded-lake-member.ts",
     "db:create-user": "tsx createUser.ts",
     "db:list-users": "tsx listUsers.ts",

--- a/packages/scripts/retrieval/supersession-probe.ts
+++ b/packages/scripts/retrieval/supersession-probe.ts
@@ -364,15 +364,24 @@ async function clearPreviousRun(): Promise<void> {
   const existingIds = await fabFileRepository.findIdsByDataLakeTag({ kind: 'registry', datalakeTag: DATALAKE_TAG });
   if (existingIds.length === 0) return;
   logger.log(`Removing ${existingIds.length} FabFile(s) from a previous run...`);
-  for (const id of existingIds) await fabFileChunkRepository.deleteManyByFabFileId(id);
-  // hardDeleteByIds, NOT deleteManyInIds: `FabFileSchema` carries the soft-delete plugin, whose
+  // Each row goes first and its own chunks immediately after (#2583), the same ordering as the
+  // three production sites. Chunks-then-rows left an interruption between the two stranding a ROW
+  // with a stale vectorizedChunkCount over zero real chunks - unretrievable while every
+  // counter-based health surface reads it as vectorized, which on this probe's own lake is
+  // precisely the corruption it would then go on to measure. Paired per id rather than bulk so an
+  // interrupted clear leaves the ids it has not reached still named by `findIdsByDataLakeTag`.
+  //
+  // hardDelete, NOT deleteManyInIds: `FabFileSchema` carries the soft-delete plugin, whose
   // `deleteMany` override only stamps `deletedAt`, while `findIdsByDataLakeTag` above reads with
   // `includeDeleted`. A soft delete therefore leaves every prior run's rows in that id list forever,
   // so the count logged above becomes an all-time total rather than this clear's work and the probe
   // lake accumulates tombstones on a shared stage. The measurement itself was never at risk - chunks
   // are hard-deleted and the search's scoped-file read is plugin-filtered, so a stale generation has
   // no chunks and is out of scope - but the log line was wrong and the growth was unbounded.
-  await fabFileRepository.hardDeleteByIds(existingIds);
+  for (const id of existingIds) {
+    await fabFileRepository.hardDeleteOneById(id);
+    await fabFileChunkRepository.deleteManyByFabFileId(id);
+  }
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Refs #2583.

Deliberately a reference and not a closing link: this PR implements items 1 and 3 of that issue's four. Items 2 (repair the ~1,028 already-stranded files, including the 62 of 113 system-help documents currently unretrievable) and 4 (queue-ify the help ingest) are still open work, and #2583 is the only place their analysis is written down. Retiring it on merge would take that record with it.

1,028 files (including 62/113 system-help documents) declare `vectorizedChunkCount > 0` in Mongo but have zero rows in `fabfilechunks` - unretrievable by both the ANN index and the brute-force scan, while every counter-based health surface reports them as healthy/vectorized. Root cause: four code paths (three production, one developer probe) deleted `FabFileChunk` rows before deleting/updating the owning `FabFile` row, non-atomically, so a crash/interruption between the two steps stranded a file with a stale count and zero real chunks.

This PR covers items 1 and 3 of the issue's suggested work: invert the delete order at all four sites, and add a detection sweep backed by the derived-rollup pattern from #1666. Repairing the already-stranded files and queue-ifying the help-ingest cron are separate follow-ups, deliberately out of scope here.

## Changes

- Inverted delete order (file row before chunks) at the four affected sites:
  - `dataLakeService/purgeDataLakeDocument.ts` (interactive permanent delete)
  - `dataLakeService/cleanupDeletedDataLake.ts` (queue-driven lake purge)
  - `scripts/help/ingestHelpDatalake.ts` (help-corpus ingest cron)
  - `scripts/retrieval/supersession-probe.ts` (developer probe's own prior-run cleanup)
- In `cleanupDeletedDataLake.ts` the row and chunk deletes are **paired per file id** inside one fan-out, rather than a bulk row delete followed by a separate chunk sweep. `fileIds` is derived from the rows themselves, so deleting them all first would leave a DLQ retry re-resolving an empty list and skipping the chunk sweep for the whole lake. Paired, the ids a dead run never reached are still resolvable on replay, which is what the function's own retry-safety docstring promises.
- Fixed two failure modes the reorder introduced in `purgeDataLakeDocument.ts`:
  - An interruption after the row delete but before the chunk delete used to throw uncaught and skip the owner's storage-quota refund with no retry path left. That step now falls through to the existing `verified:false` receipt instead of swallowing the refund.
  - `shredDocumentMemory` is now gated on `documentDeleted` rather than `verified`. Gated on `verified`, a transient chunk-delete failure left the row permanently gone with the document's extracted beliefs never shredded and no retry able to reach it (a re-POST 404s once the row no longer resolves) - the document would keep speaking through those beliefs forever.
- The session unlink in `purgeDataLakeDocument.ts` now has its own `try` and folds its outcome into `verified`. Nothing in the read-back re-reads sessions, so a failed unlink previously filed a `verified: true` receipt over chats still holding the dead id in `knowledgeIds`.
- Added two bounded, index-covered repository methods (`findFileIdsWithPositiveVectorizedCount`, `findFabFileIdsWithChunks`) and a new report-only script, `datalake:check-stale-vector-claims`, that sweeps files declaring vectorized chunks and cross-references actual chunk existence. Deliberately not wired into the live `GET /health` endpoint, which has a hard, tested invariant against scanning the chunk collection at request time. The sweep itself lives in `collectStaleVectorClaims.ts` so its paging and pairing are testable without a DB.
- Tests: order-assertion + interruption-safety tests at all three production sites (one new suite, `cleanupDeletedDataLake.test.ts`, had none before), a real-Mongo suite for the two new repository methods including cursor paging, and unit coverage for the detection sweep.

## Guide for Testers

This is a backend/data-integrity fix with no new UI surface. Verification is via API and script, not a page.

1. In a data lake, upload a file and let it finish vectorizing (`chunked: true`, `vectorized: true`).
2. Call `POST /api/data-lakes/:id/files/:fabFileId/purge` (permanent delete) for that file.
   - Expected: 200 response, receipt has `documentDeleted: true`, `chunksRemaining: 0`, `verified: true`.
3. Run `pnpm datalake:check-stale-vector-claims` (needs `sst shell` for a DB connection) against the same environment.
   - Expected: exits 0, reports "None are stale" for a healthy corpus (or lists only pre-existing stranded files, none newly introduced by a purge run through this PR).

**Regression watch:** delete a whole data lake (permanent delete, which runs the queue-driven `cleanupDeletedDataLake` sweep) with several vectorized files in it, and confirm the lake, its files, its batches and its chunks are all gone afterwards - the file sweep was restructured from a bulk row delete into a paired per-id fan-out.

**What NOT to test:** no UI changed. The repair of the ~1,028 already-stranded files and any change to the help-ingest cron's delivery guarantees are out of scope for this PR.

## Additional Information

Verified: `pnpm turbo:typecheck` (all affected packages), targeted test suites for every changed/new file, lint clean on the diff, ASCII/smart-punctuation guards clean on the diff vs `main`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI change
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A
