### PR TITLE
chore(ci): install bubblewrap so the bot-review agent can start

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -244,7 +244,18 @@ jobs:
           # above: with the scrub on, the Claude CLI requires bwrap and its installer
           # aborts without it. The runner image does not ship bubblewrap, so dropping
           # this step silently reds every review with "Failed to install Claude Code".
-          sudo apt-get update
+          # Retried because one mirror timeout here would red the review just as hard
+          # as the install failure this step exists to prevent.
+          for attempt in 1 2 3; do
+            if sudo apt-get update; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::apt-get update failed after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
           sudo apt-get install -y bubblewrap
 
       - name: Run /bot-review

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -237,6 +237,16 @@ jobs:
           # second early so a review posted in the same second still compares >=.
           echo "at=$(date -u -d '1 second ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      - name: Install bubblewrap
+        if: steps.size_check.outputs.skip == 'false' && steps.substantive.outputs.skip == 'false'
+        run: |
+          # Must stay in sync with CLAUDE_CODE_SUBPROCESS_ENV_SCRUB in the job env
+          # above: with the scrub on, the Claude CLI requires bwrap and its installer
+          # aborts without it. The runner image does not ship bubblewrap, so dropping
+          # this step silently reds every review with "Failed to install Claude Code".
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+
       - name: Run /bot-review
         id: bot_review
         if: steps.size_check.outputs.skip == 'false' && steps.substantive.outputs.skip == 'false'


### PR DESCRIPTION
## Description

`pr-bot-review` has failed on every labelled run since #2409 landed on `main` at 05:26 UTC today. The reviewer agent never starts, so PRs get a red `review` check and no review at all.

#2409 added `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: '1'` to the job env - deliberate hardening that strips the Anthropic key and the runner's Actions credentials from every subprocess env. That setting makes the Claude CLI require `bubblewrap` for subprocess isolation, and the GitHub-hosted runner image (`ubuntu24/20260831.293`) does not ship it. The installer aborts, retries three times, and the step dies:

```
error: bubblewrap is required for subprocess env scrubbing and isolation.
Install with: sudo apt-get install -y bubblewrap, set sandbox.bwrapPath in
managed settings, or set CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0 to disable
(loses subprocess isolation).
Action failed with error: Failed to install Claude Code after 3 attempts
```

The `Report incomplete review` step then reds the job on purpose. That part is working as designed - it exists so a run that posts no review cannot pass as green.

This installs `bubblewrap` rather than setting the scrub to `0`, so the isolation #2409 added is kept.

Worth knowing: this broke PRs that do not contain #2409 themselves. `pull_request` workflows execute from the PR's merge ref (head merged with base), so the new job env applied to every open PR the moment #2409 landed on `main`.

### Affected PRs

Seven failed runs across three PRs so far, every one of them left with a red `review` check and no review:

| PR | Failed runs (UTC) | State |
|---|---|---|
| #2629 | 3 - 09:55, 10:06, 10:10 | open, still red |
| #2628 | 3 - 07:41, 08:15, 08:38 | open, still red |
| #2486 | 1 - 07:13 | merged since |

Any PR labelled `bot-review` from now on hits the same thing until this lands.

## Changes

- `.github/workflows/pr-bot-review.yml`: added an `Install bubblewrap` step immediately before `Run /bot-review`, carrying the same `size_check` / `substantive` skip guard so it costs nothing on runs where the review is skipped.

## Guide for Testers

CI-only change. There is nothing to exercise in the application.

1. Open any PR against `main` whose branch includes this commit, or merge this first and then use any open PR - the merge ref picks it up automatically.
2. Add the `bot-review` label to that PR.
3. Go to the PR's Checks tab and open the `review` job.
4. Expected: a new `Install bubblewrap` step appears immediately before `Run /bot-review` and completes in a few seconds.
5. Expected: `Run /bot-review` no longer logs `Failed to install Claude Code after 3 attempts`. The step gets past install and into the review itself.
6. Expected: within a few minutes the bot posts a single review on the PR, and the `review` check turns green.

### Regression Checks

7. Apply `bot-review` to a PR whose diff trips the size guard (over 100 changed files). Expected: the run skips exactly as before, and the new `Install bubblewrap` step is skipped too, because it carries the same guard. No added runtime on skipped runs.
8. Push a changeset-only commit to an already-reviewed PR, then re-apply `bot-review`. Expected: the substantive-change guard still skips the re-review, unchanged.
9. Confirm the fail-loud path still works: `Verify a review was actually posted` and `Report incomplete review` are untouched, so a run that posts nothing must still red the job.

### What NOT to test

- No application behaviour changes. Do not open the app, request a preview, or test any UI.
- Do not test on a fork PR. The job is same-repo-only by design, because fork PRs get no secrets.

## Additional Information

**Evidence.** Every run whose effective workflow carried the scrub env failed with this error, and every run before it passed.

The decisive case is #2486: head `9920501ea` passed four times between 06:45 and 07:11 UTC. The next push, `d81727239` - a `Merge branch 'main'` that pulled in #2409 - failed at 07:13 with the bubblewrap error. Nothing else about that branch or the workflow changed between those two runs.

**Verification status.** The YAML parses, and the new step is confirmed to sit immediately before `Run /bot-review` with an `if` guard byte-identical to the action's. The fix is **not** verified end to end yet - that needs a labelled run. Adding `bot-review` to this PR self-tests it, since the merge ref includes this change.

**Alternative considered.** Setting `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: '0'` also unblocks the workflow, but it discards exactly what #2409 set out to add, so it is not the right trade. One caveat on the chosen fix: if `vars.RUNNER_LABEL` ever points at a self-hosted pool, the new step needs passwordless sudo there.

**Title type.** Deliberately `chore(ci)`, not `fix(ci)`: this ships no runtime code, and a `fix` title would drive a spurious patch version bump through auto-changeset.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A
