### PR TITLE
fix(ci): queue the duplicate preview-gate run instead of cancelling it

### DIFF
--- a/.github/workflows/sst-infra-preview-gate.yml
+++ b/.github/workflows/sst-infra-preview-gate.yml
@@ -21,12 +21,16 @@ on:
 
 # A label swap - one label removed and another added in the same instant - emits
 # `unlabeled` and `labeled` together, which starts two identical runs on the same SHA.
-# Collapsing per PR keeps the survivor, which is the one that reports; the cancelled
-# twin would have reached the same verdict. Keyed off the PR number because a
-# merge_group event carries none, and a constant key would let one PR cancel another.
+# Keyed per PR so they serialize, and on the PR specifically because a constant key
+# would let one PR cancel another.
+#
+# NOT cancel-in-progress. Cancelling the twin saves the minutes but leaves a CANCELLED
+# check run behind, and as a required check GitHub can read that as the current verdict
+# - blocking a PR whose real verdict was a pass. Queueing costs one extra short run and
+# both report the truth.
 concurrency:
   group: preview-gate-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/packages/scripts/src/checkPreviewGateConcurrency.test.ts
+++ b/packages/scripts/src/checkPreviewGateConcurrency.test.ts
@@ -39,9 +39,11 @@ describe('preview gate duplicate-run collapse', () => {
   const src = fs.readFileSync(GATE, 'utf8');
   const block = concurrencyBlock(src);
 
-  it('declares a top-level concurrency group that cancels the superseded run', () => {
+  it('declares a top-level concurrency group that serializes rather than cancels', () => {
     expect(block).not.toBe('');
-    expect(block).toMatch(/^ {2}cancel-in-progress: true$/m);
+    // Cancelling leaves a CANCELLED check run that a required gate can read as the
+    // current verdict, blocking a PR whose real verdict was a pass.
+    expect(block).toMatch(/^ {2}cancel-in-progress: false$/m);
   });
 
   it('keys the group on the PR, so one PR can never cancel another', () => {


### PR DESCRIPTION
## What

Flips the preview gate's concurrency from `cancel-in-progress: true` to `false`. Follow-up to the concurrency group added in 2644 - this commit was pushed to that branch after it had already merged, so it never landed.

## Why

Cancelling the duplicate run that a label swap starts does save the runner minutes, but it leaves a `CANCELLED` check run behind. Testing the same change on a sibling repo running this gate showed the cancelled twin sitting as the *latest* `preview gate` entry in the PR's check rollup. As a required check, GitHub can read that as the current verdict and block a PR whose real verdict was a pass - which is a worse outcome than the duplicate run it was meant to prevent.

Queueing costs one extra short run and both report the truth. It also matches the convention already used on the deploy workflows in the deployer repo, where `cancel-in-progress: false` keeps a deploy from being killed mid-apply.

## Tests

The existing assertion in `packages/scripts/src/checkPreviewGateConcurrency.test.ts` is updated to require `false`, so a revert to `true` fails the suite rather than passing quietly.
