### PR TITLE
fix(api): gate edit-image and generate-video on ai:generate scope

### DIFF
--- a/apps/client/pages/api/ai/__tests__/edit-image.integration.test.ts
+++ b/apps/client/pages/api/ai/__tests__/edit-image.integration.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+/**
+ * Integration test for POST /api/ai/edit-image scope enforcement.
+ *
+ * Mirrors generate-image.integration.test.ts: drives the real next-connect chain
+ * `baseApi` assembles to prove the `baseApi({ requiredScopes: [AI_GENERATE] })`
+ * wiring reaches `apiKeyAuth` - a key lacking `ai:generate` is rejected 403 before
+ * the handler runs (and before any billable edit is enqueued); a key holding it,
+ * and JWT callers, pass through. Guards a billable + access-control surface against
+ * an accidental future removal of `requiredScopes`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { createMocks } from 'node-mocks-http';
+
+const { mockValidate, mockUserFindById, mockRateLimit, mockInvoke } = vi.hoisted(() => ({
+  mockValidate: vi.fn(),
+  mockUserFindById: vi.fn(),
+  mockRateLimit: vi.fn(),
+  mockInvoke: vi.fn(),
+}));
+
+const RATE_LIMIT_HEADERS = {
+  'X-RateLimit-Limit-Minute': '60',
+  'X-RateLimit-Remaining-Minute': '59',
+  'X-RateLimit-Reset-Minute': '0',
+  'X-RateLimit-Limit-Day': '1000',
+  'X-RateLimit-Remaining-Day': '999',
+  'X-RateLimit-Reset-Day': '0',
+};
+
+vi.mock('@server/utils/apiKeyRateLimitCheck', async orig => ({
+  // Keep the real (pure) extractApiKeyFromHeaders - apiKeyAuth imports it; only
+  // checkApiKeyRateLimit is stubbed.
+  ...(await orig<Record<string, unknown>>()),
+  checkApiKeyRateLimit: (...a: unknown[]) => mockRateLimit(...a),
+}));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('@bike4mind/services', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  return {
+    ...actual,
+    userApiKeyService: {
+      ...(actual.userApiKeyService as object),
+      validateUserApiKey: (...a: unknown[]) => mockValidate(...a),
+    },
+  };
+});
+
+vi.mock('@bike4mind/database', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  const RealUser = actual.User as Record<string, unknown>;
+  return {
+    ...actual,
+    connectDB: vi.fn().mockResolvedValue(undefined),
+    User: Object.assign(Object.create(RealUser), { findById: (...a: unknown[]) => mockUserFindById(...a) }),
+  };
+});
+
+vi.mock('@server/queueHandlers/imageEdit', () => ({
+  getImageEdit: () => ({ invoke: (...a: unknown[]) => mockInvoke(...a) }),
+}));
+
+const JWT_USER = { id: 'jwt-user', _id: 'jwt-user', isBanned: false, disputePending: false };
+vi.mock('@server/auth/auth', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  return {
+    ...actual,
+    // any: node-mocks-http req/res aren't structurally the Express types this seam is typed for.
+    auth: (req: any, _res: any, next: any) => {
+      if (!req.user) req.user = JWT_USER;
+      next();
+    },
+  };
+});
+
+import handler from '../edit-image';
+import { ApiKeyScope } from '@bike4mind/common';
+
+const VALID_KEY = 'sk-test-valid-key';
+
+function fire({ apiKey = VALID_KEY as string | null }: { apiKey?: string | null } = {}) {
+  const { req, res } = createMocks(
+    {
+      method: 'POST',
+      url: '/api/ai/edit-image',
+      body: { prompt: 'make the sky bluer' },
+      headers: { ...(apiKey ? { 'x-api-key': apiKey } : {}) },
+    },
+    { eventEmitter: EventEmitter }
+  );
+  // any: node-mocks-http mocks aren't structurally the Express Request/Response types.
+  return { req: req as any, res: res as any };
+}
+
+function validateWithScopes(scopes: ApiKeyScope[] | string[]) {
+  mockValidate.mockResolvedValue({
+    isValid: true,
+    keyId: 'k1',
+    userId: 'user-1',
+    scopes,
+    rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
+  });
+}
+
+describe('POST /api/ai/edit-image (integration - ai:generate scope enforcement)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindById.mockResolvedValue({ id: 'user-1', _id: 'user-1', isBanned: false, disputePending: false });
+    mockRateLimit.mockResolvedValue({ allowed: true, retryAfter: undefined, headers: RATE_LIMIT_HEADERS });
+    mockInvoke.mockResolvedValue({ id: 'quest-1', status: 'pending' });
+  });
+
+  it('rejects a key lacking ai:generate (403) before enqueuing the edit', async () => {
+    validateWithScopes([ApiKeyScope.READ_FILES]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error).toMatch(/insufficient/i);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('accepts a key with ai:generate (200) and enqueues the edit', async () => {
+    validateWithScopes([ApiKeyScope.AI_GENERATE]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({ id: 'quest-1' });
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves JWT/browser callers unaffected (200, no api key)', async () => {
+    const { req, res } = fire({ apiKey: null });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/ai/__tests__/generate-video.integration.test.ts
+++ b/apps/client/pages/api/ai/__tests__/generate-video.integration.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+/**
+ * Integration test for POST /api/ai/generate-video scope enforcement.
+ *
+ * Mirrors generate-image.integration.test.ts: drives the real next-connect chain
+ * `baseApi` assembles to prove the `baseApi({ requiredScopes: [AI_GENERATE] })`
+ * wiring reaches `apiKeyAuth` - a key lacking `ai:generate` is rejected 403 before
+ * the handler runs (and before any billable generation is enqueued); a key holding
+ * it, and JWT callers, pass through. Guards a billable + access-control surface
+ * against an accidental future removal of `requiredScopes`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { createMocks } from 'node-mocks-http';
+
+const { mockValidate, mockUserFindById, mockRateLimit, mockGetOrCreateSession, mockInvoke } = vi.hoisted(() => ({
+  mockValidate: vi.fn(),
+  mockUserFindById: vi.fn(),
+  mockRateLimit: vi.fn(),
+  mockGetOrCreateSession: vi.fn(),
+  mockInvoke: vi.fn(),
+}));
+
+const RATE_LIMIT_HEADERS = {
+  'X-RateLimit-Limit-Minute': '60',
+  'X-RateLimit-Remaining-Minute': '59',
+  'X-RateLimit-Reset-Minute': '0',
+  'X-RateLimit-Limit-Day': '1000',
+  'X-RateLimit-Remaining-Day': '999',
+  'X-RateLimit-Reset-Day': '0',
+};
+
+vi.mock('@server/utils/apiKeyRateLimitCheck', async orig => ({
+  // Keep the real (pure) extractApiKeyFromHeaders - apiKeyAuth imports it; only
+  // checkApiKeyRateLimit is stubbed.
+  ...(await orig<Record<string, unknown>>()),
+  checkApiKeyRateLimit: (...a: unknown[]) => mockRateLimit(...a),
+}));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('@bike4mind/services', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  return {
+    ...actual,
+    userApiKeyService: {
+      ...(actual.userApiKeyService as object),
+      validateUserApiKey: (...a: unknown[]) => mockValidate(...a),
+    },
+  };
+});
+
+vi.mock('@bike4mind/database', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  const RealUser = actual.User as Record<string, unknown>;
+  return {
+    ...actual,
+    connectDB: vi.fn().mockResolvedValue(undefined),
+    User: Object.assign(Object.create(RealUser), { findById: (...a: unknown[]) => mockUserFindById(...a) }),
+  };
+});
+
+vi.mock('@server/managers/sessionManager', () => ({
+  getOrCreateSession: (...a: unknown[]) => mockGetOrCreateSession(...a),
+}));
+
+vi.mock('@server/queueHandlers/videoGeneration', () => ({
+  getVideoGeneration: () => ({ invoke: (...a: unknown[]) => mockInvoke(...a) }),
+}));
+
+const JWT_USER = { id: 'jwt-user', _id: 'jwt-user', isBanned: false, disputePending: false };
+vi.mock('@server/auth/auth', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  return {
+    ...actual,
+    // any: node-mocks-http req/res aren't structurally the Express types this seam is typed for.
+    auth: (req: any, _res: any, next: any) => {
+      if (!req.user) req.user = JWT_USER;
+      next();
+    },
+  };
+});
+
+import handler from '../generate-video';
+import { ApiKeyScope } from '@bike4mind/common';
+
+const VALID_KEY = 'sk-test-valid-key';
+
+function fire({ apiKey = VALID_KEY as string | null }: { apiKey?: string | null } = {}) {
+  const { req, res } = createMocks(
+    {
+      method: 'POST',
+      url: '/api/ai/generate-video',
+      body: { prompt: 'a red bicycle riding through a forest' },
+      headers: { ...(apiKey ? { 'x-api-key': apiKey } : {}) },
+    },
+    { eventEmitter: EventEmitter }
+  );
+  // any: node-mocks-http mocks aren't structurally the Express Request/Response types.
+  return { req: req as any, res: res as any };
+}
+
+function validateWithScopes(scopes: ApiKeyScope[] | string[]) {
+  mockValidate.mockResolvedValue({
+    isValid: true,
+    keyId: 'k1',
+    userId: 'user-1',
+    scopes,
+    rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
+  });
+}
+
+describe('POST /api/ai/generate-video (integration - ai:generate scope enforcement)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindById.mockResolvedValue({ id: 'user-1', _id: 'user-1', isBanned: false, disputePending: false });
+    mockRateLimit.mockResolvedValue({ allowed: true, retryAfter: undefined, headers: RATE_LIMIT_HEADERS });
+    mockGetOrCreateSession.mockResolvedValue({ sessionId: 'sess-1', asyncPromises: [], session: { id: 'sess-1' } });
+    mockInvoke.mockResolvedValue({ id: 'quest-1', status: 'pending' });
+  });
+
+  it('rejects a key lacking ai:generate (403) before enqueuing generation', async () => {
+    validateWithScopes([ApiKeyScope.READ_FILES]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error).toMatch(/insufficient/i);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('accepts a key with ai:generate (200) and enqueues generation', async () => {
+    validateWithScopes([ApiKeyScope.AI_GENERATE]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({ quest: { id: 'quest-1' } });
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves JWT/browser callers unaffected (200, no api key)', async () => {
+    const { req, res } = fire({ apiKey: null });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/ai/edit-image.ts
+++ b/apps/client/pages/api/ai/edit-image.ts
@@ -1,7 +1,11 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { getImageEdit } from '@server/queueHandlers/imageEdit';
+import { ApiKeyScope } from '@bike4mind/common';
 
-const handler = baseApi().post(async (req, res) => {
+// Gate API-key callers on `ai:generate` so this billable action is auditable, mirroring
+// generate-image.ts. Scope checks apply only to API-key requests; browser/JWT sessions fall
+// through untouched (see apiKeyAuth).
+const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(async (req, res) => {
   // Include organizationId from request body or fall back to user's organization
   const effectiveOrgId =
     req.body.organizationId !== undefined ? req.body.organizationId : (req.user.organizationId?.toString() ?? null);

--- a/apps/client/pages/api/ai/generate-video.ts
+++ b/apps/client/pages/api/ai/generate-video.ts
@@ -2,7 +2,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { getVideoGeneration } from '@server/queueHandlers/videoGeneration';
 import { Request } from 'express';
 import { z } from 'zod';
-import { GenerateVideoRequestBodySchema, GenerateVideoInvokeParams } from '@bike4mind/common';
+import { GenerateVideoRequestBodySchema, GenerateVideoInvokeParams, ApiKeyScope } from '@bike4mind/common';
 import { getOrCreateSession } from '@server/managers/sessionManager';
 import { resolveBillingOrgId } from '@server/utils/orgAccess';
 
@@ -10,7 +10,10 @@ type GenerateVideoRequestBody = z.infer<typeof GenerateVideoRequestBodySchema>;
 
 type GenerateVideoRequest = Request<unknown, unknown, GenerateVideoRequestBody>;
 
-const handler = baseApi().post(async (req: GenerateVideoRequest, res) => {
+// Gate API-key callers on `ai:generate` so this billable action is auditable, mirroring
+// generate-image.ts. Scope checks apply only to API-key requests; browser/JWT sessions fall
+// through untouched (see apiKeyAuth).
+const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(async (req: GenerateVideoRequest, res) => {
   req.logger.updateMetadata({
     userId: req.user?.id,
     userEmail: req.user?.email,


### PR DESCRIPTION
## What

Add the `ai:generate` (`ApiKeyScope.AI_GENERATE`) API-key scope gate to two public
AI routes that were missing it:

- `POST /api/ai/edit-image`
- `POST /api/ai/generate-video`

Both are billable generation surfaces. Their sibling `POST /api/ai/generate-image`
already carries this gate; these two were overlooked, so an API key **without**
`ai:generate` could still drive image edits and video generation.

The change is the same one-line `baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] })`
wrapper used by `generate-image.ts`. Scope checks apply only to API-key callers
(via `apiKeyAuth`); JWT/browser sessions are unaffected.

## Why

Least-privilege: a key scoped only for reads (or any scope short of `ai:generate`)
should not be able to enqueue billable image-edit or video-generation work. This
closes that gap and makes the billable action auditable by scope.

## Guide for Testers

Preview stage required (API-key auth can't be exercised in local dev).

1. Mint two API keys: one **with** `ai:generate`, one **without** (e.g. read-only).
2. `POST /api/ai/edit-image` and `POST /api/ai/generate-video` with each key:
   - key **without** `ai:generate` -> **403** (`insufficient` scope), no quest enqueued.
   - key **with** `ai:generate` -> **200**, quest enqueued as before.
3. Drive both routes from the browser app (JWT session) -> unchanged, still **200**.

## Regression Checks

- `POST /api/ai/generate-image` still behaves identically (its gate is untouched).
- Existing browser/JWT flows for edit-image and generate-video are unaffected.
- The async POST -> poll `GET /api/quests/{id}` flow is unchanged; the poll
  endpoint already accepts `ai:generate`.

## What NOT to test

- Other AI routes (chat, TTS, transcription, etc.) - out of scope; this PR only
  touches the two image/video generation routes that mirror `generate-image`.

## Verification

- `pnpm --filter @bike4mind/client test` for the two new integration tests:
  each asserts 403-before-enqueue for an under-scoped key, 200 + enqueue for a
  scoped key, and 200 for JWT/no-key callers (mirrors the generate-image test).
- Typecheck + lint green.

## Checklist

- [x] Scope gate added to both routes, mirroring `generate-image.ts`
- [x] Integration test per route (co-located under `pages/api/ai/__tests__/`)
- [x] JWT/browser callers verified unaffected by test
- [ ] Preview-stage QA with a real under-scoped key (needs deployed preview)
