### PR TITLE
test(client): cover incidental route-like method calls

### DIFF
--- a/apps/client/server/__tests__/dataLakeApiKeyScopeCoverage.test.ts
+++ b/apps/client/server/__tests__/dataLakeApiKeyScopeCoverage.test.ts
@@ -130,8 +130,8 @@ describe('methodBlocks splitter', () => {
     const source = [
       'const handler = baseApi({ requiredScopes: DATA_LAKE_READ_SCOPES })',
       '  .post(async (req, res) => {',
-      '    assertDataLakeWriteScope(req);',
       '    const x = userById.get(id);',
+      '    assertDataLakeWriteScope(req);',
       '  });',
     ].join('\n');
     const blocks = methodBlocks(source);


### PR DESCRIPTION
## Description

Closes #2627.

This stacked follow-up to #2595 moves the incidental `Map.get()` call before the write-scope assertion in the source-scanner fixture. The regression now proves that the scanner ignores the incidental call and keeps the assertion in the real `.post` block. Same-line `baseApi(...).get/post` detection remains covered by the prerequisite matcher.

## Verification

- [x] Focused Node-project test: pass, 1 file / 48 tests
- [x] Client typecheck: pass
- [x] Repository typecheck: pass, 40/40 tasks
- [x] Lint: pass
- [ ] Full client suite: inconclusive; the review runner timed out before a summary
- [ ] Full repository test gate: unrelated integration failures in Mongo/client suites remain documented in the build report

## Review notes

- Approved with 0 P0 and 0 P1 findings.
- One optional P3 scanner limitation remains for expression-valued incidental receivers such as `getMap().get()`; it is outside this regression and is not addressed here.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
