### PR TITLE
fix(admin): confirm before discarding unsaved Admin -> Users card edits

### DIFF
--- a/apps/client/app/components/admin/Users/Views/FullUserViewModal.test.tsx
+++ b/apps/client/app/components/admin/Users/Views/FullUserViewModal.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { useConfirmationModal } from '@client/app/hooks/useConfirmation';
+import type { ReactNode } from 'react';
+import FullUserViewModal, { useFullUserViewModal } from './FullUserViewModal';
+
+vi.mock('@client/app/hooks/data/user', () => ({
+  useGetUser: (id: string | null) => ({ isLoading: false, data: id ? { id, name: 'Test User' } : undefined }),
+}));
+
+// The card under test here is the modal's close guard, not the card itself; the stub
+// stands in for an admin staging an edit inside it.
+vi.mock('@client/app/components/admin/Users/Views/FullUsersView', () => ({
+  FullUsersView: ({ onUnsavedFieldsChange }: { onUnsavedFieldsChange?: (fieldKeys: string[]) => void }) => (
+    <>
+      <button data-testid="stub-stage-edits" onClick={() => onUnsavedFieldsChange?.(['tags', 'currentCredits'])}>
+        stage edits
+      </button>
+      <button data-testid="stub-clear-edits" onClick={() => onUnsavedFieldsChange?.([])}>
+        clear edits
+      </button>
+    </>
+  ),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const renderOpenModal = () => {
+  act(() => useFullUserViewModal.setState({ userId: 'u1' }));
+  return render(<FullUserViewModal />, { wrapper: TestWrapper });
+};
+
+describe('FullUserViewModal - discard guard', () => {
+  beforeEach(() => {
+    act(() => {
+      useFullUserViewModal.setState({ userId: null });
+      useConfirmationModal.setState({ open: false, title: undefined, description: undefined });
+    });
+  });
+
+  it('closes straight away when nothing is staged', () => {
+    renderOpenModal();
+    fireEvent.click(screen.getByTestId('modal-close-btn'));
+
+    expect(useFullUserViewModal.getState().userId).toBeNull();
+    expect(useConfirmationModal.getState().open).toBe(false);
+  });
+
+  it('asks before discarding, and names every unsaved field', () => {
+    renderOpenModal();
+    fireEvent.click(screen.getByTestId('stub-stage-edits'));
+    fireEvent.click(screen.getByTestId('modal-close-btn'));
+
+    const confirmation = useConfirmationModal.getState();
+    expect(confirmation.open).toBe(true);
+    expect(confirmation.title).toBe('Discard changes?');
+    expect(confirmation.description).toContain('Tags and product access, Credits');
+    expect(confirmation.okLabel).toBe('Discard changes');
+    expect(confirmation.cancelLabel).toBe('Keep editing');
+    // Still open: the edits are only lost once the admin confirms.
+    expect(useFullUserViewModal.getState().userId).toBe('u1');
+  });
+
+  it('closes once the discard is confirmed', async () => {
+    renderOpenModal();
+    fireEvent.click(screen.getByTestId('stub-stage-edits'));
+    fireEvent.click(screen.getByTestId('modal-close-btn'));
+
+    await act(async () => {
+      await useConfirmationModal.getState().onOk();
+    });
+
+    expect(useFullUserViewModal.getState().userId).toBeNull();
+  });
+
+  it('stops guarding once the card reports the edits are gone', () => {
+    renderOpenModal();
+    fireEvent.click(screen.getByTestId('stub-stage-edits'));
+    // A save clears the card's staged state, which it reports straight back up.
+    fireEvent.click(screen.getByTestId('stub-clear-edits'));
+    fireEvent.click(screen.getByTestId('modal-close-btn'));
+
+    expect(useConfirmationModal.getState().open).toBe(false);
+    expect(useFullUserViewModal.getState().userId).toBeNull();
+  });
+});

--- a/apps/client/app/components/admin/Users/Views/FullUserViewModal.tsx
+++ b/apps/client/app/components/admin/Users/Views/FullUserViewModal.tsx
@@ -1,6 +1,9 @@
 import { FullUsersView } from '@client/app/components/admin/Users/Views/FullUsersView';
+import { unsavedFieldLabels } from '@client/app/components/admin/Users/unsavedFieldLabels';
 import { useGetUser } from '@client/app/hooks/data/user';
+import { useConfirmation } from '@client/app/hooks/useConfirmation';
 import { LinearProgress, Modal, ModalClose, ModalDialog } from '@mui/joy';
+import { useState } from 'react';
 import { create } from 'zustand';
 
 export const useFullUserViewModal = create<{
@@ -14,11 +17,35 @@ export const useFullUserViewModal = create<{
 const FullUserViewModal = () => {
   const userId = useFullUserViewModal(state => state.userId);
   const setUserId = useFullUserViewModal(state => state.setUserId);
+  const confirm = useConfirmation();
+  // Field keys, not labels: the card owns what changed, this owns how to say it.
+  const [unsavedFields, setUnsavedFields] = useState<string[]>([]);
 
   const user = useGetUser(userId);
 
+  /**
+   * The card stages every edit locally and sends them only on Update, so closing
+   * this modal silently throws away anything staged - which cost a tester a
+   * debugging round when a Custom Tags grant looked applied and was not (#2441).
+   * Name what would be lost rather than just asking "are you sure".
+   */
+  const handleRequestClose = () => {
+    if (unsavedFields.length === 0) {
+      setUserId(null);
+      return;
+    }
+    confirm({
+      type: 'danger',
+      title: 'Discard changes?',
+      description: `These edits have not been saved: ${unsavedFieldLabels(unsavedFields).join(', ')}. Closing this window discards them. Use Update to save instead.`,
+      okLabel: 'Discard changes',
+      cancelLabel: 'Keep editing',
+      onOk: () => setUserId(null),
+    });
+  };
+
   return (
-    <Modal open={!!userId} onClose={() => setUserId(null)}>
+    <Modal open={!!userId} onClose={handleRequestClose}>
       <ModalDialog
         data-testid="full-user-view-modal"
         sx={{
@@ -38,7 +65,7 @@ const FullUserViewModal = () => {
         {user.isLoading ? (
           <LinearProgress />
         ) : user.data ? (
-          <FullUsersView index={0} user={user.data} inModal />
+          <FullUsersView index={0} user={user.data} inModal onUnsavedFieldsChange={setUnsavedFields} />
         ) : (
           <p>User not found</p>
         )}

--- a/apps/client/app/components/admin/Users/Views/FullUsersView.test.tsx
+++ b/apps/client/app/components/admin/Users/Views/FullUsersView.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
+import type { ReactNode } from 'react';
+import { FullUsersView } from './FullUsersView';
+
+// Only the Roles column is exercised here (it owns the Custom Tags control that #2441 is
+// about), so the card's other sections are stubbed to keep their data hooks out of it.
+vi.mock('../../AdminProfile', () => ({ default: () => null }));
+vi.mock('../Details/Bike4MindUserDetails', () => ({ default: () => null }));
+vi.mock('../Details/LoginDetails', () => ({ default: () => null }));
+vi.mock('../Details/UserDetails', () => ({ default: () => null }));
+vi.mock('../Details/UserSubscriptionStatus', () => ({ default: () => null }));
+vi.mock('../SpicyUserActions', () => ({ default: () => null }));
+vi.mock('../ProductAccess', () => ({ default: () => null }));
+vi.mock('../SystemMessageModal', () => ({ default: () => null }));
+vi.mock('@client/app/components/help/ContextHelpButton', () => ({ default: () => null }));
+vi.mock('../ComplianceModal', () => ({ useComplianceModal: () => vi.fn() }));
+vi.mock('@client/app/components/admin/Users/Views/FullUserViewModal', () => ({
+  useFullUserViewModal: () => vi.fn(),
+}));
+vi.mock('@client/app/hooks/data/user', () => ({
+  useDeleteUser: () => ({ mutate: vi.fn() }),
+  useUpdateUser: () => ({ mutate: vi.fn(), isPending: false }),
+  useLoginAsUser: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: (selector: (state: { currentUser: { id: string }; setCurrentUser: () => void }) => unknown) =>
+    selector({ currentUser: { id: 'admin-1' }, setCurrentUser: () => {} }),
+}));
+vi.mock('@client/app/contexts/AdminSettingsContext', () => ({
+  useAdminSettings: () => ({ settings: {} }),
+}));
+vi.mock('@client/app/contexts/ApiContext', () => ({ api: { get: vi.fn() } }));
+vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const savedUser = () =>
+  ({
+    id: 'u1',
+    name: 'Ada',
+    username: 'ada',
+    email: 'ada@example.com',
+    isAdmin: false,
+    tags: ['research'],
+    level: 'DemoUser',
+  }) as AdminUserListItem;
+
+const addCustomTag = (tag: string) => {
+  fireEvent.change(screen.getByPlaceholderText('Input a custom tag'), { target: { value: tag } });
+  fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+};
+
+describe('FullUsersView - unsaved field reporting', () => {
+  it('reports nothing unsaved on a freshly opened card', () => {
+    const onUnsavedFieldsChange = vi.fn();
+    render(<FullUsersView index={0} user={savedUser()} inModal onUnsavedFieldsChange={onUnsavedFieldsChange} />, {
+      wrapper: TestWrapper,
+    });
+    expect(onUnsavedFieldsChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('reports tags as unsaved once a Custom Tag is staged through the real control', () => {
+    const onUnsavedFieldsChange = vi.fn();
+    render(<FullUsersView index={0} user={savedUser()} inModal onUnsavedFieldsChange={onUnsavedFieldsChange} />, {
+      wrapper: TestWrapper,
+    });
+
+    addCustomTag('qa-unsaved-test');
+
+    expect(screen.getByTestId('remove-tag-qa-unsaved-test')).toBeInTheDocument();
+    expect(onUnsavedFieldsChange).toHaveBeenLastCalledWith(['tags']);
+  });
+
+  it('goes back to reporting nothing when that tag is removed again', () => {
+    const onUnsavedFieldsChange = vi.fn();
+    render(<FullUsersView index={0} user={savedUser()} inModal onUnsavedFieldsChange={onUnsavedFieldsChange} />, {
+      wrapper: TestWrapper,
+    });
+
+    addCustomTag('qa-unsaved-test');
+    fireEvent.click(screen.getByTestId('remove-tag-qa-unsaved-test'));
+
+    expect(onUnsavedFieldsChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('does not re-notify when an edit leaves the same field set unsaved', () => {
+    const onUnsavedFieldsChange = vi.fn();
+    render(<FullUsersView index={0} user={savedUser()} inModal onUnsavedFieldsChange={onUnsavedFieldsChange} />, {
+      wrapper: TestWrapper,
+    });
+
+    addCustomTag('first-tag');
+    const callsAfterFirstTag = onUnsavedFieldsChange.mock.calls.length;
+    addCustomTag('second-tag');
+
+    // Still just 'tags' unsaved, so the host has nothing new to hear about.
+    expect(onUnsavedFieldsChange.mock.calls.length).toBe(callsAfterFirstTag);
+  });
+
+  it('stops reporting an edit once a fresh server snapshot arrives', () => {
+    const onUnsavedFieldsChange = vi.fn();
+    const { rerender } = render(
+      <FullUsersView index={0} user={savedUser()} inModal onUnsavedFieldsChange={onUnsavedFieldsChange} />,
+      { wrapper: TestWrapper }
+    );
+
+    addCustomTag('qa-unsaved-test');
+    expect(onUnsavedFieldsChange).toHaveBeenLastCalledWith(['tags']);
+
+    // What Verify Email does: it saves through its own mutation and then syncs the card,
+    // so the refetched user lands here and the staged values are replaced wholesale.
+    rerender(
+      <FullUsersView
+        index={0}
+        user={{ ...savedUser(), emailVerified: true }}
+        inModal
+        onUnsavedFieldsChange={onUnsavedFieldsChange}
+      />
+    );
+
+    expect(onUnsavedFieldsChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('reports the card as clean when it unmounts, so the host stops guarding', () => {
+    const onUnsavedFieldsChange = vi.fn();
+    const { unmount } = render(
+      <FullUsersView index={0} user={savedUser()} inModal onUnsavedFieldsChange={onUnsavedFieldsChange} />,
+      { wrapper: TestWrapper }
+    );
+
+    addCustomTag('qa-unsaved-test');
+    expect(onUnsavedFieldsChange).toHaveBeenLastCalledWith(['tags']);
+
+    unmount();
+    expect(onUnsavedFieldsChange).toHaveBeenLastCalledWith([]);
+  });
+});

--- a/apps/client/app/components/admin/Users/Views/FullUsersView.tsx
+++ b/apps/client/app/components/admin/Users/Views/FullUsersView.tsx
@@ -50,11 +50,19 @@ import { api } from '@client/app/contexts/ApiContext';
 import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
 import { useNavigate } from '@tanstack/react-router';
 import { useAdminSettings } from '@client/app/contexts/AdminSettingsContext';
+import { unsavedFieldKeys } from '../unsavedFieldLabels';
+import { stageFieldEdit } from '../stageFieldEdit';
 
 interface UsersViewProps {
   user: AdminUserListItem;
   index: number;
   inModal?: boolean;
+  /**
+   * Reports which fields are staged-but-unsaved, so a host that can navigate away
+   * from the card (FullUserViewModal) can warn before the edits are lost. Must be
+   * referentially stable - it is an effect dependency.
+   */
+  onUnsavedFieldsChange?: (fieldKeys: string[]) => void;
 }
 
 // Keyed by IUserDocument, not the narrower list-projection row: admins edit fields the
@@ -64,7 +72,7 @@ export type EditedFieldsState = {
   [key in keyof Partial<IUserDocument>]: boolean;
 };
 
-export const FullUsersView: React.FC<UsersViewProps> = ({ user, index, inModal }) => {
+export const FullUsersView: React.FC<UsersViewProps> = ({ user, index, inModal, onUnsavedFieldsChange }) => {
   const deleteUser = useDeleteUser();
   const updateUser = useUpdateUser();
   const loginAsUser = useLoginAsUser();
@@ -96,9 +104,17 @@ export const FullUsersView: React.FC<UsersViewProps> = ({ user, index, inModal }
     setCreditReason('');
   }, [user]);
 
+  useEffect(() => {
+    if (!onUnsavedFieldsChange) return;
+    onUnsavedFieldsChange(unsavedFieldKeys(editedFields));
+    // Unmounting means the card is gone and so are its staged edits, so the host
+    // must not keep guarding against them.
+    return () => onUnsavedFieldsChange([]);
+  }, [editedFields, onUnsavedFieldsChange]);
+
   const handleFormFieldChange = (key: keyof IUserDocument, value: unknown) => {
     setFormState(prev => ({ ...prev, [key]: value }));
-    setEditedFields(prev => ({ ...prev, [key]: true }));
+    setEditedFields(prev => stageFieldEdit(prev, key, value, user));
   };
 
   const handleDeleteUser = async (userId: string) => {

--- a/apps/client/app/components/admin/Users/Views/FullUsersView.tsx
+++ b/apps/client/app/components/admin/Users/Views/FullUsersView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Card,
   Chip,
@@ -59,8 +59,8 @@ interface UsersViewProps {
   inModal?: boolean;
   /**
    * Reports which fields are staged-but-unsaved, so a host that can navigate away
-   * from the card (FullUserViewModal) can warn before the edits are lost. Must be
-   * referentially stable - it is an effect dependency.
+   * from the card (FullUserViewModal) can warn before the edits are lost. Called only
+   * when the set of unsaved fields actually changes, and safe to pass inline.
    */
   onUnsavedFieldsChange?: (fieldKeys: string[]) => void;
 }
@@ -102,15 +102,32 @@ export const FullUsersView: React.FC<UsersViewProps> = ({ user, index, inModal, 
     setFormState({ ...user });
     setTempUserLevel(user.level);
     setCreditReason('');
+    // The staged values are being replaced by this snapshot, so the flags that described
+    // them have to go too. Without this they survive an action that already saved (Verify
+    // Email writes through its own mutation, then syncs the card via onFieldChange) and
+    // the card keeps claiming an unsaved edit that no longer exists.
+    setEditedFields({});
   }, [user]);
 
+  // Latest-callback ref: keeps the report effect off the callback's identity, so a caller
+  // passing an inline arrow cannot turn it into a re-render loop.
+  const reportUnsavedFields = useRef(onUnsavedFieldsChange);
   useEffect(() => {
-    if (!onUnsavedFieldsChange) return;
-    onUnsavedFieldsChange(unsavedFieldKeys(editedFields));
-    // Unmounting means the card is gone and so are its staged edits, so the host
-    // must not keep guarding against them.
-    return () => onUnsavedFieldsChange([]);
-  }, [editedFields, onUnsavedFieldsChange]);
+    reportUnsavedFields.current = onUnsavedFieldsChange;
+  });
+
+  // Keyed on a signature rather than the array, so a keystroke that leaves the same set of
+  // fields unsaved does not re-notify the host. Field keys are identifiers, so no key can
+  // contain the separator.
+  const unsavedSignature = unsavedFieldKeys(editedFields).join('|');
+  const unsavedKeys = useMemo(() => (unsavedSignature ? unsavedSignature.split('|') : []), [unsavedSignature]);
+
+  useEffect(() => {
+    // Runs whenever that set changes, and on unmount - the case that motivates the reset:
+    // the card is gone, so its staged edits are too, and the host must stop guarding them.
+    reportUnsavedFields.current?.(unsavedKeys);
+    return () => reportUnsavedFields.current?.([]);
+  }, [unsavedKeys]);
 
   const handleFormFieldChange = (key: keyof IUserDocument, value: unknown) => {
     setFormState(prev => ({ ...prev, [key]: value }));

--- a/apps/client/app/components/admin/Users/stageFieldEdit.test.ts
+++ b/apps/client/app/components/admin/Users/stageFieldEdit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
+import { stageFieldEdit } from './stageFieldEdit';
+
+const savedUser = (overrides: Partial<AdminUserListItem> = {}) =>
+  ({
+    id: 'u1',
+    name: 'Ada',
+    isAdmin: false,
+    tags: ['research', 'beta'],
+    currentCredits: 100,
+    ...overrides,
+  }) as AdminUserListItem;
+
+describe('stageFieldEdit', () => {
+  it('marks a field that differs from the saved value', () => {
+    expect(stageFieldEdit({}, 'name', 'Grace', savedUser())).toEqual({ name: true });
+  });
+
+  it('clears the mark when the value is put back by hand', () => {
+    const edited = stageFieldEdit({}, 'name', 'Grace', savedUser());
+    expect(stageFieldEdit(edited, 'name', 'Ada', savedUser())).toEqual({ name: false });
+  });
+
+  it('clears the mark when a tag is added and then removed again', () => {
+    const saved = savedUser();
+    const added = stageFieldEdit({}, 'tags', ['research', 'beta', 'opti'], saved);
+    expect(added).toEqual({ tags: true });
+    expect(stageFieldEdit(added, 'tags', ['research', 'beta'], saved)).toEqual({ tags: false });
+  });
+
+  it('compares tag lists by content, not identity', () => {
+    expect(stageFieldEdit({}, 'tags', ['research', 'beta'], savedUser())).toEqual({ tags: false });
+  });
+
+  it('treats null and undefined as the same unset value', () => {
+    expect(stageFieldEdit({}, 'emailVerifiedAt', null, savedUser())).toEqual({ emailVerifiedAt: false });
+  });
+
+  it('marks a date field that gained a value', () => {
+    expect(stageFieldEdit({}, 'emailVerifiedAt', new Date('2026-01-01'), savedUser())).toEqual({
+      emailVerifiedAt: true,
+    });
+  });
+
+  it('compares dates by value rather than by reference', () => {
+    const saved = savedUser({ subscribedUntil: new Date('2026-01-01') } as Partial<AdminUserListItem>);
+    expect(stageFieldEdit({}, 'subscribedUntil', new Date('2026-01-01'), saved)).toEqual({
+      subscribedUntil: false,
+    });
+  });
+
+  it('leaves the marks on other fields alone', () => {
+    const edited = stageFieldEdit({}, 'name', 'Grace', savedUser());
+    expect(stageFieldEdit(edited, 'currentCredits', 250, savedUser())).toEqual({
+      name: true,
+      currentCredits: true,
+    });
+  });
+});

--- a/apps/client/app/components/admin/Users/stageFieldEdit.ts
+++ b/apps/client/app/components/admin/Users/stageFieldEdit.ts
@@ -1,0 +1,33 @@
+import { isEqual } from 'lodash';
+import type { IUserDocument } from '@bike4mind/common';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
+import type { EditedFieldsState } from '@client/app/components/admin/Users/Views/FullUsersView';
+
+/**
+ * Whether a staged value still matches what the server gave us. `null` and
+ * `undefined` both mean "unset" on these fields, so they compare equal - otherwise
+ * clearing a field that was never set would read as an edit.
+ *
+ * Known conservative case: the subscription date input hands back a 'YYYY-MM-DD'
+ * string while the server sends a full timestamp, so retyping the original date
+ * still reads as edited. Over-reporting is the safe direction here.
+ */
+const matchesSavedValue = (staged: unknown, saved: unknown): boolean =>
+  (staged == null && saved == null) || isEqual(staged, saved);
+
+/**
+ * Records a field edit as "differs from what is saved" rather than "was touched".
+ * Typing into a field and undoing it, or adding a tag and removing it again, leaves
+ * nothing to save - so it must not light up the card or warn on the way out.
+ */
+export const stageFieldEdit = (
+  editedFields: EditedFieldsState,
+  key: keyof IUserDocument,
+  value: unknown,
+  savedUser: AdminUserListItem
+): EditedFieldsState => ({
+  ...editedFields,
+  // savedUser is the list projection, which is narrower than the fields admins edit
+  // (e.g. emailVerifiedAt), so index it structurally.
+  [key]: !matchesSavedValue(value, (savedUser as Record<string, unknown>)[key]),
+});

--- a/apps/client/app/components/admin/Users/unsavedFieldLabels.test.ts
+++ b/apps/client/app/components/admin/Users/unsavedFieldLabels.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { unsavedFieldKeys, unsavedFieldLabels } from './unsavedFieldLabels';
+
+describe('unsavedFieldKeys', () => {
+  it('returns only the fields actually marked as edited', () => {
+    expect(unsavedFieldKeys({})).toEqual([]);
+    expect(unsavedFieldKeys({ tags: false })).toEqual([]);
+    expect(unsavedFieldKeys({ tags: true, name: false })).toEqual(['tags']);
+  });
+});
+
+describe('unsavedFieldLabels', () => {
+  it('names the tags field, the one the Custom Tags Add button stages', () => {
+    expect(unsavedFieldLabels(['tags'])).toEqual(['Tags and product access']);
+  });
+
+  it('collapses fields that always move together into one label', () => {
+    expect(unsavedFieldLabels(['emailVerified', 'emailVerifiedAt'])).toEqual(['Email verification']);
+  });
+
+  it('lists multiple fields in a stable order regardless of edit order', () => {
+    expect(unsavedFieldLabels(['currentCredits', 'name'])).toEqual(['Name', 'Credits']);
+    expect(unsavedFieldLabels(['name', 'currentCredits'])).toEqual(['Name', 'Credits']);
+  });
+
+  it('falls back to a prettified key for a field with no label mapping', () => {
+    expect(unsavedFieldLabels(['stripeCustomerId'])).toEqual(['Stripe Customer Id']);
+  });
+
+  it('returns nothing for no keys', () => {
+    expect(unsavedFieldLabels([])).toEqual([]);
+  });
+});

--- a/apps/client/app/components/admin/Users/unsavedFieldLabels.ts
+++ b/apps/client/app/components/admin/Users/unsavedFieldLabels.ts
@@ -1,0 +1,48 @@
+import type { IUserDocument } from '@bike4mind/common';
+import type { EditedFieldsState } from '@client/app/components/admin/Users/Views/FullUsersView';
+
+/**
+ * Human labels for the admin-editable fields on the user card, in the order they
+ * are listed back to the admin. Must stay in sync with the `onFieldChange` keys
+ * the card's sections emit (UserDetails, UserPermissions, ProductAccess,
+ * Bike4MindUserDetails, SpicyUserActions); an unmapped key still shows,
+ * prettified from its name. Several keys deliberately share a label (they always
+ * move together, and the admin thinks of them as one thing) - duplicates are
+ * collapsed.
+ */
+const FIELD_LABELS: Partial<Record<keyof IUserDocument, string>> = {
+  name: 'Name',
+  username: 'Username',
+  email: 'Email',
+  emailVerified: 'Email verification',
+  emailVerifiedAt: 'Email verification',
+  level: 'User level',
+  isAdmin: 'Role',
+  tags: 'Tags and product access',
+  currentCredits: 'Credits',
+  storageLimit: 'Storage limit',
+  numReferralsAvailable: 'Referrals available',
+  subscribedUntil: 'Subscribed until',
+  isBanned: 'Banned',
+  isModerated: 'Moderated',
+};
+
+const prettifyKey = (key: string): string =>
+  key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, char => char.toUpperCase())
+    .trim();
+
+/** The field keys the card has staged but not yet sent to the server. */
+export const unsavedFieldKeys = (editedFields: EditedFieldsState): string[] =>
+  Object.entries(editedFields)
+    .filter(([, isEdited]) => isEdited)
+    .map(([key]) => key);
+
+/** The distinct labels behind those keys, for "you have not saved X yet". */
+export const unsavedFieldLabels = (keys: readonly string[]): string[] => {
+  const known = Object.keys(FIELD_LABELS).filter(key => keys.includes(key));
+  const unknown = keys.filter(key => !(key in FIELD_LABELS));
+  const labels = [...known.map(key => FIELD_LABELS[key as keyof IUserDocument] as string), ...unknown.map(prettifyKey)];
+  return Array.from(new Set(labels));
+};

--- a/apps/client/app/hooks/useConfirmation.test.ts
+++ b/apps/client/app/hooks/useConfirmation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useConfirmationModal } from './useConfirmation';
+
+const confirm = useConfirmationModal.getState().confirm;
+
+describe('useConfirmationModal', () => {
+  it("does not leak one dialog's labels into the next one that omits them", () => {
+    confirm({
+      title: 'Discard changes?',
+      okLabel: 'Discard changes',
+      cancelLabel: 'Keep editing',
+      onOk: () => {},
+    });
+    confirm({ title: 'Reset User MFA', onOk: () => {} });
+
+    const state = useConfirmationModal.getState();
+    expect(state.title).toBe('Reset User MFA');
+    // Undefined, so ConfirmationModal falls back to its own Ok / Cancel defaults.
+    expect(state.okLabel).toBeUndefined();
+    expect(state.cancelLabel).toBeUndefined();
+  });
+
+  it("does not leak one dialog's onOk into the next one that omits it", async () => {
+    const firstOnOk = vi.fn();
+    confirm({ title: 'Discard changes?', onOk: firstOnOk });
+    confirm({ title: 'Something else' });
+
+    await useConfirmationModal.getState().onOk();
+    expect(firstOnOk).not.toHaveBeenCalled();
+  });
+
+  it('clears the description and type between dialogs', () => {
+    confirm({ type: 'danger', description: 'Tags and product access', onOk: () => {} });
+    confirm({ title: 'Plain dialog', onOk: () => {} });
+
+    const state = useConfirmationModal.getState();
+    expect(state.type).toBe('default');
+    expect(state.description).toBeUndefined();
+  });
+});

--- a/apps/client/app/hooks/useConfirmation.tsx
+++ b/apps/client/app/hooks/useConfirmation.tsx
@@ -16,7 +16,21 @@ interface ConfirmationModalStore {
 export const useConfirmationModal = create<ConfirmationModalStore>(set => ({
   open: false,
   type: 'default',
-  confirm: value => set({ type: 'default', open: true, ...value }),
+  // Zustand shallow-merges, so every optional field has to be cleared explicitly here:
+  // otherwise one caller's okLabel/onOk survives into the next dialog that omits it, and
+  // a destructive action ends up wearing the previous dialog's labels (or worse, its onOk).
+  confirm: value =>
+    set({
+      type: 'default',
+      title: undefined,
+      description: undefined,
+      okLabel: undefined,
+      cancelLabel: undefined,
+      onCancel: undefined,
+      onOk: async () => {},
+      open: true,
+      ...value,
+    }),
   onOk: async () => {},
 }));
 


### PR DESCRIPTION
# Pull Request

Fixes #2441

## Optional Screenshot/Video

The discard dialog is captured inline at step 5 of the Guide for Testers below. It is the app's existing shared `ConfirmationModal` (danger variant), so it matches every other confirm in the app.

## Description

In **Admin -> Users**, the user card stages every edit locally and commits once via the **Update** button in the card header. The Custom Tags **Add** button reads as a self-contained commit - it fires no request - so an admin who clicks Add and then closes the user modal loses the tag silently. Issue #2441 was filed after that cost a tester a debugging round on the permissions path, where "looks saved but is not" reads as broken access control.

This PR keeps the card's stage-then-Update behaviour and guards the exit instead: closing the user modal with staged edits now asks **Discard changes?** and names precisely which edits would be lost. No control on the card starts behaving unlike its neighbours.

Making that warning honest needed one change to how the card tracks edits. It marked a field as edited the moment it was *touched*, and never re-checked - so typing into a field and undoing it, or adding a tag and removing it again, left the field flagged forever. The prompt would then name a field whose value had already been put back. A field now counts as edited when its value differs from what the server sent.

## Changes

- New `unsavedFieldLabels.ts`: maps the card's `editedFields` keys to admin-facing labels ("Tags and product access", "Credits", ...), collapsing keys that always move together (`emailVerified` / `emailVerifiedAt`) and falling back to a prettified key for anything unmapped, so a newly-added editable field can never silently vanish from the warning.
- New `stageFieldEdit.ts`: records an edit as "differs from the saved value" rather than "was touched", comparing with lodash `isEqual` and treating `null` / `undefined` as the same unset value. Reverting a field by hand now clears its mark, which also stops the card highlighting a reverted field and stops a no-op value riding along in the update payload.
- `FullUsersView`: gains one optional `onUnsavedFieldsChange` prop and an effect that reports its staged-but-unsaved field keys to whatever hosts it, and routes `handleFormFieldChange` through `stageFieldEdit`. No behavioural change for the inline list view, which does not pass the prop. The header Update button, the save flow and the local-staging model are otherwise exactly as on `main`.
- `FullUserViewModal`: holds the reported keys and intercepts close. A clean card closes immediately; a dirty one raises the shared `useConfirmation` dialog - **Discard changes?** / "These edits have not been saved: Tags and product access, Credits. Closing this window discards them. Use Update to save instead." with **Discard changes** / **Keep editing** buttons. All three close paths (the X, the backdrop, Esc) route through the guard. Saving via Update closes the modal directly, so a successful save never triggers the prompt.
- `useConfirmation`: `confirm()` now clears every per-call field (title, description, labels, `onOk`) before applying the new one. The store shallow-merges, so this PR's `Discard changes` / `Keep editing` labels would otherwise have survived into the next dialog raised without labels - **Reset User MFA** right there in the same card could have rendered wearing them. A leaked `onOk` is the worse version of the same bug, so that is reset too. Pre-existing, but this PR is what made it reachable from one card.
- `FullUsersView`: the effect that replaces `formState` from a fresh server snapshot now clears `editedFields` with it. Verify/Unverify Email saves through its own mutation and then syncs the card via `onFieldChange`, which left the guard warning about an "unsaved" edit the update payload cannot even carry.
- The report effect fires only when the set of unsaved fields actually changes (not on every keystroke), and reads its callback through a ref, so the prop no longer carries a referential-stability contract that nothing enforced.
- Unit tests for the label derivation (ordering, de-duplication, unmapped-key fallback), the modal guard (clean close, prompt contents, confirm-then-close, guard lifting), the confirmation store's isolation between dialogs, and - new - the real card: `FullUsersView.test.tsx` drives the actual Custom Tags control and asserts what reaches the host, which is what would catch the prop being renamed or never wired.

## Guide for Testers

Prerequisite: an admin account on this PR's preview environment, `https://app.pr2676.preview.bike4mind.com`. Previews are created on demand by a maintainer through the internal deployer; when one is triggered a bot comment with the URL appears on this PR. Do not test this on staging - the change is not deployed there.

1. Log in as an admin and navigate to **Sidebar -> Admin -> Users**. The default **Slim** view is the one to use.
2. Find any non-admin test user and click the **A** (admin) button on their row. The full user card opens in a modal.
3. Close the modal with the **X** without touching anything.
   - Expected: it closes immediately, with no prompt.
4. Reopen the same user, scroll to **Custom Tags**, type `qa-unsaved-test` into the input, and click **Add**. The chip appears.
5. Click the modal's **X**.
    <img width="818" height="258" alt="user-discard-changes-modal" src="https://github.com/user-attachments/assets/635c9ae0-c477-4ed0-9e9b-c979226ecb8b" />
   - Expected: a **Discard changes?** dialog appears reading `These edits have not been saved: Tags and product access. Closing this window discards them. Use Update to save instead.`, with **Keep editing** and **Discard changes** buttons.
6. Click **Keep editing**.
   - Expected: the dialog closes, the user modal is still open, and the `qa-unsaved-test` chip is still there.
7. Click the **X** again, then click **Discard changes**.
   - Expected: both the dialog and the user modal close.
8. Reopen the same user and check **Custom Tags**.
   - Expected: `qa-unsaved-test` is NOT there - discarding really discarded it.
9. Reopen, add `qa-unsaved-test` again, and this time click the green **Update** button in the card header.
   - Expected: a `Profile updated successfully` toast appears and the modal closes with NO discard prompt (saving is not discarding).
10. Reopen the same user.
    - Expected: `qa-unsaved-test` is listed under Custom Tags. This is the persistence #2441 reported as missing.
11. Click the `x` on the `qa-unsaved-test` chip, then click the modal's **X**.
    - Expected: the same discard prompt appears - removals are staged the same way additions are.
12. Stage several different kinds of edit at once: change the **Role** radio, edit **Credits** in the B4M Settings column, and edit **Name**. Then click the modal's **X**.
    - Expected: the prompt lists all of them, e.g. `Name, Role, Tags and product access, Credits`.
13. With edits staged, press **Esc**, and separately click the dark backdrop outside the modal.
    - Expected: both raise the same discard prompt rather than closing straight away.

Revert behaviour (the reason edits are tracked by value):

14. Reopen the user, edit **Name** to something else, then type the original name back by hand.
    - Expected: the green **Update** button in the header disappears again, and closing the modal raises NO discard prompt - there is nothing left to save.
15. Add a Custom Tag, then immediately remove it with the chip's `x`, then close the modal.
    - Expected: no discard prompt.
16. Add tag `keep-me`, then edit **Name** and type the original name back. Close the modal.
    - Expected: the prompt appears and names ONLY `Tags and product access` - not `Name`.

Cases raised in review:

17. Reopen the user, click **Verify Email** in the User Details column, wait for it to succeed, then click the modal's **X**.
    - Expected: it closes with NO discard prompt. That action saves on its own, so there is nothing unsaved to warn about.
18. Stage any edit, click the **X** to raise **Discard changes?**, click **Keep editing**, then click **Reset MFA** in the User Details column.
    - Expected: the MFA dialog's buttons read **Ok** / **Cancel** - NOT **Discard changes** / **Keep editing**. Repeat with **Delete user** under Admin Actions.

Regression checks:

19. Switch the view selector to **User Journey** and open a user through its admin button.
    - Expected: the same modal and the same guard behaviour.
20. Switch the view selector to **Full**, where cards render inline on the page rather than in a modal. Stage a Custom Tag there and confirm the header **Update** button still appears and still saves.
    - Expected: unchanged from `main`. There is no modal to exit in this view, so there is no discard prompt here - see Additional Information.
21. Confirm other confirmation dialogs in the same card still work: **Reset MFA** in User Details, and **Delete user** under Admin Actions.
22. Confirm confirmation dialogs elsewhere in the app still carry their own labels, since `confirm()` changed: **Settings -> Webhooks** (Unsubscribe) and an organization's **Delete Organization**.
23. On a narrow/mobile viewport, confirm the user modal still opens, the discard prompt is readable, and both its buttons are tappable.

What NOT to test: the update endpoint (`PUT /api/users/{id}/update`) is untouched. The save payload now omits fields that were touched and reverted, which is the point of the change - it never omits a field whose value actually differs.

## Additional Information

The issue carries the `awaiting designer review` label. The issue author argued for a persistent unsaved-changes bar (option 2); this PR takes the lighter route of confirming on exit, which leaves the card itself byte-for-byte as it is on `main` and adds no new persistent UI. The dialog's copy is the reviewable surface if design wants to adjust it.

Scope note: the guard hangs off the user modal, which is how the default **Slim** and **User Journey** views open a user card. The opt-in **Full** view renders cards inline on the page, where there is no close event to hook - staged edits there are still lost on reload or navigation, as on `main`. Guarding that path needs a different mechanism (a `beforeunload` handler plus a router-level block); say the word if it is wanted here rather than as a follow-up.

`pnpm --filter @bike4mind/client typecheck` is clean, and the admin Users plus confirmation-hook suites (18 files / 113 tests) pass locally. The whole `@bike4mind/client` suite was run too because `useConfirmation` is shared: 1207 files / 13235 tests pass, with one pre-existing failure unrelated to this change (`__tests__/premiumMigrationsWiring.test.ts`, the premium overlay's generated migration glue in my working copy - it fails identically with this branch's changes stashed). The repo-wide pre-push typecheck was skipped on push: it fails on my working copy for two pre-existing, unrelated reasons (a locally uninstalled `@aws-sdk/client-cloudwatch` from a recent main commit, and the premium overlay). CI runs the real checks.

## Developer Notes (Optional)

- `FullUsersView` now has an extension point for dirty state: `onUnsavedFieldsChange` reports staged field keys to any host, so the inline list view could be guarded later without touching the card again.
- `unsavedFieldLabels.ts` is the one place mapping `IUserDocument` keys to admin-facing labels. Adding a new editable field to the card means adding a label there; an unmapped key degrades to a prettified key rather than dropping out of the warning.
- `stageFieldEdit.ts` is the one place deciding what "edited" means for this card. Known conservative case: the subscription date input hands back a `YYYY-MM-DD` string while the server sends a full timestamp, so retyping the original date still reads as edited. Over-reporting is the safe direction for a data-loss warning.
- The guard reuses the app-wide `useConfirmation` store rather than adding a nested `Modal`, so the prompt stacks correctly above the user modal and inherits the standard dialog styling.
- `confirm()` is now isolating: each call starts from a clean slate rather than inheriting the previous dialog's fields. Any caller can pass `okLabel` / `cancelLabel` / `onOk` without leaking them onto the next dialog, which was previously a live footgun for every label-free caller in the app.
- `FullUsersView.test.tsx` establishes a pattern for testing this card: stub the sibling sections and their data hooks, keep the one column under test real. Worth reusing for the other columns, which have no direct coverage.
