### PR TITLE
fix(chat): seed promptMeta.session at the writers that materialize promptMeta

### DIFF
--- a/apps/client/server/utils/persistRunAsQuest.test.ts
+++ b/apps/client/server/utils/persistRunAsQuest.test.ts
@@ -103,7 +103,9 @@ describe('persistRunAsQuest finishReason (#293)', () => {
       await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'end_turn');
 
       const [doc] = createMock.mock.calls[0];
-      expect(doc.promptMeta).toEqual({ finishReason: 'end_turn' });
+      // session is seeded by materializePromptMetaSession - see the dedicated
+      // promptMeta.session describe block below for that behavior.
+      expect(doc.promptMeta).toEqual({ finishReason: 'end_turn', session: { id: 's1', userId: 'u1' } });
     });
 
     it('composes finishReason AND mementoIds without either clobbering the other', async () => {
@@ -112,7 +114,11 @@ describe('persistRunAsQuest finishReason (#293)', () => {
       await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'max_tokens');
 
       const [doc] = createMock.mock.calls[0];
-      expect(doc.promptMeta).toEqual({ finishReason: 'max_tokens', context: { mementoIds: ['m1', 'm2'] } });
+      expect(doc.promptMeta).toEqual({
+        finishReason: 'max_tokens',
+        context: { mementoIds: ['m1', 'm2'] },
+        session: { id: 's1', userId: 'u1' },
+      });
     });
 
     it('still writes mementoIds when only those are present', async () => {
@@ -121,7 +127,7 @@ describe('persistRunAsQuest finishReason (#293)', () => {
       await persistRunAsQuest(EXECUTION_ID, 'reply', logger);
 
       const [doc] = createMock.mock.calls[0];
-      expect(doc.promptMeta).toEqual({ context: { mementoIds: ['m1'] } });
+      expect(doc.promptMeta).toEqual({ context: { mementoIds: ['m1'] }, session: { id: 's1', userId: 'u1' } });
     });
 
     it('omits promptMeta entirely when neither finishReason nor mementoIds are present', async () => {
@@ -170,7 +176,58 @@ describe('persistRunAsQuest retrieval (#1867)', () => {
       await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'end_turn', undefined, retrieval);
 
       const [doc] = createMock.mock.calls[0];
-      expect(doc.promptMeta).toEqual({ finishReason: 'end_turn', retrieval });
+      expect(doc.promptMeta).toEqual({ finishReason: 'end_turn', retrieval, session: { id: 's1', userId: 'u1' } });
+    });
+  });
+});
+
+describe('persistRunAsQuest promptMeta.session (bike4mind#2004)', () => {
+  describe('UPDATE branch (existing Quest patched)', () => {
+    beforeEach(() => {
+      findOneAndUpdateMock.mockResolvedValue({ _id: 'q1' }); // truthy -> update path taken
+    });
+
+    it('sets promptMeta.session when another promptMeta field is touched', async () => {
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'end_turn');
+
+      const [, update] = findOneAndUpdateMock.mock.calls[0];
+      expect(update.$set['promptMeta.session']).toEqual({ id: 's1', userId: 'u1' });
+    });
+
+    it('sets promptMeta.session when only mementoIds are touched', async () => {
+      stubExecution({ usedMementoIds: ['m1'] });
+
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger);
+
+      const [, update] = findOneAndUpdateMock.mock.calls[0];
+      expect(update.$set['promptMeta.session']).toEqual({ id: 's1', userId: 'u1' });
+    });
+
+    it('omits promptMeta.session when no promptMeta field is touched, leaving the quest promptMeta-less', async () => {
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger);
+
+      const [, update] = findOneAndUpdateMock.mock.calls[0];
+      expect(update.$set).not.toHaveProperty('promptMeta.session');
+    });
+  });
+
+  describe('CREATE branch (no existing Quest)', () => {
+    beforeEach(() => {
+      findOneAndUpdateMock.mockResolvedValue(null); // falsy -> create path taken
+    });
+
+    it('seeds promptMeta.session when composing a new promptMeta record', async () => {
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'end_turn');
+
+      const [doc] = createMock.mock.calls[0];
+      expect(doc.promptMeta.session).toEqual({ id: 's1', userId: 'u1' });
+    });
+
+    it('omits promptMeta (and therefore session) entirely when nothing touches it', async () => {
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger);
+
+      const [doc] = createMock.mock.calls[0];
+      expect(doc).not.toHaveProperty('promptMeta');
     });
   });
 });

--- a/apps/client/server/utils/persistRunAsQuest.ts
+++ b/apps/client/server/utils/persistRunAsQuest.ts
@@ -15,7 +15,7 @@
  */
 import { agentExecutionRepository, Quest } from '@bike4mind/database';
 import type { Logger } from '@bike4mind/observability';
-import type { PromptMeta } from '@bike4mind/common';
+import { materializePromptMetaSession, type PromptMeta } from '@bike4mind/common';
 import { persistAgentArtifacts } from './persistAgentArtifacts';
 
 export async function persistRunAsQuest(
@@ -77,6 +77,12 @@ export async function persistRunAsQuest(
     // pollers (CommandHandler / WorkflowStepHandler) only observe `done`
     // once `replies` is populated - flipping it earlier would let pollers
     // read an empty reply array and silently drop the response.
+    // The dispatch-time Quest (`startAgentExecution.ts`) is created with no promptMeta at all, so
+    // this is a first materialization, same as the writers bike4mind#2004 fixed - and this write
+    // goes through findOneAndUpdate (no validators), so a promptMeta with no session block would
+    // persist silently instead of throwing. Only set when some OTHER promptMeta.* key is also
+    // being set: an untouched quest should stay with no promptMeta, matching the dispatch-time shape.
+    const promptMetaTouched = Boolean(execution.usedMementoIds?.length || finishReason || retrieval);
     const updated = await Quest.findOneAndUpdate(
       { agentExecutionId: executionId },
       {
@@ -92,6 +98,7 @@ export async function persistRunAsQuest(
           // Dotted key coexists with `promptMeta.context.mementoIds` above - no clobber.
           ...(finishReason ? { 'promptMeta.finishReason': finishReason } : {}),
           ...(retrieval ? { 'promptMeta.retrieval': retrieval } : {}),
+          ...(promptMetaTouched ? { 'promptMeta.session': { id: execution.sessionId, userId: execution.userId } } : {}),
           // The agent Quest is authored once at completion (no subagent race like images),
           // so a plain $set is safe here.
           ...(sideEffects ? { uiSideEffects: sideEffects } : {}),
@@ -119,14 +126,23 @@ export async function persistRunAsQuest(
         // iteration trace on a "Show reasoning" disclosure under the reply.
         agentExecutionId: executionId,
         // Compose one promptMeta from both sources so neither clobbers the
-        // other; omit it entirely when both are absent.
+        // other; omit it entirely when both are absent. Quest.create() DOES run validators
+        // (unlike the findOneAndUpdate above), so a non-empty promptMeta with no session block
+        // throws here rather than persisting silently - materializePromptMetaSession supplies it.
         ...(() => {
           const promptMeta = {
             ...(finishReason ? { finishReason } : {}),
             ...(execution.usedMementoIds?.length ? { context: { mementoIds: execution.usedMementoIds } } : {}),
             ...(retrieval ? { retrieval } : {}),
           };
-          return Object.keys(promptMeta).length ? { promptMeta } : {};
+          return Object.keys(promptMeta).length
+            ? {
+                promptMeta: materializePromptMetaSession(promptMeta, {
+                  sessionId: execution.sessionId,
+                  userId: execution.userId,
+                }),
+              }
+            : {};
         })(),
       });
     }

--- a/b4m-core/common/src/utils/promptMetaSessionBinding.test.ts
+++ b/b4m-core/common/src/utils/promptMetaSessionBinding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { rebindPromptMetaSession } from './promptMetaSessionBinding';
+import { materializePromptMetaSession, rebindPromptMetaSession } from './promptMetaSessionBinding';
 
 describe('rebindPromptMetaSession', () => {
   it('supplies a session block when the source promptMeta carries none', () => {
@@ -77,5 +77,47 @@ describe('rebindPromptMetaSession', () => {
   it('leaves an absent promptMeta absent rather than inventing one', () => {
     expect(rebindPromptMetaSession(undefined, { sessionId: 'fork-1', userId: 'caller-1' })).toBeUndefined();
     expect(rebindPromptMetaSession(null, { sessionId: 'fork-1', userId: 'caller-1' })).toBeUndefined();
+  });
+});
+
+describe('materializePromptMetaSession', () => {
+  it('builds a fresh promptMeta with a session block when none existed', () => {
+    // The bike4mind#2004 bug: `quest.promptMeta = quest.promptMeta ?? {}` writers left `session`
+    // out entirely, and that shape passes silently through update() (validators off).
+    expect(materializePromptMetaSession(undefined, { sessionId: 'session-1', userId: 'user-1' })).toEqual({
+      session: { id: 'session-1', userId: 'user-1' },
+    });
+    expect(materializePromptMetaSession(null, { sessionId: 'session-1', userId: 'user-1' })).toEqual({
+      session: { id: 'session-1', userId: 'user-1' },
+    });
+  });
+
+  it('adds the session block to an existing promptMeta that has none, preserving other fields', () => {
+    const materialized = materializePromptMetaSession(
+      { warnings: ['partial coverage'] },
+      { sessionId: 'session-1', userId: 'user-1' }
+    );
+
+    expect(materialized).toEqual({
+      warnings: ['partial coverage'],
+      session: { id: 'session-1', userId: 'user-1' },
+    });
+  });
+
+  it('re-asserts session on every call rather than trusting a prior write in the same turn', () => {
+    const materialized = materializePromptMetaSession(
+      { session: { id: 'session-1', userId: 'user-1' } },
+      { sessionId: 'session-1', userId: 'user-1' }
+    );
+
+    expect(materialized.session).toEqual({ id: 'session-1', userId: 'user-1' });
+  });
+
+  it('does not mutate the source promptMeta', () => {
+    const source = { warnings: ['partial coverage'] };
+
+    materializePromptMetaSession(source, { sessionId: 'session-1', userId: 'user-1' });
+
+    expect(source).toEqual({ warnings: ['partial coverage'] });
   });
 });

--- a/b4m-core/common/src/utils/promptMetaSessionBinding.ts
+++ b/b4m-core/common/src/utils/promptMetaSessionBinding.ts
@@ -8,11 +8,12 @@ import type { PromptMeta } from '../types/entities/PromptMetaTypes';
  * 1. The store REQUIRES it. `PromptMetaSchema.session.id`/`.userId` are `required: true`
  *    (QuestModel), and a copy is inserted through `create()` - the only quest write that runs
  *    Mongoose validators. Live quest writes go through `update()` (findOneAndUpdate + $set,
- *    validators off), and several writers materialize promptMeta from nothing
+ *    validators off), and several writers used to materialize promptMeta from nothing
  *    (`quest.promptMeta = quest.promptMeta ?? {}` in ChatCompletionFeatures, addStatusToQuest in
- *    Image/VideoGeneration, applyQuestStatusChanges' no-existing-meta branch), so quests DO exist
- *    on disk carrying promptMeta with no session block at all. Copying one verbatim threw
- *    ValidationError and failed the whole fork.
+ *    Image/VideoGeneration, applyQuestStatusChanges' no-existing-meta branch - now routed through
+ *    `materializePromptMetaSession` below), so quests written before that fix can still carry
+ *    promptMeta with no session block at all. Copying one verbatim throws ValidationError and
+ *    fails the whole fork.
  *
  * 2. `session.userId` is a scoping key, not just telemetry: `databaseSearcher.ts` scopes
  *    deep-research's internal quest search by `promptMeta.session.userId`. A copy that keeps the
@@ -52,4 +53,31 @@ export function rebindPromptMetaSession(
       userId: destination.userId,
     },
   };
+}
+
+/**
+ * Materialize a quest's `promptMeta` with a valid `session` block, for writers that build
+ * promptMeta from nothing on a live quest - as opposed to `rebindPromptMetaSession` above, which
+ * retargets an already-complete promptMeta at a NEW session when a quest is copied.
+ *
+ * Every call site here is a live turn writing to the quest's own session, so overwriting
+ * `session.id`/`.userId` unconditionally is safe and idempotent - it isn't changing ownership, it's
+ * asserting the invariant `PromptMetaSchema.session.{id,userId}` are `required: true` on every
+ * write, not just the `create()` path. Without it, quests with no session block at all pass
+ * silently through `update()` (findOneAndUpdate + $set, no validators) and become invisible to
+ * `databaseSearcher.ts`'s owner-scoped search and to the `session.userId`-keyed admin rollups
+ * (analytics.ts, model-metrics.ts).
+ *
+ * Always returns a `PromptMeta` (never `undefined`) - unlike `rebindPromptMetaSession`, there is no
+ * "absent promptMeta, leave it absent" case: the caller is about to assign one either way.
+ */
+export function materializePromptMetaSession(
+  promptMeta: PromptMeta | null | undefined,
+  destination: { sessionId: string; userId: string }
+): PromptMeta {
+  return (
+    rebindPromptMetaSession(promptMeta, destination) ?? {
+      session: { id: destination.sessionId, userId: destination.userId },
+    }
+  );
 }

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -3217,12 +3217,16 @@ describe('ChatCompletionProcess', () => {
           files: [{ id: 'f1', fileName: 'f1.pdf', vectorized: true, chunkCount: 2 }],
         });
 
-        const quest = { promptMeta: { retrieval } } as any;
-        applyQuestStatusChanges(quest, {
-          promptMeta: {
-            retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: [] },
-          },
-        } as any);
+        const quest = { sessionId: 's1', promptMeta: { retrieval } } as any;
+        applyQuestStatusChanges(
+          quest,
+          {
+            promptMeta: {
+              retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: [] },
+            },
+          } as any,
+          'user-1'
+        );
 
         expect(quest.promptMeta.retrieval).toEqual({
           attempted: true,

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -61,6 +61,7 @@ import {
   LAKE_RECALL_K_DEFAULT,
   DATALAKE_TAG_PREFIX,
   PROMPT_TEXT_MAX,
+  materializePromptMetaSession,
   type SupportedEmbeddingModel,
 } from '@bike4mind/common';
 import {
@@ -764,7 +765,10 @@ export class LakeMemoryFeature implements ChatCompletionFeature {
       dataLakeTags: string[],
       injected?: NonNullable<RetrievalSummary['injected']>
     ) => {
-      quest.promptMeta = quest.promptMeta ?? {};
+      quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+        sessionId: quest.sessionId,
+        userId: this.user.id,
+      });
       quest.promptMeta.retrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, {
         attempted: true,
         outcome,
@@ -827,7 +831,10 @@ export class LakeMemoryFeature implements ChatCompletionFeature {
 
       // Telemetry: record that the card fired and from which lakes, so an eval row shows lake grounding
       // independent of whether the model then also called the knowledge tools.
-      quest.promptMeta = quest.promptMeta ?? {};
+      quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+        sessionId: quest.sessionId,
+        userId: this.user.id,
+      });
       quest.promptMeta.context = quest.promptMeta.context ?? {};
       // beliefBudget rides along so `beliefCount` is readable on its own: below the budget means that
       // is all that qualified, AT the budget means the turn saturated it. Saturation is not proof the
@@ -1955,7 +1962,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       `🔒 Forced retrieval: PARTIAL coverage - ${reasons.join('; ')}. Grounding is based on an incomplete library scan.`
     );
 
-    quest.promptMeta = quest.promptMeta || {};
+    quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+      sessionId: quest.sessionId,
+      userId: this.chatCompletion.user.id,
+    });
     quest.promptMeta.warnings = [
       ...(quest.promptMeta.warnings ?? []),
       `Knowledge-base grounding scanned only part of the library for this message (${reasons.join('; ')}).`,
@@ -1995,7 +2005,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       const preauthorizedLakeIdsUsed = prompts.map(p => p.id).filter(id => preauthorizedSet.has(id));
       // Recorded whenever this injection site ran, even if nothing qualified (present-and-empty
       // is distinct from absent - see the field's own comment in promptMeta.ts).
-      quest.promptMeta = quest.promptMeta ?? {};
+      quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+        sessionId: quest.sessionId,
+        userId: user.id,
+      });
       quest.promptMeta.retrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, {
         attempted: true,
         surfaces: [],
@@ -2214,7 +2227,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
     quest: IChatHistoryItemDocument,
     forcedSkipReason: NonNullable<RetrievalSummary['forcedSkipReason']>
   ): void {
-    quest.promptMeta = quest.promptMeta ?? {};
+    quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+      sessionId: quest.sessionId,
+      userId: this.chatCompletion.user.id,
+    });
     quest.promptMeta.retrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, {
       attempted: false,
       mode: 'forced',
@@ -2273,7 +2289,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       dataLakeTags: string[],
       injected?: NonNullable<RetrievalSummary['injected']>
     ) => {
-      quest.promptMeta = quest.promptMeta ?? {};
+      quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+        sessionId: quest.sessionId,
+        userId: user.id,
+      });
       quest.promptMeta.retrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, {
         attempted: true,
         outcome,
@@ -2749,7 +2768,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
           },
         };
       });
-      quest.promptMeta = quest.promptMeta || {};
+      quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+        sessionId: quest.sessionId,
+        userId: user.id,
+      });
       const existingCitables = quest.promptMeta.citables || [];
       const citableKey = (c: CitableSource) => c.id || c.url || c.title;
       if (this.citationStyle === 'indexed') {

--- a/b4m-core/services/src/llm/ImageGeneration.ts
+++ b/b4m-core/services/src/llm/ImageGeneration.ts
@@ -25,6 +25,7 @@ import {
   PromptIntentSchema,
   ImageModerationIncident as ImageModerationIncidentInput,
   AttachmentLakeAccess,
+  materializePromptMetaSession,
 } from '@bike4mind/common';
 import {
   BFL_IMAGE_MODELS,
@@ -477,10 +478,8 @@ export class ImageGenerationService {
     return { requiredCredits, usdCost: usdCost * n };
   }
 
-  private addStatusToQuest(quest: IChatHistoryItemDocument, status: string) {
-    if (!quest.promptMeta) {
-      quest.promptMeta = {};
-    }
+  private addStatusToQuest(quest: IChatHistoryItemDocument, status: string, userId: string) {
+    quest.promptMeta = materializePromptMetaSession(quest.promptMeta, { sessionId: quest.sessionId, userId });
     if (!quest.promptMeta.statusLog) {
       quest.promptMeta.statusLog = [];
     }
@@ -743,7 +742,7 @@ export class ImageGenerationService {
       // Encode the prompt to tokens
       const promptTokens = await this.tokenizer.encodeTokens(prompt, model);
 
-      this.addStatusToQuest(quest, 'Preparing to paint...');
+      this.addStatusToQuest(quest, 'Preparing to paint...', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -753,7 +752,7 @@ export class ImageGenerationService {
       const settings = await getSettingsMap(this.db);
 
       if (getSettingsValue('ModerationEnabled', settings)) {
-        this.addStatusToQuest(quest, 'Checking prompt...');
+        this.addStatusToQuest(quest, 'Checking prompt...', userId);
         await clientMessageSender.sendToClient(userId, wsEndpoint, {
           action: 'streamed_chat_completion',
           quest: parseQuestToStreamPayload(quest),
@@ -780,7 +779,7 @@ export class ImageGenerationService {
       });
 
       if (truncated) {
-        this.addStatusToQuest(quest, 'Trimming the prompt...');
+        this.addStatusToQuest(quest, 'Trimming the prompt...', userId);
         await clientMessageSender.sendToClient(userId, wsEndpoint, {
           action: 'streamed_chat_completion',
           quest: parseQuestToStreamPayload(quest),
@@ -788,7 +787,7 @@ export class ImageGenerationService {
         });
       }
 
-      this.addStatusToQuest(quest, 'Now painting...');
+      this.addStatusToQuest(quest, 'Now painting...', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -926,9 +925,7 @@ export class ImageGenerationService {
             quest.status = 'done';
 
             // Store clarification metadata for potential future retry
-            if (!quest.promptMeta) {
-              quest.promptMeta = {};
-            }
+            quest.promptMeta = materializePromptMetaSession(quest.promptMeta, { sessionId, userId });
             (quest.promptMeta as any).imageClarification = {
               clarificationId: clarificationResponse.clarificationId,
               question: clarificationResponse.question,
@@ -936,7 +933,7 @@ export class ImageGenerationService {
               timestamp: new Date(),
             };
 
-            this.addStatusToQuest(quest, 'Clarification requested');
+            this.addStatusToQuest(quest, 'Clarification requested', userId);
             await this.db.quests.update(quest);
             await clientMessageSender.sendToClient(userId, wsEndpoint, {
               action: 'streamed_chat_completion',
@@ -1196,7 +1193,7 @@ export class ImageGenerationService {
       );
 
       // download images and store to s3
-      this.addStatusToQuest(quest, 'Tucking your image into storage...');
+      this.addStatusToQuest(quest, 'Tucking your image into storage...', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -1249,7 +1246,7 @@ export class ImageGenerationService {
         })
       );
 
-      this.addStatusToQuest(quest, 'Adding to the notebook...');
+      this.addStatusToQuest(quest, 'Adding to the notebook...', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -1281,7 +1278,7 @@ export class ImageGenerationService {
       }
 
       // Add final status
-      this.addStatusToQuest(quest, 'Image generation completed');
+      this.addStatusToQuest(quest, 'Image generation completed', userId);
 
       Logger.globalInstance.debug(`[DEBUG] Quest before update:`, {
         id: quest.id,
@@ -1375,7 +1372,7 @@ export class ImageGenerationService {
       }
     } catch (error) {
       logger.error('Error processing image generation:', error);
-      this.addStatusToQuest(quest, `Error: ${(error as Error).message}`);
+      this.addStatusToQuest(quest, `Error: ${(error as Error).message}`, userId);
       quest.reply = (error as Error).message;
       quest.type = 'error';
       quest.status = 'done';

--- a/b4m-core/services/src/llm/VideoGeneration.ts
+++ b/b4m-core/services/src/llm/VideoGeneration.ts
@@ -18,6 +18,7 @@ import {
   ICreditTransactionRepository,
   IUsageEventRepository,
   CreditHolderType,
+  materializePromptMetaSession,
 } from '@bike4mind/common';
 import {
   aiVideoService,
@@ -298,10 +299,8 @@ export class VideoGenerationService {
   /**
    * Add a status update to the quest's status log
    */
-  private addStatusToQuest(quest: IChatHistoryItemDocument, status: string) {
-    if (!quest.promptMeta) {
-      quest.promptMeta = {};
-    }
+  private addStatusToQuest(quest: IChatHistoryItemDocument, status: string, userId: string) {
+    quest.promptMeta = materializePromptMetaSession(quest.promptMeta, { sessionId: quest.sessionId, userId });
     if (!quest.promptMeta.statusLog) {
       quest.promptMeta.statusLog = [];
     }
@@ -385,7 +384,7 @@ export class VideoGenerationService {
         usageCostUsd = usdCost;
       }
 
-      this.addStatusToQuest(quest, 'Preparing to generate video...');
+      this.addStatusToQuest(quest, 'Preparing to generate video...', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -395,7 +394,7 @@ export class VideoGenerationService {
       // Create the video service
       const service = aiVideoService('openai', apiKeyTable.openai, logger);
 
-      this.addStatusToQuest(quest, 'Generating video... This may take several minutes.');
+      this.addStatusToQuest(quest, 'Generating video... This may take several minutes.', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -429,7 +428,7 @@ export class VideoGenerationService {
       );
 
       // Download and store videos to S3
-      this.addStatusToQuest(quest, 'Storing your video...');
+      this.addStatusToQuest(quest, 'Storing your video...', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -471,7 +470,7 @@ export class VideoGenerationService {
         })
       );
 
-      this.addStatusToQuest(quest, 'Adding to the notebook...');
+      this.addStatusToQuest(quest, 'Adding to the notebook...', userId);
       await clientMessageSender.sendToClient(userId, wsEndpoint, {
         action: 'streamed_chat_completion',
         quest: parseQuestToStreamPayload(quest),
@@ -496,7 +495,7 @@ export class VideoGenerationService {
         };
       }
 
-      this.addStatusToQuest(quest, 'Video generation completed');
+      this.addStatusToQuest(quest, 'Video generation completed', userId);
 
       logger.info('[VideoGenerationService] Quest updated', {
         id: quest.id,
@@ -565,7 +564,7 @@ export class VideoGenerationService {
       }
     } catch (error) {
       logger.error('Error processing video generation:', error);
-      this.addStatusToQuest(quest, `Error: ${(error as Error).message}`);
+      this.addStatusToQuest(quest, `Error: ${(error as Error).message}`, userId);
       quest.reply = (error as Error).message;
       quest.type = 'error';
       quest.status = 'done';

--- a/b4m-core/services/src/llm/tools/ToolBuilder.applyQuestStatusChanges.test.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.applyQuestStatusChanges.test.ts
@@ -14,34 +14,34 @@ describe('applyQuestStatusChanges', () => {
       // sending only its own image through statusUpdate. Wholesale overwrite
       // collapsed this to "Image 1 of 1"; merge-append must keep all four.
       const quest = makeQuest();
-      applyQuestStatusChanges(quest, { images: ['a.jpg'] });
-      applyQuestStatusChanges(quest, { images: ['b.jpg'] });
-      applyQuestStatusChanges(quest, { images: ['c.jpg'] });
-      applyQuestStatusChanges(quest, { images: ['d.jpg'] });
+      applyQuestStatusChanges(quest, { images: ['a.jpg'] }, 'user-1');
+      applyQuestStatusChanges(quest, { images: ['b.jpg'] }, 'user-1');
+      applyQuestStatusChanges(quest, { images: ['c.jpg'] }, 'user-1');
+      applyQuestStatusChanges(quest, { images: ['d.jpg'] }, 'user-1');
       expect(quest.images).toEqual(['a.jpg', 'b.jpg', 'c.jpg', 'd.jpg']);
     });
 
     it('appends a multi-image batch from a single call', () => {
       const quest = makeQuest({ images: ['a.jpg'] });
-      applyQuestStatusChanges(quest, { images: ['b.jpg', 'c.jpg'] });
+      applyQuestStatusChanges(quest, { images: ['b.jpg', 'c.jpg'] }, 'user-1');
       expect(quest.images).toEqual(['a.jpg', 'b.jpg', 'c.jpg']);
     });
 
     it('dedupes already-present paths (idempotent with onToolFinish append)', () => {
       const quest = makeQuest({ images: ['a.jpg'] });
-      applyQuestStatusChanges(quest, { images: ['a.jpg'] });
+      applyQuestStatusChanges(quest, { images: ['a.jpg'] }, 'user-1');
       expect(quest.images).toEqual(['a.jpg']);
     });
 
     it('initializes images when the quest has none', () => {
       const quest = makeQuest();
-      applyQuestStatusChanges(quest, { images: ['a.jpg'] });
+      applyQuestStatusChanges(quest, { images: ['a.jpg'] }, 'user-1');
       expect(quest.images).toEqual(['a.jpg']);
     });
 
     it('leaves images untouched when the change set has none', () => {
       const quest = makeQuest({ images: ['a.jpg'] });
-      applyQuestStatusChanges(quest, { reply: 'hi' } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(quest, { reply: 'hi' } as Partial<IChatHistoryItemDocument>, 'user-1');
       expect(quest.images).toEqual(['a.jpg']);
     });
   });
@@ -51,23 +51,58 @@ describe('applyQuestStatusChanges', () => {
       const quest = makeQuest({
         promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: {
-          citables: [
-            { id: '1', url: 'u1', title: 't1' },
-            { id: '2', url: 'u2', title: 't2' },
-          ],
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: {
+            citables: [
+              { id: '1', url: 'u1', title: 't1' },
+              { id: '2', url: 'u2', title: 't2' },
+            ],
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.citables?.map(c => c.id)).toEqual(['1', '2']);
     });
 
     it('sets promptMeta when the quest had none', () => {
       const quest = makeQuest();
-      applyQuestStatusChanges(quest, {
-        promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.citables?.map(c => c.id)).toEqual(['1']);
+    });
+  });
+
+  describe('promptMeta.session (bike4mind#2004)', () => {
+    it('seeds session on the no-existing-meta branch instead of leaving it absent', () => {
+      // This is the exact shape the issue reports on disk: promptMeta materialized with no
+      // session block, which passes silently through update() (no validators) but fails
+      // ValidationError the moment the quest is copied via create() (fork/snip/clone).
+      const quest = makeQuest();
+      applyQuestStatusChanges(quest, { promptMeta: { warnings: ['partial'] } }, 'user-1');
+      expect(quest.promptMeta?.session).toEqual({ id: 's1', userId: 'user-1' });
+    });
+
+    it('seeds session on the merge branch when the existing promptMeta predates the fix', () => {
+      // A legacy row can have promptMeta (with other fields) but still no session - the merge
+      // branch below only guards on `quest.promptMeta` being truthy, so it can hit this shape too.
+      const quest = makeQuest({ promptMeta: { warnings: ['keep me'] } } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(quest, { promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] } }, 'user-1');
+      expect(quest.promptMeta?.session).toEqual({ id: 's1', userId: 'user-1' });
+    });
+
+    it('re-asserts session even when the existing promptMeta already had one', () => {
+      const quest = makeQuest({
+        promptMeta: { session: { id: 's1', userId: 'user-1' } },
+      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(quest, { promptMeta: { warnings: ['more'] } }, 'user-1');
+      expect(quest.promptMeta?.session).toEqual({ id: 's1', userId: 'user-1' });
     });
   });
 
@@ -78,9 +113,13 @@ describe('applyQuestStatusChanges', () => {
       const quest = makeQuest({
         promptMeta: { warnings: ['Response was truncated against the output-token limit.'] },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: { warnings: ['Partial knowledge-base results: 1 file(s) were excluded.'] },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: { warnings: ['Partial knowledge-base results: 1 file(s) were excluded.'] },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.warnings).toEqual([
         'Response was truncated against the output-token limit.',
         'Partial knowledge-base results: 1 file(s) were excluded.',
@@ -89,7 +128,11 @@ describe('applyQuestStatusChanges', () => {
 
     it('dedupes an identical warning reported twice', () => {
       const quest = makeQuest({ promptMeta: { warnings: ['same'] } } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, { promptMeta: { warnings: ['same'] } } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        { promptMeta: { warnings: ['same'] } } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.warnings).toEqual(['same']);
     });
 
@@ -97,15 +140,19 @@ describe('applyQuestStatusChanges', () => {
       // Already held before the merge was added (spreading an object without the key cannot
       // delete it); locked here so the new merge does not regress it.
       const quest = makeQuest({ promptMeta: { warnings: ['keep me'] } } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.warnings).toEqual(['keep me']);
     });
 
     it('adds no warnings key when neither side has one', () => {
       const quest = makeQuest({ promptMeta: { citables: [] } } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, { promptMeta: { citables: [] } } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(quest, { promptMeta: { citables: [] } } as Partial<IChatHistoryItemDocument>, 'user-1');
       expect(quest.promptMeta && 'warnings' in quest.promptMeta).toBe(false);
     });
   });
@@ -117,11 +164,15 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'ok', surfaces: ['lake-memory'], dataLakeTags: ['lake-a'] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: {
-          retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-b'] },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: {
+            retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-b'] },
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.retrieval).toEqual({
         attempted: true,
         outcome: 'ok',
@@ -136,11 +187,15 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'failed', surfaces: ['lake-memory'], dataLakeTags: [] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: {
-          retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-a'] },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: {
+            retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-a'] },
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.retrieval?.outcome).toBe('failed');
     });
 
@@ -153,11 +208,15 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'no_lakes', surfaces: ['lake-memory'], dataLakeTags: [] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: {
-          retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-a'] },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: {
+            retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-a'] },
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.retrieval?.outcome).toBe('ok');
     });
 
@@ -167,11 +226,15 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'no_lakes', surfaces: ['lake-memory'], dataLakeTags: [] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: {
-          retrieval: { attempted: true, outcome: 'failed', surfaces: ['knowledgeBaseSearch'], dataLakeTags: [] },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: {
+            retrieval: { attempted: true, outcome: 'failed', surfaces: ['knowledgeBaseSearch'], dataLakeTags: [] },
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.retrieval?.outcome).toBe('failed');
     });
 
@@ -188,11 +251,15 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'not_indexed', surfaces: ['forced-retrieval'], dataLakeTags: [] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(forcedFirst, {
-        promptMeta: {
-          retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-a'] },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        forcedFirst,
+        {
+          promptMeta: {
+            retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-a'] },
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(forcedFirst.promptMeta?.retrieval?.outcome).toBe('not_indexed');
 
       const searchFirst = makeQuest({
@@ -200,11 +267,15 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'ok', surfaces: ['knowledgeBaseSearch'], dataLakeTags: ['lake-a'] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(searchFirst, {
-        promptMeta: {
-          retrieval: { attempted: true, outcome: 'not_indexed', surfaces: ['forced-retrieval'], dataLakeTags: [] },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        searchFirst,
+        {
+          promptMeta: {
+            retrieval: { attempted: true, outcome: 'not_indexed', surfaces: ['forced-retrieval'], dataLakeTags: [] },
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(searchFirst.promptMeta?.retrieval?.outcome).toBe('not_indexed');
     });
 
@@ -216,11 +287,15 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'not_indexed', surfaces: ['forced-retrieval'], dataLakeTags: [] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: {
-          retrieval: { attempted: true, outcome: 'failed', surfaces: ['knowledgeBaseSearch'], dataLakeTags: [] },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: {
+            retrieval: { attempted: true, outcome: 'failed', surfaces: ['knowledgeBaseSearch'], dataLakeTags: [] },
+          },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.retrieval?.outcome).toBe('failed');
     });
 
@@ -240,16 +315,20 @@ describe('applyQuestStatusChanges', () => {
           },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: {
-          retrieval: {
-            attempted: true,
-            outcome: 'ok',
-            surfaces: ['knowledgeBaseSearch', 'knowledgeBaseRetrieve'],
-            dataLakeTags: ['lake-a', 'lake-b'],
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: {
+            retrieval: {
+              attempted: true,
+              outcome: 'ok',
+              surfaces: ['knowledgeBaseSearch', 'knowledgeBaseRetrieve'],
+              dataLakeTags: ['lake-a', 'lake-b'],
+            },
           },
-        },
-      } as Partial<IChatHistoryItemDocument>);
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.retrieval?.surfaces).toEqual([
         'knowledgeBaseSearch',
         'lake-memory',
@@ -264,9 +343,13 @@ describe('applyQuestStatusChanges', () => {
           retrieval: { attempted: true, outcome: 'ok', surfaces: ['lake-memory'], dataLakeTags: ['lake-a'] },
         },
       } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, {
-        promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] },
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          promptMeta: { citables: [{ id: '1', url: 'u1', title: 't1' }] },
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.promptMeta?.retrieval).toEqual({
         attempted: true,
         outcome: 'ok',
@@ -279,17 +362,21 @@ describe('applyQuestStatusChanges', () => {
   describe('other fields', () => {
     it('overwrites non-accreting fields wholesale', () => {
       const quest = makeQuest({ status: 'running' } as Partial<IChatHistoryItemDocument>);
-      applyQuestStatusChanges(quest, { status: 'done', reply: 'final' } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(quest, { status: 'done', reply: 'final' } as Partial<IChatHistoryItemDocument>, 'user-1');
       expect(quest.status).toBe('done');
       expect(quest.reply).toBe('final');
     });
 
     it('applies images and other fields together in one call', () => {
       const quest = makeQuest({ images: ['a.jpg'] });
-      applyQuestStatusChanges(quest, {
-        images: ['b.jpg'],
-        status: 'done',
-      } as Partial<IChatHistoryItemDocument>);
+      applyQuestStatusChanges(
+        quest,
+        {
+          images: ['b.jpg'],
+          status: 'done',
+        } as Partial<IChatHistoryItemDocument>,
+        'user-1'
+      );
       expect(quest.images).toEqual(['a.jpg', 'b.jpg']);
       expect(quest.status).toBe('done');
     });

--- a/b4m-core/services/src/llm/tools/ToolBuilder.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.ts
@@ -7,6 +7,7 @@ import {
   IUsageEventInput,
   ModelInfo,
   MusicGenerationVendor,
+  materializePromptMetaSession,
 } from '@bike4mind/common';
 import type { SoundGenerationVendor, VoiceGenerationVendor } from '@bike4mind/common';
 import { type ApiKeyTable, type ICompletionBackend, type ICompletionOptionTools } from '@bike4mind/llm-adapters';
@@ -228,11 +229,19 @@ function resolveToolStatus(toolName: string, data: any): string | null {
  *     (or vice versa) would silently erase the other's outcome. See
  *     mergeRetrievalSummary (retrievalSummaryMerge.ts) for the merge policy.
  *
+ * `userId` seeds `promptMeta.session` (via materializePromptMetaSession) on every write that
+ * touches promptMeta, in EITHER branch below - not just the no-existing-meta one - because a quest
+ * read off disk can carry a promptMeta with no session block at all (bike4mind#2004: several
+ * writers used to materialize promptMeta this way, and older rows never got backfilled). Without
+ * this, `PromptMetaSchema.session.id`/`.userId` (required: true) go unenforced forever, since this
+ * write goes through update() (findOneAndUpdate + $set, no validators).
+ *
  * Mutates `quest` in place.
  */
 export function applyQuestStatusChanges(
   quest: IChatHistoryItemDocument,
-  changes: Partial<IChatHistoryItemDocument>
+  changes: Partial<IChatHistoryItemDocument>,
+  userId: string
 ): void {
   const { promptMeta: changedPromptMeta, images: changedImages, ...otherChanges } = changes;
 
@@ -247,19 +256,22 @@ export function applyQuestStatusChanges(
     });
     const mergedWarnings = [...(quest.promptMeta.warnings || []), ...(changedPromptMeta.warnings || [])];
     const mergedRetrieval = mergeRetrievalSummary(quest.promptMeta.retrieval, changedPromptMeta.retrieval);
-    quest.promptMeta = {
-      ...quest.promptMeta,
-      ...changedPromptMeta,
-      citables: dedupedCitables,
-      // Omit the key entirely when neither side has warnings, so an untouched quest is not
-      // given an empty array it never had.
-      ...(mergedWarnings.length ? { warnings: [...new Set(mergedWarnings)] } : {}),
-      // Explicit override, not left to the spread above: an incoming write here must MERGE onto
-      // an existing forced-arm value, never replace it (see the docblock above).
-      ...(mergedRetrieval ? { retrieval: mergedRetrieval } : {}),
-    };
+    quest.promptMeta = materializePromptMetaSession(
+      {
+        ...quest.promptMeta,
+        ...changedPromptMeta,
+        citables: dedupedCitables,
+        // Omit the key entirely when neither side has warnings, so an untouched quest is not
+        // given an empty array it never had.
+        ...(mergedWarnings.length ? { warnings: [...new Set(mergedWarnings)] } : {}),
+        // Explicit override, not left to the spread above: an incoming write here must MERGE onto
+        // an existing forced-arm value, never replace it (see the docblock above).
+        ...(mergedRetrieval ? { retrieval: mergedRetrieval } : {}),
+      },
+      { sessionId: quest.sessionId, userId }
+    );
   } else if (changedPromptMeta) {
-    quest.promptMeta = changedPromptMeta;
+    quest.promptMeta = materializePromptMetaSession(changedPromptMeta, { sessionId: quest.sessionId, userId });
   }
 
   if (changedImages) {
@@ -739,7 +751,7 @@ export class ToolBuilder {
           // Merge nested fields that accrete across a turn (promptMeta.citables,
           // images) instead of overwriting them wholesale - see
           // applyQuestStatusChanges.
-          applyQuestStatusChanges(quest, changes as Partial<IChatHistoryItemDocument>);
+          applyQuestStatusChanges(quest, changes as Partial<IChatHistoryItemDocument>, this.deps.user.id);
           await this.deps.sendStatusUpdate(quest, status ?? null);
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -856,7 +868,10 @@ export class ToolBuilder {
           await saveQuest(quest);
         },
         onArtifactExtracted: artifact => {
-          if (!quest.promptMeta) quest.promptMeta = {} as NonNullable<typeof quest.promptMeta>;
+          quest.promptMeta = materializePromptMetaSession(quest.promptMeta, {
+            sessionId: quest.sessionId,
+            userId: this.deps.user.id,
+          });
           if (!quest.promptMeta!.artifacts) quest.promptMeta!.artifacts = [];
           quest.promptMeta!.artifacts.push(artifact as (typeof quest.promptMeta.artifacts)[number]);
           // Fire-and-forget save


### PR DESCRIPTION
## Description
Several quest writers materialize `promptMeta` from nothing without seeding `promptMeta.session`. This matters because `PromptMetaSchema.session.id`/`.userId` are `required: true` on the Mongoose model, but that's only enforced on `create()` — live-turn writes go through `findOneAndUpdate`/`update()` with `$set`, which skips validators entirely. A quest whose `promptMeta` has no session block becomes:
- invisible to `databaseSearcher.ts`'s owner-scoped internal quest search (keyed on `promptMeta.session.userId`)
- absent from admin cost/model analytics rollups (`analytics.ts`, `model-metrics.ts`), which filter on the same field

Fixes #2004.

## Changes
- Added `materializePromptMetaSession` (`b4m-core/common/src/utils/promptMetaSessionBinding.ts`), a shared primitive built on the existing `rebindPromptMetaSession`, that always returns a `PromptMeta` with a valid `session` block.
- Routed it through every writer that builds `promptMeta` from nothing:
  - `ChatCompletionFeatures.ts` — 7 sites
  - `ImageGeneration.ts` / `VideoGeneration.ts` — `addStatusToQuest` (now takes a required `userId`), all call sites
  - `ToolBuilder.ts` — `applyQuestStatusChanges` (both branches — extended past the issue's literal "no-existing-meta" framing as defense-in-depth against legacy no-session data reaching the merge branch) + `onArtifactExtracted`
  - `persistRunAsQuest.ts` (agent-mode chat-history persistence) — a 5th writer with the identical bug class, found during self-review and not named in the original issue; folded into this PR to keep data-lake-related fixes consolidated
- Added/updated unit tests at every touched call site, including load-bearing tests asserting the `session` block is actually present (verified they fail without the fix).

## Guide for Testers
This is a backend data-integrity fix with no user-visible surface change — behavior is identical from the chat UI's perspective.

**What NOT to test:** no UI changes to click through. The fix is only observable in the persisted `promptMeta.session` shape.

Regression checks (all covered by the updated unit suites, re-runnable locally):
1. `pnpm --filter @bike4mind/common test promptMetaSessionBinding` — passes, 10/10.
2. `pnpm --filter @bike4mind/services test ChatCompletionFeatures ImageGeneration VideoGeneration ToolBuilder ChatCompletion` — passes, 464/464.
3. `pnpm --filter @bike4mind/client test --project node persistRunAsQuest` — passes, 24/24.

## Additional Information
Verified via `pnpm turbo:core:build && pnpm turbo:typecheck && pnpm lint:check` — all green.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — N/A, no AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) — N/A, no UI change
- [ ] I have made corresponding changes to the documentation (if applicable) — N/A
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc — N/A, no new telemetry field
