### PR TITLE
fix(client): surface the real error instead of a generic @datalake reply

### DIFF
--- a/apps/client/server/slack/handleDataLakeCommand.test.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ForbiddenError } from '@bike4mind/common';
 
 // The @datalake grammar parser is unit-tested in the slack package; here we mock it and exercise
 // the handler's dispatch, listing and ingest-reply behavior in isolation.
@@ -861,5 +862,62 @@ describe('runDataLakeSlackCommand (gate + dispatch)', () => {
 
     expect(logger.error).toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('went wrong') }));
+  });
+
+  it('surfaces an HTTPError message rethrown by the write gate (#2639)', async () => {
+    // dataLakeIngestAuthz.ts rethrows anything that is not a refusal (NotFoundError/BadRequestError),
+    // so an HTTPError subclass reaching here already carries a message written to be shown to the
+    // caller, unlike the generic "db down" case above.
+    getSettingsValue.mockResolvedValue(true);
+    parseDataLakeCommand.mockReturnValue({ subcommand: 'add', lakeSlug: 'sales', rawArgs: '' });
+    ingestSlackFilesIntoLake.mockRejectedValue(new ForbiddenError('This lake is locked pending a compliance review'));
+
+    await runDataLakeSlackCommand({ ...baseDeps(), files: [{ id: 'F1' }] as never });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'This lake is locked pending a compliance review' })
+    );
+  });
+
+  it('surfaces the message from an HTTPError-shaped error that fails instanceof (cross-realm)', async () => {
+    // Simulates @bike4mind/common resolving as two module realms across the
+    // @bike4mind/services -> this file boundary: a class with the exact shape a real
+    // ForbiddenError constructor produces (statusCode, a name ending in "Error", and an
+    // additionalInfo key) but NOT an instance of the imported HTTPError class.
+    class OtherRealmForbiddenError extends Error {
+      statusCode = 403;
+      additionalInfo?: Record<string, unknown>;
+      constructor(message: string) {
+        super(message);
+        this.name = 'ForbiddenError';
+      }
+    }
+    getSettingsValue.mockResolvedValue(true);
+    parseDataLakeCommand.mockReturnValue({ subcommand: 'add', lakeSlug: 'sales', rawArgs: '' });
+    ingestSlackFilesIntoLake.mockRejectedValue(new OtherRealmForbiddenError('Cross-realm refusal message'));
+
+    await runDataLakeSlackCommand({ ...baseDeps(), files: [{ id: 'F1' }] as never });
+
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: 'Cross-realm refusal message' }));
+  });
+
+  it('falls back to the generic reply for an HTTPError with an empty message', async () => {
+    getSettingsValue.mockResolvedValue(true);
+    parseDataLakeCommand.mockReturnValue({ subcommand: 'add', lakeSlug: 'sales', rawArgs: '' });
+    ingestSlackFilesIntoLake.mockRejectedValue(new ForbiddenError(''));
+
+    await runDataLakeSlackCommand({ ...baseDeps(), files: [{ id: 'F1' }] as never });
+
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('went wrong') }));
+  });
+
+  it('caps an oversized HTTPError message instead of relaying it verbatim', async () => {
+    getSettingsValue.mockResolvedValue(true);
+    parseDataLakeCommand.mockReturnValue({ subcommand: 'add', lakeSlug: 'sales', rawArgs: '' });
+    ingestSlackFilesIntoLake.mockRejectedValue(new ForbiddenError('x'.repeat(400)));
+
+    await runDataLakeSlackCommand({ ...baseDeps(), files: [{ id: 'F1' }] as never });
+
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({ text: `${'x'.repeat(300)}...` }));
   });
 });

--- a/apps/client/server/slack/handleDataLakeCommand.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.ts
@@ -5,7 +5,7 @@ import {
   type SlackAttachment,
 } from '@bike4mind/slack';
 import { dataLakeService } from '@bike4mind/services';
-import { STATIC_LAKE_IDS } from '@bike4mind/common';
+import { HTTPError, STATIC_LAKE_IDS } from '@bike4mind/common';
 import type { AccessContext, IDataLakeRepository, ManageableDataLakeConfig } from '@bike4mind/common';
 import { buildSlackAccessContext, type SlackIngestActor } from './dataLakeIngestAuthz';
 import { ingestSlackFilesIntoLake, type SlackLakeIngestDeps, type SlackLakeIngestOutcome } from './dataLakeFileIngest';
@@ -95,6 +95,33 @@ export function formatBareDataLakeMentionHint(): string {
 
 /** Rows shown by `list` before a "+N more" tail. Keeps the reply well inside Slack's 40k limit. */
 const LIST_LIMIT = 50;
+
+// Mirrors CommandHandler.ts's cap on the assistant path (#2486): a curated refusal message
+// (see dataLakeIngestAuthz.ts) is always short, so this only bounds an unclassified
+// HTTPError's raw message before it reaches a Slack channel that may not be private.
+const MAX_ERROR_REPLY_LENGTH = 300;
+
+function capErrorReply(reply: string): string {
+  return reply.length > MAX_ERROR_REPLY_LENGTH ? `${reply.slice(0, MAX_ERROR_REPLY_LENGTH)}...` : reply;
+}
+
+/**
+ * `error instanceof HTTPError` is unreliable if `@bike4mind/common` ever resolves as two
+ * distinct module realms across the `@bike4mind/services` -> this file's boundary (same
+ * concern CommandHandler.ts's isHttpError documents for #2486) - every HTTPError subclass
+ * still sets a numeric `statusCode`, a `name` ending in `Error`, and an `additionalInfo` key
+ * (present, even if `undefined`, as a constructor parameter property), so duck-type on that
+ * shape as a fallback instead of trusting the bare instanceof alone.
+ */
+function isHttpError(err: unknown): err is HTTPError {
+  return (
+    err instanceof HTTPError ||
+    (err instanceof Error &&
+      typeof (err as { statusCode?: unknown }).statusCode === 'number' &&
+      err.name.endsWith('Error') &&
+      'additionalInfo' in err)
+  );
+}
 
 export async function handleDataLakeCommand(params: HandleDataLakeCommandParams): Promise<string> {
   const parsed = parseDataLakeCommand(params.command);
@@ -494,12 +521,17 @@ export async function runDataLakeSlackCommand(deps: RunDataLakeSlackCommandDeps)
     deps.logger.error('@datalake command failed', {
       error: err instanceof Error ? err.message : String(err),
     });
+    // dataLakeIngestAuthz.ts's write gates rethrow anything that is not a refusal
+    // (NotFoundError/BadRequestError), so an HTTPError subclass reaching here (e.g.
+    // ForbiddenError, ConflictError) already carries a message written to be shown to the
+    // caller. Anything else stays generic rather than leaking an unreviewed internal error
+    // into a channel that may not be private.
+    const text =
+      isHttpError(err) && err.message
+        ? capErrorReply(err.message)
+        : 'Something went wrong handling that `@datalake` command. Please try again.';
     try {
-      await deps.sendMessage({
-        channel: deps.channel,
-        text: 'Something went wrong handling that `@datalake` command. Please try again.',
-        threadTs: deps.threadTs,
-      });
+      await deps.sendMessage({ channel: deps.channel, text, threadTs: deps.threadTs });
     } catch {
       // Best-effort error reply; ignore a secondary sendMessage failure so we still ack 200.
     }


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="1523" height="784" alt="01-admin-settings" src="https://github.com/user-attachments/assets/74bc58f3-3160-45cf-a6fb-71b69e1de036" />

**Admin Settings Precheck**: `Enable Data Lakes` and the `@datalake add` Slack path both
already on for this preview deployment.

<img width="1014" height="284" alt="02-datalake-list-none" src="https://github.com/user-attachments/assets/7e8c31a9-6480-4c87-943c-f1edaeceabcf" />

**No Lake Yet**: `@datalake list` before any lake existed for the test account.

<img width="982" height="358" alt="02-datalake-list" src="https://github.com/user-attachments/assets/c505d629-7c6a-4f1c-af83-32c01bce0c1e" />

**Datalake List**: `@datalake list` after creating a test lake, confirming it's addressable.

<img width="982" height="512" alt="03-step1-help" src="https://github.com/user-attachments/assets/9962b6a1-0377-4648-9339-03b349776f88" />

**Help Command Unchanged**: `@datalake help` reply, unchanged by this PR.

<img width="982" height="512" alt="04-step2-add-success" src="https://github.com/user-attachments/assets/1275d1a6-3c34-40a2-bd65-bab05a1f77c5" />

**Successful Add Unchanged**: `@datalake add to <lake>` with a file, success reply unchanged.

<img width="982" height="512" alt="05-step3-unknown-lake" src="https://github.com/user-attachments/assets/2c064920-eb12-4772-b1bf-35d0cfa7fb37" />

**Unknown-Lake Refusal Unchanged**: `@datalake add to <nonexistent-slug>`, the existing
"No Data Lake found" refusal, unaffected by this PR's catch-block change.

<img width="982" height="512" alt="06-step4-no-permission" src="https://github.com/user-attachments/assets/fdd46fc3-2e40-48bb-902f-34588c0f5b37" />

**No-Permission Refusal Unchanged**: `@datalake add to opti-knowledge` (a built-in,
read-only lake), the existing "built into the platform and is read-only" refusal,
unaffected by this PR's catch-block change.

Closes #2639

## Description
The `@datalake` Slack command's outer catch (`runDataLakeSlackCommand` in
`apps/client/server/slack/handleDataLakeCommand.ts`) always replied with a hardcoded
generic string on any failure, regardless of the actual cause. This mirrors the
antipattern #2026 tracked and PR #2486 fixed for the Slack general-assistant path
(`b4m-core/slack/src/CommandHandler.ts`), in this second, distinct code path.

`dataLakeIngestAuthz.ts`'s write gates already rethrow anything that is not a
`NotFoundError`/`BadRequestError` refusal (`apps/client/server/slack/dataLakeIngestAuthz.ts:199,244`),
so an `HTTPError` subclass reaching the outer catch already carries a message written to
be shown to the caller. This PR surfaces that message (capped, so an unclassified error
cannot dump an oversized or unreviewed string into a channel that may not be private)
instead of always flattening to the generic sentence.

## Changes
- `apps/client/server/slack/handleDataLakeCommand.ts`:
  - Added `isHttpError()` (`handleDataLakeCommand.ts:116-124`), a duck-typed check
    (`instanceof HTTPError`, or a numeric `statusCode` + a `name` ending in `Error` +
    an `additionalInfo` key) mirroring `CommandHandler.ts`'s helper from PR #2486, since
    `instanceof HTTPError` alone is unreliable if `@bike4mind/common` resolves as two
    module realms across the `@bike4mind/services` boundary.
  - Added `capErrorReply()` and `MAX_ERROR_REPLY_LENGTH = 300` (`handleDataLakeCommand.ts:99-105`).
  - The outer catch in `runDataLakeSlackCommand` (`handleDataLakeCommand.ts:520-537`) now
    replies with the capped real message when the caught error is an `HTTPError`
    (and has a non-empty message); otherwise it keeps the existing generic sentence.
    `deps.logger.error` and the best-effort secondary catch around `sendMessage` are
    unchanged.
- `apps/client/server/slack/handleDataLakeCommand.test.ts`: 4 new tests in the
  `runDataLakeSlackCommand` describe block (`handleDataLakeCommand.test.ts:867-921`):
  an `HTTPError` rethrown by the write gate surfaces its message; a cross-realm
  duck-typed `HTTPError` (fails `instanceof`, matches the shape) also surfaces its
  message; an `HTTPError` with an empty message falls back to the generic sentence; an
  oversized `HTTPError` message is capped at 300 chars with a trailing `...`.

## Guide for Testers
Already verified on the PR preview (screenshots above); repeat if you want to confirm
independently. Requires a Slack workspace connected to a deployment with the
`EnableDataLakes` and `EnableDataLakeSlackAdd` admin settings both on.

### Regression Checks
1. In the connected Slack workspace, post `@datalake help` in any channel. Expected
   result: the bot replies in-thread with the help text listing the `add to`, `list`,
   and `help` subcommands.
2. Post `@datalake add to <a-lake-slug-you-can-write-to>` with a file attached. Expected
   result: the bot replies confirming the file was added to that lake and is processing.
3. Post `@datalake add to <a-slug-that-does-not-exist>` with a file attached. Expected
   result: the bot replies `No Data Lake \`<slug>\` found. Use \`@datalake list\` to see
   the lakes you can add to.` - this refusal path does not reach the code this PR
   changes, so its wording is unchanged.
4. Post `@datalake add to opti-knowledge` with a file attached (a built-in, read-only
   lake). Expected result: the bot replies `Cannot add to \`opti-knowledge\`: This data
   lake is built into the platform and is read-only` - this refusal path does not reach
   the code this PR changes, so its wording is unchanged.

### What NOT to test
- The new behavior itself (surfacing an `HTTPError`'s real message instead of the fixed
  generic sentence) has no reachable trigger in the live app today: every error the
  ingest paths (`dataLakeIngestAuthz.ts`, `dataLakeFileIngest.ts`,
  `dataLakeLinkIngest.ts`) can throw is already caught and converted to a refusal
  string before it reaches the catch this PR changes. It is defensive/forward-looking
  and is covered by the added automated tests, not a scenario reproducible by hand.
- No UI surface changes ship in this PR - nothing to click through in the web app.

## Additional Information
- `handleDataLakeCommand.test.ts` (56 tests, including the 4 new ones) passes locally;
  typecheck and `lint:check` are clean on the changed files.
- All 4 Guide for Testers checks passed on the PR preview (screenshots above): help,
  successful add, unknown-lake refusal, and the built-in-lake no-permission refusal all
  returned their existing wording with no regression to the generic error reply.
- Follow-up to #2026 / PR #2486, tracked as a child of epic #2399.
- The `isHttpError`/`capErrorReply` helper is duplicated locally in
  `handleDataLakeCommand.ts` rather than extracted into a shared package, since this is
  only the second call site (`CommandHandler.ts` being the first). Worth extracting if a
  third site needs the same pattern.
- Full reachability was traced for this change: no `HTTPError` subclass thrown anywhere
  in the code paths reachable from this catch today carries attacker-influenced text (a
  file name, URL, or page title) - both ingest paths (`dataLakeFileIngest.ts`,
  `dataLakeLinkIngest.ts`) already catch everything internally and convert it to a fixed
  or pre-escaped refusal string before it could reach here.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
