### PR TITLE
fix(data-lakes): back off in-process on a throttled Drive call, and shed a throttled walk

### DIFF
--- a/apps/client/pages/api/data-lakes/__tests__/drive-sync.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/drive-sync.test.ts
@@ -87,7 +87,7 @@ describe('POST /api/data-lakes/drive-sync - org-owned connect (D1)', () => {
     h.connRelease.mockResolvedValue(true);
     h.getValidUserDriveAccessToken.mockResolvedValue('user-access-token');
     h.createDriveClient.mockReturnValue({});
-    h.getFolderAccess.mockResolvedValue({ exists: true, isFolder: true, canRead: true });
+    h.getFolderAccess.mockResolvedValue({ ok: true, exists: true, isFolder: true, canRead: true });
   });
 
   it('captures the org-owned credential on the connection and enqueues ingest', async () => {
@@ -113,7 +113,7 @@ describe('POST /api/data-lakes/drive-sync - org-owned connect (D1)', () => {
   it('refuses to claim a folder the connecting user cannot read (anti-squat gate)', async () => {
     // Drive 404s a folder the caller can't see, so getFolderAccess reports it as non-existent - the
     // claim must be refused so a manager can't squat a folder id belonging to another org.
-    h.getFolderAccess.mockResolvedValue({ exists: false, isFolder: false, canRead: false });
+    h.getFolderAccess.mockResolvedValue({ ok: true, exists: false, isFolder: false, canRead: false });
     const { res } = makeRes();
     await expect(run(makeReq({ dataLakeId: 'lake1', driveFolderId: FOLDER_ID }), res)).rejects.toThrow(
       /do not have access/i
@@ -123,8 +123,22 @@ describe('POST /api/data-lakes/drive-sync - org-owned connect (D1)', () => {
     expect(h.sendToQueue).not.toHaveBeenCalled();
   });
 
+  it('tells the user Drive is throttling us rather than that they lost access to their folder', async () => {
+    // The conflation this guards: a throttled probe used to come back `exists: false`, so the user
+    // was told they had no access to a folder they own and went hunting a permission problem that
+    // did not exist. The claim is still refused - it just says the true reason.
+    h.getFolderAccess.mockResolvedValue({ ok: false, reason: 'rate_limited', detail: '429' });
+    const { res } = makeRes();
+    await expect(run(makeReq({ dataLakeId: 'lake1', driveFolderId: FOLDER_ID }), res)).rejects.toThrow(
+      /rate-limiting/i
+    );
+    expect(h.connFindByDriveFolderId).not.toHaveBeenCalled();
+    expect(h.connCreate).not.toHaveBeenCalled();
+    expect(h.sendToQueue).not.toHaveBeenCalled();
+  });
+
   it('rejects a readable id that is a file, not a folder', async () => {
-    h.getFolderAccess.mockResolvedValue({ exists: true, isFolder: false, canRead: true });
+    h.getFolderAccess.mockResolvedValue({ ok: true, exists: true, isFolder: false, canRead: true });
     const { res } = makeRes();
     await expect(run(makeReq({ dataLakeId: 'lake1', driveFolderId: FOLDER_ID }), res)).rejects.toThrow(/not a folder/i);
     expect(h.connCreate).not.toHaveBeenCalled();

--- a/apps/client/pages/api/data-lakes/__tests__/driveSyncFolderClaimRelease.e2e.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/driveSyncFolderClaimRelease.e2e.test.ts
@@ -144,7 +144,7 @@ beforeEach(() => {
   h.verifyOrgAccess.mockResolvedValue(undefined);
   h.getValidUserDriveAccessToken.mockResolvedValue('user-access-token');
   h.createDriveClient.mockReturnValue({});
-  h.getFolderAccess.mockResolvedValue({ exists: true, isFolder: true, canRead: true });
+  h.getFolderAccess.mockResolvedValue({ ok: true, exists: true, isFolder: true, canRead: true });
   h.sendToQueue.mockResolvedValue(undefined);
 });
 

--- a/apps/client/pages/api/data-lakes/drive-sync.ts
+++ b/apps/client/pages/api/data-lakes/drive-sync.ts
@@ -11,7 +11,13 @@ import {
 import { getValidUserDriveAccessToken } from '@server/integrations/google/drive/common';
 import { decryptToken } from '@server/security/tokenEncryption';
 import { isEncrypted } from '@server/security/secretEncryption';
-import { BadRequestError, ForbiddenError, InternalServerError, NotFoundError } from '@server/utils/errors';
+import {
+  BadRequestError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+  TooManyRequestsError,
+} from '@server/utils/errors';
 import { sendToQueue } from '@server/utils/sqs';
 import { Request } from 'express';
 import { Resource } from 'sst';
@@ -102,6 +108,14 @@ const handler = baseApi()
       createDriveClient(await getValidUserDriveAccessToken(req.user.id)),
       driveFolderId
     );
+    // A throttle is not an access verdict: without this, Drive rate-limiting the probe would tell the
+    // user they have no access to a folder they own, and they would go hunting a permission problem
+    // that does not exist (#2395).
+    if (!folderAccess.ok) {
+      throw new TooManyRequestsError(
+        'Google Drive is rate-limiting us right now, so we could not check that folder. Try connecting it again in a minute.'
+      );
+    }
     if (!folderAccess.exists) {
       throw new ForbiddenError('That Google Drive folder does not exist or you do not have access to it.');
     }

--- a/apps/client/server/integrations/google/drive/driveClient.test.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.test.ts
@@ -207,6 +207,31 @@ describe('withDriveRetry', () => {
     await expect(settleThroughBackoff(withDriveRetry('files.list', call))).resolves.toBe('listed');
     expect(call).toHaveBeenCalledTimes(2);
   });
+
+  // gaxios' disabled retry layer also covered failures with NO HTTP response at all (a dropped
+  // connection, a DNS miss, a timed-out socket) via its own noResponseRetries - this has to too, now
+  // that it is the only layer left.
+  it('retries a network-level failure with no HTTP response (ECONNRESET, ETIMEDOUT, ...)', async () => {
+    vi.useFakeTimers();
+    const call = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }))
+      .mockResolvedValue('listed');
+
+    await expect(settleThroughBackoff(withDriveRetry('files.list', call))).resolves.toBe('listed');
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a permanent failure that merely lacks a numeric code', async () => {
+    // A response IS present here (unlike the network-failure case above), so this must stay a
+    // permanent failure - retrying anything without a response would swallow ordinary bugs too.
+    const call = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('boom'), { code: 'SOME_APP_ERROR', response: { status: 400 } }));
+
+    await expect(withDriveRetry('files.get', call)).rejects.toThrow('boom');
+    expect(call).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('createDriveClient', () => {

--- a/apps/client/server/integrations/google/drive/driveClient.test.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.test.ts
@@ -1,6 +1,38 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { drive_v3 } from '@googleapis/drive';
-import { listFolderChildren, getFolderAccess, isFolder, isValidDriveFolderId, FOLDER_MIME_TYPE } from './driveClient';
+import {
+  listFolderChildren,
+  getFolderAccess,
+  isFolder,
+  isValidDriveFolderId,
+  withDriveRetry,
+  FOLDER_MIME_TYPE,
+} from './driveClient';
+
+/** The shape googleapis hands back for a throttle - a 429, or a 403 whose reason is a quota. */
+const throttle = (status = 429, reason = 'userRateLimitExceeded') =>
+  Object.assign(new Error('Rate Limit Exceeded'), {
+    code: status,
+    response: { status, data: { error: { errors: [{ reason }] } } },
+  });
+
+/**
+ * The retry sleeps for real, so every test that drives one through a throttle runs on fake timers
+ * and flushes them rather than waiting out the backoff.
+ *
+ * The outcome is captured as a thunk BEFORE the flush: an unattended rejection landing while the
+ * timers run is reported as an unhandled error, even though the caller awaits it a line later.
+ */
+const settleThroughBackoff = async <T>(pending: Promise<T>): Promise<T> => {
+  const settled = pending.then(
+    value => () => value,
+    (error: unknown) => () => {
+      throw error;
+    }
+  );
+  await vi.runAllTimersAsync();
+  return settled.then(replay => replay());
+};
 
 /**
  * Mocks just the `files.list` surface listFolderChildren uses, returning a queue of pages so
@@ -81,14 +113,19 @@ describe('getFolderAccess', () => {
     const drive = driveWithGet(async () => ({
       data: { id: 'F', mimeType: FOLDER_MIME_TYPE, capabilities: { canDownload: true } },
     }));
-    expect(await getFolderAccess(drive, 'FOLDER_X')).toEqual({ exists: true, isFolder: true, canRead: true });
+    expect(await getFolderAccess(drive, 'FOLDER_X')).toEqual({ ok: true, exists: true, isFolder: true, canRead: true });
   });
 
   it('treats a Drive error (404 for an inaccessible folder) as not-exists, failing closed', async () => {
     const drive = driveWithGet(async () => {
       throw new Error('File not found');
     });
-    expect(await getFolderAccess(drive, 'FOLDER_X')).toEqual({ exists: false, isFolder: false, canRead: false });
+    expect(await getFolderAccess(drive, 'FOLDER_X')).toEqual({
+      ok: true,
+      exists: false,
+      isFolder: false,
+      canRead: false,
+    });
   });
 
   it('flags a readable id that is a file, not a folder', async () => {
@@ -106,7 +143,12 @@ describe('getFolderAccess', () => {
   it('never issues a query for an invalid id', async () => {
     const get = vi.fn();
     const drive = { files: { get } } as unknown as drive_v3.Drive;
-    expect(await getFolderAccess(drive, "x' in parents")).toEqual({ exists: false, isFolder: false, canRead: false });
+    expect(await getFolderAccess(drive, "x' in parents")).toEqual({
+      ok: true,
+      exists: false,
+      isFolder: false,
+      canRead: false,
+    });
     expect(get).not.toHaveBeenCalled();
   });
 });
@@ -115,5 +157,92 @@ describe('isFolder', () => {
   it('detects the Drive folder mime type', () => {
     expect(isFolder({ id: '1', name: 'sub', mimeType: FOLDER_MIME_TYPE })).toBe(true);
     expect(isFolder({ id: '2', name: 'a.txt', mimeType: 'text/plain' })).toBe(false);
+  });
+});
+
+describe('withDriveRetry', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('retries a throttled call and returns the value once Drive lets it through', async () => {
+    vi.useFakeTimers();
+    const call = vi.fn().mockRejectedValueOnce(throttle()).mockResolvedValue('listed');
+
+    await expect(settleThroughBackoff(withDriveRetry('files.list', call))).resolves.toBe('listed');
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a 403 whose reason is a quota, not a permission denial', async () => {
+    vi.useFakeTimers();
+    const call = vi.fn().mockRejectedValueOnce(throttle(403, 'rateLimitExceeded')).mockResolvedValue('listed');
+
+    await expect(settleThroughBackoff(withDriveRetry('files.list', call))).resolves.toBe('listed');
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows the ORIGINAL error when the throttle outlives the budget, so callers can still detect it', async () => {
+    vi.useFakeTimers();
+    const err = throttle();
+    const call = vi.fn().mockRejectedValue(err);
+
+    // Identity matters: the caller sheds load by re-testing this error with isDriveRateLimitError,
+    // which a wrapper error would defeat.
+    await expect(settleThroughBackoff(withDriveRetry('files.list', call))).rejects.toBe(err);
+    expect(call).toHaveBeenCalledTimes(4); // the attempt plus DRIVE_RETRY_MAX_RETRIES
+  });
+
+  it('does not retry a permanent failure', async () => {
+    const call = vi.fn().mockRejectedValue(Object.assign(new Error('File not found'), { code: 404 }));
+
+    await expect(withDriveRetry('files.get', call)).rejects.toThrow('File not found');
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient 5xx, which createDriveClient no longer lets googleapis retry for us', async () => {
+    vi.useFakeTimers();
+    const call = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('Backend Error'), { code: 503, response: { status: 503 } }))
+      .mockResolvedValue('listed');
+
+    await expect(settleThroughBackoff(withDriveRetry('files.list', call))).resolves.toBe('listed');
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('createDriveClient', () => {
+  it('turns googleapis own retry layer off, so withDriveRetry is the only one', async () => {
+    // Two layers compose multiplicatively (~16 HTTP attempts per call) and googleapis backs off
+    // without jitter, which is what re-collides connections sharing one Drive project quota.
+    const { createDriveClient: create } = await import('./driveClient');
+    const client = create('token') as unknown as { context: { _options: { retry?: boolean } } };
+    expect(client.context._options.retry).toBe(false);
+  });
+});
+
+describe('rate limits', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('listFolderChildren retries a throttled page rather than failing the walk', async () => {
+    vi.useFakeTimers();
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(throttle())
+      .mockResolvedValue({ data: { files: [{ id: '1', name: 'a.txt', mimeType: 'text/plain' }] } });
+    const drive = { files: { list } } as unknown as drive_v3.Drive;
+
+    const files = await settleThroughBackoff(listFolderChildren(drive, 'FOLDER_X'));
+    expect(files.map(f => f.id)).toEqual(['1']);
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it('getFolderAccess reports a sustained throttle as rate_limited, NOT as a missing folder', async () => {
+    // The bug: `exists: false` here told a user they had lost access to a folder they own, and sent
+    // them hunting a Drive permission problem that did not exist.
+    vi.useFakeTimers();
+    const get = vi.fn().mockRejectedValue(throttle());
+    const drive = { files: { get } } as unknown as drive_v3.Drive;
+
+    const access = await settleThroughBackoff(getFolderAccess(drive, 'FOLDER_X'));
+    expect(access).toMatchObject({ ok: false, reason: 'rate_limited' });
   });
 });

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -52,6 +52,72 @@ export function isDriveRateLimitError(e: unknown): boolean {
   return false;
 }
 
+const isTransientDriveStatus = (status: number) => status === 408 || (status >= 500 && status < 600);
+
+/**
+ * Worth one more attempt: a throttle, or a Drive hiccup/timeout. Deliberately WIDER than
+ * isDriveRateLimitError, which stays the narrow "shed load" signal - a Drive outage retried here
+ * and still failing must end at the DLQ where an operator sees it, not be deferred quietly as
+ * though it were a quota problem that will pass on its own.
+ */
+function isRetryableDriveError(e: unknown): boolean {
+  if (isDriveRateLimitError(e)) return true;
+  if (typeof e !== 'object' || e === null) return false;
+  const err = e as Record<string, unknown>;
+  const response = err.response as Record<string, unknown> | undefined;
+  for (const raw of [err.code, err.status, response?.status]) {
+    const status = typeof raw === 'string' ? Number(raw) : raw;
+    if (typeof status === 'number' && isTransientDriveStatus(status)) return true;
+  }
+  return false;
+}
+
+// In-process retry budget for a failed Drive call. Deliberately small: this absorbs the
+// second-scale blip (a burst against Drive's per-user 100-second bucket), and a throttle that
+// outlives it is a sustained quota problem the CALLER has to shed by deferring its work - not
+// something to keep sleeping on inside a Lambda with a 10-minute ceiling. Windows of 1s/2s/4s put
+// the worst case at 7s of sleep per call; raising the retry count is a budget decision, not a
+// tuning one, because the folder walk pays this per THROTTLED folder.
+const DRIVE_RETRY_MAX_RETRIES = 3;
+const DRIVE_RETRY_BASE_DELAY_MS = 1_000;
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Run one Drive call, retrying a transient failure with exponential backoff and jitter.
+ *
+ * This is the ONLY retry layer on the Drive path - createDriveClient turns the googleapis one off
+ * (see there for why). It covers the same classes that layer did, plus the 403-with-quota-reason
+ * shape it did not retry at all.
+ *
+ * The jitter is half the window, not a wobble around a fixed delay: several connections sync
+ * against ONE Drive project quota, so a fixed backoff just re-collides the same callers at the
+ * same new instant and the throttle repeats.
+ *
+ * A permanent failure (404, a genuine permission denial) rethrows on the first attempt, and an
+ * error that outlives the budget rethrows the ORIGINAL, so `isDriveRateLimitError` still identifies
+ * a throttle upstream and the caller can defer rather than record a permanent failure (#2395).
+ */
+export async function withDriveRetry<T>(operation: string, call: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await call();
+    } catch (e) {
+      if (attempt >= DRIVE_RETRY_MAX_RETRIES || !isRetryableDriveError(e)) throw e;
+      const window = DRIVE_RETRY_BASE_DELAY_MS * 2 ** attempt;
+      const delayMs = Math.floor(window / 2 + Math.random() * (window / 2));
+      Logger.globalInstance.warn('[withDriveRetry] transient Drive failure; backing off', {
+        operation,
+        attempt: attempt + 1,
+        maxRetries: DRIVE_RETRY_MAX_RETRIES,
+        rateLimited: isDriveRateLimitError(e),
+        delayMs,
+      });
+      await sleep(delayMs);
+    }
+  }
+}
+
 // Drive file/folder ids are URL-safe tokens ([A-Za-z0-9_-]); the alias 'root' also matches. The
 // length bound (real ids are ~33-44 chars) stops ~1MB of legal characters being interpolated into
 // the `q` string and sent outbound. Validate before interpolating so a crafted id can't break out.
@@ -72,40 +138,61 @@ const MAX_LIST_PAGES = 100;
  * IMPORTANT: constructs a FRESH OAuth2 client every call. Never reuse the module-level
  * singleton in common.ts - its credentials are mutable shared state (`setCredentials`), so
  * concurrent multi-tenant syncs on one process would race and bleed tokens across tenants.
+ *
+ * `retry: false` is load-bearing, not a disabling of resilience. googleapis-common opts every
+ * request into its own retry layer by default (3 retries over 408/429/5xx), which is
+ * DETERMINISTIC - no jitter, so several connections sharing one Drive project quota all come back
+ * at the same instant - silent, and blind to the 403-with-quota-reason shape Drive uses as often as
+ * a 429. Left on it would also compose with withDriveRetry into ~16 HTTP attempts per call with an
+ * unknowable total sleep, inside a handler that has a 10-minute ceiling. One layer, ours, so the
+ * budget is knowable and a throttle is visible (#2395).
  */
 export function createDriveClient(accessToken: string): drive_v3.Drive {
   const auth = new googleAuth.OAuth2();
   auth.setCredentials({ access_token: accessToken });
-  return driveApi({ version: 'v3', auth });
+  return driveApi({ version: 'v3', auth, retry: false });
 }
+
+/**
+ * `ok: false` means Drive never gave an access ANSWER - it throttled us. Modelled as its own arm
+ * rather than a flag on the success shape so a caller cannot read `exists: false` off a throttle
+ * and tell the user they lost access to their own folder (#2395).
+ */
+export type FolderAccess =
+  | { ok: true; exists: boolean; isFolder: boolean; canRead: boolean }
+  | { ok: false; reason: 'rate_limited'; detail?: string };
 
 /**
  * Read-access probe for a single folder, using the CALLER's own Drive credential. Drive returns 404
  * (not 403) for a file the caller can't see, so a successful `files.get` is itself proof the caller
  * can read the folder - that is the signal drive-sync uses to gate the global folder claim (a user
- * must be able to read a folder before they can claim it for a lake). Never throws: any error (no
- * access, bad id, transient) resolves to `exists: false` so the caller fails closed.
+ * must be able to read a folder before they can claim it for a lake). Never throws: a permanent
+ * error (no access, bad id) resolves to `exists: false` so the caller fails closed, and a throttle
+ * that outlives the retry budget comes back as `ok: false` so the caller can say so instead.
  */
-export async function getFolderAccess(
-  drive: drive_v3.Drive,
-  folderId: string
-): Promise<{ exists: boolean; isFolder: boolean; canRead: boolean }> {
-  if (!isValidDriveFolderId(folderId)) return { exists: false, isFolder: false, canRead: false };
+export async function getFolderAccess(drive: drive_v3.Drive, folderId: string): Promise<FolderAccess> {
+  if (!isValidDriveFolderId(folderId)) return { ok: true, exists: false, isFolder: false, canRead: false };
   try {
-    const res = await drive.files.get({
-      fileId: folderId,
-      fields: 'id, mimeType, capabilities/canDownload',
-      supportsAllDrives: true,
-    });
+    const res = await withDriveRetry('files.get(folder)', () =>
+      drive.files.get({
+        fileId: folderId,
+        fields: 'id, mimeType, capabilities/canDownload',
+        supportsAllDrives: true,
+      })
+    );
     const file = res.data;
     return {
+      ok: true,
       exists: true,
       isFolder: file.mimeType === FOLDER_MIME_TYPE,
       // canDownload is often absent for folders; only an EXPLICIT false denies read.
       canRead: file.capabilities?.canDownload !== false,
     };
-  } catch {
-    return { exists: false, isFolder: false, canRead: false };
+  } catch (e) {
+    if (isDriveRateLimitError(e)) {
+      return { ok: false, reason: 'rate_limited', detail: e instanceof Error ? e.message : String(e) };
+    }
+    return { ok: true, exists: false, isFolder: false, canRead: false };
   }
 }
 
@@ -129,14 +216,16 @@ export async function listFolderChildren(drive: drive_v3.Drive, folderId: string
   let pages = 0;
 
   do {
-    const res = await drive.files.list({
-      q: `'${folderId}' in parents and trashed = false`,
-      fields: 'nextPageToken, files(id, name, mimeType, modifiedTime, md5Checksum, size)',
-      pageSize: 1000,
-      supportsAllDrives: true,
-      includeItemsFromAllDrives: true,
-      pageToken,
-    });
+    const res = await withDriveRetry('files.list', () =>
+      drive.files.list({
+        q: `'${folderId}' in parents and trashed = false`,
+        fields: 'nextPageToken, files(id, name, mimeType, modifiedTime, md5Checksum, size)',
+        pageSize: 1000,
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
+        pageToken,
+      })
+    );
 
     for (const f of res.data.files ?? []) {
       // Skip anything missing an id/name/mimeType - it isn't a usable ingest candidate. Logged

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -69,6 +69,13 @@ function isRetryableDriveError(e: unknown): boolean {
     const status = typeof raw === 'string' ? Number(raw) : raw;
     if (typeof status === 'number' && isTransientDriveStatus(status)) return true;
   }
+  // A GaxiosError with NO response at all is a network-level failure (ECONNRESET, ETIMEDOUT,
+  // ENOTFOUND, a socket hangup, ...) - gaxios' own (now-disabled) retry layer covered these via
+  // noResponseRetries regardless of the specific code, for any method in httpMethodsToRetry, which
+  // GET is. `err.code` on this shape is the system error code, always a STRING (never one of the
+  // numeric statuses checked above), so that combination is the signal. All four Drive calls here
+  // are idempotent GETs, so retrying is safe.
+  if (response == null && typeof err.code === 'string') return true;
   return false;
 }
 

--- a/apps/client/server/integrations/google/drive/driveContent.test.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { drive_v3 } from '@googleapis/drive';
 import { SupportedFabFileMimeTypes } from '@bike4mind/common';
 import { walkFolder, fetchDriveFileContent } from './driveContent';
@@ -40,6 +40,9 @@ describe('walkFolder', () => {
 });
 
 describe('fetchDriveFileContent', () => {
+  // Several cases drive the in-process throttle retry, which sleeps for real.
+  afterEach(() => vi.useRealTimers());
+
   const bufOf = (s: string) => new TextEncoder().encode(s).buffer;
 
   it('exports a Google Doc to plain text', async () => {
@@ -109,6 +112,7 @@ describe('fetchDriveFileContent', () => {
   // The whole point of the separate reason: `error` is permanent to the caller, so a throttle
   // landing there drops the file from the lake and still finalizes the batch clean.
   it('reports rate_limited (not error) when Drive throttles a native download', async () => {
+    vi.useFakeTimers();
     const getFn = vi.fn(async () => {
       throw Object.assign(new Error('Rate Limit Exceeded'), {
         code: 429,
@@ -117,11 +121,29 @@ describe('fetchDriveFileContent', () => {
     });
     const drive = { files: { export: vi.fn(), get: getFn } } as unknown as drive_v3.Drive;
 
-    const res = await fetchDriveFileContent(drive, file('n', 'notes.txt', 'text/plain'));
-    expect(res).toMatchObject({ ok: false, reason: 'rate_limited' });
+    const pending = fetchDriveFileContent(drive, file('n', 'notes.txt', 'text/plain'));
+    await vi.runAllTimersAsync();
+    expect(await pending).toMatchObject({ ok: false, reason: 'rate_limited' });
+    // Only a throttle that outlives the in-process retries reaches the caller as rate_limited.
+    expect(getFn.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('retries a throttled download in-process and succeeds without ever reporting rate_limited', async () => {
+    vi.useFakeTimers();
+    const getFn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('Rate Limit Exceeded'), { code: 429, response: { status: 429 } }))
+      .mockResolvedValue({ data: new TextEncoder().encode('hi').buffer });
+    const drive = { files: { export: vi.fn(), get: getFn } } as unknown as drive_v3.Drive;
+
+    const pending = fetchDriveFileContent(drive, file('n', 'notes.txt', 'text/plain'));
+    await vi.runAllTimersAsync();
+    expect(await pending).toMatchObject({ ok: true, mimeType: 'text/plain' });
+    expect(getFn).toHaveBeenCalledTimes(2);
   });
 
   it('reports rate_limited for a 403 whose reason is a quota, not a permission denial', async () => {
+    vi.useFakeTimers();
     const exportFn = vi.fn(async () => {
       throw Object.assign(new Error('The user has exceeded their rate limit.'), {
         code: 403,
@@ -130,8 +152,9 @@ describe('fetchDriveFileContent', () => {
     });
     const drive = { files: { export: exportFn, get: vi.fn() } } as unknown as drive_v3.Drive;
 
-    const res = await fetchDriveFileContent(drive, file('d', 'Doc', 'application/vnd.google-apps.document'));
-    expect(res).toMatchObject({ ok: false, reason: 'rate_limited' });
+    const pending = fetchDriveFileContent(drive, file('d', 'Doc', 'application/vnd.google-apps.document'));
+    await vi.runAllTimersAsync();
+    expect(await pending).toMatchObject({ ok: false, reason: 'rate_limited' });
   });
 
   it('still reports a permanent error for a non-throttle failure', async () => {

--- a/apps/client/server/integrations/google/drive/driveContent.test.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { drive_v3 } from '@googleapis/drive';
 import { SupportedFabFileMimeTypes } from '@bike4mind/common';
-import { walkFolder, fetchDriveFileContent } from './driveContent';
+import { walkFolder, fetchDriveFileContent, DriveWalkTimeBudgetExceededError } from './driveContent';
 import { FOLDER_MIME_TYPE, isDriveRateLimitError } from './driveClient';
 
 const folder = (id: string, name: string) => ({ id, name, mimeType: FOLDER_MIME_TYPE });
@@ -36,6 +36,34 @@ describe('walkFolder', () => {
 
     const files = await walkFolder(drive, 'root');
     expect(files.map(f => f.relativePath)).toEqual(['loop/c.txt']);
+  });
+
+  it('does not check the time budget when no remainingMs is given', async () => {
+    const { drive } = mockTreeDrive({ root: [file('a', 'a.txt', 'text/plain')] });
+    await expect(walkFolder(drive, 'root')).resolves.toEqual([
+      { id: 'a', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' },
+    ]);
+  });
+
+  it('throws DriveWalkTimeBudgetExceededError before listing another folder once the budget runs low', async () => {
+    // Two folders deep so the guard has a second folder to trip on before ever reaching it.
+    const { drive, list } = mockTreeDrive({
+      root: [folder('sub', 'sub')],
+      sub: [file('b', 'b.txt', 'text/plain')],
+    });
+    // Plenty of time for the root listing, then below the buffer for the next one.
+    const remainingMs = vi.fn().mockReturnValueOnce(120_000).mockReturnValue(1_000);
+
+    await expect(walkFolder(drive, 'root', remainingMs)).rejects.toBeInstanceOf(DriveWalkTimeBudgetExceededError);
+    expect(list).toHaveBeenCalledTimes(1); // root only - never reached 'sub'
+  });
+
+  it('never starts the walk at all if the budget is already spent', async () => {
+    const { drive, list } = mockTreeDrive({ root: [file('a', 'a.txt', 'text/plain')] });
+    const remainingMs = () => 1_000;
+
+    await expect(walkFolder(drive, 'root', remainingMs)).rejects.toBeInstanceOf(DriveWalkTimeBudgetExceededError);
+    expect(list).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/server/integrations/google/drive/driveContent.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.ts
@@ -1,7 +1,7 @@
 import type { drive_v3 } from '@googleapis/drive';
 import { SupportedFabFileMimeTypes } from '@bike4mind/common';
 import { resolveSupportedMimeType } from '@bike4mind/utils';
-import { listFolderChildren, isFolder, isDriveRateLimitError, type DriveFile } from './driveClient';
+import { listFolderChildren, isFolder, isDriveRateLimitError, withDriveRetry, type DriveFile } from './driveClient';
 
 const GOOGLE_DOC = 'application/vnd.google-apps.document';
 const GOOGLE_SHEET = 'application/vnd.google-apps.spreadsheet';
@@ -22,6 +22,11 @@ export type WalkedDriveFile = DriveFile & { relativePath: string };
  * Recursively walk a Drive folder tree, returning every non-folder file with its relativePath.
  * A `visited` set guards against cycles - a Drive folder graph can contain shortcuts/loops, and
  * an unguarded walk would recurse forever. Reuses the one-level `listFolderChildren` primitive.
+ *
+ * Throws on any listing failure, throttles included (each page is retried in-process first). A
+ * caller that can shed load MUST test the thrown error with `isDriveRateLimitError` and defer:
+ * re-running a failed walk costs a fresh listing of every page it already fetched, which adds to
+ * the very quota that is exhausted (#2395).
  */
 export async function walkFolder(drive: drive_v3.Drive, rootFolderId: string): Promise<WalkedDriveFile[]> {
   const files: WalkedDriveFile[] = [];
@@ -73,7 +78,9 @@ export async function fetchDriveFileContent(drive: drive_v3.Drive, file: DriveFi
       if (!exportMime) {
         return { ok: false, reason: 'unsupported', detail: file.mimeType };
       }
-      const res = await drive.files.export({ fileId: file.id, mimeType: exportMime }, { responseType: 'arraybuffer' });
+      const res = await withDriveRetry('files.export', () =>
+        drive.files.export({ fileId: file.id, mimeType: exportMime }, { responseType: 'arraybuffer' })
+      );
       return { ok: true, bytes: Buffer.from(res.data as ArrayBuffer), mimeType: exportMime };
     }
 
@@ -82,9 +89,8 @@ export async function fetchDriveFileContent(drive: drive_v3.Drive, file: DriveFi
     if (!supported) {
       return { ok: false, reason: 'unsupported', detail: file.mimeType };
     }
-    const res = await drive.files.get(
-      { fileId: file.id, alt: 'media', supportsAllDrives: true },
-      { responseType: 'arraybuffer' }
+    const res = await withDriveRetry('files.get(media)', () =>
+      drive.files.get({ fileId: file.id, alt: 'media', supportsAllDrives: true }, { responseType: 'arraybuffer' })
     );
     return { ok: true, bytes: Buffer.from(res.data as ArrayBuffer), mimeType };
   } catch (e) {
@@ -94,7 +100,9 @@ export async function fetchDriveFileContent(drive: drive_v3.Drive, file: DriveFi
       return { ok: false, reason: 'export_too_large', detail };
     }
     // Transient, and reported apart from `error` because the caller treats `error` as a permanent
-    // per-file skip - which for a throttle silently drops the file from the lake (#2394).
+    // per-file skip - which for a throttle silently drops the file from the lake (#2394). Reaching
+    // here means the in-process retries above were already spent, so the caller must defer rather
+    // than retry this file again immediately.
     if (isDriveRateLimitError(e)) {
       return { ok: false, reason: 'rate_limited', detail };
     }

--- a/apps/client/server/integrations/google/drive/driveContent.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.ts
@@ -18,22 +18,56 @@ const EDITOR_EXPORTS: Record<string, string> = {
 /** A file discovered by the recursive walk, with its path relative to the ingested root. */
 export type WalkedDriveFile = DriveFile & { relativePath: string };
 
+// Checked between folders (not pages - a mid-listing pagination cost is bounded separately by
+// MAX_LIST_PAGES), so it has to cover the worst case of one MORE folder's listing: withDriveRetry's
+// own budget maxes out around 7s of sleep, plus the request itself. Generous margin below that
+// because a walk that trips this still has to unwind back out to the caller's shed path before the
+// invocation dies.
+const WALK_DEADLINE_BUFFER_MS = 60_000;
+
+/**
+ * Thrown when a walk runs low on invocation time mid-tree, rather than being killed with the sync
+ * claim stranded. Deliberately its own type, not folded into `isDriveRateLimitError` - this is not
+ * Drive telling us to slow down, and conflating the two would make a slow-but-healthy walk look like
+ * a quota problem to anything that inspects the reason. The caller treats both the same way (shed
+ * and let a continuation redo the walk), since neither can finish this attempt (#2395 review).
+ */
+export class DriveWalkTimeBudgetExceededError extends Error {
+  constructor() {
+    super('Drive folder walk ran out of invocation time');
+    this.name = 'DriveWalkTimeBudgetExceededError';
+  }
+}
+
 /**
  * Recursively walk a Drive folder tree, returning every non-folder file with its relativePath.
  * A `visited` set guards against cycles - a Drive folder graph can contain shortcuts/loops, and
  * an unguarded walk would recurse forever. Reuses the one-level `listFolderChildren` primitive.
  *
- * Throws on any listing failure, throttles included (each page is retried in-process first). A
- * caller that can shed load MUST test the thrown error with `isDriveRateLimitError` and defer:
- * re-running a failed walk costs a fresh listing of every page it already fetched, which adds to
- * the very quota that is exhausted (#2395).
+ * `remainingMs`, when given, is checked before every folder: a large tree can now spend the whole
+ * invocation just walking (each folder's call carries withDriveRetry's own retry budget on top of
+ * the request itself), and without this a slow walk would be killed mid-tree with the sync claim
+ * stranded rather than ever reaching the caller's shed-and-retry path (#2395 review).
+ *
+ * Throws on any listing failure, throttles and a spent time budget included (each page is retried
+ * in-process first). A caller that can shed load MUST test the thrown error with
+ * `isDriveRateLimitError` or `instanceof DriveWalkTimeBudgetExceededError` and defer: re-running a
+ * failed walk costs a fresh listing of every page it already fetched, which adds to the very quota
+ * that is exhausted (#2395).
  */
-export async function walkFolder(drive: drive_v3.Drive, rootFolderId: string): Promise<WalkedDriveFile[]> {
+export async function walkFolder(
+  drive: drive_v3.Drive,
+  rootFolderId: string,
+  remainingMs?: () => number
+): Promise<WalkedDriveFile[]> {
   const files: WalkedDriveFile[] = [];
   const visited = new Set<string>();
   const queue: Array<{ id: string; path: string }> = [{ id: rootFolderId, path: '' }];
 
   while (queue.length > 0) {
+    if (remainingMs && remainingMs() < WALK_DEADLINE_BUFFER_MS) {
+      throw new DriveWalkTimeBudgetExceededError();
+    }
     const { id, path } = queue.shift()!;
     if (visited.has(id)) continue;
     visited.add(id);

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -119,10 +119,18 @@ vi.mock('@server/integrations/google/drive/driveClient', async importOriginal =>
   ...(await importOriginal<typeof import('@server/integrations/google/drive/driveClient')>()),
   createDriveClient: () => ({}),
 }));
-vi.mock('@server/integrations/google/drive/driveContent', () => ({
-  walkFolder: h.walkFolder,
-  fetchDriveFileContent: h.fetchDriveFileContent,
-}));
+// Mocks only the two Drive calls; keeps the real DriveWalkTimeBudgetExceededError export so tests
+// and the handler agree on the class an `instanceof` check below is testing against.
+vi.mock('@server/integrations/google/drive/driveContent', async () => {
+  const actual = await vi.importActual<typeof import('@server/integrations/google/drive/driveContent')>(
+    '@server/integrations/google/drive/driveContent'
+  );
+  return {
+    ...actual,
+    walkFolder: h.walkFolder,
+    fetchDriveFileContent: h.fetchDriveFileContent,
+  };
+});
 vi.mock('@server/queueHandlers/dataLakeBatchProgress', () => ({
   finalizeBatchIfComplete: h.finalizeBatchIfComplete,
 }));
@@ -136,6 +144,7 @@ import {
   MAX_INGEST_REDRIVES,
   MAX_INGEST_SLICES,
 } from './driveLakeIngest';
+import { DriveWalkTimeBudgetExceededError } from '@server/integrations/google/drive/driveContent';
 
 const logger = { warn: vi.fn(), error: vi.fn(), log: vi.fn(), info: vi.fn(), updateMetadata: vi.fn() } as never;
 const makeEvent = (body: unknown) => ({ Records: [{ body: JSON.stringify(body) }] }) as never;
@@ -943,6 +952,23 @@ describe('driveLakeIngest consumer', () => {
         expect.any(Number)
       );
       expect(h.sendToQueue.mock.calls[0][2]).toBeGreaterThanOrEqual(60);
+    });
+
+    it('defers the whole sync when the folder walk runs out of invocation time, not just on a throttle', async () => {
+      // walkFolder throws this when its own remainingMs() check trips mid-tree - a large folder can
+      // now spend the whole invocation just walking, and this must not be killed with the claim
+      // stranded any more than an actual Drive throttle is.
+      h.walkFolder.mockRejectedValue(new DriveWalkTimeBudgetExceededError());
+
+      await expect(run({ connectionId: 'conn1' })).resolves.toBeUndefined();
+
+      expect(h.batchCreate).not.toHaveBeenCalled();
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
+      expect(h.sendToQueue).toHaveBeenCalledWith(
+        'ingest-queue-url',
+        { connectionId: 'conn1', redriveCount: 1 },
+        expect.any(Number)
+      );
     });
 
     it('releases before it enqueues, so the deferred run finds a connection it can claim', async () => {

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -113,7 +113,12 @@ vi.mock('@server/integrations/google/drive/common', () => ({
   getValidConnectionDriveAccessToken: async () => 'access-token',
   disableDriveConnectionForLake: h.disableDriveConnectionForLake,
 }));
-vi.mock('@server/integrations/google/drive/driveClient', () => ({ createDriveClient: () => ({}) }));
+// Only the client factory is stubbed: isDriveRateLimitError is the real predicate, because the
+// walk-throttle deferral below is exactly the behaviour a stubbed one would fake away.
+vi.mock('@server/integrations/google/drive/driveClient', async importOriginal => ({
+  ...(await importOriginal<typeof import('@server/integrations/google/drive/driveClient')>()),
+  createDriveClient: () => ({}),
+}));
 vi.mock('@server/integrations/google/drive/driveContent', () => ({
   walkFolder: h.walkFolder,
   fetchDriveFileContent: h.fetchDriveFileContent,
@@ -124,7 +129,13 @@ vi.mock('@server/queueHandlers/dataLakeBatchProgress', () => ({
 vi.mock('@server/utils/sqs', () => ({ sendToQueue: h.sendToQueue }));
 vi.mock('sst', () => ({ Resource: { driveLakeIngestQueue: { url: 'ingest-queue-url' } } }));
 
-import { dispatch, hasDriveFileChanged, MAX_INGEST_CANDIDATES, MAX_INGEST_SLICES } from './driveLakeIngest';
+import {
+  dispatch,
+  hasDriveFileChanged,
+  MAX_INGEST_CANDIDATES,
+  MAX_INGEST_REDRIVES,
+  MAX_INGEST_SLICES,
+} from './driveLakeIngest';
 
 const logger = { warn: vi.fn(), error: vi.fn(), log: vi.fn(), info: vi.fn(), updateMetadata: vi.fn() } as never;
 const makeEvent = (body: unknown) => ({ Records: [{ body: JSON.stringify(body) }] }) as never;
@@ -910,6 +921,88 @@ describe('driveLakeIngest consumer', () => {
       // Unlike the deadline yield, a throttled slice delays its continuation - coming straight back
       // would hit the same exhausted quota.
       expect(h.sendToQueue.mock.calls[0][2]).toBeGreaterThanOrEqual(60);
+    });
+
+    it('defers the whole sync when Drive throttles the folder WALK, rather than letting it DLQ', async () => {
+      // The walk is the one Drive call with no slice to hand off to, so a throttle there used to
+      // throw for SQS to redeliver - flat, twice, DLQ. Each redelivery also re-walks the folder from
+      // scratch, adding load to the very quota that is exhausted.
+      h.walkFolder.mockRejectedValue(
+        Object.assign(new Error('Rate Limit Exceeded'), { code: 429, response: { status: 429 } })
+      );
+
+      await expect(run({ connectionId: 'conn1' })).resolves.toBeUndefined();
+
+      // Nothing was touched, the claim is handed back so the deferred run can take it, and the
+      // deferral is delayed rather than immediate.
+      expect(h.batchCreate).not.toHaveBeenCalled();
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
+      expect(h.sendToQueue).toHaveBeenCalledWith(
+        'ingest-queue-url',
+        { connectionId: 'conn1', redriveCount: 1 },
+        expect.any(Number)
+      );
+      expect(h.sendToQueue.mock.calls[0][2]).toBeGreaterThanOrEqual(60);
+    });
+
+    it('releases before it enqueues, so the deferred run finds a connection it can claim', async () => {
+      // Enqueuing first would land a delayed message against a connection still marked 'syncing';
+      // it would lose the claim, redrive again, and burn the bounded deferrals on the wrong problem.
+      h.walkFolder.mockRejectedValue(Object.assign(new Error('429'), { code: 429 }));
+      h.releaseSyncClaim.mockImplementation(async () => {
+        h.order.push('release');
+        return { id: 'conn1', status: 'connected' };
+      });
+      h.sendToQueue.mockImplementation(async () => void h.order.push('enqueue'));
+
+      await run({ connectionId: 'conn1' });
+
+      expect(h.order).toEqual(['release', 'enqueue']);
+    });
+
+    it('settles a continuation batch before deferring, so it cannot strand in processing', async () => {
+      // A continuation throttled at its walk produced nothing, and the deferral comes back as a
+      // FRESH chain - so its adopted batch has no later slice to close it out.
+      h.walkFolder.mockRejectedValue(Object.assign(new Error('429'), { code: 429 }));
+      h.batchFindById.mockResolvedValue({
+        id: 'batch1',
+        dataLakeId: 'lake1',
+        status: 'processing',
+        totalFiles: 2,
+        skippedFiles: 0,
+        files: [],
+        vectorizedFiles: 0,
+        failedFiles: 0,
+      });
+
+      await run({ connectionId: 'conn1', resumeBatchId: 'batch1', claimToken: 'token-prev', slice: 1 });
+
+      expect(h.setTotalFilesIfActive).toHaveBeenCalled();
+      expect(h.sendToQueue).toHaveBeenCalledWith(
+        'ingest-queue-url',
+        { connectionId: 'conn1', redriveCount: 1 },
+        expect.any(Number)
+      );
+    });
+
+    it('stops deferring a throttled walk once the redrives are spent, and says so', async () => {
+      h.walkFolder.mockRejectedValue(Object.assign(new Error('429'), { code: 429 }));
+
+      await run({ connectionId: 'conn1', redriveCount: MAX_INGEST_REDRIVES });
+
+      expect(h.sendToQueue).not.toHaveBeenCalled();
+      const [, , lastError] = h.releaseSyncClaim.mock.calls[0];
+      expect(lastError).toContain('rate-limiting');
+      expect(lastError).not.toContain('subfolders');
+    });
+
+    it('still throws a non-throttle walk failure through to SQS', async () => {
+      // Only a throttle is sheddable. A broken folder id or a dead credential has to keep reaching
+      // the DLQ, or a permanently-failing connection would defer quietly forever.
+      h.walkFolder.mockRejectedValue(Object.assign(new Error('File not found'), { code: 404 }));
+
+      await expect(run({ connectionId: 'conn1' })).rejects.toThrow('File not found');
+      expect(h.sendToQueue).not.toHaveBeenCalled();
     });
 
     it('tells the operator the sync was rate-limited when a throttled chain hits the ceiling', async () => {

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -38,6 +38,7 @@ import { createDriveClient, isDriveRateLimitError } from '@server/integrations/g
 import {
   walkFolder,
   fetchDriveFileContent,
+  DriveWalkTimeBudgetExceededError,
   type WalkedDriveFile,
 } from '@server/integrations/google/drive/driveContent';
 import { finalizeBatchIfComplete } from '@server/queueHandlers/dataLakeBatchProgress';
@@ -469,21 +470,26 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     //    removeFileFromLake throws NotFoundError, aborting the reconcile mid-prune).
     let walkedRaw: WalkedDriveFile[];
     try {
-      walkedRaw = await walkFolder(drive, connection.driveFolderId);
+      walkedRaw = await walkFolder(drive, connection.driveFolderId, remainingMs);
     } catch (err) {
-      if (!isDriveRateLimitError(err)) throw err;
-      // A throttle that outlived the per-call retries is a quota problem, not a broken sync. Throwing
-      // it on would DLQ the connection after two flat SQS redeliveries - and each of those re-walks
-      // the folder from scratch, re-listing every page it already fetched, which ADDS load to the
-      // quota that is already exhausted. Shed instead: release the claim and come back later, with
-      // the same jittered delay the content-fetch deferral uses. Bounded by redriveCount so a folder
-      // Drive never lets us walk cannot spin forever.
+      const timedOut = err instanceof DriveWalkTimeBudgetExceededError;
+      if (!timedOut && !isDriveRateLimitError(err)) throw err;
+      // A throttle that outlived the per-call retries, or a walk that ran out of invocation time, is
+      // not a broken sync. Throwing it on would DLQ the connection after two flat SQS redeliveries -
+      // and each of those re-walks the folder from scratch, re-listing every page it already fetched,
+      // which ADDS load to a quota that may already be exhausted. Shed instead: release the claim and
+      // come back later, on the same jittered delay the content-fetch deferral uses - a timeout gets
+      // it too, not because it needs to dodge a quota, but so a folder that keeps outrunning its
+      // invocation budget doesn't spin straight back into the same wall. Both share redriveCount with
+      // the claim-contention deferral above, so a folder that keeps coming back around - for whatever
+      // reason - cannot spin forever.
       const delaySeconds = rateLimitBackoffSeconds();
       const canDefer = redriveCount < MAX_INGEST_REDRIVES;
-      logger.warn('[driveLakeIngest] Drive rate-limited the folder walk', {
+      logger.warn('[driveLakeIngest] folder walk deferred', {
         connectionId,
         slice,
         redriveCount,
+        reason: timedOut ? 'time_budget_exceeded' : 'rate_limited',
         deferring: canDefer,
         delaySeconds: canDefer ? delaySeconds : undefined,
         error: err instanceof Error ? err.message : String(err),
@@ -499,7 +505,13 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       await releaseClaim(
         canDefer
           ? null
-          : `Google Drive is rate-limiting this sync and it gave up after ${MAX_INGEST_REDRIVES} deferrals without listing the folder. Nothing was ingested. The next scheduled poll retries it; if it keeps happening, sync fewer folders on the same schedule.`
+          : // redriveCount is shared with the claim-contention deferral above, so a chain landing here
+            // may have spent most of its deferrals on someone else's sync being in flight, not on this -
+            // never attribute the full count to one cause the operator cannot verify.
+            `This sync's folder walk did not finish - Google Drive rate-limiting and/or the invocation's ` +
+              `time budget - and gave up after ${MAX_INGEST_REDRIVES} total deferrals without listing the ` +
+              `folder. Nothing was ingested. The next scheduled poll retries it; if it keeps happening, sync ` +
+              `fewer folders on the same schedule.`
       );
       ingestClaimToken = undefined;
       if (canDefer) {

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -34,8 +34,12 @@ import {
   disableDriveConnectionForLake,
   getValidConnectionDriveAccessToken,
 } from '@server/integrations/google/drive/common';
-import { createDriveClient } from '@server/integrations/google/drive/driveClient';
-import { walkFolder, fetchDriveFileContent } from '@server/integrations/google/drive/driveContent';
+import { createDriveClient, isDriveRateLimitError } from '@server/integrations/google/drive/driveClient';
+import {
+  walkFolder,
+  fetchDriveFileContent,
+  type WalkedDriveFile,
+} from '@server/integrations/google/drive/driveContent';
 import { finalizeBatchIfComplete } from '@server/queueHandlers/dataLakeBatchProgress';
 import { sendToQueue } from '@server/utils/sqs';
 import { Resource } from 'sst';
@@ -57,12 +61,14 @@ const Payload = z.object({
   slice: z.number().int().min(0).default(0),
 });
 
-// A claim loser re-enqueues itself (with a delay) so a GENUINE second sync - files added to the
-// folder while a long run is mid-loop - isn't silently dropped until the next scheduled poll.
-// Bounded so a permanently-losing message can't spin: past this many redrives we give up and let
-// the next real sync pick the files up. Delay x max stays comfortably past the handler's 10-minute
+// A run that cannot proceed re-enqueues itself (with a delay) rather than dropping the work: a claim
+// loser, so a GENUINE second sync - files added to the folder while a long run is mid-loop - isn't
+// silently dropped until the next scheduled poll, and a walk Drive throttled, which defers on the
+// rate-limit backoff below instead of this delay. One counter bounds both, since both mean "this
+// message has come back around" and neither may spin: past this many redrives we give up and let the
+// next real sync pick the files up. Delay x max stays comfortably past the handler's 10-minute
 // in-flight ceiling.
-const MAX_INGEST_REDRIVES = 12;
+export const MAX_INGEST_REDRIVES = 12;
 const INGEST_REDRIVE_DELAY_SECONDS = 90;
 
 // Per-file hard cap. Files are fetched and uploaded ONE at a time (only one buffer is ever live),
@@ -81,8 +87,8 @@ const INGEST_DEADLINE_BUFFER_MS = 90_000;
 
 // Wait before the continuation slice when Drive throttled this one. The jitter is what makes it
 // shedding rather than a reschedule: several connections poll on the same tick against ONE Drive
-// project quota, so a fixed delay would just re-collide them at the new time. Per-call retry inside
-// each Drive call site is separate hardening (#2395); this is the amount the deferral itself needs.
+// project quota, so a fixed delay would just re-collide them at the new time. Shared by both shed
+// points: the throttled content fetch, and the throttled folder walk that has no slice to hand off to.
 const INGEST_RATE_LIMIT_DELAY_SECONDS = 60;
 const INGEST_RATE_LIMIT_JITTER_SECONDS = 30;
 const rateLimitBackoffSeconds = () =>
@@ -461,7 +467,50 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     //    multi-parented Drive file surfaces once per parent inside the walked subtree, and a duplicate
     //    would otherwise double-ingest (two FabFiles for one add) and double-remove (the second
     //    removeFileFromLake throws NotFoundError, aborting the reconcile mid-prune).
-    const walkedRaw = await walkFolder(drive, connection.driveFolderId);
+    let walkedRaw: WalkedDriveFile[];
+    try {
+      walkedRaw = await walkFolder(drive, connection.driveFolderId);
+    } catch (err) {
+      if (!isDriveRateLimitError(err)) throw err;
+      // A throttle that outlived the per-call retries is a quota problem, not a broken sync. Throwing
+      // it on would DLQ the connection after two flat SQS redeliveries - and each of those re-walks
+      // the folder from scratch, re-listing every page it already fetched, which ADDS load to the
+      // quota that is already exhausted. Shed instead: release the claim and come back later, with
+      // the same jittered delay the content-fetch deferral uses. Bounded by redriveCount so a folder
+      // Drive never lets us walk cannot spin forever.
+      const delaySeconds = rateLimitBackoffSeconds();
+      const canDefer = redriveCount < MAX_INGEST_REDRIVES;
+      logger.warn('[driveLakeIngest] Drive rate-limited the folder walk', {
+        connectionId,
+        slice,
+        redriveCount,
+        deferring: canDefer,
+        delaySeconds: canDefer ? delaySeconds : undefined,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // The walk is the first thing every slice does, so a continuation that dies here produced
+      // nothing: settle its batch rather than leave it `processing` for the reconciler to force-fail,
+      // and let the deferred message start a fresh chain.
+      if (resumeBatchId) await settleChainedBatch(resumeBatchId);
+      // Release BEFORE enqueuing: the delayed message has to find a 'connected' connection to claim
+      // when it lands, or it would just lose the claim and spend a deferral on the wrong problem. An
+      // enqueue that then throws falls to the catch below and out to SQS with the claim already
+      // released, so the redelivery can re-walk rather than the connection stranding at 'syncing'.
+      await releaseClaim(
+        canDefer
+          ? null
+          : `Google Drive is rate-limiting this sync and it gave up after ${MAX_INGEST_REDRIVES} deferrals without listing the folder. Nothing was ingested. The next scheduled poll retries it; if it keeps happening, sync fewer folders on the same schedule.`
+      );
+      ingestClaimToken = undefined;
+      if (canDefer) {
+        await sendToQueue(
+          Resource.driveLakeIngestQueue.url,
+          { connectionId, redriveCount: redriveCount + 1 },
+          delaySeconds
+        );
+      }
+      return;
+    }
     const walkedIds = new Set<string>();
     const walked = walkedRaw.filter(f => {
       if (walkedIds.has(f.id)) return false;

--- a/apps/client/server/utils/errors.ts
+++ b/apps/client/server/utils/errors.ts
@@ -13,6 +13,7 @@ import {
   ForbiddenError,
   ConflictError,
   BadGatewayError,
+  TooManyRequestsError,
   isZodError,
   canAccessTavern,
 } from '@bike4mind/common';
@@ -28,6 +29,7 @@ export {
   ForbiddenError,
   ConflictError,
   BadGatewayError,
+  TooManyRequestsError,
   isZodError,
 };
 


### PR DESCRIPTION
## Description

Every Google Drive call site retried nothing on a 429/quota-403: `listFolderChildren` threw straight up, `getFolderAccess` conflated a throttle with "folder not found", and the ingest queue handler's folder walk had no shed path so a sustained throttle fell through to `throw err` and DLQ'd after two flat SQS redeliveries - each of which re-walked the folder from scratch and added load to the already-exhausted quota.

PR #2479 (merged 2026-09-08, #2394) had already shipped the `isDriveRateLimitError` detector and the content-fetch deferral, and deliberately reserved the rest for this issue (see the comment at `driveLakeIngest.ts:85`). This PR is that remainder: a shared in-process retry wrapper on every Drive call, an unconflated `getFolderAccess`, and a walk-throttle deferral that shreds the whole run into the same shed-and-retry path the content fetch already uses.

One thing the issue didn't know: `googleapis-common`'s own default retry layer was already retrying 429s - deterministic (no jitter, so several connections sharing one Drive project quota all come back at the same instant), silent, and blind to the 403-with-quota-reason shape Drive uses as often as a 429. Stacking a new retry layer on top of it would have meant up to ~16 HTTP attempts per call with an unknowable total sleep, inside a handler with a 10-minute ceiling. So `createDriveClient` now passes `retry: false` and the new helper is the only retry layer on the path - which also makes the issue's "optional" retryConfig item non-optional.

## Changes

- `driveClient.ts`: new `withDriveRetry(operation, call)` - exponential backoff (1s/2s/4s windows) with half-window jitter, retrying on `isDriveRateLimitError` plus 408/5xx plus a no-response network failure (ECONNRESET/ETIMEDOUT/socket hangup - see review round below). Rethrows the *original* error when the budget is spent, so `isDriveRateLimitError` still works upstream. Wraps all four Drive calls: `files.list`, `files.get` (folder probe), `files.export`, `files.get?alt=media`.
- `createDriveClient` passes `retry: false` to disable googleapis' own retry layer, now that `withDriveRetry` owns the policy.
- `getFolderAccess` returns a discriminated `FolderAccess` (`{ok: true, exists, isFolder, canRead} | {ok: false, reason: 'rate_limited'}`) instead of collapsing a throttle into `exists: false`.
- `drive-sync.ts`: a throttled folder-access probe now answers `429 TooManyRequestsError` with a real message, instead of telling the user they lost access to their own folder.
- `driveLakeIngest.ts`: a throttled folder walk - or one that runs out of invocation time (see review round below) - now settles its chained batch, releases the sync claim, and re-enqueues itself on the same jittered rate-limit backoff the content-fetch deferral uses - bounded by the existing `MAX_INGEST_REDRIVES` so a folder Drive never lets us walk can't spin forever. A non-throttle walk failure still throws through to SQS/DLQ unchanged.
- Tests: a 429 retried in-process and then succeeding (helper, `listFolderChildren`, `fetchDriveFileContent`); `getFolderAccess` reporting `rate_limited` rather than `exists: false`; the walk-throttle deferral (release-before-enqueue ordering, redrive-exhausted give-up message, non-throttle errors still throwing, a resumed chain's batch settling before deferral); `createDriveClient` actually disabling googleapis' retry.

### Review round: addressed feedback (commit 8985285)

- `driveClient.ts` - `isRetryableDriveError` now also retries a no-response GaxiosError (ECONNRESET/ETIMEDOUT/socket hangup): `retry: false` silently dropped gaxios' own `noResponseRetries` cover for these, and the new helper didn't pick it up.
- `driveContent.ts` - `walkFolder` takes an optional `remainingMs()` and throws `DriveWalkTimeBudgetExceededError` before starting another folder once the budget runs low, so an intermittent-throttle walk that would otherwise blow the 10-minute ceiling yields to a continuation instead of being killed mid-tree with the sync claim stranded. `driveLakeIngest.ts`'s walk-throttle catch sheds on this the same way it already sheds a Drive throttle.
- `driveLakeIngest.ts` - the walk give-up message no longer implies every deferral in the shared `redriveCount` was caused by Drive rate limiting (it's also shared with the claim-contention deferral, and now the walk-deadline shed).

## Guide for Testers

This is backend hardening on a low-frequency failure path (Drive rate-limiting), not reachable through a normal UI flow without actually exhausting a Drive quota. The behavior is unit-tested at every layer; there's no practical way to trigger a real 429 from Drive on demand.

**What NOT to test:** there is no manual UI repro for this - forcing Drive to return a 429 requires either a script that hammers the Drive API past its quota or mocking the client, both already covered by the automated tests below. Don't attempt to reproduce a live rate limit against production Drive.

**Regression checks (existing Drive flows, unaffected by this change):**
1. Connect a Google Drive folder to a data lake (Data Lakes → a lake → connect Drive folder). Confirm the folder is claimed and files begin ingesting as before.
2. Confirm `getFolderAccess`'s existing behavior is unchanged for the non-throttled cases: a folder you can't see still refuses the claim with "does not exist or you do not have access", and a file id (not a folder) still refuses with "not a folder".
3. Run the automated suite covering this: `pnpm --filter @bike4mind/client exec vitest run --project node server/integrations/google/drive/ server/queueHandlers/driveLakeIngest.test.ts pages/api/data-lakes/__tests__/drive-sync.test.ts` - 165 tests, all passing.

## Additional Information

Closes #2395.

Verified: `pnpm --filter @bike4mind/client test` (13,223 passed, 81 skipped), `pnpm turbo:typecheck`, `pnpm lint:check` all green. The `driveSyncFolderClaimRelease.e2e.test.ts` integration file (real mongod) also passes.

Review round: re-verified `pnpm turbo:typecheck` and `pnpm lint:check` green, and the 165-test suite above passing, after addressing @vinchi777's feedback.

## Developer Notes (Optional)

- `withDriveRetry` in `driveClient.ts` is now the one retry layer for any future Drive call site - wrap new calls with it rather than adding ad hoc retry logic, and don't re-enable googleapis' own retry on the client.
- The walk-throttle deferral reuses `rateLimitBackoffSeconds()` and `MAX_INGEST_REDRIVES`, the same primitives the claim-contention redrive path already used - one counter now bounds both "someone else is syncing" and "Drive throttled (or ran out of time on) the walk", since all of those mean "this message is coming back around" and neither may spin.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
