### PR TITLE
fix(data-lake): carry the audit principal into purge's other-lakes recompute

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/files/[fabFileId]/__tests__/purge.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/files/[fabFileId]/__tests__/purge.test.ts
@@ -144,9 +144,12 @@ describe('POST /api/data-lakes/[id]/files/[fabFileId]/purge', () => {
   });
 
   /** Drive the service's post-destruction hook the way the service itself would. */
-  const runOnPurged = async (purged: { ownerUserId: string; fileSize: number; tagNames: string[] }) => {
+  const runOnPurged = async (
+    purged: { ownerUserId: string; fileSize: number; tagNames: string[] },
+    auth?: { user?: { id: string }; apiKeyInfo?: { keyId: string } }
+  ) => {
     const { res } = makeRes();
-    await call(req({ id: 'lake-oid-1', fabFileId: FILE_ID }), res);
+    await call(req({ id: 'lake-oid-1', fabFileId: FILE_ID }, auth), res);
     await h.purgeDataLakeDocument.mock.calls[0][3].onPurged(purged);
   };
 
@@ -214,6 +217,26 @@ describe('POST /api/data-lakes/[id]/files/[fabFileId]/purge', () => {
     expect(h.recomputeStatsForLakeTags).toHaveBeenCalledWith(
       ['datalake:archive'],
       expect.objectContaining({ actor: { userId: 'u1', isAdmin: false } })
+    );
+  });
+
+  it('carries the key principal into the other-lakes rebuild, which can auto-activate a draft lake', async () => {
+    // A narrower actor here records a key-driven auto-activation (recomputeLakeStats) as the owning
+    // human's own edit, permanently, on a lake the caller never named.
+    await runOnPurged(
+      { ownerUserId: 'owner-9', fileSize: 10, tagNames: ['datalake:archive'] },
+      { user: { id: 'u1' }, apiKeyInfo: { keyId: 'key-abc' } }
+    );
+
+    expect(h.recomputeStatsForLakeTags).toHaveBeenCalledWith(
+      ['datalake:archive'],
+      expect.objectContaining({
+        actor: {
+          userId: 'u1',
+          isAdmin: false,
+          auditPrincipal: { principalKind: 'apiKey', principalId: 'key-abc', onBehalfOfUserId: 'u1' },
+        },
+      })
     );
   });
 

--- a/apps/client/pages/api/data-lakes/[id]/files/[fabFileId]/purge.ts
+++ b/apps/client/pages/api/data-lakes/[id]/files/[fabFileId]/purge.ts
@@ -174,12 +174,12 @@ const handler = baseApi()
           // same helper both file-delete routes call, over the file's pre-delete tags. That lake's
           // own meta-tag is filtered out: it is in `tagNames`, and leaving it in would run a second
           // identical aggregation over the lake the service already rebuilt.
+          //
+          // Same `actor` built above, not a narrowed literal - this rebuild can auto-activate a
+          // draft lake too, and must carry the same attribution.
           const purgedLakeTag = lake.datalakeTag?.toLowerCase();
           const otherLakeTags = tagNames.filter(name => name.toLowerCase() !== purgedLakeTag);
-          await recomputeStatsForLakeTags(otherLakeTags, {
-            logger: req.logger,
-            actor: { userId: ctx.userId, isAdmin: ctx.isAdmin },
-          });
+          await recomputeStatsForLakeTags(otherLakeTags, { logger: req.logger, actor });
         },
         logger: req.logger,
       });

--- a/apps/client/server/dataLakes/recomputeStatsForLakeTags.ts
+++ b/apps/client/server/dataLakes/recomputeStatsForLakeTags.ts
@@ -1,6 +1,15 @@
+import type { LakeAuditPrincipal } from '@bike4mind/common';
 import { dataLakeRepository, fabFileRepository } from '@bike4mind/database';
 import { dataLakeService } from '@bike4mind/services';
 import { lakeConfigAuditDb } from './lakeConfigAuditDb';
+
+/**
+ * A `ManageActor` that has to SAY what it attributes to, even if the answer is `undefined`.
+ * Required-but-nullable rather than optional, so an actor literal built at a call site cannot
+ * silently omit the field: omitting it is what recorded a key-driven auto-activate as the human
+ * (see `lakeConfigAuditPrincipal` for which callers have a principal to name).
+ */
+export type AttributedActor = dataLakeService.ManageActor & { auditPrincipal: LakeAuditPrincipal | undefined };
 
 /**
  * Rebuild the persisted stats of every lake named by a `datalake:` meta-tag in `tagNames` - for
@@ -50,11 +59,11 @@ export const recomputeStatsForLakeTags = async (
      * event or storage webhook with no user at all. Omitted, a draft -> active flip records under
      * a `system` principal, which is the honest answer rather than an invented one.
      *
-     * A `ManageActor` rather than the bare pair, so a route under `baseApi()` can carry
-     * `auditPrincipal` and have a key-driven flip recorded as the KEY instead of its owning human
+     * An `AttributedActor` rather than the bare pair, so a route under `baseApi()` carries
+     * `auditPrincipal` and has a key-driven flip recorded as the KEY instead of its owning human
      * (see `lakeConfigAuditPrincipal`).
      */
-    actor?: dataLakeService.ManageActor;
+    actor?: AttributedActor;
   }
 ): Promise<void> => {
   // Concurrent, not sequential: the lakes are independent and share no state, so a bulk delete

--- a/apps/client/server/dataLakes/recomputeStatsForUploadedFile.ts
+++ b/apps/client/server/dataLakes/recomputeStatsForUploadedFile.ts
@@ -1,5 +1,4 @@
-import type { dataLakeService } from '@bike4mind/services';
-import { recomputeStatsForLakeTags } from './recomputeStatsForLakeTags';
+import { recomputeStatsForLakeTags, type AttributedActor } from './recomputeStatsForLakeTags';
 
 /** The file fields this needs; a lean projection or a hydrated document both satisfy it. */
 type UploadedFile = { batchId?: string | null; tags?: ({ name?: string | null } | null)[] | null };
@@ -38,7 +37,7 @@ export const recomputeStatsForUploadedFile = async (
      * Only the self-host upload proxy has one - the S3 event and the MinIO webhook arrive with no
      * request behind them. Omitted, a draft -> active flip records under a `system` principal.
      */
-    actor?: dataLakeService.ManageActor;
+    actor?: AttributedActor;
   }
 ): Promise<void> => {
   if (file.batchId) return;


### PR DESCRIPTION
# Pull Request

## Description

`POST /api/data-lakes/:id/files/:fabFileId/purge` resolves the caller's audit principal once and passes it into the primary recompute, but its `onPurged` callback rebuilt a narrower actor for the *other* lakes the destroyed document also belonged to:

```ts
actor: { userId: ctx.userId, isAdmin: ctx.isAdmin },   // auditPrincipal dropped
```

`recomputeLakeStats` activates any lake whose recomputed `fileCount > 0` while its stored status is still `draft`, so that sibling recompute can emit the same `auto-activate` config-change row the primary one does - but without the principal that was already sitting one scope up. A `b4m_live_` key-driven purge therefore recorded that row as the owning human's own edit. Config-change rows are append-only and retained, so it cannot be corrected after the fact.

Closes #2622

## Changes

- `apps/client/pages/api/data-lakes/[id]/files/[fabFileId]/purge.ts` - reuse the `actor` already built at the top of the handler (the one the primary recompute gets) instead of rebuilding a narrower literal in `onPurged`.
- `apps/client/server/dataLakes/recomputeStatsForLakeTags.ts` - new exported `AttributedActor` type (`ManageActor & { auditPrincipal: LakeAuditPrincipal | undefined }`) and use it for the `actor` option. Required-but-nullable, so a call site that builds an actor literal must name a principal or explicitly say there is none.
- `apps/client/server/dataLakes/recomputeStatsForUploadedFile.ts` - same narrowed type on the forwarder.
- `apps/client/pages/api/data-lakes/[id]/files/[fabFileId]/__tests__/purge.test.ts` - new case asserting a key-driven purge carries the key principal into the other-lakes rebuild.

No call-site changes were needed: the three other callers already pass `auditPrincipal`, and the S3-event/webhook callers omit `actor` entirely (still allowed - that records a `system` principal, which is the honest answer there).

## Guide for Testers

Backend-only, API-key driven. No UI surface changes.

### Setup

1. Sign in to `app.staging.bike4mind.com` and create an API key (Sidebar -> Settings -> API Keys -> Create). Copy the `b4m_live_...` value.
2. Create data lake **A** and upload one file to it. Expected: lake A shows 1 file and becomes active.
3. Create data lake **B** and leave it in `draft` (do not upload through the wizard).
4. Add lake B's `datalake:` meta-tag to two files: the file from step 2 and one other file, so B still has a member after the purge. Expected: both files carry both lakes' tags.

### Verify

5. Purge the shared file from lake A with the key:
   ```
   curl -X POST "https://app.staging.bike4mind.com/api/data-lakes/<lakeA-id>/files/<fabFileId>/purge" \
     -H "Authorization: Bearer <b4m_live_...>"
   ```
   Expected: HTTP 200 with a purge receipt JSON (`verified: true`).
6. Open lake B's config history (Sidebar -> Data Lakes -> lake B -> History). Expected: lake B is now `active`, and its `auto-activate` row names the **key** - `principalKind: apiKey`, `principalId: <keyId>`, `onBehalfOfUserId: <your user id>`.
7. Before this PR that row read `principalKind: user`, `principalId: <your user id>`, with no key attribution. That is the bug.

### Regression Checks

8. Repeat steps 2-6 signed in through the app (no API key, session only). Expected: lake B's `auto-activate` row reads `principalKind: user` with your user id - unchanged behaviour.
9. Delete a file that belongs to a draft lake via the UI (Files -> row -> Delete). Expected: that lake still activates and its history row still names you. This path was already correct and must stay so.
10. Upload a file into a draft lake through the upload wizard. Expected: the lake activates and the row names you.

### What NOT to test

- No UI, styling, or responsiveness changes - nothing visual to check.
- Purge semantics themselves (what gets destroyed, the receipt shape, quota refund) are untouched by this PR.
- Self-host / MinIO upload paths need no key attribution: those events arrive with no request behind them and correctly record a `system` principal.

## Additional Information

Verification run locally:

- `pnpm --filter @bike4mind/client typecheck` - clean.
- 68 tests pass across the six affected suites (`purge`, `recomputeStatsForLakeTags`, `recomputeStatsForUploadedFile`, `files/[id] delete`, `files/[id] upload`, `bulk-delete`).
- Mutation-checked: restoring the narrowed literal fails exactly one test, and now also fails `tsc` with `Type '{ userId: string; isAdmin: boolean; }' is not assignable to type 'AttributedActor'`.

Coverage boundary worth knowing: the new test asserts the principal reaches `recomputeStatsForLakeTags`. The helper-to-audit-row half is already mutation-covered by the existing suites for the file-delete and bulk-delete doors, so it is not re-asserted here.

## Developer Notes (Optional)

- **New extension point**: `AttributedActor` (exported from `server/dataLakes/recomputeStatsForLakeTags.ts`) is the shape for any door that recomputes lake stats on behalf of a caller. Required-but-nullable `auditPrincipal` is the pattern - it forces a decision at the call site without forcing a value, which is what makes a dropped principal a compile error rather than a silent wrong audit row.
- **Why not deeper**: making `auditPrincipal` required on `ManageActor` in `b4m-core` would cover every config-write door, but it is imported in ~30 files plus test files that construct bare `{ userId, isAdmin }` actors for pure authorization checks. Disproportionate for a concern that only matters at the route boundary, so the stricter type is scoped to the two functions this bug went through.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI surface
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no new telemetry fields
