### PR TITLE
fix(services): degrade grant-held slug lookup on a failed grants query

### DIFF
--- a/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
+++ b/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
@@ -192,6 +192,13 @@ async function resolveFallbackLake(
  * only reserves the org-less meta-tag, so an ORG-SCOPED lake may legitimately carry a registry
  * slug - exactly the foreign-org shape this arm serves - and skipping the query there resolves the
  * synthetic registry lake in place of the caller's own grant-held lake.
+ *
+ * A registry-slug match DOES change behavior on failure, though: degrading to no reach here
+ * would return null, and resolveLakeAccessWithGrants's `??` chain would then fall through to
+ * resolveFallbackLake and silently resolve the WRONG lake (the generic registry fallback)
+ * instead of the caller's own - a 200 with the wrong content, not an error. So a slug colliding
+ * with a DATA_LAKES id/slug rethrows on a grants-query failure instead of degrading; every other
+ * slug still degrades to no reach as before.
  */
 const resolveGrantHeldLakeBySlug = async (
   slug: string,
@@ -209,6 +216,9 @@ const resolveGrantHeldLakeBySlug = async (
     dataLakeAccessGrants,
     false
   ).catch(err => {
+    // See the doc comment above: a slug matching a DATA_LAKES id/slug would otherwise fall
+    // through to resolveFallbackLake and silently resolve the wrong lake on this failure.
+    if (DATA_LAKES.some(dl => dl.id === slug || dl.slug === slug)) throw err;
     logger?.warn?.('[dataLakes] grant-held slug fallback query failed; resolving with no grant reach', err);
     return { grantedLakeIds: [], orgGrantedLakes: {} };
   });

--- a/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
+++ b/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
@@ -181,12 +181,24 @@ async function resolveFallbackLake(
  * here, but `canManageLake` in the caller still gates what the grant actually admits the caller
  * to do with it. Extracted so the miss-only laziness is visible at the call site (an `??` on two
  * awaited calls) rather than hidden inside a thunk passed into the repository method.
+ *
+ * The reach read degrades to no reach rather than propagating, like every other optional-adapter
+ * read in this file (see `resolveFallbackLake`): this arm sits behind two already-caught lookups,
+ * so a transient grants-collection failure must not newly 500 a request path that had no prior
+ * dependency on that collection. Degrading to EMPTY can only narrow what resolves, never widen it.
+ *
+ * Deliberately NOT short-circuited on a registry slug, tempting as it looks: a slug matching a
+ * DATA_LAKES id does not mean the registry lake is what the caller is after. `disambiguateSlug`
+ * only reserves the org-less meta-tag, so an ORG-SCOPED lake may legitimately carry a registry
+ * slug - exactly the foreign-org shape this arm serves - and skipping the query there resolves the
+ * synthetic registry lake in place of the caller's own grant-held lake.
  */
 const resolveGrantHeldLakeBySlug = async (
   slug: string,
   ctx: AccessContext,
   dataLakeAccessGrants: AssertLakeAccessAdapters['db']['dataLakeAccessGrants'],
-  dataLakes: Pick<IDataLakeRepository, 'findBySlugAmongIds'>
+  dataLakes: Pick<IDataLakeRepository, 'findBySlugAmongIds'>,
+  logger?: LakeAccessLogger
 ): Promise<IDataLakeDocument | null> => {
   if (!dataLakeAccessGrants) return null;
   // Owner/curator only (includeReaders=false), so the reach's org half is always empty here - the
@@ -196,7 +208,10 @@ const resolveGrantHeldLakeBySlug = async (
     ctx.organizationIds ?? [],
     dataLakeAccessGrants,
     false
-  );
+  ).catch(err => {
+    logger?.warn?.('[dataLakes] grant-held slug fallback query failed; resolving with no grant reach', err);
+    return { grantedLakeIds: [], orgGrantedLakes: {} };
+  });
   if (grantedLakeIds.length === 0) return null;
   return dataLakes.findBySlugAmongIds(slug, grantedLakeIds);
 };
@@ -234,7 +249,7 @@ const resolveLakeAccessWithGrants = async (
   const lake =
     (await db.dataLakes.findById(lakeIdOrSlug).catch(() => null)) ??
     (await db.dataLakes.findBySlug(lakeIdOrSlug, ctx.organizationIds)) ??
-    (await resolveGrantHeldLakeBySlug(lakeIdOrSlug, ctx, db.dataLakeAccessGrants, db.dataLakes));
+    (await resolveGrantHeldLakeBySlug(lakeIdOrSlug, ctx, db.dataLakeAccessGrants, db.dataLakes, logger));
   if (lake) {
     // A persisted lake may carry grants; a fallback lake never does. Fetch only when the repo is
     // wired, so callers that have not threaded it keep the createdByUserId + org/tag/public behavior.

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -400,6 +400,36 @@ describe('assertLakeAccess — hardcoded fallback lakes (no backing document)', 
     );
     expect(resolved.id).toBe('real-db-id');
   });
+
+  // #2510 follow-up (human review): a slug colliding with a DATA_LAKES id/slug must not degrade on
+  // a grants-query failure the way every other slug does - degrading would return null here and let
+  // resolveLakeAccessWithGrants's ?? chain fall through to resolveFallbackLake, silently swapping the
+  // caller's own grant-held lake for the generic registry fallback (a 200 with the wrong content,
+  // not an error).
+  it('rethrows the grants-query failure instead of degrading when the slug collides with a fallback lake', async () => {
+    const db = {
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: vi.fn().mockResolvedValue(null),
+        findBySlugAmongIds: vi.fn().mockResolvedValue(null),
+      },
+      dataLakeAccessGrants: {
+        listByPrincipal: vi.fn().mockRejectedValue(new Error('grants collection unavailable')),
+        listByLake: vi.fn().mockResolvedValue([]),
+      },
+    };
+    const logger = { warn: vi.fn() };
+
+    // The Opti tag is held on purpose: it is what would make the fallback resolve and mask the bug
+    // if the failure were degraded instead of rethrown.
+    await expect(
+      assertLakeAccess('opti-knowledge', ctx({ userId: 'grantee', organizationIds: ['orgB'], userTags: ['opti'] }), {
+        db,
+        logger,
+      })
+    ).rejects.toThrow('grants collection unavailable');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });
 
 /**

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -364,6 +364,42 @@ describe('assertLakeAccess — hardcoded fallback lakes (no backing document)', 
       assertLakeAccess('opti-knowledge', ctx({ userTags: ['opti'], organizationIds: ['orgB'] }), { db })
     ).rejects.toThrow(/not found/i);
   });
+
+  // #2510: the grant arm must NOT be skipped just because the slug matches a registry id.
+  // disambiguateSlug only reserves the org-less meta-tag (datalake:<slug>), so an ORG-SCOPED lake
+  // may legitimately carry a registry slug; skipping the query for it hands back the synthetic
+  // registry lake in place of the caller's own grant-held lake - a wrong lake, not a denial.
+  it('an org-scoped DB lake carrying a registry slug still resolves via a foreign-org grant', async () => {
+    const shadow = lake({
+      id: 'real-db-id',
+      slug: 'opti-knowledge',
+      createdByUserId: 'other',
+      organizationId: 'orgA',
+    });
+    const db = {
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: vi.fn().mockResolvedValue(null),
+        findBySlugAmongIds: vi
+          .fn()
+          .mockImplementation(async (_s: string, ids: string[]) => (ids.includes(shadow.id) ? shadow : null)),
+      },
+      dataLakeAccessGrants: {
+        listByPrincipal: vi.fn().mockResolvedValue([{ dataLakeId: shadow.id, role: 'owner' }]),
+        listByLake: vi
+          .fn()
+          .mockResolvedValue([{ dataLakeId: shadow.id, principalType: 'user', principalId: 'grantee', role: 'owner' }]),
+      },
+    };
+
+    // The Opti tag is held on purpose: it is what would make the fallback resolve and mask the bug.
+    const resolved = await assertLakeAccess(
+      'opti-knowledge',
+      ctx({ userId: 'grantee', organizationIds: ['orgB'], userTags: ['opti'] }),
+      { db }
+    );
+    expect(resolved.id).toBe('real-db-id');
+  });
 });
 
 /**
@@ -478,6 +514,27 @@ describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => 
       assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgA'] }), { db })
     ).resolves.toBe(theirs);
     expect(findBySlugAmongIds).not.toHaveBeenCalled();
+  });
+
+  // #2510: previously uncaught - a transient grants-collection failure propagated straight out of
+  // assertLakeAccess, 500ing a request path (e.g. sessions/create.ts) that had no prior dependency
+  // on that collection. It must degrade like every other optional-adapter read in this file.
+  it('degrades to no grant-held match when the grants query fails, rather than throwing raw', async () => {
+    const db = {
+      dataLakes: {
+        findById: vi.fn().mockRejectedValue(new Error('bad id')),
+        findBySlug: findBySlugMiss(),
+        findBySlugAmongIds: findBySlugAmongIdsFake(),
+      },
+      dataLakeAccessGrants: {
+        listByPrincipal: vi.fn().mockRejectedValue(new Error('grants collection unavailable')),
+        listByLake: vi.fn().mockResolvedValue([]),
+      },
+    };
+
+    await expect(
+      assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgB'] }), { db })
+    ).rejects.toThrow(/not found/i);
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -531,10 +531,17 @@ describe('assertLakeAccess - foreign-org grant resolves by slug (#2425)', () => 
         listByLake: vi.fn().mockResolvedValue([]),
       },
     };
+    const logger = { warn: vi.fn() };
 
     await expect(
-      assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgB'] }), { db })
+      assertLakeAccess('foreign-granted', ctx({ userId: 'grantee', organizationIds: ['orgB'] }), { db, logger })
     ).rejects.toThrow(/not found/i);
+    // A dropped warn call would go unnoticed - it's the only signal an operator gets that this
+    // degrade path fired at all, since the caller-facing result is identical to "no grant exists".
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[dataLakes] grant-held slug fallback query failed; resolving with no grant reach',
+      expect.any(Error)
+    );
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="1512" height="801" alt="check1-qa-test-lake-2510-pass" src="https://github.com/user-attachments/assets/cadeb224-7c26-43f3-bb43-55d163c28f46" />

**User-Owned Lake Session**: A session scoped to a test data lake ("QA Test Lake 2510") returns a sourced answer citing the uploaded file (qa-test-doc.txt) with no errors - confirms the untouched findById/findBySlug hit path still works.

<img width="1512" height="801" alt="check2-opti-knowledge-fallback-lake-pass" src="https://github.com/user-attachments/assets/5be170dd-a68c-4284-868d-be6f123d0f6a" />

**Fallback Lake Session**: A session scoped to the built-in "Optimization Knowledge Base" lake - the exact miss-then-grant-lookup arm this PR changes (assertLakeAccess falls through to resolveGrantHeldLakeBySlug for this slug) - resolves cleanly with no error toast.

## Description

Closes #2510.

`assertLakeAccess`'s `#2425` foreign-org grant-lookup arm (`resolveGrantHeldLakeBySlug` in
`b4m-core/services/src/dataLakeService/assertLakeAccess.ts`) called `grantedLakeReachFor`
with no `.catch()`. That arm only runs on a `findById`/`findBySlug` miss - so a transient
failure in the grants collection propagated straight out of `assertLakeAccess` uncaught,
on a request path that previously had no dependency on that collection (e.g.
`apps/client/pages/api/sessions/create.ts`'s `dataLakeId` resolution).

This PR degrades that read to no grant reach on failure, the same graceful-degrade
convention every other optional-adapter read in this file already follows (see
`resolveFallbackLake`). Degrading to empty can only narrow what resolves, never widen it.

An `isFallbackLake` short-circuit was also drafted for this arm (skip the grants query
entirely when the slug matches a built-in registry lake id), but was dropped after testing
proved it unsafe: slug reservation (`createDataLake.ts`'s `disambiguateSlug`) only reserves
the *org-less* meta-tag, so an org-scoped lake can legitimately carry a registry slug. The
short-circuit made that case resolve to the synthetic registry lake instead of the caller's
own grant-held lake - a silent wrong-lake resolution. The code now documents why that skip
must not be reintroduced.

Follow-up from review on #2468.

## Changes

- `b4m-core/services/src/dataLakeService/assertLakeAccess.ts` - `resolveGrantHeldLakeBySlug` (line 196) now catches a failed `grantedLakeReachFor` call and degrades to no grant reach, logging a warning via the threaded `logger` param instead of propagating.
- `b4m-core/services/src/dataLakeService/dataLakeService.test.ts` - two new tests: the grants-query-failure degrade (denies not-found instead of throwing raw), and a regression test proving an org-scoped DB lake carrying a registry slug still resolves via a foreign-org grant.

## Tests

- `b4m-core/services/src/dataLakeService/dataLakeService.test.ts` - added `degrades to no grant-held match when the grants query fails, rather than throwing raw` and `an org-scoped DB lake carrying a registry slug still resolves via a foreign-org grant`.

## Guide for Testers

1. Start a new chat, open the "Optimization Knowledge Base" data lake from the Data Lakes
   picker, and send a message asking to see the lake (e.g. "hello, can you see this
   lake?"). Expected: the session opens with no error toast, the response streams
   normally, and the lake's name appears in the reply. See the Fallback Lake Session
   screenshot above.
2. Create (or use) a data lake with at least one uploaded file, start a session scoped to
   it, and ask the assistant to search that lake for the file's content. Expected: the
   response cites the source file and quotes its content, with no error. See the
   User-Owned Lake Session screenshot above.

### What NOT to test

This PR does not change any UI component - the two steps above exercise the underlying
access-resolution code (`assertLakeAccess`) through the existing chat UI. There is nothing
to visually inspect beyond the normal chat flow completing without error.

### Regression Checks

- [x] Opening a lake by id (a user-owned lake) still works with no error - verified on the
      preview link, screenshot attached above.
- [x] Opening the built-in fallback lake (the miss-then-grant-lookup arm this PR changes)
      still works with no error - verified on the preview link, screenshot attached above.

## Additional Information

Verified on the preview link: opened a user-owned data lake and the built-in fallback
lake, sent a message through each, and confirmed via network request inspection that the
relevant requests (`POST /api/sessions/create` and related session calls) returned 200
with no 500s and no console errors in either case.

No automated regression exists yet for the actual "grants collection unavailable" scenario
in production (staging/prod) - the fix and its tests are unit-level, mocking the grants
repository's rejection directly.

#2510 also suggested a one-line clarifying comment on `DataLakeModel.test.ts`'s tie-break
tests (test-determinism vs sort-correctness, a pre-existing gap called out in #2468's own
PR body). That's a lower-priority documentation note, not addressed here, and left out
scope for this PR.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
