### PR TITLE
refactor(data-lakes): stamp lake prefix tag in core createFabFile

### DIFF
--- a/apps/client/pages/api/files/createFabFile.ts
+++ b/apps/client/pages/api/files/createFabFile.ts
@@ -78,13 +78,6 @@ const handler = baseApi()
         }
       );
 
-      // A file joining a lake must also land under that lake's content prefix, or it is
-      // invisible to tag-counts and to the Explorer's tag tree.
-      const tags = await dataLakeService.reconcileDataLakeFallbackTags(params.tags ?? [], {
-        db: { dataLakes: dataLakeRepository },
-        logger: req.logger,
-      });
-
       // Verify batch ownership before stamping - batchId comes from the body (IDOR otherwise).
       // Shared with the presign routes (see assertBatchOwnership).
       if (params.batchId) {
@@ -94,45 +87,42 @@ const handler = baseApi()
       }
 
       const result = await withTransaction(async () => {
-        return fabFilesService.createFabFile(
-          user.id,
-          { ...params, ...(tags.length > 0 && { tags }) },
-          {
-            db: {
-              adminSettings: adminSettingsRepository,
-              fabFiles: FabFile,
-              users: User,
-              dataLakes: dataLakeRepository,
-              // The service re-gates the lake tag internally, so its inputs must stay at least as
-              // wide as the route's own prologue above: without the grant repo that re-gate loses
-              // the curator and transferred-owner rungs and refuses a caller this route just
-              // authorized. Same shape as proposalAdmissionDeps.ts / dataLakeIngestDeps.ts.
-              dataLakeAccessGrants: dataLakeAccessGrantRepository,
-              scopedSettings: scopedSettingsRepository,
+        return fabFilesService.createFabFile(user.id, params, {
+          db: {
+            adminSettings: adminSettingsRepository,
+            fabFiles: FabFile,
+            users: User,
+            dataLakes: dataLakeRepository,
+            // The service re-gates the lake tag internally, so its inputs must stay at least as
+            // wide as the route's own prologue above: without the grant repo that re-gate loses
+            // the curator and transferred-owner rungs and refuses a caller this route just
+            // authorized. Same shape as proposalAdmissionDeps.ts / dataLakeIngestDeps.ts.
+            dataLakeAccessGrants: dataLakeAccessGrantRepository,
+            scopedSettings: scopedSettingsRepository,
+          },
+          logger: req.logger,
+          storage: {
+            upload: async (filepath, content, option) => {
+              await getFilesStorage().upload(content, filepath, {
+                ContentType: option?.ContentType || 'text/plain',
+                ContentLength: option?.ContentLength || Buffer.byteLength(content, 'utf8'),
+              });
+              return filepath;
             },
-            storage: {
-              upload: async (filepath, content, option) => {
-                await getFilesStorage().upload(content, filepath, {
-                  ContentType: option?.ContentType || 'text/plain',
-                  ContentLength: option?.ContentLength || Buffer.byteLength(content, 'utf8'),
-                });
-                return filepath;
-              },
-              generateSignedUrl: (filepath: string, expireInSeconds: number) =>
-                getFilesStorage().getSignedUrl(filepath, 'put', {
-                  expiresIn: expireInSeconds,
-                }),
-            },
-            // Admission provenance (#1679): a direct-API upload is a manual door. Passed as the
-            // server-side `provenance` adapter, never from the request body, so the origin cannot be
-            // forged. Not defaulted inside the service - other callers (e.g. research) are not manual.
-            provenance: { sourceType: FabFileSourceType.MANUAL_UPLOAD },
-            // The other half of the same parity: the grant repo restores the grant rungs, but the
-            // org rungs need the actor's administered-org set, which the service cannot read off a
-            // user document.
-            administeredOrgIds: ctx.administeredOrgIds,
-          }
-        );
+            generateSignedUrl: (filepath: string, expireInSeconds: number) =>
+              getFilesStorage().getSignedUrl(filepath, 'put', {
+                expiresIn: expireInSeconds,
+              }),
+          },
+          // Admission provenance (#1679): a direct-API upload is a manual door. Passed as the
+          // server-side `provenance` adapter, never from the request body, so the origin cannot be
+          // forged. Not defaulted inside the service - other callers (e.g. research) are not manual.
+          provenance: { sourceType: FabFileSourceType.MANUAL_UPLOAD },
+          // The other half of the same parity: the grant repo restores the grant rungs, but the
+          // org rungs need the actor's administered-org set, which the service cannot read off a
+          // user document.
+          administeredOrgIds: ctx.administeredOrgIds,
+        });
       });
 
       await logEvent(

--- a/b4m-core/services/src/emailIngestionService/processAttachments.ts
+++ b/b4m-core/services/src/emailIngestionService/processAttachments.ts
@@ -43,7 +43,8 @@ function mapToFabFileAdapters(
     fabFiles: IFabFileRepository;
     adminSettings: IAdminSettingsRepository;
     users: IUserRepository;
-    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag'>;
+    // 'find' is forwarded straight to createFabFile, for its fallback tagger's prefix-overlap check.
+    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag' | 'find'>;
   }
 ) {
   return {
@@ -96,7 +97,8 @@ export async function processAttachments(
       fabFiles: IFabFileRepository;
       adminSettings: IAdminSettingsRepository;
       users: IUserRepository;
-      dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag'>;
+      // 'find' is forwarded straight to createFabFile, for its fallback tagger's prefix-overlap check.
+      dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag' | 'find'>;
     };
   },
   organizationId?: string

--- a/b4m-core/services/src/emailIngestionService/processEmailBody.ts
+++ b/b4m-core/services/src/emailIngestionService/processEmailBody.ts
@@ -46,7 +46,8 @@ export async function processEmailBody(
       fabFiles: IFabFileRepository;
       adminSettings: IAdminSettingsRepository;
       users: IUserRepository;
-      dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag'>;
+      // 'find' is forwarded straight to createFabFile, for its fallback tagger's prefix-overlap check.
+      dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag' | 'find'>;
     };
   },
   organizationId?: string

--- a/b4m-core/services/src/emailIngestionService/types.ts
+++ b/b4m-core/services/src/emailIngestionService/types.ts
@@ -107,7 +107,8 @@ export interface EmailIngestionAdapters {
     ingestedEmails: IIngestedEmailRepository;
     fabFiles: IFabFileRepository;
     adminSettings: IAdminSettingsRepository;
-    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag'>;
+    // 'find' is forwarded straight to createFabFile, for its fallback tagger's prefix-overlap check.
+    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag' | 'find'>;
   };
   storage: IStorageAdapter;
   /**

--- a/b4m-core/services/src/fabFileService/create.test.ts
+++ b/b4m-core/services/src/fabFileService/create.test.ts
@@ -356,7 +356,7 @@ describe('createFabFile - lake-tag gate at create time', () => {
   // This is exactly the call shape packages/scripts/datalake/ingest-pdf-datalake.ts makes to seed
   // a STATIC REGISTRY lake (datalake:opti-knowledge, no owning DB document) - the only supported
   // way to populate one. Centralizing assertCanWriteDataLakeTags here must not break it.
-  it('allows an admin to create a file tagged into a static-registry lake with no DB lookup', async () => {
+  it('allows an admin to create a file tagged into a static-registry lake, minting no fallback stamp', async () => {
     findByDatalakeTag.mockClear();
     const result = await createFabFile(
       'u1',
@@ -369,7 +369,11 @@ describe('createFabFile - lake-tag gate at create time', () => {
       mockAdaptersFor(true)
     );
     expect(result.id).toBe('fab-1');
-    expect(findByDatalakeTag).not.toHaveBeenCalled();
+    // assertCanWriteDataLakeTags' static-registry arm does no DB lookup (line 231-235 above), but
+    // the fallback tagger (#2397) still resolves the meta-tag - a static-registry lake has no
+    // owning document, so this returns null and mints no stamp, same as a stale/orphaned tag would.
+    expect(findByDatalakeTag).toHaveBeenCalledTimes(1);
+    expect(result.tags).toEqual([{ name: 'datalake:opti-knowledge', strength: 1 }]);
   });
 
   it('refuses a non-admin creating a file tagged into a static-registry lake', async () => {
@@ -385,5 +389,85 @@ describe('createFabFile - lake-tag gate at create time', () => {
         mockAdaptersFor(false)
       )
     ).rejects.toThrow(/only an admin can change this data lake/i);
+  });
+});
+
+// #2397: createFabFile used to persist a lake meta-tag with no content-prefix stamp, unlike
+// updateFabFile (which runs every whole-array tag write through reconcileLakeTags). A file
+// created this way sat in its lake contributing nothing to tag-counts and appearing under no
+// category in the Explorer tree until some later edit happened to trigger the stamp.
+describe('createFabFile - lake fallback-tag stamp at create time (#2397)', () => {
+  const lake = {
+    id: 'lake1',
+    name: 'Project Docs',
+    fileTagPrefix: 'proj:',
+    datalakeTag: 'datalake:project-docs',
+    createdByUserId: 'u1',
+  };
+
+  const mockAdapters = (): CreateFabFileAdapters =>
+    ({
+      db: {
+        fabFiles: { create: vi.fn().mockImplementation(async data => ({ id: 'fab-1', ...data })) },
+        adminSettings: { findAll: vi.fn().mockResolvedValue([]), findBySettingNames: vi.fn().mockResolvedValue([]) },
+        users: { findById: vi.fn().mockResolvedValue({ id: 'u1', isAdmin: false }) },
+        dataLakes: {
+          findByDatalakeTag: vi.fn().mockResolvedValue(lake),
+          // No colliding lakes in scope, so decideStampPrefix's overlap check clears.
+          find: vi.fn().mockResolvedValue([]),
+        },
+      },
+      storage: { generateSignedUrl: vi.fn().mockResolvedValue('url'), upload: vi.fn() },
+    }) as unknown as CreateFabFileAdapters;
+
+  it('stamps <prefix>uncategorized on a file created with only the lake meta-tag', async () => {
+    const result = await createFabFile(
+      'u1',
+      {
+        ...base,
+        fileName: 'notes.txt',
+        mimeType: 'text/plain',
+        tags: [{ name: 'datalake:project-docs', strength: 1 }],
+      },
+      mockAdapters()
+    );
+
+    // Same tag-counts/Explorer-tree signal reconcileLakeTags stamps on the update path - this is
+    // the parity the acceptance criteria ask for.
+    expect(result.tags).toEqual(
+      expect.arrayContaining([
+        { name: 'datalake:project-docs', strength: 1 },
+        { name: 'proj:uncategorized', strength: 1 },
+      ])
+    );
+  });
+
+  it('mints no stamp when the file already carries a tag under the lake prefix', async () => {
+    const result = await createFabFile(
+      'u1',
+      {
+        ...base,
+        fileName: 'notes.txt',
+        mimeType: 'text/plain',
+        tags: [
+          { name: 'datalake:project-docs', strength: 1 },
+          { name: 'proj:onboarding', strength: 1 },
+        ],
+      },
+      mockAdapters()
+    );
+
+    expect(result.tags).toEqual([
+      { name: 'datalake:project-docs', strength: 1 },
+      { name: 'proj:onboarding', strength: 1 },
+    ]);
+  });
+
+  it('leaves a create with no tags at all untouched (no dataLakes round trip)', async () => {
+    const adapters = mockAdapters();
+    const result = await createFabFile('u1', { ...base, fileName: 'notes.txt', mimeType: 'text/plain' }, adapters);
+
+    expect(result.tags).toBeUndefined();
+    expect(adapters.db.dataLakes.findByDatalakeTag).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/fabFileService/create.ts
+++ b/b4m-core/services/src/fabFileService/create.ts
@@ -23,6 +23,7 @@ import {
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import { assertCanWriteDataLakeTags, assertCanWriteStaticRegistryTags } from '../dataLakeService/authorizeLakeWrite';
+import { reconcileDataLakeFallbackTags } from '../dataLakeService/fallbackLakeTags';
 
 export const createFabFileSchema = z.object({
   fileName: z.string(),
@@ -63,7 +64,9 @@ export interface CreateFabFileAdapters {
     organizations?: {
       findById: (id: string) => Promise<IOrganizationDocument | null>;
     };
-    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag'>;
+    // 'find' is for the fallback tagger's prefix-overlap check (decideStampPrefix), not the write
+    // gate above - the two happen to share this adapter.
+    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag' | 'find'>;
     // Optional, but WIRE IT on any door that stamps a lake tag on behalf of someone who may manage
     // that lake by grant or by org role. Absent, loadActiveLakeGrants returns [] and
     // assertCanWriteDataLakeTags degrades to the createdByUserId + org rungs only - which is
@@ -96,6 +99,8 @@ export interface CreateFabFileAdapters {
     sourceType: FabFileSourceType;
     sourceMetadata?: Record<string, unknown>;
   };
+  /** Forwarded to the fallback tagger's skip-path diagnostics; never fails the write on its own. */
+  logger?: { warn?: (msg: string, ...args: unknown[]) => void };
   /**
    * The acting principal's org-admin set, when the caller has already resolved it (toAccessContext
    * does). It cannot be read off the user document, so omitting it silently drops the two org rungs
@@ -124,11 +129,18 @@ const DEFAULT_EXPIRE_IN_SECONDS = 3600 * 24 * 5; // 5 days
  * `fabFileRepository.create()`/a direct model call) gets NO such gate; today's few such bypasses
  * only ever set hardcoded or no tags, never a caller-controlled name, but a future one gaining a
  * caller-supplied `tags` field must route through here instead.
+ *
+ * The tags this persists also run through `reconcileDataLakeFallbackTags` (#2397), the same
+ * fallback stamper `updateFabFile` runs on every whole-array tag write: a file created with only
+ * a `datalake:*` meta-tag and no content tag under that lake's prefix gets its
+ * `<prefix>uncategorized` stamp here, rather than being invisible to `tag-counts` and the
+ * Explorer's tag tree until some later edit happens to trigger it. `previousTags` is deliberately
+ * omitted - a create has no prior state to retract a stamp against.
  */
 export const createFabFile = async (
   userId: string,
   parameters: CreateFabFileParameters,
-  { db, storage, provenance, administeredOrgIds }: CreateFabFileAdapters
+  { db, storage, provenance, administeredOrgIds, logger }: CreateFabFileAdapters
 ) => {
   const params = secureParameters(parameters, createFabFileSchema);
   const user = await db.users.findById(userId);
@@ -144,6 +156,11 @@ export const createFabFile = async (
   // The file is created under `userId`, so it is its own owner-to-be for the admission contract.
   await assertCanWriteDataLakeTags(actor, tagNames, { db, members: [{ userId }] });
   assertCanWriteStaticRegistryTags(actor, tagNames);
+
+  // A file joining a lake here must also land under that lake's content prefix, or it
+  // contributes nothing to tag-counts and appears nowhere in the Explorer's tag tree (#2397).
+  // No-ops (no `dataLakes` round trip) when `params.tags` carries no `datalake:*` meta-tag.
+  const tags = params.tags === undefined ? undefined : await reconcileDataLakeFallbackTags(params.tags, { db, logger });
 
   const ext = getFileExtension(params.fileName);
   let mimeType = params.mimeType || getMimeTypeByExtension(ext);
@@ -175,6 +192,7 @@ export const createFabFile = async (
   const buildData: Omit<IFabFileDocument, 'id'> = {
     userId,
     ...params,
+    ...(tags !== undefined && { tags }),
     ...(provenance && {
       sourceType: provenance.sourceType,
       ...(provenance.sourceMetadata && { sourceMetadata: provenance.sourceMetadata }),

--- a/b4m-core/services/src/fabFileService/createByUrl.ts
+++ b/b4m-core/services/src/fabFileService/createByUrl.ts
@@ -38,7 +38,8 @@ type CreateFabFileByUrlAdapters = {
     users: {
       findById: (id: string) => Promise<IUserDocument | null>;
     };
-    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag'>;
+    // 'find' is forwarded straight to createFabFile, for its fallback tagger's prefix-overlap check.
+    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag' | 'find'>;
     // Forwarded to createFabFile's lake-tag write gate. Wire it whenever the caller stamps a lake
     // tag on behalf of a principal who may manage that lake by grant rather than by having created
     // it, or the gate silently loses the curator and transferred-owner rungs.

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -199,9 +199,11 @@ interface DatabaseAdapters {
     findById: (id: string) => Promise<ILatticeModel | null>;
     update: (data: any) => Promise<ILatticeModel | null>;
   };
+  // 'find' is forwarded to ToolContext.db.dataLakes -> createFabFile (persistGeneratedFileAsFabFile),
+  // for its fallback tagger's prefix-overlap check.
   dataLakes?: Pick<
     IDataLakeRepository,
-    'findActiveByUserTags' | 'findActiveByUserTagsAndEntitlements' | 'findByDatalakeTag' | 'findById'
+    'findActiveByUserTags' | 'findActiveByUserTagsAndEntitlements' | 'findByDatalakeTag' | 'findById' | 'find'
   >;
   /**
    * Access-grant lookup shared by two independent optional features:

--- a/b4m-core/services/src/llm/tools/base/types.ts
+++ b/b4m-core/services/src/llm/tools/base/types.ts
@@ -104,9 +104,11 @@ export interface ToolContext {
     >;
     users?: Pick<IUserRepository, 'findById'>;
     projects?: IProjectRepository;
+    // 'find' is forwarded straight to createFabFile (persistGeneratedFileAsFabFile), for its
+    // fallback tagger's prefix-overlap check.
     dataLakes?: Pick<
       IDataLakeRepository,
-      'findActiveByUserTags' | 'findActiveByUserTagsAndEntitlements' | 'findByDatalakeTag' | 'findById'
+      'findActiveByUserTags' | 'findActiveByUserTagsAndEntitlements' | 'findByDatalakeTag' | 'findById' | 'find'
     >;
     /**
      * Optional overlay lookup for a static (registry) lake's `systemPrompt` (Phase 2 - see

--- a/b4m-core/services/src/notebookCurationService/index.ts
+++ b/b4m-core/services/src/notebookCurationService/index.ts
@@ -592,9 +592,10 @@ export class NotebookCurationService {
             // back to defaults and the limit check effectively no-ops for curated notebooks (default 1GB).
             users: { findById: async (id: string) => ({ id }) as unknown as IUserDocument },
             // Minimal stub, same reasoning as `users` above: the tag here is always the literal
-            // 'curated-notebook', never a lake meta-tag or a registry prefix, so the gate this
-            // feeds can never actually fire and a real lookup would be dead weight.
-            dataLakes: { findByDatalakeTag: async () => null },
+            // 'curated-notebook', never a lake meta-tag or a registry prefix, so neither this gate
+            // nor the fallback tagger's overlap check can ever actually fire and a real lookup
+            // would be dead weight.
+            dataLakes: { findByDatalakeTag: async () => null, find: async () => [] },
           },
           storage: this.adapters.fileStorageService,
         }

--- a/b4m-core/services/src/researchTaskService/downloadRelevantLinks.test.ts
+++ b/b4m-core/services/src/researchTaskService/downloadRelevantLinks.test.ts
@@ -530,7 +530,8 @@ describe('downloadRelevantLinks', () => {
           { name: 'Important', strength: 1.0 },
         ],
       }),
-      adapters
+      // Narrowed to {db, storage} - createFabFile never sees this door's `jobs`/`logger` adapters.
+      { db: adapters.db, storage: adapters.storage }
     );
   });
 
@@ -565,7 +566,8 @@ describe('downloadRelevantLinks', () => {
         organizationId: 'test-org-id',
         prefix: 'research-tasks/test-task-id',
       }),
-      adapters
+      // Narrowed to {db, storage} - createFabFile never sees this door's `jobs`/`logger` adapters.
+      { db: adapters.db, storage: adapters.storage }
     );
     expect(mockDb.researchDatas.existsByUrlAndResearchTaskId).toHaveBeenCalledWith(
       'https://example.com/document1.pdf',
@@ -607,7 +609,8 @@ describe('downloadRelevantLinks', () => {
         fileSize: mockFileBuffer.length,
         content: mockFileBuffer,
       }),
-      adapters
+      // Narrowed to {db, storage} - createFabFile never sees this door's `jobs`/`logger` adapters.
+      { db: adapters.db, storage: adapters.storage }
     );
   });
 

--- a/b4m-core/services/src/researchTaskService/downloadRelevantLinks.ts
+++ b/b4m-core/services/src/researchTaskService/downloadRelevantLinks.ts
@@ -43,7 +43,8 @@ interface IResearchTaskDownloadRelevantLinksAdapters {
     // resolves its enforcement lever from here. Absent, the lever resolves platform-only and a
     // per-org/owner/lake override silently does nothing on this door.
     scopedSettings?: Pick<IScopedSettingsRepository, 'findOverrides'>;
-    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag'>;
+    // 'find' is forwarded straight to createFabFile, for its fallback tagger's prefix-overlap check.
+    dataLakes: Pick<IDataLakeRepository, 'findByDatalakeTag' | 'find'>;
   };
   storage: CreateFabFileAdapters['storage'];
   logger?: {
@@ -167,7 +168,13 @@ export const downloadRelevantLinks = async (
               } (${buffer.length} bytes)`
             );
           } else {
-            downloadedFile = await fabFilesService.createFabFile(user.id, downloadedFileData, adapters);
+            // Narrowed rather than forwarding `adapters` wholesale: its `logger` is
+            // `{info, error}`-shaped, not the `{warn?}` shape createFabFile's fallback-tagger
+            // diagnostics expect, and `jobs` is unrelated to file creation.
+            downloadedFile = await fabFilesService.createFabFile(user.id, downloadedFileData, {
+              db: adapters.db,
+              storage: adapters.storage,
+            });
             logger?.info(
               `✅ [DOWNLOAD_${index + 1}] File created: ${downloadedFile.id} ${
                 downloadedFile.mimeType

--- a/b4m-core/services/src/researchTaskService/process.ts
+++ b/b4m-core/services/src/researchTaskService/process.ts
@@ -59,9 +59,10 @@ interface ResearchTaskProcessAdapters {
     apiKeys: Pick<IApiKeyRepository, 'findByUserIdAndType' | 'findByUserIdAndTypes'>;
     // Widened to match ToolContext.db.dataLakes below (this whole `db` object is passed through
     // to it), not just what the new write-gate call needs.
+    // 'find' is forwarded straight to createFabFile, for its fallback tagger's prefix-overlap check.
     dataLakes: Pick<
       IDataLakeRepository,
-      'findByDatalakeTag' | 'findActiveByUserTags' | 'findActiveByUserTagsAndEntitlements' | 'findById'
+      'findByDatalakeTag' | 'findActiveByUserTags' | 'findActiveByUserTagsAndEntitlements' | 'findById' | 'find'
     >;
     // Required: this whole `db` object is passed through to ToolContext.db below, whose
     // `organizations` field is itself required (#1674 - the data-lake retrieval resolver reads


### PR DESCRIPTION
# Pull Request

## Description

`updateFabFile` runs every whole-array tag write through `reconcileLakeTags`, which stamps a
`<lake-prefix>uncategorized` fallback tag whenever a file joins a lake via its `datalake:*`
meta-tag but carries no content tag under that lake's prefix. `createFabFile` never did this: a
file created with only the bare meta-tag (the common case for a flat, non-folder upload) sat in
its lake contributing nothing to `tag-counts` and appearing under no category in the Explorer's
tag tree, until some later edit happened to trigger the stamp.

This closes that gap by routing every create through `reconcileDataLakeFallbackTags` - the
lighter, one-shot form of the same fallback tagger, already built for "creation doors, which have
no prior state" (as opposed to `reconcileLakeTags`, which additionally re-runs join/admission
gating that `createFabFile`'s own write gate already covers).

## Changes

- `createFabFile` now stamps the lake's content-prefix fallback tag when a create carries a bare
  `datalake:*` meta-tag with no covering content tag - the same invariant `updateFabFile` already
  enforces.
- Removed the now-redundant manual `reconcileDataLakeFallbackTags` call from the
  `pages/api/files/createFabFile.ts` route, which was stamping this by hand for exactly this
  reason - `createFabFile` now does it once, centrally.
- Widened every declared adapter type between `createFabFile` and its callers that only `Pick`'d
  `findByDatalakeTag` off the data-lake repository, to also `Pick` `find` (needed by the fallback
  tagger's prefix-overlap check). All real production wiring already passes the full repository,
  so this is type-only with no runtime change.
- Added a `logger?: { warn?: ... }` adapter to `createFabFile`, forwarded to the fallback tagger's
  skip-path diagnostics; never fails the write on its own.

Closes #2397

## Guide for Testers

This is a backend invariant fix with no new UI surface - the existing Data Lake Manager /
Explorer tag tree is the observable surface.

1. Open a session, go to Files → Upload Files → Data Lakes and create (or pick) a data lake with
   a custom tag prefix, e.g. `proj:`.
2. Upload a single flat file (not inside a folder) and tag it into that lake via its
   `datalake:*` meta-tag only, with no other category tag.
3. Open the Explorer's tag tree for that lake. Expected: the file now appears under a
   `proj:uncategorized` node immediately after creation - previously it would not appear under any
   category until a later edit.
4. Check the lake's tag-counts view. Expected: the newly created file is counted.

### Regression Checks

- Create a file into the same lake with an explicit category tag under the lake's prefix (e.g.
  `proj:onboarding`) already supplied. Expected: no additional `proj:uncategorized` tag is minted
  - only the caller-supplied tag is present.
- Create a file with no lake tags at all. Expected: behaves exactly as before (no data-lake
  lookups, no tags array set).
- Existing lake-tag write-gate behavior (who may tag a file into a lake at create time) is
  unchanged - only the presence of the fallback content tag is new.

### What NOT to test

- The idempotent backfill migration (`20260803000000_backfill-datalake-content-prefix-tag`) is
  pre-existing and unrelated to this change; per the issue, re-running it after this deploys is a
  separate ops step, not something this PR touches or that needs testing here.
- No admin-settings, UI copy, or telemetry changes are part of this PR.

## Additional Information

Ops note: the idempotent backfill migration should be re-run after this deploys, to catch any
legacy rows created before this fix landed. That is a deploy-time step, not part of this PR.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI change
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, internal invariant fix
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A
