### PR TITLE
feat(data-lakes): incremental Drive re-sync via changes.list

### DIFF
--- a/apps/client/pages/api/data-lakes/__tests__/drive-sync.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/drive-sync.test.ts
@@ -254,7 +254,9 @@ describe('POST /api/data-lakes/drive-sync - org-owned connect (D1)', () => {
     // connectedBy is re-stamped to the re-syncing caller so ingest never runs as a deleted user.
     expect(h.connUpdateCredential).toHaveBeenCalledWith('conn1', 'orgA', 'enc-refresh', 'u1');
     expect(h.connCreate).not.toHaveBeenCalled();
-    expect(h.sendToQueue).toHaveBeenCalledWith('queue-url', { connectionId: 'conn1' });
+    // This IS the "Re-sync everything" surface (#2396): reconnecting an existing connection forces a
+    // full walk rather than trusting its (possibly stale, possibly absent) syncCursor.
+    expect(h.sendToQueue).toHaveBeenCalledWith('queue-url', { connectionId: 'conn1', forceFullWalk: true });
     expect(status).toHaveBeenCalledWith(202);
   });
 

--- a/apps/client/pages/api/data-lakes/drive-sync.ts
+++ b/apps/client/pages/api/data-lakes/drive-sync.ts
@@ -179,7 +179,14 @@ const handler = baseApi({ requiredScopes: DATA_LAKE_WRITE_SCOPES })
     }
 
     try {
-      await sendToQueue(Resource.driveLakeIngestQueue.url, { connectionId });
+      // A reconnect of an EXISTING connection (byFolder matched, claimedByThisRequest false) is the
+      // "Re-sync" button on a folder that already has a syncCursor - the explicit "re-sync everything"
+      // action (#2396), so it bypasses the cursor and forces a full walk. A brand-new connection has no
+      // cursor yet regardless, so forceFullWalk is a no-op there and omitted for clarity.
+      await sendToQueue(
+        Resource.driveLakeIngestQueue.url,
+        claimedByThisRequest ? { connectionId } : { connectionId, forceFullWalk: true }
+      );
     } catch (e) {
       // The connection row is what holds the GLOBAL driveFolderId claim, so an enqueue that fails
       // after we created it (SQS unavailable/throttled, an IAM denial, an unregistered queue) would

--- a/apps/client/server/cron/driveLakeResyncPoll.test.ts
+++ b/apps/client/server/cron/driveLakeResyncPoll.test.ts
@@ -33,6 +33,9 @@ const bothFlagsOn = () =>
     async (key: string) => key === 'EnableDataLakes' || key === 'EnableDataLakeDrivePoll'
   );
 
+// A connection that re-walked recently, so the periodic forced re-walk does not fire for it.
+const recentFullWalk = () => new Date(Date.now() - 60 * 60 * 1000);
+
 describe('driveLakeResyncPoll cron', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -61,14 +64,44 @@ describe('driveLakeResyncPoll cron', () => {
   });
 
   it('enqueues each due connection by id onto the ingest queue', async () => {
-    h.findDueForPoll.mockResolvedValue([{ id: 'conn1' }, { id: 'conn2' }, { id: 'conn3' }]);
+    h.findDueForPoll.mockResolvedValue([
+      { id: 'conn1', lastFullWalkAt: recentFullWalk() },
+      { id: 'conn2', lastFullWalkAt: recentFullWalk() },
+      { id: 'conn3', lastFullWalkAt: recentFullWalk() },
+    ]);
 
     const res = await handler();
 
     expect(h.sendToQueue).toHaveBeenCalledTimes(3);
+    // No forceFullWalk: each of these re-walked recently, so the handler goes incremental.
     expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', { connectionId: 'conn1' });
     expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', { connectionId: 'conn3' });
-    expect(JSON.parse(res.body)).toMatchObject({ enqueued: 3 });
+    expect(JSON.parse(res.body)).toMatchObject({ enqueued: 3, forcedFullWalks: 0 });
+  });
+
+  it('forces a full re-walk on a connection that has not walked in 24h, and leaves the rest incremental', async () => {
+    // Drive's changes feed is per-FILE: a subfolder dragged into or out of the connected root emits
+    // one record for the folder and none for its descendants, so no number of incremental pulls
+    // reclassifies them. The periodic re-walk is the only thing that reconciles that.
+    h.findDueForPoll.mockResolvedValue([
+      { id: 'fresh', lastFullWalkAt: recentFullWalk() },
+      { id: 'stale', lastFullWalkAt: new Date(Date.now() - 25 * 60 * 60 * 1000) },
+    ]);
+
+    const res = await handler();
+
+    expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', { connectionId: 'fresh' });
+    expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', { connectionId: 'stale', forceFullWalk: true });
+    expect(JSON.parse(res.body)).toMatchObject({ enqueued: 2, forcedFullWalks: 1 });
+  });
+
+  it('forces a full re-walk on a connection that has never recorded one', async () => {
+    // Brand new (the handler full-walks anyway) or predating the field - both want the re-walk.
+    h.findDueForPoll.mockResolvedValue([{ id: 'conn1' }]);
+
+    await handler();
+
+    expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', { connectionId: 'conn1', forceFullWalk: true });
   });
 
   it('scans with a 6h cutoff and the 200-per-run limit', async () => {
@@ -92,7 +125,11 @@ describe('driveLakeResyncPoll cron', () => {
   it('keeps sweeping past a connection whose enqueue fails, and counts it', async () => {
     // One unroutable id used to reject out of a sequential loop and abandon every connection behind
     // it, so a single bad row stalled the whole sweep - tick after tick, since nothing else clears it.
-    h.findDueForPoll.mockResolvedValue([{ id: 'conn1' }, { id: 'bad' }, { id: 'conn3' }]);
+    h.findDueForPoll.mockResolvedValue([
+      { id: 'conn1', lastFullWalkAt: recentFullWalk() },
+      { id: 'bad', lastFullWalkAt: recentFullWalk() },
+      { id: 'conn3', lastFullWalkAt: recentFullWalk() },
+    ]);
     h.sendToQueue.mockImplementation(async (_url: string, body: { connectionId: string }) => {
       if (body.connectionId === 'bad') throw new Error('queue does not exist');
     });

--- a/apps/client/server/cron/driveLakeResyncPoll.ts
+++ b/apps/client/server/cron/driveLakeResyncPoll.ts
@@ -7,6 +7,10 @@
  * cron only DECIDES who is due and hands off - one delta-aware apply path, no duplicated sync logic.
  * The handler's per-connection `claimForSync` serializes against any manual Re-sync already running.
  *
+ * Most polls hand off an INCREMENTAL pull (the handler goes incremental whenever the connection has a
+ * cursor). This cron is also where the periodic FULL re-walk is decided - see FULL_WALK_INTERVAL_MS for
+ * the Drive-feed gap that reconcile exists to close.
+ *
  * Dark by default: gated on the parent `EnableDataLakes` AND the child `EnableDataLakeDrivePoll`
  * flag, so enabling the feature does not silently start hitting Google on a schedule - an admin opts
  * into polling explicitly. Near-real-time sync (Drive `changes.watch`) is the #1591 E2 follow-up.
@@ -26,6 +30,15 @@ const logger = new Logger({ metadata: { service: 'driveLakeResyncPoll' } });
 // a several-hour cadence catches same-day edits/deletes while keeping Drive API load modest. The
 // ingest handler stamps `lastPolledAt` on every run, so this is measured from the last actual sync.
 const POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+// How long a connection may go on incremental pulls alone before the next poll forces a FULL folder
+// re-walk. Drive's changes feed is per-FILE: dragging a subfolder into or out of the connected root
+// mutates only that folder's own `parents` and emits no records for the files underneath it, so no
+// number of incremental pulls will ever reclassify them. A periodic re-walk is the reconcile behind
+// that gap - it bounds how far the lake can drift from Drive, and it also backstops any single change
+// an incremental run had to leave unresolved. Sized well above POLL_INTERVAL_MS so the overwhelming
+// majority of polls stay O(1), and a connection self-heals within a day rather than on a human's click.
+const FULL_WALK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 // Bound the enqueue burst per run so one tick can't flood the ingest queue; the remainder stay "due"
 // and are picked up on the next tick. findDueForPoll returns oldest-polled-first, so nothing starves.
@@ -48,7 +61,9 @@ export async function handler() {
     return { statusCode: 200, body: JSON.stringify({ enqueued: 0, disabled: true }) };
   }
 
-  const cutoff = new Date(Date.now() - POLL_INTERVAL_MS);
+  const now = Date.now();
+  const cutoff = new Date(now - POLL_INTERVAL_MS);
+  const fullWalkCutoff = now - FULL_WALK_INTERVAL_MS;
   const due = await orgGoogleDriveConnectionRepository.findDueForPoll(cutoff, MAX_ENQUEUE_PER_RUN);
 
   // Bounded-concurrency fan-out with a PER-CONNECTION catch. One unroutable id (a stale queue URL, a
@@ -56,12 +71,21 @@ export async function handler() {
   // single bad row could stall the whole sweep tick after tick. Now it costs only itself.
   let enqueued = 0;
   let failed = 0;
-  const enqueueOne = async (connectionId: string) => {
+  let forcedFullWalks = 0;
+  const enqueueOne = async (connection: (typeof due)[number]) => {
+    const connectionId = connection.id;
+    // A connection that has never recorded a full walk is either brand new (the handler full-walks
+    // anyway, so the flag costs nothing) or predates this field - both want a re-walk.
+    const forceFullWalk = !connection.lastFullWalkAt || new Date(connection.lastFullWalkAt).getTime() < fullWalkCutoff;
     try {
-      // Enqueue by id only; the handler re-reads the connection + folder and claimForSync guards the
-      // race with an in-flight manual Re-sync or a prior poll's still-running job.
-      await sendToQueue(Resource.driveLakeIngestQueue.url, { connectionId });
+      // Enqueue by id (plus the re-walk flag); the handler re-reads the connection + folder and
+      // claimForSync guards the race with an in-flight manual Re-sync or a prior poll's running job.
+      await sendToQueue(Resource.driveLakeIngestQueue.url, {
+        connectionId,
+        ...(forceFullWalk && { forceFullWalk: true }),
+      });
       enqueued++;
+      if (forceFullWalk) forcedFullWalks++;
     } catch (e) {
       failed++;
       logger.error('[driveLakeResyncPoll] failed to enqueue connection', {
@@ -71,11 +95,11 @@ export async function handler() {
     }
   };
   for (let i = 0; i < due.length; i += ENQUEUE_CONCURRENCY) {
-    await Promise.all(due.slice(i, i + ENQUEUE_CONCURRENCY).map(connection => enqueueOne(connection.id)));
+    await Promise.all(due.slice(i, i + ENQUEUE_CONCURRENCY).map(enqueueOne));
   }
 
   // A failed send leaves lastPolledAt untouched, so the connection stays due and the next tick
   // retries it - the count is the operator's signal, not a lost-work marker.
-  logger.info('[driveLakeResyncPoll] sweep complete', { due: due.length, enqueued, failed });
-  return { statusCode: 200, body: JSON.stringify({ enqueued, failed }) };
+  logger.info('[driveLakeResyncPoll] sweep complete', { due: due.length, enqueued, failed, forcedFullWalks });
+  return { statusCode: 200, body: JSON.stringify({ enqueued, failed, forcedFullWalks }) };
 }

--- a/apps/client/server/integrations/google/drive/driveClient.test.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.test.ts
@@ -7,6 +7,10 @@ import {
   isValidDriveFolderId,
   withDriveRetry,
   FOLDER_MIME_TYPE,
+  listChanges,
+  getStartPageToken,
+  isDriveInvalidCursorError,
+  getFileParents,
 } from './driveClient';
 
 /** The shape googleapis hands back for a throttle - a 429, or a 403 whose reason is a quota. */
@@ -269,5 +273,144 @@ describe('rate limits', () => {
 
     const access = await settleThroughBackoff(getFolderAccess(drive, 'FOLDER_X'));
     expect(access).toMatchObject({ ok: false, reason: 'rate_limited' });
+  });
+});
+
+describe('getStartPageToken', () => {
+  it('returns the baseline cursor', async () => {
+    const drive = { changes: { getStartPageToken: vi.fn(async () => ({ data: { startPageToken: 'p1' } })) } };
+    expect(await getStartPageToken(drive as unknown as drive_v3.Drive)).toBe('p1');
+  });
+
+  it('throws if Drive omits the token (never silently returns an unusable cursor)', async () => {
+    const drive = { changes: { getStartPageToken: vi.fn(async () => ({ data: {} })) } };
+    await expect(getStartPageToken(drive as unknown as drive_v3.Drive)).rejects.toThrow(/did not return/);
+  });
+});
+
+describe('listChanges', () => {
+  function mockChangesDrive(pages: Array<{ changes?: unknown[]; nextPageToken?: string; newStartPageToken?: string }>) {
+    const list = vi.fn();
+    for (const page of pages) list.mockResolvedValueOnce({ data: page });
+    return { drive: { changes: { list } } as unknown as drive_v3.Drive, list };
+  }
+
+  it('scopes the request to the given pageToken and requests shared-drive items', async () => {
+    const { drive, list } = mockChangesDrive([{ changes: [], newStartPageToken: 'p2' }]);
+    await listChanges(drive, 'p1');
+
+    const args = list.mock.calls[0][0];
+    expect(args.pageToken).toBe('p1');
+    expect(args.supportsAllDrives).toBe(true);
+    expect(args.includeItemsFromAllDrives).toBe(true);
+  });
+
+  it('follows pagination, concatenating changes, and returns the LAST page newStartPageToken', async () => {
+    const { drive, list } = mockChangesDrive([
+      {
+        changes: [{ fileId: '1', removed: false, file: { id: '1', name: 'a.txt', mimeType: 'text/plain' } }],
+        nextPageToken: 'p2',
+      },
+      { changes: [{ fileId: '2', removed: true }], newStartPageToken: 'p3' },
+    ]);
+
+    const { changes, newStartPageToken } = await listChanges(drive, 'p1');
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list.mock.calls[1][0].pageToken).toBe('p2');
+    expect(changes.map(c => c.fileId)).toEqual(['1', '2']);
+    expect(newStartPageToken).toBe('p3');
+  });
+
+  it('carries removed/trashed/parents through for the caller to classify', async () => {
+    const { drive } = mockChangesDrive([
+      {
+        changes: [
+          {
+            fileId: '1',
+            removed: false,
+            file: { id: '1', name: 'a.txt', mimeType: 'text/plain', parents: ['ROOT'], trashed: true },
+          },
+        ],
+        newStartPageToken: 'p2',
+      },
+    ]);
+
+    const { changes } = await listChanges(drive, 'p1');
+    expect(changes).toEqual([
+      {
+        fileId: '1',
+        removed: false,
+        file: { id: '1', name: 'a.txt', mimeType: 'text/plain', parents: ['ROOT'], trashed: true },
+      },
+    ]);
+  });
+
+  it('represents a genuine removal with no `file`', async () => {
+    const { drive } = mockChangesDrive([{ changes: [{ fileId: '1', removed: true }], newStartPageToken: 'p2' }]);
+    const { changes } = await listChanges(drive, 'p1');
+    expect(changes).toEqual([{ fileId: '1', removed: true, file: undefined }]);
+  });
+
+  it('throws if the last page never carries a newStartPageToken (would advance the cursor nowhere)', async () => {
+    const { drive } = mockChangesDrive([{ changes: [] }]);
+    await expect(listChanges(drive, 'p1')).rejects.toThrow(/newStartPageToken/);
+  });
+});
+
+describe('isDriveInvalidCursorError', () => {
+  it.each([
+    ['a 400 (bad/malformed pageToken)', { code: 400 }],
+    ['a 404 (pageToken no longer resolvable)', { response: { status: 404 } }],
+  ])('detects %s', (_label, shape) => {
+    expect(isDriveInvalidCursorError(Object.assign(new Error('bad token'), shape))).toBe(true);
+  });
+
+  it.each([
+    ['a 429 (rate limit, not an invalid cursor)', { code: 429 }],
+    ['a plain error', {}],
+  ])('does not treat %s as an invalid cursor', (_label, shape) => {
+    expect(isDriveInvalidCursorError(Object.assign(new Error('nope'), shape))).toBe(false);
+  });
+
+  it('is safe on non-object rejections', () => {
+    expect(isDriveInvalidCursorError(undefined)).toBe(false);
+  });
+});
+
+describe('getFileParents', () => {
+  it('returns the current parent ids', async () => {
+    const drive = { files: { get: vi.fn(async () => ({ data: { parents: ['P1', 'P2'] } })) } };
+    expect(await getFileParents(drive as unknown as drive_v3.Drive, 'F')).toEqual(['P1', 'P2']);
+  });
+
+  it('returns null for a trashed file (not a usable ancestor)', async () => {
+    const drive = { files: { get: vi.fn(async () => ({ data: { trashed: true, parents: ['P1'] } })) } };
+    expect(await getFileParents(drive as unknown as drive_v3.Drive, 'F')).toBeNull();
+  });
+
+  it('returns null on a CONFIRMED 404 (the file is genuinely gone)', async () => {
+    const drive = {
+      files: {
+        get: vi.fn(async () => {
+          throw Object.assign(new Error('not found'), { code: 404 });
+        }),
+      },
+    };
+    expect(await getFileParents(drive as unknown as drive_v3.Drive, 'F')).toBeNull();
+  });
+
+  // Rethrown, not swallowed into null: null also means "confirmed gone", and isUnderRoot's caller
+  // reads that as "moved out of the tree" for an already-tracked file - misreading a rate
+  // limit/5xx/network blip the same way would silently evict a still-live file from the lake.
+  it('rethrows a TRANSIENT failure rather than treating it as a confirmed not-found', async () => {
+    const drive = {
+      files: {
+        get: vi.fn(async () => {
+          throw new Error('rate limited');
+        }),
+      },
+    };
+    await expect(getFileParents(drive as unknown as drive_v3.Drive, 'F')).rejects.toThrow('rate limited');
   });
 });

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -321,9 +321,13 @@ const CHANGES_FIELDS =
 
 /**
  * Establish the baseline cursor for incremental sync: the pageToken meaning "now". Call once right
- * after a full walk succeeds (first sync, or a cursor-invalidation fallback - see
- * isDriveInvalidCursorError) and persist the result as the connection's syncCursor; `listChanges` from
- * that token onward reports everything that happens AFTER the walk that just ran, never before it.
+ * BEFORE a full walk (first sync, or a cursor-invalidation fallback - see isDriveInvalidCursorError)
+ * and persist the result as the connection's syncCursor only once that walk has been applied.
+ *
+ * Before, not after, and the order is the point: a file created mid-walk, after its parent folder was
+ * already listed, is in neither the walk's result nor a feed read from a token taken afterwards. Taken
+ * first, the token instead overlaps the walk - `listChanges` replays some changes the walk already
+ * covered, which the caller diffs out as no-ops. Overlap is recoverable; a gap is not.
  */
 export async function getStartPageToken(drive: drive_v3.Drive): Promise<string> {
   const res = await withDriveRetry('changes.getStartPageToken', () =>

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -125,6 +125,41 @@ export async function withDriveRetry<T>(operation: string, call: () => Promise<T
   }
 }
 
+/**
+ * Is this error Drive telling us a stored `changes.list` pageToken is no longer valid (expired, or
+ * the corresponding startPageToken was reset)? Classified structurally off the status code, like
+ * isDriveRateLimitError - the message text carries no stable marker. Callers MUST treat a true here
+ * as "fall back to a full walk", not a permanent failure: an invalid cursor is routine (Drive expires
+ * them; see the syncCursor doc comment) and dropping the sync instead would silently stop re-syncing
+ * the folder forever.
+ */
+export function isDriveInvalidCursorError(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) return false;
+  const err = e as Record<string, unknown>;
+  const response = err.response as Record<string, unknown> | undefined;
+  for (const raw of [err.code, err.status, response?.status]) {
+    const code = typeof raw === 'string' ? Number(raw) : raw;
+    if (code === 400 || code === 404) return true;
+  }
+  return false;
+}
+
+/**
+ * Is this error Drive confirming a file is genuinely gone (a plain 404), as opposed to a transient
+ * failure (rate limit, 5xx, network blip)? getFileParents uses this to decide whether an ancestry
+ * lookup failure means "this ancestor no longer exists" (safe to fold into null/no-chain) versus
+ * "we couldn't tell right now" (must NOT be read the same way - see getFileParents).
+ */
+export function isDriveNotFoundError(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) return false;
+  const err = e as Record<string, unknown>;
+  const response = err.response as Record<string, unknown> | undefined;
+  for (const raw of [err.code, err.status, response?.status]) {
+    if ((typeof raw === 'string' ? Number(raw) : raw) === 404) return true;
+  }
+  return false;
+}
+
 // Drive file/folder ids are URL-safe tokens ([A-Za-z0-9_-]); the alias 'root' also matches. The
 // length bound (real ids are ~33-44 chars) stops ~1MB of legal characters being interpolated into
 // the `q` string and sent outbound. Validate before interpolating so a crafted id can't break out.
@@ -266,4 +301,128 @@ export async function listFolderChildren(drive: drive_v3.Drive, folderId: string
   } while (pageToken);
 
   return files;
+}
+
+/**
+ * One entry from `drive.changes.list`: either a file that changed (added/edited/moved/re-shared -
+ * `file` present) or one that is gone for good (deleted, or the caller lost access - `removed: true`,
+ * `file` absent). `file.trashed` is a SEPARATE, softer signal (still resolvable, still in `file`) -
+ * both read as "no longer live" by the caller, but only `removed` means Drive will never mention this
+ * id again.
+ */
+export type DriveChange = {
+  fileId: string;
+  removed: boolean;
+  file?: DriveFile & { parents?: string[]; trashed?: boolean };
+};
+
+const CHANGES_FIELDS =
+  'nextPageToken, newStartPageToken, changes(fileId, removed, file(id, name, mimeType, modifiedTime, md5Checksum, size, parents, trashed))';
+
+/**
+ * Establish the baseline cursor for incremental sync: the pageToken meaning "now". Call once right
+ * after a full walk succeeds (first sync, or a cursor-invalidation fallback - see
+ * isDriveInvalidCursorError) and persist the result as the connection's syncCursor; `listChanges` from
+ * that token onward reports everything that happens AFTER the walk that just ran, never before it.
+ */
+export async function getStartPageToken(drive: drive_v3.Drive): Promise<string> {
+  const res = await withDriveRetry('changes.getStartPageToken', () =>
+    drive.changes.getStartPageToken({ supportsAllDrives: true })
+  );
+  const token = res.data.startPageToken;
+  if (!token) {
+    throw new Error('Drive did not return a startPageToken');
+  }
+  return token;
+}
+
+/**
+ * Pull every change since `pageToken`, following pagination (same page-cap discipline as
+ * listFolderChildren - see MAX_LIST_PAGES). The Changes API is Drive-WIDE: it has no folder filter,
+ * so this returns every change the credential can see across the whole Drive/shared-drive, not just
+ * the connected folder's subtree - narrowing to that subtree is the caller's job (driveLakeIngest
+ * resolves per-candidate membership via driveContent.isUnderRoot).
+ *
+ * `newStartPageToken` is only present on the LAST page and is the cursor to persist for the next
+ * poll; a caller that stops paginating early (it never should - see the throw below) would have
+ * nothing valid to advance the cursor to.
+ */
+export async function listChanges(
+  drive: drive_v3.Drive,
+  pageToken: string
+): Promise<{ changes: DriveChange[]; newStartPageToken: string }> {
+  const changes: DriveChange[] = [];
+  let token: string | undefined = pageToken;
+  let newStartPageToken: string | undefined;
+  let pages = 0;
+
+  do {
+    // Explicit params type: without it, TS's overload resolution against the googleapis
+    // client's several list() signatures (callback vs promise vs streamed) infers `res` in
+    // terms of itself and fails to compile (TS7022).
+    const params: drive_v3.Params$Resource$Changes$List = {
+      pageToken: token,
+      fields: CHANGES_FIELDS,
+      pageSize: 1000,
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
+    };
+    const res = await withDriveRetry('changes.list', () => drive.changes.list(params));
+
+    for (const c of res.data.changes ?? []) {
+      if (!c.fileId) continue;
+      const f = c.file;
+      changes.push({
+        fileId: c.fileId,
+        removed: !!c.removed,
+        file: f
+          ? {
+              id: f.id ?? c.fileId,
+              name: f.name ?? '',
+              mimeType: f.mimeType ?? '',
+              ...(f.modifiedTime && { modifiedTime: f.modifiedTime }),
+              ...(f.md5Checksum && { md5Checksum: f.md5Checksum }),
+              ...(f.size != null && { size: Number(f.size) }),
+              ...(f.parents && { parents: f.parents }),
+              ...(f.trashed != null && { trashed: f.trashed }),
+            }
+          : undefined,
+      });
+    }
+
+    token = res.data.nextPageToken ?? undefined;
+    newStartPageToken = res.data.newStartPageToken ?? newStartPageToken;
+    pages++;
+    if (token && pages >= MAX_LIST_PAGES) {
+      throw new Error(`Drive changes feed exceeded ${MAX_LIST_PAGES} pages; listing is not exhaustive`);
+    }
+  } while (token);
+
+  if (!newStartPageToken) {
+    throw new Error('Drive changes.list did not return a newStartPageToken on its last page');
+  }
+  return { changes, newStartPageToken };
+}
+
+/**
+ * A file/folder's current direct parent ids, for live ancestor-chain resolution (see
+ * driveContent.isUnderRoot). Returns null for anything CONFIRMED unusable as an ancestor: gone (404)
+ * or trashed - the conservative (exclude, don't include) side of that check.
+ *
+ * A transient failure (rate limit, 5xx, network blip) is NOT folded into that same null: isUnderRoot's
+ * caller uses a false/null result to decide a tracked file moved out of the connected tree and should
+ * be evicted from the lake, so misreading "Drive hiccuped" as "confirmed gone" would silently drop a
+ * still-live file (the #2394 failure mode). Rethrown so the caller can tell the two apart.
+ */
+export async function getFileParents(drive: drive_v3.Drive, fileId: string): Promise<string[] | null> {
+  try {
+    const res = await withDriveRetry('files.get(parents)', () =>
+      drive.files.get({ fileId, fields: 'id, parents, trashed', supportsAllDrives: true })
+    );
+    if (res.data.trashed) return null;
+    return res.data.parents ?? [];
+  } catch (e) {
+    if (isDriveNotFoundError(e)) return null;
+    throw e;
+  }
 }

--- a/apps/client/server/integrations/google/drive/driveContent.test.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { drive_v3 } from '@googleapis/drive';
 import { SupportedFabFileMimeTypes } from '@bike4mind/common';
-import { walkFolder, fetchDriveFileContent, DriveWalkTimeBudgetExceededError } from './driveContent';
+import { walkFolder, fetchDriveFileContent, isUnderRoot, DriveWalkTimeBudgetExceededError } from './driveContent';
 import { FOLDER_MIME_TYPE, isDriveRateLimitError } from './driveClient';
 
 const folder = (id: string, name: string) => ({ id, name, mimeType: FOLDER_MIME_TYPE });
@@ -193,6 +193,57 @@ describe('fetchDriveFileContent', () => {
 
     const res = await fetchDriveFileContent(drive, file('n', 'notes.txt', 'text/plain'));
     expect(res).toMatchObject({ ok: false, reason: 'error' });
+  });
+});
+
+describe('isUnderRoot', () => {
+  /** A drive whose files.get resolves id -> parents per the given map (trashed/missing -> null). */
+  function mockAncestryDrive(parentsOf: Record<string, string[] | 'trashed' | undefined>) {
+    const get = vi.fn(async ({ fileId }: { fileId: string }) => {
+      const entry = parentsOf[fileId];
+      if (entry === 'trashed') return { data: { trashed: true } };
+      return { data: { parents: entry } };
+    });
+    return { drive: { files: { get } } as unknown as drive_v3.Drive, get };
+  }
+
+  it('resolves true when a direct parent IS the root', async () => {
+    const { drive } = mockAncestryDrive({});
+    expect(await isUnderRoot(drive, ['ROOT'], 'ROOT', new Map())).toBe(true);
+  });
+
+  it('resolves true through several levels of ancestry', async () => {
+    const { drive } = mockAncestryDrive({ mid: ['ROOT'], near: ['mid'] });
+    expect(await isUnderRoot(drive, ['near'], 'ROOT', new Map())).toBe(true);
+  });
+
+  it('resolves false once the chain runs out before reaching the root', async () => {
+    const { drive } = mockAncestryDrive({ top: [] });
+    expect(await isUnderRoot(drive, ['top'], 'ROOT', new Map())).toBe(false);
+  });
+
+  it('resolves false (not throws) through a cyclic parents graph', async () => {
+    const { drive } = mockAncestryDrive({ a: ['b'], b: ['a'] });
+    expect(await isUnderRoot(drive, ['a'], 'ROOT', new Map())).toBe(false);
+  });
+
+  it('resolves false when an ancestor is trashed (not a usable chain)', async () => {
+    const { drive } = mockAncestryDrive({ mid: 'trashed' });
+    expect(await isUnderRoot(drive, ['mid'], 'ROOT', new Map())).toBe(false);
+  });
+
+  it('memoizes ancestor lookups across calls sharing one cache', async () => {
+    const { drive, get } = mockAncestryDrive({ shared: ['ROOT'] });
+    const cache = new Map<string, string[] | null>();
+    await isUnderRoot(drive, ['shared'], 'ROOT', cache);
+    await isUnderRoot(drive, ['shared'], 'ROOT', cache);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves false with no parents to check', async () => {
+    const { drive } = mockAncestryDrive({});
+    expect(await isUnderRoot(drive, undefined, 'ROOT', new Map())).toBe(false);
+    expect(await isUnderRoot(drive, [], 'ROOT', new Map())).toBe(false);
   });
 });
 

--- a/apps/client/server/integrations/google/drive/driveContent.ts
+++ b/apps/client/server/integrations/google/drive/driveContent.ts
@@ -1,7 +1,14 @@
 import type { drive_v3 } from '@googleapis/drive';
 import { SupportedFabFileMimeTypes } from '@bike4mind/common';
 import { resolveSupportedMimeType } from '@bike4mind/utils';
-import { listFolderChildren, isFolder, isDriveRateLimitError, withDriveRetry, type DriveFile } from './driveClient';
+import {
+  listFolderChildren,
+  isFolder,
+  isDriveRateLimitError,
+  withDriveRetry,
+  getFileParents,
+  type DriveFile,
+} from './driveClient';
 
 const GOOGLE_DOC = 'application/vnd.google-apps.document';
 const GOOGLE_SHEET = 'application/vnd.google-apps.spreadsheet';
@@ -84,6 +91,64 @@ export async function walkFolder(
   }
 
   return files;
+}
+
+// Bounds the total number of ancestor-chain lookups isUnderRoot pays for ONE candidate file, and so
+// (transitively) how much a pathological/cyclic parents graph can cost. Not a tree-depth limit as
+// such - each step is one Drive call - but a folder tree deep enough to exceed it is already a
+// pathological input for this check, not a real customer structure.
+const MAX_ANCESTOR_LOOKUPS = 25;
+
+/**
+ * Is `fileId`'s CURRENT position in Drive under `rootFolderId`, resolved by walking its live parent
+ * chain? Needed only for incremental sync: the Changes API (driveClient.listChanges) is Drive-WIDE,
+ * with no folder filter, so a file this connection has never ingested has to be proven to live in
+ * OUR tree before it becomes a candidate - a full walk never faces this because listFolderChildren is
+ * already scoped to one folder at a time.
+ *
+ * Unresolved - the chain runs out before reaching root (a CONFIRMED dead end: getFileParents returned
+ * null for a 404/trashed ancestor), or MAX_ANCESTOR_LOOKUPS is hit - resolves to false. That is the
+ * deliberately conservative side for an ADD decision: excluding a file that genuinely belongs here is
+ * recoverable (the next full walk, or cursor-invalidation fallback, picks it up), while including one
+ * that does not would ingest content from outside the folder the org actually connected.
+ *
+ * A TRANSIENT lookup failure (rate limit, 5xx, network blip) is different: getFileParents rethrows
+ * rather than returning null, and this function does not catch it - it propagates to the caller
+ * uncaught. That distinction matters because this same result also drives REMOVAL of an already-
+ * tracked file (classifyDriveChanges): folding a transient blip into a bare `false` there would read
+ * as "moved out of the tree" and silently evict a still-live file. Callers for whom that risk applies
+ * MUST catch and treat the ambiguity as "leave alone, re-resolve next run" - never as a confirmed false.
+ *
+ * `cache` memoizes id -> parents across every candidate resolved in one run (pass the SAME map to
+ * every call), since sibling files under one new subfolder would otherwise each re-walk an identical
+ * tail of the chain.
+ */
+export async function isUnderRoot(
+  drive: drive_v3.Drive,
+  parents: string[] | undefined,
+  rootFolderId: string,
+  cache: Map<string, string[] | null>
+): Promise<boolean> {
+  const queue = [...(parents ?? [])];
+  const visited = new Set<string>();
+  let lookups = 0;
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (id === rootFolderId) return true;
+    if (visited.has(id)) continue;
+    visited.add(id);
+
+    let grandparents = cache.get(id);
+    if (grandparents === undefined) {
+      if (lookups >= MAX_ANCESTOR_LOOKUPS) return false;
+      lookups++;
+      grandparents = await getFileParents(drive, id);
+      cache.set(id, grandparents);
+    }
+    if (grandparents) queue.push(...grandparents);
+  }
+  return false;
 }
 
 /**

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -1855,7 +1855,7 @@ describe('driveLakeIngest consumer', () => {
 
       expect(h.listChanges).not.toHaveBeenCalled(); // no cursor on the connection yet
       expect(h.getStartPageToken).toHaveBeenCalled();
-      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date), { fullWalk: true });
     });
 
     it('does not fail the run when a cursor cannot be established after a full walk', async () => {
@@ -1891,7 +1891,9 @@ describe('driveLakeIngest consumer', () => {
       expect(h.fetchDriveFileContent).not.toHaveBeenCalled();
       expect(h.createFabFile).not.toHaveBeenCalled();
       expect(h.batchCreate).not.toHaveBeenCalled();
-      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date), {
+        fullWalk: false,
+      });
       expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
     });
 
@@ -1913,7 +1915,9 @@ describe('driveLakeIngest consumer', () => {
 
       expect(h.isUnderRoot).toHaveBeenCalledWith(expect.anything(), ['FOLDER'], 'FOLDER', expect.anything());
       expect(h.createFabFile).toHaveBeenCalledWith(expect.objectContaining({ driveFileId: 'd1' }), expect.anything());
-      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date), {
+        fullWalk: false,
+      });
     });
 
     it('ignores a changed file that does not resolve under the connected root (Drive-wide feed, folder-scoped lake)', async () => {
@@ -1933,7 +1937,9 @@ describe('driveLakeIngest consumer', () => {
       await run();
 
       expect(h.createFabFile).not.toHaveBeenCalled();
-      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date), {
+        fullWalk: false,
+      });
     });
 
     it('prunes a previously-tracked file that Drive reports removed', async () => {
@@ -1952,7 +1958,9 @@ describe('driveLakeIngest consumer', () => {
         'ff-d1',
         expect.anything()
       );
-      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date), {
+        fullWalk: false,
+      });
     });
 
     it('prunes a previously-tracked file that moved out of the connected tree (still live in Drive, no longer here)', async () => {
@@ -1992,7 +2000,9 @@ describe('driveLakeIngest consumer', () => {
 
       expect(h.walkFolder).toHaveBeenCalled();
       expect(h.createFabFile).toHaveBeenCalledWith(expect.objectContaining({ driveFileId: 'd1' }), expect.anything());
-      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'fresh-cursor', expect.any(Date));
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'fresh-cursor', expect.any(Date), {
+        fullWalk: true,
+      });
     });
 
     it('rethrows a changes.list failure that is not an invalid-cursor error rather than silently falling back', async () => {
@@ -2032,6 +2042,76 @@ describe('driveLakeIngest consumer', () => {
         'ingest-queue-url',
         expect.objectContaining({ connectionId: 'conn1', resumeBatchId: 'batch1', forceFullWalk: true })
       );
+    });
+
+    it('retires EVERY stored copy of a removed driveFileId, not just the newest', async () => {
+      // The full-walk arm unpicks every copy; this arm used to take newestCopyOf only. The duplicate
+      // sweep deliberately skips an id gone from the folder, and Drive never mentions a removed id
+      // again - so an older copy missed here would stay a live lake member forever, holding content
+      // the user deleted from Drive.
+      withCursor();
+      setExisting([
+        { id: 'ff-older', driveFileId: 'd1', userId: 'user1', createdAt: '2026-01-01T00:00:00.000Z' },
+        { id: 'ff-newest', driveFileId: 'd1', userId: 'user1', createdAt: '2026-02-01T00:00:00.000Z' },
+      ]);
+      h.listChanges.mockResolvedValue({
+        changes: [{ fileId: 'd1', removed: true }],
+        newStartPageToken: 'cursor-1',
+      });
+
+      await run();
+
+      expect(h.removeFileFromLake).toHaveBeenCalledTimes(2);
+      expect(h.removeFileFromLake).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'ff-older',
+        expect.anything()
+      );
+      expect(h.removeFileFromLake).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'ff-newest',
+        expect.anything()
+      );
+    });
+
+    it('holds the cursor back when an ancestry check could not be resolved this run', async () => {
+      // The feed reports a modification ONCE. Advancing past an entry this run could not decide would
+      // put it permanently behind the cursor, so the file would sit missing until a human re-synced.
+      withCursor();
+      h.listChanges.mockResolvedValue({
+        changes: [
+          {
+            fileId: 'd1',
+            removed: false,
+            file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['FOLDER'] },
+          },
+        ],
+        newStartPageToken: 'cursor-1',
+      });
+      h.isUnderRoot.mockRejectedValue(new Error('rate limited'));
+
+      await run();
+
+      expect(h.createFabFile).not.toHaveBeenCalled();
+      expect(h.updateSyncCursor).not.toHaveBeenCalled();
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
+    });
+
+    it('takes the baseline cursor BEFORE the walk, so a file created mid-walk is not lost by both modes', async () => {
+      // Taken afterwards, a file created after its parent folder was listed is in neither the walk's
+      // result nor the first incremental pull. Taken first, the pull merely replays covered changes.
+      h.walkFolder.mockImplementation(async () => {
+        expect(h.getStartPageToken).toHaveBeenCalled();
+        return [{ id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' }];
+      });
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      h.getStartPageToken.mockResolvedValue('cursor-1');
+
+      await run();
+
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date), { fullWalk: true });
     });
 
     it('does not advance the cursor when the chain stops short (claim lost mid-slice)', async () => {
@@ -2077,6 +2157,7 @@ describe('classifyDriveChanges', () => {
       adds: [{ id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' }],
       changed: [],
       removedFileIds: [],
+      ambiguous: 0,
     });
   });
 
@@ -2106,7 +2187,7 @@ describe('classifyDriveChanges', () => {
       () => undefined,
       logger
     );
-    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [], ambiguous: 0 });
     expect(h.isUnderRoot).not.toHaveBeenCalled();
   });
 
@@ -2193,7 +2274,7 @@ describe('classifyDriveChanges', () => {
       id => (id === 'd1' ? { driveMd5Checksum: 'A' } : undefined),
       logger
     );
-    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [], ambiguous: 1 });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('tracked file'),
       expect.objectContaining({ fileId: 'd1' })
@@ -2209,7 +2290,7 @@ describe('classifyDriveChanges', () => {
       () => undefined,
       logger
     );
-    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [], ambiguous: 1 });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('new file'),
       expect.objectContaining({ fileId: 'd1' })
@@ -2231,7 +2312,92 @@ describe('classifyDriveChanges', () => {
       id => (id === 'd1' ? { driveMd5Checksum: 'SAME' } : undefined),
       logger
     );
-    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [], ambiguous: 0 });
+  });
+
+  it('collapses repeated entries for one fileId to the last one (the feed is a log, not a snapshot)', async () => {
+    // Drive only collapses records WITHIN a page, so a file edited either side of a page boundary
+    // arrives twice. Un-collapsed, a never-tracked id would be pushed into `adds` twice and ingest as
+    // two FabFiles for one Drive file.
+    h.isUnderRoot.mockResolvedValue(true);
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        {
+          fileId: 'd1',
+          removed: false,
+          file: { id: 'd1', name: 'old.txt', mimeType: 'text/plain', parents: ['ROOT'] },
+        },
+        {
+          fileId: 'd1',
+          removed: false,
+          file: { id: 'd1', name: 'new.txt', mimeType: 'text/plain', parents: ['ROOT'] },
+        },
+      ],
+      'ROOT',
+      () => undefined,
+      logger
+    );
+    expect(result.adds).toEqual([{ id: 'd1', name: 'new.txt', mimeType: 'text/plain', relativePath: 'new.txt' }]);
+  });
+
+  it('emits a removed fileId only once when the feed reports it more than once', async () => {
+    // A doubled removal makes the second removeFileFromLake throw NotFoundError mid-prune, outside
+    // the try that settles reclaimed bytes - so the whole run aborts and retries to the DLQ.
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        { fileId: 'd1', removed: false, file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', trashed: true } },
+        { fileId: 'd1', removed: true },
+      ],
+      'ROOT',
+      id => (id === 'd1' ? { driveMd5Checksum: 'A' } : undefined),
+      logger
+    );
+    expect(result.removedFileIds).toEqual(['d1']);
+  });
+
+  it('takes the LAST entry per fileId, so a file edited and then deleted classifies as removed', async () => {
+    h.isUnderRoot.mockResolvedValue(true);
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        {
+          fileId: 'd1',
+          removed: false,
+          file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', md5Checksum: 'NEW', parents: ['ROOT'] },
+        },
+        { fileId: 'd1', removed: true },
+      ],
+      'ROOT',
+      id => (id === 'd1' ? { driveMd5Checksum: 'OLD' } : undefined),
+      logger
+    );
+    expect(result.removedFileIds).toEqual(['d1']);
+    expect(result.changed).toEqual([]);
+  });
+
+  it('counts one ambiguous entry per unresolved candidate, and still applies the resolvable ones', async () => {
+    h.isUnderRoot.mockImplementation(async (_drive: never, parents: string[]) => {
+      if (parents[0] === 'FLAKY') throw new Error('rate limited');
+      return true;
+    });
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        { fileId: 'ok', removed: false, file: { id: 'ok', name: 'a.txt', mimeType: 'text/plain', parents: ['ROOT'] } },
+        {
+          fileId: 'bad',
+          removed: false,
+          file: { id: 'bad', name: 'b.txt', mimeType: 'text/plain', parents: ['FLAKY'] },
+        },
+      ],
+      'ROOT',
+      () => undefined,
+      logger
+    );
+    expect(result.adds.map(f => f.id)).toEqual(['ok']);
+    expect(result.ambiguous).toBe(1);
   });
 });
 

--- a/apps/client/server/queueHandlers/driveLakeIngest.test.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.test.ts
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   connFindById: vi.fn(),
   claimForSync: vi.fn(),
   releaseSyncClaim: vi.fn(),
+  updateSyncCursor: vi.fn(),
   lakeFindById: vi.fn(),
   lakeFind: vi.fn(),
   userFindById: vi.fn(),
@@ -43,6 +44,10 @@ const h = vi.hoisted(() => ({
   walkFolder: vi.fn(),
   disableDriveConnectionForLake: vi.fn(),
   fetchDriveFileContent: vi.fn(),
+  listChanges: vi.fn(),
+  getStartPageToken: vi.fn(),
+  isDriveInvalidCursorError: vi.fn(),
+  isUnderRoot: vi.fn(),
   finalizeBatchIfComplete: vi.fn(),
   sendToQueue: vi.fn(),
   assertLakeAdmission: vi.fn(),
@@ -87,6 +92,7 @@ vi.mock('@bike4mind/database', () => ({
     adoptSyncClaim: h.adoptSyncClaim,
     renewSyncClaim: h.renewSyncClaim,
     releaseSyncClaim: h.releaseSyncClaim,
+    updateSyncCursor: h.updateSyncCursor,
   },
 }));
 vi.mock('@bike4mind/services', () => ({
@@ -113,14 +119,21 @@ vi.mock('@server/integrations/google/drive/common', () => ({
   getValidConnectionDriveAccessToken: async () => 'access-token',
   disableDriveConnectionForLake: h.disableDriveConnectionForLake,
 }));
-// Only the client factory is stubbed: isDriveRateLimitError is the real predicate, because the
-// walk-throttle deferral below is exactly the behaviour a stubbed one would fake away.
-vi.mock('@server/integrations/google/drive/driveClient', async importOriginal => ({
-  ...(await importOriginal<typeof import('@server/integrations/google/drive/driveClient')>()),
-  createDriveClient: () => ({}),
-}));
-// Mocks only the two Drive calls; keeps the real DriveWalkTimeBudgetExceededError export so tests
-// and the handler agree on the class an `instanceof` check below is testing against.
+// isFolder/isValidDriveFolderId etc. stay real (classifyDriveChanges depends on the real isFolder),
+// and so does isDriveRateLimitError - the throttle deferrals below are exactly the behaviour a
+// stubbed predicate would fake away. Only the network-touching calls are mocked.
+vi.mock('@server/integrations/google/drive/driveClient', async importOriginal => {
+  const actual = await importOriginal<typeof import('@server/integrations/google/drive/driveClient')>();
+  return {
+    ...actual,
+    createDriveClient: () => ({}),
+    listChanges: h.listChanges,
+    getStartPageToken: h.getStartPageToken,
+    isDriveInvalidCursorError: h.isDriveInvalidCursorError,
+  };
+});
+// Mocks only the network-touching calls; keeps the real DriveWalkTimeBudgetExceededError export so
+// tests and the handler agree on the class an `instanceof` check below is testing against.
 vi.mock('@server/integrations/google/drive/driveContent', async () => {
   const actual = await vi.importActual<typeof import('@server/integrations/google/drive/driveContent')>(
     '@server/integrations/google/drive/driveContent'
@@ -129,6 +142,7 @@ vi.mock('@server/integrations/google/drive/driveContent', async () => {
     ...actual,
     walkFolder: h.walkFolder,
     fetchDriveFileContent: h.fetchDriveFileContent,
+    isUnderRoot: h.isUnderRoot,
   };
 });
 vi.mock('@server/queueHandlers/dataLakeBatchProgress', () => ({
@@ -140,6 +154,7 @@ vi.mock('sst', () => ({ Resource: { driveLakeIngestQueue: { url: 'ingest-queue-u
 import {
   dispatch,
   hasDriveFileChanged,
+  classifyDriveChanges,
   MAX_INGEST_CANDIDATES,
   MAX_INGEST_REDRIVES,
   MAX_INGEST_SLICES,
@@ -249,6 +264,16 @@ describe('driveLakeIngest consumer', () => {
     });
     let n = 0;
     h.createFabFile.mockImplementation(async () => ({ id: `ff${++n}` }));
+    // Full-walk mode is the default across the existing suite (no connection carries a syncCursor
+    // unless a test sets one), so these only matter for the incremental-sync tests below.
+    h.getStartPageToken.mockResolvedValue('start-token-1');
+    h.isDriveInvalidCursorError.mockReturnValue(false);
+    h.isUnderRoot.mockResolvedValue(true);
+    h.updateSyncCursor.mockResolvedValue({ id: 'conn1' });
+    // vi.clearAllMocks() (above) clears call history but NOT a standing mockRejectedValue - reset the
+    // admission gate to its happy-path default so a later test's own rejection can't leak forward into
+    // whichever test runs next in file order.
+    h.assertLakeAdmission.mockResolvedValue(undefined);
   });
 
   it('is a cheap no-op when the claim is lost and there is nothing in flight to defer behind', async () => {
@@ -763,11 +788,15 @@ describe('driveLakeIngest consumer', () => {
       // start a competing walk that duplicates the tail, which is the same failure by another route.
       expect(h.renewSyncClaim).toHaveBeenCalledWith('conn1', 'batch1', 'token-claim');
       expect(h.releaseSyncClaim).not.toHaveBeenCalled();
+      // forceFullWalk: true even though the original payload never set it - this run took the full-walk
+      // branch (no stored cursor yet) and the continuation must stay in that SAME mode, not re-derive it
+      // from a syncCursor that (correctly) has not advanced mid-chain (#2396).
       expect(h.sendToQueue).toHaveBeenCalledWith('ingest-queue-url', {
         connectionId: 'conn1',
         resumeBatchId: 'batch1',
         slice: 1,
         claimToken: 'token-renew',
+        forceFullWalk: true,
       });
       // The batch belongs to the chain until it ends, so this slice must not settle it.
       expect(h.finalizeBatchIfComplete).not.toHaveBeenCalled();
@@ -791,6 +820,7 @@ describe('driveLakeIngest consumer', () => {
         resumeBatchId: 'batch1',
         slice: 1,
         claimToken: 'token-renew',
+        forceFullWalk: true,
       });
     });
 
@@ -924,7 +954,7 @@ describe('driveLakeIngest consumer', () => {
       expect(h.releaseSyncClaim).not.toHaveBeenCalled();
       expect(h.sendToQueue).toHaveBeenCalledWith(
         'ingest-queue-url',
-        { connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'token-renew' },
+        { connectionId: 'conn1', resumeBatchId: 'batch1', slice: 1, claimToken: 'token-renew', forceFullWalk: true },
         expect.any(Number)
       );
       // Unlike the deadline yield, a throttled slice delays its continuation - coming straight back
@@ -1205,6 +1235,7 @@ describe('driveLakeIngest consumer', () => {
         resumeBatchId: 'batch1',
         slice: 2,
         claimToken: 'token-renew',
+        forceFullWalk: true,
       });
     });
 
@@ -1398,6 +1429,29 @@ describe('driveLakeIngest consumer', () => {
         expect.any(Number)
       );
       expect(h.walkFolder).not.toHaveBeenCalled();
+    });
+
+    it('forwards forceFullWalk through a claim-race defer too, not just resumeBatchId (#2396)', async () => {
+      // Same failure mode as the resumeBatchId one above: a manual "Re-sync everything" that loses this
+      // race must not come back on its deferred retry as a plain run that could take the incremental
+      // branch - that would silently drop the explicit full-walk the user asked for.
+      h.claimForSync.mockResolvedValue(null);
+      h.connFindById.mockResolvedValue({
+        id: 'conn1',
+        status: 'syncing',
+        targetDataLakeId: 'lake1',
+        connectedBy: 'user1',
+        organizationId: 'org1',
+        driveFolderId: 'FOLDER',
+      });
+
+      await run({ connectionId: 'conn1', forceFullWalk: true });
+
+      expect(h.sendToQueue).toHaveBeenCalledWith(
+        'ingest-queue-url',
+        { connectionId: 'conn1', redriveCount: 1, forceFullWalk: true },
+        expect.any(Number)
+      );
     });
   });
 
@@ -1778,6 +1832,406 @@ describe('driveLakeIngest consumer', () => {
 
     await expect(run()).rejects.toThrow('settings store unreachable');
     expect(h.batchCreate).not.toHaveBeenCalled();
+  });
+
+  describe('incremental sync (#2396)', () => {
+    const withCursor = (overrides: Record<string, unknown> = {}) =>
+      h.connFindById.mockResolvedValue({
+        id: 'conn1',
+        targetDataLakeId: 'lake1',
+        connectedBy: 'user1',
+        organizationId: 'org1',
+        driveFolderId: 'FOLDER',
+        syncCursor: 'cursor-0',
+        ...overrides,
+      });
+
+    it('establishes a Drive changes cursor after a full walk (first sync - no cursor yet)', async () => {
+      h.walkFolder.mockResolvedValue([{ id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' }]);
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      h.getStartPageToken.mockResolvedValue('cursor-1');
+
+      await run();
+
+      expect(h.listChanges).not.toHaveBeenCalled(); // no cursor on the connection yet
+      expect(h.getStartPageToken).toHaveBeenCalled();
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+    });
+
+    it('does not fail the run when a cursor cannot be established after a full walk', async () => {
+      h.walkFolder.mockResolvedValue([{ id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' }]);
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      h.getStartPageToken.mockRejectedValue(new Error('quota'));
+
+      await run();
+
+      expect(h.createFabFile).toHaveBeenCalled(); // the reconcile itself still completed
+      expect(h.updateSyncCursor).not.toHaveBeenCalled();
+      expect(h.releaseSyncClaim).toHaveBeenCalled();
+    });
+
+    it('goes incremental once the connection carries a cursor, and never walks the folder', async () => {
+      withCursor();
+      h.listChanges.mockResolvedValue({ changes: [], newStartPageToken: 'cursor-1' });
+
+      await run();
+
+      expect(h.walkFolder).not.toHaveBeenCalled();
+      expect(h.listChanges).toHaveBeenCalledWith(expect.anything(), 'cursor-0');
+    });
+
+    it('an unchanged folder produces no per-file fetches on the second run (O(1) poll)', async () => {
+      withCursor();
+      setExisting([{ id: 'ff-d1', driveFileId: 'd1' }]);
+      h.listChanges.mockResolvedValue({ changes: [], newStartPageToken: 'cursor-1' });
+
+      await run();
+
+      expect(h.walkFolder).not.toHaveBeenCalled();
+      expect(h.fetchDriveFileContent).not.toHaveBeenCalled();
+      expect(h.createFabFile).not.toHaveBeenCalled();
+      expect(h.batchCreate).not.toHaveBeenCalled();
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+      expect(h.releaseSyncClaim).toHaveBeenCalledWith('conn1', 'token-claim', null);
+    });
+
+    it('ingests a new file surfaced by changes.list once its ancestry proves it is under the connected root', async () => {
+      withCursor();
+      h.listChanges.mockResolvedValue({
+        changes: [
+          {
+            fileId: 'd1',
+            removed: false,
+            file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['FOLDER'] },
+          },
+        ],
+        newStartPageToken: 'cursor-1',
+      });
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+
+      await run();
+
+      expect(h.isUnderRoot).toHaveBeenCalledWith(expect.anything(), ['FOLDER'], 'FOLDER', expect.anything());
+      expect(h.createFabFile).toHaveBeenCalledWith(expect.objectContaining({ driveFileId: 'd1' }), expect.anything());
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+    });
+
+    it('ignores a changed file that does not resolve under the connected root (Drive-wide feed, folder-scoped lake)', async () => {
+      withCursor();
+      h.listChanges.mockResolvedValue({
+        changes: [
+          {
+            fileId: 'elsewhere',
+            removed: false,
+            file: { id: 'elsewhere', name: 'other.txt', mimeType: 'text/plain', parents: ['SOME_OTHER_FOLDER'] },
+          },
+        ],
+        newStartPageToken: 'cursor-1',
+      });
+      h.isUnderRoot.mockResolvedValue(false);
+
+      await run();
+
+      expect(h.createFabFile).not.toHaveBeenCalled();
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+    });
+
+    it('prunes a previously-tracked file that Drive reports removed', async () => {
+      withCursor();
+      setExisting([{ id: 'ff-d1', driveFileId: 'd1', userId: 'user1' }]);
+      h.listChanges.mockResolvedValue({
+        changes: [{ fileId: 'd1', removed: true }],
+        newStartPageToken: 'cursor-1',
+      });
+
+      await run();
+
+      expect(h.removeFileFromLake).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'ff-d1',
+        expect.anything()
+      );
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'cursor-1', expect.any(Date));
+    });
+
+    it('prunes a previously-tracked file that moved out of the connected tree (still live in Drive, no longer here)', async () => {
+      withCursor();
+      setExisting([{ id: 'ff-d1', driveFileId: 'd1', userId: 'user1' }]);
+      h.listChanges.mockResolvedValue({
+        changes: [
+          {
+            fileId: 'd1',
+            removed: false,
+            file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['ELSEWHERE'] },
+          },
+        ],
+        newStartPageToken: 'cursor-1',
+      });
+      h.isUnderRoot.mockResolvedValue(false);
+
+      await run();
+
+      expect(h.removeFileFromLake).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'ff-d1',
+        expect.anything()
+      );
+    });
+
+    it('falls back to a full walk when the stored cursor is invalid, and re-establishes a fresh one', async () => {
+      withCursor({ syncCursor: 'stale-cursor' });
+      h.listChanges.mockRejectedValue(new Error('invalid token'));
+      h.isDriveInvalidCursorError.mockReturnValue(true);
+      h.walkFolder.mockResolvedValue([{ id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' }]);
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      h.getStartPageToken.mockResolvedValue('fresh-cursor');
+
+      await run();
+
+      expect(h.walkFolder).toHaveBeenCalled();
+      expect(h.createFabFile).toHaveBeenCalledWith(expect.objectContaining({ driveFileId: 'd1' }), expect.anything());
+      expect(h.updateSyncCursor).toHaveBeenCalledWith('conn1', 'fresh-cursor', expect.any(Date));
+    });
+
+    it('rethrows a changes.list failure that is not an invalid-cursor error rather than silently falling back', async () => {
+      withCursor();
+      h.listChanges.mockRejectedValue(new Error('network blip'));
+
+      await expect(run()).rejects.toThrow('network blip');
+      expect(h.walkFolder).not.toHaveBeenCalled();
+    });
+
+    it('bypasses an existing cursor and forces a full walk when forceFullWalk is set (manual Re-sync)', async () => {
+      withCursor();
+      h.walkFolder.mockResolvedValue([{ id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' }]);
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+
+      await run({ connectionId: 'conn1', forceFullWalk: true });
+
+      expect(h.listChanges).not.toHaveBeenCalled();
+      expect(h.walkFolder).toHaveBeenCalled();
+    });
+
+    it('keeps a forced full walk in full mode across a continuation slice, even with a valid stored cursor', async () => {
+      // The bug this guards: syncCursor never advances mid-chain, so a continuation slice that
+      // re-derived its mode from the connection's (still valid, unadvanced) cursor would wrongly go
+      // incremental and silently truncate the "Re-sync everything" the user explicitly asked for.
+      withCursor(); // a valid cursor is already stored - would normally win the incremental branch
+      h.walkFolder.mockResolvedValue([
+        { id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' },
+        { id: 'd2', name: 'b.txt', mimeType: 'text/plain', relativePath: 'b.txt' },
+      ]);
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+
+      await run({ connectionId: 'conn1', forceFullWalk: true }, contextAllowingFiles(1));
+
+      expect(h.listChanges).not.toHaveBeenCalled();
+      expect(h.sendToQueue).toHaveBeenCalledWith(
+        'ingest-queue-url',
+        expect.objectContaining({ connectionId: 'conn1', resumeBatchId: 'batch1', forceFullWalk: true })
+      );
+    });
+
+    it('does not advance the cursor when the chain stops short (claim lost mid-slice)', async () => {
+      // A run that never finishes applying its delta must not advance past it - the next scheduled
+      // poll relies on going incremental from the SAME cursor to pick the remainder back up.
+      withCursor();
+      h.listChanges.mockResolvedValue({
+        changes: [
+          {
+            fileId: 'd1',
+            removed: false,
+            file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['FOLDER'] },
+          },
+        ],
+        newStartPageToken: 'cursor-1',
+      });
+      h.fetchDriveFileContent.mockResolvedValue(okBytes());
+      h.renewSyncClaim.mockResolvedValue(null); // claim lost -> chain ends without finishing
+
+      await run({ connectionId: 'conn1' }, contextWithNoBudget());
+
+      expect(h.updateSyncCursor).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('classifyDriveChanges', () => {
+  const drive = {} as never;
+  const logger = { warn: vi.fn() };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('adds a new file once its ancestry resolves under the root', async () => {
+    h.isUnderRoot.mockResolvedValue(true);
+    const result = await classifyDriveChanges(
+      drive,
+      [{ fileId: 'd1', removed: false, file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['ROOT'] } }],
+      'ROOT',
+      () => undefined,
+      logger
+    );
+    expect(result).toEqual({
+      adds: [{ id: 'd1', name: 'a.txt', mimeType: 'text/plain', relativePath: 'a.txt' }],
+      changed: [],
+      removedFileIds: [],
+    });
+  });
+
+  it('never adds a new file whose ancestry does not resolve under the root', async () => {
+    h.isUnderRoot.mockResolvedValue(false);
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        {
+          fileId: 'd1',
+          removed: false,
+          file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['ELSEWHERE'] },
+        },
+      ],
+      'ROOT',
+      () => undefined,
+      logger
+    );
+    expect(result.adds).toEqual([]);
+  });
+
+  it('ignores a new (never-tracked) file that Drive reports removed - nothing to add or prune', async () => {
+    const result = await classifyDriveChanges(
+      drive,
+      [{ fileId: 'd1', removed: true }],
+      'ROOT',
+      () => undefined,
+      logger
+    );
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
+    expect(h.isUnderRoot).not.toHaveBeenCalled();
+  });
+
+  it('never classifies a folder change entry as an add (folders are not ingest candidates)', async () => {
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        {
+          fileId: 'f1',
+          removed: false,
+          file: { id: 'f1', name: 'Sub', mimeType: 'application/vnd.google-apps.folder' },
+        },
+      ],
+      'ROOT',
+      () => undefined,
+      logger
+    );
+    expect(result.adds).toEqual([]);
+    expect(h.isUnderRoot).not.toHaveBeenCalled();
+  });
+
+  it('marks a tracked file removed on Drive removal without checking ancestry', async () => {
+    const result = await classifyDriveChanges(
+      drive,
+      [{ fileId: 'd1', removed: true }],
+      'ROOT',
+      id => (id === 'd1' ? { driveMd5Checksum: 'A' } : undefined),
+      logger
+    );
+    expect(result.removedFileIds).toEqual(['d1']);
+    expect(h.isUnderRoot).not.toHaveBeenCalled();
+  });
+
+  it('marks a tracked file removed when it moved out of the connected tree (still live elsewhere)', async () => {
+    h.isUnderRoot.mockResolvedValue(false);
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        {
+          fileId: 'd1',
+          removed: false,
+          file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['ELSEWHERE'] },
+        },
+      ],
+      'ROOT',
+      id => (id === 'd1' ? { driveMd5Checksum: 'A' } : undefined),
+      logger
+    );
+    expect(result.removedFileIds).toEqual(['d1']);
+    expect(result.changed).toEqual([]);
+  });
+
+  it('marks a tracked file changed when its content moved and it is still under the root', async () => {
+    h.isUnderRoot.mockResolvedValue(true);
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        {
+          fileId: 'd1',
+          removed: false,
+          file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', md5Checksum: 'NEW', parents: ['ROOT'] },
+        },
+      ],
+      'ROOT',
+      id => (id === 'd1' ? { driveMd5Checksum: 'OLD' } : undefined),
+      logger
+    );
+    // parents is ancestry-only metadata used to resolve isUnderRoot; it does not carry through to the
+    // emitted candidate, matching the plain WalkedDriveFile shape a full walk would have produced.
+    expect(result.changed).toEqual([
+      { id: 'd1', name: 'a.txt', mimeType: 'text/plain', md5Checksum: 'NEW', relativePath: 'a.txt' },
+    ]);
+    expect(result.removedFileIds).toEqual([]);
+  });
+
+  it('leaves a tracked file untouched (does not evict it) when its ancestry check fails transiently', async () => {
+    // A rate limit/5xx/network blip mid ancestry-walk must NOT be read as "moved out of the tree" -
+    // that would silently evict a still-live file from the lake (see isUnderRoot's doc comment).
+    h.isUnderRoot.mockRejectedValue(new Error('rate limited'));
+    const result = await classifyDriveChanges(
+      drive,
+      [{ fileId: 'd1', removed: false, file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['ROOT'] } }],
+      'ROOT',
+      id => (id === 'd1' ? { driveMd5Checksum: 'A' } : undefined),
+      logger
+    );
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('tracked file'),
+      expect.objectContaining({ fileId: 'd1' })
+    );
+  });
+
+  it('excludes a new file (does not add it) when its ancestry check fails transiently', async () => {
+    h.isUnderRoot.mockRejectedValue(new Error('rate limited'));
+    const result = await classifyDriveChanges(
+      drive,
+      [{ fileId: 'd1', removed: false, file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', parents: ['ROOT'] } }],
+      'ROOT',
+      () => undefined,
+      logger
+    );
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('new file'),
+      expect.objectContaining({ fileId: 'd1' })
+    );
+  });
+
+  it('is a no-op for a tracked file under the root whose content did not actually change', async () => {
+    h.isUnderRoot.mockResolvedValue(true);
+    const result = await classifyDriveChanges(
+      drive,
+      [
+        {
+          fileId: 'd1',
+          removed: false,
+          file: { id: 'd1', name: 'a.txt', mimeType: 'text/plain', md5Checksum: 'SAME', parents: ['ROOT'] },
+        },
+      ],
+      'ROOT',
+      id => (id === 'd1' ? { driveMd5Checksum: 'SAME' } : undefined),
+      logger
+    );
+    expect(result).toEqual({ adds: [], changed: [], removedFileIds: [] });
   });
 });
 

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -177,6 +177,12 @@ export type DriveChangeClassification = {
   changed: WalkedDriveFile[];
   /** driveFileIds to prune: Drive deleted/trashed them, or they moved out of the connected tree. */
   removedFileIds: string[];
+  /**
+   * Entries this run could not DECIDE: the ancestry lookup hit a transient Drive failure, so neither
+   * "under the root" nor "moved out" was proven and the entry was left unapplied. Non-zero means this
+   * run's delta is incomplete and the caller must hold the cursor back - see the note in the header.
+   */
+  ambiguous: number;
 };
 
 /**
@@ -201,12 +207,23 @@ function toWalkedDriveFile(file: DriveFile & { parents?: string[]; trashed?: boo
  * which case it is folded into removedFileIds - matching what a full walk would report for a file
  * that moved out of the tree (present elsewhere in Drive, but no longer a candidate here).
  *
+ * The feed is a LOG, not a snapshot: one record per modification, and Drive only collapses records
+ * WITHIN a page. A file renamed and later edited, or edited either side of a page boundary, arrives
+ * as several entries for one fileId. They are collapsed to the last entry per id up front (last wins -
+ * it is the file's most recent state) because the downstream apply is not idempotent per id: a
+ * doubled add ingests two FabFiles for one Drive file, and a doubled removal makes the second
+ * removeFileFromLake throw NotFoundError mid-prune, outside the try that settles reclaimed bytes.
+ * Same hazard the full walk's `seenIds` de-dup exists to prevent.
+ *
  * isUnderRoot can also throw (a TRANSIENT Drive failure mid ancestry-walk, not a confirmed answer -
  * see its doc comment). That is caught here per-candidate rather than left to fail the whole batch:
- * for a new file the candidate is simply excluded this run (same outcome as a confirmed false - the
- * next poll or full walk re-resolves it); for an already-tracked file the candidate is left untouched
- * rather than evicted - misreading a Drive hiccup as "moved out of the tree" would silently drop a
- * still-live file from the lake.
+ * a new file is excluded from this run, and an already-tracked file is left untouched rather than
+ * evicted - misreading a Drive hiccup as "moved out of the tree" would silently drop a still-live
+ * file from the lake. Neither is a free skip: the feed reports a modification ONCE, so a caller that
+ * advanced its cursor past an unresolved entry would never be told about it again, and the file would
+ * sit missing (or stale) until a human clicked Re-sync. Every such entry is counted into `ambiguous`
+ * so the caller can hold the cursor and let the next poll replay the same window - cheap, and
+ * idempotent, since anything already applied diffs out as a no-op.
  */
 export async function classifyDriveChanges(
   drive: drive_v3.Drive,
@@ -219,8 +236,14 @@ export async function classifyDriveChanges(
   const changed: WalkedDriveFile[] = [];
   const removedFileIds: string[] = [];
   const ancestryCache = new Map<string, string[] | null>();
+  let ambiguous = 0;
 
-  for (const { fileId, removed, file } of changes) {
+  // Last entry per fileId wins; Map.set keeps the first insertion's position, so feed order is
+  // otherwise preserved. See the header for why a repeated id is not survivable downstream.
+  const latestPerFileId = new Map<string, DriveChange>();
+  for (const change of changes) latestPerFileId.set(change.fileId, change);
+
+  for (const { fileId, removed, file } of latestPerFileId.values()) {
     const tracked = newestCopyOf(fileId);
     const gone = removed || file?.trashed === true;
 
@@ -234,6 +257,7 @@ export async function classifyDriveChanges(
       try {
         underRoot = await isUnderRoot(drive, file.parents, rootFolderId, ancestryCache);
       } catch (e) {
+        ambiguous++;
         logger.warn('[driveLakeIngest] ancestry check failed for a tracked file; leaving it in place this run', {
           fileId,
           error: e instanceof Error ? e.message : String(e),
@@ -253,6 +277,7 @@ export async function classifyDriveChanges(
     try {
       underRoot = await isUnderRoot(drive, file.parents, rootFolderId, ancestryCache);
     } catch (e) {
+      ambiguous++;
       logger.warn('[driveLakeIngest] ancestry check failed for a new file; excluding it from this run', {
         fileId,
         error: e instanceof Error ? e.message : String(e),
@@ -268,7 +293,7 @@ export async function classifyDriveChanges(
     }
   }
 
-  return { adds, changed, removedFileIds };
+  return { adds, changed, removedFileIds, ambiguous };
 }
 
 /**
@@ -594,10 +619,13 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     //    happened since the stored cursor) whenever the connection already carries one and the caller
     //    did not force a full walk, otherwise the full recursive folder walk - first sync, an
     //    invalidated cursor (Drive expires them - isDriveInvalidCursorError), or the manual "Re-sync
-    //    everything" action (drive-sync.ts sets forceFullWalk on its reconnect branch). Whichever mode
-    //    runs, `pendingSyncCursor` is only PERSISTED once this run's delta is fully applied with no
+    //    everything" action (drive-sync.ts sets forceFullWalk on its reconnect branch), or the poll
+    //    cron's periodic forced re-walk (driveLakeResyncPoll.FULL_WALK_INTERVAL_MS - the reconcile for
+    //    subtree moves, which Drive's per-file changes feed cannot report). Whichever mode runs,
+    //    `pendingSyncCursor` is only PERSISTED once this run's delta is fully applied with no
     //    continuation pending (see the two call sites below) - advancing it any earlier would let a
-    //    chain that stops short skip the very changes it never got to ingest.
+    //    chain that stops short skip the very changes it never got to ingest, and an incremental run
+    //    that could not resolve every entry drops it outright for the same reason.
     let syncMode: 'full' | 'incremental' = 'full';
     let rawChanges: DriveChange[] = [];
     let pendingSyncCursor: string | undefined;
@@ -691,6 +719,22 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     // known, purely for the cap check and logging - it never populates walkedRaw/seenIds.
     let walkedRaw: WalkedDriveFile[] = [];
     if (syncMode === 'full') {
+      // Baseline cursor BEFORE the walk, not after. A file created mid-walk - after its parent folder
+      // was already listed - is in neither the walk's result nor, if the token were taken afterwards,
+      // the first incremental pull: its change record would already sit behind that cursor. On a large
+      // first sync that blind window is minutes wide. Taking it first inverts the error into a harmless
+      // one - the first incremental pull replays some changes this walk already covered, and they diff
+      // out as no-ops (hasDriveFileChanged) against the set this run is about to store.
+      //
+      // Not fatal on failure: the walk still reconciles, the connection just falls back to another full
+      // walk next time instead of going incremental.
+      pendingSyncCursor = await getStartPageToken(drive).catch(e => {
+        logger.warn('[driveLakeIngest] could not establish a Drive changes cursor before a full walk', {
+          connectionId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        return undefined;
+      });
       try {
         walkedRaw = await walkFolder(drive, connection.driveFolderId, remainingMs);
       } catch (err) {
@@ -747,9 +791,22 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       pureAdds = classified.adds;
       changed = classified.changed;
       const removedIds = new Set(classified.removedFileIds);
-      removed = classified.removedFileIds
-        .map(newestCopyOf)
-        .filter((doc): doc is (typeof existingDocs)[number] => doc != null);
+      // EVERY stored copy of a removed id, not just the newest - matching the full-walk arm below.
+      // The duplicate-retire sweep in step 4b deliberately skips an id gone from the folder (all of
+      // its copies are supposed to be here), and Drive never mentions a removed id again, so no later
+      // incremental run revisits it either. An older copy missed here would stay a live, searchable
+      // lake member holding content the user deleted from Drive, with nothing left to clean it up.
+      removed = classified.removedFileIds.flatMap(id => existingByDriveId.get(id) ?? []);
+      // An unresolved entry means this run's delta is INCOMPLETE, so do not advance past it: dropping
+      // pendingSyncCursor leaves the stored cursor where it is and the next poll re-pulls the same
+      // window. Re-applying a delta is idempotent; losing one of its changes is not (classifyDriveChanges).
+      if (classified.ambiguous > 0) {
+        logger.warn('[driveLakeIngest] holding the Drive cursor back; some changes could not be resolved', {
+          connectionId,
+          ambiguous: classified.ambiguous,
+        });
+        pendingSyncCursor = undefined;
+      }
       walkedIds = new Set(existingByDriveId.keys());
       for (const id of removedIds) walkedIds.delete(id);
       for (const add of pureAdds) walkedIds.add(add.id);
@@ -777,18 +834,6 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         });
         removed = [];
       }
-
-      // A full walk just proved the current tree; establish (or re-establish) the baseline cursor the
-      // NEXT run can go incremental from. Not fatal on failure - the walk itself already succeeded, so
-      // this run's reconcile proceeds regardless; the connection just falls back to another full walk
-      // next time instead of going incremental.
-      pendingSyncCursor = await getStartPageToken(drive).catch(e => {
-        logger.warn('[driveLakeIngest] could not establish a Drive changes cursor after a full walk', {
-          connectionId,
-          error: e instanceof Error ? e.message : String(e),
-        });
-        return undefined;
-      });
     }
 
     // The batch a previous slice of this chain was filling, if this run is a continuation of one. Only
@@ -1136,7 +1181,9 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         // past it now. Also the O(1) fast path for an incremental poll with zero relevant changes:
         // nothing below this point runs.
         if (pendingSyncCursor) {
-          await orgGoogleDriveConnectionRepository.updateSyncCursor(connectionId, pendingSyncCursor, new Date());
+          await orgGoogleDriveConnectionRepository.updateSyncCursor(connectionId, pendingSyncCursor, new Date(), {
+            fullWalk: syncMode === 'full',
+          });
         }
         await releaseClaim(null);
         return;
@@ -1465,7 +1512,9 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       // make the "next scheduled poll continues from here" promise above false - a poll that goes
       // incremental from an already-advanced cursor would never see them again.
       if (deferred === 0 && pendingSyncCursor) {
-        await orgGoogleDriveConnectionRepository.updateSyncCursor(connectionId, pendingSyncCursor, new Date());
+        await orgGoogleDriveConnectionRepository.updateSyncCursor(connectionId, pendingSyncCursor, new Date(), {
+          fullWalk: syncMode === 'full',
+        });
       }
       await releaseClaim(stoppedShort);
     } finally {

--- a/apps/client/server/queueHandlers/driveLakeIngest.ts
+++ b/apps/client/server/queueHandlers/driveLakeIngest.ts
@@ -1,3 +1,5 @@
+import type { drive_v3 } from '@googleapis/drive';
+import type { Logger } from '@bike4mind/observability';
 import { dispatchWithLogger } from '@server/queueHandlers/utils';
 import {
   User,
@@ -34,10 +36,20 @@ import {
   disableDriveConnectionForLake,
   getValidConnectionDriveAccessToken,
 } from '@server/integrations/google/drive/common';
-import { createDriveClient, isDriveRateLimitError } from '@server/integrations/google/drive/driveClient';
+import {
+  createDriveClient,
+  isDriveRateLimitError,
+  listChanges,
+  getStartPageToken,
+  isDriveInvalidCursorError,
+  isFolder,
+  type DriveChange,
+  type DriveFile,
+} from '@server/integrations/google/drive/driveClient';
 import {
   walkFolder,
   fetchDriveFileContent,
+  isUnderRoot,
   DriveWalkTimeBudgetExceededError,
   type WalkedDriveFile,
 } from '@server/integrations/google/drive/driveContent';
@@ -60,6 +72,10 @@ const Payload = z.object({
   claimToken: z.string().optional(),
   // Continuation depth, incremented per self-re-enqueue and bounded by MAX_INGEST_SLICES.
   slice: z.number().int().min(0).default(0),
+  // Bypass an existing syncCursor and run a full folder walk regardless. Set only by the manual
+  // "Re-sync" button (drive-sync.ts) on an already-connected folder - the explicit "re-sync
+  // everything" action (#2396) - never by the scheduled poll, which always prefers incremental.
+  forceFullWalk: z.boolean().default(false),
 });
 
 // A run that cannot proceed re-enqueues itself (with a delay) rather than dropping the work: a claim
@@ -154,10 +170,116 @@ export function hasDriveFileChanged(
   return false;
 }
 
+export type DriveChangeClassification = {
+  /** Genuinely new files, resolved to live under the connected root - ready to ingest as ADDs. */
+  adds: WalkedDriveFile[];
+  /** Previously-tracked files whose content moved and are still under the connected root. */
+  changed: WalkedDriveFile[];
+  /** driveFileIds to prune: Drive deleted/trashed them, or they moved out of the connected tree. */
+  removedFileIds: string[];
+};
+
 /**
- * Background reconcile of an org Google Drive folder against a data lake (#1589, #1591). Walks the
- * folder, diffs it against the files this connection has already ingested, and applies the delta:
- * ADD a new file, RE-INGEST an edited one, and REMOVE from the lake one that is gone from the folder.
+ * Strip a changes.list `file`'s ancestry-only fields (`parents`, `trashed`) down to the plain
+ * WalkedDriveFile shape `walkFolder` produces, so a candidate looks identical to downstream code
+ * regardless of which sync mode found it.
+ */
+function toWalkedDriveFile(file: DriveFile & { parents?: string[]; trashed?: boolean }): WalkedDriveFile {
+  const { parents: _parents, trashed: _trashed, ...driveFile } = file;
+  return { ...driveFile, relativePath: driveFile.name };
+}
+
+/**
+ * Turn one `changes.list` page into the same ADD/CHANGE/REMOVE shape a full-walk diff produces
+ * (driveLakeIngest's dispatch), so the candidate-cap check, the apply/retire logic and the per-file
+ * ingest loop run identically regardless of which one supplied the delta.
+ *
+ * The Changes API is Drive-wide, not folder-scoped (see driveClient.listChanges), so a file this
+ * connection has never seen has its live membership PROVEN via isUnderRoot - the one extra Drive cost
+ * incremental sync pays, and only for genuinely new candidates. An already-tracked file skips that
+ * check (newestCopyOf already proves it belongs here) unless it no longer resolves under the root, in
+ * which case it is folded into removedFileIds - matching what a full walk would report for a file
+ * that moved out of the tree (present elsewhere in Drive, but no longer a candidate here).
+ *
+ * isUnderRoot can also throw (a TRANSIENT Drive failure mid ancestry-walk, not a confirmed answer -
+ * see its doc comment). That is caught here per-candidate rather than left to fail the whole batch:
+ * for a new file the candidate is simply excluded this run (same outcome as a confirmed false - the
+ * next poll or full walk re-resolves it); for an already-tracked file the candidate is left untouched
+ * rather than evicted - misreading a Drive hiccup as "moved out of the tree" would silently drop a
+ * still-live file from the lake.
+ */
+export async function classifyDriveChanges(
+  drive: drive_v3.Drive,
+  changes: DriveChange[],
+  rootFolderId: string,
+  newestCopyOf: (driveFileId: string) => { driveMd5Checksum?: string; driveModifiedTime?: Date | string } | undefined,
+  logger: Pick<Logger, 'warn'>
+): Promise<DriveChangeClassification> {
+  const adds: WalkedDriveFile[] = [];
+  const changed: WalkedDriveFile[] = [];
+  const removedFileIds: string[] = [];
+  const ancestryCache = new Map<string, string[] | null>();
+
+  for (const { fileId, removed, file } of changes) {
+    const tracked = newestCopyOf(fileId);
+    const gone = removed || file?.trashed === true;
+
+    if (tracked) {
+      if (gone) {
+        removedFileIds.push(fileId);
+        continue;
+      }
+      if (!file || isFolder(file)) continue; // nothing ingestible changed
+      let underRoot: boolean;
+      try {
+        underRoot = await isUnderRoot(drive, file.parents, rootFolderId, ancestryCache);
+      } catch (e) {
+        logger.warn('[driveLakeIngest] ancestry check failed for a tracked file; leaving it in place this run', {
+          fileId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        continue;
+      }
+      if (!underRoot) {
+        removedFileIds.push(fileId); // moved out of the connected tree
+      } else if (hasDriveFileChanged(tracked, file)) {
+        changed.push(toWalkedDriveFile(file));
+      }
+      continue;
+    }
+
+    if (gone || !file || isFolder(file)) continue; // never tracked; nothing to remove or add
+    let underRoot: boolean;
+    try {
+      underRoot = await isUnderRoot(drive, file.parents, rootFolderId, ancestryCache);
+    } catch (e) {
+      logger.warn('[driveLakeIngest] ancestry check failed for a new file; excluding it from this run', {
+        fileId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      continue;
+    }
+    if (underRoot) {
+      // Flat relativePath (bare name, no ancestor path): reconstructing the full nested path here
+      // would cost the same ancestor walk again for display purposes only. A subsequent full walk
+      // (cursor invalidation, or an explicit Re-sync) fills in the real path - relativePath is
+      // display metadata, not an identity key (dedup and diff are keyed on driveFileId throughout).
+      adds.push(toWalkedDriveFile(file));
+    }
+  }
+
+  return { adds, changed, removedFileIds };
+}
+
+/**
+ * Background reconcile of an org Google Drive folder against a data lake (#1589, #1591, #2396). Gets
+ * this run's ADD/RE-INGEST/REMOVE delta one of two ways - a `changes.list` pull scoped to what
+ * happened since the connection's stored syncCursor (incremental; the common case once one exists),
+ * or a full recursive folder walk (first sync, an invalidated cursor, or an explicit "Re-sync
+ * everything") - then applies it identically either way: ADD a new file, RE-INGEST an edited one, and
+ * REMOVE from the lake one that is gone from the connected tree. See the mode branch just above the
+ * candidate-cap enforcement for how each one computes pureAdds/changed/removed/walkedIds, and
+ * classifyDriveChanges for how a Drive-wide changes feed is narrowed to this connection's own subtree.
  * Adds/re-ingests fetch and upload ONE file at a time - creating a lake-tagged FabFile and its
  * batch-manifest entry BEFORE the bytes land - and let the existing S3 objectCreated -> chunk ->
  * vectorize -> finalize pipeline do the rest. Both the manual Re-sync button and the scheduled poll
@@ -283,7 +405,7 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
   try {
     const payload = Payload.parse(JSON.parse(event.Records[0].body));
     connectionId = payload.connectionId;
-    const { redriveCount, resumeBatchId, slice } = payload;
+    const { redriveCount, resumeBatchId, slice, forceFullWalk } = payload;
     logger.updateMetadata({ handler: 'driveLakeIngest', connectionId });
 
     // `?? ` alone is not enough: a non-finite reading is not nullish and every comparison against it
@@ -399,6 +521,10 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
             // resumeBatchId, subtract nothing, and re-ingest the chain's already-`pending` tail as
             // duplicate ADDs - the exact spiral chaining exists to prevent.
             ...(resumeBatchId && { resumeBatchId, slice, claimToken: payload.claimToken }),
+            // Forward an explicit "Re-sync everything" through the redrive too - dropping it here
+            // would silently downgrade a manual re-sync into a plain (possibly incremental) run the
+            // moment it lost a claim race, defeating the action the user just took (#2396).
+            ...(forceFullWalk && { forceFullWalk: true }),
           },
           INGEST_REDRIVE_DELAY_SECONDS
         );
@@ -464,76 +590,126 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     const accessToken = await getValidConnectionDriveAccessToken(connectionId, connection.organizationId);
     const drive = createDriveClient(accessToken);
 
-    // 1) Walk the folder tree (one level per Drive call, recursed). De-dup by driveFileId: a legacy
-    //    multi-parented Drive file surfaces once per parent inside the walked subtree, and a duplicate
-    //    would otherwise double-ingest (two FabFiles for one add) and double-remove (the second
-    //    removeFileFromLake throws NotFoundError, aborting the reconcile mid-prune).
-    let walkedRaw: WalkedDriveFile[];
-    try {
-      walkedRaw = await walkFolder(drive, connection.driveFolderId, remainingMs);
-    } catch (err) {
-      const timedOut = err instanceof DriveWalkTimeBudgetExceededError;
-      if (!timedOut && !isDriveRateLimitError(err)) throw err;
-      // A throttle that outlived the per-call retries, or a walk that ran out of invocation time, is
-      // not a broken sync. Throwing it on would DLQ the connection after two flat SQS redeliveries -
-      // and each of those re-walks the folder from scratch, re-listing every page it already fetched,
-      // which ADDS load to a quota that may already be exhausted. Shed instead: release the claim and
-      // come back later, on the same jittered delay the content-fetch deferral uses - a timeout gets
-      // it too, not because it needs to dodge a quota, but so a folder that keeps outrunning its
-      // invocation budget doesn't spin straight back into the same wall. Both share redriveCount with
-      // the claim-contention deferral above, so a folder that keeps coming back around - for whatever
-      // reason - cannot spin forever.
+    // 1) Resolve this run's Drive-side signal: an incremental `changes.list` pull (scoped to what
+    //    happened since the stored cursor) whenever the connection already carries one and the caller
+    //    did not force a full walk, otherwise the full recursive folder walk - first sync, an
+    //    invalidated cursor (Drive expires them - isDriveInvalidCursorError), or the manual "Re-sync
+    //    everything" action (drive-sync.ts sets forceFullWalk on its reconnect branch). Whichever mode
+    //    runs, `pendingSyncCursor` is only PERSISTED once this run's delta is fully applied with no
+    //    continuation pending (see the two call sites below) - advancing it any earlier would let a
+    //    chain that stops short skip the very changes it never got to ingest.
+    let syncMode: 'full' | 'incremental' = 'full';
+    let rawChanges: DriveChange[] = [];
+    let pendingSyncCursor: string | undefined;
+
+    /**
+     * Shed this run instead of failing it: a throttle that outlived the per-call retries, or a walk
+     * that ran out of invocation time, is not a broken sync. Throwing it on would DLQ the connection
+     * after two flat SQS redeliveries - and each of those redoes the Drive pull from scratch, which
+     * ADDS load to a quota that may already be exhausted. Come back later instead, on the same
+     * jittered delay the content-fetch deferral uses - a timeout gets it too, not because it needs to
+     * dodge a quota, but so a folder that keeps outrunning its invocation budget doesn't spin straight
+     * back into the same wall. Shares redriveCount with the claim-contention deferral above, so a
+     * chain that keeps coming back around - for whatever reason - cannot spin forever.
+     *
+     * Callers MUST return immediately after awaiting this: the claim is released and the batch settled.
+     */
+    const deferDriveSync = async (
+      phase: 'incremental_pull' | 'folder_walk',
+      reason: 'rate_limited' | 'time_budget_exceeded',
+      err: unknown
+    ) => {
       const delaySeconds = rateLimitBackoffSeconds();
       const canDefer = redriveCount < MAX_INGEST_REDRIVES;
-      logger.warn('[driveLakeIngest] folder walk deferred', {
+      logger.warn('[driveLakeIngest] Drive sync deferred before any diff', {
         connectionId,
         slice,
         redriveCount,
-        reason: timedOut ? 'time_budget_exceeded' : 'rate_limited',
+        phase,
+        reason,
         deferring: canDefer,
         delaySeconds: canDefer ? delaySeconds : undefined,
         error: err instanceof Error ? err.message : String(err),
       });
-      // The walk is the first thing every slice does, so a continuation that dies here produced
+      // This pull is the first thing every slice does, so a continuation that dies here produced
       // nothing: settle its batch rather than leave it `processing` for the reconciler to force-fail,
       // and let the deferred message start a fresh chain.
       if (resumeBatchId) await settleChainedBatch(resumeBatchId);
       // Release BEFORE enqueuing: the delayed message has to find a 'connected' connection to claim
       // when it lands, or it would just lose the claim and spend a deferral on the wrong problem. An
       // enqueue that then throws falls to the catch below and out to SQS with the claim already
-      // released, so the redelivery can re-walk rather than the connection stranding at 'syncing'.
+      // released, so the redelivery can retry rather than the connection stranding at 'syncing'.
       await releaseClaim(
         canDefer
           ? null
           : // redriveCount is shared with the claim-contention deferral above, so a chain landing here
             // may have spent most of its deferrals on someone else's sync being in flight, not on this -
             // never attribute the full count to one cause the operator cannot verify.
-            `This sync's folder walk did not finish - Google Drive rate-limiting and/or the invocation's ` +
-              `time budget - and gave up after ${MAX_INGEST_REDRIVES} total deferrals without listing the ` +
-              `folder. Nothing was ingested. The next scheduled poll retries it; if it keeps happening, sync ` +
-              `fewer folders on the same schedule.`
+            `This sync never got as far as reading your folder's contents - Google Drive rate-limiting ` +
+              `and/or the invocation's time budget - and gave up after ${MAX_INGEST_REDRIVES} total ` +
+              `deferrals. Nothing was ingested. The next scheduled poll retries it; if it keeps happening, ` +
+              `sync fewer folders on the same schedule.`
       );
       ingestClaimToken = undefined;
       if (canDefer) {
         await sendToQueue(
           Resource.driveLakeIngestQueue.url,
-          { connectionId, redriveCount: redriveCount + 1 },
+          // Carry forceFullWalk across the deferral: a user who asked for "Re-sync everything" must
+          // still get a full walk when the retry lands, not a silent downgrade to incremental.
+          { connectionId, redriveCount: redriveCount + 1, ...(forceFullWalk && { forceFullWalk: true }) },
           delaySeconds
         );
       }
-      return;
+    };
+
+    if (!forceFullWalk && connection.syncCursor) {
+      try {
+        const pulled = await listChanges(drive, connection.syncCursor);
+        syncMode = 'incremental';
+        rawChanges = pulled.changes;
+        pendingSyncCursor = pulled.newStartPageToken;
+      } catch (e) {
+        if (isDriveInvalidCursorError(e)) {
+          logger.info('[driveLakeIngest] stored Drive cursor is invalid; falling back to a full walk', {
+            connectionId,
+          });
+        } else if (isDriveRateLimitError(e)) {
+          // Same shed as a throttled walk below. Deferring leaves syncCursor untouched, so the retry
+          // pulls the same delta from the same point rather than skipping past it.
+          await deferDriveSync('incremental_pull', 'rate_limited', e);
+          return;
+        } else {
+          throw e;
+        }
+      }
     }
-    const walkedIds = new Set<string>();
-    const walked = walkedRaw.filter(f => {
-      if (walkedIds.has(f.id)) return false;
-      walkedIds.add(f.id);
+
+    // De-dup by driveFileId: a legacy multi-parented Drive file surfaces once per parent inside the
+    // walked subtree, and a duplicate would otherwise double-ingest (two FabFiles for one add) and
+    // double-remove (the second removeFileFromLake throws NotFoundError, aborting mid-prune). Only
+    // meaningful in full-walk mode; incremental mode reassigns `walked` below, once its own delta is
+    // known, purely for the cap check and logging - it never populates walkedRaw/seenIds.
+    let walkedRaw: WalkedDriveFile[] = [];
+    if (syncMode === 'full') {
+      try {
+        walkedRaw = await walkFolder(drive, connection.driveFolderId, remainingMs);
+      } catch (err) {
+        const timedOut = err instanceof DriveWalkTimeBudgetExceededError;
+        if (!timedOut && !isDriveRateLimitError(err)) throw err;
+        await deferDriveSync('folder_walk', timedOut ? 'time_budget_exceeded' : 'rate_limited', err);
+        return;
+      }
+    }
+    const seenIds = new Set<string>();
+    let walked = walkedRaw.filter(f => {
+      if (seenIds.has(f.id)) return false;
+      seenIds.add(f.id);
       return true;
     });
 
-    // 2) Diff the walk against everything THIS connection has in the lake, keyed by the stable
-    //    driveFileId, and split into ADD (new), UPDATE (same id, moved md5/modifiedTime), and
-    //    REMOVE (in the lake, gone from the folder). The stored set is the connection's own files
-    //    so a re-sync never touches files added by other means.
+    // 2) Diff against everything THIS connection has in the lake, keyed by the stable driveFileId,
+    //    into ADD (new), UPDATE (same id, content moved) and REMOVE (gone from the tree). The stored
+    //    set is the connection's own files so a re-sync never touches files added by other means.
     const datalakeTag = lake.datalakeTag;
     const existingDocs = await fabFileRepository.findByDriveConnectionIdInDataLake(connectionId, datalakeTag);
     //    One driveFileId can map to SEVERAL stored copies: `main`'s add-only handler had no walk
@@ -556,24 +732,63 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       copies.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     }
     const newestCopyOf = (driveFileId: string) => existingByDriveId.get(driveFileId)?.[0];
-    const pureAdds = walked.filter(f => !existingByDriveId.has(f.id));
-    const changed = walked.filter(f => {
-      const prior = newestCopyOf(f.id);
-      return prior != null && hasDriveFileChanged(prior, f);
-    });
-    let removed = existingDocs.filter(doc => doc.driveFileId != null && !walkedIds.has(doc.driveFileId));
 
-    // Transient-glitch guard: an EMPTY walk while the lake still holds this connection's files is
-    // far likelier a permission blip or a Drive hiccup than a real empty-out. walkFolder throws on a
-    // listing error (so an empty result is a genuine "no children", not a truncated one), but
-    // pruning an entire lake on one empty pass is too destructive to trust - refuse it. A real
-    // empty-out still reconciles once even one file remains to anchor the walk as trustworthy.
-    if (walked.length === 0 && existingDocs.length > 0) {
-      logger.warn('[driveLakeIngest] folder walk returned empty while lake holds files; skipping prune', {
-        connectionId,
-        existing: existingDocs.length,
+    let pureAdds: WalkedDriveFile[];
+    let changed: WalkedDriveFile[];
+    let removed: (typeof existingDocs)[number][];
+    // Everything currently believed live, by driveFileId - what the cap check and the duplicate-retire
+    // scan below both mean by "still in the folder". A full walk answers this directly (walkedIds);
+    // incremental mode has no fresh listing to read it off, so it is reconstructed from what IS known
+    // (the existing set) adjusted by this run's own delta.
+    let walkedIds: Set<string>;
+
+    if (syncMode === 'incremental') {
+      const classified = await classifyDriveChanges(drive, rawChanges, connection.driveFolderId, newestCopyOf, logger);
+      pureAdds = classified.adds;
+      changed = classified.changed;
+      const removedIds = new Set(classified.removedFileIds);
+      removed = classified.removedFileIds
+        .map(newestCopyOf)
+        .filter((doc): doc is (typeof existingDocs)[number] => doc != null);
+      walkedIds = new Set(existingByDriveId.keys());
+      for (const id of removedIds) walkedIds.delete(id);
+      for (const add of pureAdds) walkedIds.add(add.id);
+      // Log/cap-check stand-in for "what this run saw": the actual delta, not a corpus-wide listing
+      // (there isn't one to report - see walkAndDiffSize's use of existingDocs.length below).
+      walked = [...pureAdds, ...changed];
+    } else {
+      pureAdds = walked.filter(f => !existingByDriveId.has(f.id));
+      changed = walked.filter(f => {
+        const prior = newestCopyOf(f.id);
+        return prior != null && hasDriveFileChanged(prior, f);
       });
-      removed = [];
+      removed = existingDocs.filter(doc => doc.driveFileId != null && !seenIds.has(doc.driveFileId));
+      walkedIds = seenIds;
+
+      // Transient-glitch guard: an EMPTY walk while the lake still holds this connection's files is
+      // far likelier a permission blip or a Drive hiccup than a real empty-out. walkFolder throws on a
+      // listing error (so an empty result is a genuine "no children", not a truncated one), but
+      // pruning an entire lake on one empty pass is too destructive to trust - refuse it. A real
+      // empty-out still reconciles once even one file remains to anchor the walk as trustworthy.
+      if (walked.length === 0 && existingDocs.length > 0) {
+        logger.warn('[driveLakeIngest] folder walk returned empty while lake holds files; skipping prune', {
+          connectionId,
+          existing: existingDocs.length,
+        });
+        removed = [];
+      }
+
+      // A full walk just proved the current tree; establish (or re-establish) the baseline cursor the
+      // NEXT run can go incremental from. Not fatal on failure - the walk itself already succeeded, so
+      // this run's reconcile proceeds regardless; the connection just falls back to another full walk
+      // next time instead of going incremental.
+      pendingSyncCursor = await getStartPageToken(drive).catch(e => {
+        logger.warn('[driveLakeIngest] could not establish a Drive changes cursor after a full walk', {
+          connectionId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        return undefined;
+      });
     }
 
     // The batch a previous slice of this chain was filling, if this run is a continuation of one. Only
@@ -917,6 +1132,12 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         // A chain whose last slice happened to consume the remainder exactly lands here, with its
         // batch still open on the previous slice's plan. Settle it rather than leaving it processing.
         if (adoptedBatch) await settleChainedBatch(adoptedBatch.id);
+        // Nothing was deferred - this run's delta (if any) is fully applied, so it is safe to advance
+        // past it now. Also the O(1) fast path for an incremental poll with zero relevant changes:
+        // nothing below this point runs.
+        if (pendingSyncCursor) {
+          await orgGoogleDriveConnectionRepository.updateSyncCursor(connectionId, pendingSyncCursor, new Date());
+        }
         await releaseClaim(null);
         return;
       }
@@ -1171,6 +1392,12 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
               resumeBatchId: batch.id,
               slice: slice + 1,
               claimToken: renewedToken,
+              // Carry the CHAIN's mode forward, not the original payload's flag: syncCursor never
+              // advances mid-chain (see the cursor-persistence gate below), so a fresh read on the
+              // next slice would still see the SAME cursor and could wrongly take the incremental
+              // branch there - silently truncating a full walk (first sync, invalidated cursor, or an
+              // explicit "Re-sync everything") the moment it needs more than one slice (#2396).
+              ...(syncMode === 'full' && { forceFullWalk: true }),
             },
             ...backoff
           );
@@ -1233,6 +1460,13 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
           : rateLimited
             ? `Google Drive is rate-limiting this sync, and it stopped after ${MAX_INGEST_SLICES} continuation runs with ${deferred} files still to ingest. Those files are NOT in the lake yet. The next scheduled poll retries them; if it keeps happening, sync fewer folders on the same schedule.`
             : `Sync stopped after ${MAX_INGEST_SLICES} continuation runs with ${deferred} files left. The next scheduled poll continues from here; split very large folders into subfolders to converge faster.`;
+      // Advance the cursor ONLY on a clean finish (deferred === 0, stoppedShort null): a chain that
+      // hit the slice ceiling still has files it never got to, and advancing past them here would
+      // make the "next scheduled poll continues from here" promise above false - a poll that goes
+      // incremental from an already-advanced cursor would never see them again.
+      if (deferred === 0 && pendingSyncCursor) {
+        await orgGoogleDriveConnectionRepository.updateSyncCursor(connectionId, pendingSyncCursor, new Date());
+      }
       await releaseClaim(stoppedShort);
     } finally {
       await flushReclaimedStorage();

--- a/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
+++ b/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
@@ -114,6 +114,16 @@ export interface IOrgGoogleDriveConnection {
    * also reconciles by modifiedTime. Advance only after a sync batch is durably created.
    */
   syncCursor?: string;
+
+  /**
+   * When this connection last completed a FULL recursive folder walk (as opposed to an incremental
+   * changes pull). Drive's changes feed is per-FILE: moving a folder mutates only that folder's own
+   * `parents` and emits no records for its descendants, so incremental sync alone never notices a
+   * subtree dragged into or out of the connected root. The poll cron re-forces a full walk once this
+   * goes stale (driveLakeResyncPoll), which is the reconcile behind that gap - and the backstop for
+   * any other change an incremental run could not resolve.
+   */
+  lastFullWalkAt?: Date;
 }
 
 export interface IOrgGoogleDriveConnectionDocument extends IOrgGoogleDriveConnection, IMongoDocument {}
@@ -258,8 +268,16 @@ export interface IOrgGoogleDriveConnectionRepository extends IBaseRepository<IOr
     update: IGoogleDriveConnectionHealthUpdate
   ): Promise<IOrgGoogleDriveConnectionDocument | null>;
 
-  /** Advance the incremental-sync cursor after a sync batch is durably created. */
-  updateSyncCursor(id: string, syncCursor: string, polledAt: Date): Promise<IOrgGoogleDriveConnectionDocument | null>;
+  /**
+   * Advance the incremental-sync cursor after a sync batch is durably created. `fullWalk` also stamps
+   * `lastFullWalkAt`, which is what resets the poll cron's forced-re-walk clock.
+   */
+  updateSyncCursor(
+    id: string,
+    syncCursor: string,
+    polledAt: Date,
+    opts?: { fullWalk?: boolean }
+  ): Promise<IOrgGoogleDriveConnectionDocument | null>;
 
   /**
    * Guarded per-connection ingest lock. Atomically flips `status` to 'syncing' (stamping

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
@@ -95,6 +95,9 @@ const OrgGoogleDriveConnectionSchema = new Schema<IOrgGoogleDriveConnectionDocum
 
     // Incremental-sync resumption (Drive changes pageToken)
     syncCursor: { type: String },
+    // Last completed FULL folder walk; the poll cron forces another once this goes stale, which is
+    // what reconciles the subtree moves Drive's per-file changes feed cannot report.
+    lastFullWalkAt: { type: Date },
   },
   {
     timestamps: true,
@@ -304,13 +307,22 @@ class OrgGoogleDriveConnectionRepository
     return this.model.findByIdAndUpdate(id, { $set: set, ...(unset && { $unset: unset }) }, { new: true });
   }
 
-  /** Advance the incremental-sync cursor after a sync batch is durably created. */
+  /**
+   * Advance the incremental-sync cursor after a sync batch is durably created. `fullWalk` also stamps
+   * `lastFullWalkAt` - the clock findDueForPoll's caller reads to decide when to force a re-walk - so
+   * only a run that actually re-walked the tree may reset it.
+   */
   async updateSyncCursor(
     id: string,
     syncCursor: string,
-    polledAt: Date
+    polledAt: Date,
+    opts?: { fullWalk?: boolean }
   ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
-    return this.model.findByIdAndUpdate(id, { $set: { syncCursor, lastPolledAt: polledAt } }, { new: true });
+    return this.model.findByIdAndUpdate(
+      id,
+      { $set: { syncCursor, lastPolledAt: polledAt, ...(opts?.fullWalk && { lastFullWalkAt: polledAt }) } },
+      { new: true }
+    );
   }
 
   /**


### PR DESCRIPTION
## Description
Incremental Drive re-sync did not exist: `syncCursor` was on the connection model but wired to nothing, and there was no `changes.list` call anywhere in the repo, so every ingest run did a full recursive folder re-walk regardless of how much changed upstream.

This wires the connection's `syncCursor` to Drive's Changes API. A poll with no upstream changes now costs O(1) Drive calls instead of a full walk. A full walk stays available for the first sync, after a cursor is confirmed invalid, on an explicit "Re-sync everything", and on a periodic schedule - and that mode now survives every redrive/continuation path in a chained (multi-slice) sync.

## Changes
- `driveClient.ts`: add `getStartPageToken` / `listChanges` (paginated `changes.list`), `isDriveInvalidCursorError`, `isDriveNotFoundError`, and `getFileParents` for live ancestor-chain lookups.
- `driveContent.ts`: add `isUnderRoot`, resolving a candidate's live parent chain up to the connected root - needed because `changes.list` is Drive-wide, not folder-scoped.
- `driveLakeIngest.ts`: `classifyDriveChanges` turns one `changes.list` page into the same ADD/CHANGE/REMOVE shape a full walk produces, so the existing candidate-cap, apply, and retire logic runs identically regardless of mode. The connection's cursor is only ever persisted after a run's delta is fully, durably applied - never mid-chain.
- `drive-sync.ts`: the manual "Re-sync" reconnect path now sets `forceFullWalk` so it always re-walks rather than trusting a possibly-stale cursor.
- Every Drive call the incremental path adds (`changes.getStartPageToken`, `changes.list`, and the ancestry `files.get`) goes through the shared `withDriveRetry` helper, so it carries the same backoff budget as the folder walk. A throttle that outlives those retries sheds the run and re-enqueues on the jittered backoff instead of failing the connection out to the DLQ, and that deferral carries `forceFullWalk` so an explicit "Re-sync everything" is never silently downgraded to an incremental pull when the retry lands.
- A transient Drive failure mid ancestry-walk (rate limit, 5xx, network blip) is never read as a confirmed removal: it is rethrown rather than swallowed, and the caller leaves an already-tracked file in place instead of evicting it from the lake.

### Correctness properties the changes feed forces on us

Drive's `changes.list` is a **Drive-wide log**, not a folder-scoped snapshot, and three of its properties each need an explicit guard:

- **One record per modification, collapsed only within a page.** A file renamed and later edited, or edited either side of a page boundary, arrives as several entries for one `fileId`. `classifyDriveChanges` collapses the feed to the last entry per id before classifying - last wins, being the file's most recent state. Without it a doubled add ingests two FabFiles for one Drive file, and a doubled removal makes the second `removeFileFromLake` throw `NotFoundError` mid-prune, outside the `try` that settles reclaimed bytes. This is the same hazard the full walk's `seenIds` de-dup exists to prevent.
- **A change is reported exactly once.** An entry this run could not decide (the ancestry lookup hit a transient Drive failure) is counted into `classification.ambiguous`, and the handler then **holds the cursor back** rather than advancing past it. Re-pulling the same window next poll is cheap and idempotent - anything already applied diffs out as a no-op - whereas advancing would put the change permanently behind the cursor and leave the file missing (or stale) until a human clicked Re-sync.
- **Change records are per-file, so folder moves are invisible.** Moving a folder mutates only that folder's own `parents`; its descendants emit no records at all. No number of incremental pulls will ever reclassify them. Re-walking the subtree named in a folder entry does not fix this either: the feed is Drive-wide, so a folder that resolves *not* under the root is indistinguishable from any unrelated folder anywhere in the org's Drive, and walking each one would cost a subtree walk per unrelated rename. The reconcile is instead a **periodic forced full walk** - new `lastFullWalkAt` on the connection (stamped only by a run that actually re-walked), and `driveLakeResyncPoll` sets `forceFullWalk` once it passes `FULL_WALK_INTERVAL_MS` (24h). That bounds how far the lake can drift from Drive in either direction, and backstops any single entry an incremental run had to leave unresolved.

An incremental removal also retires **every** stored copy of a `driveFileId`, matching the full-walk arm. The duplicate-retire sweep deliberately skips an id gone from the folder, and Drive never mentions a removed id again, so a newest-copy-only removal would leave older copies as live, searchable lake members holding content the user had deleted.

The baseline cursor is taken **before** the full walk, not after. Taken afterwards, a file created mid-walk - after its parent folder was already listed - is in neither the walk's result nor the first incremental pull, a blind window minutes wide on a large first sync. Taken first, the first incremental pull merely replays some changes the walk already covered, which diff out as no-ops. Overlap is recoverable; a gap is not.

## Guide for Testers
This is a backend-only change to a queue-driven background job (no UI surface changed beyond the existing "Re-sync" button's request payload). It cannot be exercised by clicking through the app without a live SQS worker and a real Google Drive folder connection.

### What NOT to test
- No new UI. The "Re-sync" button (Files -> Upload Files -> Data Lakes -> connect a Drive folder -> Re-sync) still looks and behaves the same from a user's perspective; only its enqueued payload changed internally.
- Do not attempt to manually trigger `driveLakeIngest` or `driveLakeResyncPoll` outside of a real AWS SQS + worker environment - there is no local UI path to invoke them directly.
- Do not try to observe the 24h periodic full walk by waiting. It is driven by `lastFullWalkAt` vs `FULL_WALK_INTERVAL_MS` in the poll cron and is covered by unit tests; reproducing it live would mean backdating the field in the DB.

### Regression Checks
1. Connect a new Google Drive folder to a data lake (Files -> Upload Files -> Data Lakes -> Connect Google Drive -> pick a folder). Expected: the connect flow succeeds and files begin ingesting, same as before this PR (first sync always does a full walk).
2. Click "Re-sync" on an already-connected Drive folder. Expected: ingest re-runs and completes successfully, same as before.
3. `pnpm --filter @bike4mind/client exec vitest run --project node server/integrations/google/drive/driveClient.test.ts server/integrations/google/drive/driveContent.test.ts server/queueHandlers/driveLakeIngest.test.ts server/cron/driveLakeResyncPoll.test.ts pages/api/data-lakes/__tests__/drive-sync.test.ts` - expect 216/216 passing (includes the O(1)-poll acceptance test and the cursor/ancestry/forceFullWalk/feed-de-dup/periodic-re-walk regression tests).

## Additional Information
Closes #2396.

`lastFullWalkAt` is a new optional field on `OrgGoogleDriveConnection`; no migration is needed, since a connection without it is treated as due for a full walk (which is also what the handler would do anyway for a connection with no cursor).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no AdminSettings added
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI changed
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A
