### PR TITLE
feat(retrieval): instrument document answerability for optional-path turns

### DIFF
--- a/apps/client/app/components/admin/RetrievalRateTab.test.tsx
+++ b/apps/client/app/components/admin/RetrievalRateTab.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
@@ -42,6 +42,13 @@ const summary = (over: Partial<OptionalPathRetrievalRate> = {}): OptionalPathRet
   },
   forcedTurns: 12,
   unclassifiedTurns: 7,
+  answerability: {
+    cutoff: 0.75,
+    answerable: { turns: 18, retrievedTurns: 10, rate: 0.556 },
+    notAnswerable: { turns: 15, retrievedTurns: 2, rate: 0.133 },
+    unknown: { turns: 7, retrievedTurns: 0, rate: 0 },
+    inconclusiveTurns: 0,
+  },
   ...over,
 });
 
@@ -142,5 +149,28 @@ describe('RetrievalRateTab', () => {
     mockGet.mockRejectedValue(new Error('boom'));
     renderTab();
     await waitFor(() => expect(screen.getByTestId('retrieval-rate-error').textContent).toContain('boom'));
+  });
+
+  it('renders the answerability split with the miss/waste figures the routing decision needs', async () => {
+    renderTab();
+    // Miss rate is hand-computed in the component (not read off the fold), so this pins the
+    // arithmetic directly: 8 of 18 answerable turns went unsearched. Scoped to the section since
+    // a bare '7' also matches the unrelated Unclassified card in this fixture.
+    const section = await screen.findByTestId('retrieval-rate-answerability');
+    expect(within(section).getByText('44.4%')).toBeTruthy();
+    expect(within(section).getByText('8 of 18 answerable turns where the model did not search')).toBeTruthy();
+    expect(within(section).getByText('13.3%')).toBeTruthy();
+    expect(within(section).getByText('2 of 15 turns with nothing to find where it searched anyway')).toBeTruthy();
+    expect(within(section).getByText('7')).toBeTruthy();
+  });
+
+  it('renders the rest of the panel when the response predates the answerability field', async () => {
+    // A real shape, not a hypothetical: an API pod one deploy behind the client bundle returns
+    // exactly this - the fold gained the field, but the response this request actually got did
+    // not. The panel must degrade by omitting the section, not by crashing the whole tab.
+    mockGet.mockResolvedValue(response({ summary: summary({ answerability: undefined }) }));
+    renderTab();
+    expect(await screen.findByText('25.0%')).toBeTruthy();
+    expect(screen.queryByTestId('retrieval-rate-answerability')).toBeNull();
   });
 });

--- a/apps/client/app/components/admin/RetrievalRateTab.tsx
+++ b/apps/client/app/components/admin/RetrievalRateTab.tsx
@@ -200,51 +200,56 @@ export default function RetrievalRateTab() {
             />
           </Stack>
 
-          <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }} data-testid="retrieval-rate-answerability">
-            <Typography level="title-sm">Could the corpus have answered?</Typography>
-            <Typography level="body-xs" textColor="text.secondary" sx={{ mb: 1.5 }}>
-              Offered turns split by whether an offline replay found anything in the corpus at or above a cosine of{' '}
-              {summary.answerability.cutoff.toFixed(2)}. A turn where the model did not retrieve is only a defect if
-              there was something to find.
-            </Typography>
+          {/* The type says this is always present - the fold never omits it - but the client trusts a
+             live HTTP response, not the fold directly, and a response from an API pod one deploy behind
+             the client bundle predates this field. Guard rather than crash the whole tab over it. */}
+          {summary.answerability && (
+            <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }} data-testid="retrieval-rate-answerability">
+              <Typography level="title-sm">Could the corpus have answered?</Typography>
+              <Typography level="body-xs" textColor="text.secondary" sx={{ mb: 1.5 }}>
+                Offered turns split by whether an offline replay found anything in the corpus at or above a cosine of{' '}
+                {summary.answerability.cutoff.toFixed(2)}. A turn where the model did not retrieve is only a defect if
+                there was something to find.
+              </Typography>
 
-            {summary.answerability.unknown.turns === summary.offeredTurns && summary.offeredTurns > 0 ? (
-              <Alert color="neutral" data-testid="retrieval-rate-answerability-unreplayed">
-                No turn in this window has been replayed, so the split below is empty. Run the answerability replay
-                (packages/scripts/retrieval/answerability-replay.ts) over this window to populate it.
-              </Alert>
-            ) : (
-              <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap' }}>
-                <StatCard
-                  label="Missed retrievals"
-                  value={formatRate(missRate(summary.answerability.answerable))}
-                  caption={`${(
-                    summary.answerability.answerable.turns - summary.answerability.answerable.retrievedTurns
-                  ).toLocaleString()} of ${summary.answerability.answerable.turns.toLocaleString()} answerable turns where the model did not search`}
-                />
-                <StatCard
-                  label="Wasted retrievals"
-                  value={formatRate(summary.answerability.notAnswerable.rate)}
-                  caption={`${summary.answerability.notAnswerable.retrievedTurns.toLocaleString()} of ${summary.answerability.notAnswerable.turns.toLocaleString()} turns with nothing to find where it searched anyway`}
-                />
-                <StatCard
-                  label="Not replayed"
-                  value={summary.answerability.unknown.turns.toLocaleString()}
-                  caption={`Excluded from both figures${
-                    summary.answerability.inconclusiveTurns > 0
-                      ? `, including ${summary.answerability.inconclusiveTurns.toLocaleString()} whose scan hit its ceiling below the cutoff`
-                      : ''
-                  }`}
-                />
-              </Stack>
-            )}
+              {summary.answerability.unknown.turns === summary.offeredTurns && summary.offeredTurns > 0 ? (
+                <Alert color="neutral" data-testid="retrieval-rate-answerability-unreplayed">
+                  No turn in this window has been replayed, so the split below is empty. Run the answerability replay
+                  (packages/scripts/retrieval/answerability-replay.ts) over this window to populate it.
+                </Alert>
+              ) : (
+                <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap' }}>
+                  <StatCard
+                    label="Missed retrievals"
+                    value={formatRate(missRate(summary.answerability.answerable))}
+                    caption={`${(
+                      summary.answerability.answerable.turns - summary.answerability.answerable.retrievedTurns
+                    ).toLocaleString()} of ${summary.answerability.answerable.turns.toLocaleString()} answerable turns where the model did not search`}
+                  />
+                  <StatCard
+                    label="Wasted retrievals"
+                    value={formatRate(summary.answerability.notAnswerable.rate)}
+                    caption={`${summary.answerability.notAnswerable.retrievedTurns.toLocaleString()} of ${summary.answerability.notAnswerable.turns.toLocaleString()} turns with nothing to find where it searched anyway`}
+                  />
+                  <StatCard
+                    label="Not replayed"
+                    value={summary.answerability.unknown.turns.toLocaleString()}
+                    caption={`Excluded from both figures${
+                      summary.answerability.inconclusiveTurns > 0
+                        ? `, including ${summary.answerability.inconclusiveTurns.toLocaleString()} whose scan hit its ceiling below the cutoff`
+                        : ''
+                    }`}
+                  />
+                </Stack>
+              )}
 
-            <Typography level="body-xs" textColor="text.secondary" sx={{ mt: 1 }}>
-              Replayed after the fact, not measured during the turn: the corpus may have moved since, and for turns
-              where retrieval never ran the lake scope is reconstructed from the session as it stands now. Treat a
-              replay run long after the window as weak evidence.
-            </Typography>
-          </Sheet>
+              <Typography level="body-xs" textColor="text.secondary" sx={{ mt: 1 }}>
+                Replayed after the fact, not measured during the turn: the corpus may have moved since, and for turns
+                where retrieval never ran the lake scope is reconstructed from the session as it stands now. Treat a
+                replay run long after the window as weak evidence.
+              </Typography>
+            </Sheet>
+          )}
 
           <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }}>
             <Typography level="title-sm" sx={{ mb: 1 }}>

--- a/apps/client/app/components/admin/RetrievalRateTab.tsx
+++ b/apps/client/app/components/admin/RetrievalRateTab.tsx
@@ -40,6 +40,14 @@ const formatRate = (rate: number | null): string => (rate === null ? 'n/a' : `${
 
 const formatDate = (iso: string | null): string => (iso ? new Date(iso).toLocaleString() : 'n/a');
 
+/**
+ * The share of answerable turns where the model did NOT retrieve - the defect the answerability
+ * split exists to isolate. Not derivable as `1 - arm.rate` without care: that expression turns a
+ * null (empty arm) into 1, reporting a 100% miss rate over no turns at all.
+ */
+const missRate = (arm: { turns: number; retrievedTurns: number }): number | null =>
+  arm.turns === 0 ? null : (arm.turns - arm.retrievedTurns) / arm.turns;
+
 function StatCard({ label, value, caption }: { label: string; value: string; caption: string }) {
   return (
     <Card variant="soft" sx={{ flex: '1 1 200px', minWidth: 200 }}>
@@ -57,14 +65,18 @@ function StatCard({ label, value, caption }: { label: string; value: string; cap
 export default function RetrievalRateTab() {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-  const [appliedWindow, setAppliedWindow] = useState({ startDate: '', endDate: '' });
+  // Blank means "let the server pick", which pins the cutoff to the live forced-retrieval floor
+  // rather than to a number this component invented. Kept as a string so the field can be cleared.
+  const [answerableMinScore, setAnswerableMinScore] = useState('');
+  const [appliedFilters, setAppliedFilters] = useState({ startDate: '', endDate: '', answerableMinScore: '' });
 
   const { data, isLoading, isFetching, error, refetch } = useQuery<RetrievalRateResponse>({
-    queryKey: ['retrievalRate', appliedWindow],
+    queryKey: ['retrievalRate', appliedFilters],
     queryFn: async () => {
       const params = new URLSearchParams();
-      if (appliedWindow.startDate) params.append('startDate', appliedWindow.startDate);
-      if (appliedWindow.endDate) params.append('endDate', appliedWindow.endDate);
+      if (appliedFilters.startDate) params.append('startDate', appliedFilters.startDate);
+      if (appliedFilters.endDate) params.append('endDate', appliedFilters.endDate);
+      if (appliedFilters.answerableMinScore) params.append('answerableMinScore', appliedFilters.answerableMinScore);
       const response = await api.get(`/api/admin/retrieval-rate?${params.toString()}`);
       return response.data;
     },
@@ -110,9 +122,20 @@ export default function RetrievalRateTab() {
             data-testid="retrieval-rate-end-input"
           />
         </FormControl>
+        <FormControl size="sm">
+          <FormLabel>Answerable cutoff</FormLabel>
+          <Input
+            type="number"
+            slotProps={{ input: { min: 0, max: 1, step: 0.05 } }}
+            placeholder="default"
+            value={answerableMinScore}
+            onChange={e => setAnswerableMinScore(e.target.value)}
+            data-testid="retrieval-rate-cutoff-input"
+          />
+        </FormControl>
         <Button
           size="sm"
-          onClick={() => setAppliedWindow({ startDate, endDate })}
+          onClick={() => setAppliedFilters({ startDate, endDate, answerableMinScore })}
           loading={isFetching}
           data-testid="retrieval-rate-apply-btn"
         >
@@ -176,6 +199,52 @@ export default function RetrievalRateTab() {
               caption="No mode recorded - pre-deploy turns, agent-mode runs, or a tool-only write"
             />
           </Stack>
+
+          <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }} data-testid="retrieval-rate-answerability">
+            <Typography level="title-sm">Could the corpus have answered?</Typography>
+            <Typography level="body-xs" textColor="text.secondary" sx={{ mb: 1.5 }}>
+              Offered turns split by whether an offline replay found anything in the corpus at or above a cosine of{' '}
+              {summary.answerability.cutoff.toFixed(2)}. A turn where the model did not retrieve is only a defect if
+              there was something to find.
+            </Typography>
+
+            {summary.answerability.unknown.turns === summary.offeredTurns && summary.offeredTurns > 0 ? (
+              <Alert color="neutral" data-testid="retrieval-rate-answerability-unreplayed">
+                No turn in this window has been replayed, so the split below is empty. Run the answerability replay
+                (packages/scripts/retrieval/answerability-replay.ts) over this window to populate it.
+              </Alert>
+            ) : (
+              <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap' }}>
+                <StatCard
+                  label="Missed retrievals"
+                  value={formatRate(missRate(summary.answerability.answerable))}
+                  caption={`${(
+                    summary.answerability.answerable.turns - summary.answerability.answerable.retrievedTurns
+                  ).toLocaleString()} of ${summary.answerability.answerable.turns.toLocaleString()} answerable turns where the model did not search`}
+                />
+                <StatCard
+                  label="Wasted retrievals"
+                  value={formatRate(summary.answerability.notAnswerable.rate)}
+                  caption={`${summary.answerability.notAnswerable.retrievedTurns.toLocaleString()} of ${summary.answerability.notAnswerable.turns.toLocaleString()} turns with nothing to find where it searched anyway`}
+                />
+                <StatCard
+                  label="Not replayed"
+                  value={summary.answerability.unknown.turns.toLocaleString()}
+                  caption={`Excluded from both figures${
+                    summary.answerability.inconclusiveTurns > 0
+                      ? `, including ${summary.answerability.inconclusiveTurns.toLocaleString()} whose scan hit its ceiling below the cutoff`
+                      : ''
+                  }`}
+                />
+              </Stack>
+            )}
+
+            <Typography level="body-xs" textColor="text.secondary" sx={{ mt: 1 }}>
+              Replayed after the fact, not measured during the turn: the corpus may have moved since, and for turns
+              where retrieval never ran the lake scope is reconstructed from the session as it stands now. Treat a
+              replay run long after the window as weak evidence.
+            </Typography>
+          </Sheet>
 
           <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }}>
             <Typography level="title-sm" sx={{ mb: 1 }}>

--- a/apps/client/pages/api/admin/__tests__/retrieval-rate.test.ts
+++ b/apps/client/pages/api/admin/__tests__/retrieval-rate.test.ts
@@ -177,4 +177,43 @@ describe('GET /api/admin/retrieval-rate', () => {
     await promise;
     expect(body(res).summary).toMatchObject({ unclassifiedTurns: 1, offeredTurns: 0, rate: null });
   });
+
+  describe('answerability cutoff', () => {
+    const probed = (topScore: number) => ({
+      attempted: false,
+      mode: 'optional',
+      surfaces: [],
+      answerability: { topScore, candidatesAboveFloor: 1, floor: 0.75, scanTruncated: false, probedAt: TIMESTAMP },
+    });
+
+    it('projects the probe, so the fold is not handed an undefined column', () => {
+      expect(RETRIEVAL_RATE_FIELDS).toContain('answerability');
+    });
+
+    it('defaults the cutoff when the caller does not name one', async () => {
+      mockFind.mockReturnValue(questChain([row(probed(0.8)), row(probed(0.5))]));
+      const { res, promise } = run();
+      await promise;
+      const summary = body(res).summary;
+      expect(summary.answerability.cutoff).toBe(0.75);
+      expect(summary.answerability.answerable.turns).toBe(1);
+      expect(summary.answerability.notAnswerable.turns).toBe(1);
+    });
+
+    it('re-thresholds the stored scores when the caller sweeps the cutoff', async () => {
+      mockFind.mockReturnValue(questChain([row(probed(0.8)), row(probed(0.5))]));
+      const { res, promise } = run({ answerableMinScore: '0.4' });
+      await promise;
+      const summary = body(res).summary;
+      expect(summary.answerability.cutoff).toBe(0.4);
+      expect(summary.answerability.answerable.turns).toBe(2);
+    });
+
+    it('rejects a cutoff given as a percentage rather than silently failing every turn', async () => {
+      // 75 would put the bar above any cosine, so every turn would read as not-answerable and the
+      // panel would show a confident, wrong zero. Loud here, like the date bounds above.
+      const { promise } = run({ answerableMinScore: '75' });
+      await expect(promise).rejects.toThrow();
+    });
+  });
 });

--- a/apps/client/pages/api/admin/retrieval-rate.ts
+++ b/apps/client/pages/api/admin/retrieval-rate.ts
@@ -32,6 +32,15 @@ const MAX_TURNS_SCANNED = 50_000;
 const querySchema = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),
+  /**
+   * Cosine cutoff for the answerability split, as a fraction. Sweeping it re-reads the SAME
+   * replayed scores at a different bar, which is the whole reason the probe stores a raw score
+   * instead of a verdict - a caller comparing 0.7 against 0.8 needs no second replay.
+   *
+   * Coerced because it arrives as a query string. Bounded to 0..1 so a caller passing a percentage
+   * (75) fails loudly here rather than silently classifying every turn as not-answerable.
+   */
+  answerableMinScore: z.coerce.number().min(0).max(1).optional(),
 });
 
 /** `<input type="date">` sends this; anything else is treated as a caller-supplied exact instant. */
@@ -123,7 +132,8 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
     }
 
     const summary = summarizeOptionalPathRetrieval(
-      scanned.map(row => row.promptMeta?.retrieval as RetrievalRateInput | undefined)
+      scanned.map(row => row.promptMeta?.retrieval as RetrievalRateInput | undefined),
+      { answerableMinScore: params.answerableMinScore }
     );
 
     res.json({

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -556,6 +556,69 @@ export const RetrievalSummarySchema = z.object({
     })
     .optional(),
   /**
+   * Could the corpus in scope have answered this turn, whether or not the model went looking?
+   *
+   * The denominator the optional-path retrieval rate has always been missing (#1394). A rate of
+   * "the model retrieved on 20% of offered turns" cannot say whether the other 80% were misses or
+   * turns with nothing to find, and the two argue for opposite things: the first for routing work,
+   * the second for leaving the optional path alone. Crossing this field with the rate separates
+   * them.
+   *
+   * THE ONLY FIELD IN THIS BLOCK NOT WRITTEN BY THE TURN. Every sibling is stamped point-in-time
+   * while the turn runs; this one is written afterwards by an offline replay
+   * (packages/scripts/retrieval/answerability-replay.ts) that re-scores the recorded prompt against
+   * the corpus. That is deliberate - the population it exists to measure is the turns where
+   * retrieval did NOT run, so computing it live would mean adding a full brute-force chunk scan
+   * (ChatCompletionFeatures' forced path, which has no ANN index) to exactly the turns that pay
+   * nothing for retrieval today. The measurement is not worth that latency on live traffic.
+   *
+   * BEING A RECONSTRUCTION, IT CARRIES TWO DRIFTS THE OTHER FIELDS DO NOT:
+   * 1. Corpus CONTENT moves. A document added or reindexed between the turn and the replay is
+   *    scored as though it had been there. `probedAt` discloses the gap; a replay run long after
+   *    the window is weak evidence, not strong.
+   * 2. Corpus SCOPE is inferred, not recorded. The seed writes `dataLakeTags: []` on a turn where
+   *    retrieval never ran (ChatCompletionProcess), so the replay reconstructs scope from the
+   *    session's lakes as they stand at replay time. A session whose lake selection changed is
+   *    replayed against a corpus the turn never had, and NOTHING here flags that. Recording real
+   *    scope at seed time would fix it for future turns and is not done yet.
+   * 3. The QUESTION can move out from under it. The probe is keyed to the quest, not to the
+   *    prompt text it scored, so a turn whose prompt is later rewritten in place keeps a probe
+   *    describing the question it used to ask. mergeRetrievalSummary preserves the probe across
+   *    a runtime write deliberately - dropping it would erase the backfill - so nothing
+   *    invalidates a stale one. Re-run the replay with --force over a window whose turns were
+   *    edited.
+   *
+   * RAW SCORE, NOT A VERDICT, so the cutoff lives in the reader. summarizeOptionalPathRetrieval
+   * applies it at fold time, which lets the same replay be re-thresholded without re-running -
+   * the point of storing the number, given the two live floors disagree by construction (forced
+   * retrieval's absolute default is 0.75, the knowledge tool's is 0).
+   *
+   * `topScore` is the same raw cosine scale as `injected.topScore` and comparable to it. It is NOT
+   * comparable to lake memory's belief relevance, for the reason `injected` documents at length.
+   *
+   * `scanTruncated` inherits forced retrieval's saturation: the replay bounds its scan the same
+   * way, so a low `topScore` on a truncated scan is not proof the corpus lacked an answer - it is
+   * proof the part that was scanned did. Treat those turns as unknown rather than as negatives.
+   *
+   * Absence means NOT PROBED - never "not answerable". Every turn predating the replay, and every
+   * turn the replay skipped or failed on, is absent, so a fold must keep it as its own arm rather
+   * than letting it fall in with the negatives.
+   */
+  answerability: z
+    .object({
+      /** Best cosine the replay found across the reconstructed corpus. */
+      topScore: z.number(),
+      /** Chunks at or above `floor`. Separates "one lucky match" from "a rich seam". */
+      candidatesAboveFloor: z.number(),
+      /** The absolute floor the replay counted `candidatesAboveFloor` against, as a fraction. */
+      floor: z.number(),
+      /** The scan hit its chunk ceiling, so `topScore` is a floor on the true best, not the best. */
+      scanTruncated: z.boolean(),
+      /** When the replay ran, NOT when the turn ran - the disclosure for content drift above. */
+      probedAt: JsonSafeDate,
+    })
+    .optional(),
+  /**
    * Which of this turn's injected lake prompt ids were BOTH in the session's pre-authorized (manage-
    * but-not-member admission) set AND injected on this turn - see unionPreauthorizedLakeAccess and
    * pages/api/sessions/create.ts. A subset of injectedLakePromptIds, never a superset. Narrows the

--- a/b4m-core/common/src/utils/retrievalRate.test.ts
+++ b/b4m-core/common/src/utils/retrievalRate.test.ts
@@ -229,4 +229,134 @@ describe('summarizeOptionalPathRetrieval', () => {
     const summary = summarizeOptionalPathRetrieval([undefined, null, offeredRetrieved]);
     expect(summary).toMatchObject({ offeredTurns: 1, retrievedTurns: 1, unclassifiedTurns: 0 });
   });
+
+  describe('answerability split', () => {
+    const probe = (over: Partial<NonNullable<RetrievalSummary['answerability']>> = {}) => ({
+      topScore: 0.9,
+      candidatesAboveFloor: 3,
+      floor: 0.75,
+      scanTruncated: false,
+      probedAt: new Date('2026-09-11T00:00:00.000Z'),
+      ...over,
+    });
+
+    const answerableRetrieved = turn({
+      mode: 'optional',
+      attempted: true,
+      outcome: 'ok',
+      surfaces: ['knowledgeBaseSearch'],
+      answerability: probe(),
+    });
+    const answerableMissed = turn({ mode: 'optional', answerability: probe() });
+    const emptyCorpusNoRetrieval = turn({ mode: 'optional', answerability: probe({ topScore: 0.2 }) });
+    const emptyCorpusRetrieved = turn({
+      mode: 'optional',
+      attempted: true,
+      outcome: 'ok',
+      surfaces: ['knowledgeBaseSearch'],
+      answerability: probe({ topScore: 0.2 }),
+    });
+
+    it('gives the 2x2 the routing decision needs, with the arms summing to the offered population', () => {
+      const summary = summarizeOptionalPathRetrieval([
+        answerableRetrieved,
+        answerableMissed,
+        answerableMissed,
+        answerableMissed,
+        emptyCorpusRetrieved,
+        emptyCorpusNoRetrieval,
+        offeredNoRetrieval,
+      ]);
+
+      // The miss cell: 3 of 4 answerable turns where the model did not search.
+      expect(summary.answerability.answerable).toEqual({ turns: 4, retrievedTurns: 1, rate: 0.25 });
+      // The wasted cell: it searched on 1 of the 2 turns with nothing to find.
+      expect(summary.answerability.notAnswerable).toEqual({ turns: 2, retrievedTurns: 1, rate: 0.5 });
+      expect(summary.answerability.unknown).toEqual({ turns: 1, retrievedTurns: 0, rate: 0 });
+
+      const { answerable, notAnswerable, unknown } = summary.answerability;
+      expect(answerable.turns + notAnswerable.turns + unknown.turns).toBe(summary.offeredTurns);
+    });
+
+    it('keeps an unprobed turn out of the negatives rather than crediting it as nothing-to-find', () => {
+      // The failure this arm exists to prevent: counting a turn nobody replayed as evidence that
+      // the corpus was empty manufactures exactly the conclusion under test.
+      const summary = summarizeOptionalPathRetrieval([offeredNoRetrieval, offeredNoRetrieval]);
+      expect(summary.answerability.unknown.turns).toBe(2);
+      expect(summary.answerability.notAnswerable.turns).toBe(0);
+      expect(summary.answerability.answerable.turns).toBe(0);
+    });
+
+    it('treats a truncated scan below the cutoff as unknown, not as a negative', () => {
+      // The scan stopped early, so the best score it found is a floor on the true best - the
+      // corpus may well hold a better match past the ceiling.
+      const summary = summarizeOptionalPathRetrieval([
+        turn({ mode: 'optional', answerability: probe({ topScore: 0.4, scanTruncated: true }) }),
+      ]);
+      expect(summary.answerability.unknown.turns).toBe(1);
+      expect(summary.answerability.notAnswerable.turns).toBe(0);
+      expect(summary.answerability.inconclusiveTurns).toBe(1);
+    });
+
+    it('still counts a truncated scan that cleared the cutoff as answerable', () => {
+      // Ordering: truncation can only mean the true best is HIGHER, so it rescues a negative and
+      // can never overturn a positive.
+      const summary = summarizeOptionalPathRetrieval([
+        turn({ mode: 'optional', answerability: probe({ topScore: 0.9, scanTruncated: true }) }),
+      ]);
+      expect(summary.answerability.answerable.turns).toBe(1);
+      expect(summary.answerability.inconclusiveTurns).toBe(0);
+    });
+
+    it('defaults the cutoff to the live forced-retrieval floor, inclusive at the boundary', () => {
+      const summary = summarizeOptionalPathRetrieval([
+        turn({ mode: 'optional', answerability: probe({ topScore: 0.75 }) }),
+        turn({ mode: 'optional', answerability: probe({ topScore: 0.7499 }) }),
+      ]);
+      expect(summary.answerability.cutoff).toBe(0.75);
+      expect(summary.answerability.answerable.turns).toBe(1);
+      expect(summary.answerability.notAnswerable.turns).toBe(1);
+    });
+
+    it('re-thresholds the same replayed scores without a second replay', () => {
+      // Why the probe stores a raw score instead of a verdict: sweeping the bar is a re-read.
+      const turns = [
+        turn({ mode: 'optional', answerability: probe({ topScore: 0.62 }) }),
+        turn({ mode: 'optional', answerability: probe({ topScore: 0.81 }) }),
+      ];
+      expect(summarizeOptionalPathRetrieval(turns, { answerableMinScore: 0.6 }).answerability).toMatchObject({
+        cutoff: 0.6,
+        answerable: { turns: 2 },
+        notAnswerable: { turns: 0 },
+      });
+      expect(summarizeOptionalPathRetrieval(turns, { answerableMinScore: 0.9 }).answerability).toMatchObject({
+        cutoff: 0.9,
+        answerable: { turns: 0 },
+        notAnswerable: { turns: 2 },
+      });
+    });
+
+    it('counts the empty-corpus sentinel as not-answerable rather than as unprobed', () => {
+      // The replay writes -1 when nothing came back at all. It is a recorded fact, not missing
+      // data, so it belongs with the negatives - landing it in `unknown` would hide the commonest
+      // honest negative there is and make the corpus look unmeasured.
+      const summary = summarizeOptionalPathRetrieval([
+        turn({ mode: 'optional', answerability: probe({ topScore: -1, candidatesAboveFloor: 0 }) }),
+      ]);
+      expect(summary.answerability.notAnswerable.turns).toBe(1);
+      expect(summary.answerability.unknown.turns).toBe(0);
+    });
+
+    it('classifies only the offered population, leaving forced turns out of the split', () => {
+      // A forced turn retrieved because it was told to, so it says nothing about whether the model
+      // would have chosen to - including it would answer a different question.
+      const summary = summarizeOptionalPathRetrieval([
+        turn({ mode: 'forced', attempted: true, outcome: 'ok', answerability: probe() }),
+        answerableMissed,
+      ]);
+      expect(summary.forcedTurns).toBe(1);
+      expect(summary.answerability.answerable.turns).toBe(1);
+      expect(summary.answerability.unknown.turns).toBe(0);
+    });
+  });
 });

--- a/b4m-core/common/src/utils/retrievalRate.ts
+++ b/b4m-core/common/src/utils/retrievalRate.ts
@@ -1,6 +1,22 @@
+import { FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT } from '../constants/forcedRetrieval';
 import type { PromptMeta } from '../types/entities/PromptMetaTypes';
 
 type RetrievalSummary = NonNullable<PromptMeta['retrieval']>;
+
+/**
+ * The `topScore` at which a replayed turn counts as answerable, pinned to the live forced-retrieval
+ * absolute floor rather than being a number of its own. The question the split asks is whether
+ * retrieval would have surfaced something the SYSTEM considers relevant, so the bar has to be the
+ * bar production uses; a bar invented here would measure this file's opinion instead.
+ *
+ * Deliberately not the knowledge tool's floor, which defaults to 0 (KB_SEARCH_MIN_RELEVANCE_PCT_
+ * DEFAULT) and would call every turn with any corpus at all answerable.
+ *
+ * Overridable per call. The replay stores the raw cosine precisely so the cutoff can be swept
+ * without re-running it, which matters because this default is a setting's default, not a law -
+ * an installation that has tuned forcedRetrievalMinSimilarityPct should sweep to its own value.
+ */
+const DEFAULT_ANSWERABLE_MIN_SCORE = FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT / 100;
 
 /**
  * How often the model retrieves when retrieval is OFFERED rather than forced (#1394).
@@ -39,9 +55,44 @@ export type OptionalPathRetrievalRate = {
    * the experiment. The arms describe traffic, not configuration.
    */
   guidance: {
-    injected: GuidanceArm;
-    notInjected: GuidanceArm;
-    unrecorded: GuidanceArm;
+    injected: RateArm;
+    notInjected: RateArm;
+    unrecorded: RateArm;
+  };
+  /**
+   * The same offered turns, partitioned by whether the corpus in scope COULD have answered them.
+   * This is the denominator the headline rate has always been missing (#1394): a turn where the
+   * model did not retrieve is a defect only if there was something to find, and until this split
+   * existed the two were indistinguishable.
+   *
+   * Read it as a 2x2 - each arm's `turns` and `retrievedTurns` give both cells:
+   *
+   *                    retrieved        did not retrieve
+   *   answerable       correct          THE MISS  <- the number that justifies routing work
+   *   notAnswerable    wasted round trip correct abstain
+   *
+   * `unknown` is turns the offline replay never probed, plus turns it probed inconclusively (see
+   * `inconclusiveTurns`). Its own arm for the same reason `guidance.unrecorded` is: folding
+   * unprobed turns into `notAnswerable` would manufacture the conclusion that there was nothing
+   * to retrieve, which is precisely the claim under test. The three arms always sum to
+   * `offeredTurns`.
+   *
+   * A large `unknown` means the replay has not been run over this window, NOT that the corpus is
+   * thin. Check it before reading anything into the other two arms.
+   */
+  answerability: {
+    /** The `topScore` at or above which a turn counts as answerable, as a cosine fraction. */
+    cutoff: number;
+    answerable: RateArm;
+    notAnswerable: RateArm;
+    unknown: RateArm;
+    /**
+     * Of `unknown`, the turns that WERE probed but whose scan hit its chunk ceiling below the
+     * cutoff. Their true best score could be higher, so they are not negatives; counted here so a
+     * big `unknown` can be told apart as "not replayed yet" versus "replayed against a corpus too
+     * large to scan". The rest of `unknown` is turns with no probe at all.
+     */
+    inconclusiveTurns: number;
   };
   /**
    * Turns where forced retrieval was ON but a rule suppressed it, leaving the model on the
@@ -79,16 +130,17 @@ export type OptionalPathRetrievalRate = {
 };
 
 /**
- * One arm of the guidance A/B. Same numerator as the headline rate (the model choosing to
- * retrieve), over the subset of offered turns in that arm.
+ * One arm of a partition of the offered turns - the guidance A/B, or the answerability split.
+ * Same numerator throughout (the model choosing to retrieve), over the subset of offered turns in
+ * that arm, so arms are directly comparable to each other and to the headline `rate`.
  */
-export type GuidanceArm = {
+export type RateArm = {
   turns: number;
   retrievedTurns: number;
   rate: number | null;
 };
 
-const emptyRate = (): OptionalPathRetrievalRate => ({
+const emptyRate = (cutoff: number): OptionalPathRetrievalRate => ({
   offeredTurns: 0,
   retrievedTurns: 0,
   rate: null,
@@ -96,6 +148,13 @@ const emptyRate = (): OptionalPathRetrievalRate => ({
     injected: { turns: 0, retrievedTurns: 0, rate: null },
     notInjected: { turns: 0, retrievedTurns: 0, rate: null },
     unrecorded: { turns: 0, retrievedTurns: 0, rate: null },
+  },
+  answerability: {
+    cutoff,
+    answerable: { turns: 0, retrievedTurns: 0, rate: null },
+    notAnswerable: { turns: 0, retrievedTurns: 0, rate: null },
+    unknown: { turns: 0, retrievedTurns: 0, rate: null },
+    inconclusiveTurns: 0,
   },
   forcedSuppressed: {
     turns: 0,
@@ -137,6 +196,30 @@ const modelRetrieved = (turn: RetrievalRateInput): boolean =>
   Boolean(turn.attempted) && Boolean(turn.surfaces?.some(surface => MODEL_INITIATED_SURFACES.has(surface)));
 
 /**
+ * Which answerability arm an offered turn belongs to, and the one place `scanTruncated` is
+ * honoured. Mutates `summary.inconclusiveTurns` as a side effect of the truncated case rather than
+ * making the caller re-derive it - the count and the arm assignment are the same decision.
+ *
+ * Ordering is load-bearing: the cutoff test comes BEFORE the truncation test, because a truncated
+ * scan that already cleared the bar is answerable regardless. Truncation only means the true best
+ * score may be HIGHER than recorded, so it can rescue a negative and can never overturn a positive.
+ */
+const classifyAnswerability = (
+  turn: RetrievalRateInput,
+  cutoff: number,
+  summary: OptionalPathRetrievalRate
+): RateArm => {
+  const probe = turn.answerability;
+  if (!probe) return summary.answerability.unknown;
+  if (probe.topScore >= cutoff) return summary.answerability.answerable;
+  if (probe.scanTruncated) {
+    summary.answerability.inconclusiveTurns += 1;
+    return summary.answerability.unknown;
+  }
+  return summary.answerability.notAnswerable;
+};
+
+/**
  * The fields the fold reads. Narrower than the stored summary on purpose: it lets a caller project
  * just these out of Mongo and leave `dataLakeTags` - which lakes a turn touched - in the database
  * rather than egressing lake identity to build a counter (see the redaction CAUTION on
@@ -145,7 +228,7 @@ const modelRetrieved = (turn: RetrievalRateInput): boolean =>
  */
 export type RetrievalRateInput = Pick<
   RetrievalSummary,
-  'attempted' | 'mode' | 'forcedSkipReason' | 'surfaces' | 'knowledgeBaseGuidanceInjected'
+  'attempted' | 'mode' | 'forcedSkipReason' | 'surfaces' | 'knowledgeBaseGuidanceInjected' | 'answerability'
 >;
 
 /**
@@ -160,6 +243,9 @@ const RETRIEVAL_RATE_FIELD_SET: Record<keyof RetrievalRateInput, true> = {
   forcedSkipReason: true,
   surfaces: true,
   knowledgeBaseGuidanceInjected: true,
+  // Scalar scores and a timestamp only - no lake or file identity, so widening the projection to
+  // reach it does not egress corpus identity the way `dataLakeTags` would (see the type above).
+  answerability: true,
 };
 
 export const RETRIEVAL_RATE_FIELDS = Object.keys(RETRIEVAL_RATE_FIELD_SET) as (keyof RetrievalRateInput)[];
@@ -169,9 +255,11 @@ export const RETRIEVAL_RATE_FIELDS = Object.keys(RETRIEVAL_RATE_FIELD_SET) as (k
  * bounding (see `mode` in RetrievalSummarySchema) and the population it hands over.
  */
 export function summarizeOptionalPathRetrieval(
-  turns: ReadonlyArray<RetrievalRateInput | undefined | null>
+  turns: ReadonlyArray<RetrievalRateInput | undefined | null>,
+  options: { answerableMinScore?: number } = {}
 ): OptionalPathRetrievalRate {
-  const summary = emptyRate();
+  const cutoff = options.answerableMinScore ?? DEFAULT_ANSWERABLE_MIN_SCORE;
+  const summary = emptyRate(cutoff);
 
   for (const turn of turns) {
     if (!turn) continue;
@@ -195,6 +283,10 @@ export function summarizeOptionalPathRetrieval(
             : summary.guidance.notInjected;
       arm.turns += 1;
       if (retrieved) arm.retrievedTurns += 1;
+
+      const answerabilityArm = classifyAnswerability(turn, cutoff, summary);
+      answerabilityArm.turns += 1;
+      if (retrieved) answerabilityArm.retrievedTurns += 1;
       continue;
     }
 
@@ -216,6 +308,13 @@ export function summarizeOptionalPathRetrieval(
 
   summary.rate = ratio(summary.retrievedTurns, summary.offeredTurns);
   for (const arm of [summary.guidance.injected, summary.guidance.notInjected, summary.guidance.unrecorded]) {
+    arm.rate = ratio(arm.retrievedTurns, arm.turns);
+  }
+  for (const arm of [
+    summary.answerability.answerable,
+    summary.answerability.notAnswerable,
+    summary.answerability.unknown,
+  ]) {
     arm.rate = ratio(arm.retrievedTurns, arm.turns);
   }
   summary.forcedSuppressed.rate = ratio(summary.forcedSuppressed.retrievedTurns, summary.forcedSuppressed.turns);

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.test.ts
@@ -333,4 +333,30 @@ describe('mergeRetrievalSummary', () => {
       expect(merged?.preauthorizedLakeIdsUsed).toEqual(['lake1']);
     });
   });
+
+  describe('answerability', () => {
+    const probe = {
+      topScore: 0.88,
+      candidatesAboveFloor: 4,
+      floor: 0.75,
+      scanTruncated: false,
+      probedAt: new Date('2026-09-11T00:00:00.000Z'),
+    };
+
+    it('preserves a backfilled probe against a later runtime write that knows nothing about it', () => {
+      // The real hazard: this function returns an object literal, so a field with no case here is
+      // dropped. A regenerate on an already-replayed quest would silently erase the measurement.
+      const merged = mergeRetrievalSummary(base({ answerability: probe }), base({ surfaces: ['knowledgeBaseSearch'] }));
+      expect(merged?.answerability).toEqual(probe);
+    });
+
+    it('stays absent on turns that were never replayed', () => {
+      const merged = mergeRetrievalSummary(base(), base());
+      expect(merged && 'answerability' in merged).toBe(false);
+    });
+
+    it('accepts the probe from either side, since only one writer ever sets it', () => {
+      expect(mergeRetrievalSummary(base(), base({ answerability: probe }))?.answerability).toEqual(probe);
+    });
+  });
 });

--- a/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
+++ b/b4m-core/services/src/llm/tools/retrievalSummaryMerge.ts
@@ -87,6 +87,12 @@ function mergeInjected(
  * - knowledgeBaseGuidanceInjected: first-writer-wins pass-through. Only the seed writes it, and
  *   `??` rather than `||` because an explicit `false` is a real value (the A/B control arm) that
  *   a boolean OR against an absent incoming side would silently discard.
+ * - answerability: existing-wins pass-through, and it is here to PRESERVE rather than to combine.
+ *   Nothing in a turn writes it - the offline replay backfills it straight to Mongo - so a
+ *   two-sided merge is not reachable. What IS reachable is a later runtime write on a quest that
+ *   was already backfilled (a regenerate, an edit), and since this function returns an explicit
+ *   object literal, a field with no case here is DROPPED rather than carried. That silent erase is
+ *   the failure this rule exists to prevent.
  * - surfaces / dataLakeTags / injectedLakePromptIds / preauthorizedLakeIdsUsed: union, deduped.
  *   injectedLakePromptCount is derived from the merged injectedLakePromptIds, not merged
  *   independently, so a two-sided merge can never leave the two disagreeing.
@@ -122,6 +128,7 @@ export function mergeRetrievalSummary(
   const forcedSkipReason = existing.forcedSkipReason ?? incoming.forcedSkipReason;
   const knowledgeBaseGuidanceInjected =
     existing.knowledgeBaseGuidanceInjected ?? incoming.knowledgeBaseGuidanceInjected;
+  const answerability = existing.answerability ?? incoming.answerability;
   const injectedLakePromptIds =
     existing.injectedLakePromptIds || incoming.injectedLakePromptIds
       ? [...new Set([...(existing.injectedLakePromptIds ?? []), ...(incoming.injectedLakePromptIds ?? [])])]
@@ -140,6 +147,7 @@ export function mergeRetrievalSummary(
     ...(mode !== undefined ? { mode } : {}),
     ...(forcedSkipReason !== undefined ? { forcedSkipReason } : {}),
     ...(knowledgeBaseGuidanceInjected !== undefined ? { knowledgeBaseGuidanceInjected } : {}),
+    ...(answerability !== undefined ? { answerability } : {}),
     surfaces: [...new Set([...existing.surfaces, ...incoming.surfaces])],
     dataLakeTags: [...new Set([...existing.dataLakeTags, ...incoming.dataLakeTags])],
     ...(injectedLakePromptIds ? { injectedLakePromptIds, injectedLakePromptCount: injectedLakePromptIds.length } : {}),

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -71,6 +71,18 @@ const InjectedVolumeSchema = subSchema({
   postRelativeFloorCandidates: { type: Number, required: false },
 });
 
+// Written by the offline answerability replay, not by the turn - see the field's comment in
+// promptMeta.ts for why the measurement is reconstructed rather than computed live, and for the
+// two drifts that follow from that. Date is stored as a real Date; the Zod side accepts its JSON
+// form too (JsonSafeDate) because promptMeta round-trips through the client.
+const AnswerabilityProbeSchema = subSchema({
+  topScore: { type: Number, required: true },
+  candidatesAboveFloor: { type: Number, required: true },
+  floor: { type: Number, required: true },
+  scanTruncated: { type: Boolean, required: true },
+  probedAt: { type: Date, required: true },
+});
+
 // Same rationale as LakeMemorySchema above (subSchema + default:undefined to suppress
 // auto-vivification of `surfaces`/`dataLakeTags` as empty arrays, which would fail the Zod
 // re-parse since `attempted` is required). Top-level on promptMeta, not nested under
@@ -96,6 +108,9 @@ const RetrievalSummarySchema = subSchema({
   // preserves the field's presence contract, since a materialized empty object would report
   // "unknown volume" as a recorded one.
   injected: { type: InjectedVolumeSchema, required: false, default: undefined },
+  // default: undefined for the same auto-vivification reason as `injected` above - and here it
+  // also preserves the presence contract that absence means NOT PROBED, never "not answerable".
+  answerability: { type: AnswerabilityProbeSchema, required: false, default: undefined },
   // default: undefined for the same auto-vivification reason as injectedLakePromptIds above.
   preauthorizedLakeIdsUsed: { type: [String], required: false, default: undefined },
 });

--- a/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
+++ b/packages/database/src/models/content/__tests__/QuestModel.promptMetaPersistence.test.ts
@@ -126,6 +126,16 @@ const FULL_PROMPT_META = {
     // Deliberately `false`, not `true`: a falsy leaf is where a Mongoose/Zod mismatch silently
     // drops a value, and `false` is this field's load-bearing case (the A/B's control arm).
     knowledgeBaseGuidanceInjected: false,
+    // The offline replay's probe. A Date against Zod's JsonSafeDate is the likeliest type slip in
+    // the block, and it is invisible to the parity test, which compares path names only. Falsy
+    // leaves again on the two that have one.
+    answerability: {
+      topScore: 0.42,
+      candidatesAboveFloor: 0,
+      floor: 0.75,
+      scanTruncated: false,
+      probedAt: new Date('2026-09-11T00:00:00.000Z'),
+    },
   },
   // Top-level for the same reason as `retrieval` above. The chat coverage banner keys on this
   // field surviving the round-trip, so a shape that persists but fails the Zod re-parse would

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -57,6 +57,7 @@
     "retrieval:recall-probe": "tsx retrieval/recall-probe.ts",
     "retrieval:supersession-probe": "tsx retrieval/supersession-probe.ts",
     "retrieval:capture-embeddings": "tsx retrieval/capture-embeddings.ts",
+    "retrieval:answerability-replay": "tsx retrieval/answerability-replay.ts",
     "retrieval:model-comparison": "tsx retrieval/model-comparison.ts"
   },
   "dependencies": {

--- a/packages/scripts/retrieval/answerability-replay.ts
+++ b/packages/scripts/retrieval/answerability-replay.ts
@@ -41,6 +41,9 @@
  */
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+// `Resource` needs a real SST-linked environment (a deployed stage via `sst shell`, or the
+// self-host container's `--import` alias hook) - a plain `tsx` run against local self-host
+// throws "It does not look like SST links are active", same known limitation as createUser.ts.
 import { Resource } from 'sst';
 import {
   adminSettingsRepository,

--- a/packages/scripts/retrieval/answerability-replay.ts
+++ b/packages/scripts/retrieval/answerability-replay.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill `promptMeta.retrieval.answerability` over historical optional-path turns (#1394).
+ *
+ * WHAT IT ANSWERS. The optional-path retrieval rate says the model reaches for the corpus on about
+ * a fifth of the turns where the tools are offered. It cannot say whether the other four fifths
+ * were misses or turns with nothing to find, and those argue for opposite things - the first for
+ * building per-turn routing, the second for leaving the optional path alone. This replays each
+ * turn's prompt against the corpus and records what retrieval WOULD have found, which is the
+ * denominator that separates them. `summarizeOptionalPathRetrieval` folds the result into a 2x2 and
+ * the admin Retrieval Rate tab renders it.
+ *
+ * WHY OFFLINE. The population that matters is the turns where retrieval never ran, so measuring it
+ * live would mean adding an embedding call and a brute-force chunk scan to exactly the turns that
+ * pay nothing for retrieval today. That is a latency regression on the majority of traffic in
+ * exchange for a metric. Run here instead, close to the window being measured.
+ *
+ * WHAT IT IS NOT. Not a measurement of the turn as it happened. Two drifts, both documented on
+ * RetrievalSummarySchema.answerability and neither fixable here:
+ *   1. The corpus CONTENT has moved since the turn. `probedAt` is stamped so a reader can see how
+ *      far. A replay long after the window is weak evidence.
+ *   2. The corpus SCOPE is reconstructed, because the seed writes `dataLakeTags: []` on a turn
+ *      where retrieval never ran. Scope here is the session's `retrievalTags` intersected with the
+ *      owner's CURRENT lake access, so a session whose lakes changed is replayed against a corpus
+ *      the turn never had.
+ *
+ * IT UNDER-COUNTS ANSWERABLE TURNS, AND THAT IS THE SAFE DIRECTION. The knowledge tool's corpus is
+ * the session's lakes plus the caller's own files; this sees only the lakes. A lake reachable at
+ * the time through an admission path that has since lapsed is also missed. Both make a turn look
+ * less answerable than it was, so the "missed retrievals" figure this feeds is a FLOOR. A metric
+ * whose job is to justify building a classifier must not be the one arguing for itself - the same
+ * reason MODEL_INITIATED_SURFACES is an allowlist.
+ *
+ * WRITES. One `$set` of `promptMeta.retrieval.answerability` per probed turn, and nothing else.
+ * Idempotent: an already-probed turn is skipped unless `--force`. Use `--dry-run` first.
+ *
+ * Usage (needs DB + an embedding key, which `sst shell` provides):
+ *   for-env dev pnpm sst shell --stage dev -- \
+ *     packages/scripts/node_modules/.bin/tsx packages/scripts/retrieval/answerability-replay.ts \
+ *     --start 2026-08-12 --end 2026-09-11 --dry-run
+ */
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { Resource } from 'sst';
+import {
+  adminSettingsRepository,
+  apiKeyRepository,
+  connectDB,
+  dataLakeRepository,
+  fabFileChunkRepository,
+  fabFileRepository,
+  organizationRepository,
+  Quest,
+  sessionRepository,
+  userRepository,
+} from '@bike4mind/database';
+import { getSettingsByNames } from '@bike4mind/utils';
+import { Logger } from '@bike4mind/observability';
+import { apiKeyService, dataLakeService } from '@bike4mind/services';
+import {
+  FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+  isSupportedEmbeddingModel,
+  type SupportedEmbeddingModel,
+} from '@bike4mind/common';
+import {
+  buildAnswerabilityProbe,
+  formatReplaySummary,
+  selectReplayTargets,
+  type ReplayRow,
+  type ReplayTally,
+} from './answerabilityReplay.js';
+
+const logger = new Logger();
+
+/**
+ * Deep enough to see past the floor without paying for a long tail: the probe only needs the top
+ * score and a count of what cleared the bar, and both are settled well inside this.
+ */
+const SEARCH_TOP_K = 20;
+
+/**
+ * The search itself must NOT filter. Passing the floor as `minScore` would collapse "the corpus
+ * held nothing at all" and "the corpus held something weak" into the same empty result, and the
+ * difference between those is exactly what a swept cutoff is meant to explore later.
+ */
+const SEARCH_MIN_SCORE = 0;
+
+type ApiKeyTable = { openai?: string | null; voyageai?: string | null; ollama?: string | null };
+
+type OwnerScope = {
+  dataLakeTags: string[];
+  dataLakeTagPrefixes: string[];
+  lakeMemberships: ReturnType<typeof dataLakeService.lakeMembershipsFrom>;
+  lakes: Awaited<ReturnType<typeof dataLakeService.getDynamicDataLakeAccess>>['lakes'];
+  apiKeyTable: ApiKeyTable;
+};
+
+/**
+ * Per-owner lake access and API keys, resolved once. A window is overwhelmingly a handful of heavy
+ * users, so without this the run spends most of its time re-resolving the same access graph.
+ */
+async function resolveOwnerScope(userId: string, cache: Map<string, OwnerScope | null>): Promise<OwnerScope | null> {
+  const cached = cache.get(userId);
+  if (cached !== undefined) return cached;
+
+  const user = await userRepository.findById(userId);
+  if (!user) {
+    cache.set(userId, null);
+    return null;
+  }
+
+  const access = await dataLakeService.getDynamicDataLakeAccess({
+    db: { dataLakes: dataLakeRepository, organizations: organizationRepository },
+    user: { id: String(user.id), tags: user.tags ?? [] },
+  });
+  const keys = await apiKeyService.getEffectiveLLMApiKeys(userId, {
+    db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository },
+    getSettingsByNames,
+  });
+
+  const scope: OwnerScope = {
+    dataLakeTags: access.dataLakeTags,
+    dataLakeTagPrefixes: access.dataLakeTagPrefixes,
+    lakeMemberships: dataLakeService.lakeMembershipsFrom(access.lakes),
+    lakes: access.lakes,
+    apiKeyTable: { openai: keys?.openai, voyageai: keys?.voyageai, ollama: keys?.ollama },
+  };
+  cache.set(userId, scope);
+  return scope;
+}
+
+async function resolveEmbeddingModel(): Promise<SupportedEmbeddingModel> {
+  const configured = await adminSettingsRepository.getSettingsValue('defaultEmbeddingModel');
+  // Unset is its own failure, and a loud one: falling back to a default model here would score the
+  // whole window against embeddings the corpus was never built with, and report the resulting
+  // near-zero cosines as a corpus that had nothing to offer.
+  if (typeof configured !== 'string' || !isSupportedEmbeddingModel(configured)) {
+    throw new Error(`defaultEmbeddingModel is "${String(configured)}", not a supported embedding model.`);
+  }
+  return configured;
+}
+
+type Options = {
+  start?: string;
+  end?: string;
+  limit: number;
+  floor: number;
+  dryRun: boolean;
+  force: boolean;
+};
+
+async function main(opts: Options): Promise<number> {
+  await connectDB(Resource.MONGODB_URI.value.replace('%STAGE%', Resource.App.stage));
+
+  const timestamp: Record<string, Date> = {};
+  if (opts.start) timestamp.$gte = new Date(opts.start);
+  if (opts.end) timestamp.$lte = new Date(opts.end);
+
+  const found = (await Quest.find({
+    'promptMeta.retrieval.mode': 'optional',
+    ...(opts.start || opts.end ? { timestamp } : {}),
+  })
+    .select('prompt sessionId userId promptMeta.retrieval.mode promptMeta.retrieval.answerability')
+    .sort({ timestamp: -1 })
+    .limit(opts.limit)
+    .lean()) as unknown as (Omit<ReplayRow, '_id'> & { _id: unknown; userId?: string })[];
+
+  // `_id` arrives as an ObjectId. Stringified once, here, so the id that reaches the target list
+  // and the id that keys the lookup below are the same value - comparing an ObjectId against its
+  // own string silently matches nothing.
+  const rows = found.map(row => ({ ...row, _id: String(row._id) }));
+  const selection = selectReplayTargets(rows, { force: opts.force });
+  const byId = new Map(rows.map(row => [row._id, row]));
+  const embeddingModel = await resolveEmbeddingModel();
+  const scopeCache = new Map<string, OwnerScope | null>();
+  const tally: ReplayTally = { probed: 0, written: 0, failed: 0, skipped: selection.skipped };
+
+  console.log(`stage:     ${Resource.App.stage}`);
+  console.log(`window:    ${opts.start ?? 'all'} to ${opts.end ?? 'now'}`);
+  console.log(`model:     ${embeddingModel}`);
+  console.log(`floor:     ${opts.floor}`);
+  console.log(`targets:   ${selection.targets.length} of ${rows.length} scanned`);
+  if (opts.dryRun) console.log('DRY RUN - probing without writing.');
+  if (opts.force) console.log('FORCE - overwriting probes that already exist.');
+  console.log('');
+
+  // Sequential on purpose: every target is an embedding call plus a vector scan, and this runs
+  // against a live stage whose interactive traffic has a stronger claim on both than a backfill.
+  for (const target of selection.targets) {
+    const ownerId = byId.get(target.questId)?.userId;
+    const scope = ownerId ? await resolveOwnerScope(ownerId, scopeCache) : null;
+    if (!ownerId || !scope) {
+      // An anomaly, not a routine skip: a turn whose owner cannot be resolved means the quest
+      // outlived its user record. Counted as a failure so it cannot hide inside a skip tally.
+      tally.failed += 1;
+      console.error(`  no resolvable owner for quest ${target.questId} (userId ${String(ownerId)})`);
+      continue;
+    }
+
+    const session = await sessionRepository.findById(target.sessionId);
+    const sessionTags = session?.retrievalTags ?? [];
+    // The turn's own lakes, not everything the owner can reach now: a session is scoped to what
+    // was selected in it, and searching the owner's whole library would answer a question no turn
+    // ever asked.
+    const dataLakeTags = scope.dataLakeTags.filter(tag => sessionTags.includes(tag));
+    if (dataLakeTags.length === 0) {
+      tally.skipped.no_lake_scope += 1;
+      continue;
+    }
+
+    try {
+      const search = await dataLakeService.semanticDataLakeSearch(
+        {
+          userId: ownerId,
+          query: target.prompt,
+          topK: SEARCH_TOP_K,
+          minScore: SEARCH_MIN_SCORE,
+          embeddingModel,
+          apiKeyTable: scope.apiKeyTable,
+          dataLakeTags,
+          dataLakeTagPrefixes: scope.dataLakeTagPrefixes,
+          lakeMemberships: scope.lakeMemberships,
+          lakes: scope.lakes,
+          logger,
+        },
+        { db: { fabfiles: fabFileRepository, fabfilechunks: fabFileChunkRepository } }
+      );
+
+      const probe = buildAnswerabilityProbe(search.results, search.scan, {
+        floor: opts.floor,
+        probedAt: new Date(),
+      });
+      tally.probed += 1;
+
+      if (!opts.dryRun) {
+        await Quest.updateOne({ _id: target.questId }, { $set: { 'promptMeta.retrieval.answerability': probe } });
+        tally.written += 1;
+      }
+    } catch (err) {
+      // One unanswerable turn must not end the run - a single bad lake or a rate limit would
+      // otherwise throw away every probe before it. Counted, named, and carried on from.
+      tally.failed += 1;
+      console.error(`  probe failed for quest ${target.questId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  console.log(formatReplaySummary(tally));
+  // Nonzero only when NOTHING was probed and something failed - a wholesale failure (bad stage,
+  // no embedding key) rather than a few unlucky turns, which are reported in the tally above and
+  // are a normal outcome for a backfill. A caller that needs to react to partial failure should
+  // read `failed` in the summary, not the exit code.
+  return tally.failed > 0 && tally.probed === 0 ? 1 : 0;
+}
+
+const argv = yargs(hideBin(process.argv))
+  .option('start', { type: 'string', describe: 'Inclusive start of the turn window, e.g. 2026-08-12' })
+  .option('end', { type: 'string', describe: 'Inclusive end of the turn window' })
+  .option('limit', { type: 'number', default: 1000, describe: 'Maximum turns to scan, newest first' })
+  .option('floor', {
+    type: 'number',
+    default: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT / 100,
+    describe: 'Cosine floor for candidatesAboveFloor; defaults to the forced-retrieval floor',
+  })
+  .option('dry-run', { type: 'boolean', default: false, describe: 'Probe and report without writing' })
+  .option('force', { type: 'boolean', default: false, describe: 'Re-probe turns that already carry a probe' })
+  .strict()
+  .parseSync();
+
+main({
+  start: argv.start,
+  end: argv.end,
+  limit: argv.limit,
+  floor: argv.floor,
+  dryRun: argv['dry-run'],
+  force: argv.force,
+})
+  .then(code => process.exit(code))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/scripts/retrieval/answerabilityReplay.test.ts
+++ b/packages/scripts/retrieval/answerabilityReplay.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAnswerabilityProbe,
+  formatReplaySummary,
+  selectReplayTargets,
+  type ReplayRow,
+} from './answerabilityReplay';
+
+const row = (over: Partial<ReplayRow> = {}): ReplayRow => ({
+  _id: 'quest1',
+  prompt: 'what is our refund window',
+  sessionId: 'session1',
+  promptMeta: { retrieval: { mode: 'optional' } },
+  ...over,
+});
+
+describe('selectReplayTargets', () => {
+  it('takes the offered turns and reports why it passed over the rest', () => {
+    const selection = selectReplayTargets([
+      row({ _id: 'a' }),
+      row({ _id: 'b', promptMeta: { retrieval: { mode: 'forced' } } }),
+      row({ _id: 'c', prompt: '   ' }),
+      row({ _id: 'd', sessionId: null }),
+      row({ _id: 'e', promptMeta: { retrieval: { mode: 'optional', answerability: { topScore: 0.4 } } } }),
+      row({ _id: 'f', promptMeta: {} }),
+    ]);
+
+    expect(selection.targets.map(target => target.questId)).toEqual(['a']);
+    expect(selection.skipped).toEqual({
+      not_optional: 2,
+      no_prompt: 1,
+      no_session: 1,
+      already_probed: 1,
+      // Never set here - the runner assigns it once the session is loaded.
+      no_lake_scope: 0,
+    });
+  });
+
+  it('leaves an already-probed turn alone by default, since a re-probe widens the drift', () => {
+    const probed = row({ promptMeta: { retrieval: { mode: 'optional', answerability: { topScore: 0.4 } } } });
+    expect(selectReplayTargets([probed]).targets).toHaveLength(0);
+    expect(selectReplayTargets([probed], { force: true }).targets).toHaveLength(1);
+  });
+
+  it('trims the prompt it hands on, so a padded turn is not embedded with its padding', () => {
+    const [target] = selectReplayTargets([row({ prompt: '  what is our refund window  ' })]).targets;
+    expect(target.prompt).toBe('what is our refund window');
+  });
+});
+
+describe('buildAnswerabilityProbe', () => {
+  const probedAt = new Date('2026-09-11T00:00:00.000Z');
+
+  it('reads the top score off the sorted results and counts the seam below it', () => {
+    const probe = buildAnswerabilityProbe(
+      [{ score: 0.91 }, { score: 0.8 }, { score: 0.75 }, { score: 0.6 }],
+      { truncated: false },
+      { floor: 0.75, probedAt }
+    );
+    expect(probe).toEqual({
+      topScore: 0.91,
+      // Inclusive at the floor: the same boundary the fold's cutoff uses.
+      candidatesAboveFloor: 3,
+      floor: 0.75,
+      scanTruncated: false,
+      probedAt,
+    });
+  });
+
+  it('scores an empty result set with a sentinel below the valid cosine range, not zero', () => {
+    // A real cosine of 0 means "something came back and matched nothing", which is a different
+    // fact from "nothing came back at all" - and 0 would read as answerable under a cutoff of 0.
+    const probe = buildAnswerabilityProbe([], { truncated: false }, { floor: 0.75, probedAt });
+    expect(probe.topScore).toBe(-1);
+    expect(probe.candidatesAboveFloor).toBe(0);
+  });
+
+  it('carries the scan truncation through, since it is what makes a low score inconclusive', () => {
+    const probe = buildAnswerabilityProbe([{ score: 0.4 }], { truncated: true }, { floor: 0.75, probedAt });
+    expect(probe.scanTruncated).toBe(true);
+  });
+});
+
+describe('formatReplaySummary', () => {
+  it('reports probed and written separately, so a dry run and a failing write path differ', () => {
+    const summary = formatReplaySummary({
+      probed: 10,
+      written: 0,
+      failed: 0,
+      skipped: { not_optional: 3, no_prompt: 0, no_session: 0, already_probed: 0, no_lake_scope: 0 },
+    });
+    expect(summary).toContain('probed:  10');
+    expect(summary).toContain('written: 0');
+    expect(summary).toContain('  not_optional: 3');
+    // Reasons that did not fire stay out of the block rather than padding it with zeroes.
+    expect(summary).not.toContain('no_prompt');
+  });
+});

--- a/packages/scripts/retrieval/answerabilityReplay.ts
+++ b/packages/scripts/retrieval/answerabilityReplay.ts
@@ -1,0 +1,168 @@
+/**
+ * The pure half of the answerability replay (#1394) - everything that decides WHAT to probe and
+ * WHAT the probe says, with no Mongo, no embeddings and no network, so it can be unit-tested.
+ * `answerability-replay.ts` is the runner that supplies the I/O.
+ *
+ * Why a replay at all: the optional-path retrieval rate cannot tell a turn where the model should
+ * have searched from a turn with nothing to find, and the population that separates them is the
+ * turns where retrieval never ran. Measuring those live would mean adding a brute-force chunk scan
+ * to the turns that today pay nothing for retrieval, so the measurement is reconstructed after the
+ * fact instead. See RetrievalSummarySchema.answerability for the drifts that follow from that.
+ */
+
+/** Structural, not the imported service types: the module stays free of the search stack. */
+export type ScoredResult = { score: number };
+
+/** The scan accounting `semanticDataLakeSearch` returns alongside its results. */
+export type ScanAccounting = { truncated: boolean };
+
+export type AnswerabilityProbe = {
+  topScore: number;
+  candidatesAboveFloor: number;
+  floor: number;
+  scanTruncated: boolean;
+  probedAt: Date;
+};
+
+/** The shape the runner projects out of Mongo. Narrow on purpose - see selectReplayTargets. */
+export type ReplayRow = {
+  _id: string;
+  prompt?: string | null;
+  sessionId?: string | null;
+  promptMeta?: {
+    retrieval?: {
+      mode?: string;
+      answerability?: unknown;
+    };
+  };
+};
+
+export type ReplayTarget = {
+  questId: string;
+  prompt: string;
+  sessionId: string;
+};
+
+/**
+ * `no_lake_scope` is the one reason the RUNNER assigns rather than selectReplayTargets: it needs
+ * the session loaded to know the turn had no lake selected, which is I/O this module does not do.
+ * It is a skip and not a zero score on purpose - the knowledge tool's corpus is the session's
+ * lakes PLUS the caller's own files, so a turn with no lake can still have been answerable from
+ * files this replay cannot see, and scoring it as "nothing to find" would invent a negative.
+ */
+export type SkipReason = 'not_optional' | 'no_prompt' | 'no_session' | 'already_probed' | 'no_lake_scope';
+
+export type ReplaySelection = {
+  targets: ReplayTarget[];
+  skipped: Record<SkipReason, number>;
+};
+
+const emptySkips = (): Record<SkipReason, number> => ({
+  not_optional: 0,
+  no_prompt: 0,
+  no_session: 0,
+  already_probed: 0,
+  no_lake_scope: 0,
+});
+
+/**
+ * Which rows this run should probe, and a tally of why the rest were passed over.
+ *
+ * The tally is not decoration. A run that probes 4 turns out of 5,000 is indistinguishable from a
+ * broken query unless the skips are reported, and `already_probed` in particular is the difference
+ * between "nothing left to do" and "the window was never covered".
+ *
+ * `already_probed` is skipped by default because a re-probe measures a LATER corpus against an
+ * older turn, widening the content drift the field already carries. `force` exists for the case
+ * where that is the point (the corpus was reindexed and the old scores are known stale), and the
+ * runner is expected to say loudly that it is overwriting.
+ *
+ * Only `mode: 'optional'` turns are eligible: a forced turn retrieved because it was told to, so
+ * its answerability says nothing about what the model would have chosen, and probing it would
+ * spend a search per turn to populate a column no fold reads.
+ */
+export const selectReplayTargets = (
+  rows: ReadonlyArray<ReplayRow>,
+  options: { force?: boolean } = {}
+): ReplaySelection => {
+  const selection: ReplaySelection = { targets: [], skipped: emptySkips() };
+
+  for (const row of rows) {
+    const retrieval = row.promptMeta?.retrieval;
+    if (retrieval?.mode !== 'optional') {
+      selection.skipped.not_optional += 1;
+      continue;
+    }
+    if (retrieval.answerability !== undefined && !options.force) {
+      selection.skipped.already_probed += 1;
+      continue;
+    }
+    // A turn with no prompt text cannot be re-scored at all - there is no query to embed. Counted
+    // rather than dropped so a corpus of voice turns or empty prompts is visible as a coverage
+    // hole instead of looking like a window with nothing in it.
+    const prompt = row.prompt?.trim();
+    if (!prompt) {
+      selection.skipped.no_prompt += 1;
+      continue;
+    }
+    if (!row.sessionId) {
+      selection.skipped.no_session += 1;
+      continue;
+    }
+    selection.targets.push({ questId: row._id, prompt, sessionId: row.sessionId });
+  }
+
+  return selection;
+};
+
+/**
+ * The probe record for one replayed turn.
+ *
+ * `topScore` is read off the results rather than recomputed: semanticDataLakeSearch returns them
+ * sorted by score descending, and taking the max here as well would only mask a future change to
+ * that ordering. An empty result set scores -1 rather than 0 - a real cosine can legitimately be
+ * 0 for an orthogonal chunk, so a sentinel below the valid range is what distinguishes "nothing
+ * came back" from "something came back and matched nothing". The admin endpoint bounds the
+ * cutoff to 0..1, so the sentinel always classifies as not-answerable there, which is what it
+ * means - a direct caller of the fold could pass a negative cutoff and would not want to.
+ *
+ * `floor` is stored alongside `candidatesAboveFloor` because the count is meaningless without the
+ * bar it was counted against, and the bar is a per-run flag.
+ */
+export const buildAnswerabilityProbe = (
+  results: ReadonlyArray<ScoredResult>,
+  scan: ScanAccounting,
+  options: { floor: number; probedAt: Date }
+): AnswerabilityProbe => ({
+  topScore: results.length > 0 ? results[0].score : -1,
+  candidatesAboveFloor: results.filter(result => result.score >= options.floor).length,
+  floor: options.floor,
+  scanTruncated: scan.truncated,
+  probedAt: options.probedAt,
+});
+
+export type ReplayTally = {
+  probed: number;
+  written: number;
+  failed: number;
+  skipped: Record<SkipReason, number>;
+};
+
+/**
+ * One block of plain text for the end of a run. Deliberately reports `probed` and `written`
+ * separately: a dry run probes everything and writes nothing, and on a real run a gap between the
+ * two is a write path failing quietly.
+ */
+export const formatReplaySummary = (tally: ReplayTally): string => {
+  const skippedTotal = Object.values(tally.skipped).reduce((sum, count) => sum + count, 0);
+  const lines = [
+    `probed:  ${tally.probed}`,
+    `written: ${tally.written}`,
+    `failed:  ${tally.failed}`,
+    `skipped: ${skippedTotal}`,
+  ];
+  for (const [reason, count] of Object.entries(tally.skipped)) {
+    if (count > 0) lines.push(`  ${reason}: ${count}`);
+  }
+  return lines.join('\n');
+};


### PR DESCRIPTION
## Description

Toward #1394, one checklist item: instrument document answerability so "the model should have
retrieved and didn't" is separable from "there was nothing to retrieve".

The optional-path retrieval rate is 20.1% - the model reaches for the corpus on about a fifth of
the turns where the tools are offered. That number cannot carry the routing decision on its own,
because it says nothing about the other four fifths. If those turns had nothing to find, the
optional path is behaving correctly and a classifier buys latency for nothing. If they were misses,
the gap is real. The issue's own decision rule depends on telling them apart, and nothing in the
telemetry does.

This adds the missing denominator: an offline replay re-scores each recorded prompt against the
corpus and records what retrieval *would* have found.

**Why offline, and why the runtime is untouched.** The population that matters is precisely the
turns where retrieval never ran. Measuring it live would mean adding an embedding call and a
brute-force chunk scan (the forced path has no ANN index) to exactly the turns that pay nothing for
retrieval today - a latency regression on the majority of traffic, levied to collect a metric. So
the writer is a script and the request path is unchanged.

**It under-counts answerable turns, deliberately.** It sees the session's lakes but not the caller's
own files, and a lake reachable at the time through an admission path that has since lapsed is
invisible to it. Both make a turn look less answerable than it was, so the "missed retrievals"
figure is a floor. A metric whose job is to justify building a classifier must not be the one
arguing for itself - the same reason `MODEL_INITIATED_SURFACES` is an allowlist.

## Changes

- `promptMeta.retrieval.answerability` (Zod + the Mongoose twin): `topScore`, `candidatesAboveFloor`,
  `floor`, `scanTruncated`, `probedAt`. Scalars only - no lake or file identity, so widening the
  fold's projection to reach it does not egress corpus identity the way `dataLakeTags` would.
- `summarizeOptionalPathRetrieval` crosses the probe with the existing rate to give the 2x2:
  `answerable` / `notAnswerable` / `unknown`, each against retrieved-or-not. The three arms always
  sum to `offeredTurns`.
- The probe stores a **raw cosine, not a verdict**, so the cutoff lives in the reader.
  `/api/admin/retrieval-rate` takes `answerableMinScore` and the tab exposes it as a field - the
  same replay can be swept at a different bar without re-running.
- `mergeRetrievalSummary` now preserves the probe. It returns an object literal, so a field with no
  case there is dropped, and a later runtime write on an already-replayed quest would have silently
  erased the backfill.
- `packages/scripts/retrieval/answerability-replay.ts` (runner) + `answerabilityReplay.ts` (pure,
  unit-tested), following the family's existing split.
- Admin Retrieval Rate tab renders the split, with an explicit "not replayed" state so an empty
  window cannot read as "the corpus is thin".
- Renamed the exported `GuidanceArm` type to `RateArm`, now that two different splits share it.
  Checked all five overlay repos for consumers - none - so this is not a breaking change and the
  title carries no `!`.

## Guide for Testers

The runtime is unchanged, so there is nothing to test in chat. Everything below is the admin panel.

**Part 1 - the panel before any replay has run**

1. Go to `app.staging.bike4mind.com` and sign in as an admin.
2. Navigate: Sidebar -> Admin -> Retrieval Rate.
3. Confirm the existing cards still render: "Optional-path retrieval rate", "After a
   forced-retrieval skip", "Forced turns", "Unclassified". Their numbers must be unchanged by this
   PR.
4. Find the new panel titled **"Could the corpus have answered?"** below those cards.
5. Expect the neutral notice: "No turn in this window has been replayed, so the split below is
   empty." This is the correct state before a replay - it must NOT show zeroes as if measured.
6. Confirm a new **"Answerable cutoff"** field appears next to Start date / End date, empty, with
   placeholder `default`.

**Part 2 - the cutoff is validated, not silently coerced**

7. Type `75` into "Answerable cutoff" and click Apply.
8. Expect an error rather than a result. (75 is a percentage; the field wants a cosine fraction.
   Accepting it would put the bar above every possible score and report a confident, wrong "nothing
   was answerable".)
9. Clear the field, type `0.8`, click Apply. Expect the panel to load normally.

**Part 3 - run the replay (needs a terminal, dev stage)**

10. Run, from the repo root:
    `for-env dev pnpm sst shell --stage dev -- packages/scripts/node_modules/.bin/tsx packages/scripts/retrieval/answerability-replay.ts --start 2026-08-12 --dry-run`
11. Expect a header block (stage, window, model, floor, targets), then a summary reporting
    `probed:` greater than 0 and `written: 0`. A dry run must probe and write nothing.
12. Re-run without `--dry-run`. Expect `written:` to equal `probed:`.
13. Re-run the same command a third time. Expect `probed: 0` and a skip tally showing
    `already_probed:` - the script is idempotent and must not re-probe.
14. Reload the Retrieval Rate tab. The "not replayed" notice is gone, replaced by three cards:
    "Missed retrievals", "Wasted retrievals", "Not replayed".
15. Change "Answerable cutoff" to `0.5`, Apply. Expect "Missed retrievals" to change without any
    re-run of the script - the stored scores are being re-thresholded.

**Regression Checks**

16. The four original stat cards report the same numbers as before this PR for the same date window.
17. Start date / End date filtering still works, and the "window exceeds the scan ceiling" warning
    still appears for a wide enough window.
18. Send a normal chat message in a session with a data lake attached. Confirm the reply is
    unaffected and arrives in the usual time - this PR must not change chat latency or behaviour at
    all.

**What NOT to test**

- The per-turn classifier. It does not exist; this PR is the measurement that decides whether to
  build it.
- The knowledge-base guidance A/B (#2540). Separate arms, separate readout, unchanged here.
- Retrieval quality or ranking. The replay reuses the existing search; it does not tune it.

## Additional Information

Three drifts are documented on the field itself and are inherent to reconstructing a measurement
after the fact, not defects to be fixed here:

1. Corpus **content** moves between the turn and the replay. `probedAt` discloses the gap.
2. Corpus **scope** is inferred. The seed writes `dataLakeTags: []` on a turn where retrieval never
   ran, so scope is reconstructed from the session's lakes as they stand now. Recording real scope
   at seed time would fix this going forward and is the natural follow-up - it was left out here
   because it is a runtime change and this PR deliberately makes none.
3. The **question** can move out from under the probe if a prompt is rewritten in place. `--force`
   re-probes.

Follow-ups worth filing rather than widening this PR:
- Record lake scope at the seed site so future turns need no reconstruction.
- The tab still does not render the `guidance` A/B arms from #2540 - that readout is JSON-only.

## Developer Notes

- **Data model**: `promptMeta.retrieval.answerability` is the first field in that block written by a
  backfill rather than by the turn. The pattern is reusable - the fold and the endpoint needed no
  knowledge of the writer, and `RETRIEVAL_RATE_FIELDS` being derived from
  `Record<keyof RetrievalRateInput, true>` meant widening the fold's input broke the build at the
  field set instead of silently folding an unselected column as `undefined`.
- **Separating writer from readout**: if this ever needs to be live, the writer swaps and nothing
  downstream changes.
- **Script split**: `answerability-replay.ts` (I/O) + `answerabilityReplay.ts` (pure, tested)
  follows `model-comparison.ts` / `modelComparison.ts`. The selection logic and the probe
  construction are unit-tested with no Mongo and no embeddings.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new setting
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a, admin telemetry
