### PR TITLE
docs(retrieval): record the measured embedding-model comparison

### DIFF
--- a/packages/scripts/retrieval/MODEL-COMPARISON.md
+++ b/packages/scripts/retrieval/MODEL-COMPARISON.md
@@ -218,17 +218,82 @@ and every cosine is the same width, so the only remaining difference is the one-
 
 ## Results
 
-No credentialed run has happened yet. **Do not fill this in from memory or estimate any cell** - the
-whole point of the harness is that the numbers come from a measurement.
+Captured 2026-09-11 against the `system-help` lake on the `dev` (staging) stage: 51 capturable files,
+452 chunks, 62 files unreachable by the served path. The baseline reused the corpus's stored ada-002
+vectors (0 excluded - no unlabeled, mismatched, missing or wrong-width vector), and both candidates
+were embedded fresh for $0.0140 total. Scores are exact cosine, NOT the ANN path prod measures
+through.
 
-| arm | chunks | band min | band max | width | spread | posTop | negTop | recall | mrr |
-|---|---|---|---|---|---|---|---|---|---|
-| `text-embedding-ada-002@1536` (baseline) | | | | | | | | | |
-| `text-embedding-3-small@1536` | | | | | | | | | |
-| `text-embedding-3-small@512` | | | | | | | | | |
-| `text-embedding-3-large@3072` | | | | | | | | | |
-| `text-embedding-3-large@1536` | | | | | | | | | |
-| `text-embedding-3-large@512` | | | | | | | | | |
+**This corpus is NOT in the long-document regime** (median chunk 638 chars against the prod reference
+of 2182), so read the table for what it can support and no further - see the findings below.
+
+| arm | chunks | band min | band max | width | spread | posTop | negTop | recall | prec | hit | mrr |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `text-embedding-ada-002@1536` (baseline) | 452 | 0.7191 | 0.8110 | 0.0918 | 0.0279 | 0.7699 | 0.7647 | 0.910 | 0.295 | 1.000 | 0.707 |
+| `text-embedding-3-small@1536` | 452 | 0.2293 | 0.5588 | 0.3294 | 0.0968 | 0.4269 | 0.3615 | 0.867 | 0.353 | 1.000 | 0.897 |
+| `text-embedding-3-small@512` | 452 | 0.2608 | 0.5719 | 0.3111 | 0.0940 | 0.4619 | 0.3939 | 0.833 | 0.306 | 0.960 | 0.843 |
+| `text-embedding-3-large@3072` | 452 | 0.2104 | 0.5197 | 0.3093 | 0.0984 | 0.4031 | 0.3246 | 0.877 | 0.338 | 1.000 | 0.890 |
+| `text-embedding-3-large@1536` | 452 | 0.2161 | 0.5430 | 0.3269 | 0.0977 | 0.4261 | 0.3499 | 0.843 | 0.323 | 1.000 | 0.890 |
+| `text-embedding-3-large@512` | 452 | 0.2458 | 0.5946 | 0.3488 | 0.0973 | 0.4599 | 0.3761 | 0.843 | 0.336 | 1.000 | 0.845 |
+
+`prec` and `hit` are added to the columns this section originally listed: the harness prints both, and
+`hit` is what carries the truncation finding below.
+
+### SETTLED: ada-002 loses on every axis that matters
+
+Band width 3.5x, rank-1-to-rank-10 spread 3.5x, MRR 0.707 -> 0.897. The decisive one is the gap between
+`posTop` and `negTop` - how far a real answer outscores the best false lead on a question the corpus
+cannot answer:
+
+| arm | posTop - negTop |
+|---|---|
+| `ada-002@1536` | **0.0052** |
+| `3-small@1536` | 0.0654 |
+| `3-small@512` | 0.0680 |
+| `3-large@1536` | 0.0762 |
+| `3-large@3072` | 0.0785 |
+| `3-large@512` | 0.0838 |
+
+Every 3-* arm separates answerable from unanswerable 12-16x better than ada-002, whose 0.0052 leaves no
+absolute floor able to tell them apart at all. This conclusion does not depend on the corpus regime.
+
+ada-002 does win `recall` (0.910 against 0.867). With `hit` at 1.000 for both that edge buys little - it
+drags more of the supporting set into the top 10 while ranking it worse - but it belongs in the table
+rather than dropped.
+
+### NOT SETTLED: 3-small against 3-large
+
+They are within noise of each other here, and `3-small` costs 6.5x less - which is exactly the tempting
+conclusion this corpus cannot support. At a 638-char median this run reproduces the short-text regime
+the Mementos table was already in, where small ties large for the stated reason that the extra capacity
+is for long documents. Untested, not refuted. **Do not record a model verdict from this run.**
+
+### NEW: 512-dim truncation is not free at this chunk size
+
+Mementos measured 512 lossless on short facts (`b4m-core/memory/src/eval/dimensions.test.ts`). Here it
+costs real quality: `3-small` MRR 0.897 -> 0.843 and hit 1.000 -> 0.960, `3-large` MRR 0.890 -> 0.845.
+`3-small@512` is the only arm in the table that fails to place a supporting document in the top 10 for
+every question. Two points now sit on that curve - lossless at memento length, lossy at 638 chars - and
+the FAB corpus at 2182 chars sits further along the same axis, so expect the loss to grow rather than
+shrink. Directional, not proven.
+
+### NEW: what the measured bands do to the live cosine floors
+
+`3-small@1536` spans 0.2293-0.5588 and `3-large@3072` spans 0.2104-0.5197. The `0.75` floors in
+`forcedRetrieval.ts`, `ChatCompletionFeatures.ts` and `getFirstIterationMementosPreamble.ts` sit ABOVE
+the whole band in either space, so after the flip they reject every chunk on every query - the silent
+outage `b4m-core/common/src/schemas/embedding.ts` records this codebase hitting twice already.
+
+A FAB replacement floor is bracketed by `posTop` and `negTop`: roughly 0.38-0.40 for `3-small@1536`.
+That is NOT `MEMENTO_MIN_SIMILARITY` (0.25), which sits below this corpus's `negTop` of 0.3615 and would
+admit the noise. The memento floor does not transfer to the file corpus.
+
+`FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT` (85) changes character on the flip. Under ada-002 a
+per-turn spread of 0.0279 against a top near 0.77 puts rank 10 at ~96% of rank 1, so 85 rejects nothing.
+Under `3-small` a spread of ~0.097 against a top near 0.43 puts rank 10 near 78%, so 85 begins cutting
+around rank 5-6. Given precision of 0.35 that may well be an improvement, but it is a dormant gate
+switching on rather than a no-op, and it is the opposite direction from the "tune it UPWARD" note at its
+definition.
 
 ## Out of scope
 


### PR DESCRIPTION
# Pull Request

## Description

`MODEL-COMPARISON.md`'s Results table shipped empty in #2470, with an explicit instruction not to
fill it in from memory. This fills it in from the first credentialed run of the harness.

Captured against the `system-help` lake on staging: 51 capturable files, 452 chunks, 62 files
unreachable by the served path. The baseline reused the corpus's stored ada-002 vectors (0 excluded -
no unlabeled, mismatched, missing or wrong-width vector); both candidates were embedded fresh for
$0.0140 total. Scores are exact cosine, not the ANN path the earlier production probe measured
through.

**The instrument check passes.** The ada-002 arm reproduces the 0.72-0.81 cosine band that #471
documents, measured here on an entirely different corpus (0.7191 - 0.8110). The harness reproducing
an independently published number is what makes the rest of the table worth reading.

## Changes

- Fills the six measured rows into the Results table, and adds `prec` and `hit` to the column set
  the section originally listed (the harness prints both, and `hit` is what carries the truncation
  finding). The addition is called out in the doc so it does not read as drift.
- Adds provenance above the table: stage, corpus size, reuse-vs-embed split, cost, and the
  exact-cosine caveat.
- Adds four findings sections:
  - **SETTLED: ada-002 loses on every axis that matters.** Band width 3.5x, rank spread 3.5x, MRR
    0.707 -> 0.897, and `posTop - negTop` separation 12-16x better on every 3-* arm (ada-002's is
    0.0052, which leaves no absolute floor able to separate an answerable question from an
    unanswerable one). Regime-independent.
  - **NOT SETTLED: 3-small against 3-large.** The regime gate fired (median chunk 638 chars against
    a prod reference of 2182). The two are within noise here, which reproduces the short-text regime
    the Mementos table was already in - the exact bias the harness exists to remove. Recorded as
    untested, not refuted.
  - **NEW: 512-dim truncation is not free at this chunk size.** `3-small` hit 1.000 -> 0.960 and MRR
    0.897 -> 0.843, where the memory corpus measured 512 lossless on short facts.
  - **NEW: what the measured bands do to the live cosine floors.** The `0.75` literals sit above the
    entire band in either candidate space, so the flip would reject every chunk on every query; and
    the 85 percent relative floor goes from inert under ada-002 to cutting around rank 5-6.

The measurement and these findings are also posted on #471 so the decision record lives with the
issue.

## Guide for Testers

Doc-only. Nothing to exercise in the app, and no reviewer needs credentials to check the arithmetic.

To verify the harness still renders the table end to end (no credentials, no network):

1. From the repo root, run:
   `pnpm --filter @bike4mind/scripts retrieval:model-comparison --fixtures retrieval/fixtures/tiny-comparison.fixture.json --widths 16,8`
2. Expected: a comparison table prints, plus a note that the fixture is synthetic. No number it
   produces is a measurement of any embedding model.
3. Run `pnpm --filter @bike4mind/scripts test retrieval/` - expected: all tests pass.

### What NOT to test

No UI, no API, no setting, and no data changed. `defaultEmbeddingModel` is untouched, no cosine floor
was moved, and no corpus was re-embedded - all of those are later steps in #471 that depend on this
result.

## Additional Information

Two things a reviewer should push back on if they disagree:

1. **The refusal to pick a model is deliberate.** The cheap read of this table is "3-small ties
   3-large and costs 6.5x less, ship it." That is the conclusion the corpus cannot support, and
   writing it down would re-introduce the bias #2470 was built to remove. The model+width choice
   needs a long-document lake.
2. **`system-help` cannot become that lake.** Its articles are shorter documents, not
   coarsely-chunked long ones. Raising `chunkByHeadings`'s `minSectionLength` would merge unrelated
   H2 sections and pass the gate without answering the question, so it is recorded as a fallback
   rather than the plan.

Also worth noting for whoever picks up the floor work: the bracketed FAB floor (~0.38-0.40 for
`3-small@1536`) is NOT `MEMENTO_MIN_SIMILARITY` (0.25), which sits below this corpus's `negTop` of
0.3615 and would admit the noise. The memento floor does not transfer to the file corpus.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [ ] I have commented my code, particularly in hard-to-understand areas - n/a, doc-only
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
