### PR TITLE
feat(admin): render the guidance A/B arms on the Retrieval Rate panel

### DIFF
--- a/apps/client/app/components/admin/RetrievalRateTab.test.tsx
+++ b/apps/client/app/components/admin/RetrievalRateTab.test.tsx
@@ -164,6 +164,112 @@ describe('RetrievalRateTab', () => {
     expect(within(section).getByText('7')).toBeTruthy();
   });
 
+  it('renders the guidance A/B arms and the lift between them', async () => {
+    renderTab();
+    // The lift is hand-computed in the component, so this pins the arithmetic and the sign:
+    // 35.0% with the section against 20.0% without it. Scoped to the section because the arm
+    // denominators overlap other cards in this fixture.
+    const section = await screen.findByTestId('retrieval-rate-guidance');
+    expect(within(section).getByText('+15.0 pp')).toBeTruthy();
+    expect(within(section).getByText('35.0%')).toBeTruthy();
+    expect(within(section).getByText('7 of 20 turns carrying the section')).toBeTruthy();
+    expect(within(section).getByText('20.0%')).toBeTruthy();
+    expect(within(section).getByText('3 of 15 turns with the setting cleared')).toBeTruthy();
+    // Pre-flag turns are their own arm, not the control group.
+    expect(within(section).getByText('5')).toBeTruthy();
+  });
+
+  it('signs a lift that went the wrong way rather than dropping the sign', async () => {
+    mockGet.mockResolvedValue(
+      response({
+        summary: summary({
+          guidance: {
+            injected: { turns: 20, retrievedTurns: 4, rate: 0.2 },
+            notInjected: { turns: 20, retrievedTurns: 7, rate: 0.35 },
+            unrecorded: { turns: 5, retrievedTurns: 0, rate: 0 },
+          },
+        }),
+      })
+    );
+    renderTab();
+    const section = await screen.findByTestId('retrieval-rate-guidance');
+    expect(within(section).getByText('-15.0 pp')).toBeTruthy();
+  });
+
+  it('distinguishes a measured no-effect from an unmeasurable one', async () => {
+    // The pair to the empty-control case below: both arms ran, and the section moved nothing. That
+    // has to read as a result (+0.0 pp), never as the n/a an absent arm gets.
+    mockGet.mockResolvedValue(
+      response({
+        summary: summary({
+          guidance: {
+            injected: { turns: 20, retrievedTurns: 4, rate: 0.2 },
+            notInjected: { turns: 15, retrievedTurns: 3, rate: 0.2 },
+            unrecorded: { turns: 5, retrievedTurns: 0, rate: 0 },
+          },
+        }),
+      })
+    );
+    renderTab();
+    const section = await screen.findByTestId('retrieval-rate-guidance');
+    expect(within(section).getByText('+0.0 pp')).toBeTruthy();
+    expect(within(section).queryByText('n/a')).toBeNull();
+  });
+
+  it('reports an absent control arm instead of a zero lift', async () => {
+    // The failure this guards: nobody has cleared the setting, so there is no comparison - which
+    // must not render as "the section was tried and moved nothing".
+    mockGet.mockResolvedValue(
+      response({
+        summary: summary({
+          guidance: {
+            injected: { turns: 35, retrievedTurns: 7, rate: 0.2 },
+            notInjected: { turns: 0, retrievedTurns: 0, rate: null },
+            unrecorded: { turns: 5, retrievedTurns: 0, rate: 0 },
+          },
+        }),
+      })
+    );
+    renderTab();
+    const alert = await screen.findByTestId('retrieval-rate-guidance-no-control');
+    expect(alert.textContent).toContain('KnowledgeBaseRetrievalPrompt');
+    const section = screen.getByTestId('retrieval-rate-guidance');
+    expect(within(section).queryByText('+0.0 pp')).toBeNull();
+    // The treatment arm is the live rate and stays readable without a control to compare it to.
+    expect(within(section).getByText('7 of 35 turns carrying the section')).toBeTruthy();
+  });
+
+  it('does not ask for a control arm when there is no optional-path traffic at all', async () => {
+    // An empty window is not a one-armed experiment, and telling the operator to clear a setting
+    // would send them after traffic that does not exist.
+    mockGet.mockResolvedValue(
+      response({
+        summary: summary({
+          offeredTurns: 0,
+          retrievedTurns: 0,
+          rate: null,
+          guidance: {
+            injected: { turns: 0, retrievedTurns: 0, rate: null },
+            notInjected: { turns: 0, retrievedTurns: 0, rate: null },
+            unrecorded: { turns: 0, retrievedTurns: 0, rate: null },
+          },
+        }),
+      })
+    );
+    renderTab();
+    await screen.findByTestId('retrieval-rate-guidance');
+    expect(screen.queryByTestId('retrieval-rate-guidance-no-control')).toBeNull();
+  });
+
+  it('renders the rest of the panel when the response predates the guidance field', async () => {
+    // Same shape as the answerability case below: the fold always emits `guidance`, but a response
+    // from an API pod behind the client bundle does not have to.
+    mockGet.mockResolvedValue(response({ summary: summary({ guidance: undefined }) }));
+    renderTab();
+    expect(await screen.findByText('25.0%')).toBeTruthy();
+    expect(screen.queryByTestId('retrieval-rate-guidance')).toBeNull();
+  });
+
   it('renders the rest of the panel when the response predates the answerability field', async () => {
     // A real shape, not a hypothetical: an API pod one deploy behind the client bundle returns
     // exactly this - the fold gained the field, but the response this request actually got did

--- a/apps/client/app/components/admin/RetrievalRateTab.tsx
+++ b/apps/client/app/components/admin/RetrievalRateTab.tsx
@@ -11,7 +11,7 @@ import Input from '@mui/joy/Input';
 import Sheet from '@mui/joy/Sheet';
 import Stack from '@mui/joy/Stack';
 import Typography from '@mui/joy/Typography';
-import type { OptionalPathRetrievalRate } from '@bike4mind/common';
+import type { OptionalPathRetrievalRate, RateArm } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
 
 /**
@@ -47,6 +47,24 @@ const formatDate = (iso: string | null): string => (iso ? new Date(iso).toLocale
  */
 const missRate = (arm: { turns: number; retrievedTurns: number }): number | null =>
   arm.turns === 0 ? null : (arm.turns - arm.retrievedTurns) / arm.turns;
+
+/**
+ * The A/B's verdict: treatment rate minus control rate. Null unless BOTH arms hold turns - a lift
+ * measured against an empty control arm is not a small effect, it is no comparison at all, and
+ * rendering it as 0 would report the section as having been tried and found useless.
+ *
+ * Recomputed from the two counts rather than read off `arm.rate` so it cannot contradict either
+ * the denominators printed beside it or the empty-control banner, which ask `turns` the same
+ * question. Equivalent at the producer, which sets every arm's rate from exactly this ratio.
+ */
+const rateLift = (treatment: RateArm, control: RateArm): number | null =>
+  treatment.turns === 0 || control.turns === 0
+    ? null
+    : treatment.retrievedTurns / treatment.turns - control.retrievedTurns / control.turns;
+
+/** Signed percentage points, because a difference of rates is not itself a rate. */
+const formatLift = (lift: number | null): string =>
+  lift === null ? 'n/a' : `${lift < 0 ? '-' : '+'}${Math.abs(lift * 100).toFixed(1)} pp`;
 
 function StatCard({ label, value, caption }: { label: string; value: string; caption: string }) {
   return (
@@ -247,6 +265,58 @@ export default function RetrievalRateTab() {
                 Replayed after the fact, not measured during the turn: the corpus may have moved since, and for turns
                 where retrieval never ran the lake scope is reconstructed from the session as it stands now. Treat a
                 replay run long after the window as weak evidence.
+              </Typography>
+            </Sheet>
+          )}
+
+          {/* Guarded for the same reason the answerability section above is: a response from an API
+             pod one deploy behind the client bundle predates the field. */}
+          {summary.guidance && (
+            <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }} data-testid="retrieval-rate-guidance">
+              <Typography level="title-sm">Does the when-to-retrieve guidance help?</Typography>
+              <Typography level="body-xs" textColor="text.secondary" sx={{ mb: 1.5 }}>
+                Offered turns split by whether the knowledge-base when-to-retrieve section shipped on the turn. The
+                control arm is produced by clearing the KnowledgeBaseRetrievalPrompt admin setting, which needs no
+                deploy to throw.
+              </Typography>
+
+              {/* Unlike the answerability split, the arms stay visible with no control traffic: the
+                 treatment arm is the live rate and is worth reading on its own. */}
+              {summary.guidance.injected.turns > 0 && summary.guidance.notInjected.turns === 0 && (
+                <Alert color="neutral" sx={{ mb: 1.5 }} data-testid="retrieval-rate-guidance-no-control">
+                  No offered turn in this window ran with the section cleared, so there is no control arm and no lift to
+                  read. Clear the KnowledgeBaseRetrievalPrompt admin setting to open one.
+                </Alert>
+              )}
+
+              <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap' }}>
+                <StatCard
+                  label="Lift from guidance"
+                  value={formatLift(rateLift(summary.guidance.injected, summary.guidance.notInjected))}
+                  caption="Retrieval rate with the section minus the rate without it"
+                />
+                <StatCard
+                  label="With guidance"
+                  value={formatRate(summary.guidance.injected.rate)}
+                  caption={`${summary.guidance.injected.retrievedTurns.toLocaleString()} of ${summary.guidance.injected.turns.toLocaleString()} turns carrying the section`}
+                />
+                <StatCard
+                  label="Without guidance"
+                  value={formatRate(summary.guidance.notInjected.rate)}
+                  caption={`${summary.guidance.notInjected.retrievedTurns.toLocaleString()} of ${summary.guidance.notInjected.turns.toLocaleString()} turns with the setting cleared`}
+                />
+                <StatCard
+                  label="Unrecorded"
+                  value={summary.guidance.unrecorded.turns.toLocaleString()}
+                  caption="Excluded from both arms - offered turns from before the flag shipped, not a control group"
+                />
+              </Stack>
+
+              <Typography level="body-xs" textColor="text.secondary" sx={{ mt: 1 }}>
+                The arms are whatever traffic arrived, not a matched sample: they are not balanced on answerability, so
+                a lift over few turns can be a difference in the questions asked rather than in the section. A non-zero
+                Unrecorded count means the window reaches back before the flag shipped - narrow the dates to drop those
+                turns rather than reading them as a third arm.
               </Typography>
             </Sheet>
           )}


### PR DESCRIPTION
# Pull Request

## Description

Closes #2703.

The knowledge-base when-to-retrieve guidance A/B (#2540) has been in the retrieval-rate fold since
it shipped -- `guidance.injected` / `notInjected` / `unrecorded` -- but the admin panel never grew a
section for it. It rendered the headline optional-path rate and the answerability split (#2699) and
left the A/B JSON-only behind `/api/admin/retrieval-rate`. This adds the matching section so the
comparison the routing decision in #1394 depends on is readable without curling the endpoint.

The new section sits beside the answerability split it mirrors (#2699), and follows both that
section's card layout and its guard against a response from an API pod one deploy behind the client
bundle.

## Changes

- New "Does the when-to-retrieve guidance help?" section in `RetrievalRateTab.tsx`, styled like the
  existing answerability split: lift, with-guidance rate, without-guidance rate, unrecorded count.
- Lift is recomputed from each arm's `turns`/`retrievedTurns` rather than read off the transmitted
  `rate`, so it can never contradict the denominators printed beside it.
- An empty control arm (nobody has cleared `KnowledgeBaseRetrievalPrompt` yet) renders as `n/a`
  behind a banner naming the setting, never as a `0 pp` lift -- "no experiment run" must not read as
  "experiment run, no effect".
- The Unrecorded arm is captioned as pre-#2540 history, not a third live arm: only the seed in
  `ChatCompletionProcess` writes `mode: 'optional'`, and it records the flag whenever it writes that
  mode, so turns bypassing the seed land in `unclassifiedTurns` instead and can never reach here.
- 8 new tests in `RetrievalRateTab.test.tsx` covering the lift's sign in both directions, the
  measured-no-effect vs. unmeasurable-no-effect distinction, the empty-control banner, the
  no-optional-traffic case (banner must not fire), and the pre-flag-field degrade path.

## Guide for Testers

This is an admin-only, read-only panel change with no new admin setting and no data-model change --
same policy as #2699's testing guide.

1. Go to `app.staging.bike4mind.com` -> Admin (sidebar) -> Retrieval Rate tab.
2. The existing "Optional-path retrieval rate" and "Could the corpus have answered?" sections
   render as before.
3. A new "Does the when-to-retrieve guidance help?" section appears below them, with four cards:
   Lift from guidance, With guidance, Without guidance, Unrecorded.
4. If the `KnowledgeBaseRetrievalPrompt` admin setting has never been cleared on this environment,
   the Lift card reads `n/a` and a neutral banner above the cards names the setting to clear to open
   a control arm -- it does not read `+0.0 pp`.
5. No new admin setting is introduced by this PR; nothing to add to Staging/prod/hydration.

### What NOT to test

- No behavior change to retrieval itself, forced-retrieval routing, or the `KnowledgeBaseRetrievalPrompt`
  section's injection logic -- this PR only renders numbers the fold already produces.
- Not blocked on live A/B traffic: the section renders correctly with zero `notInjected` turns (that
  is exactly the "no control arm yet" case covered above).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- N/A, no new setting
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have made corresponding changes to the documentation (if applicable) -- N/A, no docs page covers this panel
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- N/A, no new field; renders an existing one
