### PR TITLE
fix(retrieval): drop the inert Lake rung from the data-lake scan budgets

### DIFF
--- a/apps/client/app/components/admin/ScopedOverridesByScope.test.tsx
+++ b/apps/client/app/components/admin/ScopedOverridesByScope.test.tsx
@@ -107,6 +107,29 @@ describe('ScopedOverridesByScope', () => {
     );
   });
 
+  // #2624 removed the Lake rung from the data-lake scan budgets. A row saved there before that is
+  // still in the collection and is no longer resolved, so calling it "overridden here" would show
+  // the operator a value that nothing reads.
+  it('reports a stored override at a rung the setting lost as inert, and still offers Clear', () => {
+    overrides = [
+      {
+        settingName: 'dataLakeSearchMaxFiles',
+        scopeLevel: 'lake',
+        scopeId: 'lake-1',
+        settingValue: '1',
+      } as IScopedSetting,
+    ];
+    renderPanel();
+    fireEvent.click(screen.getByTestId('scoped-overrides-by-scope-level-select'));
+    fireEvent.click(screen.getByTestId('scoped-overrides-by-scope-level-option-lake'));
+    enterAddress('lake-1');
+
+    const inertRow = screen.getByTestId('scoped-overrides-by-scope-row-dataLakeSearchMaxFiles');
+    expect(inertRow).toHaveTextContent('1 is stored here, but it is inert');
+    expect(inertRow).not.toHaveTextContent('overridden here');
+    expect(screen.getByTestId('scoped-overrides-by-scope-clear-btn-dataLakeSearchMaxFiles')).toBeInTheDocument();
+  });
+
   it('clears the override at the address it is listed under', () => {
     overrides = [
       {

--- a/apps/client/app/components/admin/ScopedOverridesByScope.tsx
+++ b/apps/client/app/components/admin/ScopedOverridesByScope.tsx
@@ -8,9 +8,33 @@ import { getErrorMessage } from '@client/app/utils/error';
 import TuneIcon from '@mui/icons-material/Tune';
 import { Alert, Box, Button, Card, FormControl, FormLabel, Input, Option, Select, Stack, Typography } from '@mui/joy';
 import { useMemo, useState } from 'react';
-import { displayValue, LEVEL_LABELS, OVERRIDE_STALENESS_NOTE, type OverrideLevel } from './ScopedSettingOverrides';
+import {
+  displayValue,
+  INERT_RUNG_NOTE,
+  LEVEL_LABELS,
+  OVERRIDE_STALENESS_NOTE,
+  type AdminSetting,
+  type OverrideLevel,
+} from './ScopedSettingOverrides';
 
 const ALL_LEVELS: OverrideLevel[] = [SettingScopeLevel.Organization, SettingScopeLevel.Owner, SettingScopeLevel.Lake];
+
+/** See INERT_RUNG_NOTE for why a stored value at an unsettable rung is not reported as applying. */
+function describeOverride(
+  setting: AdminSetting,
+  storedValue: string | undefined,
+  isSettableHere: boolean,
+  platformValue: string
+): string {
+  if (storedValue === undefined) {
+    return isSettableHere
+      ? `no override at this rung (platform: ${displayValue(setting, platformValue)})`
+      : 'not settable at this rung';
+  }
+  return isSettableHere
+    ? `overridden here: ${displayValue(setting, storedValue)}`
+    : `${displayValue(setting, storedValue)} is stored here, but it is ${INERT_RUNG_NOTE}`;
+}
 
 /**
  * The inverse view of the per-setting sections: given one scope address, which scope-capable
@@ -113,11 +137,7 @@ export function ScopedOverridesByScope() {
                 <Typography level="body-sm" sx={{ flex: 1, minWidth: 0 }}>
                   <strong>{setting.name}</strong>
                   {' - '}
-                  {override
-                    ? `overridden here: ${displayValue(setting, override.settingValue)}`
-                    : isSettableHere
-                      ? `no override at this rung (platform: ${displayValue(setting, String(platformValue))})`
-                      : 'not settable at this rung'}
+                  {describeOverride(setting, override?.settingValue, isSettableHere, String(platformValue))}
                 </Typography>
                 {override && (
                   <Button

--- a/apps/client/app/components/admin/ScopedSettingOverrides.test.tsx
+++ b/apps/client/app/components/admin/ScopedSettingOverrides.test.tsx
@@ -70,6 +70,15 @@ describe('ScopedSettingOverrides level options', () => {
     expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual(['Organization', 'Owner']);
   });
 
+  // The operator-facing half of #2624: the Lake option is what let an inert override be saved in
+  // the first place, so the picker - not just the schema - is where its absence has to be pinned.
+  it('offers no lake rung on a data-lake scan budget, so an inert override cannot be created', () => {
+    renderSection(settingsMap.dataLakeSearchMaxFiles);
+    fireEvent.click(screen.getByTestId('scoped-override-dataLakeSearchMaxFiles-level-select'));
+
+    expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual(['Organization', 'Owner']);
+  });
+
   it('renders nothing for a setting that does not opt into scoping', () => {
     renderSection(settingsMap.DefaultAPIModel);
     expect(screen.queryByTestId('scoped-override-DefaultAPIModel-header')).not.toBeInTheDocument();
@@ -224,6 +233,26 @@ describe('ScopedSettingOverrides existing rows', () => {
       scopeLevel: 'lake',
       scopeId: 'lake-1',
     });
+  });
+
+  // #2624 removed the Lake rung from the data-lake scan budgets. Overrides an operator already
+  // saved there stay in the collection and are never read again, so the row has to say so - listing
+  // one under "Scoped overrides" with no qualifier repeats the lie the rung removal was meant to end.
+  it('marks a stored override at a rung the setting no longer declares as inert, and keeps Clear', () => {
+    overrides = [
+      row({ settingName: 'dataLakeSearchMaxFiles', scopeLevel: 'lake', scopeId: 'lake-1', settingValue: '1' }),
+      row({ settingName: 'dataLakeSearchMaxFiles', scopeLevel: 'organization', scopeId: 'org-1', settingValue: '2' }),
+    ];
+    renderSection(settingsMap.dataLakeSearchMaxFiles);
+
+    expect(screen.getByTestId('scoped-override-dataLakeSearchMaxFiles-row-lake-lake-1')).toHaveTextContent(
+      'Lake lake-1 = 1 - inert - no longer settable at this rung'
+    );
+    // The still-settable rung is untouched, so the note cannot be a blanket suffix.
+    expect(screen.getByTestId('scoped-override-dataLakeSearchMaxFiles-row-organization-org-1')).not.toHaveTextContent(
+      'inert'
+    );
+    expect(screen.getByTestId('scoped-override-dataLakeSearchMaxFiles-clear-btn-lake-lake-1')).toBeInTheDocument();
   });
 
   it('says so when nothing is overridden, and discloses the propagation delay', () => {

--- a/apps/client/app/components/admin/ScopedSettingOverrides.tsx
+++ b/apps/client/app/components/admin/ScopedSettingOverrides.tsx
@@ -40,6 +40,15 @@ export const LEVEL_LABELS: Record<OverrideLevel, string> = {
 export const OVERRIDE_STALENESS_NOTE =
   'A change applies immediately on the instance that served it and within ~5 min (one cache TTL) everywhere else.';
 
+/**
+ * A stored override outlives the rung it was written at: dropping a level from a setting's
+ * `settableAt` leaves rows already saved there in the collection, where the resolver no longer
+ * looks for them (#2624 did exactly that to the data-lake scan budgets). Presenting one as a value
+ * that applies would repeat the lie the removal was meant to end, so both override views label it
+ * and both keep offering Clear. Shared so the two cannot drift into saying different things.
+ */
+export const INERT_RUNG_NOTE = 'inert - no longer settable at this rung, so nothing reads it';
+
 /** Booleans are stored as 'true'/'false'; show the operator the switch position, not the string. */
 export const displayValue = (setting: AdminSetting, storedValue: string): string =>
   setting.type === 'boolean' ? (storedValue === 'true' ? 'On' : 'Off') : storedValue;
@@ -120,6 +129,7 @@ const ScopedSettingOverrides = ({ setting }: { setting: AdminSetting }) => {
               <Typography level="body-sm" sx={{ flex: 1, minWidth: 0 }}>
                 <strong>{LEVEL_LABELS[row.scopeLevel]}</strong> {row.scopeId}
                 {row.ownerType ? ` (${row.ownerType})` : ''} = {displayValue(setting, row.settingValue)}
+                {settableAt.includes(row.scopeLevel) ? '' : ` - ${INERT_RUNG_NOTE}`}
               </Typography>
               <Button
                 data-testid={`scoped-override-${setting.key}-clear-btn-${row.scopeLevel}-${row.scopeId}`}

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -609,6 +609,29 @@ describe('forcedRetrievalCharBudget agrees with the forced-retrieval fallback (#
   });
 });
 
+describe('data-lake scan budgets are caller-altitude, not per-lake (#2624)', () => {
+  const SCAN_BUDGET_KEYS = ['dataLakeSearchMaxFiles', 'dataLakeSearchMaxChunks'] as const;
+
+  it('declares Organization and Owner but NOT Lake', () => {
+    // These two advertised a Lake rung that no retrieval caller ever resolved, so an operator could
+    // save a Lake-scoped override, see it in the admin UI, and have every search keep using the
+    // platform value. The rung is not merely unwired: resolveRetrievalLakeScope hands one scan every
+    // lake the caller can reach as a single dataLakeTags array, so there is no lakeId to key on.
+    // Restoring Lake here without per-lake sub-budgets in the scan would re-create that same lie.
+    for (const key of SCAN_BUDGET_KEYS) {
+      expect(settingsMap[key].scope?.settableAt).toEqual([SettingScopeLevel.Organization, SettingScopeLevel.Owner]);
+    }
+  });
+
+  it('still declares a scope, so the read path must stay on the scoped resolver', () => {
+    // Dropping the block entirely would be the wrong fix: the Org and Owner rungs are resolvable
+    // (the caller is known) and resolveSearchBudgets honors them. Only Lake was unkeyable.
+    for (const key of SCAN_BUDGET_KEYS) {
+      expect(settingsMap[key].scope).toBeDefined();
+    }
+  });
+});
+
 describe('forced-retrieval relevance floors are levers (#2497)', () => {
   const FLOOR_KEYS = ['forcedRetrievalRelativeFloorPct', 'forcedRetrievalMinSimilarityPct'] as const;
 
@@ -662,7 +685,7 @@ describe('forced-retrieval relevance floors are levers (#2497)', () => {
     expect(settingsMap.forcedRetrievalMinSimilarityPct.schema.parse(1)).toBe(1);
   });
 
-  it('is settable at org and owner but NOT per lake, unlike dataLakeSearchMaxChunks', () => {
+  it('is settable at org and owner but NOT per lake', () => {
     // Deliberate, and the reason is structural rather than an oversight: one forced-retrieval turn
     // scans an uncapped SET of lakes into a single pool with a single top score, so there is no one
     // lake for a narrower rung to key on. Same call as kbSearchMinRelevancePct, whose corpus has the
@@ -672,7 +695,6 @@ describe('forced-retrieval relevance floors are levers (#2497)', () => {
       expect(settingsMap[key].scope?.settableAt).toEqual([SettingScopeLevel.Organization, SettingScopeLevel.Owner]);
       expect(settingsMap[key].scope?.settableAt).not.toContain(SettingScopeLevel.Lake);
     }
-    expect(settingsMap.dataLakeSearchMaxChunks.scope?.settableAt).toContain(SettingScopeLevel.Lake);
   });
 
   it('declares a scope, so the read path must go through the scoped resolver', () => {
@@ -724,9 +746,10 @@ describe('kbSearchDefaultResults agrees with the search_knowledge_base tool fall
 
   it('is settable at the org/owner (caller) altitude, but deliberately not at Lake (#1955)', () => {
     // A knowledge-base search spans a mixed multi-lake corpus plus the caller's own/shared files -
-    // there is no single lake for a Lake rung to key on, unlike dataLakeSearchMaxFiles/MaxChunks
-    // (which scan one lake at a time and do declare Lake). Pinned so adding Lake later is a
-    // deliberate decision rather than silent drift.
+    // there is no single lake for a Lake rung to key on. dataLakeSearchMaxFiles/MaxChunks were once
+    // believed to differ (one lake at a time) and declared Lake on that basis; #2624 found the
+    // premise false and they now match. Pinned so adding Lake later is a deliberate decision
+    // rather than silent drift.
     expect(settingsMap.kbSearchDefaultResults.scope?.settableAt).toEqual([
       SettingScopeLevel.Organization,
       SettingScopeLevel.Owner,

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3425,8 +3425,13 @@ export const settingsMap = {
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 2,
-    // A scan budget an org/owner/lake may tighten below the platform ceiling (#1661 org/lake rungs).
-    scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner, SettingScopeLevel.Lake] },
+    // A scan budget an org/owner may tighten below the platform ceiling. No Lake rung (#2624): one
+    // search is not scoped to one lake - resolveRetrievalLakeScope hands the scan EVERY lake the
+    // caller can reach as a single dataLakeTags array and the scan walks that whole set in one pass,
+    // so there is no single lakeId for a narrower rung to key on. The rung was declared here
+    // speculatively and no caller ever resolved it, so a Lake-scoped override was silently inert.
+    // Reinstating it needs per-lake sub-budgets in the scan first, not just this line.
+    scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
   }),
   dataLakeSearchMaxChunks: makeNumberSetting({
     key: 'dataLakeSearchMaxChunks',
@@ -3438,7 +3443,8 @@ export const settingsMap = {
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 3,
-    scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner, SettingScopeLevel.Lake] },
+    // Same rungs, and the same reason for no Lake rung, as dataLakeSearchMaxFiles above (#2624).
+    scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
   }),
   forcedRetrievalCharBudget: makeNumberSetting({
     key: 'forcedRetrievalCharBudget',
@@ -3490,8 +3496,9 @@ export const settingsMap = {
     order: 5,
     // Caller altitude (#1955): a knowledge-base search spans a mixed multi-lake corpus plus the
     // caller's own/shared files (see the "MIXED corpus" comment on trySemanticKbSearch's lakeIds
-    // in knowledgeBaseSearch/index.ts), so there is no single lake for a Lake rung to key on -
-    // unlike dataLakeSearchMaxFiles/MaxChunks below, which scan one lake at a time.
+    // in knowledgeBaseSearch/index.ts), so there is no single lake for a Lake rung to key on. The
+    // same turned out to be true of dataLakeSearchMaxFiles/MaxChunks below, which were believed to
+    // scan one lake at a time and do not: they lost their Lake rung in #2624.
     scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
   }),
   kbSearchResultTokenBudget: makeNumberSetting({
@@ -3589,10 +3596,11 @@ export const settingsMap = {
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 9,
-    // Organization/Owner only, no Lake rung - deliberately matching kbSearchMinRelevancePct rather
-    // than dataLakeSearchMaxChunks. A forced-retrieval turn scans an uncapped SET of lakes into one
-    // pool with one top score, so there is no single lake for a narrower rung to key on, and the
-    // relative floor is a per-turn quantity by construction. See scopeForCaller's doc comment.
+    // Organization/Owner only, no Lake rung - the altitude every retrieval-budget setting settles
+    // at, kbSearchMinRelevancePct and dataLakeSearchMaxFiles/MaxChunks (#2624) included, and for
+    // the same reason. A forced-retrieval turn scans an uncapped SET of lakes into one pool with
+    // one top score, so there is no single lake for a narrower rung to key on, and the relative
+    // floor is a per-turn quantity by construction. See scopeForCaller's doc comment.
     scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
   }),
   forcedRetrievalMinSimilarityPct: makeNumberSetting({

--- a/b4m-core/services/src/dataLakeService/resolveSearchBudgets.test.ts
+++ b/b4m-core/services/src/dataLakeService/resolveSearchBudgets.test.ts
@@ -124,15 +124,42 @@ describe('resolveSearchBudgets - scoped path', () => {
   it('a narrower override tightens the budget below the platform ceiling', async () => {
     const db = makeDb({ dataLakeSearchMaxFiles: '3000', dataLakeSearchMaxChunks: '50000' }, [
       {
-        scopeLevel: SettingScopeLevel.Lake,
-        scopeId: 'l1',
+        scopeLevel: SettingScopeLevel.Organization,
+        scopeId: 'o1',
         settingName: 'dataLakeSearchMaxFiles',
         settingValue: '1000',
       },
     ]);
     const budgets = await resolveSearchBudgets(db, undefined, scope);
-    expect(budgets.maxFiles).toBe(1000); // lake override
+    expect(budgets.maxFiles).toBe(1000); // org override
     expect(budgets.maxChunks).toBe(50000); // no override -> platform
+  });
+
+  it('a Lake-scoped override of a scan budget is never resolved (#2624)', async () => {
+    // `scope` carries a lakeId and the row is present, so settableAt is the only thing excluding it.
+    // These two budgets advertised a Lake rung nothing resolved: one search spans EVERY lake the
+    // caller can reach (resolveRetrievalLakeScope hands the scan one dataLakeTags array), so there
+    // is no lakeId to key a budget on. Pinned here rather than only in the schema test, because the
+    // schema saying "not settable at Lake" is worth nothing if this resolver honoured the row anyway.
+    //
+    // maxFiles also carries an Organization row: it resolving proves the scoped branch RAN, so the
+    // lake row losing is exclusion rather than a silent degrade to the platform path - and since
+    // Lake is the narrower rung, it would have won outright if settableAt were ignored.
+    const db = makeDb({ dataLakeSearchMaxFiles: '3000', dataLakeSearchMaxChunks: '50000' }, [
+      { scopeLevel: SettingScopeLevel.Lake, scopeId: 'l1', settingName: 'dataLakeSearchMaxFiles', settingValue: '1' },
+      {
+        scopeLevel: SettingScopeLevel.Organization,
+        scopeId: 'o1',
+        settingName: 'dataLakeSearchMaxFiles',
+        settingValue: '900',
+      },
+      { scopeLevel: SettingScopeLevel.Lake, scopeId: 'l1', settingName: 'dataLakeSearchMaxChunks', settingValue: '1' },
+    ]);
+
+    const budgets = await resolveSearchBudgets(db, undefined, scope);
+
+    expect(budgets.maxFiles).toBe(900);
+    expect(budgets.maxChunks).toBe(50000);
   });
 
   it('falls back to the platform path if scoped resolution throws', async () => {
@@ -165,7 +192,12 @@ describe('resolveSearchBudgets - scoped path', () => {
     // 300 tokens derives 1800 chars: a number neither the deleted 1200 constant nor the default
     // policy (3072) can produce, so a scoped branch that hardcoded either one fails here.
     const db = makeDb({ DefaultChunkSize: '300', dataLakeSearchMaxFiles: '3000' }, [
-      { scopeLevel: SettingScopeLevel.Lake, scopeId: 'l1', settingName: 'dataLakeSearchMaxFiles', settingValue: '25' },
+      {
+        scopeLevel: SettingScopeLevel.Organization,
+        scopeId: 'o1',
+        settingName: 'dataLakeSearchMaxFiles',
+        settingValue: '25',
+      },
     ]);
 
     const scoped = await resolveSearchBudgets(db, undefined, scope);
@@ -178,11 +210,18 @@ describe('resolveSearchBudgets - scoped path', () => {
     expect(scoped.maxChunkChars).not.toBe(DEFAULT_SERVE_CHARS);
   });
 
-  it('does not let a lake rung override the chunk policy - that is not a lever yet', async () => {
+  it('does not let a narrower rung override the chunk policy - that is not a lever yet', async () => {
     // DefaultChunkSize declares no scope.settableAt, so an override row for it must be inert:
     // #1661 derives the serve budget, it does not add an org/lake chunk-policy rung (that is #1662).
+    // The row sits at Organization, a rung this resolver demonstrably DOES honour for the scan
+    // budgets above - on a Lake row the assertion would hold even if settableAt were ignored.
     const db = makeDb({ DefaultChunkSize: '300' }, [
-      { scopeLevel: SettingScopeLevel.Lake, scopeId: 'l1', settingName: 'DefaultChunkSize', settingValue: '6554' },
+      {
+        scopeLevel: SettingScopeLevel.Organization,
+        scopeId: 'o1',
+        settingName: 'DefaultChunkSize',
+        settingValue: '6554',
+      },
     ]);
 
     const budgets = await resolveSearchBudgets(db, undefined, scope);

--- a/b4m-core/services/src/dataLakeService/resolveSearchBudgets.ts
+++ b/b4m-core/services/src/dataLakeService/resolveSearchBudgets.ts
@@ -67,11 +67,14 @@ export type ResolvedSearchBudgets = SemanticSearchBudgets & {
  * because the symptom of a bad value would otherwise be "retrieval quietly covers less than the
  * admin configured", which is indistinguishable from a small corpus.
  *
- * Scope (epic #1658 lane 0 / #1660): callers that know the org/owner/lake a search runs for may pass
- * a `scope` (and the `scopedSettings` overlay repo) to let a narrower rung tighten the budget below
- * the platform ceiling. Omitting both - every caller today - takes the byte-identical platform path
- * below, so this change is additive. Chunk-policy rungs ride this same seam when #1662 gives
- * `DefaultChunkSize` its `scope.settableAt`; the serve budget below picks them up with no edit here.
+ * Scope (epic #1658 lane 0 / #1660): callers that know the org/owner a search runs for may pass a
+ * `scope` (and the `scopedSettings` overlay repo) to let a narrower rung tighten the budget below
+ * the platform ceiling. Org and Owner are the only rungs on offer: every key read here lost or
+ * never had a Lake rung, because one search spans EVERY lake the caller can reach (#2624), so a
+ * `scope.lakeId` reaching this function resolves nothing no matter what is stored against it.
+ * Omitting both - every caller today - takes the byte-identical platform path below, so this
+ * change is additive. Chunk-policy rungs ride this same seam when #1662 gives `DefaultChunkSize`
+ * its `scope.settableAt`; the serve budget below picks them up with no edit here.
  */
 export async function resolveSearchBudgets(
   db: {

--- a/b4m-core/services/src/settings/resolveScopedSetting.test.ts
+++ b/b4m-core/services/src/settings/resolveScopedSetting.test.ts
@@ -21,7 +21,10 @@ import {
   scopeForLake,
 } from './resolveScopedSetting';
 
-const KEY = 'dataLakeSearchMaxFiles'; // registered settableAt [organization, owner, lake], number, min 1
+const KEY = 'dataLakeSearchMaxFiles'; // registered settableAt [organization, owner], number, min 1
+// A key that still declares all three rungs, for the tests that exercise the full ladder. KEY lost
+// its Lake rung in #2624 because no retrieval caller could key one.
+const LAKE_KEY = 'LakeConvergenceBulkChangeSharePct'; // settableAt [organization, owner, lake], number, 1-100
 
 const owner = { id: 'u1', type: CreditHolderType.User } as const;
 const fullScope: SettingScope = { organizationId: 'o1', owner, lakeId: 'l1' };
@@ -56,8 +59,13 @@ function makeDb(
   } as const;
 }
 
-function override(scopeLevel: SettingScopeLevel, scopeId: string, settingValue: string): Partial<IScopedSetting> {
-  return { scopeLevel: scopeLevel as IScopedSetting['scopeLevel'], scopeId, settingName: KEY, settingValue };
+function override(
+  scopeLevel: SettingScopeLevel,
+  scopeId: string,
+  settingValue: string,
+  settingName: string = KEY
+): Partial<IScopedSetting> {
+  return { scopeLevel: scopeLevel as IScopedSetting['scopeLevel'], scopeId, settingName, settingValue };
 }
 
 // The global caches are process-wide; reset both so each test reads its own mock repos fresh.
@@ -217,17 +225,29 @@ describe('resolveScopedSetting (integration, through the real settingsMap)', () 
   });
 
   it('lake beats owner and org (narrowest wins)', async () => {
-    const db = makeDb({ [KEY]: '3000' }, [
-      override(SettingScopeLevel.Organization, 'o1', '2000'),
-      override(SettingScopeLevel.Owner, 'u1', '1500'),
-      override(SettingScopeLevel.Lake, 'l1', '1000'),
+    // On LAKE_KEY, since the ladder under test is the resolver's and KEY no longer climbs that far.
+    const db = makeDb({ [LAKE_KEY]: '80' }, [
+      override(SettingScopeLevel.Organization, 'o1', '60', LAKE_KEY),
+      override(SettingScopeLevel.Owner, 'u1', '40', LAKE_KEY),
+      override(SettingScopeLevel.Lake, 'l1', '20', LAKE_KEY),
     ]);
+    const r = await resolveScopedSetting(LAKE_KEY, fullScope, db);
+    expect(r).toEqual({ value: 20, source: SettingScopeLevel.Lake });
+  });
+
+  it('never consults a rung the setting does not declare, even with one in scope (#2624)', async () => {
+    // fullScope carries a lakeId and the row exists, so the ONLY thing keeping it out of the answer
+    // is settableAt. This is the defect the issue reported, pinned from the read side: a stored
+    // Lake override on a scan budget must not resolve.
+    const db = makeDb({ [KEY]: '3000' }, [override(SettingScopeLevel.Lake, 'l1', '1000')]);
     const r = await resolveScopedSetting(KEY, fullScope, db);
-    expect(r).toEqual({ value: 1000, source: SettingScopeLevel.Lake });
+    expect(r).toEqual({ value: 3000, source: SettingScopeLevel.Platform });
   });
 
   it('ignores overrides when no scoped store is wired (platform-only db)', async () => {
-    const db = makeDb({ [KEY]: '3000' }, [override(SettingScopeLevel.Lake, 'l1', '1000')]);
+    // An Organization row, not a Lake one: on a Lake row this would pass whether or not the store
+    // gate worked, because KEY has no Lake rung to resolve it with.
+    const db = makeDb({ [KEY]: '3000' }, [override(SettingScopeLevel.Organization, 'o1', '1000')]);
     const platformOnly = { adminSettings: db.adminSettings };
     const r = await resolveScopedSetting(KEY, fullScope, platformOnly);
     expect(r).toEqual({ value: 3000, source: SettingScopeLevel.Platform });
@@ -256,14 +276,14 @@ describe('resolveScopedSetting (integration, through the real settingsMap)', () 
 
   it('resolves several keys in one call, each keeping its own value', async () => {
     const db = makeDb({ dataLakeSearchMaxFiles: '3000', dataLakeSearchMaxChunks: '50000' }, [
-      override(SettingScopeLevel.Lake, 'l1', '1000'),
+      override(SettingScopeLevel.Organization, 'o1', '1000'),
     ]);
     const values = await resolveScopedSettingValues(
       ['dataLakeSearchMaxFiles', 'dataLakeSearchMaxChunks'],
       fullScope,
       db
     );
-    expect(values.dataLakeSearchMaxFiles).toBe(1000); // lake override
+    expect(values.dataLakeSearchMaxFiles).toBe(1000); // org override
     expect(values.dataLakeSearchMaxChunks).toBe(50000); // no override -> platform
   });
 });

--- a/b4m-core/services/src/settings/writeScopedOverride.test.ts
+++ b/b4m-core/services/src/settings/writeScopedOverride.test.ts
@@ -4,7 +4,7 @@ import { invalidateScopedSettingsCache, invalidateSettingsCache } from '@bike4mi
 import { resolveScopedSetting } from './resolveScopedSetting';
 import { clearScopedOverride, writeScopedOverride } from './writeScopedOverride';
 
-const KEY = 'dataLakeSearchMaxFiles'; // registered settableAt [organization, owner, lake], number, min 1
+const KEY = 'dataLakeSearchMaxFiles'; // registered settableAt [organization, owner], number, min 1
 // No `scope` metadata at all, so the "not settable" refusal fires before the (also true) isSensitive
 // check ever would - no registered setting is both scoped and sensitive (settings.scopeMetadata.test.ts
 // enforces that), so the isSensitive branch has no real key to exercise; it is the same kind of
@@ -12,6 +12,7 @@ const KEY = 'dataLakeSearchMaxFiles'; // registered settableAt [organization, ow
 const NOT_SETTABLE_KEY = 'openaiDemoKey';
 
 const lakeRef = { scopeLevel: SettingScopeLevel.Lake, scopeId: 'l1' } as const;
+const orgRef = { scopeLevel: SettingScopeLevel.Organization, scopeId: 'o1' } as const;
 const ownerRef = { scopeLevel: SettingScopeLevel.Owner, scopeId: 'u1' } as const;
 const fullScope = { organizationId: 'o1', owner: { id: 'u1', type: 'User' as const }, lakeId: 'l1' };
 
@@ -70,17 +71,27 @@ describe('writeScopedOverride validation (fails loud, never reaches the db on re
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('refuses a Lake-scoped write for a setting whose rungs stop at Owner (#2624)', async () => {
+    // The scan budgets used to advertise a Lake rung no retrieval caller resolved, so an operator
+    // could save an override that was accepted, displayed, and then ignored by every search. With
+    // the rung gone the write is refused instead, which the admin route turns into a 400.
+    const db = makeWritableDb();
+    const spy = vi.spyOn(db.scopedSettings, 'upsertOverride');
+    await expect(writeScopedOverride(KEY, lakeRef, '1000', db)).rejects.toThrow(/not settable/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it('refuses an unparseable value', async () => {
     const db = makeWritableDb();
     const spy = vi.spyOn(db.scopedSettings, 'upsertOverride');
-    await expect(writeScopedOverride(KEY, lakeRef, 'not-a-number', db)).rejects.toThrow(/validation/);
+    await expect(writeScopedOverride(KEY, orgRef, 'not-a-number', db)).rejects.toThrow(/validation/);
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('refuses a value below the schema minimum (edge value, not a truthy check)', async () => {
     const db = makeWritableDb();
     const spy = vi.spyOn(db.scopedSettings, 'upsertOverride');
-    await expect(writeScopedOverride(KEY, lakeRef, '0', db)).rejects.toThrow(/validation/);
+    await expect(writeScopedOverride(KEY, orgRef, '0', db)).rejects.toThrow(/validation/);
     expect(spy).not.toHaveBeenCalled();
   });
 
@@ -94,7 +105,7 @@ describe('writeScopedOverride validation (fails loud, never reaches the db on re
   it('refuses ownerType on a non-owner-scoped write', async () => {
     const db = makeWritableDb();
     const spy = vi.spyOn(db.scopedSettings, 'upsertOverride');
-    await expect(writeScopedOverride(KEY, { ...lakeRef, ownerType: 'User' as const }, '1000', db)).rejects.toThrow(
+    await expect(writeScopedOverride(KEY, { ...orgRef, ownerType: 'User' as const }, '1000', db)).rejects.toThrow(
       /only meaningful at the owner scope/
     );
     expect(spy).not.toHaveBeenCalled();
@@ -109,23 +120,23 @@ describe('writeScopedOverride / clearScopedOverride: read-your-writes against th
     const before = await resolveScopedSetting(KEY, fullScope, db);
     expect(before).toEqual({ value: 3000, source: SettingScopeLevel.Platform });
 
-    await writeScopedOverride(KEY, lakeRef, '1000', db);
+    await writeScopedOverride(KEY, orgRef, '1000', db);
 
     // Without invalidateScopedSettingsCache actually firing, this would still read the stale negative
     // entry cached above and wrongly return the platform value - this is the regression test for the
     // "forgetting to invalidate" trap the issue describes.
     const after = await resolveScopedSetting(KEY, fullScope, db);
-    expect(after).toEqual({ value: 1000, source: SettingScopeLevel.Lake });
+    expect(after).toEqual({ value: 1000, source: SettingScopeLevel.Organization });
   });
 
   it('clearing an override falls back to the next wider scope on the very next resolve', async () => {
     const db = makeWritableDb({ [KEY]: '3000' });
-    await writeScopedOverride(KEY, lakeRef, '1000', db);
+    await writeScopedOverride(KEY, orgRef, '1000', db);
 
     const before = await resolveScopedSetting(KEY, fullScope, db);
-    expect(before).toEqual({ value: 1000, source: SettingScopeLevel.Lake });
+    expect(before).toEqual({ value: 1000, source: SettingScopeLevel.Organization });
 
-    await clearScopedOverride(KEY, lakeRef, db);
+    await clearScopedOverride(KEY, orgRef, db);
 
     const after = await resolveScopedSetting(KEY, fullScope, db);
     expect(after).toEqual({ value: 3000, source: SettingScopeLevel.Platform });


### PR DESCRIPTION
## Description

`dataLakeSearchMaxFiles` and `dataLakeSearchMaxChunks` declared a **Lake** rung in `settableAt`, so
the admin UI offered a per-lake override for them, but no retrieval caller ever resolved settings at
that rung. An operator could scope either budget to a lake, see it saved and listed, and every search
would keep using the platform value with no error.

The rung wasn't just unwired - it's structurally unkeyable: one search is not scoped to one lake.
`resolveRetrievalLakeScope` hands the scan every lake the caller can reach as a single
`dataLakeTags` array, and the scan walks that whole set in a single pass. There is no single
`lakeId` a budget could apply to (option 1 from the issue - see it for options 2/3 and the tradeoffs).

Closes #2624

## Changes

- Drop `SettingScopeLevel.Lake` from both budgets' `settableAt`; they now stop at Owner, the same
  altitude `kbSearchMinRelevancePct` and the forced-retrieval floors already settled at for the
  identical structural reason.
- Correct four comments that asserted the premise this issue refutes (that these two budgets "scan
  one lake at a time") - left alone, they'd re-seed the same mistake.
- Both admin override panels now label a Lake-scoped row still sitting in the collection as inert
  (`... - inert - no longer settable at this rung, so nothing reads it`) rather than as an applied
  override, and keep the Clear button - no data migration, the resolver simply stops querying that
  rung.
- The admin "add override" picker no longer offers Lake for these two settings.
- Two pre-existing tests were exercising unrelated gates through a Lake-scoped row, so they'd have
  passed whether or not the gate under test worked once Lake stopped resolving; moved to Organization
  rows. New tests pin the removal from the write side (400 on a Lake write), the read side (a stored
  Lake row is never consulted, proven alongside an Organization row that IS), and the UI (picker
  offers only Organization/Owner; a stored Lake row renders as inert).

### Out of scope (filed as #2709, not in this PR)

Neither production caller in `apps/client/pages/api/data-lakes/semantic-search.ts` passes ANY
scope to `resolveSearchBudgets` (`resolveSearchBudgets.ts`'s own docblock already documents this),
so Organization/Owner overrides are also inert on that route today - only the knowledge-base-search
tool path honors them. Wiring the search route to a scope is a live behavior change (it changes what
every search returns for anyone with an override already stored) that also needs a decision on which
organization identity is authoritative at that call site, since the route deliberately re-reads the
user rather than trusting the JWT claim for billing. Dropping an unkeyable rung and wiring a keyable
one are different risk classes, so this PR does only the former. #2709 also covers why
`settings.scopeMetadata.test.ts` did not catch #2624 in the first place, which this PR does not
change either.

## Guide for Testers

**Setup:** Any org, and a data lake in it with several vectorized files. No feature flag involved.

### A. The Lake option is gone from the picker

1. Go to `Admin -> General Ops -> Admin Settings`.
2. Find `Data Lake Search Max Files` (Embedding category). Click to expand its scoped-override
   section.
3. Click the scope-level dropdown in the "add override" row.
   - **Expected:** the dropdown offers `Organization` and `Owner` only - no `Lake` option.
4. Repeat steps 2-3 for `Data Lake Search Max Chunks`.
   - **Expected:** same - no `Lake` option.

### B. An Organization override still resolves - on the path that actually passes a scope

**Read this before step 6.** The knowledge-base-search tool path is the only caller that passes a
scope to `resolveSearchBudgets`. `POST /api/data-lakes/semantic-search` passes none and resolves
platform-only, before and after this PR (see "Out of scope" above). Verifying this rung through that
route would show you the platform value and read as a broken lever, when nothing about that route
changed here - so use the tool path.

5. Set an **Organization**-scoped override for `Data Lake Search Max Files` to `1`, using your own
   org id.
6. In chat, ask a question that drives the knowledge-base-search tool against a lake in that org
   holding more than one matching file.
   - **Expected:** the scan stops at a 1-file ceiling and reports itself truncated, rather than
     scanning every matching file.
7. Clear the override (Clear button next to the row you created).
   - **Expected:** the row disappears, and the next search is back to the platform ceiling.

### C. A Lake row saved BEFORE this change reads as inert

This PR makes the Lake rung unwritable, so the row that exercises the inert label cannot be created
on this branch. Create it first, then come back:

8. On `main` - or on the preview before repointing it at this branch - set a **Lake**-scoped
   override for `Data Lake Search Max Files` to `1` against a real lake id. Also set an
   **Organization**-scoped override on the same setting, so there is a still-valid row to compare
   against.
9. Switch to this branch (redeploy the preview), and reopen that setting's scoped-override section.
   - **Expected:** the Lake row still lists, now suffixed `- inert - no longer settable at this
     rung, so nothing reads it`. The Organization row alongside it carries no such suffix.
10. Open `Overrides by scope`, choose scope level `Lake`, and enter that lake id.
    - **Expected:** the row reads `1 is stored here, but it is inert - ...`, not
      `overridden here: 1`.
11. Click Clear on the inert Lake row.
    - **Expected:** it clears and disappears. Writing at this rung is refused, but clearing one that
      already exists deliberately is not - otherwise an operator could see an inert row and have no
      way to remove it.

### Regression Checks

- Existing Organization/Owner overrides for these two settings (if any were set before this PR)
  continue to work exactly as before - only the Lake rung was removed.
- `PauseLakeConvergence`, `EnforceLakeAdmission`, and `LakeConvergenceBulkChangeSharePct` still offer
  and honor a Lake-scoped override (unaffected by this change; unrelated settings).
- A Lake-scoped write to either budget via `PUT /api/admin/scoped-settings` answers 400 with the
  service's own wording, rather than storing the row.

### What NOT to test

- No change to the `/api/data-lakes/semantic-search` route's actual scope resolution - it still
  resolves platform-only for search-budget settings, before and after this PR (see "Out of scope"
  above). This is why step 6 uses the knowledge-base-search tool path instead.
- No change to `DefaultChunkSize`'s scoping (still platform-only, unrelated to this issue).

## Additional Information

Triage verdict before starting: RELEVANT (high confidence) - premise reproduces line-for-line, no
code drift since filing, nothing superseded it, and adjacent settings show the Lake-rung machinery
is real and exercised elsewhere (making these two the odd ones out, not evidence the rung is
generally dead).

## Developer Notes (Optional)

- **Reusable pattern**: a setting that drops a `settableAt` rung can leave orphaned rows in the
  `ScopedSetting` collection that the resolver silently stops querying. Both admin override panels
  (`ScopedSettingOverrides.tsx`, `ScopedOverridesByScope.tsx`) now share an `INERT_RUNG_NOTE` constant
  and a `describeOverride`/inline check that labels such a row instead of reporting it as applied.
  Any future `settableAt` narrowing should reuse this rather than re-deriving the label.
- **Load-bearing asymmetry**: `writeScopedOverride` gates on `settableAt` and `clearScopedOverride`
  deliberately does not, which is the only reason an inert row stays clearable. Adding a
  `settableAt` check to the clear path "for symmetry" would make every orphaned row permanently
  unremovable, and no test currently fails if someone does.
