### PR TITLE
refactor(api-keys): lift the revoked check into apiKeyRevocation.ts

### DIFF
--- a/apps/client/app/components/admin/EmbedKeysTab.tsx
+++ b/apps/client/app/components/admin/EmbedKeysTab.tsx
@@ -62,7 +62,7 @@ import { useGetOrganization, useSearchOrganizations } from '@client/app/hooks/da
 import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
 import { useCopyToClipboard } from '@client/app/hooks/useCopyToClipboard';
 import { tableHeaderSx } from '@client/app/components/ProfileModal/settingsStyles';
-import { revocationTooltip } from '@client/app/utils/apiKeyRevocation';
+import { isRevoked, revocationTooltip } from '@client/app/utils/apiKeyRevocation';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import dayjs from 'dayjs';
@@ -722,7 +722,7 @@ export default function EmbedKeysTab() {
             </thead>
             <tbody>
               {embedKeys.map(key => {
-                const disabled = key.status === 'disabled';
+                const revoked = isRevoked(key);
                 const boundAgent = key.agentId ? agentById.get(key.agentId) : undefined;
                 return (
                   <tr key={key.id} data-testid={`embed-key-row-${key.id}`}>
@@ -773,8 +773,8 @@ export default function EmbedKeysTab() {
                     </td>
                     <td>
                       <Tooltip title={revocationTooltip(key) ?? ''} data-testid={`embed-key-status-${key.id}`}>
-                        <Chip variant="soft" color={disabled ? 'danger' : 'success'}>
-                          {disabled ? 'Revoked' : 'Active'}
+                        <Chip variant="soft" color={revoked ? 'danger' : 'success'}>
+                          {revoked ? 'Revoked' : 'Active'}
                         </Chip>
                       </Tooltip>
                     </td>
@@ -793,7 +793,7 @@ export default function EmbedKeysTab() {
                             size="sm"
                             variant="outlined"
                             onClick={() => setConfiguringKey(key)}
-                            disabled={disabled}
+                            disabled={revoked}
                             data-testid={`embed-key-configure-${key.id}`}
                           >
                             <SettingsIcon />
@@ -805,7 +805,7 @@ export default function EmbedKeysTab() {
                             variant="outlined"
                             onClick={() => rotateMutation.mutate(key.id)}
                             loading={rotateMutation.isPending}
-                            disabled={disabled}
+                            disabled={revoked}
                           >
                             <RotateLeftIcon />
                           </IconButton>
@@ -817,7 +817,7 @@ export default function EmbedKeysTab() {
                             color="danger"
                             onClick={() => revokeMutation.mutate({ keyId: key.id, reason: 'Revoked by admin' })}
                             loading={revokeMutation.isPending}
-                            disabled={disabled}
+                            disabled={revoked}
                             data-testid={`embed-key-revoke-${key.id}`}
                           >
                             <BlockIcon />

--- a/apps/client/app/components/profile/UserApiKeysTab.tsx
+++ b/apps/client/app/components/profile/UserApiKeysTab.tsx
@@ -53,7 +53,7 @@ import WarningIcon from '@mui/icons-material/Warning';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { IUserApiKeyDocument, ApiKeyScope } from '@bike4mind/common';
 import { GENERIC_MODAL_API_KEY_SCOPES } from '@client/app/constants/apiKeyScopes';
-import { revocationTooltip } from '@client/app/utils/apiKeyRevocation';
+import { isRevoked, revocationTooltip } from '@client/app/utils/apiKeyRevocation';
 import ConfirmationModal from '@client/app/components/common/ConfirmationModal';
 import { toast } from 'sonner';
 import { useState } from 'react';
@@ -1713,14 +1713,6 @@ ai_response = response.json()`,
     </Box>
   );
 }
-
-/**
- * `disabled` is the only state any revoke path writes (revokeUserApiKey, the
- * bulk deactivation, the cc-bridge device revoke all stamp revokedAt with it),
- * so it reads as "revoked" everywhere - and it is the only state the delete
- * route accepts.
- */
-const isRevoked = (key: IUserApiKeyDocument) => key.status === 'disabled';
 
 export default function UserApiKeysTab() {
   const { data, isLoading, error, refetch } = useGetUserApiKeys();

--- a/apps/client/app/utils/apiKeyRevocation.test.ts
+++ b/apps/client/app/utils/apiKeyRevocation.test.ts
@@ -1,10 +1,34 @@
 import { describe, it, expect } from 'vitest';
-import { revocationTooltip } from './apiKeyRevocation';
+import { ApiKeyStatus } from '@bike4mind/common';
+import { isRevoked, revocationTooltip } from './apiKeyRevocation';
 
 // Built from local-time components, not a 'Z' string: the helper formats in local
 // time, so a UTC fixture would render a different calendar day either side of the
 // date line and the assertion below would depend on the host timezone.
 const REVOKED_AT = new Date(2026, 0, 15, 9, 30);
+
+describe('isRevoked', () => {
+  it('is true for a key parked at the disabled status', () => {
+    expect(isRevoked({ status: ApiKeyStatus.DISABLED })).toBe(true);
+  });
+
+  // The other three listed out rather than sampled: expired and rate-limited are
+  // the ones that could plausibly be folded in, and neither is a revocation - the
+  // tables this predicate feeds render them as states of their own.
+  it.each([ApiKeyStatus.ACTIVE, ApiKeyStatus.EXPIRED, ApiKeyStatus.RATE_LIMITED])('is false for %s', status => {
+    expect(isRevoked({ status })).toBe(false);
+  });
+
+  // Revoked-ness is the stored status, never the audit trail: keys disabled
+  // before revocation metadata existed have no revokedAt, and they are still
+  // revoked even though revocationTooltip has nothing to render for them.
+  it('is true for a key disabled before revocation metadata existed', () => {
+    const key = { status: ApiKeyStatus.DISABLED };
+
+    expect(isRevoked(key)).toBe(true);
+    expect(revocationTooltip(key)).toBeNull();
+  });
+});
 
 describe('revocationTooltip', () => {
   it('returns null for a key with no revocation timestamp', () => {

--- a/apps/client/app/utils/apiKeyRevocation.ts
+++ b/apps/client/app/utils/apiKeyRevocation.ts
@@ -1,3 +1,4 @@
+import { ApiKeyStatus, IUserApiKey } from '@bike4mind/common';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
@@ -11,6 +12,20 @@ dayjs.extend(relativeTime);
 interface RevocationFields {
   revokedAt?: Date | string;
   revokedReason?: string;
+}
+
+/**
+ * Whether a key has been revoked. `disabled` is the only state any revoke path
+ * writes - revokeUserApiKey, the bulk deactivation and the cc-bridge device
+ * revoke all stamp revokedAt with it - so it reads as "revoked" everywhere, and
+ * it is the only state the delete route accepts.
+ *
+ * Compared against `ApiKeyStatus` rather than the bare string because the server
+ * owns the value - `userApiKeyService/revoke.ts` writes the enum - and a literal
+ * copied onto the client is the one spelling that could silently diverge.
+ */
+export function isRevoked(key: Pick<IUserApiKey, 'status'>): boolean {
+  return key.status === ApiKeyStatus.DISABLED;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Closes #2667

"Is this key revoked" was written out twice on the client: a module-local `isRevoked` in `UserApiKeysTab.tsx` and a bare `key.status === 'disabled'` in `EmbedKeysTab.tsx`. `apps/client/app/utils/apiKeyRevocation.ts` already exists for exactly this pair of tables - both import `revocationTooltip` from it - so the predicate moves there and both files pick it up with no new wiring.

The two spellings had already drifted in intent: both tables render the state as "Revoked", but only one of them named the predicate that way. Anything that changed the stored status value, or added a third key surface, had to find both copies and keep them in sync.

The lifted helper also compares against `ApiKeyStatus.DISABLED` rather than the bare string, which is the second half of the issue. The values match today so this is not a bug fix - but the server owns that value (`userApiKeyService/revoke.ts` writes the enum, `userApiKeyService/delete.ts:58` gates on it) and a hand-copied literal on the client is the one spelling that could silently diverge from it. This predicate drives the personal table's revoked filter and its delete gate, so that divergence would be user-visible.

## Changes

- `apps/client/app/utils/apiKeyRevocation.ts` - added `export function isRevoked(key: Pick<IUserApiKey, 'status'>): boolean`, returning `key.status === ApiKeyStatus.DISABLED`. `UserApiKeysTab`'s docblock explaining why `disabled` reads as "revoked" moved here with the predicate, plus a note on why the comparison is against the enum.
- `apps/client/app/components/profile/UserApiKeysTab.tsx` - deleted the module-local `isRevoked` and its docblock; added `isRevoked` to the existing `apiKeyRevocation` import. All call sites (`getStatusColor`, `getStatusText`, `revokedCount`, `visibleKeys`, the rotate and revoke `disabled=` props, and the delete tooltip + its `disabled=`) are unchanged and now resolve to the shared helper.
- `apps/client/app/components/admin/EmbedKeysTab.tsx` - the row-local `const disabled = key.status === 'disabled'` became `const revoked = isRevoked(key)`, with its 5 references renamed to match. The rename is deliberate: the flag fed a `disabled=` prop of the same name while the row it controls renders a chip reading "Revoked", so it was shadowing the prop rather than naming the domain state.
- `apps/client/app/utils/apiKeyRevocation.test.ts` - new `describe('isRevoked')` with 3 cases: true for `DISABLED`; false for `ACTIVE` / `EXPIRED` / `RATE_LIMITED`; and a key disabled before revocation metadata existed, asserting `isRevoked` is true while `revocationTooltip` is null (revoked-ness is the stored status, never the audit trail).

## Guide for Testers

This is a no-behaviour-change refactor, so every step below should behave exactly as it does on `main`. Test on the PR preview env (`pr2710.preview.bike4mind.com`, live once a maintainer deploys one - a bot comment on this PR confirms it) or on `app.staging.bike4mind.com`.

**Prerequisites:** a signed-in account, and an admin account for part B.

### Part A - personal API keys table

1. Go to `app.staging.bike4mind.com/profile?tab=api-keys` (or: Avatar menu -> Profile -> "API Keys" tab). Expected: the "My API Keys" sub-tab loads with a table of your keys and no console errors.
2. Click "Create API Key", name it `revoke-check-a`, and save. Expected: the key is created, the one-time secret is shown, and after closing the modal the row appears with a green "Active" chip in the Status column.
3. Click "Create API Key" again, name it `revoke-check-b`, and save. Expected: a second row with a green "Active" chip.
4. On the `revoke-check-b` row, hover the red circle-slash (Revoke key) button and click it. Expected: revoke applies immediately with no confirmation prompt (only Delete confirms) - a success toast, and the `revoke-check-b` row disappears from the table.
5. Look at the header row, to the left of the refresh button. Expected: a `Show revoked (1)` checkbox is now present (it is hidden entirely when you have no revoked keys).
6. Tick `Show revoked (1)`. Expected: the `revoke-check-b` row reappears, with a red "Revoked" chip in the Status column.
7. Hover the red "Revoked" chip. Expected: a tooltip reading `Revoked a few seconds ago (<date> <time>) - Revoked by user`.
8. On the revoked `revoke-check-b` row, hover the rotate (circular arrow) and revoke (circle-slash) buttons. Expected: both are greyed out and unclickable.
9. On the same revoked row, hover the trash-can (delete) button. Expected: it is enabled, and its tooltip reads `Delete permanently`.
10. On the still-active `revoke-check-a` row, hover the trash-can button. Expected: it is greyed out and its tooltip reads `Revoke this API key before deleting it`.
11. Click the trash-can on the revoked `revoke-check-b` row and confirm the deletion. Expected: a success toast, the row is gone, and the `Show revoked` checkbox disappears (the count is back to 0).
12. Untick nothing else; delete `revoke-check-a` by revoking it first and then deleting it, to leave the account as you found it.

### Part B - admin embed keys table

13. Sign in as an admin and go to `app.staging.bike4mind.com/admin`. Expected: the admin page loads.
14. In the left sidebar, open the "AI & Agents" section and click "Embed Keys". Expected: the embed keys table loads with no console errors.
15. Find (or create) an embed key whose Status column shows a green "Active" chip. Expected: its gear (configure), rotate, and circle-slash (revoke) buttons are all enabled.
16. Click the circle-slash (revoke) button on that key. Expected: a success toast, and the row's Status chip turns red and reads "Revoked".
17. Hover the red "Revoked" chip. Expected: a tooltip with the revocation time and `Revoked by admin`.
18. Hover each of the gear (configure), rotate, and circle-slash (revoke) buttons on that revoked row. Expected: all three are greyed out and unclickable.

### Regression Checks

- The `Show revoked (N)` count in part A matches the number of red "Revoked" rows revealed when the box is ticked.
- Keys in a state other than active/revoked still render as their own state, not as "Revoked": an expired key shows an "Expired" chip, a rate-limited key shows "Rate Limited". Neither is counted by `Show revoked`.
- The delete gate is still one-directional: delete is only clickable on a revoked key, and revoke is only clickable on a non-revoked one. There is no row where both are enabled or both are disabled.
- Nothing on the third key surface (Admin -> Users -> a user -> API keys modal) changed; its per-status chips should render exactly as before.

### What NOT to test

- No API request shape, response, or endpoint changed - there is no server-side change in this PR, so no curl/Postman verification is needed.
- The revoke, rotate, delete, and create flows themselves are unchanged; the steps above exercise them only as a way to reach the states the predicate reads.

## Additional Information

The issue suggested typing the new helper "against the revocation fields that module already models" (the module-local `RevocationFields` interface). It is typed `Pick<IUserApiKey, 'status'>` instead, deliberately: `status` is *required* on the entity and a string enum survives the wire intact, unlike `revokedAt`, whose `Date`-vs-ISO-string mismatch is the whole reason `RevocationFields` is hand-written. Keeping `status` required also means a caller cannot pass a malformed object and silently fail *open* to "not revoked" - which matters, since this predicate gates the rotate/revoke/delete buttons.

Two things deliberately left out:

- **`AdminApiKeysModal.tsx`**, a third key surface, renders a full `Record<ApiKeyStatus, chip>` map rather than a boolean predicate, so `isRevoked` does not apply to it.
- **No exhaustiveness guard** on `ApiKeyStatus`. Nothing forces a newly-added status to be classified against this predicate, and a meta-test that asserted otherwise would break on unrelated enum additions.

The server side is untouched. `userApiKeyService/delete.ts:58` already gates on `ApiKeyStatus.DISABLED` - it is the authority the issue points at, not a duplicate to fold in.

A post-change sweep confirms `apiKeyRevocation.ts` now holds the only api-key revoked predicate in `apps/client`. (`SecurityDashboard.tsx:280` and `LLMDashboardTab.tsx` also compare against `'disabled'`, but for unrelated domains.)

### Verification

| check | result |
|---|---|
| `pnpm turbo:typecheck` | 40/40 successful |
| `pnpm lint:check` | clean |
| `apps/client` unit suite, `node` project | 682 files / 7936 tests passed, 0 failed |
| `apps/client` unit suite, `jsdom` project | 532 files / 5439 tests passed, 0 failed |
| the 3 directly-affected test files | 40 passed |
| `pnpm turbo:core:build` | 18/18 successful |

## Developer Notes (Optional)

- **Reusable pattern:** `apiKeyRevocation.ts` is now the single client-side home for "how do I ask a question about a key's revocation state", holding both `isRevoked` and `revocationTooltip`. A fourth key surface should import from there rather than re-deriving the check, and any future revocation-shaped predicate (say `isRevocable`) belongs in the same module.
- **Architecture decision:** client-side status comparisons go through `ApiKeyStatus` from `@bike4mind/common`, not string literals. The server owns those values; a literal on the client is an un-typechecked copy of a contract that lives elsewhere.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no AdminSettings touched
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - no UI change; both tables render identically
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a, no user-facing behaviour changed
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - n/a, no telemetry fields

