### PR TITLE
docs(api-keys): scope the delete docblock to what revocation records

### DIFF
--- a/b4m-core/services/src/userApiKeyService/delete.ts
+++ b/b4m-core/services/src/userApiKeyService/delete.ts
@@ -31,9 +31,10 @@ export interface DeleteUserApiKeyResult {
  * Remove a revoked key's record, scoped by resolveOwnedApiKey (the key's minter,
  * or an admin of the org it is billed to). This is list hygiene, never a
  * security control: only a key already DISABLED may go, so revocation - the
- * write that actually kills the credential and stamps revokedAt/revokedBy - has
- * always happened first and is always recorded. An active key gets a 409, so
- * there is no path to drop a live credential without leaving that trail.
+ * write that actually kills the credential and stamps revokedAt (and revokedBy
+ * where there is a human actor) - has always happened first. An active key gets
+ * a 409, so there is no path to drop a live credential without leaving that
+ * trail.
  *
  * `db.userApiKeys.delete` is a soft delete (UserApiKeySchema carries
  * softDeletePlugin): the document stays in the collection with its audit fields


### PR DESCRIPTION
## Description

Closes #2670

The `deleteUserApiKey` docblock oversold the audit trail that the delete path leans on. It said revocation "stamps revokedAt/revokedBy" and that this "is always recorded". Neither half is unconditionally true, and a reviewer caught the first one on #2633, the PR that introduced the file.

**`revokedBy` is not always stamped.** Four production writes move a key to DISABLED. All four stamp `revokedAt`; only two stamp `revokedBy`, because the other two have no human actor and each already says so in its own comment:

| Path | `revokedAt` | `revokedBy` |
|---|---|---|
| `userApiKeyService/revoke.ts:47-48` | yes | yes (acting caller) |
| `CcBridgeDeviceModel.ts:121-128` (device revoke) | yes | yes (`userId`) |
| `UserApiKeyModel.ts:104-110` (`deactivateAllByUserId`) | yes | no - "Bulk deactivation has no human actor" |
| `pages/api/cc-bridge/redeem.ts:127-138` (lost-race rollback) | yes | no - "System-initiated, so no revokedBy" |

**"and is always recorded" is not true either.** Every path scopes its stamp to a real status transition, so a key that was already DISABLED before these fields existed carries no `revokedAt` at all. The repo already says this in two other places: `apps/client/app/utils/apiKeyRevocation.ts:20-22` ("keys disabled before revocation metadata existed carry no timestamp") and `revoke.ts:44-45` ("keeps an honest blank"). That clause is the same species of overstatement the issue names, in the same sentence, so fixing only the first half would have left the docblock still wrong.

The load-bearing claim is unchanged and still true: all four paths stamp `revokedAt`, so a revocation write always precedes a delete, and the following sentence ("no path to drop a live credential without leaving that trail") still carries that guarantee. No caveat paragraph was added - deleting the false clause leaves the docblock both accurate and slightly shorter.

## Changes

- `b4m-core/services/src/userApiKeyService/delete.ts` - reworded one docblock sentence: `stamps revokedAt/revokedBy` becomes `stamps revokedAt (and revokedBy where there is a human actor)`, and `and is always recorded` is dropped.

Comment-only: no behaviour, signature, export, or test changes.

## Guide for Testers

Nothing to test at runtime - this PR changes one block comment and nothing else. The whole diff is four lines in one file.

To verify the reasoning rather than take it on faith:

1. Check out the branch and run `git diff origin/main`. Expected: one file changed, 4 insertions and 3 deletions, all of it inside a `/** ... */` block in `b4m-core/services/src/userApiKeyService/delete.ts`.
2. Run `grep -rn "ApiKeyStatus.DISABLED" apps b4m-core packages --include='*.ts' | grep -v test`. Expected: 8 hits across 5 files.
3. Separate the writes from the guards in that output. Expected writes: `revoke.ts:54`, `CcBridgeDeviceModel.ts:124`, `UserApiKeyModel.ts:108`, `redeem.ts:133`. The other four hits are `!==` guards or `$ne` query filters, not writes.
4. Open each of those four writes and check whether it also sets `revokedBy`. Expected: `revoke.ts` and `CcBridgeDeviceModel.ts` do; `UserApiKeyModel.ts` and `redeem.ts` do not, and each carries a comment explaining why.
5. Read the reworded docblock at `delete.ts:30-37`. Expected: it now claims `revokedAt` unconditionally and `revokedBy` only "where there is a human actor", which matches what step 4 found.

### Regression Checks

None applicable - a comment cannot regress. CI typecheck, test, and lint on `@bike4mind/services` are the only signals that matter here.

### What NOT to test

No UI, no API surface, no runtime behaviour. There is nothing to click, so no preview deploy is needed. The API key list, revoke, and delete flows are all untouched.

## Additional Information

Verified locally on this branch after rebasing onto current `main`: `pnpm turbo:core:build` (18/18 tasks), `pnpm --filter @bike4mind/services typecheck` (clean), `pnpm --filter @bike4mind/services test` (407 files / 6841 tests passed, 4 files / 13 tests skipped), `pnpm lint:check` (clean), plus `scripts/check-no-control-bytes.sh` and `scripts/check-no-smart-punctuation.sh`.

This work started while #2633 was still open and branched off it; #2633 has since merged, so this is now a single commit on top of `main`.

Side observation, deliberately not acted on here: `deactivateAllByUserId` (`UserApiKeyModel.ts:104`) currently has no production callers, and `findExpiredKeys` (`UserApiKeyModel.ts:113`) is declared and implemented but likewise uncalled - there is no expiry sweeper, so expired keys stay ACTIVE in the DB and get filtered at validation time instead. Neither affects this docblock, which does not enumerate paths, but both may be worth a separate look.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI in this PR
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
