### PR TITLE
fix(api-keys): stop a failed analytics write 500ing a committed key change

### DIFF
--- a/apps/client/pages/api/user-api-keys/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/__tests__/index.test.ts
@@ -71,8 +71,8 @@ const userApiKeyRepository = vi.hoisted(() => ({
   findByOrganizationIdsAndId: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('@bike4mind/database/auth', () => ({ userApiKeyRepository }));
-const logEvent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-vi.mock('@server/utils/analyticsLog', () => ({ logEvent }));
+const logEventSafe = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@server/utils/analyticsLog', () => ({ logEventSafe }));
 
 // The real gateEmbedBrandingWrite AND embedKeyOwnerHasEntitlement run; only the
 // leaf entitlement source (getUserEntitlements) and the owner-doc lookups are
@@ -95,19 +95,21 @@ import '@pages/api/user-api-keys/[id]/index';
 function patch(id: string | undefined, body: unknown) {
   const { req, res } = createMocks({ method: 'PATCH', query: id === undefined ? {} : { id }, body });
   (req as any).user = { id: 'u1', isAdmin: false };
+  (req as any).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   return { req, res };
 }
 
 function del(id: string | undefined) {
   const { req, res } = createMocks({ method: 'DELETE', query: id === undefined ? {} : { id } });
   (req as any).user = { id: 'u1', isAdmin: false };
+  (req as any).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   return { req, res };
 }
 
 describe('DELETE /api/user-api-keys/[id] - remove a revoked key', () => {
   beforeEach(() => {
     deleteUserApiKey.mockClear();
-    logEvent.mockClear();
+    logEventSafe.mockClear();
   });
 
   it('forwards the key id with both adapters and logs the DELETED event', async () => {
@@ -122,10 +124,18 @@ describe('DELETE /api/user-api-keys/[id] - remove a revoked key', () => {
       // would have no dependency to resolve with.
       { db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository } }
     );
-    expect(logEvent).toHaveBeenCalledWith(
+    expect(logEventSafe).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: { keyId: 'key-1', name: 'widget' } }),
+      expect.anything(),
       expect.anything()
     );
+  });
+
+  it('logs the deletion through logEventSafe with the request logger', async () => {
+    const { req, res } = del('key-1');
+    await mockRefs.deleteHandler!(req, res);
+
+    expect(logEventSafe).toHaveBeenCalledWith(expect.anything(), expect.anything(), req.logger);
   });
 
   it('rejects a missing key id with 400 and never calls the service', async () => {
@@ -139,14 +149,14 @@ describe('DELETE /api/user-api-keys/[id] - remove a revoked key', () => {
     const { req, res } = del('key-1');
 
     await expect(mockRefs.deleteHandler!(req, res)).rejects.toThrow(/Revoke this API key/i);
-    expect(logEvent).not.toHaveBeenCalled();
+    expect(logEventSafe).not.toHaveBeenCalled();
   });
 });
 
 describe('PATCH /api/user-api-keys/[id] - embed-key configure', () => {
   beforeEach(() => {
     updateEmbedKey.mockClear();
-    logEvent.mockClear();
+    logEventSafe.mockClear();
   });
 
   it('updates the provided fields with normalized origins and returns 200', async () => {
@@ -176,8 +186,9 @@ describe('PATCH /api/user-api-keys/[id] - embed-key configure', () => {
     await mockRefs.patchHandler!(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(logEvent).toHaveBeenCalledWith(
+    expect(logEventSafe).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: expect.objectContaining({ updatedFields: ['agentId'] }) }),
+      expect.anything(),
       expect.anything()
     );
   });
@@ -446,5 +457,19 @@ describe('PATCH /api/user-api-keys/[id] - embed-key configure', () => {
       expect.anything(),
       expect.objectContaining({ db: expect.objectContaining({ organizations: organizationRepository }) })
     );
+  });
+});
+
+/**
+ * The analytics write happens after the key change has committed, so it goes
+ * through the best-effort wrapper with the request logger attached: a failed
+ * counter write gets recorded, not turned into a 5xx the client will retry.
+ */
+describe('PATCH /api/user-api-keys/[id] - analytics is best effort', () => {
+  it('logs the update through logEventSafe with the request logger', async () => {
+    const { req, res } = patch('key-1', { agentId: 'agent-2' });
+    await mockRefs.patchHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(logEventSafe).toHaveBeenCalledWith(expect.anything(), expect.anything(), req.logger);
   });
 });

--- a/apps/client/pages/api/user-api-keys/[id]/__tests__/rate-limit.test.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/__tests__/rate-limit.test.ts
@@ -45,14 +45,15 @@ const updateApiKeyRateLimit = vi.hoisted(() =>
 );
 vi.mock('@bike4mind/services', () => ({ userApiKeyService: { updateApiKeyRateLimit } }));
 vi.mock('@bike4mind/database/auth', () => ({ userApiKeyRepository: {} }));
-const logEvent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-vi.mock('@server/utils/analyticsLog', () => ({ logEvent }));
+const logEventSafe = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@server/utils/analyticsLog', () => ({ logEventSafe }));
 
 import '@pages/api/user-api-keys/[id]/rate-limit';
 
 function patch(id: string | undefined, body: unknown) {
   const { req, res } = createMocks({ method: 'PATCH', query: id === undefined ? {} : { id }, body });
   (req as any).user = { id: 'u1', isAdmin: false };
+  (req as any).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   return { req, res };
 }
 
@@ -84,10 +85,11 @@ describe('PATCH /api/user-api-keys/[id]/rate-limit', () => {
     const { req, res } = patch('key-1', { requestsPerDay: 5000 });
     await mockRefs.patchHandler!(req, res);
 
-    expect(logEvent).toHaveBeenCalledWith(
+    expect(logEventSafe).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.objectContaining({ updatedFields: ['rateLimit.requestsPerDay'] }),
       }),
+      expect.anything(),
       expect.anything()
     );
   });
@@ -101,5 +103,19 @@ describe('PATCH /api/user-api-keys/[id]/rate-limit', () => {
   it('registers PATCH only, so next-connect 405s every other verb', () => {
     expect(mockRefs.patchHandler).not.toBeNull();
     expect(mockRefs.otherVerbs).toEqual([]);
+  });
+});
+
+/**
+ * The analytics write happens after the key change has committed, so it goes
+ * through the best-effort wrapper with the request logger attached: a failed
+ * counter write gets recorded, not turned into a 5xx the client will retry.
+ */
+describe('PATCH /api/user-api-keys/[id]/rate-limit - analytics is best effort', () => {
+  it('logs the update through logEventSafe with the request logger', async () => {
+    const { req, res } = patch('key-1', { requestsPerMinute: 600 });
+    await mockRefs.patchHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(logEventSafe).toHaveBeenCalledWith(expect.anything(), expect.anything(), req.logger);
   });
 });

--- a/apps/client/pages/api/user-api-keys/[id]/__tests__/revoke.analytics-failure.test.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/__tests__/revoke.analytics-failure.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * The regression this family was written for: the key change commits, then the
+ * analytics write fails. Deliberately does NOT mock @server/utils/analyticsLog -
+ * the real logEventSafe runs, and the counter write underneath it is what throws,
+ * so this exercises the guard through the route rather than around it.
+ *
+ * Revoke stands in for the family (they share the shape); the wrapper's own
+ * contract is covered in server/utils/analyticsLog.test.ts.
+ */
+
+const mockRefs = vi.hoisted(() => ({ postHandler: null as null | ((req: any, res: any) => unknown) }));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    get: () => chain,
+    patch: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const revokeUserApiKey = vi.hoisted(() => vi.fn().mockResolvedValue({ name: 'CLI key' }));
+const incrementUserCounter = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@bike4mind/services', () => ({
+  userApiKeyService: { revokeUserApiKey },
+  counterService: { incrementUserCounter },
+}));
+vi.mock('@bike4mind/database/auth', () => ({ userApiKeyRepository: {} }));
+vi.mock('@bike4mind/database', () => ({
+  organizationRepository: {},
+  mongoose: {},
+  Ability: class {},
+  User: {},
+  UserActivityCounter: {},
+  CounterLog: {},
+}));
+
+import '@pages/api/user-api-keys/[id]/revoke';
+
+function post() {
+  const { req, res } = createMocks({ method: 'POST', query: { id: 'key-1' }, body: { reason: 'leaked' } });
+  (req as any).user = { id: 'u1', isAdmin: false };
+  (req as any).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { req, res };
+}
+
+describe('POST /api/user-api-keys/[id]/revoke - failed analytics write', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('still answers 200 when the counter write throws, and records the failure', async () => {
+    incrementUserCounter.mockRejectedValueOnce(new Error('counter write failed'));
+    const { req, res } = post();
+
+    await expect(mockRefs.postHandler!(req, res)).resolves.not.toThrow();
+
+    // A 5xx here reads as retryable, but the key is already revoked - the retry
+    // would come back 404 on a revoke that actually succeeded.
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+    expect(revokeUserApiKey).toHaveBeenCalledTimes(1);
+    expect((req as any).logger.error).toHaveBeenCalledWith(expect.stringMatching(/analytics/i), expect.any(Error));
+  });
+
+  it('answers 200 on the happy path with the counter write attempted', async () => {
+    const { req, res } = post();
+    await mockRefs.postHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(incrementUserCounter).toHaveBeenCalledTimes(1);
+    expect((req as any).logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/user-api-keys/[id]/__tests__/rotate-revoke.test.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/__tests__/rotate-revoke.test.ts
@@ -41,8 +41,8 @@ const userApiKeyRepository = vi.hoisted(() => ({}));
 vi.mock('@bike4mind/database/auth', () => ({ userApiKeyRepository }));
 const organizationRepository = vi.hoisted(() => ({ findIdsAdministeredBy: vi.fn() }));
 vi.mock('@bike4mind/database', () => ({ organizationRepository }));
-const logEvent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-vi.mock('@server/utils/analyticsLog', () => ({ logEvent }));
+const logEventSafe = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@server/utils/analyticsLog', () => ({ logEventSafe }));
 
 import { NotFoundError } from '@server/utils/errors';
 // Order matters: the first baseApi() call is rotate, the second is revoke.
@@ -52,6 +52,7 @@ import '@pages/api/user-api-keys/[id]/revoke';
 function post(id: string | undefined, body: unknown = {}) {
   const { req, res } = createMocks({ method: 'POST', query: id === undefined ? {} : { id }, body });
   (req as any).user = { id: 'admin-user', isAdmin: false };
+  (req as any).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   return { req, res };
 }
 
@@ -94,5 +95,28 @@ describe('POST /api/user-api-keys/[id]/revoke', () => {
     revokeUserApiKey.mockRejectedValueOnce(new NotFoundError('API key not found'));
     const { req, res } = post('key-1');
     await expect(mockRefs.revokeHandler!(req, res)).rejects.toThrow(/not found/i);
+  });
+});
+
+/**
+ * Both writes happen after the key change has committed, so they go through the
+ * best-effort wrapper with the request logger attached: a failed counter write
+ * gets recorded, not turned into a 5xx the client will retry.
+ */
+describe('rotate and revoke - analytics is best effort', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rotate logs through logEventSafe with the request logger', async () => {
+    const { req, res } = post('key-1');
+    await mockRefs.rotateHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(logEventSafe).toHaveBeenCalledWith(expect.anything(), expect.anything(), req.logger);
+  });
+
+  it('revoke logs through logEventSafe with the request logger', async () => {
+    const { req, res } = post('key-1', { reason: 'rotated out' });
+    await mockRefs.revokeHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(logEventSafe).toHaveBeenCalledWith(expect.anything(), expect.anything(), req.logger);
   });
 });

--- a/apps/client/pages/api/user-api-keys/[id]/index.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/index.ts
@@ -4,7 +4,7 @@ import { organizationRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
 import { validateEmbedBranding, validateEmbedKeyOrigins } from '@server/services/publish';
 import { gateEmbedBrandingWrite } from '@server/entitlements/embedKeyEntitlement';
-import { logEvent } from '@server/utils/analyticsLog';
+import { logEventSafe } from '@server/utils/analyticsLog';
 import { IEmbedBranding, UserApiKeyEvents } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { BadRequestError } from '@server/utils/errors';
@@ -83,7 +83,7 @@ const handler = baseApi()
         { db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository } }
       );
 
-      await logEvent(
+      await logEventSafe(
         {
           userId,
           type: UserApiKeyEvents.UPDATED,
@@ -97,7 +97,8 @@ const handler = baseApi()
             ],
           },
         },
-        { ability: req.ability }
+        { ability: req.ability },
+        req.logger
       );
 
       return res.status(200).json(updated);
@@ -119,13 +120,14 @@ const handler = baseApi()
         { db: { userApiKeys: userApiKeyRepository, organizations: organizationRepository } }
       );
 
-      await logEvent(
+      await logEventSafe(
         {
           userId,
           type: UserApiKeyEvents.DELETED,
           metadata: { keyId, name },
         },
-        { ability: req.ability }
+        { ability: req.ability },
+        req.logger
       );
 
       return res.status(200).json({ success: true });

--- a/apps/client/pages/api/user-api-keys/[id]/rate-limit.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/rate-limit.ts
@@ -1,7 +1,7 @@
 import { userApiKeyService } from '@bike4mind/services';
 import { userApiKeyRepository } from '@bike4mind/database/auth';
 import { baseApi } from '@server/middlewares/baseApi';
-import { logEvent } from '@server/utils/analyticsLog';
+import { logEventSafe } from '@server/utils/analyticsLog';
 import { UserApiKeyEvents } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { csrfProtection } from '@server/middlewares/csrfProtection';
@@ -46,7 +46,7 @@ const handler = baseApi()
         { db: { userApiKeys: userApiKeyRepository } }
       );
 
-      await logEvent(
+      await logEventSafe(
         {
           userId,
           type: UserApiKeyEvents.UPDATED,
@@ -59,7 +59,8 @@ const handler = baseApi()
             ],
           },
         },
-        { ability: req.ability }
+        { ability: req.ability },
+        req.logger
       );
 
       return res.status(200).json(updated);

--- a/apps/client/pages/api/user-api-keys/[id]/revoke.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/revoke.ts
@@ -2,7 +2,7 @@ import { userApiKeyService } from '@bike4mind/services';
 import { userApiKeyRepository } from '@bike4mind/database/auth';
 import { organizationRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
-import { logEvent } from '@server/utils/analyticsLog';
+import { logEventSafe } from '@server/utils/analyticsLog';
 import { UserApiKeyEvents } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { BadRequestError } from '@server/utils/errors';
@@ -26,7 +26,7 @@ const handler = baseApi().post(
       }
     );
 
-    await logEvent(
+    await logEventSafe(
       {
         userId,
         type: UserApiKeyEvents.REVOKED,
@@ -36,7 +36,8 @@ const handler = baseApi().post(
           reason,
         },
       },
-      { ability: req.ability }
+      { ability: req.ability },
+      req.logger
     );
 
     return res.status(200).json({ success: true });

--- a/apps/client/pages/api/user-api-keys/[id]/rotate.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/rotate.ts
@@ -2,7 +2,7 @@ import { userApiKeyService } from '@bike4mind/services';
 import { userApiKeyRepository } from '@bike4mind/database/auth';
 import { organizationRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
-import { logEvent } from '@server/utils/analyticsLog';
+import { logEventSafe } from '@server/utils/analyticsLog';
 import { UserApiKeyEvents } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { BadRequestError } from '@server/utils/errors';
@@ -25,7 +25,7 @@ const handler = baseApi().post(
       }
     );
 
-    await logEvent(
+    await logEventSafe(
       {
         userId,
         type: UserApiKeyEvents.ROTATED,
@@ -34,7 +34,8 @@ const handler = baseApi().post(
           name: rotatedKey.name,
         },
       },
-      { ability: req.ability }
+      { ability: req.ability },
+      req.logger
     );
 
     return res.status(200).json(rotatedKey);

--- a/apps/client/pages/api/user-api-keys/__tests__/index.test.ts
+++ b/apps/client/pages/api/user-api-keys/__tests__/index.test.ts
@@ -57,7 +57,8 @@ vi.mock('@bike4mind/database', () => ({
   organizationRepository: { findIdsAdministeredBy, findById: organizationFindById },
   userRepository,
 }));
-vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+const logEventSafe = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@server/utils/analyticsLog', () => ({ logEventSafe }));
 
 // The real gateEmbedBrandingWrite AND embedKeyOwnerHasEntitlement run; only the
 // leaf entitlement source (getUserEntitlements) is stubbed, so these tests
@@ -71,6 +72,7 @@ import '@pages/api/user-api-keys/index';
 function post(body: unknown, opts: { isAdmin?: boolean } = {}) {
   const { req, res } = createMocks({ method: 'POST', body });
   (req as any).user = { id: 'u1', isAdmin: opts.isAdmin ?? false };
+  (req as any).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   return { req, res };
 }
 
@@ -471,5 +473,19 @@ describe('GET /api/user-api-keys - ownerHasWhitelabel (#891)', () => {
     await mockRefs.getHandler!(req, res);
     // Two distinct owners -> two resolutions, not three.
     expect(userRepository.findById).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The analytics write happens after the key change has committed, so it goes
+ * through the best-effort wrapper with the request logger attached: a failed
+ * counter write gets recorded, not turned into a 5xx the client will retry.
+ */
+describe('POST /api/user-api-keys - analytics is best effort', () => {
+  it('logs the mint through logEventSafe with the request logger', async () => {
+    const { req, res } = post({ name: 'k', scopes: [] });
+    await mockRefs.postHandler!(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(logEventSafe).toHaveBeenCalledWith(expect.anything(), expect.anything(), req.logger);
   });
 });

--- a/apps/client/pages/api/user-api-keys/index.ts
+++ b/apps/client/pages/api/user-api-keys/index.ts
@@ -9,7 +9,7 @@ import {
   type EmbedKeyOwnerRef,
 } from '@server/entitlements/embedKeyEntitlement';
 import { EMBED_WHITELABEL_ENTITLEMENT_KEY } from '@client/lib/entitlements/registry';
-import { logEvent } from '@server/utils/analyticsLog';
+import { logEventSafe } from '@server/utils/analyticsLog';
 import {
   ApiKeyScope,
   CreditHolderType,
@@ -218,7 +218,7 @@ const handler = baseApi()
       }
     );
 
-    await logEvent(
+    await logEventSafe(
       {
         userId,
         type: UserApiKeyEvents.CREATED,
@@ -232,7 +232,8 @@ const handler = baseApi()
           organizationId: newApiKey.organizationId,
         },
       },
-      { ability: req.ability }
+      { ability: req.ability },
+      req.logger
     );
 
     return res.status(201).json(newApiKey);

--- a/apps/client/server/utils/analyticsLog.test.ts
+++ b/apps/client/server/utils/analyticsLog.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * logEventSafe is the entry point every post-mutation call site uses: the
+ * analytics write is a side effect of an operation that already committed, so a
+ * failed write must be recorded and dropped rather than surfaced as a 5xx that
+ * invites a retry. logEvent itself keeps throwing - /api/analytics/log-event
+ * exists only to perform the write and has to answer with its outcome.
+ */
+
+const incrementUserCounter = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@bike4mind/services', () => ({ counterService: { incrementUserCounter } }));
+vi.mock('@bike4mind/database', () => ({
+  mongoose: {},
+  Ability: class {},
+  User: {},
+  UserActivityCounter: {},
+  CounterLog: {},
+}));
+
+import { UserApiKeyEvents } from '@bike4mind/common';
+import { logEvent, logEventSafe } from './analyticsLog';
+
+const event = {
+  userId: 'u1',
+  type: UserApiKeyEvents.REVOKED,
+  metadata: { keyId: 'key-1', name: 'CLI key' },
+} as const;
+
+describe('logEventSafe', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('resolves and reports through the request logger when the write throws', async () => {
+    const boom = new Error('counter write failed');
+    incrementUserCounter.mockRejectedValueOnce(boom);
+    const logger = { error: vi.fn() };
+
+    await expect(logEventSafe(event, { ability: undefined }, logger)).resolves.toBeUndefined();
+
+    // The event type has to reach the log line: it is the only thing that says
+    // which analytics write was dropped.
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining(UserApiKeyEvents.REVOKED), boom);
+  });
+
+  it('falls back to console.error so a failure is never silently dropped', async () => {
+    incrementUserCounter.mockRejectedValueOnce(new Error('counter write failed'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(logEventSafe(event)).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(UserApiKeyEvents.REVOKED), expect.any(Error));
+  });
+
+  it('forwards the event and options to logEvent on the success path', async () => {
+    const logger = { error: vi.fn() };
+    await logEventSafe(event, undefined, logger);
+
+    expect(incrementUserCounter).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ action: UserApiKeyEvents.REVOKED, metadata: event.metadata }),
+      expect.anything()
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('leaves logEvent throwing, for callers whose response IS the write', async () => {
+    incrementUserCounter.mockRejectedValueOnce(new Error('counter write failed'));
+    await expect(logEvent(event)).rejects.toThrow(/counter write failed/);
+  });
+});

--- a/apps/client/server/utils/analyticsLog.ts
+++ b/apps/client/server/utils/analyticsLog.ts
@@ -2,18 +2,22 @@ import { IUserDocument, WithOrgRef, IOrganizationDocument, ICounterLog } from '@
 import { mongoose, Ability, User, UserActivityCounter, CounterLog } from '@bike4mind/database';
 import { counterService } from '@bike4mind/services';
 import { isValidEnumValue } from '@bike4mind/utils';
+import type { ILogger } from '@bike4mind/observability';
 import { ANALYTICS_EVENTS, AnalyticsEventPayloads, AnalyticsEvents } from '@server/types/analytics';
+
+interface LogEventOptions {
+  session?: mongoose.ClientSession;
+  ability?: Ability;
+}
 
 /**
  * This is a generic function to log an event to the database.
+ *
+ * Throws on a failed write. A caller that only wants the event recorded as a
+ * side effect - the common case - should use `logEventSafe` instead, so an
+ * analytics outage cannot fail the operation it is describing.
  */
-export async function logEvent(
-  event: AnalyticsEventPayloads,
-  options?: {
-    session?: mongoose.ClientSession;
-    ability?: Ability;
-  }
-): Promise<void> {
+export async function logEvent(event: AnalyticsEventPayloads, options?: LogEventOptions): Promise<void> {
   // No transaction wrapping: UserActivityCounter.updateOne ($inc upsert) and CounterLog.create
   // are both single-document atomic operations that don't require multi-document transaction
   // guarantees for analytics data. Wrapping in withTransaction caused "transaction aborted"
@@ -92,4 +96,30 @@ export async function logEvent(
       },
     }
   );
+}
+
+/**
+ * Fire-and-forget wrapper: logs failures, never throws.
+ *
+ * Use this from any route that logs an event AFTER its mutation has already
+ * committed. Awaiting a bare `logEvent` there turns an analytics-write failure
+ * into a 5xx for an operation that actually succeeded, which reads as retryable
+ * to a client - so the retry re-runs a mutation that already happened, and
+ * either duplicates it or fails against the state the first call left behind.
+ *
+ * Falls back to console.error so a failure is still recorded when no request
+ * logger is threaded through.
+ */
+export async function logEventSafe(
+  event: AnalyticsEventPayloads,
+  options?: LogEventOptions,
+  logger?: Pick<ILogger, 'error'>
+): Promise<void> {
+  try {
+    await logEvent(event, options);
+  } catch (error) {
+    const message = `Failed to log analytics event ${event.type}; continuing`;
+    if (logger) logger.error(message, error);
+    else console.error(message, error);
+  }
 }


### PR DESCRIPTION
Closes #2669. Follow-up from #2633, spotted by @onoya in review.

## Description

Every mutating route in the `/api/user-api-keys` family did its work and then `await`ed an unguarded `logEvent(...)`. `logEvent` (`apps/client/server/utils/analyticsLog.ts`) has no internal error handling - it awaits `counterService.incrementUserCounter` and its writes directly - so an analytics-write failure propagated out to `errorHandler`, which defaults to 500. By that point the key change had already committed, so the caller got a 5xx for an operation that actually succeeded.

That reads as retryable to a client, which is the real damage: the retry re-runs a mutation that already happened, and either duplicates it or fails against the state the first call left behind. @onoya's example was DELETE - the 500 looks retryable, the delete already happened, and the retry 404s. Minting is the worst of the six: the 201 body carries the plaintext key, so a 500 there means the caller never sees the secret for a key that now exists.

The issue asked us to decide once whether the guard belongs at each call site or inside `logEvent` itself. **Inside `logEvent` is wrong**, for a concrete reason rather than a hypothetical one: `apps/client/pages/api/analytics/log-event.ts` exists *only* to perform the analytics write, and answers 204. If `logEvent` swallowed, that endpoint would report success on a failed write. That is the "caller that does want the throw" the issue anticipated, and it is real. There are 108 further bare `logEvent(...)` call sites across 81 non-test files, so a global swallow would also be a large silent behaviour change well outside this family.

So the decision is made once, in a named wrapper, following this repo's existing `...Safe` precedent (`materializePublicSettingsArtifactSafe` in `apps/client/server/utils/publicSettingsArtifact.ts`): `logEventSafe` is best-effort and never throws, `logEvent` still throws, and each call site still reads as deliberate. No other caller's behaviour changes.

## Changes

- `apps/client/server/utils/analyticsLog.ts`: added `logEventSafe(event, options?, logger?)`. It awaits `logEvent`, catches, and reports `Failed to log analytics event <type>; continuing` through the supplied logger, falling back to `console.error` when no logger is threaded through, so a failure is never silently dropped.
- `logEvent` itself is behaviourally unchanged; its docblock now states that it still throws and points at the wrapper. The inline options type was extracted to a named `LogEventOptions` so both functions share it (behaviour-identical).
- Switched all six call sites the issue lists to `logEventSafe(..., req.logger)`: mint (`pages/api/user-api-keys/index.ts`), embed-config PATCH and DELETE (`pages/api/user-api-keys/[id]/index.ts`), rate-limit PATCH (`[id]/rate-limit.ts`), `[id]/rotate.ts`, and `[id]/revoke.ts`. `req.logger` is installed first in the `baseApi` chain, so it is always present.
- New `apps/client/server/utils/analyticsLog.test.ts` (4 tests) covers the wrapper's own contract: it resolves and reports through the request logger when the counter write throws, falls back to `console.error`, forwards event and options on the success path, and `logEvent` still rejects.
- New `apps/client/pages/api/user-api-keys/[id]/__tests__/revoke.analytics-failure.test.ts` (2 tests) covers the regression end-to-end through a route. It deliberately does **not** mock `@server/utils/analyticsLog`: the real `logEventSafe` runs and the mocked `counterService.incrementUserCounter` underneath it throws, so the guard is exercised through the route rather than around it. Mutation-checked - reverting `revoke.ts` to a bare `logEvent` makes it fail.
- Four existing route test files updated for the rename, with a `req.logger` stub added to their request factories and a "threads req.logger" assertion added per route.

## Guide for Testers

This changes error handling only. On the happy path all six routes behave exactly as before, so this is a regression pass rather than a new-feature pass.

### Regression Checks

1. Open `app.staging.bike4mind.com` and sign in.
2. Open the sidebar profile menu and click **API Keys**, then select the **My API Keys** tab. Expected: the key list renders, no error toast.
3. Mint a new key with the name `analytics-guard-check`. Expected: the request succeeds and the plaintext key is shown exactly once, and `analytics-guard-check` appears in the list.
4. Rotate `analytics-guard-check`. Expected: the request succeeds and a new plaintext key is shown once.
5. Edit the rate limit on `analytics-guard-check` to `60` requests per minute and save. Expected: the request succeeds and the list shows the new limit.
6. If the key is an embed key, change its allowed origins to `https://example.com` and save. Expected: the request succeeds and the saved origin reads back as `https://example.com`.
7. Revoke `analytics-guard-check`. Expected: the request succeeds and the key shows as revoked.
8. Turn on the revoked-keys toggle, then delete the revoked `analytics-guard-check`. Expected: the request succeeds and the key disappears from the list.
9. Confirm no step above returned a 5xx, and that every list state after each step matches what you would expect on `main`.

### What NOT to test

- **The analytics-failure path itself.** It only fires when the `UserActivityCounter` / `CounterLog` write throws, which cannot be induced from the UI or from a normal staging environment without breaking Mongo. That path is covered by the two new test files instead, one at the wrapper and one end-to-end through the revoke route.
- Any route outside `/api/user-api-keys`. `logEvent`'s own behaviour is unchanged, so no other caller is affected.
- Analytics data correctness. This does not change what gets written on the success path, only what happens when the write fails.

## Additional Information

Rebased onto `main` after #2633 merged. That is where the DELETE route came from: the issue lists it as one of the six sites and notes it was not introduced by #2633, so with #2633 now on `main` all six sites named in the issue are covered here and this closes the issue outright.

Verified on the rebased branch: `pnpm turbo:core:build` (18/18), `pnpm turbo:typecheck` (40/40), `pnpm lint:check` clean, and the `apps/client` node project suite green. The jsdom project was not run - no file under `apps/client/app/` imports `analyticsLog`, so it cannot be affected.

Deliberately out of scope: the 108 remaining bare `logEvent(...)` call sites elsewhere in the codebase (81 non-test files, 5 of which already guard inline). They share the same latent shape, but each needs its own judgment about whether the mutation had already committed, and folding them in would swamp this diff. `logEventSafe` is now the tool for them, and that is worth its own follow-up. Also left alone: the five existing inline `try { await logEvent } catch` sites (`auth/[strategy]/callback.ts`, `feedback/index.ts`, `email/verify.ts`, `email/verify-change.ts`) - already correct, and migrating them to the wrapper would be churn rather than a fix.

## Developer Notes (Optional)

- **Reusable pattern**: `logEventSafe` is the one to reach for from any handler that logs an event *after* its mutation has committed. The rule of thumb: if the response has already been decided by the time you log, use the wrapper; if the analytics write *is* the operation, keep `logEvent`.
- **Architecture decision**: the guard is a named wrapper rather than a swallow inside `logEvent`, specifically so `pages/api/analytics/log-event.ts` can keep reporting a failed write honestly. That reasoning is recorded in both docblocks so the next person does not "simplify" it by moving the try/catch down a level.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new settings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - N/A, no telemetry fields added or changed
