### PR TITLE
style(client): draw the app's own scrollbar in the chat composer

### DIFF
--- a/apps/client/app/components/Session/LexicalChatInput.tsx
+++ b/apps/client/app/components/Session/LexicalChatInput.tsx
@@ -52,6 +52,8 @@ import type { BeautifulMentionsMenuProps } from 'lexical-beautiful-mentions';
 import React, { forwardRef, useImperativeHandle, useRef, useEffect, useMemo, useCallback } from 'react';
 import { toast } from 'sonner';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { Box } from '@mui/joy';
+import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 
 // Custom menu component - minimal wrapper to preserve event handlers
 // Memoized to prevent unnecessary re-renders when agent list hasn't changed
@@ -613,7 +615,14 @@ export const LexicalChatInput = forwardRef<LexicalChatInputRef, LexicalChatInput
 
     return (
       <LexicalComposer initialConfig={initialConfig}>
-        <div className="lexical-chat-input-container">
+        <Box
+          className="lexical-chat-input-container"
+          // The composer scrolls once it passes its max height (globals.css), and left
+          // to the platform it drew a stock bar inside the chat box while every other
+          // scroll region in the app draws this one. Shared object rather than a copy of
+          // its rules, so the composer and the sidenav cannot drift apart.
+          sx={{ '& .lexical-chat-input': scrollbarStyles }}
+        >
           <RichTextPlugin
             contentEditable={
               <ContentEditable
@@ -704,7 +713,7 @@ export const LexicalChatInput = forwardRef<LexicalChatInputRef, LexicalChatInput
           <PluginErrorBoundary pluginName="EditorRefPlugin">
             <EditorRefPlugin onRef={handleEditorRef} skipSyncRef={skipSyncRef} />
           </PluginErrorBoundary>
-        </div>
+        </Box>
       </LexicalComposer>
     );
   }


### PR DESCRIPTION
## Description

The chat composer scrolls once its content passes the max height set in `globals.css`. Left to the platform it drew a stock scrollbar inside the chat box, while the sidenav, the menus and every other scroll region in the app draw the shared one - so the single most-used input in the product was the one place showing a default bar.

This applies the existing `scrollbarStyles` object to the composer's scroll region. It takes the shared object rather than a copy of its rules, so the composer cannot drift from the rest of the app the next time that style changes.

## Changes

- `apps/client/app/components/Session/LexicalChatInput.tsx`: the `lexical-chat-input-container` wrapper becomes a Joy `Box` so it can carry an `sx`, and that `sx` applies the shared `scrollbarStyles` to the `.lexical-chat-input` scroll region.

No other file changes. No new dependency, no change to composer behaviour, sizing, or key handling.

## Guide for Testers

1. Open `app.staging.bike4mind.com` and sign in.
2. Open any chat session (or start a new one).
3. Click into the message composer at the bottom of the chat.
4. Type or paste enough text to pass the composer's max height - about 12 lines. A quick way: paste the same sentence 12 times, each on its own line.
5. Expected: the composer stops growing and starts scrolling, and the scrollbar that appears matches the one in the left sidenav (same width and colour treatment) rather than the browser default.
6. Scroll the composer with the mouse wheel and by dragging the bar. Expected: both work, and the caret stays where it was.
7. Send the message. Expected: it sends normally and the composer collapses back to one line with no scrollbar.
8. Switch the app between light and dark mode with a long draft still in the composer. Expected: the scrollbar follows the theme, same as the sidenav's.

### Regression Checks

1. Type `@` in the composer. Expected: the mention menu opens over the composer and is not clipped by the wrapper.
2. Type `/` in the composer. Expected: the slash-command menu opens and is not clipped.
3. Attach a file via the paperclip. Expected: the attachment chip renders above the input as before.
4. Paste an image into the composer. Expected: unchanged behaviour.
5. Press Enter to send, and Shift+Enter for a newline. Expected: unchanged.
6. Resize the browser to a narrow width (about 400px). Expected: the composer is unchanged and does not scroll horizontally.

### What NOT to test

Nothing server-side changed - no API, queue, or model behaviour is touched by this PR. Scroll regions outside the composer are untouched; they already used this style.

## Additional Information

Purely presentational, scoped to one component.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
