### PR TITLE
fix(data-lakes): repair stale vector claims and make the help mirror chunk-aware

### DIFF
--- a/packages/scripts/datalake/check-stale-vector-claims.ts
+++ b/packages/scripts/datalake/check-stale-vector-claims.ts
@@ -17,22 +17,29 @@
  * detectLakeInconsistencies, which is also owner/operator-triggered for the same reason.
  *
  * Standalone script rather than a queue/migration: bounded, one-time detection over existing data,
- * not an ongoing pipeline stage. Report-only - repairing the flagged population (re-vectorize the
- * ones still in a lake, `resetChunkStateByIds` the rest) is deliberately out of scope here.
+ * not an ongoing pipeline stage. Report-only BY DEFAULT; `--repair` opts into the write, which is
+ * `resetChunkStateByIds` over the flagged ids - see `repairStaleVectorClaims` for why that single
+ * reset covers the lake members too, rather than this script re-implementing a re-vectorize.
+ *
+ * The `system-help` slice of the population does not need `--repair`: the help mirror's reuse gate
+ * now consults chunk rows (ingestHelpDatalake.ts), so its members are re-created on the next
+ * 6-hourly tick and stay self-healing against any future source of this state.
  *
  * Usage (needs DB, provided by `sst shell`):
  *   npx sst shell --stage dev        -- tsx packages/scripts/datalake/check-stale-vector-claims.ts
  *   npx sst shell --stage production -- tsx packages/scripts/datalake/check-stale-vector-claims.ts
+ *   npx sst shell --stage production -- tsx packages/scripts/datalake/check-stale-vector-claims.ts --repair
  */
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { Resource } from 'sst';
 import { connectDB, fabFileChunkRepository, fabFileRepository } from '@bike4mind/database';
-import { collectStaleVectorClaims } from './collectStaleVectorClaims';
+import { collectStaleVectorClaims, repairStaleVectorClaims } from './collectStaleVectorClaims';
 
 interface Options {
   batchSize: number;
+  repair: boolean;
 }
 
 async function main(opts: Options): Promise<number> {
@@ -61,18 +68,38 @@ async function main(opts: Options): Promise<number> {
   for (const file of stale) {
     console.log(`  id=${file.id} fileName=${JSON.stringify(file.fileName ?? '')}`);
   }
-  console.log(
-    '\nThese are unretrievable by both read paths but read as vectorized by every counter-based ' +
-      'health surface. Repair is a separate, deliberate follow-up - see #2583.'
+
+  if (!opts.repair) {
+    console.log(
+      '\nThese are unretrievable by both read paths but read as vectorized by every counter-based ' +
+        'health surface. Re-run with --repair to reset them.'
+    );
+    return 1;
+  }
+
+  const { reset, skipped } = await repairStaleVectorClaims(
+    { resetChunkStateByIds: ids => fabFileRepository.resetChunkStateByIds(ids) },
+    stale.map(file => file.id)
   );
+  console.log(`\nReset ${reset.length} of ${stale.length} file(s); their counters no longer claim chunks.`);
+  if (skipped.length === 0) {
+    console.log('Any that are lake members are now offered the "Rebuild passages" repair on their lake.');
+    return 0;
+  }
+
+  // Not an error: the reset is preconditioned on `isChunking: {$ne: true}`, so a file a worker
+  // holds is left to that worker. It is reported, and a re-run picks up whatever is still stale.
+  console.log(`Skipped ${skipped.length} held by an in-flight chunk worker; re-run to pick them up:`);
+  for (const id of skipped) console.log(`  id=${id}`);
   return 1;
 }
 
 const argv = yargs(hideBin(process.argv))
   .option('batch-size', { type: 'number', default: 2_000, describe: 'Candidate files read per page' })
+  .option('repair', { type: 'boolean', default: false, describe: 'Reset the flagged files (writes)' })
   .parseSync();
 
-main({ batchSize: argv['batch-size'] })
+main({ batchSize: argv['batch-size'], repair: argv.repair })
   .then(code => process.exit(code))
   .catch(err => {
     console.error(err);

--- a/packages/scripts/datalake/collectStaleVectorClaims.test.ts
+++ b/packages/scripts/datalake/collectStaleVectorClaims.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { collectStaleVectorClaims, type StaleVectorClaimCandidate } from './collectStaleVectorClaims';
+import {
+  collectStaleVectorClaims,
+  repairStaleVectorClaims,
+  type StaleVectorClaimCandidate,
+} from './collectStaleVectorClaims';
 
 /**
  * Fakes the two repository primitives (proven separately against real Mongo in
@@ -61,5 +65,34 @@ describe('collectStaleVectorClaims (#2583)', () => {
 
     expect(report).toEqual({ scanned: 0, stale: [] });
     expect(deps.findFabFileIdsWithChunks).not.toHaveBeenCalled();
+  });
+});
+
+describe('repairStaleVectorClaims (#2583)', () => {
+  it('resets exactly the flagged ids through the canonical reset', async () => {
+    const resetChunkStateByIds = vi.fn(async (ids: string[]) => ids);
+
+    const repair = await repairStaleVectorClaims({ resetChunkStateByIds }, ['f2', 'f5']);
+
+    expect(resetChunkStateByIds).toHaveBeenCalledWith(['f2', 'f5']);
+    expect(repair).toEqual({ reset: ['f2', 'f5'], skipped: [] });
+  });
+
+  it('reports the ids the reset refused rather than claiming it repaired them', async () => {
+    // `resetChunkStateByIds` is preconditioned on `isChunking: {$ne: true}` and returns only the
+    // ids it changed. Counting the request as the result would report a clean repair over files
+    // still claiming chunks they do not have - the silent-success this issue is about.
+    const resetChunkStateByIds = vi.fn(async (ids: string[]) => ids.filter(id => id !== 'busy'));
+
+    const repair = await repairStaleVectorClaims({ resetChunkStateByIds }, ['free', 'busy']);
+
+    expect(repair).toEqual({ reset: ['free'], skipped: ['busy'] });
+  });
+
+  it('writes nothing when the sweep found nothing to repair', async () => {
+    const resetChunkStateByIds = vi.fn(async (ids: string[]) => ids);
+
+    expect(await repairStaleVectorClaims({ resetChunkStateByIds }, [])).toEqual({ reset: [], skipped: [] });
+    expect(resetChunkStateByIds).not.toHaveBeenCalled();
   });
 });

--- a/packages/scripts/datalake/collectStaleVectorClaims.ts
+++ b/packages/scripts/datalake/collectStaleVectorClaims.ts
@@ -1,9 +1,9 @@
 /**
  * The pairing behind `check-stale-vector-claims` (#2583), split out from the script so it is
  * testable without a live DB: the script owns the connection, the argv and the reporting, this owns
- * the sweep. A file is stale when it DECLARES vectorized chunks (`vectorizedChunkCount > 0`) but has
- * zero rows in fabfilechunks - unretrievable by both read paths while every counter-based health
- * surface reads it as vectorized.
+ * the sweep and the repair. A file is stale when it DECLARES vectorized chunks
+ * (`vectorizedChunkCount > 0`) but has zero rows in fabfilechunks - unretrievable by both read paths
+ * while every counter-based health surface reads it as vectorized.
  */
 
 export interface StaleVectorClaimCandidate {
@@ -49,4 +49,45 @@ export async function collectStaleVectorClaims(
   }
 
   return { scanned, stale };
+}
+
+export interface StaleVectorClaimRepairDeps {
+  /** The canonical reset (`fabFileRepository.resetChunkStateByIds`); returns only the ids it changed. */
+  resetChunkStateByIds(ids: string[]): Promise<string[]>;
+}
+
+export interface StaleVectorClaimRepair {
+  reset: string[];
+  /** Selected but not reset - a worker held `isChunking` at the moment of the write. */
+  skipped: string[];
+}
+
+/**
+ * Make the flagged files stop asserting a corpus that is not there.
+ *
+ * `resetChunkStateByIds` is the whole repair, and it is enough for both halves of the population
+ * the issue splits (#2583). For a file outside any lake it simply makes the counter honest. For a
+ * lake member it ALSO enrolls the file in the repair door that already exists: the reset writes
+ * `chunkRebuildRequestedAt` alongside `vectorizedChunkCount: 0`, `error: null` and
+ * `isChunking: false`, which is exactly the STALE-PENDING arm of
+ * `FabFileModel.findConvergencePausedFilesByScope` once REBUILD_PENDING_STALE_MS has passed - so
+ * the lake's own "Rebuild passages" surface offers the re-vectorize, and this script does not grow
+ * a second copy of the queue-send machinery to do it.
+ *
+ * Deliberately NOT preceded by a re-read: the sweep's selection is `vectorizedChunkCount > 0` with
+ * no chunk rows, and the per-document `isChunking: {$ne: true}` precondition inside the reset is
+ * what keeps it off a file a worker has since claimed. A file that gained real chunks between the
+ * sweep and here is reset anyway - correctly, since a rebuild is the safe outcome either way.
+ */
+export async function repairStaleVectorClaims(
+  deps: StaleVectorClaimRepairDeps,
+  ids: string[]
+): Promise<StaleVectorClaimRepair> {
+  if (ids.length === 0) return { reset: [], skipped: [] };
+  const reset = await deps.resetChunkStateByIds(ids);
+  // Report the shortfall rather than the request. The reset returns only the ids it actually
+  // changed, so treating `ids` as the result would report a clean repair over files still claiming
+  // chunks they do not have - the same silent-success this whole issue is about.
+  const resetSet = new Set(reset);
+  return { reset, skipped: ids.filter(id => !resetSet.has(id)) };
 }

--- a/packages/scripts/help/__tests__/ingestHelpDatalake.test.ts
+++ b/packages/scripts/help/__tests__/ingestHelpDatalake.test.ts
@@ -75,6 +75,9 @@ function makeHarness(lake: { id: string; status?: string } | null = { id: 'lake-
         bulkInsert: vi.fn(async (payloads: { fabFileId: string }[]) => {
           chunks.push(...payloads);
         }),
+        findFabFileIdsWithChunks: vi.fn(
+          async (ids: string[]) => new Set(chunks.filter(c => ids.includes(c.fabFileId)).map(c => c.fabFileId))
+        ),
       } as never,
       dataLakes: {
         findBySlug: vi.fn(async () => (lake ? ({ status: 'active', ...lake } as never) : null)),
@@ -151,6 +154,32 @@ describe('ingestHelpDatalake', () => {
     // The point of the differential mirror: no re-embed, and no delete window on the live lake.
     expect(h.embed.mock.calls).toHaveLength(embedCallsAfterFirstRun);
     expect(h.deletedFileIds).toEqual([]);
+  });
+
+  it('re-creates a member whose chunks are gone even though its body never changed (#2583)', async () => {
+    writeCorpus([makeEntry('features/a'), makeEntry('features/b')], {
+      'features/a': '## One\n\nalpha\n',
+      'features/b': '## Two\n\nbeta\n',
+    });
+    const h = makeHarness();
+    await ingestHelpDatalake(h.deps, opts());
+    const strandedId = h.files.find(f => f.tags.some(t => t.name === 'help:features/a'))!.id;
+
+    // The state #2583 reports: an interrupted delete took the chunks and left the file row
+    // standing, still claiming `vectorized: true` over a positive vectorizedChunkCount. The body
+    // and the embedding model are untouched, so a hash-and-model reuse gate re-elects it on every
+    // tick and the article is silently unanswerable forever.
+    for (let i = h.chunks.length - 1; i >= 0; i--) {
+      if (h.chunks[i].fabFileId === strandedId) h.chunks.splice(i, 1);
+    }
+
+    const result = await ingestHelpDatalake(h.deps, opts());
+
+    // Healed on the very next tick, and the sibling that still has its chunks is not re-embedded.
+    expect(result).toMatchObject({ created: 1, removed: 1, unchanged: 1 });
+    expect(h.files.some(f => f.id === strandedId)).toBe(false);
+    const replacement = h.files.find(f => f.tags.some(t => t.name === 'help:features/a'))!;
+    expect(h.chunks.some(c => c.fabFileId === replacement.id)).toBe(true);
   });
 
   it('re-embeds an article whose body changed, and leaves its untouched sibling alone', async () => {

--- a/packages/scripts/help/ingestHelpDatalake.ts
+++ b/packages/scripts/help/ingestHelpDatalake.ts
@@ -13,11 +13,12 @@
  * vectors + file metadata from Mongo (excludeContent), not the file body.
  *
  * DIFFERENTIAL, not delete-and-recreate. Each article's body is fingerprinted into the FabFile's
- * `contentHash`, so a re-run keeps every member whose hash AND `embeddingModel` still match, and
- * only deletes/creates what actually moved. That is what makes an unattended re-run safe on a live
- * retrieval surface: a blanket re-mirror would empty the lake and spend a full re-embed on every
- * tick, leaving a window on each one where `search_knowledge_base` finds no help at all. The
- * steady state here is zero writes and zero embedding calls.
+ * `contentHash`, so a re-run keeps every member whose hash AND `embeddingModel` still match AND
+ * which still has chunk rows behind its vectorized claim (#2583), and only deletes/creates what
+ * actually moved. That is what makes an unattended re-run safe on a live retrieval surface: a
+ * blanket re-mirror would empty the lake and spend a full re-embed on every tick, leaving a window
+ * on each one where `search_knowledge_base` finds no help at all. The steady state here is zero
+ * writes and zero embedding calls.
  *
  * Convergence is still total in both directions - a newly published slug is created, and a slug
  * that left the corpus (or a duplicate member for a slug) is deleted, so it stops being retrievable.
@@ -95,7 +96,7 @@ export interface HelpDatalakeLogger {
 export interface HelpDatalakeIngestDeps {
   db: {
     fabFiles: Pick<IFabFileRepository, 'findIdsByDataLakeTag' | 'findAllInIds' | 'deleteManyInIds' | 'create'>;
-    fabFileChunks: Pick<IFabFileChunkRepository, 'deleteManyByFabFileId' | 'bulkInsert'>;
+    fabFileChunks: Pick<IFabFileChunkRepository, 'deleteManyByFabFileId' | 'bulkInsert' | 'findFabFileIdsWithChunks'>;
     dataLakes: Pick<IDataLakeRepository, 'findBySlug' | 'create' | 'update'>;
   };
   /** Embeds one chunk with the deployment's `defaultEmbeddingModel`. */
@@ -127,7 +128,7 @@ export interface HelpDatalakeIngestOptions {
 
 export interface HelpDatalakeIngestResult {
   publicEntries: number;
-  /** Members kept as-is: content hash and embedding model both still match. */
+  /** Members kept as-is: hash and embedding model still match, and chunk rows still exist. */
   unchanged: number;
   created: number;
   removed: number;
@@ -242,9 +243,29 @@ export async function ingestHelpDatalake(
   });
   const existing = existingIds.length > 0 ? await deps.db.fabFiles.findAllInIds(existingIds) : [];
 
+  // Reuse is decided against the chunk rows, not only the member's own counters (#2583). A member
+  // left chunkless by an interrupted delete still carries `vectorized: true` and a positive
+  // `vectorizedChunkCount`, so a hash-and-model predicate keeps re-electing it forever while it
+  // answers nothing - which is how 62 of the 113 system-help articles stayed unretrievable across
+  // every 6-hourly tick. Consulting the rows makes the mirror self-healing against ANY source of
+  // that state, not just the delete ordering already fixed below.
+  //
+  // One index-covered $group over the current membership (`{fabFileId:1,_id:1}`, no chunk content
+  // read), so the steady-state tick pays one extra aggregate on ~100 ids and still does zero
+  // writes. Its failure mode is a THROW, not an empty set - the aggregate is uncaught, so a broken
+  // read aborts the run rather than quietly invalidating everyone. A genuinely empty result would
+  // re-create the whole corpus in one tick (`maxCreatesPerRun` is 200 against ~113 articles, so the
+  // cap does not bite at this size) - but creates-before-deletes means no retrieval gap while it
+  // happens, and it is the same shape as a defaultEmbeddingModel change, which already does this.
+  const withChunks =
+    existing.length > 0
+      ? await deps.db.fabFileChunks.findFabFileIdsWithChunks(existing.map(file => file.id))
+      : new Set<string>();
+
   // Diff by slug. A member is reusable only if its body fingerprint AND its embedding model still
-  // match; anything else - a stale body, a re-embedded model, a member whose slug left the corpus,
-  // a second member for a slug, a member with no `help:` tag at all - is removed.
+  // match AND it has chunk rows behind its claim; anything else - a stale body, a re-embedded
+  // model, a chunkless member, a member whose slug left the corpus, a second member for a slug, a
+  // member with no `help:` tag at all - is removed.
   const desiredBySlug = new Map(desired.map(d => [d.entry.slug, d]));
   const keepBySlug = new Map<string, IFabFileDocument>();
   // Carries the slug, not just the id: what makes a member safe to delete is whether the revision
@@ -259,7 +280,8 @@ export async function ingestHelpDatalake(
       !keepBySlug.has(slug) &&
       file.contentHash === want.contentHash &&
       file.embeddingModel === deps.embeddingModel &&
-      !!file.vectorized;
+      !!file.vectorized &&
+      withChunks.has(file.id);
     if (reusable) keepBySlug.set(slug, file);
     else removable.push({ id: file.id, slug });
   }


### PR DESCRIPTION
## Description

`system-help` mirror re-elected chunkless members forever (fixes the last user-facing gap left by #2583/#2652), plus an operator repair for the stranded population elsewhere.

A file left chunkless by an interrupted chunk/file delete keeps `vectorized: true` and a positive `vectorizedChunkCount`, so it is unretrievable by both read paths while every counter-based health surface reads it as vectorized (#2583). The write ordering that produced this state was fixed in #2652, and a report-only detection sweep (`check-stale-vector-claims`) shipped with it — but nothing repaired the existing population, and the help mirror could never heal its own slice of it: `ingestHelpDatalake`'s reuse gate checked `contentHash` + `embeddingModel` + the `vectorized` flag, never chunk presence, so a chunkless member whose article text hadn't changed was kept on every 6-hourly re-sync tick, forever. That is the mechanism behind 62 of the 113 system-help articles being permanently unretrievable.

## Changes

- `ingestHelpDatalake`'s reuse predicate now also requires chunk rows behind the claim, via one index-covered `$group` over current membership (no chunk content read). A chunkless member is re-created on the next tick, making the mirror self-healing against any source of this state, not only the delete ordering #2652 fixed.
- `repairStaleVectorClaims` + a `--repair` flag on `check-stale-vector-claims` (previously report-only). The repair is `resetChunkStateByIds` and nothing else: for a file outside any lake it makes the counter honest; for a lake member the same write lands it in the STALE-PENDING arm of `findConvergencePausedFilesByScope`, so the existing "Rebuild passages" surface (`pages/api/data-lakes/[id]/rechunk.ts`) offers the re-vectorize — no second copy of the queue-send machinery.
- The repair reports the ids the reset actually changed vs. the ids it skipped (an in-flight chunk worker holds `isChunking`), rather than assuming the request succeeded.

**Deliberately out of scope**, per the restated ticket: items already shipped in #2652 (write ordering, detection sweep), and queueing the help ingest cron (item 4) — post-#2652 an interrupted run only strands harmless orphan chunks, so that's hardening, not a correctness gap, and belongs in its own lower-priority follow-up.

## Guide for Testers

This is a backend/library-only change (a data-repair script + a mirror's internal reuse predicate) with no new UI surface. Verification is via the automated test suite, not manual UI steps.

1. Run `pnpm --filter @bike4mind/scripts test ingestHelpDatalake` — the added case `re-creates a member whose chunks are gone even though its body never changed (#2583)` pins the self-heal: a member stripped of its chunk rows (but with an unchanged body) is deleted and re-created on the next run, while a sibling with intact chunks is left alone.
2. Run `pnpm --filter @bike4mind/scripts test collectStaleVectorClaims` — the three added `repairStaleVectorClaims` cases pin: it resets exactly the ids it's given, it reports (not swallows) ids the reset refused, and it makes zero calls when there's nothing to repair.
3. Optional operator verification on a real stage (not required for this PR to merge): `npx sst shell --stage dev -- tsx packages/scripts/datalake/check-stale-vector-claims.ts --repair` reports how many stale files it found and reset.

### What NOT to test
- No UI change; nothing to click through in the app.
- Do not run `--repair` against production as part of reviewing this PR — it's a live write path meant for a deliberate operator run, not CI or manual QA.

## Additional Information

- Both callers of `ingestHelpDatalake` (`ingest-help-datalake.ts` bootstrap CLI and `apps/client/server/cron/helpDatalakeIngest.ts` scheduled cron) already pass whole repository objects, so widening the `Pick`-typed deps needed no caller changes.
- `HelpDatalakeIngestDeps` gained a required member on an exported type; `@bike4mind/scripts` is `private: true` and no overlay repo (`b4m-optihashi`, `b4m-libreoncology`, `b4m-pi`, `b4m-overwatch`, `b4m-tavern`) implements it, so this ships as `fix:`, not a breaking change.
- Not yet re-measured against live data: the original 1,028/62 counts are staging-only and as-filed; prod was never verified even in the original report. Running `--repair` per stage is a follow-up operator action, not something this PR does.
- Closes #2583.
