### PR TITLE
feat(data-lakes): record supersession collapse counts and zero-result retrieval rows

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.test.tsx
@@ -72,6 +72,7 @@ const fullView: LakeAccessView = {
       principalId: 'u2',
       principalName: 'Bob',
       readCount: 7,
+      noResultCount: 2,
       firstAccessedAt: new Date('2026-08-01T00:00:00.000Z'),
       lastAccessedAt: new Date('2026-08-10T00:00:00.000Z'),
       surfaces: ['chat-kb-search'],
@@ -83,6 +84,12 @@ const fullView: LakeAccessView = {
     turnsWithSignal: 9,
     turnsAtCap: 4,
     lastAtCapAt: new Date('2026-08-10T00:00:00.000Z'),
+  },
+  supersessionPressure: {
+    turnsWithSignal: 9,
+    turnsWithSuppression: 3,
+    filesSuppressed: 5,
+    lastSuppressedAt: new Date('2026-08-09T00:00:00.000Z'),
   },
   generatedAt: new Date('2026-08-14T12:00:00.000Z'),
 };
@@ -168,6 +175,48 @@ describe('DataLakeAccessModal', () => {
     viewState = loaded(withoutPressure as LakeAccessView);
     render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
     expect(screen.getByTestId('datalake-access-cap-pressure')).toHaveTextContent(/not reported for this window/i);
+  });
+
+  it('reports supersession pressure with both counts and the total withheld', () => {
+    render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+    const line = screen.getByTestId('datalake-access-supersession-pressure');
+    expect(line).toHaveTextContent(/3 of 9 reported read/i);
+    expect(line).toHaveTextContent(/5 withheld in total/i);
+    // Suppression is recoverable, and saying so is the contract the collapse itself states: the
+    // weakest identity tier is a bare file name, so a wrong collapse has to be actionable.
+    expect(line).toHaveTextContent(/still retrievable by id or name/i);
+  });
+
+  it('says not reported for supersession when no read ran the collapse', () => {
+    // The COMMON case, not an edge: the collapse is admin-gated and ships off, so a lake whose
+    // reads never ran it must not read as a lake with no duplicate generations.
+    viewState = loaded({
+      ...fullView,
+      supersessionPressure: { turnsWithSignal: 0, turnsWithSuppression: 0, filesSuppressed: 0 },
+    });
+    render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+    expect(screen.getByTestId('datalake-access-supersession-pressure')).toHaveTextContent(
+      /not reported for this window/i
+    );
+  });
+
+  it('degrades to not-reported when the view carries no supersession object at all', () => {
+    const { supersessionPressure: _omitted, ...withoutPressure } = fullView;
+    viewState = loaded(withoutPressure as LakeAccessView);
+    render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+    expect(screen.getByTestId('datalake-access-supersession-pressure')).toHaveTextContent(
+      /not reported for this window/i
+    );
+  });
+
+  it('shows empty searches beside reads, so a starved lake is visible rather than absent', () => {
+    render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
+    expect(screen.getByTestId('datalake-access-history-noresults')).toHaveTextContent('2');
+    // The caveat has to cover BOTH columns: only lake-scoped chat sessions record an empty search,
+    // so a 0 there is a lower bound, not a clean bill of health.
+    expect(screen.getByTestId('datalake-access-history-caveat')).toHaveTextContent(
+      /not proof that every search found something/i
+    );
   });
 
   it('drops the window qualification when the history was not truncated', () => {

--- a/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.test.tsx
@@ -154,8 +154,11 @@ describe('DataLakeAccessModal', () => {
   it('reports candidate-cap pressure with both counts, qualified as window-scoped', () => {
     render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
     const line = screen.getByTestId('datalake-access-cap-pressure');
-    // Both numbers, never the at-cap count alone: 4 on its own reads as a rate out of every read.
-    expect(line).toHaveTextContent(/4 of 9 reported read/i);
+    // Both numbers, never the at-cap count alone: 4 on its own reads as a rate out of every turn.
+    // TURN, not read: a zero row raises this counter while staying out of readCount, so the label
+    // has to be the wider word or the two numbers cannot be reconciled by the person reading them.
+    expect(line).toHaveTextContent(/4 of 9 reported turn/i);
+    expect(line).not.toHaveTextContent(/reported read/i);
     expect(line).toHaveTextContent(/in this window/i);
     // Attribution wording: the cap is a property of the turn's whole candidate listing, so the
     // contrast is with caps this lake caused - never with reads, which it plainly did cause.
@@ -180,7 +183,8 @@ describe('DataLakeAccessModal', () => {
   it('reports supersession pressure with both counts and the total withheld', () => {
     render(<DataLakeAccessModal lake={lake} onClose={vi.fn()} />, { wrapper: Wrapper });
     const line = screen.getByTestId('datalake-access-supersession-pressure');
-    expect(line).toHaveTextContent(/3 of 9 reported read/i);
+    expect(line).toHaveTextContent(/3 of 9 reported turn/i);
+    expect(line).not.toHaveTextContent(/reported read/i);
     expect(line).toHaveTextContent(/5 withheld in total/i);
     // Suppression is recoverable, and saying so is the contract the collapse itself states: the
     // weakest identity tier is a bare file name, so a wrong collapse has to be actionable.

--- a/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.tsx
@@ -67,10 +67,10 @@ const describeCapPressure = (view: LakeAccessView): string => {
   const windowScope = view.historyTruncated ? ' in this window' : '';
   const lastRead = pressure.lastAtCapAt ? `, most recently ${fmtDateTime(pressure.lastAtCapAt)}` : '';
   return (
-    `Candidate-cap pressure: ${pressure.turnsAtCap} of ${pressure.turnsWithSignal} reported read(s)${windowScope} ` +
-    `hit the forced-retrieval candidate cap${lastRead} - a capped read considers only part of the readable library. ` +
-    'The cap applies to the whole candidate listing for a turn, so this counts reads of this lake that hit it, not ' +
-    'caps this lake caused.'
+    `Candidate-cap pressure: ${pressure.turnsAtCap} of ${pressure.turnsWithSignal} reported turn(s)${windowScope} ` +
+    `hit the forced-retrieval candidate cap${lastRead} - a capped turn considers only part of the readable library. ` +
+    'The cap applies to the whole candidate listing for a turn, so this counts turns that searched this lake and hit ' +
+    'it, not caps this lake caused. Turns, not reads: an empty search counts here too.'
   );
 };
 
@@ -86,9 +86,9 @@ const describeSupersessionPressure = (view: LakeAccessView): string => {
   const last = pressure.lastSuppressedAt ? `, most recently ${fmtDateTime(pressure.lastSuppressedAt)}` : '';
   return (
     `Superseded-version pressure: ${pressure.turnsWithSuppression} of ${pressure.turnsWithSignal} reported ` +
-    `read(s)${windowScope} withheld an older version of a document this lake also holds a newer copy of ` +
+    `turn(s)${windowScope} withheld an older version of a document this lake also holds a newer copy of ` +
     `(${pressure.filesSuppressed} withheld in total)${last}. A withheld version leaves the ranking, not the lake - ` +
-    'it is still retrievable by id or name.'
+    'it is still retrievable by id or name. Turns, not reads: an empty search counts here too.'
   );
 };
 

--- a/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeAccessModal.tsx
@@ -74,6 +74,24 @@ const describeCapPressure = (view: LakeAccessView): string => {
   );
 };
 
+/**
+ * The supersession line, alongside the candidate-cap one and collapsing to the same "not reported"
+ * sentence for the same reason - with one extra way to get there: the collapse is admin-gated and
+ * ships off, so a lake whose reads never ran it is the COMMON case, not a stale-client edge.
+ */
+const describeSupersessionPressure = (view: LakeAccessView): string => {
+  const pressure = view.supersessionPressure;
+  if (!pressure || pressure.turnsWithSignal === 0) return 'Superseded-version pressure: not reported for this window.';
+  const windowScope = view.historyTruncated ? ' in this window' : '';
+  const last = pressure.lastSuppressedAt ? `, most recently ${fmtDateTime(pressure.lastSuppressedAt)}` : '';
+  return (
+    `Superseded-version pressure: ${pressure.turnsWithSuppression} of ${pressure.turnsWithSignal} reported ` +
+    `read(s)${windowScope} withheld an older version of a document this lake also holds a newer copy of ` +
+    `(${pressure.filesSuppressed} withheld in total)${last}. A withheld version leaves the ranking, not the lake - ` +
+    'it is still retrievable by id or name.'
+  );
+};
+
 // Keyed by the role enum so a new role fails the build here rather than silently rendering blank.
 const ROLE_COLOR: Record<DataLakeAccessRole, ColorPaletteProp> = {
   owner: 'primary',
@@ -168,6 +186,18 @@ function HistoryRow({ entry }: { entry: LakeAccessHistoryEntry }) {
       </td>
       <td>
         <Typography level="body-sm">{entry.readCount}</Typography>
+      </td>
+      <td>
+        {/* Muted at zero and emphasized otherwise: an empty-search count is a corpus-gap signal, so
+            it should catch the eye only when there is something to look at. `?? 0` covers a
+            response cached from before the field rather than rendering a blank cell. */}
+        <Typography
+          level="body-sm"
+          textColor={entry.noResultCount ? 'text.primary' : 'text.tertiary'}
+          data-testid="datalake-access-history-noresults"
+        >
+          {entry.noResultCount ?? 0}
+        </Typography>
       </td>
       <td>
         <Typography level="body-sm">{fmtDateTime(entry.lastAccessedAt)}</Typography>
@@ -795,10 +825,20 @@ function AccessViewBody({
           data-testid="datalake-access-history-caveat"
         >
           Covers reads through instrumented retrieval surfaces, within the audit retention window. Treat this as a lower
-          bound - an empty list is not proof that no one has read this lake.
+          bound - an empty list is not proof that no one has read this lake. The Empty searches column counts queries
+          that searched this lake and got nothing back; only lake-scoped chat sessions record those, so a 0 there is not
+          proof that every search found something.
         </Typography>
         <Typography level="body-xs" textColor="text.tertiary" sx={{ mb: 1 }} data-testid="datalake-access-cap-pressure">
           {describeCapPressure(view)}
+        </Typography>
+        <Typography
+          level="body-xs"
+          textColor="text.tertiary"
+          sx={{ mb: 1 }}
+          data-testid="datalake-access-supersession-pressure"
+        >
+          {describeSupersessionPressure(view)}
         </Typography>
         {view.historyTruncated && (
           <Alert
@@ -824,6 +864,10 @@ function AccessViewBody({
                 <tr>
                   <th>Reader</th>
                   <th>Reads</th>
+                  {/* Reads is content served; this is searches of the lake that came back empty.
+                      Only forced retrieval on a lake-scoped session records one, so it is a lower
+                      bound - the caveat above the table covers that for both columns. */}
+                  <th>Empty searches</th>
                   <th>Last read</th>
                   <th>Surfaces</th>
                 </tr>

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/access.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/access.test.ts
@@ -66,6 +66,12 @@ const view: LakeAccessView = {
     turnsAtCap: 2,
     lastAtCapAt: new Date('2026-08-13T00:00:00.000Z'),
   },
+  supersessionPressure: {
+    turnsWithSignal: 4,
+    turnsWithSuppression: 1,
+    filesSuppressed: 3,
+    lastSuppressedAt: new Date('2026-08-12T00:00:00.000Z'),
+  },
   generatedAt: new Date('2026-08-14T12:00:00.000Z'),
 };
 
@@ -115,6 +121,12 @@ describe('GET /api/data-lakes/[id]/access', () => {
       turnsWithSignal: 6,
       turnsAtCap: 2,
       lastAtCapAt: new Date('2026-08-13T00:00:00.000Z'),
+    });
+    expect(body.data.supersessionPressure).toEqual({
+      turnsWithSignal: 4,
+      turnsWithSuppression: 1,
+      filesSuppressed: 3,
+      lastSuppressedAt: new Date('2026-08-12T00:00:00.000Z'),
     });
   });
 

--- a/apps/client/server/dataLakes/lakeAccessViewCsv.test.ts
+++ b/apps/client/server/dataLakes/lakeAccessViewCsv.test.ts
@@ -10,16 +10,18 @@ const baseView = (over: Partial<LakeAccessView> = {}): LakeAccessView => ({
   history: [],
   historyTruncated: false,
   candidateCapPressure: { turnsWithSignal: 0, turnsAtCap: 0 },
+  supersessionPressure: { turnsWithSignal: 0, turnsWithSuppression: 0, filesSuppressed: 0 },
   generatedAt: new Date('2026-08-14T12:00:00.000Z'),
   ...over,
 });
 
 describe('lakeAccessViewToCsv', () => {
-  it('emits four labeled sections with headers', () => {
+  it('emits five labeled sections with headers', () => {
     const csv = lakeAccessViewToCsv(baseView());
     expect(csv).toContain('# Members and grants');
     expect(csv).toContain('# Access channels');
     expect(csv).toContain('# Candidate-cap pressure');
+    expect(csv).toContain('# Supersession pressure');
     expect(csv).toContain('# Access history');
     // Every field is quoted (shared escapeCsvCell), headers included.
     expect(csv).toContain('"principalType","principalId","principalName","role","status"');
@@ -139,6 +141,7 @@ describe('lakeAccessViewToCsv', () => {
             principalKind: 'user',
             principalId: 'u1',
             readCount: 2,
+            noResultCount: 0,
             firstAccessedAt: new Date('2026-08-01T00:00:00.000Z'),
             lastAccessedAt: new Date('2026-08-02T00:00:00.000Z'),
             surfaces: ['chat-kb-search'],
@@ -180,6 +183,7 @@ describe('lakeAccessViewToCsv', () => {
             principalId: 'u2',
             principalName: 'Bob',
             readCount: 5,
+            noResultCount: 0,
             firstAccessedAt: new Date('2026-08-01T00:00:00.000Z'),
             lastAccessedAt: new Date('2026-08-10T00:00:00.000Z'),
             surfaces: ['chat-kb-search', 'data-lake-semantic-search'],
@@ -197,6 +201,52 @@ describe('lakeAccessViewToCsv', () => {
     expect(csv).toContain('access history truncated to the most recent window');
     expect(csv).toContain('"historyWindowStartsAt","2026-08-01T00:00:00.000Z"');
     expect(csv).toContain('# NOTE: readCount and firstAccessedAt below cover only the truncated window');
+  });
+
+  it('exports the supersession section even when nothing was reported, with the reason', () => {
+    const csv = lakeAccessViewToCsv(baseView());
+    // A section that vanished at zero would be indistinguishable from a lake whose reads suppressed
+    // nothing - and here the two are genuinely different: the collapse ships admin-gated OFF.
+    expect(csv).toContain('"turnsWithSignal","turnsWithSuppression","filesSuppressed","lastSuppressedAt"');
+    expect(csv).toContain('"0","0","0",""');
+    expect(csv).toContain('turnsWithSignal 0 means not reported');
+  });
+
+  it('renders reported supersession counters with the last-suppressed date', () => {
+    const csv = lakeAccessViewToCsv(
+      baseView({
+        supersessionPressure: {
+          turnsWithSignal: 9,
+          turnsWithSuppression: 4,
+          filesSuppressed: 11,
+          lastSuppressedAt: new Date('2026-08-09T00:00:00.000Z'),
+        },
+      })
+    );
+    expect(csv).toContain('"9","4","11","2026-08-09T00:00:00.000Z"');
+  });
+
+  it('exports noResultCount beside readCount, labeled as the narrower signal it is', () => {
+    const csv = lakeAccessViewToCsv(
+      baseView({
+        history: [
+          {
+            principalKind: 'user',
+            principalId: 'u3',
+            readCount: 0,
+            noResultCount: 4,
+            firstAccessedAt: new Date('2026-08-01T00:00:00.000Z'),
+            lastAccessedAt: new Date('2026-08-02T00:00:00.000Z'),
+            surfaces: ['forced-retrieval'],
+          },
+        ],
+      })
+    );
+    expect(csv).toContain('"readCount","noResultCount","firstAccessedAt"');
+    // readCount 0 with a nonzero noResultCount is the row this split exists to make representable:
+    // someone queried the lake four times and it answered none of them.
+    expect(csv).toContain('"user","u3","","","","0","4"');
+    expect(csv).toContain('# NOTE: readCount counts reads that returned content');
   });
 
   it('adds no truncation signal when the history was not capped', () => {

--- a/apps/client/server/dataLakes/lakeAccessViewCsv.test.ts
+++ b/apps/client/server/dataLakes/lakeAccessViewCsv.test.ts
@@ -246,7 +246,10 @@ describe('lakeAccessViewToCsv', () => {
     // readCount 0 with a nonzero noResultCount is the row this split exists to make representable:
     // someone queried the lake four times and it answered none of them.
     expect(csv).toContain('"user","u3","","","","0","4"');
-    expect(csv).toContain('# NOTE: readCount counts reads that returned content');
+    // The note must NOT say "reads that returned content": a catalog browse row returns no ids and
+    // still counts, so that phrasing would make the artifact lie about its own column.
+    expect(csv).toContain('# NOTE: readCount counts every recorded read (a catalog browse included');
+    expect(csv).not.toContain('readCount counts reads that returned content');
   });
 
   it('adds no truncation signal when the history was not capped', () => {

--- a/apps/client/server/dataLakes/lakeAccessViewCsv.ts
+++ b/apps/client/server/dataLakes/lakeAccessViewCsv.ts
@@ -91,14 +91,17 @@ export function lakeAccessViewToCsv(view: LakeAccessView): string {
   }
   lines.push('');
 
-  lines.push('# Candidate-cap pressure (turns that read this lake and hit the forced-retrieval candidate cap)');
+  lines.push('# Candidate-cap pressure (turns that searched this lake and hit the forced-retrieval candidate cap)');
   // Exported even at zero, with the reason: a section that vanished when nothing was reported would
   // be indistinguishable from a lake whose reads all had full candidate coverage.
   lines.push(
-    '# NOTE: turnsWithSignal counts reads whose surface reports this at all - turnsWithSignal 0 means not reported, which is not the same as no read hitting the cap'
+    '# NOTE: turnsWithSignal counts turns whose surface reports this at all - turnsWithSignal 0 means not reported, which is not the same as no turn hitting the cap'
   );
   lines.push(
-    '# NOTE: attribution is approximate - the cap applies to the whole candidate listing for a turn, across every source that turn could read; read this as turns that read this lake hit the cap, not as this lake causing it'
+    '# NOTE: attribution is approximate - the cap applies to the whole candidate listing for a turn, across every source that turn could read; read this as turns that searched this lake hit the cap, not as this lake causing it'
+  );
+  lines.push(
+    '# NOTE: counts TURNS, not reads - a search that served nothing raises these counters but is excluded from readCount below; reconcile against readCount + noResultCount'
   );
   if (view.historyTruncated) {
     lines.push('# NOTE: these counts cover only the truncated window above, not all time');
@@ -113,17 +116,22 @@ export function lakeAccessViewToCsv(view: LakeAccessView): string {
   );
   lines.push('');
 
-  lines.push('# Supersession pressure (older document generations withheld from ranking on reads of this lake)');
+  lines.push(
+    '# Supersession pressure (older document generations withheld from ranking on turns that searched this lake)'
+  );
   // Exported even at zero, and for the same reason as the block above: a vanishing section cannot be
   // told apart from a lake whose reads suppressed nothing.
   lines.push(
-    '# NOTE: turnsWithSignal counts reads whose surface actually ran the collapse - turnsWithSignal 0 means not reported (it is admin-gated and off by default), which is not the same as nothing being suppressed'
+    '# NOTE: turnsWithSignal counts turns whose surface actually ran the collapse - turnsWithSignal 0 means not reported (it is admin-gated and off by default), which is not the same as nothing being suppressed'
   );
   lines.push(
     '# NOTE: suppression is recoverable - a withheld generation leaves the ranking, not the lake, and is still retrievable by id or name'
   );
   lines.push(
-    '# NOTE: filesSuppressed sums per turn, so one stale document suppressed on ten reads counts ten; it measures ranking slots reclaimed, not how many stale documents the lake holds'
+    '# NOTE: filesSuppressed sums per turn, so one stale document suppressed on ten turns counts ten; it measures ranking slots reclaimed, not how many stale documents the lake holds'
+  );
+  lines.push(
+    '# NOTE: counts TURNS, not reads - a search that served nothing raises these counters but is excluded from readCount below; reconcile against readCount + noResultCount'
   );
   if (view.historyTruncated) {
     lines.push('# NOTE: these counts cover only the truncated window above, not all time');
@@ -139,7 +147,7 @@ export function lakeAccessViewToCsv(view: LakeAccessView): string {
   );
   lines.push('');
 
-  lines.push('# Access history (who actually read the lake)');
+  lines.push('# Access history (who touched the lake, and whether it answered)');
   // Unconditional, exported populated or empty: only instrumented retrieval surfaces emit events and
   // events age out on their retention TTL, so this section is a lower bound. Without the note an
   // empty section reads as "nobody touched it" - a claim this file cannot support.
@@ -149,7 +157,7 @@ export function lakeAccessViewToCsv(view: LakeAccessView): string {
   // Without this the two columns read as one number split in half. They are not: readCount is every
   // instrumented surface, noResultCount only the one surface that records its own empty outcome.
   lines.push(
-    '# NOTE: readCount counts reads that returned content; noResultCount counts searches that returned nothing, which only forced retrieval on a lake-scoped session records - so it is a lower bound and 0 is not proof that every search succeeded'
+    '# NOTE: readCount counts every recorded read (a catalog browse included, which returns no file or chunk ids); noResultCount counts searches that returned nothing, which only forced retrieval on a lake-scoped session records - so it is a lower bound and 0 is not proof that every search succeeded'
   );
   if (view.historyTruncated) {
     // readCount/firstAccessedAt are window-scoped when truncated - label them so, never as all-time.

--- a/apps/client/server/dataLakes/lakeAccessViewCsv.ts
+++ b/apps/client/server/dataLakes/lakeAccessViewCsv.ts
@@ -14,8 +14,8 @@ const iso = (d: Date | null | undefined): string => (d ? new Date(d).toISOString
 
 /**
  * Render an assembled access view as a sectioned CSV compliance artifact - a metadata block plus
- * four labeled blocks (members & grants, access channels, candidate-cap pressure, access history)
- * in one downloadable file.
+ * five labeled blocks (members & grants, access channels, candidate-cap pressure, supersession
+ * pressure, access history) in one downloadable file.
  * Sectioned rather than one wide sparse table because the audience is human compliance review in a
  * spreadsheet; each block keeps its own header so every column is meaningful. A blank line separates
  * blocks. Static section labels are raw `#` comments; every value that could carry user input goes
@@ -113,12 +113,43 @@ export function lakeAccessViewToCsv(view: LakeAccessView): string {
   );
   lines.push('');
 
+  lines.push('# Supersession pressure (older document generations withheld from ranking on reads of this lake)');
+  // Exported even at zero, and for the same reason as the block above: a vanishing section cannot be
+  // told apart from a lake whose reads suppressed nothing.
+  lines.push(
+    '# NOTE: turnsWithSignal counts reads whose surface actually ran the collapse - turnsWithSignal 0 means not reported (it is admin-gated and off by default), which is not the same as nothing being suppressed'
+  );
+  lines.push(
+    '# NOTE: suppression is recoverable - a withheld generation leaves the ranking, not the lake, and is still retrievable by id or name'
+  );
+  lines.push(
+    '# NOTE: filesSuppressed sums per turn, so one stale document suppressed on ten reads counts ten; it measures ranking slots reclaimed, not how many stale documents the lake holds'
+  );
+  if (view.historyTruncated) {
+    lines.push('# NOTE: these counts cover only the truncated window above, not all time');
+  }
+  lines.push(row(['turnsWithSignal', 'turnsWithSuppression', 'filesSuppressed', 'lastSuppressedAt']));
+  lines.push(
+    row([
+      view.supersessionPressure.turnsWithSignal,
+      view.supersessionPressure.turnsWithSuppression,
+      view.supersessionPressure.filesSuppressed,
+      iso(view.supersessionPressure.lastSuppressedAt),
+    ])
+  );
+  lines.push('');
+
   lines.push('# Access history (who actually read the lake)');
   // Unconditional, exported populated or empty: only instrumented retrieval surfaces emit events and
   // events age out on their retention TTL, so this section is a lower bound. Without the note an
   // empty section reads as "nobody touched it" - a claim this file cannot support.
   lines.push(
     '# NOTE: covers reads through instrumented retrieval surfaces within the audit retention window - a lower bound; an empty section is not proof that no one read this lake'
+  );
+  // Without this the two columns read as one number split in half. They are not: readCount is every
+  // instrumented surface, noResultCount only the one surface that records its own empty outcome.
+  lines.push(
+    '# NOTE: readCount counts reads that returned content; noResultCount counts searches that returned nothing, which only forced retrieval on a lake-scoped session records - so it is a lower bound and 0 is not proof that every search succeeded'
   );
   if (view.historyTruncated) {
     // readCount/firstAccessedAt are window-scoped when truncated - label them so, never as all-time.
@@ -132,6 +163,7 @@ export function lakeAccessViewToCsv(view: LakeAccessView): string {
       'onBehalfOfUserId',
       'onBehalfOfName',
       'readCount',
+      'noResultCount',
       'firstAccessedAt',
       'lastAccessedAt',
       'surfaces',
@@ -146,6 +178,7 @@ export function lakeAccessViewToCsv(view: LakeAccessView): string {
         h.onBehalfOfUserId,
         h.onBehalfOfName,
         h.readCount,
+        h.noResultCount,
         iso(h.firstAccessedAt),
         iso(h.lastAccessedAt),
         h.surfaces.join(';'),

--- a/b4m-core/common/src/types/entities/LakeAccessEventTypes.ts
+++ b/b4m-core/common/src/types/entities/LakeAccessEventTypes.ts
@@ -16,8 +16,10 @@ import { IMongoDocument } from './common';
 // guard), so for them this trail answers "what was read", not "what was asked".
 //
 // FORCED RETRIEVAL is the one exception, and it is narrow on purpose: it writes a ZERO ROW on
-// exactly one exit, the turn that searched its resolved lake scope and had no chunk clear the
-// similarity floor. Without that row "how often did this lake serve nothing" is unanswerable here,
+// exactly one exit, the turn that searched its resolved lake scope WHOLE and had no chunk clear
+// the similarity floor. "Whole" is a gate, not a description: a session that narrows the lake with
+// a content tag of its own searched a slice, and a starve against a slice is not evidence about
+// the lake, so it records nothing. Without that row "how often did this lake serve nothing" is unanswerable here,
 // because a starved turn and a turn that never ran are both equally absent - and the starve is the
 // outcome a lake owner most needs counted, being the one their own corpus can fix. Every other
 // empty forced-retrieval exit (no reachable lake, no readable document, nothing vectorized, an
@@ -29,6 +31,10 @@ import { IMongoDocument } from './common';
 // files to reverse into lakes. It carries `servedNothing: true` - read that flag, never a
 // zero-count test - and any consumer that counts rows as reads must exclude or label it (see
 // `assembleLakeAccessView`, which does).
+// The per-TURN rollups are the deliberate exception: `candidateCapPressure` and
+// `supersessionPressure` DO count zero rows, because a turn that hit the cap and then served
+// nothing is the most diagnostic row of the lot. They are named and documented as turns, not
+// reads, and they reconcile against `readCount + noResultCount` - never against `readCount`.
 // One consequence to be deliberate about: a probing query that matches nothing now DOES leave a
 // row, and on a lake that opted into query-text logging it leaves the query text too. That is the
 // point (an unanswered question is the most actionable thing a lake owner can see), but it is a

--- a/b4m-core/common/src/types/entities/LakeAccessEventTypes.ts
+++ b/b4m-core/common/src/types/entities/LakeAccessEventTypes.ts
@@ -11,11 +11,28 @@ import { IMongoDocument } from './common';
 // SCOPE: this module is the event shape and vocabulary. The write path lives on
 // LakeAccessEventModel.record(); the retrieval surfaces call it via recordLakeAccessEvent.
 //
-// PRODUCT DECISION: a query that returns zero lake content is not recorded at all, even though
-// the query itself happened - every retrieval surface skips the write on an empty/unattributable
-// result (see each call site's own guard). This trail answers "what was read", not "what was
-// asked" - a principal probing a lake's contents with queries that happen to match nothing leaves
-// no row here. Revisit if that gap ever needs closing; it is deliberate, not an oversight.
+// PRODUCT DECISION, amended: most surfaces still record nothing for a query that returns zero lake
+// content - they skip the write on an empty/unattributable result (see each call site's own
+// guard), so for them this trail answers "what was read", not "what was asked".
+//
+// FORCED RETRIEVAL is the one exception, and it is narrow on purpose: it writes a ZERO ROW on
+// exactly one exit, the turn that searched its resolved lake scope and had no chunk clear the
+// similarity floor. Without that row "how often did this lake serve nothing" is unanswerable here,
+// because a starved turn and a turn that never ran are both equally absent - and the starve is the
+// outcome a lake owner most needs counted, being the one their own corpus can fix. Every other
+// empty forced-retrieval exit (no reachable lake, no readable document, nothing vectorized, an
+// outage) still records nothing: those are access/config/health states rather than evidence about
+// the lake's coverage, and `promptMeta.retrieval` already separates them per turn.
+//
+// A ZERO ROW IS NOT THE SAME CLAIM AS EVERY OTHER ROW HERE. It records an ATTEMPT AGAINST A SCOPE,
+// not a read: its `resolvedLakeIds` is the scope that was searched, since there are no returned
+// files to reverse into lakes. It carries `servedNothing: true` - read that flag, never a
+// zero-count test - and any consumer that counts rows as reads must exclude or label it (see
+// `assembleLakeAccessView`, which does).
+// One consequence to be deliberate about: a probing query that matches nothing now DOES leave a
+// row, and on a lake that opted into query-text logging it leaves the query text too. That is the
+// point (an unanswered question is the most actionable thing a lake owner can see), but it is a
+// widening of what this collection holds, not just of how many rows it holds.
 
 /** Who performed the retrieval. Flat fields (not a nested object), mirroring
  * MemoryLedgerEventModel's principalKind/principalId shape. */
@@ -148,6 +165,50 @@ export interface ILakeAccessEvent {
    * never "this lake caused the cap".
    */
   candidateCapReached?: boolean;
+  /**
+   * How many older document generations the supersession collapse suppressed before ranking (see
+   * `dataLakeService/supersession.ts`) - content that was in scope and servable, withheld from the
+   * ranking only because the same lake holds a newer generation of it.
+   *
+   * Tri-state, with the same trap as `candidateCapReached` above:
+   * - `N > 0` - N candidate files left the ranking;
+   * - `0`     - the collapse RAN over this turn's candidates and suppressed nothing;
+   * - ABSENT  - the collapse did not run (it is admin-gated and ships default-off), the surface
+   *   does not report it (every surface but forced retrieval today), or the row predates the
+   *   field. NEVER read absent as `0`; that claims the corpus was checked for superseded
+   *   generations when it never was.
+   *
+   * A COUNT, never a set. The only other live instrument for this collapse is the semantic-search
+   * envelope's `superseded`, whose `collapsed[]` is a SAMPLE capped at that module's `SAMPLE_CAP` -
+   * cross-check this against its `collapsed_files` count, never against that array's length.
+   *
+   * ATTRIBUTION IS APPROXIMATE, exactly as `candidateCapReached`'s is: the collapse runs over the
+   * turn's whole candidate set across every lake in scope, while the row attributes it to the
+   * lakes the turn actually grounded on. The honest reading is "a turn that read this lake
+   * suppressed N", never "this lake suppressed N".
+   */
+  filesSupersededCollapsed?: number;
+  /**
+   * TRUE on a ZERO ROW: this event records a retrieval that ran against the lake scope and returned
+   * nothing at all, rather than a read of content. See the PRODUCT DECISION block above for which
+   * surface writes one and why.
+   *
+   * ABSENT on every ordinary row, and unlike `candidateCapReached` above, absent here IS safely
+   * read as `false`: the flag says how the row was written, not what a surface did or did not
+   * measure, and no zero row predates the field. Do not copy that leniency to the tri-state fields
+   * around it.
+   *
+   * `servedNothing` rather than the better-reading `servedNoContent`: this model's corpus-leak guard
+   * rejects any schema path matching /text|content|body|snippet|passage/, and the guard is worth
+   * more than the nicer name. It holds exactly one exception today; keep it that way.
+   *
+   * WHY A STORED FLAG AND NOT `returnedChunkCount === 0 && returnedFileCount === 0`: that pair is
+   * already produced by real, non-empty rows. `data-lake-public-browse` records a catalog-metadata
+   * read - lake names and descriptions - which returns lakes rather than files and so carries
+   * neither a chunk nor a file id. Deriving "served nothing" from the counts would silently
+   * reclassify every browse row ever written.
+   */
+  servedNothing?: boolean;
   surface: LakeAccessSurface;
   /**
    * The turn this retrieval happened during, for joining this audit row back to its Quest. A
@@ -192,6 +253,13 @@ export interface RecordLakeAccessEventInput {
   /** See `ILakeAccessEvent.candidateCapReached` - tri-state. Omit it entirely on a surface that
    * does not measure its candidate stage; passing `false` asserts full candidate coverage. */
   candidateCapReached?: boolean;
+  /** See `ILakeAccessEvent.filesSupersededCollapsed` - tri-state. Omit it on a surface that does
+   * not run the collapse; passing `0` asserts the collapse ran and found nothing. A non-integer,
+   * negative or non-finite value is dropped by `record()` rather than persisted. */
+  filesSupersededCollapsed?: number;
+  /** See `ILakeAccessEvent.servedNothing`. Pass `true` ONLY from a surface deliberately recording
+   * its own empty outcome; omit it on every content-serving write. */
+  servedNothing?: boolean;
   surface: LakeAccessSurface;
   /** See `ILakeAccessEvent.questId`'s doc comment - diagnostic join key, not authorization data. */
   questId?: string;

--- a/b4m-core/common/src/types/entities/LakeAccessViewTypes.ts
+++ b/b4m-core/common/src/types/entities/LakeAccessViewTypes.ts
@@ -119,10 +119,14 @@ export interface LakeAccessHistoryEntry {
   onBehalfOfUserId?: string;
   onBehalfOfName?: string;
   /**
-   * Reads that actually SERVED content. Excludes zero rows - the audit trail now also records a
+   * Recorded reads: every access row that is not a zero row. The audit trail now also records a
    * forced-retrieval turn that searched this lake and had nothing clear the similarity floor (see
    * the PRODUCT DECISION block in LakeAccessEventTypes.ts), and counting one of those as a read
    * would report content leaving the lake when none did. Those land in `noResultCount` instead.
+   *
+   * NOT "reads that served content", which it is tempting to write and which is false: a
+   * `data-lake-public-browse` row records a catalog-metadata read and carries no file or chunk ids
+   * at all. It counts here, because it IS a read - just not one that moved corpus content.
    */
   readCount: number;
   /**
@@ -130,8 +134,9 @@ export interface LakeAccessHistoryEntry {
    * here with `readCount: 0`: they queried the lake repeatedly and it never answered.
    *
    * A LOWER bound and a NARROWER population than `readCount`: only forced retrieval writes a zero
-   * row, and only for a session scoped to this lake. Present but 0 therefore means "no recorded
-   * empty search", never "every search of this lake succeeded".
+   * row, and only for a session scoped to this lake that adds no content tag of its own (a session
+   * narrowing the lake further searched a slice, so a starve there is not the lake's). Present but
+   * 0 therefore means "no recorded empty search", never "every search of this lake succeeded".
    */
   noResultCount: number;
   /** Newest event of EITHER kind - a search that served nothing is still this principal touching
@@ -155,24 +160,30 @@ export interface LakeAccessHistoryEntry {
  *
  * Attribution is APPROXIMATE for the same reason `LakeCandidateCapPressure`'s is: the collapse runs
  * over a turn's whole candidate set across every lake in scope, while the row attributes it to the
- * lakes that turn grounded on. Read it as "turns that read this lake suppressed N", never "this
+ * lakes that turn grounded on. Read it as "turns that searched this lake suppressed N", never "this
  * lake suppressed N".
+ *
+ * COUNTS TURNS, NOT READS, and the distinction is load-bearing now that a starved turn writes its
+ * own row: a zero row raises these counters while deliberately staying out of `readCount`. That is
+ * the useful direction - a turn that hit the cap or the collapse and THEN served nothing is the
+ * most diagnostic row of the lot - but it means these totals never reconcile against `readCount`.
+ * Reconcile them against `readCount + noResultCount` instead.
  */
 export interface LakeSupersessionPressure {
-  /** Reads in the window whose surface ran the collapse and reported its count either way. */
+  /** Turns in the window whose surface ran the collapse and reported its count either way. */
   turnsWithSignal: number;
-  /** Of those, the reads where the collapse actually suppressed at least one file. */
+  /** Of those, the turns where the collapse actually suppressed at least one file. */
   turnsWithSuppression: number;
   /** Files suppressed across the window, summed. Not a distinct-document count: one document
    * suppressed on ten turns contributes ten, because the quantity being measured is ranking slots
    * reclaimed per turn, not how many stale documents the lake holds. */
   filesSuppressed: number;
-  /** Newest read in the window that suppressed something; absent when `turnsWithSuppression` is 0. */
+  /** Newest turn in the window that suppressed something; absent when `turnsWithSuppression` is 0. */
   lastSuppressedAt?: Date;
 }
 
 /**
- * How often reads of this lake ran against a truncated candidate listing - projected from
+ * How often turns that searched this lake ran against a truncated candidate listing - projected from
  * `ILakeAccessEvent.candidateCapReached` over the SAME event window as `history`.
  *
  * `turnsWithSignal` is what keeps the pair honest: only some surfaces report the field at all, so
@@ -183,14 +194,17 @@ export interface LakeSupersessionPressure {
  *
  * Attribution is APPROXIMATE and a LOWER BOUND, for the reasons `history` documents plus one more:
  * the cap applies to a turn's whole mixed candidate listing, not to this lake alone. Read it as
- * "turns that read this lake hit the cap", never "this lake caused the cap".
+ * "turns that searched this lake hit the cap", never "this lake caused the cap".
+ *
+ * COUNTS TURNS, NOT READS - see the same note on `LakeSupersessionPressure`. A zero row raises
+ * these counters and stays out of `readCount`, so reconcile against `readCount + noResultCount`.
  */
 export interface LakeCandidateCapPressure {
-  /** Reads in the window whose surface reported a candidate-cap state either way. */
+  /** Turns in the window whose surface reported a candidate-cap state either way. */
   turnsWithSignal: number;
-  /** Of those, the reads whose candidate listing was truncated before scoring. */
+  /** Of those, the turns whose candidate listing was truncated before scoring. */
   turnsAtCap: number;
-  /** Newest at-cap read in the window; absent when `turnsAtCap` is 0. */
+  /** Newest at-cap turn in the window; absent when `turnsAtCap` is 0. */
   lastAtCapAt?: Date;
 }
 

--- a/b4m-core/common/src/types/entities/LakeAccessViewTypes.ts
+++ b/b4m-core/common/src/types/entities/LakeAccessViewTypes.ts
@@ -118,11 +118,57 @@ export interface LakeAccessHistoryEntry {
   /** Set when a system/agent principal read on a human's behalf, so the human stays findable. */
   onBehalfOfUserId?: string;
   onBehalfOfName?: string;
+  /**
+   * Reads that actually SERVED content. Excludes zero rows - the audit trail now also records a
+   * forced-retrieval turn that searched this lake and had nothing clear the similarity floor (see
+   * the PRODUCT DECISION block in LakeAccessEventTypes.ts), and counting one of those as a read
+   * would report content leaving the lake when none did. Those land in `noResultCount` instead.
+   */
   readCount: number;
+  /**
+   * Searches of this lake by this principal that returned nothing at all. A principal can appear
+   * here with `readCount: 0`: they queried the lake repeatedly and it never answered.
+   *
+   * A LOWER bound and a NARROWER population than `readCount`: only forced retrieval writes a zero
+   * row, and only for a session scoped to this lake. Present but 0 therefore means "no recorded
+   * empty search", never "every search of this lake succeeded".
+   */
+  noResultCount: number;
+  /** Newest event of EITHER kind - a search that served nothing is still this principal touching
+   * the lake, and a "last read" that ignored it would under-report recent activity. */
   lastAccessedAt: Date;
   firstAccessedAt: Date;
   /** The distinct surfaces this principal read through (semantic search, chat KB, forced, ...). */
   surfaces: LakeAccessSurface[];
+}
+
+/**
+ * How much of this lake's ranking the supersession collapse reclaimed - projected from
+ * `ILakeAccessEvent.filesSupersededCollapsed` over the SAME event window as `history`.
+ *
+ * `turnsWithSignal` carries the honesty, exactly as it does for `LakeCandidateCapPressure`: the
+ * collapse is admin-gated and ships default-off, and only forced retrieval reports it at all, so
+ * `turnsWithSuppression: 0` on its own cannot distinguish "the collapse found nothing to suppress"
+ * from "the collapse never ran". Rows predating the field, rows from surfaces that do not report
+ * it, and rows from turns where the collapse was off all raise NEITHER counter. Presentation
+ * surfaces must show both numbers, or say "not reported" when `turnsWithSignal` is 0.
+ *
+ * Attribution is APPROXIMATE for the same reason `LakeCandidateCapPressure`'s is: the collapse runs
+ * over a turn's whole candidate set across every lake in scope, while the row attributes it to the
+ * lakes that turn grounded on. Read it as "turns that read this lake suppressed N", never "this
+ * lake suppressed N".
+ */
+export interface LakeSupersessionPressure {
+  /** Reads in the window whose surface ran the collapse and reported its count either way. */
+  turnsWithSignal: number;
+  /** Of those, the reads where the collapse actually suppressed at least one file. */
+  turnsWithSuppression: number;
+  /** Files suppressed across the window, summed. Not a distinct-document count: one document
+   * suppressed on ten turns contributes ten, because the quantity being measured is ranking slots
+   * reclaimed per turn, not how many stale documents the lake holds. */
+  filesSuppressed: number;
+  /** Newest read in the window that suppressed something; absent when `turnsWithSuppression` is 0. */
+  lastSuppressedAt?: Date;
 }
 
 /**
@@ -187,6 +233,10 @@ export interface LakeAccessView {
   /** Candidate-cap pressure over the same window as `history` - always present (the counters carry
    * the "nothing reported" state themselves), qualified by `historyTruncated` the same way. */
   candidateCapPressure: LakeCandidateCapPressure;
+  /** Supersession-collapse pressure over the same window as `history` - always present (the
+   * counters carry the "nothing reported" state themselves), qualified by `historyTruncated` the
+   * same way. */
+  supersessionPressure: LakeSupersessionPressure;
   /** When the view was assembled - the instant grant expiry (`status`) was resolved against. */
   generatedAt: Date;
 }

--- a/b4m-core/services/src/dataLakeService/assembleLakeAccessView.test.ts
+++ b/b4m-core/services/src/dataLakeService/assembleLakeAccessView.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   aggregateAccessHistory,
   aggregateCandidateCapPressure,
+  aggregateSupersessionPressure,
   assembleLakeAccessView,
   classifyGrantStatus,
   deriveAccessChannels,
@@ -119,6 +120,122 @@ describe('aggregateAccessHistory', () => {
 
   it('empty input yields no rows', () => {
     expect(aggregateAccessHistory([])).toEqual([]);
+  });
+
+  // The zero row (#2604): forced retrieval records a turn that searched the lake and had nothing
+  // clear the similarity floor. It is a search, not a read, and the whole point of splitting the
+  // counters is that it must not report content leaving the lake.
+  it('counts a zero row toward noResultCount, never readCount', () => {
+    const rows = aggregateAccessHistory([
+      event({ principalId: 'u1', surface: 'forced-retrieval' }),
+      event({ principalId: 'u1', surface: 'forced-retrieval', servedNothing: true }),
+      event({ principalId: 'u1', surface: 'forced-retrieval', servedNothing: true }),
+    ]);
+    expect(rows[0].readCount).toBe(1);
+    expect(rows[0].noResultCount).toBe(2);
+  });
+
+  // The row shape a lake owner most needs to see: someone queried this lake repeatedly and it never
+  // answered. A principal whose only rows are zero rows must still appear, at readCount 0.
+  it('keeps a principal whose every search came back empty, at readCount 0', () => {
+    const rows = aggregateAccessHistory([
+      event({ principalId: 'starved', surface: 'forced-retrieval', servedNothing: true }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ principalId: 'starved', readCount: 0, noResultCount: 1 });
+  });
+
+  /**
+   * An empty search is still this principal touching the lake, so it belongs in the activity
+   * window and the surfaces set - only the READ count excludes it. Ends on the zero row's own
+   * timestamp so a guard that skipped zero rows entirely fails here rather than passing.
+   */
+  it('lets a zero row move the activity window and the surfaces set', () => {
+    const t0 = new Date('2026-08-10T00:00:00Z');
+    const t1 = new Date('2026-08-12T00:00:00Z');
+    const rows = aggregateAccessHistory([
+      event({ principalId: 'u1', surface: 'data-lake-semantic-search', createdAt: t0 }),
+      event({ principalId: 'u1', surface: 'forced-retrieval', createdAt: t1, servedNothing: true }),
+    ]);
+    expect(rows[0].lastAccessedAt).toEqual(t1);
+    expect(rows[0].firstAccessedAt).toEqual(t0);
+    expect(rows[0].surfaces).toEqual(['data-lake-semantic-search', 'forced-retrieval']);
+  });
+
+  /**
+   * The reason `servedNothing` is a stored flag rather than a zero-count test. A
+   * data-lake-public-browse row is a catalog-metadata read: it returns LAKES, so it carries neither
+   * a chunk nor a file id and both counts sit at zero - exactly the shape a derived predicate would
+   * have misread. Every event in this file's fixture has that shape, which is the point.
+   */
+  it('does not mistake a content-less browse row for a zero row', () => {
+    const rows = aggregateAccessHistory([
+      event({ principalId: 'u1', surface: 'data-lake-public-browse', returnedChunkCount: 0, returnedFileCount: 0 }),
+    ]);
+    expect(rows[0].readCount).toBe(1);
+    expect(rows[0].noResultCount).toBe(0);
+  });
+});
+
+describe('aggregateSupersessionPressure', () => {
+  it('counts reported rows in both directions and sums the files suppressed', () => {
+    const t0 = new Date('2026-08-10T00:00:00Z');
+    const t1 = new Date('2026-08-11T00:00:00Z');
+    const t2 = new Date('2026-08-12T00:00:00Z');
+    // Ends on the MIDDLE timestamp so a dropped max guard on lastSuppressedAt changes the result
+    // rather than passing by fixture coincidence.
+    const pressure = aggregateSupersessionPressure([
+      event({ filesSupersededCollapsed: 2, createdAt: t0 }),
+      event({ filesSupersededCollapsed: 3, createdAt: t2 }),
+      event({ filesSupersededCollapsed: 0, createdAt: t2 }),
+      event({ filesSupersededCollapsed: 1, createdAt: t1 }),
+    ]);
+    expect(pressure).toEqual({
+      turnsWithSignal: 4,
+      turnsWithSuppression: 3,
+      filesSuppressed: 6,
+      lastSuppressedAt: t2,
+    });
+  });
+
+  // The distinction the tri-state exists for, and it is the COMMON case here rather than an edge:
+  // the collapse is admin-gated and ships off, so most rows report nothing at all. Counting those
+  // as "ran, suppressed nothing" would report a corpus as duplicate-free that was never examined.
+  it('a row that does not report the field raises neither counter', () => {
+    const pressure = aggregateSupersessionPressure([event({}), event({ filesSupersededCollapsed: 0 })]);
+    expect(pressure.turnsWithSignal).toBe(1);
+    expect(pressure.turnsWithSuppression).toBe(0);
+  });
+
+  it('an all-unreported window is zeroed with no lastSuppressedAt, not reported as duplicate-free', () => {
+    const pressure = aggregateSupersessionPressure([event({}), event({})]);
+    expect(pressure).toEqual({ turnsWithSignal: 0, turnsWithSuppression: 0, filesSuppressed: 0 });
+    expect(pressure.lastSuppressedAt).toBeUndefined();
+  });
+
+  // record() refuses to persist any of these, so they cover a row that reached the collection by
+  // another door (a script, a migration, the raw driver). This projection SUMS, so one bad row must
+  // not be able to NaN the window or decrement it below what was actually suppressed.
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['a negative', -3],
+    ['a fraction', 1.5],
+  ])('ignores %s rather than corrupting the sum', (_label, bad) => {
+    const pressure = aggregateSupersessionPressure([
+      event({ filesSupersededCollapsed: bad }),
+      event({ filesSupersededCollapsed: 4 }),
+    ]);
+    expect(pressure.turnsWithSignal).toBe(1);
+    expect(pressure.filesSuppressed).toBe(4);
+  });
+
+  it('empty input yields the zero pressure', () => {
+    expect(aggregateSupersessionPressure([])).toEqual({
+      turnsWithSignal: 0,
+      turnsWithSuppression: 0,
+      filesSuppressed: 0,
+    });
   });
 });
 
@@ -356,6 +473,43 @@ describe('assembleLakeAccessView', () => {
     // A projection of rows already in hand: a second listByLake would double this lake's audit read
     // cost on every view assembly for a field derivable from the events already fetched.
     expect(spies.listByLakeEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('projects supersession pressure over the same sliced window as the history', async () => {
+    const older = new Date('2026-08-12T00:00:00Z');
+    const middle = new Date('2026-08-13T00:00:00Z');
+    const newer = new Date('2026-08-14T00:00:00Z');
+    // Same probe-row setup as the cap-pressure test above: the third event is sliced off before
+    // aggregation, so its 5 must NOT reach filesSuppressed - the two aggregates have to describe
+    // the same window as the history rows beside them.
+    const events = [
+      event({ principalId: 'u1', createdAt: newer, filesSupersededCollapsed: 2 }),
+      event({ principalId: 'u1', createdAt: middle, filesSupersededCollapsed: 0 }),
+      event({ principalId: 'u1', createdAt: older, filesSupersededCollapsed: 5 }),
+    ];
+    const { adapters } = makeAdapters({ events, users: [{ id: 'u1', name: 'Alice' }] });
+    const view = await assembleLakeAccessView(lakeDoc(), {
+      ...(adapters as object),
+      historyLimit: 2,
+      now: NOW,
+    } as never);
+
+    expect(view.supersessionPressure).toEqual({
+      turnsWithSignal: 2,
+      turnsWithSuppression: 1,
+      filesSuppressed: 2,
+      lastSuppressedAt: newer,
+    });
+  });
+
+  it('reports a lake whose reads never ran the collapse as unreported, not as duplicate-free', async () => {
+    const { adapters } = makeAdapters({ events: [event({ principalId: 'u1' })], users: [{ id: 'u1', name: 'Alice' }] });
+    const view = await assembleLakeAccessView(lakeDoc(), adapters);
+    expect(view.supersessionPressure).toEqual({
+      turnsWithSignal: 0,
+      turnsWithSuppression: 0,
+      filesSuppressed: 0,
+    });
   });
 
   it('reports a lake whose reads never measured the cap as unreported, not as cap-free', async () => {

--- a/b4m-core/services/src/dataLakeService/assembleLakeAccessView.test.ts
+++ b/b4m-core/services/src/dataLakeService/assembleLakeAccessView.test.ts
@@ -237,6 +237,18 @@ describe('aggregateSupersessionPressure', () => {
       filesSuppressed: 0,
     });
   });
+
+  // Deliberate: this rollup counts TURNS. A turn that ran the collapse and THEN served nothing is
+  // the most diagnostic row there is, so it must raise these counters even though it is kept out
+  // of readCount. Pins the decision, not just the code.
+  it('counts a zero row, which is what makes this a turn count and not a read count', () => {
+    const pressure = aggregateSupersessionPressure([
+      event({ servedNothing: true, filesSupersededCollapsed: 2, surface: 'forced-retrieval' as LakeAccessSurface }),
+    ]);
+    expect(pressure.turnsWithSignal).toBe(1);
+    expect(pressure.turnsWithSuppression).toBe(1);
+    expect(pressure.filesSuppressed).toBe(2);
+  });
 });
 
 describe('aggregateCandidateCapPressure', () => {
@@ -280,6 +292,15 @@ describe('aggregateCandidateCapPressure', () => {
 
   it('empty input yields the zero pressure', () => {
     expect(aggregateCandidateCapPressure([])).toEqual({ turnsWithSignal: 0, turnsAtCap: 0 });
+  });
+
+  // Same decision as the supersession rollup above: a starved turn that hit the cap is exactly the
+  // turn an owner needs to see, so the zero row counts here while staying out of readCount.
+  it('counts a zero row, which is what makes this a turn count and not a read count', () => {
+    const pressure = aggregateCandidateCapPressure([
+      event({ servedNothing: true, candidateCapReached: true, surface: 'forced-retrieval' as LakeAccessSurface }),
+    ]);
+    expect(pressure).toEqual({ turnsWithSignal: 1, turnsAtCap: 1, lastAtCapAt: NOW });
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/assembleLakeAccessView.ts
+++ b/b4m-core/services/src/dataLakeService/assembleLakeAccessView.ts
@@ -13,6 +13,7 @@ import type {
   LakeAccessView,
   LakeCandidateCapPressure,
   LakeGrantStatus,
+  LakeSupersessionPressure,
 } from '@bike4mind/common';
 import { orgAclRowConfersMembership } from '@bike4mind/common';
 import { normalizeId } from '@bike4mind/utils';
@@ -56,17 +57,24 @@ export function deriveAccessChannels(
  * carried through for display when a single principal has one. Pure over the event list.
  *
  * Sorted most-recently-active first so the busiest/most-recent readers head the compliance view.
+ *
+ * A ZERO ROW (`servedNothing`) counts toward `noResultCount`, the surfaces set and the first/last
+ * dates, but NEVER toward `readCount`: it records a search of this lake that returned nothing, so
+ * counting it as a read would report content leaving the lake when none did. The flag is read
+ * directly rather than inferred from the returned counts, which a catalog-metadata browse row also
+ * leaves at zero - see `ILakeAccessEvent.servedNothing`.
  */
 export function aggregateAccessHistory(
   events: Pick<
     ILakeAccessEventDocument,
-    'principalKind' | 'principalId' | 'onBehalfOfUserId' | 'surface' | 'createdAt'
+    'principalKind' | 'principalId' | 'onBehalfOfUserId' | 'surface' | 'createdAt' | 'servedNothing'
   >[]
 ): LakeAccessHistoryEntry[] {
   const byPrincipal = new Map<string, { entry: LakeAccessHistoryEntry; surfaces: Set<LakeAccessSurface> }>();
   for (const event of events) {
     const key = `${event.principalKind}:${event.principalId}`;
     const at = event.createdAt;
+    const servedNothing = event.servedNothing === true;
     const acc = byPrincipal.get(key);
     if (!acc) {
       byPrincipal.set(key, {
@@ -74,7 +82,8 @@ export function aggregateAccessHistory(
           principalKind: event.principalKind,
           principalId: event.principalId,
           onBehalfOfUserId: event.onBehalfOfUserId,
-          readCount: 1,
+          readCount: servedNothing ? 0 : 1,
+          noResultCount: servedNothing ? 1 : 0,
           lastAccessedAt: at,
           firstAccessedAt: at,
           surfaces: [],
@@ -84,7 +93,8 @@ export function aggregateAccessHistory(
       continue;
     }
     const { entry } = acc;
-    entry.readCount += 1;
+    if (servedNothing) entry.noResultCount += 1;
+    else entry.readCount += 1;
     if (at.getTime() > entry.lastAccessedAt.getTime()) entry.lastAccessedAt = at;
     if (at.getTime() < entry.firstAccessedAt.getTime()) entry.firstAccessedAt = at;
     // Keep the first on-behalf human seen; a principal reading for several humans is rare and the
@@ -118,6 +128,41 @@ export function aggregateCandidateCapPressure(
     pressure.turnsAtCap += 1;
     if (!pressure.lastAtCapAt || event.createdAt.getTime() > pressure.lastAtCapAt.getTime()) {
       pressure.lastAtCapAt = event.createdAt;
+    }
+  }
+  return pressure;
+}
+
+/**
+ * Project the per-event supersession-collapse count into the counters the view publishes. Pure over
+ * the same event list `aggregateAccessHistory` sees, so the numbers describe exactly the same
+ * window.
+ *
+ * PRESENCE-BASED, exactly as `aggregateCandidateCapPressure` above: a row raises `turnsWithSignal`
+ * iff it carries the field at all, so a surface (or an admin setting) that starts reporting the
+ * collapse later is counted with no change here. An absent field raises neither counter - see
+ * `ILakeAccessEvent.filesSupersededCollapsed` for why absent must never be read as `0`.
+ *
+ * The validity guard has no counterpart in the sibling's plain boolean check, and it is load-bearing
+ * because this projection SUMS: a `NaN` would poison `filesSuppressed` for the whole window and a
+ * negative would silently decrement it. `record()` applies the same non-negative-integer rule and so
+ * cannot persist either, which leaves only a row that reached the collection by another door - a
+ * script, a migration, the raw driver. Keep the two rules in step; they are two halves of one
+ * contract (see `ILakeAccessEvent.filesSupersededCollapsed`).
+ */
+export function aggregateSupersessionPressure(
+  events: Pick<ILakeAccessEventDocument, 'filesSupersededCollapsed' | 'createdAt'>[]
+): LakeSupersessionPressure {
+  const pressure: LakeSupersessionPressure = { turnsWithSignal: 0, turnsWithSuppression: 0, filesSuppressed: 0 };
+  for (const event of events) {
+    const suppressed = event.filesSupersededCollapsed;
+    if (typeof suppressed !== 'number' || !Number.isInteger(suppressed) || suppressed < 0) continue;
+    pressure.turnsWithSignal += 1;
+    if (!suppressed) continue;
+    pressure.turnsWithSuppression += 1;
+    pressure.filesSuppressed += suppressed;
+    if (!pressure.lastSuppressedAt || event.createdAt.getTime() > pressure.lastSuppressedAt.getTime()) {
+      pressure.lastSuppressedAt = event.createdAt;
     }
   }
   return pressure;
@@ -186,6 +231,7 @@ export async function assembleLakeAccessView(
   // Same already-sliced window as the history above - a projection of rows already in hand, never
   // a second listByLake read.
   const candidateCapPressure = aggregateCandidateCapPressure(events);
+  const supersessionPressure = aggregateSupersessionPressure(events);
   const channels = deriveAccessChannels(lake);
 
   // One batched name resolution across every user id the view references: user-principal grants,
@@ -265,6 +311,7 @@ export async function assembleLakeAccessView(
     historyTruncated,
     windowStartsAt,
     candidateCapPressure,
+    supersessionPressure,
     generatedAt: now,
   };
 }

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -2747,6 +2747,17 @@ describe('KnowledgeRetrievalFeature access-event audit: supersession count + zer
     expect(record).not.toHaveBeenCalled();
   });
 
+  /**
+   * `lakeScoped` alone is not enough to attribute a starve. A non-lake retrieval tag is AND'ed into
+   * the candidate listing, so the turn searched the lake INTERSECT that tag - a slice. Recording it
+   * would over-count a coverage gap against a lake that was never searched whole, which is the
+   * wrong direction to be wrong in for a compliance artifact.
+   */
+  it('writes no zero row when the session narrows the lake with a content tag of its own', async () => {
+    await run(makeCtx({ files: [generation('only', '2025-01-01')], score: 0.1 }), ['datalake:z', 'course:bio101']);
+    expect(record).not.toHaveBeenCalled();
+  });
+
   it('does not mark an ordinary grounded row as having served nothing', async () => {
     await run(makeCtx({ files: [generation('only', '2025-01-01')] }), ['datalake:z']);
     // The grounded write never mentions the flag at all, so key absence is the real assertion here.

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -2595,6 +2595,167 @@ describe('KnowledgeRetrievalFeature access-event audit', () => {
 });
 
 /**
+ * The two audit signals that were computed and then dropped (#2604): the supersession-collapse
+ * count, and the row for a turn that searched a lake and served nothing. Both are only ever
+ * observable in the recorded payload, so every assertion here reads the actual `record()` input
+ * rather than the returned messages.
+ */
+describe('KnowledgeRetrievalFeature access-event audit: supersession count + zero rows (#2604)', () => {
+  const OWNER = 'u1';
+  const LAKE = {
+    id: 'lakeZ',
+    slug: 'z',
+    name: 'Lake Z',
+    fileTagPrefix: 'z:',
+    datalakeTag: 'datalake:z',
+    createdByUserId: OWNER,
+    status: 'active',
+  };
+  const embeddingFactory = {
+    createEmbeddingService: () => ({ generateEmbedding: vi.fn().mockResolvedValue([1, 0]) }),
+    getDefaultEmbeddingModel: () => 'text-embedding-ada-002',
+  };
+
+  const record = vi.fn().mockResolvedValue(undefined);
+  // recordLakeAccessEvent awaits a retention read before calling record(), so the call lands one
+  // microtask after getContextMessages returns - same flush the sibling audit block uses.
+  const flushAsync = () => new Promise(resolve => setImmediate(resolve));
+  const recordedInput = () => record.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+
+  /**
+   * A unit vector whose cosine against the query [1, 0] IS `score`. The absolute floor defaults to
+   * 75%, so a 0.1 fixture starves the turn without touching any setting - the exit under test.
+   */
+  const vectorScoring = (score: number) => [score, Math.sqrt(1 - score * score)];
+
+  /** Two generations of one document: same file name, so the collapse groups them on the name tier. */
+  const generation = (id: string, createdAt: string) => ({
+    id,
+    fileName: 'Protocol.pdf',
+    tags: [{ name: 'datalake:z' }],
+    vectorized: true,
+    embeddingModel: 'text-embedding-ada-002',
+    chunkCount: 1,
+    vectorizedChunkCount: 1,
+    createdAt: new Date(createdAt),
+  });
+
+  const makeCtx = (opts: { files: Array<Record<string, unknown>>; collapseEnabled?: boolean; score?: number }) => {
+    const vector = vectorScoring(opts.score ?? 1);
+    return {
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger,
+      user: { id: OWNER, tags: [], groups: [] },
+      db: {
+        organizations: { findMembershipOrgIds: vi.fn().mockResolvedValue([]) },
+        fabfiles: {
+          search: vi.fn().mockResolvedValue({ data: opts.files, hasMore: false, total: opts.files.length }),
+        },
+        fabfilechunks: {
+          findByFabFileId: vi.fn(),
+          findVectorsByFabFileIds: vi.fn((ids: string[]) =>
+            Promise.resolve(ids.map(id => ({ id: `ch-${id}`, fabFileId: id, text: `content of ${id}`, vector })))
+          ),
+        },
+        dataLakes: {
+          findActiveByUserTags: vi.fn().mockResolvedValue([]),
+          findActiveByUserTagsAndEntitlements: vi.fn().mockResolvedValue([LAKE]),
+        },
+        adminSettings: {
+          getSettingsValue: vi.fn(async (key: string) =>
+            key === 'EnableRetrievalSupersessionCollapse' ? (opts.collapseEnabled ?? false) : undefined
+          ),
+        },
+        lakeAccessEvents: { record },
+      },
+      resolveEntitlementKeys: vi.fn().mockResolvedValue([]),
+      sendStatusUpdate: vi.fn().mockResolvedValue(undefined),
+    };
+  };
+
+  const run = async (ctx: ReturnType<typeof makeCtx>, retrievalTags?: string[]) => {
+    const feature = new KnowledgeRetrievalFeature(
+      ctx as unknown as ConstructorParameters<typeof KnowledgeRetrievalFeature>[0],
+      retrievalTags
+    );
+    const messages = await feature.getContextMessages(
+      makeQuest(),
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'what does the protocol say'
+    );
+    await flushAsync();
+    return messages;
+  };
+
+  const twoGenerations = [generation('old', '2024-01-01'), generation('new', '2025-01-01')];
+
+  beforeEach(() => record.mockClear());
+
+  it('records the suppression count on a grounded turn when the collapse ran', async () => {
+    await run(makeCtx({ files: twoGenerations, collapseEnabled: true }));
+    // 1, not 2: the count is what LEFT the ranking, and the winning generation stayed in it.
+    expect(recordedInput()).toMatchObject({ filesSupersededCollapsed: 1, fileIds: ['new'] });
+  });
+
+  it('omits the suppression count entirely when the collapse did not run', async () => {
+    await run(makeCtx({ files: twoGenerations, collapseEnabled: false }));
+    // Undefined, NOT 0. The collapse is admin-gated and off here, so nothing examined this corpus
+    // for superseded generations - and it holds two, which a persisted 0 would deny. This is the
+    // whole reason the write site reads `collapseRan` rather than `supersession.count`.
+    //
+    // Asserted on the VALUE, not on key absence: the payload carries the key with an explicit
+    // `undefined`, and `record()` is where the omit-vs-store decision is made and pinned (see
+    // LakeAccessEventModel.test.ts, which asserts the stored document has no such path).
+    expect(recordedInput()).toBeDefined();
+    expect(recordedInput()?.filesSupersededCollapsed).toBeUndefined();
+  });
+
+  it('records 0, not absence, when the collapse ran over a corpus with nothing to suppress', async () => {
+    await run(makeCtx({ files: [generation('only', '2025-01-01')], collapseEnabled: true }));
+    expect(recordedInput()?.filesSupersededCollapsed).toBe(0);
+  });
+
+  it('writes a zero row when the corpus was searched and nothing cleared the similarity floor', async () => {
+    const ctx = makeCtx({ files: [generation('only', '2025-01-01')], score: 0.1 });
+    const messages = await run(ctx, ['datalake:z']);
+
+    const input = recordedInput();
+    expect(input).toMatchObject({
+      surface: 'forced-retrieval',
+      servedNothing: true,
+      // The scope that was SEARCHED - there is no returned file whose tags could be reversed here.
+      resolvedLakeIds: ['lakeZ'],
+      fileIds: [],
+      chunkIds: [],
+      queryText: 'what does the protocol say',
+      questId: 'quest1',
+      sessionId: 'session1',
+    });
+    // No scores array: nothing was injected, so there is no chunk for a score to be aligned to.
+    expect(input).not.toHaveProperty('scores');
+    // The turn still abstains exactly as before - this row is instrumentation, not behaviour.
+    expect(messages).toHaveLength(1);
+    expect(ctx.db.fabfilechunks.findVectorsByFabFileIds).toHaveBeenCalled();
+  });
+
+  /**
+   * The narrowing that makes attributing to the whole scope honest. Without `lakeScoped` the lake
+   * was one of several mixed sources behind a question that was not about it, and counting a starve
+   * against it is the same category error the grounded write refuses via allowFullScopeFallback.
+   */
+  it('writes no zero row when the session is not scoped to the lake', async () => {
+    await run(makeCtx({ files: [generation('only', '2025-01-01')], score: 0.1 }));
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('does not mark an ordinary grounded row as having served nothing', async () => {
+    await run(makeCtx({ files: [generation('only', '2025-01-01')] }), ['datalake:z']);
+    // The grounded write never mentions the flag at all, so key absence is the real assertion here.
+    expect(recordedInput()).not.toHaveProperty('servedNothing');
+    expect(recordedInput()?.fileIds).toEqual(['only']);
+  });
+});
+
+/**
  * The session-altitude skip. Guards the composition that makes it safe: a personal-file notebook
  * stops grounding against unrelated lakes, while a lake session keeps its lake. Both directions are
  * asserted because the failing direction (never skipping) is silently today's behavior.

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2759,14 +2759,26 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         // `promptMeta.retrieval` instead. See the PRODUCT DECISION block in LakeAccessEventTypes.ts
         // for the whole rule.
         //
-        // Gated on `lakeScoped`, which is what makes attributing to the whole scope honest here.
-        // With it true, `lakes` is exactly the lake(s) the session named (narrowLakeAccessToSession
-        // filters to them), so the search WAS that lake and "it served nothing" is literally true.
-        // With it false the lake was one of several mixed sources behind a question that was not
-        // about it, and counting a starve against it would be the same category error the grounded
-        // write below refuses by passing `allowFullScopeFallback: false`. That makes the resulting
-        // per-lake count a deliberate LOWER bound, which is the direction to be wrong in.
-        const searchedLakeIds = lakeScoped ? lakes.map(lake => lake.id) : [];
+        // Gated on `lakeScoped` AND on the session adding no content tag of its own, because both
+        // are needed for "this lake served nothing" to be literally true.
+        //
+        // `lakeScoped` alone is not enough. With it true, `lakes` is exactly the lake(s) the
+        // session named (narrowLakeAccessToSession filters to them) - but `nonLakeRetrievalTags` is
+        // AND'ed into the candidate listing above, so a session scoped to `datalake:alpha` plus a
+        // content tag searches only alpha INTERSECT that tag. Attributing that starve to alpha
+        // would report a coverage gap in a lake that was never searched whole - an OVER-count, and
+        // in a compliance artifact that is the wrong direction to be wrong in. So a session
+        // carrying any non-lake retrieval tag writes no row at all.
+        //
+        // With `lakeScoped` false the lake was one of several mixed sources behind a question that
+        // was not about it, and counting a starve against it would be the same category error the
+        // grounded write below refuses by passing `allowFullScopeFallback: false`.
+        //
+        // `this.retrievalFilter` deliberately does NOT disqualify a row: it excludes files the lake
+        // itself marks unretrievable, so a starve behind it is still a fact about what this lake can
+        // serve. Both gates together keep the per-lake count a deliberate LOWER bound.
+        const attributableToLake = lakeScoped && nonLakeRetrievalTags.length === 0;
+        const searchedLakeIds = attributableToLake ? lakes.map(lake => lake.id) : [];
         if (searchedLakeIds.length > 0) {
           recordLakeAccessEvent(
             this.chatCompletion.db.lakeAccessEvents,

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -2481,15 +2481,24 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       // Off unless the admin setting says otherwise - the weakest identity tier is a bare file
       // name, so this ships default-off (see EnableRetrievalSupersessionCollapse).
       const supersessionCollapseEnabled = await this.readSupersessionCollapseSetting();
-      const collapse =
-        supersessionCollapseEnabled && lakes.length > 0
-          ? partitionBySupersession(
-              modelMatchedFiles.map(f => ({ ...f, fileTags: f.tags?.map(t => t.name) ?? [] })),
-              { lakes }
-            )
-          : { servable: modelMatchedFiles, superseded: [] };
+      // Named, rather than inlined into the ternary, because the audit trail needs the RAN /
+      // did-not-run distinction that the count alone cannot carry: `supersession.count` is 0 both
+      // when the collapse ran and suppressed nothing and when it never ran at all, and persisting
+      // the second as 0 would claim the corpus was checked for superseded generations when it
+      // never was - see ILakeAccessEvent.filesSupersededCollapsed's tri-state contract.
+      const collapseRan = supersessionCollapseEnabled && lakes.length > 0;
+      const collapse = collapseRan
+        ? partitionBySupersession(
+            modelMatchedFiles.map(f => ({ ...f, fileTags: f.tags?.map(t => t.name) ?? [] })),
+            { lakes }
+          )
+        : { servable: modelMatchedFiles, superseded: [] };
       const scanCandidates = collapse.servable;
       const supersession = buildSupersessionReport(collapse.superseded);
+      // The audit value, resolved once here and used by every write site below. Deliberately NOT
+      // read off `coverage.filesSupersededCollapsed`, which is the user-facing coverage note's
+      // number and flattens the two zeroes above into one.
+      const auditSupersededCollapsed = collapseRan ? supersession.count : undefined;
       if (supersession.count > 0) {
         this.logger.warn(`🔒 Forced retrieval: suppressed ${supersession.count} superseded document(s) before ranking`);
       }
@@ -2741,6 +2750,50 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
           postRelativeFloorCandidates: scored.length,
         });
         this.logger.log(`🔒 Forced retrieval: no chunk cleared the similarity floor (top=${topScore.toFixed(3)})`);
+        // The ZERO ROW. Unlike every other write in this collection it records an ATTEMPT AGAINST A
+        // SCOPE, not a read: nothing was returned, so there is no file tag to reverse into a lake
+        // and `resolvedLakeIds` is the scope that was searched. Written on THIS exit alone - the
+        // corpus was scanned and compared against the query - because a floor starve is the one
+        // empty outcome that says something about the LAKE's coverage rather than about access,
+        // config or corpus health, which the other empty exits report through
+        // `promptMeta.retrieval` instead. See the PRODUCT DECISION block in LakeAccessEventTypes.ts
+        // for the whole rule.
+        //
+        // Gated on `lakeScoped`, which is what makes attributing to the whole scope honest here.
+        // With it true, `lakes` is exactly the lake(s) the session named (narrowLakeAccessToSession
+        // filters to them), so the search WAS that lake and "it served nothing" is literally true.
+        // With it false the lake was one of several mixed sources behind a question that was not
+        // about it, and counting a starve against it would be the same category error the grounded
+        // write below refuses by passing `allowFullScopeFallback: false`. That makes the resulting
+        // per-lake count a deliberate LOWER bound, which is the direction to be wrong in.
+        const searchedLakeIds = lakeScoped ? lakes.map(lake => lake.id) : [];
+        if (searchedLakeIds.length > 0) {
+          recordLakeAccessEvent(
+            this.chatCompletion.db.lakeAccessEvents,
+            {
+              principalKind: 'user',
+              principalId: user.id,
+              organizationId: normalizeId(user.organizationId),
+              resolvedLakeIds: searchedLakeIds,
+              fileIds: [],
+              chunkIds: [],
+              // The marker. NOT inferable from the two empty arrays above - a
+              // data-lake-public-browse row has both empty too and is a real read.
+              servedNothing: true,
+              candidateCapReached: coverage.moreFilesBeyondCap,
+              filesSupersededCollapsed: auditSupersededCollapsed,
+              surface: 'forced-retrieval',
+              // The query that found nothing, subject to the same per-lake opt-in as any other
+              // row. This is the row where the text earns its keep: an unanswered question is the
+              // most actionable thing a lake owner can be shown about their own corpus.
+              queryText: query,
+              questId: quest.id,
+              sessionId: quest.sessionId,
+            },
+            this.logger,
+            this.chatCompletion.db.adminSettings
+          );
+        }
         return this.noContextMessages(partial ? 'no_match_partial' : 'no_match');
       }
       const partialCoverage = this.reportCoverage(quest, coverage, embeddingModel);
@@ -2911,6 +2964,7 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
             chunkIds: injectedChunkIds,
             scores: injectedScores,
             candidateCapReached: coverage.moreFilesBeyondCap,
+            filesSupersededCollapsed: auditSupersededCollapsed,
             surface: 'forced-retrieval',
             queryText: query,
             questId: quest.id,

--- a/packages/database/src/models/ai/LakeAccessEventModel.test.ts
+++ b/packages/database/src/models/ai/LakeAccessEventModel.test.ts
@@ -111,6 +111,79 @@ describe('LakeAccessEventModel / lakeAccessEventRepository.record', () => {
       expect(Object.prototype.hasOwnProperty.call(stored as object, 'candidateCapReached')).toBe(false);
     });
 
+    it('round-trips filesSupersededCollapsed, including the meaningful zero', async () => {
+      const suppressed = await repo.record(baseInput({ surface: 'forced-retrieval', filesSupersededCollapsed: 3 }));
+      expect(suppressed.filesSupersededCollapsed).toBe(3);
+
+      // `0` is an assertion in its own right - the collapse RAN and suppressed nothing - so a
+      // truthiness check in record() would be a silent data loss, exactly as it would for
+      // candidateCapReached: false above.
+      const ranClean = await repo.record(baseInput({ surface: 'forced-retrieval', filesSupersededCollapsed: 0 }));
+      expect(ranClean.filesSupersededCollapsed).toBe(0);
+    });
+
+    it('omits the filesSupersededCollapsed path entirely when the caller supplies none', async () => {
+      const event = await repo.record(baseInput());
+      // Absent, NOT 0: the collapse is admin-gated and ships off, so most rows never ran it, and
+      // recording those as 0 would claim a corpus was checked for superseded generations when it
+      // never was.
+      const stored = await LakeAccessEventModel.findById(event.id).lean();
+      expect(Object.prototype.hasOwnProperty.call(stored as object, 'filesSupersededCollapsed')).toBe(false);
+    });
+
+    it.each([
+      ['negative', -1],
+      ['fractional', 1.5],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+    ])('drops a %s filesSupersededCollapsed rather than failing the whole audit write', async (_label, value) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      // The event itself must still land: losing one diagnostic field is survivable, losing the
+      // row that records who read the lake is not. A schema `min: 0` would have thrown instead.
+      const event = await repo.record(baseInput({ principalId: 'bob', filesSupersededCollapsed: value }));
+      expect(event.principalId).toBe('bob');
+      expect(event.filesSupersededCollapsed).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('filesSupersededCollapsed'));
+      warnSpy.mockRestore();
+    });
+
+    /**
+     * The zero row (#2604) end to end: forced retrieval records a turn that searched a lake scope
+     * and had nothing clear the similarity floor. Its `resolvedLakeIds` is the scope searched, not
+     * lakes reversed from returned files - there are none to reverse.
+     */
+    it('persists a zero row: servedNothing with a scope, no ids, and both counts at zero', async () => {
+      const event = await repo.record(
+        baseInput({
+          surface: 'forced-retrieval',
+          resolvedLakeIds: ['lake-a'],
+          fileIds: [],
+          chunkIds: [],
+          servedNothing: true,
+        })
+      );
+      expect(event.servedNothing).toBe(true);
+      expect(event.resolvedLakeIds).toEqual(['lake-a']);
+      expect(event.returnedChunkCount).toBe(0);
+      expect(event.returnedFileCount).toBe(0);
+      // No scores: nothing was injected, so there is no chunk for a score to be aligned to. The
+      // turn's own promptMeta.retrieval carries the near-miss topScore instead.
+      expect(event.scores).toBeUndefined();
+    });
+
+    it('leaves servedNothing absent on an ordinary row, and stores an explicit false as absent too', async () => {
+      const ordinary = await repo.record(baseInput({ chunkIds: ['c1'] }));
+      const storedOrdinary = await LakeAccessEventModel.findById(ordinary.id).lean();
+      expect(Object.prototype.hasOwnProperty.call(storedOrdinary as object, 'servedNothing')).toBe(false);
+
+      // Unlike the two tri-state fields above, `false` here carries nothing absence does not - the
+      // flag says how the row was WRITTEN, so absent is safely read as false and a second spelling
+      // of "an ordinary row" would only invite a consumer to distinguish them.
+      const explicitFalse = await repo.record(baseInput({ chunkIds: ['c1'], servedNothing: false }));
+      const storedFalse = await LakeAccessEventModel.findById(explicitFalse.id).lean();
+      expect(Object.prototype.hasOwnProperty.call(storedFalse as object, 'servedNothing')).toBe(false);
+    });
+
     it('is absent updatedAt - an audit row that reports being updated is a lie', async () => {
       const event = await repo.record(baseInput());
       expect((event as unknown as { updatedAt?: Date }).updatedAt).toBeUndefined();

--- a/packages/database/src/models/ai/LakeAccessEventModel.ts
+++ b/packages/database/src/models/ai/LakeAccessEventModel.ts
@@ -62,6 +62,16 @@ const LakeAccessEventSchema = new Schema<ILakeAccessEventDocument>(
     // synonym for false. A `default: false` would stamp every non-reporting surface's row as
     // "considered its whole candidate set" - see ILakeAccessEvent.candidateCapReached.
     candidateCapReached: { type: Boolean, required: false, default: undefined },
+    // `default: undefined` for the same third-state reason as candidateCapReached above, and NO
+    // `min: 0` validator despite the field being a count: a validator throws, which would take the
+    // whole audit row down over one malformed field. record() sanitizes a bad value to absent
+    // instead, losing the field rather than the event.
+    filesSupersededCollapsed: { type: Number, required: false, default: undefined },
+    // `default: undefined` again, but for a plainer reason than the two above: absent is not a
+    // third state here, it is simply "not a zero row". Stored rather than derived from the two
+    // returned counts because a data-lake-public-browse row already has both at zero - see
+    // ILakeAccessEvent.servedNothing.
+    servedNothing: { type: Boolean, required: false, default: undefined },
     surface: { type: String, enum: LAKE_ACCESS_SURFACES, required: true },
     queryTextLogged: { type: Boolean, default: false },
     // No enum: this is a diagnostic join key, not a value this schema's job is to validate - see
@@ -151,6 +161,21 @@ class LakeAccessEventRepository extends BaseRepository<ILakeAccessEventDocument>
         ? input.scores.slice(0, LAKE_ACCESS_EVENT_MAX_IDS)
         : undefined;
 
+    // Same never-trust-the-caller posture as `scores`, and the same drop-rather-than-throw
+    // resolution. A count that is negative, fractional or non-finite is not a count, and absent is
+    // already this field's honest "not reported" state - so a bad value lands there rather than
+    // being persisted as a number a consumer would sum.
+    const supersededCollapsed = input.filesSupersededCollapsed;
+    const filesSupersededCollapsed =
+      typeof supersededCollapsed === 'number' && Number.isInteger(supersededCollapsed) && supersededCollapsed >= 0
+        ? supersededCollapsed
+        : undefined;
+    if (supersededCollapsed !== undefined && filesSupersededCollapsed === undefined) {
+      console.warn(
+        `[lakeAccessEvent] filesSupersededCollapsed (${supersededCollapsed}) is not a non-negative integer - dropping it`
+      );
+    }
+
     // The query-text write happens BEFORE the event, keyed to a pre-generated id, so
     // `queryTextLogged` on the event always reflects the true OUTCOME of the attempt - never just
     // the intent. A swallowed failure on the best-effort text write must not leave the event
@@ -175,11 +200,15 @@ class LakeAccessEventRepository extends BaseRepository<ILakeAccessEventDocument>
         // `scores?.length`, not `scores` - an empty array is truthy, so a caller passing
         // `scores: []` would otherwise persist one. Note this COLLAPSES the absent-vs-empty
         // distinction the `default: undefined` above preserves, rather than protecting it: an
-        // explicitly-empty array is stored as absent. That is sound only because the empty state
-        // is unreachable - every scored writer skips the write on zero results (the semantic arm
-        // returns `output: null` and never reaches here), and an empty `scores` alongside
-        // `chunkIds: []` would carry nothing `returnedChunkCount: 0` does not. If a surface ever
-        // records a genuine zero-result semantic search, revisit this rather than the default.
+        // explicitly-empty array is stored as absent.
+        //
+        // A zero-result row DOES reach here now - forced retrieval writes one when nothing clears
+        // the similarity floor (see the PRODUCT DECISION block in LakeAccessEventTypes.ts), so the
+        // "unreachable empty state" this used to rest on no longer holds. The collapse is still
+        // right, for the other reason it always had: an empty `scores` beside `chunkIds: []`
+        // carries nothing `returnedChunkCount: 0` does not. That row's near-miss diagnostic is the
+        // turn's own `promptMeta.retrieval.injected.topScore`, which is not index-aligned to a
+        // chunk and so could never live in this array anyway.
         ...(scores?.length ? { scores } : {}),
         returnedChunkCount,
         returnedFileCount,
@@ -187,6 +216,13 @@ class LakeAccessEventRepository extends BaseRepository<ILakeAccessEventDocument>
         // `typeof`, not truthiness: an explicit `false` is a real assertion (this surface
         // considered everything) and must not be silently dropped into the absent state.
         ...(typeof input.candidateCapReached === 'boolean' ? { candidateCapReached: input.candidateCapReached } : {}),
+        // `!== undefined`, not truthiness: `0` is a real assertion (the collapse ran and suppressed
+        // nothing) and must not be silently dropped into the absent state, which means the opposite.
+        ...(filesSupersededCollapsed !== undefined ? { filesSupersededCollapsed } : {}),
+        // Truthiness is right here, unlike the two spreads above: an explicit `false` carries no
+        // more than absence does, so it is stored as absence rather than as a second way to spell
+        // "an ordinary row".
+        ...(input.servedNothing ? { servedNothing: true } : {}),
         surface: input.surface,
         queryTextLogged,
         // `|| undefined`, so an empty string is stored as absent rather than indexed: the questId


### PR DESCRIPTION
## Description

`lakeaccessevents` is the only durable record of what retrieval actually served, and two signals
that were already computed never reached it. Both were visible in a single transcript or one live
API call, and neither was queryable over time - so no question of the form "how often, across the
last N turns" could be answered from the collection.

Closes #2604

**1. Supersession collapse was not recorded.** Forced retrieval computes the collapse count into its
coverage object and then dropped it at the telemetry write. Measuring what the collapse reclaimed
over real traffic meant replaying the partition offline against `returnedFileIds`.

**2. A zero-injection turn wrote no row at all.** `recordLakeAccessEvent` sat behind
`if (forcedRetrievalLakeIds.length > 0)`, and a turn where nothing cleared the similarity floor
returns via `noContextMessages(...)` before it. A starved turn and a turn that never ran were
equally absent, so "how often did this lake serve nothing" was unanswerable.

This is reporting only. No retrieval behaviour changes: the same turns ground on the same content
and abstain in the same cases.

### Two decisions worth reviewing

**The zero row is a different kind of claim, and it is marked as one.** It records an *attempt
against a scope*, not a read - there is no returned file whose tags could be reversed into a lake,
so `resolvedLakeIds` is the scope that was searched. It carries an explicit `servedNothing: true`
rather than being inferred from `returnedChunkCount === 0 && returnedFileCount === 0`, because that
pair is *already* produced by a real row: `data-lake-public-browse` returns lakes rather than files
and so carries neither a chunk nor a file id. A derived predicate would have silently reclassified
every browse row ever written.

**It is written on one exit only, and only when the lake was searched whole.** The floor starve is
the one empty outcome that says something about the lake's *coverage* rather than about access,
config or corpus health - the other empty exits report through `promptMeta.retrieval` instead.

Two gates make the attribution honest, and both are needed. `lakeScoped` gives us `lakes` as exactly
the lake(s) the session named; with it false the lake is one of several mixed sources behind a
question that was not about it, the same category error the grounded write already refuses via
`allowFullScopeFallback: false`. But that alone is not enough: `nonLakeRetrievalTags` is AND'ed into
the candidate listing, so a session scoped to `datalake:alpha` *plus* a content tag searches only
alpha INTERSECT that tag, and calling that starve alpha's would over-count a coverage gap in a lake
that was never searched whole. So a session carrying any non-lake retrieval tag writes no row.
`retrievalFilter` deliberately does not disqualify a row - it excludes files the lake itself marks
unretrievable, which is still a fact about what the lake can serve. The result stays a deliberate
lower bound.

## Changes

**Event shape** (`LakeAccessEventTypes.ts`, `LakeAccessEventModel.ts`)
- `filesSupersededCollapsed?: number` - tri-state on the `candidateCapReached` pattern: `N` suppressed,
  `0` the collapse ran and suppressed nothing, absent the collapse never ran (it is admin-gated and
  ships off). Absent must never be read as `0`.
- `servedNothing?: boolean` - the zero-row marker. Named around this model's corpus-leak guard, which
  rejects any schema path matching `/text|content|body|snippet|passage/`; `servedNoContent` would have
  needed a second exception to a guard that deliberately holds exactly one.
- `record()` sanitizes a negative/fractional/non-finite count to absent with a warning rather than
  throwing, so one malformed field cannot take the whole audit row down with it.
- Amended the `PRODUCT DECISION` block that declared the zero-row gap deliberate - it invited this
  revisit, and the amendment states which surface is now the exception and which are not.

**Write sites** (`ChatCompletionFeatures.ts`)
- Named `collapseRan`, because `supersession.count` is `0` both when the collapse ran clean and when
  it never ran; persisting the second as `0` would claim a corpus was checked when it never was.
- The grounded write now carries the count; the floor-starve exit writes the zero row.

**Consumers** (`assembleLakeAccessView.ts`, CSV export, access modal)
- `readCount` no longer counts a zero row - it is rendered to lake owners as "Reads", and a search
  that served nothing is not one. Those land in a new `noResultCount`. A principal can now appear at
  `readCount: 0` with a nonzero empty count, which is exactly the row an owner needs to see.
- New `aggregateSupersessionPressure`, modeled on `aggregateCandidateCapPressure` and projected over
  the same already-sliced window (no second `listByLake` read). Presence-based, so `turnsWithSignal`
  separates "the collapse suppressed nothing" from "the collapse never ran" - which here is the
  common case, not an edge, since the setting ships off.
- Both signals surface in the access modal and the CSV compliance export.
- **`candidateCapPressure` and `supersessionPressure` count TURNS, not reads** - and now say so. A
  zero row raises them while staying out of `readCount`, which is the useful direction (a turn that
  hit the cap and *then* served nothing is the most diagnostic row there is) but means they never
  reconcile against `readCount` alone. The type docs, both modal lines and both CSV blocks were
  reworded from "read(s)" to "turn(s)" and now name `readCount + noResultCount` as the denominator.
  The pre-existing cap rollup was already counting turns this way; the zero row is what made the
  old wording actively wrong.
- `readCount`'s doc no longer claims "reads that served content" - a `data-lake-public-browse` row
  carries no file or chunk ids and still counts, because it *is* a read.

## Guide for Testers

The signals are only observable to a **lake owner or manager**, through the Data Lake Access modal.
Everything below is on `app.staging.bike4mind.com` (see "What NOT to test" for why not a preview).

### A. The new columns render and stay honest when nothing is reported

1. Go to `app.staging.bike4mind.com` and sign in.
2. Open **Files -> Upload Files -> Data Lakes** to reach the Data Lake Manager.
3. Pick a lake you own and open its **Access** modal.
4. Scroll to the **Access history** section.
5. Expected: the history table now has an **Empty searches** column between **Reads** and **Last read**.
   On a lake with no starved turns yet, every value in it is `0`, rendered in the muted tertiary colour.
6. Expected: directly above the table, beneath the existing candidate-cap line, a second line reads
   `Superseded-version pressure: not reported for this window.` - because the collapse admin setting
   ships off. It must NOT say "0 of 0" or render blank.
7. Expected: the caveat paragraph above both lines now ends with
   `a 0 there is not proof that every search found something.`
8. Click **Export CSV**. Open the file. Expected: a new `# Supersession pressure` section with the
   header `turnsWithSignal,turnsWithSuppression,filesSuppressed,lastSuppressedAt` and a `0,0,0,` row,
   and a `noResultCount` column in the `# Access history` block.

### B. A starved turn produces an empty-search row

9. Create a chat session **scoped to that lake** (start it from the lake, so the session names it -
   a general chat session will deliberately NOT produce a row; see the Description).
10. Ask a question with no plausible answer anywhere in that lake's documents, e.g.
    `What is the airspeed velocity of an unladen swallow?`
11. Expected: the assistant abstains, exactly as it does today. No behaviour change here.
12. Reopen the lake's **Access** modal (close and reopen it so the view refetches).
13. Expected: your own row's **Empty searches** value has incremented by 1 and is no longer muted.
    Its **Reads** value has NOT changed.
14. Ask a question the lake *can* answer, then reopen the modal.
15. Expected: **Reads** incremented by 1 and **Empty searches** did not.

### C. The suppression count, on a lake with duplicate generations

16. In Admin -> Settings, turn **EnableRetrievalSupersessionCollapse** on.
17. Upload the same document to your lake twice under the same file name, a few minutes apart, so the
    lake holds two generations of it.
18. In a session scoped to that lake, ask a question the document answers.
19. Expected: the answer cites the newer generation only, and the turn's coverage note mentions
    `1 older document version(s) were not ranked`.
20. Reopen the **Access** modal. Expected: the supersession line now reads
    `Superseded-version pressure: 1 of N reported turn(s) ... (1 withheld in total)`, and ends with
    `still retrievable by id or name`.
21. Cross-check against the other instrument: `POST /api/data-lakes/semantic-search` scoped to the
    same lake reports `superseded.collapsed_files`. Compare that **count** against `filesSuppressed`.
    Do NOT compare against `superseded.collapsed[]` - that array is a sample capped at 5.

### Regression Checks

22. On a lake whose reads all served content, **Reads** must show the same number it showed before
    this PR - the split only moves zero rows, and no surface but forced retrieval writes one.
23. A `data-lake-public-browse` row (open a public lake's catalog) must still count as a **Read**. It
    carries no file or chunk ids, so this is the case a count-derived marker would have broken.
24. The existing candidate-cap line and its CSV section must be unchanged in wording and values.
25. With the collapse setting OFF, a grounded turn must still record its access event normally - only
    the suppression field is absent from it.

### What NOT to test

- **Do not try this on a PR preview.** Preview environments have no OpenAI key, so embeddings and
  therefore forced retrieval are dead there; every turn takes an exit that predates this PR and
  writes nothing. Staging is the lowest environment that can exercise it.
- No retrieval quality, ranking, citation or abstention behaviour changed - do not re-test grounding.
- No migration and no new index. The two fields are optional and simply absent on existing rows.

## Additional Information

**Verified by static gates:** `pnpm turbo:core:build`, `pnpm turbo:typecheck`, `pnpm lint:check`,
the whole `@bike4mind/services` package, and every affected suite.

**Verified live, end to end, on a local self-host stack** (real Mongo, real OpenAI embeddings - this
cannot run on a preview, which has no OpenAI key, so the retrieval path is dead there):

- A lake-scoped session (`retrievalTags: ['datalake:acquisition-review-e2e']`,
  `forceKnowledgeRetrieval: true`) asked an off-corpus question. One new row landed:
  `servedNothing: true`, `returnedFileCount: 0`, `resolvedLakeIds` exactly the session's lake,
  `filesSupersededCollapsed` **absent**. Before this change that turn wrote nothing at all.
- The same session asked an on-corpus question: a normal grounded row (`scores: [0.877]`, one chunk,
  one file) with `servedNothing` **absent, not false** - no zero row, no double write.
- With `EnableRetrievalSupersessionCollapse` flipped on, a second starve wrote
  `filesSupersededCollapsed: 0`. Absent vs `0` are distinguishable on real rows, which is the whole
  point of the tri-state and exactly what `supersession.count` alone destroyed.
- `queryTextLogged: false` on every row and `lakeaccessquerytexts` still empty - the per-lake
  `auditQueryTextEnabled` opt-in is respected on the zero row too.
- `GET /api/data-lakes/:id/access` over those real rows returned `readCount: 14, noResultCount: 2`
  and `supersessionPressure: {turnsWithSignal: 1, ...}` - the split and the presence-based rollup
  both correct against data the assembler had never seen in a fixture.
- The CSV export and the access modal both rendered it in a browser: an **Empty searches** column
  reading 2, and both pressure lines in the corrected turn-vs-read wording.

**Still not verified live:** the `filesSupersededCollapsed > 0` arm. That needs a lake holding two
generations of the same document, which the local fixture set does not have. Both other arms of the
tri-state ran live, and the `> 0` arm is unit-tested.

**Volume note:** zero rows consume the same `listByLake` history window as reads, so a heavily
starved lake will hit `historyTruncated` sooner than before. The `lakeScoped` gate is what keeps that
bounded; flagging it as the thing to watch if a busy lake's history window starts feeling short.

## Developer Notes

- **Data model:** `ILakeAccessEvent` now distinguishes a *read* from an *attempt*. Any future surface
  that wants to record its own empty outcome sets `servedNothing: true` and is counted correctly by
  every existing consumer with no further change.
- **Reusable pattern:** `aggregateSupersessionPressure` is the second instance of the
  presence-based `turnsWithSignal` rollup that `aggregateCandidateCapPressure` established. Two
  instances is the point at which the shape is worth naming: any tri-state per-event field can be
  projected into the access view this way without conflating "reported false" with "not reported".
