### PR TITLE
feat(retrieval): scope the forced-retrieval char budget to org/owner

### DIFF
--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -578,11 +578,16 @@ describe('forcedRetrievalCharBudget agrees with the forced-retrieval fallback (#
     expect(settingsMap.forcedRetrievalCharBudget.defaultValue).toBe(FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT);
   });
 
-  it('is platform-only: declares no scope, unlike its sibling dataLakeSearchMaxFiles/MaxChunks', () => {
-    // Deliberate, not an oversight - see the setting's own description. This path reads the setting
-    // directly rather than through the scoped-settings resolver, so a settableAt block here would be
-    // inert at best and could arm the resolver's fail-loud owner check at worst.
-    expect(settingsMap.forcedRetrievalCharBudget.scope).toBeUndefined();
+  it('is settable at the org/owner (caller) altitude, but deliberately not at Lake (#2572)', () => {
+    // Same rung set as the two relevance floors it is resolved alongside, and for the same reason
+    // there is no Lake rung: a forced-retrieval turn pools an uncapped SET of lakes, so no single
+    // lake can key a narrower rung. Was platform-only until #2572 pointed the read at
+    // resolveScopedSettingValues - the rungs and the read path have to move together, since
+    // settableAt is metadata only the scoped resolver honors.
+    expect(settingsMap.forcedRetrievalCharBudget.scope?.settableAt).toEqual([
+      SettingScopeLevel.Organization,
+      SettingScopeLevel.Owner,
+    ]);
   });
 
   it('prefaults to the shared constant rather than makeNumberSetting fallback 0', () => {
@@ -698,11 +703,11 @@ describe('forced-retrieval relevance floors are levers (#2497)', () => {
   });
 
   it('declares a scope, so the read path must go through the scoped resolver', () => {
-    // The inverse of forcedRetrievalCharBudget's assertion above. That one is platform-only because
-    // it is read via getSettingsValue, which ignores settableAt; these two are read via
-    // resolveScopedSettingValues, which honors it. A future change that pointed them back at
-    // getSettingsValue would silently drop every override, so the scope block is the signal that
-    // the resolver is required.
+    // These two and forcedRetrievalCharBudget above are read together, in one
+    // resolveScopedSettingValues call, which is what honors settableAt. A future change that
+    // pointed any of them back at getSettingsValue would silently drop every override, so the
+    // scope block is the signal that the resolver is required. lakeMemoryRecallK below is the
+    // live counterexample: no scope block, because its read is still the plain one.
     for (const key of FLOOR_KEYS) {
       expect(settingsMap[key].scope).toBeDefined();
     }
@@ -849,10 +854,12 @@ describe('lakeMemoryRecallK agrees with the lake-memory recall fallback (#2496)'
     expect(settingsMap.lakeMemoryRecallK.defaultValue).toBeGreaterThan(8);
   });
 
-  it('is platform-only, like its sibling forcedRetrievalCharBudget', () => {
+  it('is platform-only, unlike its sibling forcedRetrievalCharBudget', () => {
     // Deliberate, not an oversight - see the setting's own description. LakeMemoryFeature reads it
-    // directly rather than through the scoped-settings resolver, so a settableAt block here would
-    // be inert at best and could arm the resolver's fail-loud owner check at worst.
+    // via getSettingsValue, which ignores settableAt, so a scope block here would be silently
+    // inert: every override written against it would resolve to nothing. Its sibling was in the
+    // same position until #2572 moved BOTH its rungs and its read at once, which is what giving
+    // this one org/owner rungs would also take.
     expect(settingsMap.lakeMemoryRecallK.scope).toBeUndefined();
   });
 

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3464,12 +3464,18 @@ export const settingsMap = {
       'saturating on every turn against a 47-document lake, so this is the binding constraint on ' +
       'how much of a corpus reaches the model - not the relevance floor. Raising it admits more ' +
       'passages at the cost of prompt tokens and latency on every Data-Lake turn; it is NOT ' +
-      'automatically better, since more context can dilute ranking. Platform-only for now: this ' +
-      'read does not go through the scoped-settings resolver, so a `settableAt` block here would ' +
-      "be inert metadata at best and could arm the resolver's fail-loud owner check at worst.",
+      'automatically better, since more context can dilute ranking. Overridable per organization ' +
+      'and per owner, the same altitude as the two relevance floors resolved alongside it on the ' +
+      'same turn.',
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 4,
+    // Same rungs, and the same absent Lake rung, as the two floors below: one turn scans an
+    // uncapped SET of lakes into a single pool, so no single lake can key a narrower rung.
+    // MUST stay in sync with the read path - `settableAt` is metadata only the scoped resolver
+    // honors, so this block is load-bearing only while readForcedRetrievalSettings
+    // (ChatCompletionFeatures.ts) resolves this key through resolveScopedSettingValues (#2572).
+    scope: { settableAt: [SettingScopeLevel.Organization, SettingScopeLevel.Owner] },
   }),
   kbSearchDefaultResults: makeNumberSetting({
     key: 'kbSearchDefaultResults',
@@ -3568,9 +3574,10 @@ export const settingsMap = {
       'QUALIFYING beliefs can actually be used, which was pinned at 8 (inherited from personal-' +
       'memento recall) on no evidence beyond that inheritance. The sibling lever on the same turn is ' +
       'Forced Retrieval Char Budget, which governs raw chunk text rather than extracted beliefs. ' +
-      'Platform-only for now, like that sibling: this read does not go through the scoped-settings ' +
-      'resolver, so a settableAt block here would be inert metadata at best and could arm the ' +
-      "resolver's fail-loud owner check at worst.",
+      'Platform-only for now, unlike that sibling: this read goes through plain getSettingsValue, ' +
+      'which ignores settableAt, so a scope block here would be silently inert - every override ' +
+      'written against it would resolve to nothing. Pointing the read at the scoped resolver is ' +
+      'the prerequisite, not extra metadata.',
     category: 'AI',
     group: API_SERVICE_GROUPS.EMBEDDING.id,
     order: 8,

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -7,6 +7,7 @@ import {
   shouldSummarizeSession,
   SUMMARIZATION_CONFIG,
   LakeMemoryFeature,
+  FORCED_RETRIEVAL_SETTING_KEYS,
 } from './ChatCompletionFeatures';
 import { GROUNDED_NO_INVENTION_RULE } from './prompts';
 import { mergeRetrievalSummary } from './tools/retrievalSummaryMerge';
@@ -2028,10 +2029,15 @@ describe('KnowledgeRetrievalFeature untrusted-content delimiter (#1659)', () => 
 });
 
 /**
- * The forced-retrieval char budget became a lever (bike4mind#1831, resolveForcedRetrievalCharBudget)
+ * The forced-retrieval char budget became a lever (bike4mind#1831, resolveForcedRetrievalConfig)
  * rather than a module constant. This locks the settings-read contract - unset/unusable/outage all
  * fall back to FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT exactly the way resolveEmbeddingModelFallback
  * does above - and that a configured value actually changes injection, not just that it parses.
+ *
+ * Since #2572 the setting also declares Organization/Owner rungs, so the last two cases here pin
+ * the half of that change a `scope` block cannot pin on its own: that the READ honors an override.
+ * A scope block whose read still went through `getSettingsValue` would satisfy every assertion in
+ * settings.test.ts and silently ignore every override an operator wrote.
  */
 describe('KnowledgeRetrievalFeature configurable char budget (#1831)', () => {
   const END = '[Untrusted Retrieved Content - END]';
@@ -2040,9 +2046,22 @@ describe('KnowledgeRetrievalFeature configurable char budget (#1831)', () => {
     getDefaultEmbeddingModel: () => 'text-embedding-ada-002',
   };
 
+  /** Stored admin rows for `names`, omitting the unset ones so the coded default wins for those. */
+  const platformRows = (names: string[], read: (key: string) => unknown) =>
+    names
+      .map(settingName => ({ settingName, settingValue: read(settingName) }))
+      .filter(row => row.settingValue != null)
+      .map(row => ({ settingName: row.settingName, settingValue: String(row.settingValue) }));
+
   /** Every chunk shares the query's vector, so every one of `chunkCount` chunks clears the
    * similarity floor - the loop that reads the budget runs multiple iterations per turn. */
-  const makeCtx = (opts: { getSettingsValue: (key: string) => unknown; chunkText?: string; chunkCount?: number }) => {
+  const makeCtx = (opts: {
+    getSettingsValue: (key: string) => unknown;
+    chunkText?: string;
+    chunkCount?: number;
+    /** Wire the scoped overlay, optionally with an Organization-rung char-budget override. */
+    scoped?: { orgOverride?: string };
+  }) => {
     const chunkText = opts.chunkText ?? 'z'.repeat(20_000);
     const chunkCount = opts.chunkCount ?? 1;
     const rows = Array.from({ length: chunkCount }, (_, i) => ({
@@ -2052,9 +2071,26 @@ describe('KnowledgeRetrievalFeature configurable char budget (#1831)', () => {
       vector: [1, 0],
     }));
     const getSettingsValue = vi.fn((key: string) => Promise.resolve(opts.getSettingsValue(key)));
+    const scopedSettings = {
+      findOverrides: vi.fn(async () =>
+        opts.scoped?.orgOverride == null
+          ? []
+          : [
+              {
+                scopeLevel: SettingScopeLevel.Organization,
+                scopeId: 'org1',
+                settingName: 'forcedRetrievalCharBudget',
+                settingValue: opts.scoped.orgOverride,
+              },
+            ]
+      ),
+    };
     return {
-      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger,
-      user: { id: 'u1', tags: [], groups: [] },
+      // `debug` only matters on the scoped path, where the resolver calls it - a mock without it
+      // throws into the resolver's own never-throw guard, which serves coded defaults and looks
+      // exactly like an override being ignored.
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger,
+      user: { id: 'u1', organizationId: opts.scoped ? 'org1' : undefined, tags: [], groups: [] },
       db: {
         organizations: { findMembershipOrgIds: vi.fn().mockResolvedValue([]) },
         fabfiles: {
@@ -2063,12 +2099,26 @@ describe('KnowledgeRetrievalFeature configurable char budget (#1831)', () => {
             .mockResolvedValue({ data: [{ id: 'fileA', fileName: 'Budget.pdf', tags: [] }], hasMore: false, total: 1 }),
         },
         fabfilechunks: { findByFabFileId: vi.fn(), findVectorsByFabFileIds: vi.fn(() => Promise.resolve(rows)) },
-        adminSettings: { getSettingsValue },
+        // The scoped resolver does NOT reach the platform base through getSettingsValue: it goes
+        // via getSettingsByNames, whose cached path calls findAll (b4m-core/utils/src/settings.ts).
+        // Both are served from the same opts.getSettingsValue so the two read paths cannot disagree.
+        adminSettings: {
+          getSettingsValue,
+          findBySettingNames: vi.fn(async (names: string[]) => platformRows(names, opts.getSettingsValue)),
+          findAll: vi.fn(async () => platformRows([...FORCED_RETRIEVAL_SETTING_KEYS], opts.getSettingsValue)),
+        },
+        ...(opts.scoped ? { scopedSettings } : {}),
       },
       resolveEntitlementKeys: vi.fn().mockResolvedValue([]),
       sendStatusUpdate: vi.fn().mockResolvedValue(undefined),
     };
   };
+
+  beforeEach(() => {
+    // Both resolvers memoize per scope; without this a value set by one test leaks into the next.
+    invalidateSettingsCache();
+    invalidateScopedSettingsCache();
+  });
 
   const run = async (ctx: ReturnType<typeof makeCtx>) => {
     const feature = new KnowledgeRetrievalFeature(
@@ -2150,6 +2200,34 @@ describe('KnowledgeRetrievalFeature configurable char budget (#1831)', () => {
       ([key]) => key === 'forcedRetrievalCharBudget'
     );
     expect(calls).toHaveLength(1);
+  });
+
+  // Only the budget, so the two floors resolved in the same read stay at their own defaults
+  // instead of reading 2000 as a 2000% floor and warning their way back to the default.
+  const platformBudgetOnly = (value: string) => (key: string) =>
+    key === 'forcedRetrievalCharBudget' ? value : undefined;
+
+  it('an organization override beats the platform value (#2572)', async () => {
+    // The load-bearing assertion for the scope block: injection length must follow the OVERRIDE,
+    // not the platform setting. If the read regressed to getSettingsValue this would inject 2,000
+    // characters and the scope block would be inert metadata.
+    const content = await run(
+      makeCtx({
+        getSettingsValue: platformBudgetOnly('2000'),
+        chunkText: 'z'.repeat(30_000),
+        scoped: { orgOverride: '9000' },
+      })
+    );
+    expect(bodyLen(content)).toBe(9_000);
+  });
+
+  it('falls through to the platform value when the overlay holds no override (#2572)', async () => {
+    // The common case on a scoped-overlay host: an org with nothing overridden must not lose the
+    // platform value, which is what a resolver bug that treated "no override" as "unset" would do.
+    const content = await run(
+      makeCtx({ getSettingsValue: platformBudgetOnly('2000'), chunkText: 'z'.repeat(30_000), scoped: {} })
+    );
+    expect(bodyLen(content)).toBe(2_000);
   });
 });
 
@@ -2844,7 +2922,7 @@ describe('LakeMemoryFeature personal-corpus skip', () => {
 
 /**
  * The belief budget is the `lakeMemoryRecallK` admin setting, not the 8 this path used to hardcode
- * (#2496). Resolution mirrors `resolveForcedRetrievalCharBudget` below, so these pin the same three
+ * (#2496). Resolution mirrors `resolveForcedRetrievalConfig` below, so these pin the same three
  * properties: a configured value reaches the recall, anything unusable falls back LOUDLY, and a
  * settings outage costs the turn its budget but never its card.
  */

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -891,9 +891,11 @@ export class LakeMemoryFeature implements ChatCompletionFeature {
   }
 
   /**
-   * The admin's configured `lakeMemoryRecallK`, or the coded default on anything unusable. Mirrors
-   * `resolveForcedRetrievalCharBudget` in KnowledgeRetrievalFeature below: same try/catch shape,
-   * same loud-fallback policy, resolved once per turn.
+   * The admin's configured `lakeMemoryRecallK`, or the coded default on anything unusable. Same
+   * try/catch shape and loud-fallback policy as `resolveForcedRetrievalConfig` in
+   * KnowledgeRetrievalFeature below, resolved once per turn - but a plain `getSettingsValue` read,
+   * because this setting declares no `scope`. Giving it org/owner rungs means moving this read onto
+   * `resolveScopedSettingValues` in the same change; `settableAt` alone would be inert here (#2572).
    *
    * `positiveIntOr`'s unusable-value branch is defense-in-depth, not a production-reachable path:
    * `getSettingsValue` runs the setting's own schema (`.min(1)`, `.max(LAKE_RECALL_K_MAX)`) via
@@ -1703,14 +1705,20 @@ const FORCED_RETRIEVAL_MAX_SCANNED_CHUNKS = 4000;
 // large configured value could in principle admit more sections than this caps; a corpus of very
 // short chunks could inject fewer than expected regardless of budget.
 const FORCED_RETRIEVAL_MAX_SCORED_CHUNKS = 256;
-// Both relevance floors are levers now (`forcedRetrievalRelativeFloorPct` and
-// `forcedRetrievalMinSimilarityPct`, resolved once per turn by resolveForcedRetrievalFloors below),
-// so neither is a module constant - every former FORCED_RETRIEVAL_MIN_SIMILARITY reference is a
-// resolved local instead. When nothing clears them, no chunk is injected and the turn falls back to
+// The char budget and both relevance floors are levers now (all three resolved once per turn by
+// resolveForcedRetrievalConfig below), so none is a module constant - every former
+// FORCED_RETRIEVAL_CHAR_BUDGET and FORCED_RETRIEVAL_MIN_SIMILARITY reference is a resolved local
+// instead. When nothing clears the floors, no chunk is injected and the turn falls back to
 // forcedRetrievalNoContextPrompt.
-// The char budget is now a lever (`forcedRetrievalCharBudget` setting, resolved once per turn by
-// resolveForcedRetrievalCharBudget below) rather than a module constant - every former reference to
-// a FORCED_RETRIEVAL_CHAR_BUDGET constant is a resolved local variable instead.
+//
+// Exported so a test's admin-settings fixture can serve exactly the keys the read asks for: a
+// fixture that enumerated them itself would keep passing (on coded defaults) if a fourth key were
+// added here, which is the one way these tests could go quiet without failing.
+export const FORCED_RETRIEVAL_SETTING_KEYS = [
+  'forcedRetrievalCharBudget',
+  'forcedRetrievalRelativeFloorPct',
+  'forcedRetrievalMinSimilarityPct',
+] as const;
 
 /**
  * One of the two floor settings as a 0-1 cosine fraction, or `fallback` when the stored value is
@@ -2096,100 +2104,97 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
   }
 
   /**
-   * The admin's configured `forcedRetrievalCharBudget`, or the coded default on anything unusable.
-   * Mirrors `resolveEmbeddingModelFallback` above: same try/catch shape, same loud-fallback policy.
+   * The char budget and both relevance floors for this turn, on the CALLER's org/owner scope.
+   *
+   * One read for all three because all three share one scope: each declares the same
+   * Organization/Owner rungs, and `resolveAll` covers any number of keys in one platform read plus
+   * one overlay query. Resolving them in two calls would add a second overlay query to every
+   * Data-Lake-mode turn (the platform half is cache-warm, so that side costs nothing either way)
+   * and buy nothing. No Lake rung on any of them, deliberately: one turn scans an uncapped SET of
+   * lakes into a single pool with a single top score, so there is no lake for a narrower rung to
+   * key on, the same reason `kbSearchMinRelevancePct` stops at owner (see `scopeForCaller`).
+   *
    * Resolved ONCE per turn by the caller and closed over, never re-read inside the per-chunk
    * accumulation loop below.
    *
-   * `positiveIntOr`'s unset/unusable-value branches are defense-in-depth here, not something
-   * normal operation exercises: `getSettingsValue` runs the setting's own schema (`.min(1_000)`,
-   * now also `.max`) via `safeParse` before this ever sees the value, so those branches cannot
-   * fire for any input that reached the DB through the write path OR a direct edit - the schema
-   * check applies to whatever is stored, regardless of how it got there. The only branch that is
-   * genuinely reachable is the outer catch below (a settings-read failure/outage).
-   */
-  private async resolveForcedRetrievalCharBudget(): Promise<number> {
-    try {
-      const configured = await this.chatCompletion.db.adminSettings.getSettingsValue('forcedRetrievalCharBudget');
-      return positiveIntOr(
-        configured as string | number | null | undefined,
-        FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
-        'forcedRetrievalCharBudget',
-        this.logger
-      );
-    } catch (err) {
-      this.logger.warn(
-        `🔒 Forced retrieval: failed to read forcedRetrievalCharBudget; falling back to ${FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT}`,
-        err
-      );
-      return FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT;
-    }
-  }
-
-  /**
-   * Both relevance floors for this turn, on the CALLER's org/owner scope.
-   *
-   * Read via readForcedRetrievalFloorPcts below, which prefers the scoped-settings resolver over the
-   * plain `getSettingsValue` that resolveForcedRetrievalCharBudget uses: these two declare a
-   * `settableAt` block, and that metadata is only honored on the scoped path - a scoped setting read
-   * directly would silently ignore every override. No Lake rung, deliberately: one turn scans an
-   * uncapped SET of lakes into a single pool with a single top score, so there is no lake for a
-   * narrower rung to key on, the same reason `kbSearchMinRelevancePct` stops at owner (see
-   * `scopeForCaller`).
-   *
-   * Percent-to-fraction conversion happens here, once, so every comparison below is against a raw
-   * cosine. `nonNegativeIntOr` rather than `positiveIntOr` because `0` is meaningful for the
-   * RELATIVE floor (a disabled floor) and both floors share this helper. `0` is not meaningful for
-   * the absolute floor, and what keeps it out is the READ path, not the write boundary - scripts
-   * and migrations write this collection raw, but both readers re-parse through the setting's own
-   * schema (`min: 1`) and substitute the coded default on failure. Same mechanism
-   * `forcedRetrievalFloorFraction` relies on for its range check.
+   * Percent-to-fraction conversion happens here, once, so every floor comparison below is against a
+   * raw cosine. `nonNegativeIntOr` inside `forcedRetrievalFloorFraction` rather than `positiveIntOr`
+   * because `0` is meaningful for the RELATIVE floor (a disabled floor) and both floors share that
+   * helper. `0` is not meaningful for the absolute floor, and what keeps it out is the READ path,
+   * not the write boundary - scripts and migrations write this collection raw, but every reader
+   * re-parses through the setting's own schema (`min: 1`) and substitutes the coded default on
+   * failure. The `positiveIntOr` branches for the char budget are defense-in-depth on the same
+   * basis: both read paths run the setting's schema (`.min(1_000)`, `.max`) before this sees a
+   * value, so only a read failure is genuinely reachable here.
    *
    * Never throws, and the catch reaches wider than "no adminSettings adapter": the platform-only
    * path calls `getSettingsValue` unguarded, so a settings or DB outage on an overlay-less host
    * lands here too. (On the scoped path a missing adapter is swallowed inside the resolver and
-   * never reaches this catch.) Same fail-open posture as the char budget, and the defaults it
-   * falls back to are behavior-preserving.
+   * never reaches this catch.) Every default it falls back to is behavior-preserving.
    */
-  private async resolveForcedRetrievalFloors(): Promise<ForcedRetrievalFloors> {
-    const coded: ForcedRetrievalFloors = {
-      relativeFloor: FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT / 100,
-      minSimilarity: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT / 100,
-    };
+  private async resolveForcedRetrievalConfig(): Promise<{ charBudget: number; floors: ForcedRetrievalFloors }> {
     try {
-      const { relative, absolute } = await this.readForcedRetrievalFloorPcts();
+      const { charBudget, relative, absolute } = await this.readForcedRetrievalSettings();
       return {
-        relativeFloor: forcedRetrievalFloorFraction(
-          relative,
-          FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
-          'forcedRetrievalRelativeFloorPct',
+        charBudget: positiveIntOr(
+          charBudget as string | number | null | undefined,
+          FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+          'forcedRetrievalCharBudget',
           this.logger
         ),
-        minSimilarity: forcedRetrievalFloorFraction(
-          absolute,
-          FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
-          'forcedRetrievalMinSimilarityPct',
-          this.logger
-        ),
+        floors: {
+          relativeFloor: forcedRetrievalFloorFraction(
+            relative,
+            FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+            'forcedRetrievalRelativeFloorPct',
+            this.logger
+          ),
+          minSimilarity: forcedRetrievalFloorFraction(
+            absolute,
+            FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+            'forcedRetrievalMinSimilarityPct',
+            this.logger
+          ),
+        },
       };
     } catch (err) {
+      // Names every key, because one read failure degrades all three at once and an operator
+      // reading this line needs to know which levers stopped being honored.
       this.logger.warn(
-        `\u{1F512} Forced retrieval: failed to read the relevance floors; falling back to ` +
+        `\u{1F512} Forced retrieval: failed to read forcedRetrievalCharBudget / ` +
+          `forcedRetrievalRelativeFloorPct / forcedRetrievalMinSimilarityPct; falling back to ` +
+          `${FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT} chars, ` +
           `${FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT}% relative / ${FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT}% absolute`,
         err
       );
-      return coded;
+      return {
+        charBudget: FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+        floors: {
+          relativeFloor: FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT / 100,
+          minSimilarity: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT / 100,
+        },
+      };
     }
   }
 
   /**
-   * The two floor settings as stored (whole-number percents), by whichever read path this host has.
+   * The three forced-retrieval settings as stored (a char count and two whole-number percents), by
+   * whichever read path this host has.
    *
    * A `settableAt` block is only honored by the scoped resolver, so that is the path whenever the
-   * scoped overlay is wired. When it is absent there is no override to find and the platform read is
-   * byte-identical, so this takes the plain `getSettingsValue` route rather than requiring every host
-   * to carry the overlay - the same optionality `scopedSettings` is already documented with on the
-   * db contract above, and the same two-path shape `resolveSearchBudgets` uses.
+   * scoped overlay is wired. All three keys declare one, so all three MUST be read here rather than
+   * via `getSettingsValue` - a scoped setting read directly silently ignores every override, which
+   * is the "lever that does nothing" failure the scope blocks in `settings.ts` warn about. When the
+   * overlay is absent there is no override to find and the platform read is byte-identical, so this
+   * takes the plain route rather than requiring every host to carry the overlay - the same
+   * optionality `scopedSettings` is already documented with on the db contract above, and the same
+   * two-path shape `resolveSearchBudgets` uses.
+   *
+   * Propagation, worth knowing before tuning against it: the scoped path reads the platform base
+   * through `getSettingsByNames`, whose cache is in-process with a 5-minute TTL and no
+   * cross-instance invalidation, so a platform-rung edit lands on a running ChatCompletion
+   * container within one TTL rather than on the next turn. That is the same latency the two floors
+   * already have, and the trade for it is one fewer uncached `findOne` per Data-Lake-mode turn.
    *
    * The scoped branch is wrapped defensively, NOT because production takes the fallback:
    * `resolveScopedSettingValues` documents that it never throws and wraps both of its own reads, so
@@ -2198,17 +2203,22 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
    * resolves the coded default internally and returns normally, so a settings outage lands on coded
    * defaults whether or not this guard is here.
    */
-  private async readForcedRetrievalFloorPcts(): Promise<{ relative: unknown; absolute: unknown }> {
+  private async readForcedRetrievalSettings(): Promise<{
+    charBudget: unknown;
+    relative: unknown;
+    absolute: unknown;
+  }> {
     const { db, user } = this.chatCompletion;
     if (db.scopedSettings) {
       try {
         const values = await resolveScopedSettingValues(
-          ['forcedRetrievalRelativeFloorPct', 'forcedRetrievalMinSimilarityPct'],
+          FORCED_RETRIEVAL_SETTING_KEYS,
           scopeForCaller({ userId: user.id, organizationId: normalizeId(user.organizationId) }),
           { adminSettings: db.adminSettings, scopedSettings: db.scopedSettings },
           { logger: this.logger }
         );
         return {
+          charBudget: values.forcedRetrievalCharBudget,
           relative: values.forcedRetrievalRelativeFloorPct,
           absolute: values.forcedRetrievalMinSimilarityPct,
         };
@@ -2216,16 +2226,17 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         // Fall THROUGH rather than rethrow: the outer catch lands on coded defaults, which would
         // discard a platform-wide override for the duration of a transient scoped-read failure.
         this.logger.warn(
-          '\u{1F512} Forced retrieval: scoped floor read failed; falling back to the platform values',
+          '\u{1F512} Forced retrieval: scoped settings read failed; falling back to the platform values',
           err
         );
       }
     }
-    const [relative, absolute] = await Promise.all([
+    const [charBudget, relative, absolute] = await Promise.all([
+      db.adminSettings.getSettingsValue('forcedRetrievalCharBudget'),
       db.adminSettings.getSettingsValue('forcedRetrievalRelativeFloorPct'),
       db.adminSettings.getSettingsValue('forcedRetrievalMinSimilarityPct'),
     ]);
-    return { relative, absolute };
+    return { charBudget, relative, absolute };
   }
 
   private noContextMessages(finding: ForcedRetrievalNoContextFinding): IMessage[] {
@@ -2374,11 +2385,8 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       }
 
       // Resolved ONCE here, before the scan - never re-read per chunk in the accumulation loop
-      // below. In parallel because they are independent reads and this is on every lake-mode turn.
-      const [forcedRetrievalCharBudget, floors] = await Promise.all([
-        this.resolveForcedRetrievalCharBudget(),
-        this.resolveForcedRetrievalFloors(),
-      ]);
+      // below. One call for all three because they share a scope, so they share a read.
+      const { charBudget: forcedRetrievalCharBudget, floors } = await this.resolveForcedRetrievalConfig();
 
       // Only a non-lake tag survives: a `datalake:` entry (the shape a lake-created session sets
       // `retrievalTags` to) names the SESSION's lake, which is already applied above via


### PR DESCRIPTION
## Description

Item 1 of the #2572 umbrella. `forcedRetrievalCharBudget` was platform-only because its read went through the plain `getSettingsValue`, which ignores `settableAt`. Its description said a scope block "would be inert metadata at best and could arm the resolver's fail-loud owner check at worst" - the first half was true, the second half never was: `computeCandidateRefs` (`resolveScopedSetting.ts`) only `logger?.warn?.()`s when an owner-scoped setting has no owner in scope, and has no `throw` anywhere in the function. The write surface this needs (`writeScopedOverride`, the admin override UI) already shipped in #2489, eight hours before #2572 was filed - so this was more actionable than the issue described, not less.

Gives the setting Organization and Owner rungs - the same altitude as the two relevance floors it is resolved and tuned alongside, and no Lake rung for the same reason: a forced-retrieval turn pools an uncapped set of lakes under one top score, so there is no single lake for a narrower rung to key on.

## Changes

- `forcedRetrievalCharBudget` now declares `scope: { settableAt: [Organization, Owner] }` and its read moves onto `resolveScopedSettingValues`, in the same commit - `settableAt` is only honored by the scoped resolver, so a scope block without the matching read change would have been inert metadata.
- All three forced-retrieval settings (the char budget and the two floors) now resolve in **one** `resolveScopedSettingValues` call instead of two independent reads. `resolveAll` covers any number of keys in one platform read plus one overlay query, so this is free and removes a duplicated two-path reader (`resolveForcedRetrievalCharBudget` / `resolveForcedRetrievalFloors` / `readForcedRetrievalFloorPcts` collapse into `resolveForcedRetrievalConfig` / `readForcedRetrievalSettings`).
- Corrected the same copy-pasted "fail-loud owner check" claim wherever it appeared, including on `lakeMemoryRecallK`, which stays platform-only - its description now states the real reason (a scope block there would be silently inert, not fail-loud) rather than the wrong one.
- Test coverage added for the override path: an Organization-rung override wins over the platform value, and the platform value survives when the overlay holds nothing for that org.

## Operator-visible consequence (please read)

A platform-rung edit to this setting used to take effect on the very next turn (the old read was an uncached `findOne` per turn). The scoped path reads its platform base through the settings cache (`getSettingsByNames`), which is in-process with a 5-minute TTL and no cross-instance invalidation - so a platform edit now lands within that TTL window instead of immediately.

This is the same propagation latency `forcedRetrievalRelativeFloorPct` and `forcedRetrievalMinSimilarityPct` already have today, and it buys one fewer uncached Mongo read per Data-Lake-mode turn. I judged this an acceptable, even corrective, trade rather than a regression - happy to preserve immediate propagation instead if reviewers disagree, but that would mean keeping a separate uncached read just for this one setting while its two siblings stay cached.

## Guide for Testers

This is a config/admin-panel change with no new UI. All three assertions below need `EnableDataLakes`-style forced retrieval already configured on a session (i.e. a session bound to a lake) plus the scoped-settings overlay enabled - the same prerequisites #2567's floors already require.

1. Go to `Admin → Settings → AI` (search for "Forced Retrieval Char Budget").
2. Confirm the setting now shows the same per-organization/per-owner override control that "Forced Retrieval Relative Floor (%)" and "Forced Retrieval Absolute Floor (%)" already show just below it. Expected: an "Add override" control at Organization and Owner level, no Lake option.
3. Set an Organization-level override to `6000` and save.
4. Start (or continue) a Data-Lake-mode chat session as a member of that organization and send a message that triggers forced retrieval (a query against a lake with several documents).
5. Expected: the amount of retrieved text injected respects the 6,000-character override rather than the platform default (12,000 by default) - this is hard to observe directly from the UI, so cross-check via the retrieval telemetry (`Admin → Retrieval Rate` panel, or the turn's `promptMeta.injected.chars` field if you have DB access) rather than eyeballing response length.
6. Clear the override and confirm a later turn (allow up to 5 minutes, or restart the ChatCompletion service locally, for the cache to pick up the change) falls back to the platform value.

### Regression Checks
- Confirm the two existing floor settings ("Forced Retrieval Relative Floor (%)" / "Absolute Floor (%)") still behave exactly as before - their scope, description and read path are unchanged by this PR.
- Confirm a Data-Lake-mode turn on a host with the scoped-settings overlay disabled (or absent) still injects retrieved text at all - the platform-only fallback path is exercised by `ChatCompletionFeatures.test.ts`'s "falls through to the platform value when the overlay holds no override" case, but a live smoke test on a non-overlay host is good insurance.

### What NOT to test
- No new admin route, page, or component was added - the override control is the existing generic `ScopedSettingOverrides` UI, which auto-renders for any setting declaring `scope`. No UI code changed.
- Items 2-4 of #2572 (sweep tooling, per-lake floors, and post-migration tuning) are explicitly out of scope for this PR and remain open on the issue.

## Additional Information

- Ran full-repo typecheck, the whole `@bike4mind/services` suite (6875 tests) and the `@bike4mind/common` settings suite (117 tests) green, plus `lint:check` and the ASCII/control-byte guards.
- Mutation-tested both halves of the change independently (removed the `scope` block; separately reverted just the read path) - each mutation alone fails the new override test with `expected 2000 to be 9000`, confirming neither half is decoration.
- Checked all five overlay repos (`b4m-optihashi`, `b4m-pi`, `b4m-libreoncology`, `b4m-overwatch`, `b4m-tavern`) for any reference to the renamed private methods or a direct read of this setting - none found.
- No new `AdminSettings` document was added (an existing setting's code-level `scope` metadata changed, not a new key), so the "add to Staging/prod/hydration script" checklist item does not apply here.

## Developer Notes (Optional)

- **Reusable pattern**: `resolveForcedRetrievalConfig` / `readForcedRetrievalSettings` is the template for grouping several settings that share one scope into a single `resolveScopedSettingValues` call - one platform read, one overlay query, regardless of key count.
- **Data model**: no schema change. `forcedRetrievalCharBudget`'s `scope.settableAt` is the only new declaration, and it must stay in sync with its read path (commented in place at the setting's definition) - a future change that reverted the read to `getSettingsValue` would silently drop every override.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new setting added
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no new UI; reuses the existing generic override control
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - N/A, no user-facing docs reference this setting
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry field changed
