### PR TITLE
fix(data-lakes): name the convergence pause in the rechunk recovery note

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/rechunk.ts
+++ b/apps/client/pages/api/data-lakes/[id]/rechunk.ts
@@ -124,9 +124,11 @@ const handler = baseApi({ requiredScopes: DATA_LAKE_READ_SCOPES })
       // rescue sweep selects on, so it self-heals on the next pass rather than needing an undo.
       // The cost of routing recovery that way, since the reset above covers the whole wave before
       // any send: the file stays unsearchable until the chunk rescue sweep re-enqueues it - daily
-      // 05:00 UTC hosted (infra/cron.ts), ~60s self-host, and only while `enableAutoChunk` is on,
-      // which is the one condition that can hold it indefinitely. REBUILD_PENDING_STALE_MS (2h) does
-      // not gate that sweep; it gates this door's own stale-pending re-detection
+      // 05:00 UTC hosted (infra/cron.ts), ~60s self-host, and only while `enableAutoChunk` is on and
+      // the lake is not convergence-paused - either can hold it indefinitely. The refusal above is no
+      // protection against the second: it checks at request time, so a pause that lands after this
+      // wave was reset still strands the file. REBUILD_PENDING_STALE_MS (2h) does not gate that
+      // sweep; it gates this door's own stale-pending re-detection
       // (findConvergencePausedFilesByScope).
       //
       // NO `chunkSize` on purpose, unlike /converge which sends `policy.requiredTarget`. This door


### PR DESCRIPTION
## What

One comment clause in `apps/client/pages/api/data-lakes/[id]/rechunk.ts`. No executable code is touched.

The recovery note on the `/rechunk` wave asserted that `enableAutoChunk` is "the one condition that can hold [a stranded file] indefinitely." There are two. A convergence-paused lake holds the same chunk rescue sweep in the same open-ended way, until an admin unpauses it.

## Why it matters

The error ran in the misleading direction: it **understates** how recovery can stall. The reader of that comment is an operator debugging a file that came back unsearchable after a partially failed repair, and the comment sends them to check one switch when two can be holding it.

## The second gate, verified

`runChunkRescueSweep` (`apps/client/server/worker/chunkRescueSweep.ts`) is gated by the convergence pause at both stages:

- **Selection** (`:95`): the scan filter is built with `convergencePause: toChunkScanConvergencePause(pauseScope)`. Platform switch ON excludes everything except lakes overridden back to running; OFF excludes members of lakes overridden to paused. A paused lake's files are not selected. The sweep's own comment calls this clause a cap-fairness optimisation rather than the gate.
- **Enqueue** (`:116`): `resolvePlatformOnlyMembership` does **not** filter the send list - the sweep enqueues every candidate (`const ids = [...byId.keys()]`). What it decides is *provenance*: `buildChunkRescueMessage` -> `pickScopedLake` stamps the paused lake's id as `lakeId`, and the actual drop happens on the consumer, where `fabFileChunk.ts:419` calls `isConvergenceHalted({ origin, lakeId })` and refuses.

Selected or not, sent or not, the file is not re-chunked while its lake is paused, and stays that way until an admin unpauses - operator-visibly identical to the `enableAutoChunk` early return at `:77`.

## Why the handler's own kill-switch check is not cover

`rechunk.ts` has an `isConvergenceHalted` refusal earlier in the same block, so it is fair to read "the lake is not convergence-paused" and think it was already checked. It was, but only at request time. The ordering that actually strands a file slips past it: a wave resets and partially fails while the lake is running, an admin then pauses the lake, and the stranded file is left relying on a sweep the pause now holds. The commit adds a sentence saying so, because without it the new clause looks redundant with the check above it.

## Claims left intact (re-verified on this branch)

- Hosted cadence daily 05:00 UTC - `dataLakeBatchReconcileCron`, `schedule: 'cron(0 5 * * ? *)'` (`infra/cron.ts:642`).
- Self-host ~60s - `CHUNK_SCAN_INTERVAL_MS = 60_000` (`apps/client/server/worker/main.ts:54`).
- `REBUILD_PENDING_STALE_MS` does not gate the sweep (absent from `chunkScan.ts` and `chunkRescueSweep.ts`) and does gate this door's own stale-pending re-detection, `findConvergencePausedFilesByScope` (`packages/database/src/models/content/FabFileModel.ts:2187`).
- Still consistent with the "self-heals on the next pass" sentence above it - the new clause qualifies that the same way the old one did, with one more condition.

## Testing

**No test, deliberately.** This is a comment-only change with no behavior to assert, so the failing-test-first convention does not apply - there is nothing that could fail before and pass after.

Gates run locally, both green:

- `pnpm turbo:typecheck` - 40/40 successful
- `pnpm lint:check` - clean
- `prettier --check` on the touched file - clean
- `scripts/check-no-control-bytes.sh` / `scripts/check-no-smart-punctuation.sh` - clean; every added line is ASCII

Full `pnpm turbo:test` was not run: nothing outside a comment body changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
