### PR TITLE
fix(client): stop an empty nested filter shadowing the flat param

### DIFF
--- a/apps/client/pages/api/business-links/__tests__/index.test.ts
+++ b/apps/client/pages/api/business-links/__tests__/index.test.ts
@@ -188,4 +188,63 @@ describe('GET /api/business-links - nested filters from the client', () => {
     expect((mockRefs.findQuery as { $or?: unknown })?.$or).toBeUndefined();
     expect((mockRefs.findQuery as { categoryId?: unknown })?.categoryId).toBeUndefined();
   });
+
+  it('falls back to the flat searchTerm when filters[search] is present but empty', async () => {
+    // The client emits `filters[search]=` for an empty box, so a blank nested value
+    // means "unset" - it must not shadow the flat param API-key callers still send.
+    const { req, res } = invokeGet({ 'filters[search]': '', searchTerm: 'acme' });
+    await mockRefs.getHandler!(req, res);
+
+    const orConditions = (mockRefs.findQuery as { $or?: Array<Record<string, { $regex: string }>> })?.$or;
+    expect(orConditions, 'the flat searchTerm should still build a $or query').toBeInstanceOf(Array);
+    for (const condition of orConditions!) {
+      const [{ $regex }] = Object.values(condition);
+      expect($regex).toBe(escapeRegex('acme'));
+    }
+  });
+
+  it('falls back to the flat categoryId when filters[categoryId] is present but empty', async () => {
+    const categoryId = new Types.ObjectId().toString();
+    const { req, res } = invokeGet({ 'filters[categoryId]': '', categoryId });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockRefs.findQuery).toMatchObject({ categoryId });
+  });
+
+  it('rejects a malformed flat categoryId behind an empty filters[categoryId]', async () => {
+    // Reaching the flat value means it gets the same validation it gets when sent
+    // alone, rather than being silently dropped.
+    const { req, res } = invokeGet({ 'filters[categoryId]': '', categoryId: 'not-an-object-id' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: 'Invalid category ID format' });
+    expect(mockRefs.findQuery).toBeUndefined();
+  });
+
+  it('prefers a non-empty nested filter over the flat param', async () => {
+    const nestedCategoryId = new Types.ObjectId().toString();
+    const flatCategoryId = new Types.ObjectId().toString();
+    const { req, res } = invokeGet({
+      'filters[search]': 'nested',
+      searchTerm: 'flat',
+      'filters[categoryId]': nestedCategoryId,
+      categoryId: flatCategoryId,
+    });
+    await mockRefs.getHandler!(req, res);
+
+    expect(mockRefs.findQuery).toMatchObject({ categoryId: nestedCategoryId });
+    const orConditions = (mockRefs.findQuery as { $or?: Array<Record<string, { $regex: string }>> })?.$or;
+    const [{ $regex }] = Object.values(orConditions![0]);
+    expect($regex).toBe(escapeRegex('nested'));
+  });
+
+  it('builds no filter when both the nested and flat params are absent', async () => {
+    const { req, res } = invokeGet({});
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockRefs.findQuery).toEqual({});
+  });
 });

--- a/apps/client/pages/api/business-links/index.ts
+++ b/apps/client/pages/api/business-links/index.ts
@@ -40,8 +40,10 @@ const handler = baseApi()
       const queryParams = qs.parse(req.query as Record<string, string>) as IParsedQuery;
       const pageSize = parseInt(queryParams.pageSize || '10');
       const pageNumber = parseInt(queryParams.pageNumber || '1');
-      const searchTerm = filterString(queryParams.filters?.search) ?? filterString(queryParams.searchTerm) ?? '';
-      const categoryId = filterString(queryParams.filters?.categoryId) ?? filterString(queryParams.categoryId);
+      // `||`, not `??`: the client always emits the bracket key, blank when the
+      // control is empty, so a nested value only counts as supplied when non-empty.
+      const searchTerm = filterString(queryParams.filters?.search) || filterString(queryParams.searchTerm) || '';
+      const categoryId = filterString(queryParams.filters?.categoryId) || filterString(queryParams.categoryId);
 
       const query: any = {};
 


### PR DESCRIPTION
# Pull Request

## Description

The `GET /api/business-links` handler supports two shapes for its filters: the nested `filters[search]` / `filters[categoryId]` the SPA sends, and the flat `searchTerm` / `categoryId` params kept working for existing API-key callers. It resolved between them with `??`, which only falls through on `null`/`undefined`.

The client always emits the bracket key, blank when the control is empty (`apiClient` serializes params through `qs`, so an empty search box produces `filters%5Bsearch%5D=`). So a request carrying both shapes, e.g. `?filters[search]=&searchTerm=acme`, resolved `searchTerm` to `''`, the `if (searchTerm)` guard skipped, no `$or` clause was built, and every link came back unfiltered. The flat value was silently discarded rather than used as the documented fallback. `filters[categoryId]` sat one line below with the identical shape and the identical downstream guard, so it had the same defect.

This is a hardening fix for the fallback contract, not a user-visible regression: the only in-repo caller (`BusinessLink.tsx` via `useBusinessLinks`) always sends the nested shape and never the flat one, so today there is nothing for a blank nested value to shadow.

## Changes

- `apps/client/pages/api/business-links/index.ts`: resolve both filters with `||` instead of `??`, so a nested value counts as supplied only when non-empty. `filterString` returns `string | undefined`, so `''` is the only input on which the two operators differ.
- Added 5 tests to the existing `nested filters from the client` block in `apps/client/pages/api/business-links/__tests__/index.test.ts`.

## Guide for Testers

This is a backend query-parsing fix with no UI surface. The SPA never sends the flat params, so there is nothing to click through - the handler-level tests are the verification.

Reviewers who want to confirm by hand, against a deploy with an API key:

1. `GET /api/business-links?filters[search]=&searchTerm=acme` - expect only links matching `acme`. Before this change the response contained every link.
2. `GET /api/business-links?filters[categoryId]=&categoryId=<valid ObjectId>` - expect only links in that category. Before this change the response contained every link.
3. `GET /api/business-links?filters[search]=acme&searchTerm=ignored` - expect links matching `acme`. The nested param stays canonical when it is non-empty.

### Regression Checks

4. Open the Popular Targets panel (the one in-app consumer) and use the search box and category filter as usual. Behavior is unchanged - that caller only ever sends the nested shape.
5. Clear the search box. Results should return to unfiltered, as before.

### What NOT to test

Nothing in the UI changed. No schema, migration, admin setting, or response shape changed.

## Additional Information

One deliberate, narrow behavior change worth calling out: `||` now lets a flat `categoryId` reach the ObjectId validation when it sits behind an empty `filters[categoryId]`. A junk value in that position previously fell through silently and is now answered with the same `400 Invalid category ID format` it already gets when sent alone. That is the intended behavior rather than a new failure mode, and it has its own test.

Every other input resolves identically under `||` and `??` - the empty string is the only divergence, and it was already dropped by the `if (searchTerm)` / `if (categoryId)` guards downstream.

Raised as a P3 review nit on #2621 and resolved as-is at the time; this picks it up and fixes both lines, since fixing one and leaving its twin would make the remaining `??` look intentional.

## Verification

- The 3 shadowing tests fail against the handler before the change and pass after; the 2 precedence/absence tests pass both ways and guard against over-correction.
- `pnpm --filter @bike4mind/client test` - 1222 files, 13552 passed, 0 failed.
- `pnpm turbo:typecheck` - clean.
- `pnpm lint:check` - clean. No `prefer-nullish-coalescing` rule is configured, so `||` does not trip lint.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
