### PR TITLE
fix(client): scope the Popular Targets CSV export to the active filters

### DIFF
--- a/apps/client/app/components/ResearchTasks/PopularTargets/hooks.test.tsx
+++ b/apps/client/app/components/ResearchTasks/PopularTargets/hooks.test.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { api } from '@client/app/contexts/ApiContext';
+import { downloadData } from '@client/app/utils/download';
+import { toast } from 'sonner';
+import { useBusinessLinks, useExportCSV, usePopularTargets } from './hooks';
+import { PAGE_SIZE } from './utils';
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@client/app/utils/download', () => ({ downloadData: vi.fn() }));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const ACME = {
+  name: 'Acme Corp',
+  ticker: 'ACME',
+  url: 'https://acme.example.com',
+  type: 'tech',
+  category: { name: 'Earnings', description: 'Quarterly earnings' },
+};
+
+const respondWith = (links: unknown[]) =>
+  vi.mocked(api.get).mockResolvedValue({
+    data: {
+      data: links,
+      meta: {
+        pagination: { total: links.length, page: 1, totalPages: 1, pagePosition: 'first' },
+        overallTotal: links.length,
+      },
+    },
+  });
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  return Wrapper;
+}
+
+/** The store is a module singleton, so every test sets the filters it means to assert on. */
+const setActiveFilters = (categoryId: string, searchTerm = '') =>
+  usePopularTargets.getState().setState({ categoryId, searchTerm });
+
+describe('useExportCSV', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActiveFilters('', '');
+    respondWith([ACME]);
+  });
+
+  it('requests only the active category, so the export cannot outrun the list', async () => {
+    setActiveFilters('cat-1');
+
+    renderHook(() => useExportCSV(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(api.get).toHaveBeenCalledWith('/api/business-links', {
+      params: { pageSize: PAGE_SIZE, pageNumber: 1, filters: { search: '', categoryId: 'cat-1' } },
+    });
+  });
+
+  it('carries the active search term into the request', async () => {
+    setActiveFilters('cat-1', 'acme');
+
+    renderHook(() => useExportCSV(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(api.get).toHaveBeenCalledWith('/api/business-links', {
+      params: { pageSize: PAGE_SIZE, pageNumber: 1, filters: { search: 'acme', categoryId: 'cat-1' } },
+    });
+  });
+
+  it('writes exactly the rows the list is showing, from a single shared fetch', async () => {
+    setActiveFilters('cat-1');
+    const { result } = renderHook(
+      () => ({
+        // The list's own call, verbatim from BusinessLink.tsx.
+        list: useBusinessLinks(
+          { pageSize: PAGE_SIZE, pageNumber: 1, filters: { search: '', categoryId: 'cat-1' } },
+          true
+        ),
+        exportCSV: useExportCSV(),
+      }),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.list.data).toBeDefined());
+    await act(async () => {
+      await result.current.exportCSV();
+    });
+
+    expect(result.current.list.data?.data).toHaveLength(1);
+    expect(downloadData).toHaveBeenCalledWith(
+      'Company,Ticker,URL,Type,Category,Category Description\n' +
+        'Acme Corp,ACME,https://acme.example.com,tech,Earnings,Quarterly earnings',
+      'business-links-export.csv',
+      'text/csv'
+    );
+    expect(toast.success).toHaveBeenCalledWith('Exported CSV successfully');
+    // Identical params collapse list and export into one cache entry, so the modal fetches once.
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads nothing before a category resolves, rather than a header-only CSV under a success toast', async () => {
+    setActiveFilters('');
+    const { result } = renderHook(() => useExportCSV(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(api.get).not.toHaveBeenCalled();
+    expect(downloadData).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/ResearchTasks/PopularTargets/hooks.ts
+++ b/apps/client/app/components/ResearchTasks/PopularTargets/hooks.ts
@@ -175,11 +175,31 @@ function csvEscape(value: string) {
 }
 
 export function useExportCSV() {
-  const { data: linksData } = useBusinessLinks({ pageSize: PAGE_SIZE, pageNumber: 1 }, true);
+  const {
+    state: { categoryId, searchTerm },
+  } = usePopularTargets();
+  // Must stay identical to the list's call in BusinessLink.tsx: the export writes the rows on
+  // screen, and matching params also collapse both hooks into one react-query cache entry.
+  const { data: linksData } = useBusinessLinks(
+    {
+      pageSize: PAGE_SIZE,
+      pageNumber: 1,
+      filters: {
+        search: searchTerm,
+        categoryId,
+      },
+    },
+    !!categoryId
+  );
 
   return async () => {
     try {
-      const links = linksData?.data || [];
+      // No rows yet (the query is gated until a category resolves), so there is nothing to write.
+      if (!linksData) {
+        toast.error('Links are still loading, please try again');
+        return;
+      }
+      const links = linksData.data || [];
       const header = 'Company,Ticker,URL,Type,Category,Category Description';
       const rows = links.map((link: IResearchLinkWithCategory) => {
         const values = [


### PR DESCRIPTION
# Pull Request

## Description

The Popular Targets "Export CSV" button ignored the active category tab and the search box. `useExportCSV` fetched its rows with no filters at all, so the export always wrote the first `PAGE_SIZE` business links globally. `PAGE_SIZE` is 9999, so in practice the export was "the whole table" no matter what the user had narrowed the view to.

The list hook and the export hook disagreed because only one of them read the UI state. `BusinessLink.tsx` passes `filters: { search, categoryId }` from the `usePopularTargets` zustand store and gates the query on `!!categoryId`; `useExportCSV` read nothing from that store and hardcoded `enabled = true`.

This is not a new bug, but it only became visible recently. Before #2621, the API route read flat `req.query.searchTerm` / `req.query.categoryId` while the client serializes nested filters as `filters[search]=` / `filters[categoryId]=` (`apiClient.ts` uses `qs.stringify(params, { arrayFormat: 'brackets' })`, and Next.js leaves bracket keys unexpanded). The list was therefore unfiltered too, so list and export happened to agree. Now that the route `qs.parse`s and honors the nested filters, the list is correctly filtered while the export is not, and the two visibly disagree. This was spotted during that fix and deliberately left out of its scope.

The fix is client-only: give `useExportCSV` the same params and the same `enabled` gate the list already uses. No server file is touched.

**Reviewer note - this changes what an existing user-facing action produces.** Anyone relying on "Export gives me the whole dataset regardless of the selected tab" loses that; the export is now what is on screen. That behavior change is the point of the fix rather than a side effect. The practical blast radius is small because the UI never actually offered a category-less export in a settled state: `BusinessLinkCategory.tsx` auto-selects the first category as soon as the categories query settles, and `index.tsx` renders `NoDataYet` instead of the list/export UI when there are no categories at all. So `categoryId` is empty only in the transient window before categories load.

## Changes

- `apps/client/app/components/ResearchTasks/PopularTargets/hooks.ts` - `useExportCSV` now reads `categoryId` / `searchTerm` from `usePopularTargets()` and passes `filters: { search, categoryId }` with the `!!categoryId` gate, matching the list's call in `BusinessLink.tsx` exactly.
- Same file - guard the returned export function on having data. With the query gated, data is `undefined` in the window before a category resolves, where the old code would have written a header-only CSV under an "Exported CSV successfully" toast. It now reports that links are still loading and writes nothing.
- `apps/client/app/components/ResearchTasks/PopularTargets/hooks.test.tsx` (new) - four tests covering the category filter, the search filter, export-matches-the-list, and the empty-data guard. All four fail before the fix.

Secondary win, and the reason the params are matched byte-for-byte rather than merely made equivalent: the react-query key is `['business-links', JSON.stringify(params)]`, so identical params collapse the list and the export into a single cache entry. Previously they were two entries, and opening the modal fired a second unfiltered 9999-row fetch even if the user never clicked Export. The new test asserts `api.get` is called once.

## Guide for Testers

Preconditions: you need at least two Popular Targets categories, each with at least one business link. Category A and category B below refer to the first two tabs.

1. Open `app.staging.bike4mind.com` and sign in.
2. Go to a research task form with a URL field. Next to the URL input, click the trending-up icon button (tooltip: `Browse popular research targets: earnings, press releases & AI news`). The Popular Targets modal opens with the first category tab already selected and its links listed.
3. Note the company names listed under category A.
4. Click the Export CSV icon (the document icon in the top-right cluster of the modal). A toast reads `Exported CSV successfully` and `business-links-export.csv` downloads.
5. Open the downloaded CSV. Expected: it contains the header row plus exactly the links from category A, and no links from category B. Before this fix it contained every link in every category.
6. Click category B's tab. The list narrows to category B's links.
7. Click Export CSV again and open the new file. Expected: exactly category B's links, and none of category A's.
8. With category B still selected, type a term into the search box that matches only some of category B's rows. The list narrows.
9. Click Export CSV and open the file. Expected: exactly the rows still visible on screen.
10. Clear the search box, then compare the exported rows to the rows on screen once more. Expected: identical sets.

Regression checks:

11. Click the Download Template icon. Expected: `business-links-template.csv` downloads and is unchanged by this PR (it is built from static JSON, not from the query).
12. Import a small CSV through the Import icon. Expected: import still succeeds and the list refreshes.
13. Create, edit, and delete a business link in the modal. Expected: all still work and the list updates.
14. Switch category tabs several times quickly. Expected: the list follows the selected tab with no stale rows.

What NOT to test: no API route, schema, or server file changed, so no backend behavior should differ. The `/api/business-links` route already honored the nested filters before this PR.

## Additional Information

Of the three ways to satisfy "do not download a header-only CSV before a category resolves" (disable the button, early-return with an info toast, error toast), this PR takes the early return. Disabling the button would have meant giving `ExportControls.tsx` its own subscription to the store for a state the user effectively cannot reach, and the early return additionally covers the still-fetching case rather than only the no-category case.

The new test drives the real `usePopularTargets` store via `setState` rather than mocking the module. Since the bug is precisely that the hook did not read that store, exercising the real wiring is the stronger assertion, and it keeps the test from passing against a mock that no longer matches the store's shape.

Verified locally: `pnpm --filter @bike4mind/client test`, `pnpm turbo:typecheck`, and `pnpm lint:check` all green.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
