### PR TITLE
fix(client): apply the nested filter the business-links category route is sent

### DIFF
--- a/apps/client/app/components/ResearchTasks/PopularTargets/types.ts
+++ b/apps/client/app/components/ResearchTasks/PopularTargets/types.ts
@@ -10,7 +10,9 @@ const BaseQuery = z.object({
 export const BusinessLinkCategoriesQuery = BaseQuery.extend({
   filters: z
     .object({
-      name: z.string().optional(),
+      // `search`, not `name`: the route matches the term against both the category
+      // name and its description. Matches the `filters.search` the links query sends.
+      search: z.string().optional(),
     })
     .optional(),
 });

--- a/apps/client/pages/api/business-links/category/__tests__/index.test.ts
+++ b/apps/client/pages/api/business-links/category/__tests__/index.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { escapeRegex } from '@bike4mind/utils/escapeRegex';
+
+/**
+ * Handler-layer coverage for the category list's search filter. The client sends
+ * the filter nested (`filters[search]=...`), Next.js leaves the bracket key
+ * unexpanded, so a route reading `req.query.searchTerm` sees nothing and returns
+ * every category. These drive the handler with the literal bracket keys it
+ * actually receives, and pin the escaping now that user input reaches `$regex`
+ * on a path a browser request can take.
+ */
+
+// Collapse the baseApi().get().post() chain and capture the GET handler.
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+  findQuery: undefined as unknown,
+  countQuery: undefined as unknown,
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+    post: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@bike4mind/database/content', () => ({
+  ResearchLinkCategory: {
+    countDocuments: (q: unknown) => {
+      mockRefs.countQuery = q;
+      return Promise.resolve(0);
+    },
+    find: (q: unknown) => {
+      mockRefs.findQuery = q;
+      return {
+        sort: () => ({ skip: () => ({ limit: () => Promise.resolve([]) }) }),
+      };
+    },
+  },
+}));
+
+// Import after mocks are registered so the chain capture runs.
+import '@pages/api/business-links/category';
+
+const REDOS_PAYLOAD = '(a+)+$';
+
+function invokeGet(query: Record<string, string | string[]>) {
+  const { req, res } = createMocks({
+    method: 'GET',
+    query,
+    url: '/api/business-links/category',
+  });
+  return { req, res };
+}
+
+function regexOperands(query: unknown) {
+  const orConditions = (query as { $or?: Array<Record<string, { $regex: string }>> })?.$or;
+  expect(orConditions, 'search should build a $or query').toBeInstanceOf(Array);
+  return orConditions!.map(condition => Object.values(condition)[0].$regex);
+}
+
+describe('GET /api/business-links/category - nested filters from the client', () => {
+  beforeEach(() => {
+    mockRefs.findQuery = undefined;
+    mockRefs.countQuery = undefined;
+  });
+
+  it('applies filters[search] to the query', async () => {
+    expect(mockRefs.getHandler).toBeTypeOf('function');
+
+    const { req, res } = invokeGet({ 'filters[search]': 'acme' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(regexOperands(mockRefs.findQuery)).toEqual(['acme', 'acme']);
+    // The count must be filtered too, or the pagination total disagrees with the rows.
+    expect(regexOperands(mockRefs.countQuery)).toEqual(['acme', 'acme']);
+  });
+
+  it('still applies the legacy flat searchTerm', async () => {
+    const { req, res } = invokeGet({ searchTerm: 'acme' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(regexOperands(mockRefs.findQuery)).toEqual(['acme', 'acme']);
+  });
+
+  it('escapes filters[search] before it reaches $regex', async () => {
+    const { req, res } = invokeGet({ 'filters[search]': REDOS_PAYLOAD });
+    await mockRefs.getHandler!(req, res);
+
+    const escaped = escapeRegex(REDOS_PAYLOAD);
+    for (const operand of regexOperands(mockRefs.findQuery)) {
+      // The escaped, backtracking-safe literal, never the raw payload.
+      expect(operand).toBe(escaped);
+      expect(operand).not.toBe(REDOS_PAYLOAD);
+    }
+
+    // Sanity: escaping neutralizes the catastrophic-backtracking pattern.
+    expect(new RegExp(escaped).test('aaaaaaaaaaaaaaaaaaaa')).toBe(false);
+  });
+
+  it('builds an empty query when no search filter is provided', async () => {
+    const { req, res } = invokeGet({ pageSize: '10', pageNumber: '1' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockRefs.findQuery).toEqual({});
+  });
+
+  it('ignores a filter value that bracket-nests into a non-string', async () => {
+    // `filters[search][x]=1` parses to an object; it must be treated as absent
+    // rather than reaching escapeRegex, which would throw on a non-string.
+    const { req, res } = invokeGet({ 'filters[search][x]': '1' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect((mockRefs.findQuery as { $or?: unknown })?.$or).toBeUndefined();
+  });
+
+  it('ignores a repeated filters[search] that parses to an array', async () => {
+    const { req, res } = invokeGet({ 'filters[search]': ['acme', 'other'] });
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect((mockRefs.findQuery as { $or?: unknown })?.$or).toBeUndefined();
+  });
+});

--- a/apps/client/pages/api/business-links/category/index.ts
+++ b/apps/client/pages/api/business-links/category/index.ts
@@ -6,6 +6,7 @@ import { escapeRegex } from '@bike4mind/utils/escapeRegex';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ensureAdmin } from '@server/utils/errors';
+import qs from 'qs';
 
 interface IQuery {
   pageSize?: string;
@@ -13,13 +14,30 @@ interface IQuery {
   searchTerm?: string;
 }
 
+// The nested shape the app sends, recovered from the bracket keys in `req.query`.
+interface IParsedQuery extends IQuery {
+  filters?: {
+    search?: unknown;
+  };
+}
+
+// Bracket keys nest arbitrarily (`filters[search][x]=1` parses to an object) and a
+// repeated key parses to an array, so only a plain string is a usable filter value.
+// Anything else is treated as absent rather than reaching `escapeRegex`, which throws
+// on a non-string.
+const filterString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
 const handler = baseApi()
   .get(
     asyncHandler<{}, unknown, IQuery>(async (req, res) => {
-      const queryParams = req.query as IQuery;
+      // The client serializes the filters nested (`filters[search]=...`) through qs, and
+      // Next.js leaves those bracket keys unexpanded in `req.query` - so re-parse before
+      // reading them, the way the sibling `pages/api/business-links/index.ts` does. The
+      // flat `searchTerm` param stays supported for existing API-key callers.
+      const queryParams = qs.parse(req.query as Record<string, string>) as IParsedQuery;
       const pageSize = parseInt(queryParams.pageSize || '10');
       const pageNumber = parseInt(queryParams.pageNumber || '1');
-      const searchTerm = queryParams.searchTerm || '';
+      const searchTerm = filterString(queryParams.filters?.search) ?? filterString(queryParams.searchTerm) ?? '';
 
       const query = searchTerm
         ? {


### PR DESCRIPTION
## Description

`GET /api/business-links/category` could not see the filter its own client type promised. Two independent mismatches sat between the client and the route, and either one alone was enough to drop the filter:

1. **Nesting** - the client declares a nested `filters` object, and the shared axios instance serializes it to bracket keys (`filters[name]=acme`, via `qs.stringify(..., { arrayFormat: 'brackets' })`). Next.js leaves those keys unexpanded, so `req.query` carries the literal key `'filters[name]'`. The route read `req.query` directly with no `qs.parse`.
2. **Naming** - even flattened, the two disagreed: the client said `filters.name`, the route read `searchTerm`.

The result was that a caller passing `filters` got the full unfiltered first page back: `queryParams.searchTerm` was `undefined`, `searchTerm` fell back to `''`, and the Mongo query was `{}`.

**This is groundwork, not a user-visible fix.** No caller sends `filters` today - both callers of `useBusinessLinkCategories` pass pagination only, and the `searchTerm` in the zustand store feeds the *links* list, never categories. The value is that it disarms the trap for whoever first adds a category search box, who would otherwise hit the same "the refetch fires and the same rows come back" symptom that #2621 chased down on the sibling links route.

## Changes

- `apps/client/pages/api/business-links/category/index.ts`: `qs.parse` the query before reading it, and accept both shapes - nested `filters.search` first, flat `searchTerm` as a fallback. The GET branch is not admin-gated and runs under `baseApi()` default auth, which accepts an API key, so a key-bearing caller may already be sending flat `searchTerm`; that keeps working.
- Same file: added the `filterString` guard, carried over from the sibling route. This is not incidental - once `qs.parse` is in, `filters[search][x]=1` parses to an object and a repeated `filters[search]=a&filters[search]=b` parses to an array, and either one reaching `escapeRegex` throws, because it is `input.replace(...)` on a non-string. Without the guard this change would itself introduce a 500 that the previous flat read could not produce.
- `apps/client/app/components/ResearchTasks/PopularTargets/types.ts`: renamed the category filter field from `name` to `search` so the client and the route agree on one name. `search` is the accurate label, since the route matches the term against both the category `name` and its `description`, and it is what the sibling links query already sends. The rename is type-only and carries no runtime risk: `BusinessLinkCategoriesQuery` is never `.parse()`d anywhere (only a `z.infer` and the hook signature reference it), and neither call site passes `filters`.
- `apps/client/pages/api/business-links/category/__tests__/index.test.ts`: new file. The route had no tests at all. Harness copied from the sibling route's suite - `node-mocks-http`, a hoisted mock collapsing the `baseApi().get().post()` chain to capture the GET handler, and a mock of `@bike4mind/database/content` capturing the query handed to `countDocuments`/`find`.

Note: the `escapeRegex` ReDoS protection on this route previously sat on a branch no browser request could reach. Wiring the filters through puts it on a live path for the first time, so the suite pins the escaping explicitly.

## Verification

The two nested-filter tests fail on `main` and pass with the fix:

```
x applies filters[search] to the query
  AssertionError: search should build a $or query: expected undefined to be an instance of Array
x escapes filters[search] before it reaches $regex
  AssertionError: search should build a $or query: expected undefined to be an instance of Array
```

The other four (flat `searchTerm`, the no-filter case, and the two non-string guards) pass before and after - the guards exist to catch the 500 this change could otherwise introduce, not to prove the original bug.

All green locally:

- `pnpm --filter @bike4mind/client test` - 1223 files, 13553 tests passed, 81 skipped
- `pnpm turbo:typecheck` - 40/40 tasks
- `pnpm lint:check` - clean

## Guide for Testers

There is no UI path that exercises this, so it cannot be tested through the app. Verify with a direct request against a deploy that has at least two categories with distinguishable names.

1. Sign in and grab a session cookie or API key for `app.staging.bike4mind.com`.
2. Request the unfiltered list: `GET /api/business-links/category?pageSize=10&pageNumber=1`. Expected: the first page of categories, with `meta.pagination.total` equal to the full category count.
3. Request the nested filter: `GET /api/business-links/category?pageSize=10&pageNumber=1&filters[search]=<a word in exactly one category name or description>`. Expected: only the matching categories, and `meta.pagination.total` reduced to match the row count. On `main` this step returns the same full page as step 2 - that is the bug.
4. Request the legacy flat param: `GET /api/business-links/category?pageSize=10&pageNumber=1&searchTerm=<same word>`. Expected: identical to step 3 (this path already worked and must not regress).
5. Request a malformed filter: `GET /api/business-links/category?filters[search][x]=1`. Expected: HTTP 200 and the unfiltered list, treating the filter as absent. A 500 here is the regression this PR's guard prevents.
6. Request a repeated filter: `GET /api/business-links/category?filters[search]=a&filters[search]=b`. Expected: HTTP 200 and the unfiltered list, same reasoning as step 5.
7. Request a regex payload: `GET /api/business-links/category?filters[search]=(a%2B)%2B%24`. Expected: HTTP 200, returned promptly with no results, and no hang - the term is escaped to a literal before reaching `$regex`.

### Regression Checks

1. Open the Popular Targets UI and confirm the category rail and the category dropdown still populate exactly as before. Neither call site passes `filters`, so behavior there should be unchanged.
2. Confirm the links list search box still filters links (that path is the sibling route, untouched here).

### What NOT to test

- Any category search input in the UI - none exists yet. This PR is the backend groundwork for one.

## Additional Information

Follows #2621, which fixed the identical pair of mismatches on the sibling `GET /api/business-links` route and deliberately left this one alone. The route file here is now the same shape as that one.

The `name` vs `search` naming was a deliberate call rather than a silent pick. The alternative was to narrow the route to match `name` only, which sounds smaller but actually changes existing flat-`searchTerm` behavior for API-key callers - the more invasive option. Renaming the unused client field was the zero-risk direction.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI change
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
