### PR TITLE
fix(ci): build core packages for the help-docs guard and widen its trigger

### DIFF
--- a/.github/actions/changes-filter/README.md
+++ b/.github/actions/changes-filter/README.md
@@ -17,7 +17,7 @@ docs live in `docs-site/` (not `docs/`), `.changeset/` is excluded, and a second
 | Output | Meaning |
 |---|---|
 | `deployable` | `'true'` to run test + deploy, `'false'` to skip. Fails **open** (`true`) when the diff range can't be resolved. |
-| `docs-changed` | `'true'` when the changeset touches `docs-site/`. Fails **open** (`true`) on an unresolved range. Gates the `help-docs` job. |
+| `docs-changed` | `'true'` when the changeset touches `docs-site/` or the help tooling in `packages/scripts/help/`. Fails **open** (`true`) on an unresolved range. Gates the `help-docs` job. |
 
 The two are orthogonal: a docs-only PR is `deployable=false, docs-changed=true`;
 a code+docs PR is `true, true`; a `.changeset` or root-`README` change is
@@ -80,7 +80,7 @@ jobs:
 | Input | Default | Notes |
 |---|---|---|
 | `exclude-paths` | curated docs/config list | Newline-separated **git pathspecs**. If every changed file matches one, `deployable=false`. Blank lines and `#` comments ignored. |
-| `docs-paths` | `docs-site/**` | INCLUDE-form pathspecs defining the docs site for `docs-changed`. |
+| `docs-paths` | `docs-site/**`, `packages/scripts/help/**` | INCLUDE-form pathspecs defining the docs site for `docs-changed`. Includes the help tooling, so a change to those scripts runs the `help-docs` guard that covers them. |
 
 ## Gotchas baked into the default list
 

--- a/.github/actions/changes-filter/action.yml
+++ b/.github/actions/changes-filter/action.yml
@@ -62,9 +62,16 @@ inputs:
       Newline-separated git pathspecs (INCLUDE form) defining the docs site.
       docs-changed=true when the run's changeset touches any of these. Used to
       gate the help-docs job independently of the deploy gate.
+
+      Covers the help TOOLING as well as the corpus: help-docs is the only job
+      that runs packages/scripts/help/**, so listing docs-site alone let a change
+      to those scripts skip the very guard that covers them. A test there then
+      came to import a package the job never built, and the break surfaced on an
+      unrelated docs-site PR rather than on the change that caused it.
     required: false
     default: |
       docs-site/**
+      packages/scripts/help/**
 
 outputs:
   deployable:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,13 +837,21 @@ jobs:
   # holds regardless of deployability. On a deployable docs PR the suites also run in
   # the shards; the duplicate is ~1 min and worth the unconditional guarantee.
   #
-  # Deliberately does NOT need core-build: the help tooling imports only glob/gray-matter
-  # (see loadHelpArticles.ts), so this stays a light, standalone leg that a non-deployable
-  # run can satisfy on its own.
+  # This leg used to need no core build - the help tooling imported only glob/gray-matter.
+  # `ingestHelpDatalake.ts` now pulls in @bike4mind/common, whose package entries all point
+  # at dist/, so the suite fails to LOAD without it (not an assertion failure - a resolve
+  # error). `needs: core-build` alone would be a regression: core-build is gated on
+  # `deployable`, and a docs-only PR is non-deployable, so this job would inherit that skip
+  # and go quiet on exactly the changes it exists to guard. Hence the explicit `if` that
+  # keeps the `docs-changed` gate and tolerates core-build having been skipped, plus the
+  # artifact download with a local build as fallback.
   help-docs:
     name: Help Docs Guards
-    needs: changes
-    if: needs.changes.outputs.docs-changed == 'true'
+    needs: [changes, core-build]
+    if: |
+      always() &&
+      needs.changes.outputs.docs-changed == 'true' &&
+      (needs.core-build.result == 'success' || needs.core-build.result == 'skipped')
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
     timeout-minutes: 10
     permissions:
@@ -877,6 +885,22 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --recursive
+
+      - name: Download core build artifacts
+        id: download-core
+        uses: actions/download-artifact@v7
+        with:
+          name: core-build-${{ needs.core-build.outputs.core-content-hash }}
+          # Artifact paths are relative to the repo root (the common ancestor of
+          # b4m-core/*/dist and packages/database/dist).
+          path: .
+        continue-on-error: true
+
+      # Covers both misses: core-build skipped (docs-only run, so no artifact and an empty
+      # name above) and a genuine download failure.
+      - name: Build bike4mind core packages (fallback)
+        if: steps.download-core.outcome == 'failure'
+        run: pnpm core:build
 
       - name: Run help corpus and help-id suites
         run: pnpm --filter @bike4mind/scripts exec vitest run help/__tests__

--- a/packages/scripts/src/checkHelpContentGuardWired.test.ts
+++ b/packages/scripts/src/checkHelpContentGuardWired.test.ts
@@ -7,7 +7,8 @@ import path from 'node:path';
  * Guards the CI-wiring gap in #2210: .husky/check-help-content.sh enforces the Help AI chat's
  * "every indexed article has a vector" invariant, but a diff that touches ONLY that file is
  * `deployable=false` (`.husky/**` is on changes-filter's exclude list) AND `docs-changed=false`
- * (docs-paths only covers docs-site/**), so every job gated on either flag skips - and a skipped
+ * (docs-paths covers docs-site/** and packages/scripts/help/**, neither of which matches a
+ * .husky-only diff), so every job gated on either flag skips - and a skipped
  * required check counts as passing. Nothing in CI would ever run the script on a diff shaped
  * exactly like an edit to itself.
  *


### PR DESCRIPTION
## Optional Screenshot/Video

N/A - CI configuration only.

## Description

`Help Docs Guards` is red on every PR that touches `docs-site/`, which also fails the required `CI Complete` check. It is not an assertion failure - the suite never loads:

```
FAIL help/__tests__/ingestHelpDatalake.test.ts
Error: Failed to resolve entry for package "@bike4mind/common". The package may have
incorrect main/module/exports specified in its package.json.
 > help/ingestHelpDatalake.ts:35:1
```

The job installs dependencies and runs `vitest run help/__tests__` with no core build. `ingestHelpDatalake.ts` imports `@bike4mind/common`, whose package entries all resolve into `dist/`, so without a build the import cannot resolve. Because the step exits non-zero, the `Check help artifacts agree` step that follows it never runs either - so the index-vs-embeddings invariant is currently unguarded in CI on exactly the PRs meant to guard it.

Reproduced locally by moving `b4m-core/common/dist` aside and running that one test file: identical error, and it passes again once restored.

**Why `needs: core-build` alone would be a regression.** `core-build` is gated on `deployable`, and a docs-only PR is non-deployable, so adding a plain `needs` would make `help-docs` inherit that skip and go quiet on precisely the changes it exists to guard - the same "two shapes miss each other" trap already documented above the `Check help artifacts agree` step in `core-build`. So the job keeps an explicit `if` on `docs-changed`, tolerates `core-build` having been skipped, and falls back to a local `pnpm core:build` when the artifact is absent.

**Why the trigger also needed widening.** `help-docs` is the only job that runs `packages/scripts/help/**`, but `docs-changed` was driven by `docs-site/**` alone. A change to the help tooling therefore skipped the guard covering it, which is how this import landed unnoticed and only surfaced later on an unrelated docs PR. Replaying the pathspec over the commit that introduced it confirms the gap and the fix: empty under the old list, three files under the new one.

## Changes

- `.github/workflows/ci.yml` - `help-docs` now `needs: [changes, core-build]` with an explicit `if` that preserves the `docs-changed` gate and accepts a skipped `core-build`; adds the `download-artifact` step the other package-running jobs use, plus a `pnpm core:build` fallback for when the artifact is missing (docs-only run) or the download fails. Replaces the now-false comment claiming this leg needs no core build.
- `.github/actions/changes-filter/action.yml` - adds `packages/scripts/help/**` to the `docs-paths` default so a change to the help tooling runs the guard that covers it.
- `.github/actions/changes-filter/README.md` - updates the `docs-changed` and `docs-paths` rows to match.
- `packages/scripts/src/checkHelpContentGuardWired.test.ts` - updates a docblock that asserted in prose that `docs-paths` only covers `docs-site/**`. The reasoning it documents is unaffected: a `.husky`-only diff still matches neither pathspec.

The workflow half of this was worked out independently by @vinchi777 on the `feat/feedback-slash-command` branch; that approach is reproduced here rather than rewritten, so it can land on its own instead of waiting behind an unrelated feature. **It will not resolve to a silent no-op for that branch, though.** The functional YAML is byte-identical on both sides - same `needs`, same `if`, same download step, same fallback step - but both replace the *same three* original comment lines with different prose, so whichever merges first, git will conflict in the `help-docs` block. The resolution is trivial (keep one copy of the identical functional YAML, pick one side's prose), but it is a manual dedup rather than something that disappears on its own. The `changes-filter` files are untouched on that branch, so those three hunks apply clean in either order.

## Guide for Testers

This is a CI-only change, so the evidence is in the Actions run rather than the app.

**Read this first: `Help Docs Guards` is `skipped` on this PR, and necessarily so.** None of the four changed files match `docs-paths`, so `docs-changed=false`. The job also *cannot* be made to run here: `.github/workflows/**` is not on `exclude-paths`, so any PR carrying these changes is `deployable=true`, which means `core-build` runs, the artifact exists, the download succeeds and the fallback never fires. Adding a `docs-site/` touch to this PR would not help - it would still be deployable. GitHub did parse the workflow (the run started and the job was evaluated to a skip), so the YAML syntax is validated here; the step bodies are not.

1. The step bodies are exercised on #2764 instead - a throwaway PR based on this branch whose only change is one non-deployable file directly under `docs-site/`, which forces `deployable=false` -> `core-build` skipped -> empty content hash -> `download-artifact` fails -> fallback builds. Open its **Checks** tab.
2. On #2764, confirm **Core Build** reports `skipped`. That is the discriminator: it proves the empty-`core-content-hash` path was taken rather than a normal artifact download.
3. On #2764, open the **Help Docs Guards** log and confirm the step list contains **Download core build artifacts** and **Build bike4mind core packages (fallback)** between *Install dependencies* and *Run help corpus and help-id suites*; that the fallback step actually ran rather than reporting `skipped`; that **Run help corpus and help-id suites** passes with 11 files; and that **Check help artifacts agree** runs rather than reporting `skipped`.
4. Confirm **CI Complete** is green on this PR.
5. Cross-check against a docs PR: re-run the checks on #2713 (a `docs-site/` change that is currently red on this exact failure) once this is merged. Expected: `Help Docs Guards` passes there and `CI Complete` goes green, with no change to that branch.
6. Confirm the widened trigger works on this PR itself: this PR changes `packages/scripts/help/` only in a docblock under `packages/scripts/src/`, so to see the trigger fire, check a future PR that edits `packages/scripts/help/**` and confirm **Help Docs Guards** is no longer `skipped`.

### Regression Checks

7. Confirm the other legs are unaffected: **Core Build**, **Type Check**, **Lint**, **OpenAPI Spec** and the **Run Tests** shards should all behave exactly as before - this PR adds no steps to them.
8. Confirm a non-deployable docs-only PR still runs **Help Docs Guards**. This is the case the explicit `if` protects; if it reports `skipped` on such a PR, the `if` is wrong and the guard has gone quiet.
9. Confirm `check-help-content-guard.yml` still runs on a `.husky/check-help-content.sh`-only diff. Its wiring is pinned by `checkHelpContentGuardWired.test.ts`, which passes here.

### What NOT to test

- Anything in the product UI. No application code changes.
- The two known-unrelated red checks elsewhere in the queue: the `Run Tests (misc)` failures on other open PRs are Mongo `Hook timed out in 30000ms` flakes in `migrate/migrations/*` (territory of #2292), and this PR does not address them.
- The embeddings-drift failure seen on `feat/feedback-slash-command`. That is a genuine content drift needing regeneration, not a CI wiring problem, and is unaffected by this PR.

## Additional Information

**Verified with:** the repo's own CI-wiring guards (`checkChangesFilterEvents`, `checkHelpContentGuardWired`, `checkClientTestShards` - 3 files / 44 tests), the full help suite under `CI=true` (`vitest run help/__tests__`, 11 files / 129 tests), and `sh .husky/check-help-content.sh` (exit 0). The pathspec widening was verified by replaying the old and new `docs-paths` lists over the commit that introduced the import.

The YAML is not machine-validated here: this repo has no YAML parser dependency, which is why its workflow guards are text-matched. `actionlint` is not installed locally either, so the workflow syntax gets its first real parse when GitHub runs this PR - worth a glance at the Checks tab before approving.

Closes #2732

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas - the `if` and the fallback both carry the reasoning for why the obvious version is wrong
- [x] I have made corresponding changes to the documentation (if applicable) - the action README and the pinned docblock
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A

