### PR TITLE
test(scripts): declare the shared real-Mongo budget in the migration suites

### DIFF
--- a/apps/client/__tests__/mongoTestTimeoutBudget.test.ts
+++ b/apps/client/__tests__/mongoTestTimeoutBudget.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as fs from 'fs';
 import * as path from 'path';
-import * as ts from 'typescript';
+import { auditMongoTestBudget } from '../../../packages/database/src/__test__/auditMongoTestBudget';
 
 /**
- * Structural guard for the client shard's real-Mongo suites.
+ * Structural guard for the client shard's real-Mongo suites - the same invariant packages/scripts
+ * audits, so the detector itself lives in one place next to MONGO_TEST_TIMEOUT_MS.
  *
  * A suite that boots a real mongod pays a cold start whose cost scales with runner contention -
  * 3-12s per file on a healthy CI run, past 35s on a busy machine (see MONGO_TEST_TIMEOUT_MS in
@@ -15,168 +15,34 @@ import * as ts from 'typescript';
  * Auditing that by hand only holds until the next suite is added, so the audit lives here: every
  * real-Mongo suite in this shard must declare the shared budget for its tests AND its hooks, and
  * none may pin itself back with a literal.
- *
- * The checks parse the TypeScript AST rather than matching source text. Regex was tried first and
- * could not carry the invariant: it missed `30_000`, single-line `it(..., 30000)` and Prettier's
- * wrapped `},\n  30000\n)`, while false-positiving on the last line of any multi-line call such as
- * `expect(spy).toHaveBeenCalledWith({\n ... \n}, 2)`. Each `it` reports ALL offenders at once so
- * one run tells you everything to fix.
  */
 
 const CLIENT_ROOT = path.resolve(__dirname, '..');
+
 // Anchored to top-level segments: a nested directory that happens to be called `e2e` holds real
 // unit suites and must still be audited (vitest's own `exclude` is a separate glob - keeping this
 // list narrow is what stops the two from silently disagreeing).
-const SKIP_TOP_LEVEL = new Set(['.next', '.open-next', 'e2e', 'dist', '.turbo']);
+const SKIP_TOP_LEVEL = ['.next', '.open-next', 'e2e', 'dist', '.turbo'];
 
-// Only an actual import binding counts, so this guard - which names the factories in prose and in
-// the identifiers below - never flags itself.
-const MONGO_FACTORY_IMPORT = /import\s+\{[^}]*\b(?:createMongoServer|createMongoReplSet)\b[^}]*\}\s*from/;
-const SHARED_BUDGET_IMPORT = /import\s+\{[^}]*\bMONGO_TEST_TIMEOUT_MS\b[^}]*\}\s*from/;
-
-const BUDGET_IDENTIFIER = 'MONGO_TEST_TIMEOUT_MS';
-const HOOKS = new Set(['beforeAll', 'afterAll', 'beforeEach', 'afterEach']);
-const TESTS_AND_SUITES = new Set(['it', 'test', 'describe']);
-
-type SourceFile = { relativePath: string; source: ts.SourceFile };
-
-const walk = (dir: string, out: string[] = []): string[] => {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      const topLevel = path.relative(CLIENT_ROOT, full).split(path.sep)[0];
-      if (entry.name !== 'node_modules' && !SKIP_TOP_LEVEL.has(topLevel)) walk(full, out);
-    } else if (/\.test\.tsx?$/.test(entry.name)) {
-      out.push(full);
-    }
-  }
-  return out;
-};
-
-// Text-matches to pick the class out of ~1000 files, then parses only the handful that matched.
-const realMongoSuites: SourceFile[] = walk(CLIENT_ROOT)
-  .reduce<SourceFile[]>((suites, absolutePath) => {
-    const content = fs.readFileSync(absolutePath, 'utf-8');
-    if (MONGO_FACTORY_IMPORT.test(content)) {
-      suites.push({
-        relativePath: path.relative(CLIENT_ROOT, absolutePath).split(path.sep).join('/'),
-        source: ts.createSourceFile(absolutePath, content, ts.ScriptTarget.Latest, true),
-      });
-    }
-    return suites;
-  }, [])
-  .sort((a, b) => a.relativePath.localeCompare(b.relativePath));
-
-/** Leftmost identifier of a callee, so `it.each([...])(...)` and `describe.only(...)` both read as their base. */
-const rootCalleeName = (expression: ts.Expression): string | undefined => {
-  if (ts.isIdentifier(expression)) return expression.text;
-  if (ts.isPropertyAccessExpression(expression)) return rootCalleeName(expression.expression);
-  if (ts.isCallExpression(expression)) return rootCalleeName(expression.expression);
-  return undefined;
-};
-
-const forEachCall = (source: ts.SourceFile, visit: (call: ts.CallExpression) => void): void => {
-  const recurse = (node: ts.Node): void => {
-    if (ts.isCallExpression(node)) visit(node);
-    ts.forEachChild(node, recurse);
-  };
-  ts.forEachChild(source, recurse);
-};
-
-const lineOf = (source: ts.SourceFile, node: ts.Node): number =>
-  source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
-
-const isBudgetIdentifier = (node: ts.Node): boolean => ts.isIdentifier(node) && node.text === BUDGET_IDENTIFIER;
-
-/** `{ timeout: ... }` on a test/suite/hook call, if present. */
-const timeoutProperty = (argument: ts.Expression): ts.PropertyAssignment | undefined => {
-  if (!ts.isObjectLiteralExpression(argument)) return undefined;
-  return argument.properties.find(
-    (property): property is ts.PropertyAssignment =>
-      ts.isPropertyAssignment(property) && property.name.getText() === 'timeout'
-  );
-};
-
-/**
- * Timeout arguments on a test/suite/hook call that are NOT the shared budget - a trailing numeric
- * literal (`it(name, fn, 30000)`, `beforeAll(fn, 30000)`) or a `{ timeout: <literal> }` option.
- */
-const offendingTimeouts = (file: SourceFile): string[] => {
-  const offenders: string[] = [];
-
-  forEachCall(file.source, call => {
-    const callee = rootCalleeName(call.expression);
-    if (!callee || (!HOOKS.has(callee) && !TESTS_AND_SUITES.has(callee))) return;
-
-    for (const argument of call.arguments) {
-      if (ts.isNumericLiteral(argument)) {
-        offenders.push(`${file.relativePath}:${lineOf(file.source, argument)}: ${callee}(..., ${argument.getText()})`);
-        continue;
-      }
-      const timeout = timeoutProperty(argument);
-      if (timeout && !isBudgetIdentifier(timeout.initializer)) {
-        offenders.push(`${file.relativePath}:${lineOf(file.source, timeout)}: ${callee}(..., ${timeout.getText()})`);
-      }
-    }
-  });
-
-  return offenders;
-};
-
-/**
- * The budget the file actually runs on: the LAST `vi.setConfig` wins at runtime, so a file that
- * declares the shared budget up top and narrows it further down is running on the narrow one.
- */
-const effectiveSetConfig = (source: ts.SourceFile): ts.ObjectLiteralExpression | undefined => {
-  let last: ts.ObjectLiteralExpression | undefined;
-
-  forEachCall(source, call => {
-    if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== 'setConfig') return;
-    const [argument] = call.arguments;
-    if (argument && ts.isObjectLiteralExpression(argument)) last = argument;
-  });
-
-  return last;
-};
-
-const declaresSharedBudget = (source: ts.SourceFile): boolean => {
-  const config = effectiveSetConfig(source);
-  if (!config) return false;
-
-  return (['testTimeout', 'hookTimeout'] as const).every(key => {
-    const property = config.properties.find(
-      (candidate): candidate is ts.PropertyAssignment =>
-        ts.isPropertyAssignment(candidate) && candidate.name.getText() === key
-    );
-    return property !== undefined && isBudgetIdentifier(property.initializer);
-  });
-};
+const audit = auditMongoTestBudget({ root: CLIENT_ROOT, skipTopLevel: SKIP_TOP_LEVEL });
 
 describe('real-Mongo suites in the client shard declare the shared 60s budget', () => {
   it('finds the real-Mongo suites to audit (guards the detector itself)', () => {
     // A broken detector would make every assertion below vacuously pass, so pin the class as
     // non-empty and pin the suite the budget was first raised for.
-    expect(realMongoSuites.length).toBeGreaterThan(10);
-    expect(realMongoSuites.map(file => file.relativePath)).toContain(
-      'server/services/deleteOrganizationTransaction.e2e.test.ts'
-    );
+    expect(audit.suites.length).toBeGreaterThan(10);
+    expect(audit.suites).toContain('server/services/deleteOrganizationTransaction.e2e.test.ts');
   });
 
   it('imports MONGO_TEST_TIMEOUT_MS rather than inventing a budget', () => {
-    const missing = realMongoSuites
-      .filter(file => !SHARED_BUDGET_IMPORT.test(file.source.getFullText()))
-      .map(file => file.relativePath);
-
-    expect(missing).toEqual([]);
+    expect(audit.missingBudgetImport).toEqual([]);
   });
 
   it('applies the budget to tests AND hooks via the effective vi.setConfig', () => {
-    const missing = realMongoSuites.filter(file => !declaresSharedBudget(file.source)).map(file => file.relativePath);
-
-    expect(missing).toEqual([]);
+    expect(audit.missingSharedBudget).toEqual([]);
   });
 
   it('never pins a test, suite or hook back with a literal timeout', () => {
-    expect(realMongoSuites.flatMap(offendingTimeouts)).toEqual([]);
+    expect(audit.literalTimeouts).toEqual([]);
   });
 });

--- a/packages/database/src/__test__/auditMongoTestBudget.ts
+++ b/packages/database/src/__test__/auditMongoTestBudget.ts
@@ -1,0 +1,180 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+/**
+ * Shared auditor for the "a real-Mongo suite declares the shared 60s budget" invariant, consumed
+ * by one guard test per shard that owns real-Mongo suites (apps/client, packages/scripts).
+ *
+ * A suite that boots a real mongod pays a cold start whose cost scales with runner contention -
+ * 3-12s per file on a healthy CI run, past 35s on a busy machine (see MONGO_TEST_TIMEOUT_MS in
+ * ./createMongoServer). Every shard sets a 30s test budget sized for unit tests, so these suites
+ * sit inside that spread and cross it at random: a timeout that asserts nothing and goes green on
+ * re-run of the same commit. Declaring MONGO_TEST_TIMEOUT_MS per file is the fix, and this audit
+ * is what stops the next suite from being added without it.
+ *
+ * The checks parse the TypeScript AST rather than matching source text. Regex was tried first and
+ * could not carry the invariant: it missed `30_000`, single-line `it(..., 30000)` and Prettier's
+ * wrapped `},\n  30000\n)`, while false-positiving on the last line of any multi-line call such as
+ * `expect(spy).toHaveBeenCalledWith({\n ... \n}, 2)`. Every offender is collected so one run tells
+ * you everything to fix.
+ */
+
+// Only an actual import binding counts, so a guard test that names the factories in prose never
+// flags itself.
+const MONGO_FACTORY_IMPORT = /import\s+\{[^}]*\b(?:createMongoServer|createMongoReplSet)\b[^}]*\}\s*from/;
+const SHARED_BUDGET_IMPORT = /import\s+\{[^}]*\bMONGO_TEST_TIMEOUT_MS\b[^}]*\}\s*from/;
+
+const BUDGET_IDENTIFIER = 'MONGO_TEST_TIMEOUT_MS';
+const HOOKS = new Set(['beforeAll', 'afterAll', 'beforeEach', 'afterEach']);
+const TESTS_AND_SUITES = new Set(['it', 'test', 'describe']);
+
+type SourceFile = { relativePath: string; source: ts.SourceFile };
+
+export type MongoTestBudgetAudit = {
+  /** Relative paths of the real-Mongo suites found, sorted. Empty means the detector is broken. */
+  suites: string[];
+  /** Suites that invent a budget instead of importing the shared one. */
+  missingBudgetImport: string[];
+  /** Suites whose effective `vi.setConfig` does not apply the budget to both tests and hooks. */
+  missingSharedBudget: string[];
+  /** `<file>:<line>: <callee>(..., <timeout>)` for each literal timeout pinning a call back. */
+  literalTimeouts: string[];
+};
+
+const walk = (root: string, dir: string, skipTopLevel: Set<string>, out: string[] = []): string[] => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const topLevel = path.relative(root, full).split(path.sep)[0];
+      if (entry.name !== 'node_modules' && !skipTopLevel.has(topLevel)) walk(root, full, skipTopLevel, out);
+    } else if (/\.test\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+/** Leftmost identifier of a callee, so `it.each([...])(...)` and `describe.only(...)` both read as their base. */
+const rootCalleeName = (expression: ts.Expression): string | undefined => {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return rootCalleeName(expression.expression);
+  if (ts.isCallExpression(expression)) return rootCalleeName(expression.expression);
+  return undefined;
+};
+
+const forEachCall = (source: ts.SourceFile, visit: (call: ts.CallExpression) => void): void => {
+  const recurse = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) visit(node);
+    ts.forEachChild(node, recurse);
+  };
+  ts.forEachChild(source, recurse);
+};
+
+const lineOf = (source: ts.SourceFile, node: ts.Node): number =>
+  source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+
+const isBudgetIdentifier = (node: ts.Node): boolean => ts.isIdentifier(node) && node.text === BUDGET_IDENTIFIER;
+
+/** `{ timeout: ... }` on a test/suite/hook call, if present. */
+const timeoutProperty = (argument: ts.Expression): ts.PropertyAssignment | undefined => {
+  if (!ts.isObjectLiteralExpression(argument)) return undefined;
+  return argument.properties.find(
+    (property): property is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(property) && property.name.getText() === 'timeout'
+  );
+};
+
+/**
+ * Timeout arguments on a test/suite/hook call that are NOT the shared budget - a trailing numeric
+ * literal (`it(name, fn, 30000)`, `beforeAll(fn, 30000)`) or a `{ timeout: <literal> }` option.
+ */
+const offendingTimeouts = (file: SourceFile): string[] => {
+  const offenders: string[] = [];
+
+  forEachCall(file.source, call => {
+    const callee = rootCalleeName(call.expression);
+    if (!callee || (!HOOKS.has(callee) && !TESTS_AND_SUITES.has(callee))) return;
+
+    for (const argument of call.arguments) {
+      if (ts.isNumericLiteral(argument)) {
+        offenders.push(`${file.relativePath}:${lineOf(file.source, argument)}: ${callee}(..., ${argument.getText()})`);
+        continue;
+      }
+      const timeout = timeoutProperty(argument);
+      if (timeout && !isBudgetIdentifier(timeout.initializer)) {
+        offenders.push(`${file.relativePath}:${lineOf(file.source, timeout)}: ${callee}(..., ${timeout.getText()})`);
+      }
+    }
+  });
+
+  return offenders;
+};
+
+/**
+ * The budget the file actually runs on: the LAST `vi.setConfig` wins at runtime, so a file that
+ * declares the shared budget up top and narrows it further down is running on the narrow one.
+ */
+const effectiveSetConfig = (source: ts.SourceFile): ts.ObjectLiteralExpression | undefined => {
+  let last: ts.ObjectLiteralExpression | undefined;
+
+  forEachCall(source, call => {
+    if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== 'setConfig') return;
+    const [argument] = call.arguments;
+    if (argument && ts.isObjectLiteralExpression(argument)) last = argument;
+  });
+
+  return last;
+};
+
+const declaresSharedBudget = (source: ts.SourceFile): boolean => {
+  const config = effectiveSetConfig(source);
+  if (!config) return false;
+
+  return (['testTimeout', 'hookTimeout'] as const).every(key => {
+    const property = config.properties.find(
+      (candidate): candidate is ts.PropertyAssignment =>
+        ts.isPropertyAssignment(candidate) && candidate.name.getText() === key
+    );
+    return property !== undefined && isBudgetIdentifier(property.initializer);
+  });
+};
+
+/**
+ * Audits every real-Mongo suite under `root`.
+ *
+ * `skipTopLevel` names directories to leave out, anchored to top-level segments relative to
+ * `root`: a nested directory that happens to share a skipped name (an `e2e` folder holding real
+ * unit suites) must still be audited. Keep the list narrow - vitest's own `exclude` is a separate
+ * glob, and a broad list here is what lets the two silently disagree.
+ */
+export const auditMongoTestBudget = ({
+  root,
+  skipTopLevel = [],
+}: {
+  root: string;
+  skipTopLevel?: readonly string[];
+}): MongoTestBudgetAudit => {
+  // Text-matches to pick the class out of ~1000 files, then parses only the handful that matched.
+  const suites: SourceFile[] = walk(root, root, new Set(skipTopLevel))
+    .reduce<SourceFile[]>((matched, absolutePath) => {
+      const content = fs.readFileSync(absolutePath, 'utf-8');
+      if (MONGO_FACTORY_IMPORT.test(content)) {
+        matched.push({
+          relativePath: path.relative(root, absolutePath).split(path.sep).join('/'),
+          source: ts.createSourceFile(absolutePath, content, ts.ScriptTarget.Latest, true),
+        });
+      }
+      return matched;
+    }, [])
+    .sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+  return {
+    suites: suites.map(file => file.relativePath),
+    missingBudgetImport: suites
+      .filter(file => !SHARED_BUDGET_IMPORT.test(file.source.getFullText()))
+      .map(file => file.relativePath),
+    missingSharedBudget: suites.filter(file => !declaresSharedBudget(file.source)).map(file => file.relativePath),
+    literalTimeouts: suites.flatMap(offendingTimeouts),
+  };
+};

--- a/packages/scripts/migrate/migrations/20260806000000_audit-fabfile-session-owner-mismatch.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260806000000_audit-fabfile-session-owner-mismatch.integration.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import { FabFile, Session } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 import { findOwnerMismatches } from './20260806000000_audit-fabfile-session-owner-mismatch';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 // Proves the real Mongo query semantics a mocked unit test cannot: soft-delete
 // default-scoping on FabFile.find, and that a real Session._id round-trips through String()

--- a/packages/scripts/migrate/migrations/20260810000000_drop-legacy-fabfilechunk-indexes.test.ts
+++ b/packages/scripts/migrate/migrations/20260810000000_drop-legacy-fabfilechunk-indexes.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { FabFileChunk } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // At least one real core migration imports ../../utils/config, which evaluates SST Resource
 // bindings at module load time and throws outside an SST-linked process - see index.test.ts.
@@ -10,6 +10,10 @@ vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260810000000_drop-legacy-fabfilechunk-indexes';
 import { AvailableMigrations } from './index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 // Real mongod, not mocks: safeDropIndex's swallow-on-not-found behavior and the index-name/
 // key-pattern derivation this migration relies on are Mongo server behavior, not something a
@@ -43,9 +47,7 @@ describe('drop-legacy-fabfilechunk-indexes migration (real DB)', () => {
 
     const after = (await FabFileChunk.collection.indexes()).map(index => index.name).sort();
     expect(after).toEqual(['_id_', 'fabFileId_1__id_1']);
-    // Four real index builds plus two drops exceeded the 15s default under the shared "misc" CI
-    // shard's load; real-world-validation.test.ts uses the same 30s bump for similarly-heavy cases.
-  }, 30000);
+  });
 
   it('refuses to drop when the keyset compound is missing', async () => {
     await FabFileChunk.collection.createIndex({ _id: 1, fabFileId: 1 });
@@ -69,7 +71,7 @@ describe('drop-legacy-fabfilechunk-indexes migration (real DB)', () => {
 
     const after = (await FabFileChunk.collection.indexes()).map(index => index.name).sort();
     expect(after).toEqual(['_id_', 'fabFileId_1__id_1']);
-  }, 30000); // Same real-index-build cost as the happy-path test above; same 30s bump.
+  }); // Same real-index-build cost as the happy-path test above; same 30s bump.
 
   it('refuses to drop when the keyset compound is hidden (present but unusable)', async () => {
     await FabFileChunk.collection.createIndex({ fabFileId: 1, _id: 1 }, { hidden: true });

--- a/packages/scripts/migrate/migrations/20260813000000_fix-project-live-unique-name-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260813000000_fix-project-live-unique-name-index.integration.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { Project, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling drop-legacy-fabfilechunk test's guard so this stays robust if that changes.
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260813000000_fix-project-live-unique-name-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 let server: Awaited<ReturnType<typeof createMongoServer>>;
 
@@ -61,7 +65,7 @@ describe('fix-project-live-unique-name-index migration (real DB)', () => {
     await expect(
       Project.collection.insertOne({ userId: 'u1', name: 'Roadmap', deletedAt: new Date() })
     ).resolves.toBeDefined();
-  }, 30000);
+  });
 
   it('is a no-op-safe rebuild when there are no duplicates, and is idempotent on re-run', async () => {
     await Project.collection.insertMany([
@@ -75,5 +79,5 @@ describe('fix-project-live-unique-name-index migration (real DB)', () => {
     expect(await Project.collection.countDocuments({ deletedAt: null })).toBe(2);
     const idx = (await Project.collection.indexes()).find(i => i.name === 'userId_1_name_1');
     expect(idx?.unique).toBe(true);
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260813000001_ensure-organization-member-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260813000001_ensure-organization-member-index.integration.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { Organization, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling drop-legacy-fabfilechunk test's guard so this stays robust if that changes.
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260813000001_ensure-organization-member-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 let server: Awaited<ReturnType<typeof createMongoServer>>;
 
@@ -42,7 +46,7 @@ describe('ensure-organization-member-index migration (real DB)', () => {
 
     idx = (await Organization.collection.indexes()).find(i => i.name === 'users.userId_1');
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -50,5 +54,5 @@ describe('ensure-organization-member-index migration (real DB)', () => {
 
     const idx = (await Organization.collection.indexes()).find(i => i.name === 'users.userId_1');
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260814000001_ensure-fabfile-userid-tagname-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260814000001_ensure-fabfile-userid-tagname-index.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { FabFile, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling ensure-organization-member-index test's guard so this stays robust if
@@ -9,6 +9,10 @@ import { createMongoServer } from '../../../database/src/__test__/createMongoSer
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260814000001_ensure-fabfile-userid-tagname-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const INDEX_NAME = 'userId_1_tags.name_1_archivedAt_1_deletedAt_1';
 
@@ -45,7 +49,7 @@ describe('ensure-fabfile-userid-tagname-index migration (real DB)', () => {
 
     idx = (await FabFile.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -53,5 +57,5 @@ describe('ensure-fabfile-userid-tagname-index migration (real DB)', () => {
 
     const idx = (await FabFile.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260820000000_ensure-lakeaccessevent-questid-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260820000000_ensure-lakeaccessevent-questid-index.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { LakeAccessEventModel, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling ensure-organization-member-index test's guard so this stays robust if
@@ -9,6 +9,10 @@ import { createMongoServer } from '../../../database/src/__test__/createMongoSer
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260820000000_ensure-lakeaccessevent-questid-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const INDEX_NAME = 'questId_1';
 
@@ -48,7 +52,7 @@ describe('ensure-lakeaccessevent-questid-index migration (real DB)', () => {
     // sparse, not a plain index: most rows have no questId, and options
     // can't be changed after the fact without a coordinated drop-and-rebuild.
     expect(idx?.sparse).toBe(true);
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -56,5 +60,5 @@ describe('ensure-lakeaccessevent-questid-index migration (real DB)', () => {
 
     const idx = (await LakeAccessEventModel.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260825000000_feedback-derived-keys-and-text-split.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260825000000_feedback-derived-keys-and-text-split.integration.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { Session, Quest, User } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260825000000_feedback-derived-keys-and-text-split';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 let server: Awaited<ReturnType<typeof createMongoServer>>;
 

--- a/packages/scripts/migrate/migrations/20260826000000_ensure-quest-status-updatedat-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260826000000_ensure-quest-status-updatedat-index.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { Quest, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling ensure-lakeaccessevent-questid-index test's guard so this stays robust
@@ -9,6 +9,10 @@ import { createMongoServer } from '../../../database/src/__test__/createMongoSer
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260826000000_ensure-quest-status-updatedat-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const INDEX_NAME = 'status_updatedAt';
 
@@ -50,7 +54,7 @@ describe('ensure-quest-status-updatedat-index migration (real DB)', () => {
     // Dense on purpose - both fields exist on every quest, so a sparse index would index every
     // row anyway while costing a drop-and-rebuild to change later.
     expect(idx?.sparse).toBeFalsy();
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -58,5 +62,5 @@ describe('ensure-quest-status-updatedat-index migration (real DB)', () => {
 
     const idx = (await Quest.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260827000000_ensure-lake-audit-tiebreak-indexes.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260827000000_ensure-lake-audit-tiebreak-indexes.integration.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { LakeAccessEventModel, LakeConfigChangeEventModel, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // Mirrors the sibling ensure-lakeaccessevent-questid-index test's guard: a core migration imported
 // transitively via '@bike4mind/database' need not evaluate SST config, but stay robust if it does.
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260827000000_ensure-lake-audit-tiebreak-indexes';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const key = (k: Record<string, number>) => JSON.stringify(k);
 
@@ -61,7 +65,7 @@ describe('ensure-lake-audit-tiebreak-indexes migration (real DB)', () => {
     expect(accessKeys).not.toContain(key(LEGACY.byLake));
     // listByPrincipal keeps its plain { createdAt: -1 } sort, so its index is left untouched.
     expect(accessKeys).toContain(key({ principalKind: 1, principalId: 1, createdAt: -1 }));
-  }, 60000);
+  });
 
   it('refuses to drop a legacy index when its replacement was not built, leaving the read covered', async () => {
     await LakeConfigChangeEventModel.collection.createIndex(LEGACY.config);
@@ -79,7 +83,7 @@ describe('ensure-lake-audit-tiebreak-indexes migration (real DB)', () => {
       configBuild.mockRestore();
       accessBuild.mockRestore();
     }
-  }, 60000);
+  });
 
   it('is idempotent on re-run and on an environment that never had the legacy indexes', async () => {
     await migration.up();
@@ -89,5 +93,5 @@ describe('ensure-lake-audit-tiebreak-indexes migration (real DB)', () => {
     const accessKeys = (await LakeAccessEventModel.collection.indexes()).map(i => key(i.key as never));
     expect(configKeys).toContain(key(REPLACEMENT.config));
     expect(accessKeys).toContain(key(REPLACEMENT.byLake));
-  }, 60000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260827074044_normalize-questmaster-vocabularies.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260827074044_normalize-questmaster-vocabularies.integration.test.ts
@@ -1,11 +1,15 @@
 import { SUBQUEST_STATUS_VALUES } from '@bike4mind/common';
 import mongoose from 'mongoose';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260827074044_normalize-questmaster-vocabularies';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const COLLECTION = 'questmasterplans';
 

--- a/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { LEGACY_CHUNK_STALL_NOTES } from '@bike4mind/common';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260828000000_split-chunk-stall-markers-off-notes';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const VECTORIZE_PAUSED_NOTE = 'Indexing paused by the data-lake convergence kill switch - reprocess to complete.';
 const RECHUNK_PAUSED_NOTE =

--- a/packages/scripts/migrate/migrations/20260902000000_ensure-quest-retrieval-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260902000000_ensure-quest-retrieval-index.integration.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { Quest, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling ensure-*-index tests' guard so this stays robust if that changes.
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260902000000_ensure-quest-retrieval-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const INDEX_NAME = 'retrieval_timestamp_desc';
 
@@ -49,7 +53,7 @@ describe('ensure-quest-retrieval-index migration (real DB)', () => {
     // The partial filter is what makes the index usable for the endpoint's own predicate and
     // keeps it off the turns that could never have retrieved.
     expect(idx?.partialFilterExpression).toEqual({ 'promptMeta.retrieval': { $exists: true } });
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -57,5 +61,5 @@ describe('ensure-quest-retrieval-index migration (real DB)', () => {
 
     const idx = (await Quest.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260903000000_ensure-scopedsetting-settingname-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260903000000_ensure-scopedsetting-settingname-index.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { ScopedSetting, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling ensure-lakeaccessevent-questid-index test's guard so this stays robust if
@@ -10,6 +10,10 @@ vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260903000000_ensure-scopedsetting-settingname-index';
 
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
+
 const INDEX_NAME = 'settingName_1';
 
 let server: Awaited<ReturnType<typeof createMongoServer>>;
@@ -17,7 +21,7 @@ let server: Awaited<ReturnType<typeof createMongoServer>>;
 beforeAll(async () => {
   server = await createMongoServer();
   await mongoose.connect(server.getUri());
-}, 60000);
+});
 
 afterAll(async () => {
   await mongoose.disconnect();
@@ -45,7 +49,7 @@ describe('ensure-scopedsetting-settingname-index migration (real DB)', () => {
     idx = (await ScopedSetting.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
     expect(idx?.key).toEqual({ settingName: 1 });
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -53,5 +57,5 @@ describe('ensure-scopedsetting-settingname-index migration (real DB)', () => {
 
     const idx = (await ScopedSetting.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260907000000_ensure-fabfile-tagname-filename-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260907000000_ensure-fabfile-tagname-filename-index.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { FabFile, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // Mirrors the sibling ensure-fabfile-userid-tagname-index test's guard: a core migration imported
 // transitively via '@bike4mind/database' need not evaluate SST config, but this keeps it robust if
@@ -9,6 +9,10 @@ import { createMongoServer } from '../../../database/src/__test__/createMongoSer
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260907000000_ensure-fabfile-tagname-filename-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const INDEX_NAME = 'tags.name_1_fileName_1_deletedAt_1';
 
@@ -47,7 +51,7 @@ describe('ensure-fabfile-tagname-filename-index migration (real DB)', () => {
     // Key ORDER is the point, not just presence: `fileName` after `tags.name` is what lets one
     // lake's tag bound the scan before the name equality applies.
     expect(idx?.key).toEqual({ 'tags.name': 1, fileName: 1, deletedAt: 1 });
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -55,5 +59,5 @@ describe('ensure-fabfile-tagname-filename-index migration (real DB)', () => {
 
     const idx = (await FabFile.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/migrate/migrations/20260909000000_ensure-quest-images-index.integration.test.ts
+++ b/packages/scripts/migrate/migrations/20260909000000_ensure-quest-images-index.integration.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import { Quest, safeDropIndex } from '@bike4mind/database';
-import { createMongoServer } from '../../../database/src/__test__/createMongoServer';
+import { createMongoServer, MONGO_TEST_TIMEOUT_MS } from '../../../database/src/__test__/createMongoServer';
 
 // A core migration imported transitively via '@bike4mind/database' need not evaluate SST config,
 // but mirror the sibling ensure-*-index tests' guard so this stays robust if that changes.
 vi.mock('../../utils/config', () => ({ Config: {} }));
 
 import migration from './20260909000000_ensure-quest-images-index';
+
+// Boots a real mongod, so lift the whole file off the shard's unit-test budget for tests AND
+// hooks in one place (see MONGO_TEST_TIMEOUT_MS for why 30s is not enough).
+vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS });
 
 const INDEX_NAME = 'images';
 
@@ -46,7 +50,7 @@ describe('ensure-quest-images-index migration (real DB)', () => {
     expect(idx?.key).toEqual({ images: 1 });
     // Sparse keeps the index off the quests that carry no images (most of them).
     expect(idx?.sparse).toBe(true);
-  }, 30000);
+  });
 
   it('is idempotent on re-run', async () => {
     await migration.up();
@@ -54,5 +58,5 @@ describe('ensure-quest-images-index migration (real DB)', () => {
 
     const idx = (await Quest.collection.indexes()).find(i => i.name === INDEX_NAME);
     expect(idx).toBeDefined();
-  }, 30000);
+  });
 });

--- a/packages/scripts/src/mongoTestTimeoutBudget.test.ts
+++ b/packages/scripts/src/mongoTestTimeoutBudget.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { auditMongoTestBudget } from '../../database/src/__test__/auditMongoTestBudget';
+
+/**
+ * Structural guard for this shard's real-Mongo suites - the same invariant apps/client audits, so
+ * the detector itself lives in one place next to MONGO_TEST_TIMEOUT_MS.
+ *
+ * This package's real-Mongo migration suites are the ones the CI "misc" leg times out on: the
+ * shard budget is 30s for tests and 30s for hooks, both sized for unit tests, and a mongod cold
+ * start crosses that at random under the leg's file parallelism. Declaring the shared 60s budget
+ * per file is the fix; this keeps the next migration suite from landing without it.
+ */
+
+const SCRIPTS_ROOT = path.resolve(__dirname, '..');
+
+const audit = auditMongoTestBudget({ root: SCRIPTS_ROOT, skipTopLevel: ['dist', '.turbo'] });
+
+describe('real-Mongo suites in the scripts shard declare the shared 60s budget', () => {
+  it('finds the real-Mongo suites to audit (guards the detector itself)', () => {
+    // A broken detector would make every assertion below vacuously pass, so pin the class as
+    // non-empty and pin the suite the CI timeout was traced to.
+    expect(audit.suites.length).toBeGreaterThan(10);
+    expect(audit.suites).toContain('migrate/migrations/20260810000000_drop-legacy-fabfilechunk-indexes.test.ts');
+  });
+
+  it('imports MONGO_TEST_TIMEOUT_MS rather than inventing a budget', () => {
+    expect(audit.missingBudgetImport).toEqual([]);
+  });
+
+  it('applies the budget to tests AND hooks via the effective vi.setConfig', () => {
+    expect(audit.missingSharedBudget).toEqual([]);
+  });
+
+  it('never pins a test, suite or hook back with a literal timeout', () => {
+    expect(audit.literalTimeouts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

The CI `misc` leg fails intermittently on the real-DB migration suites in `packages/scripts`. The failure is always the same shape: `Test timed out in 30000ms`, no failed assertion, green on re-run of the same commit.

This is not specific to any branch. Three recent CI failures on unrelated branches were all this leg, with overlapping sets of these suites.

**Why they time out.** Booting mongod costs a cold start that scales with runner contention - Mongoose builds every model's index set on connect (`autoIndex` cannot be disabled; index-dependent suites need it) plus first-collection creation. `MONGO_TEST_TIMEOUT_MS` in `packages/database/src/__test__/createMongoServer.ts` documents the measured spread: 3-12s on a healthy run, 16-22s under shard file parallelism, past 35s on a busy machine. Locally, the three suites that failed most recently take **14.5s, 18.6s and 15.6s**.

The shard's budget is 30s for tests and 30s for hooks, both sized for unit tests. The suites sat inside that spread, so they crossed it on scheduling luck.

**Why not just raise the timeout.** That was the last attempt - this package's `vitest.config.ts` already raised the shared 15s floor to 30s for exactly this reason, and it still flakes. Raising the shard default again would also hand the same slack to ~900 unit tests in this package that must stay tight.

`apps/client` already solved this properly: real-Mongo suites declare the shared 60s budget per file, and a structural guard keeps the next suite from landing without it. That is why the client shard does not flake this way. This PR adopts the same pattern in `packages/scripts`, which never picked it up - all 15 of its real-Mongo suites were on the unit-test budget.

## Changes

- **`packages/database/src/__test__/auditMongoTestBudget.ts`** (new) - the AST auditor extracted from the client's guard, so one implementation serves every shard that owns real-Mongo suites. It lives next to the `MONGO_TEST_TIMEOUT_MS` constant it enforces.
- **`packages/scripts/src/mongoTestTimeoutBudget.test.ts`** (new) - the same structural guard for this shard. Written before the fix; it came up red listing all 15 suites.
- **15 real-Mongo migration suites** now declare `vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, hookTimeout: MONGO_TEST_TIMEOUT_MS })`.
- **24 literal timeout arguments removed** (`it(..., 30000)`, `beforeAll(..., 60000)`) across 11 of those files. The guard surfaced these - they are the "literal left behind to silently pin a suite back to the old budget" that the `MONGO_TEST_TIMEOUT_MS` docstring warns about, and several pinned individual tests *below* the file budget.
- **`apps/client/__tests__/mongoTestTimeoutBudget.test.ts`** - rewritten onto the shared auditor (-156 lines), behaviour unchanged.

No production code is touched. Every change is in test files or test-only helpers.

## Guide for Testers

This is a test-infrastructure PR with no user-facing surface. Verification is by command, not by browser.

1. Check out this branch and run `pnpm install`, then `pnpm turbo:core:build` (the migration suites import `@bike4mind/database` and `@bike4mind/common` through their built entries; a fresh worktree fails to resolve them otherwise).
2. Run `pnpm --filter @bike4mind/scripts test`.
   - Expected: all test files pass. On the last run: **82 files, 933 tests passed.**
3. Run `pnpm --filter @bike4mind/scripts test src/mongoTestTimeoutBudget.test.ts` (no `--` before the path).
   - Expected: 4 tests pass. This is the new guard.
4. Prove the guard actually bites: open any file in `packages/scripts/migrate/migrations/` ending `.integration.test.ts`, delete its `vi.setConfig({ testTimeout: MONGO_TEST_TIMEOUT_MS, ... })` line, and re-run step 3.
   - Expected: the run fails, and the failure message names that exact file under `applies the budget to tests AND hooks via the effective vi.setConfig`. Restore the line afterward.
5. Prove the literal check bites: in the same file, change one `it('...', async () => {` block to end `}, 5000);` and re-run step 3.
   - Expected: failure under `never pins a test, suite or hook back with a literal timeout`, reporting `<file>:<line>: it(..., 5000)`. Revert afterward.

### Regression Checks

6. Run `pnpm --filter @bike4mind/client test __tests__/mongoTestTimeoutBudget.test.ts`.
   - Expected: 4 tests pass. This is the pre-existing client guard, now running on the extracted auditor - it must still detect the same class and still contain `server/services/deleteOrganizationTransaction.e2e.test.ts` in its audited set.
7. Run `pnpm --filter @bike4mind/scripts typecheck` and `pnpm --filter @bike4mind/database typecheck`.
   - Expected: both clean.
8. Run `pnpm lint:check`.
   - Expected: no violations.
9. Confirm the three suites that failed in CI now pass and report real durations rather than timing out:
   - `migrate/migrations/20260810000000_drop-legacy-fabfilechunk-indexes.test.ts`
   - `migrate/migrations/20260825000000_feedback-derived-keys-and-text-split.integration.test.ts`
   - `migrate/migrations/20260828000000_split-chunk-stall-markers-off-notes.integration.test.ts`
   - Expected: all pass. Each should report roughly 14-19s, not a 30s timeout.

### What NOT to test

- **No UI, no API, no preview environment.** Nothing here is reachable from the app; a preview deploy proves nothing about this change.
- **Do not test for a speed improvement.** This does not make the suites faster - it stops a slow-but-correct suite from being failed for being slow. Wall-clock time is unchanged.
- **Do not treat one green `misc` leg as proof.** The bug is intermittent by nature, so a single pass never proved the old code correct either. The durable evidence is the structural guard, which fails deterministically.
- **No migration is run or modified.** Only the tests around them changed; no migration's `up()` logic is touched.

## Additional Information

Verified locally: `packages/scripts` suite (82 files / 933 tests), both package typechecks, and `pnpm lint:check` all pass.

The same gap exists in **`packages/database`**, where 72 real-Mongo suites are on its `data` shard's 30s `testTimeout` (its hooks already get 60s, so only test bodies are exposed). That is the same latent flake, but it is a different shard and a much larger diff, so it is deliberately left out of this PR rather than widening the blast radius. The auditor added here is what a follow-up would reuse - it takes a `root`, so covering that shard is a new guard file plus the per-file declarations.

## Developer Notes

- **`auditMongoTestBudget({ root, skipTopLevel })`** is now a reusable, shard-agnostic auditor. Any package that grows real-Mongo suites can enforce the budget with a ~20-line guard file instead of copying ~180 lines of AST logic.
- **The pattern worth noting** is that the invariant and its enforcement now live together: `MONGO_TEST_TIMEOUT_MS` and the auditor that requires it sit in the same directory, so a future change to the budget has one obvious home.
- The auditor parses the TypeScript AST rather than matching source text, and that is load-bearing - regex missed `30_000`, single-line `it(..., 30000)` and Prettier's wrapped `},\n  30000\n)`, while false-positiving on the trailing line of any multi-line call. It also resolves the *effective* `vi.setConfig` (last one wins at runtime), so a file cannot declare the shared budget up top and quietly narrow it further down.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
