### PR TITLE
feat(feedback): paginate the feedback list and make records deep-linkable

### DIFF
--- a/apps/client/app/components/Session/ChatHistory.test.tsx
+++ b/apps/client/app/components/Session/ChatHistory.test.tsx
@@ -16,6 +16,12 @@ import type { IChatHistoryItem } from '@bike4mind/common';
 
 const messageContentSpy = vi.fn();
 
+const mocks = vi.hoisted(() => ({
+  flashMessageHighlight: vi.fn(),
+  registerScrollToMessageHandler: vi.fn(() => vi.fn()),
+  search: {} as { questId?: string },
+}));
+
 vi.mock('@client/app/components/Session/MessageContent', () => ({
   default: (props: Record<string, unknown>) => {
     messageContentSpy(props);
@@ -43,10 +49,17 @@ vi.mock('react-virtuoso', () => ({
 
 vi.mock('./FallbackModelBadge', () => ({ default: () => null }));
 vi.mock('@client/app/utils/chatScroll', () => ({
-  flashMessageHighlight: vi.fn(),
-  registerScrollToMessageHandler: vi.fn(() => vi.fn()),
+  flashMessageHighlight: mocks.flashMessageHighlight,
+  registerScrollToMessageHandler: mocks.registerScrollToMessageHandler,
 }));
 vi.mock('@client/app/utils/scrollbarStyles', () => ({ scrollbarStyles: {} }));
+
+// Spread the real module: ChatHistory only needs useSearch, but its transitive imports may
+// reach other router exports, and a mock that omits an imported export throws at import time.
+vi.mock('@tanstack/react-router', async () => ({
+  ...(await vi.importActual('@tanstack/react-router')),
+  useSearch: () => mocks.search,
+}));
 
 import ChatHistory from './ChatHistory';
 
@@ -60,27 +73,38 @@ const chatCompletion = {
   rapidReply: { content: 'Give me a moment.', status: 'completed' },
 } as never;
 
-const renderHistory = (history: IChatHistoryItem[], activeStreamingQuestId: string | null) =>
-  render(
-    <ChatHistory
-      filteredChatHistory={history}
-      sessionId="session-1"
-      mode="chat"
-      activeStreamingQuestId={activeStreamingQuestId}
-      chatCompletion={chatCompletion}
-      onDelete={vi.fn()}
-      onPinToggle={vi.fn()}
-      onSendMessage={vi.fn()}
-      search=""
-      model="gpt-4o"
-      canUseAdminTools={false}
-      virtuosoRef={{ current: null }}
-      firstItemIndex={0}
-      onStartReached={vi.fn()}
-      onAtBottomStateChange={vi.fn()}
-      scrollbarWidth={0}
-    />
-  );
+type ScrollSpy = { scrollToIndex: ReturnType<typeof vi.fn> };
+
+const historyElement = (
+  history: IChatHistoryItem[],
+  activeStreamingQuestId: string | null,
+  virtuosoRef: { current: ScrollSpy | null } = { current: null }
+) => (
+  <ChatHistory
+    filteredChatHistory={history}
+    sessionId="session-1"
+    mode="chat"
+    activeStreamingQuestId={activeStreamingQuestId}
+    chatCompletion={chatCompletion}
+    onDelete={vi.fn()}
+    onPinToggle={vi.fn()}
+    onSendMessage={vi.fn()}
+    search=""
+    model="gpt-4o"
+    canUseAdminTools={false}
+    virtuosoRef={virtuosoRef as never}
+    firstItemIndex={0}
+    onStartReached={vi.fn()}
+    onAtBottomStateChange={vi.fn()}
+    scrollbarWidth={0}
+  />
+);
+
+const renderHistory = (
+  history: IChatHistoryItem[],
+  activeStreamingQuestId: string | null,
+  virtuosoRef?: { current: ScrollSpy | null }
+) => render(historyElement(history, activeStreamingQuestId, virtuosoRef));
 
 /** messageData.id -> whether that row received a chatCompletion. */
 const completionByMessage = () =>
@@ -94,6 +118,7 @@ const completionByMessage = () =>
 describe('ChatHistory - streaming state is scoped to one message', () => {
   beforeEach(() => {
     messageContentSpy.mockClear();
+    mocks.search = {};
   });
 
   it('hands the chat completion to the streaming message only', () => {
@@ -128,5 +153,60 @@ describe('ChatHistory - streaming state is scoped to one message', () => {
     renderHistory([quest('b'), quest('a')], 'not-here');
 
     expect(completionByMessage()).toEqual({ a: false, b: false });
+  });
+});
+
+/**
+ * `?questId=` on a session URL is how a feedback deep link names one turn. The list is
+ * virtualized, so the target usually has no DOM node and the scroll must go through Virtuoso's
+ * index API - a DOM query would find nothing and fail silently. The turn may also live in a
+ * history page that has not loaded yet, so the effect has to keep retrying until it lands.
+ */
+describe('ChatHistory - questId deep link', () => {
+  beforeEach(() => {
+    messageContentSpy.mockClear();
+    mocks.flashMessageHighlight.mockClear();
+    mocks.search = {};
+  });
+
+  it('scrolls to the linked turn by index and flashes it', () => {
+    mocks.search = { questId: 'b' };
+    const virtuosoRef = { current: { scrollToIndex: vi.fn() } };
+
+    // Rendered newest-first, so reversedHistory is [a, b, c] and 'b' is index 1.
+    renderHistory([quest('c'), quest('b'), quest('a')], null, virtuosoRef);
+
+    expect(virtuosoRef.current.scrollToIndex).toHaveBeenCalledWith({
+      index: 1,
+      align: 'center',
+      // Competes with Virtuoso's mount jump to the newest message; a smooth scroll loses.
+      behavior: 'auto',
+    });
+    expect(mocks.flashMessageHighlight).toHaveBeenCalledWith('b');
+  });
+
+  it('does nothing when the URL names no turn', () => {
+    const virtuosoRef = { current: { scrollToIndex: vi.fn() } };
+
+    renderHistory([quest('b'), quest('a')], null, virtuosoRef);
+
+    expect(virtuosoRef.current.scrollToIndex).not.toHaveBeenCalled();
+    expect(mocks.flashMessageHighlight).not.toHaveBeenCalled();
+  });
+
+  // The latch must close on a successful scroll, not on the first attempt: a link into an older
+  // turn arrives before the page holding it, and latching on arrival would drop the link for good.
+  it('still scrolls once a later history page brings the linked turn in', () => {
+    mocks.search = { questId: 'old' };
+    const virtuosoRef = { current: { scrollToIndex: vi.fn() } };
+
+    const { rerender } = renderHistory([quest('b'), quest('a')], null, virtuosoRef);
+    expect(virtuosoRef.current.scrollToIndex).not.toHaveBeenCalled();
+
+    rerender(historyElement([quest('b'), quest('a'), quest('old')], null, virtuosoRef));
+
+    expect(virtuosoRef.current.scrollToIndex).toHaveBeenCalledTimes(1);
+    expect(virtuosoRef.current.scrollToIndex).toHaveBeenCalledWith(expect.objectContaining({ index: 0 }));
+    expect(mocks.flashMessageHighlight).toHaveBeenCalledWith('old');
   });
 });

--- a/apps/client/app/components/Session/ChatHistory.tsx
+++ b/apps/client/app/components/Session/ChatHistory.tsx
@@ -1,6 +1,6 @@
 import { IChatHistoryItem } from '@bike4mind/common';
 import Box from '@mui/joy/Box';
-import React, { memo, useCallback, useEffect, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import MessageContent from '@client/app/components/Session/MessageContent';
 import FallbackModelBadge from './FallbackModelBadge';
@@ -8,6 +8,7 @@ import { SendMessageOptions } from '@client/app/utils/llm';
 import { useSubscribeChatCompletion } from '@client/app/hooks/useSubscribeChatCompletion';
 import { flashMessageHighlight, registerScrollToMessageHandler } from '@client/app/utils/chatScroll';
 import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
+import { useSearch } from '@tanstack/react-router';
 
 // --- Virtuoso context type ---
 // Passed via Virtuoso's `context` prop to stable module-level custom components.
@@ -165,22 +166,49 @@ const ChatHistory: React.FC<ChatHistoryProps> = memo(
 
     const virtuosoContext = useMemo<VirtuosoContext>(() => ({ sessionId, footer }), [sessionId, footer]);
 
-    // Scroll-to-message service for other components (e.g. the QuestMaster
-    // plan board). Virtuoso's index API reaches messages that are currently
-    // virtualized out and have no DOM node.
-    useEffect(() => {
-      return registerScrollToMessageHandler(messageId => {
+    // Virtuoso's index API reaches messages that are currently virtualized out and have no DOM
+    // node, so neither caller below can use a DOM query. Returns false when the turn is not in
+    // the loaded history at all.
+    const scrollToMessage = useCallback(
+      (messageId: string, behavior: 'smooth' | 'auto') => {
         const reversedIndex = reversedHistory.findIndex(item => item.id === messageId);
         if (reversedIndex === -1) return false;
         virtuosoRef.current?.scrollToIndex({
           index: firstItemIndex + reversedIndex,
           align: 'center',
-          behavior: 'smooth',
+          behavior,
         });
         flashMessageHighlight(messageId);
         return true;
-      });
-    }, [reversedHistory, firstItemIndex, virtuosoRef]);
+      },
+      [reversedHistory, firstItemIndex, virtuosoRef]
+    );
+
+    // Scroll-to-message service for other components (e.g. the QuestMaster
+    // plan board).
+    useEffect(() => {
+      return registerScrollToMessageHandler(messageId => scrollToMessage(messageId, 'smooth'));
+    }, [scrollToMessage]);
+
+    // A feedback deep link (/notebooks/<sessionId>?questId=<questId>) names one turn. The turn is
+    // virtualized out on arrival, and the history it lives in may not have loaded yet, so this
+    // retries as `reversedHistory` grows and fires once the turn is actually present. A turn whose
+    // page is never loaded is never scrolled to - the reader stays at the newest message, which is
+    // where they would have landed without the link anyway.
+    //
+    // `auto`, not `smooth`: this competes with Virtuoso's initialTopMostItemIndex jump to the
+    // newest message on mount, and an animated scroll can lose that race. The highlight flash is
+    // what draws the eye instead.
+    const scrolledToDeepLinkRef = useRef<string | null>(null);
+    const { questId: deepLinkedQuestId } = useSearch({ strict: false }) as { questId?: string };
+
+    useEffect(() => {
+      if (!deepLinkedQuestId || scrolledToDeepLinkRef.current === deepLinkedQuestId) return;
+      // Only latch once it actually scrolled, so a later history page can still satisfy the link.
+      if (scrollToMessage(deepLinkedQuestId, 'auto')) {
+        scrolledToDeepLinkRef.current = deepLinkedQuestId;
+      }
+    }, [deepLinkedQuestId, scrollToMessage]);
 
     // Don't mount Virtuoso until data is available - initialTopMostItemIndex
     // only applies on mount, so the component must mount AFTER data loads

--- a/apps/client/app/components/admin/AdminPage.tsx
+++ b/apps/client/app/components/admin/AdminPage.tsx
@@ -27,7 +27,7 @@ import {
   Tooltip,
 } from '@mui/joy';
 import { useGetWaitingSubscribersCount } from '@client/app/hooks/data/subscribers';
-import { useRouter } from '@tanstack/react-router';
+import { useRouter, useSearch } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { lazy, useEffect, useRef, useState, type ReactNode } from 'react';
 import { api } from '@client/app/contexts/ApiContext';
@@ -67,6 +67,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import ApiReferenceTab from './ApiReferenceTab';
 import ApiCookbookTab from './ApiCookbookTab';
 import { AdminTab, SIDEBAR_SECTIONS, type SidebarGate, type SidebarItem } from './adminSidebarConfig';
+import { adminTabFromSlug } from './adminTabSlugs';
 import { useAdminModal } from './useAdminModal';
 import { useAdminSidebarSections } from './useAdminSidebarSections';
 
@@ -298,6 +299,19 @@ const AdminPage = ({ enableUserMigration }: AdminPageProps) => {
   const [activeTab, setActiveTab] = useAdminModal(useShallow(state => [state.activeTab, state.setActiveTab]));
   const hiddenNotifications = useAdminNotifications(state => state.hiddenNotifications);
   const { currentUser } = useUser();
+  const { tab: requestedTabSlug } = useSearch({ strict: false }) as { tab?: string };
+
+  // A `?tab=` deep link chooses the opening tab. Keyed on the slug, NOT on activeTab, so this is
+  // an entry point rather than a mirror: activeTab is also driven by the sidebar and by the chat
+  // model picker's "manage models" shortcut (see useAdminModal), and re-asserting the URL's value
+  // on every change would fight both. Leaving the param in place is deliberate - the link stays
+  // shareable and survives a reload.
+  useEffect(() => {
+    const requestedTab = adminTabFromSlug(requestedTabSlug);
+    if (requestedTab !== undefined) {
+      setActiveTab(requestedTab);
+    }
+  }, [requestedTabSlug, setActiveTab]);
 
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
 
@@ -363,12 +377,16 @@ const AdminPage = ({ enableUserMigration }: AdminPageProps) => {
   // Get waiting subscribers count for badge
   const waitingSubscribers = useGetWaitingSubscribersCount({ enabled: currentUser?.isAdmin });
 
-  // Set default tab based on migration availability
+  // Set default tab based on migration availability. Skipped when the URL asked for a tab: both
+  // this and the `?tab=` effect above read the same `activeTab` snapshot, so on a render where
+  // enableUserMigration is already true they would both fire and this one would land last,
+  // silently overriding the deep link. Today it only loses that race because the flag arrives
+  // from a query a tick later.
   useEffect(() => {
-    if (enableUserMigration && activeTab === AdminTab.Users) {
+    if (enableUserMigration && activeTab === AdminTab.Users && !adminTabFromSlug(requestedTabSlug)) {
       setActiveTab(AdminTab.Migrate);
     }
-  }, [enableUserMigration, activeTab, setActiveTab]);
+  }, [enableUserMigration, activeTab, setActiveTab, requestedTabSlug]);
 
   if (!currentUser?.isAdmin) {
     return (

--- a/apps/client/app/components/admin/Feedback/FeedbackRowLinks.test.tsx
+++ b/apps/client/app/components/admin/Feedback/FeedbackRowLinks.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+const mocks = vi.hoisted(() => ({ copyTextWithToast: vi.fn() }));
+
+vi.mock('@client/app/utils/copyToClipboard', () => ({ copyTextWithToast: mocks.copyTextWithToast }));
+
+import FeedbackRowLinks from './FeedbackRowLinks';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const renderLinks = (feedbackItem: { _id: string; sessionId?: string; questId?: string }) =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <FeedbackRowLinks feedbackItem={feedbackItem} />
+    </CssVarsProvider>
+  );
+
+const conversationLink = () => screen.queryByTestId('feedback-open-conversation-btn');
+
+describe('FeedbackRowLinks', () => {
+  beforeEach(() => {
+    mocks.copyTextWithToast.mockReset();
+  });
+
+  /**
+   * The copied link is the one that leaves the app for Slack or a ticket, so it has to be
+   * absolute and carry both the tab slug and the record id - a path alone is unusable there.
+   */
+  it('copies an absolute link that opens the admin tab on this record', async () => {
+    renderLinks({ _id: 'fb-1' });
+
+    await userEvent.click(screen.getByTestId('feedback-copy-link-btn'));
+
+    const [copied] = mocks.copyTextWithToast.mock.calls[0];
+    expect(copied).toBe(`${window.location.origin}/admin?tab=feedback&feedbackId=fb-1`);
+  });
+
+  // The slug, not AdminTab's positional number: these links outlive any one deploy.
+  it('does not put the tab enum number in the copied link', async () => {
+    renderLinks({ _id: 'fb-1' });
+
+    await userEvent.click(screen.getByTestId('feedback-copy-link-btn'));
+
+    expect(mocks.copyTextWithToast.mock.calls[0][0]).toContain('tab=feedback');
+    expect(mocks.copyTextWithToast.mock.calls[0][0]).not.toMatch(/tab=\d/);
+  });
+
+  it('links a turn-level report straight at the turn', () => {
+    renderLinks({ _id: 'fb-1', sessionId: 'sess-1', questId: 'quest-1' });
+
+    expect(conversationLink()).toHaveAttribute('href', '/notebooks/sess-1?questId=quest-1');
+  });
+
+  // A session-level report names no turn, so the link degrades to the session rather than
+  // building one with an empty questId that ChatHistory would never match.
+  it('links a session-level report at the session', () => {
+    renderLinks({ _id: 'fb-1', sessionId: 'sess-1' });
+
+    expect(conversationLink()).toHaveAttribute('href', '/notebooks/sess-1');
+  });
+
+  it('offers no conversation link for a product-level report', () => {
+    renderLinks({ _id: 'fb-1' });
+
+    expect(conversationLink()).not.toBeInTheDocument();
+  });
+
+  // Triage happens with filters and a page cursor on screen; routing away would discard both.
+  it('opens the conversation in a new tab, without leaking the referrer', () => {
+    renderLinks({ _id: 'fb-1', sessionId: 'sess-1', questId: 'quest-1' });
+
+    expect(conversationLink()).toHaveAttribute('target', '_blank');
+    expect(conversationLink()).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('escapes ids rather than letting them inject query params', () => {
+    renderLinks({ _id: 'fb-1', sessionId: 'sess-1?tab=users', questId: 'q&x=1' });
+
+    const href = conversationLink()?.getAttribute('href') ?? '';
+    expect(href).toBe('/notebooks/sess-1%3Ftab%3Dusers?questId=q%26x%3D1');
+  });
+});

--- a/apps/client/app/components/admin/Feedback/FeedbackRowLinks.tsx
+++ b/apps/client/app/components/admin/Feedback/FeedbackRowLinks.tsx
@@ -1,0 +1,64 @@
+import { IconButton, Stack, Tooltip } from '@mui/joy';
+import LinkIcon from '@mui/icons-material/Link';
+import ForumIcon from '@mui/icons-material/Forum';
+import { adminFeedbackRecordPath, sessionPath, sessionTurnPath, toAbsoluteUrl } from '@bike4mind/common';
+import { copyTextWithToast } from '@client/app/utils/copyToClipboard';
+import { IExtendedFeedbackDocument } from './types';
+
+interface FeedbackRowLinksProps {
+  feedbackItem: Pick<IExtendedFeedbackDocument, '_id' | 'sessionId' | 'questId'>;
+}
+
+/**
+ * The two deep links a triaging admin needs on a feedback row: a shareable link back to this
+ * record, and a jump to the conversation turn the report is about.
+ *
+ * Both are built from the shared path builders in common/utils/deepLinks rather than composed
+ * here, because the same scheme is emitted server-side into Slack and email notifications - one
+ * definition keeps a link pasted into Slack and a link copied from this row identical.
+ *
+ * The conversation link is an anchor opening a new tab rather than a router navigate: the admin is
+ * mid-triage with filters and a page cursor on screen, and routing away discards all of it. It
+ * also makes the link middle-clickable, which is how anyone reading a list of reports uses it.
+ */
+const FeedbackRowLinks = ({ feedbackItem }: FeedbackRowLinksProps) => {
+  const { _id, sessionId, questId } = feedbackItem;
+
+  const copyRecordLink = () =>
+    copyTextWithToast(
+      toAbsoluteUrl(window.location.origin, adminFeedbackRecordPath(_id)),
+      'Link to this report copied'
+    );
+
+  // A product-level report has no session and a session-level one has no turn, so the target
+  // degrades from turn to session to absent rather than building a link to neither.
+  const conversationPath = sessionId ? (questId ? sessionTurnPath(sessionId, questId) : sessionPath(sessionId)) : null;
+
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center">
+      <Tooltip title="Copy link to this report">
+        <IconButton size="sm" variant="plain" onClick={copyRecordLink} data-testid="feedback-copy-link-btn">
+          <LinkIcon />
+        </IconButton>
+      </Tooltip>
+
+      {conversationPath && (
+        <Tooltip title={questId ? 'Open the conversation at this turn' : 'Open the conversation'}>
+          <IconButton
+            size="sm"
+            variant="plain"
+            component="a"
+            href={conversationPath}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="feedback-open-conversation-btn"
+          >
+            <ForumIcon />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Stack>
+  );
+};
+
+export default FeedbackRowLinks;

--- a/apps/client/app/components/admin/Feedback/FocusedFeedbackCard.test.tsx
+++ b/apps/client/app/components/admin/Feedback/FocusedFeedbackCard.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { FeedbackStatus } from '@bike4mind/common';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+const mocks = vi.hoisted(() => ({ getFeedbackByIdFromServer: vi.fn() }));
+
+vi.mock('@client/app/utils/feedbackAPICalls', () => ({
+  getFeedbackByIdFromServer: mocks.getFeedbackByIdFromServer,
+}));
+
+import FocusedFeedbackCard from './FocusedFeedbackCard';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const renderCard = (onDismiss = vi.fn()) => {
+  // retry off, so a rejected fetch reaches the error branch on the first tick.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CssVarsProvider theme={appTheme}>
+        <FocusedFeedbackCard feedbackId="fb-1" onDismiss={onDismiss} />
+      </CssVarsProvider>
+    </QueryClientProvider>
+  );
+  return { onDismiss };
+};
+
+const record = (overrides: Record<string, unknown> = {}) => ({
+  _id: 'fb-1',
+  userId: 'user-1',
+  content: 'The export button does nothing',
+  status: FeedbackStatus.New,
+  username: 'reporter',
+  userEmail: 'reporter@example.com',
+  organization: 'acme',
+  createdAt: new Date('2024-01-01').toISOString(),
+  ...overrides,
+});
+
+describe('FocusedFeedbackCard', () => {
+  beforeEach(() => {
+    mocks.getFeedbackByIdFromServer.mockReset();
+  });
+
+  it('fetches the linked record by id rather than reading the list on screen', async () => {
+    mocks.getFeedbackByIdFromServer.mockResolvedValue(record());
+
+    renderCard();
+
+    await waitFor(() => expect(screen.getByTestId('feedback-focused-card')).toBeInTheDocument());
+    expect(mocks.getFeedbackByIdFromServer).toHaveBeenCalledWith('fb-1');
+    expect(await screen.findByText('The export button does nothing')).toBeInTheDocument();
+    expect(screen.getByText('acme')).toBeInTheDocument();
+    expect(screen.getByText('reporter')).toBeInTheDocument();
+  });
+
+  /**
+   * The read route answers the same NotFoundError for a deleted record and for one belonging to
+   * someone else, so the card must not render either as an empty success. Both a null body and a
+   * rejected request have to land on the same visible notice.
+   */
+  it('shows the unavailable notice when the record resolves to null', async () => {
+    mocks.getFeedbackByIdFromServer.mockResolvedValue(null);
+
+    renderCard();
+
+    expect(await screen.findByTestId('feedback-focused-missing')).toBeInTheDocument();
+  });
+
+  it('shows the unavailable notice when the request fails', async () => {
+    mocks.getFeedbackByIdFromServer.mockRejectedValue(new Error('not found'));
+
+    renderCard();
+
+    expect(await screen.findByTestId('feedback-focused-missing')).toBeInTheDocument();
+  });
+
+  it('does not show the unavailable notice while the request is still in flight', () => {
+    mocks.getFeedbackByIdFromServer.mockReturnValue(new Promise(() => {}));
+
+    renderCard();
+
+    expect(screen.getByTestId('feedback-focused-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('feedback-focused-missing')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the expired-content marker instead of rendering a blank report', async () => {
+    mocks.getFeedbackByIdFromServer.mockResolvedValue(record({ content: undefined, contentExpired: true }));
+
+    renderCard();
+
+    expect(await screen.findByText('[content expired]')).toBeInTheDocument();
+  });
+
+  it('hands the dismiss back to the caller so it can clear the deep-link param', async () => {
+    mocks.getFeedbackByIdFromServer.mockResolvedValue(record());
+    const { onDismiss } = renderCard();
+
+    await userEvent.click(await screen.findByTestId('feedback-focused-dismiss-btn'));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/app/components/admin/Feedback/FocusedFeedbackCard.tsx
+++ b/apps/client/app/components/admin/Feedback/FocusedFeedbackCard.tsx
@@ -1,0 +1,95 @@
+import { Alert, Box, Card, Chip, CircularProgress, IconButton, Stack, Tooltip, Typography } from '@mui/joy';
+import CloseIcon from '@mui/icons-material/Close';
+import { useQuery } from '@tanstack/react-query';
+import { getFeedbackByIdFromServer } from '@client/app/utils/feedbackAPICalls';
+import { relativeTimeFormat } from '@client/app/utils/dateUtils';
+import { getFeedbackDisplayContent } from './types';
+import { feedbackRecordQueryKey } from './queryKeys';
+import FeedbackRowLinks from './FeedbackRowLinks';
+
+interface FocusedFeedbackCardProps {
+  /** The `?feedbackId=` a deep link arrived with. */
+  feedbackId: string;
+  /** Clears the deep-link param, returning the reader to the unfocused list. */
+  onDismiss: () => void;
+}
+
+/**
+ * The record a feedback deep link points at, pinned above the list.
+ *
+ * Fetched by id rather than found in the rows on screen: the list is paginated and filtered
+ * server-side, so a linked report is usually NOT on the current page - and may not match the
+ * active filters at all. That is the whole reason this renders separately instead of just
+ * highlighting a row.
+ */
+const FocusedFeedbackCard = ({ feedbackId, onDismiss }: FocusedFeedbackCardProps) => {
+  const {
+    data: feedbackItem,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: feedbackRecordQueryKey(feedbackId),
+    queryFn: () => getFeedbackByIdFromServer(feedbackId),
+  });
+
+  return (
+    <Card variant="soft" color="primary" sx={{ mb: 1 }} data-testid="feedback-focused-card">
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography level="body-xs" sx={{ textTransform: 'uppercase', letterSpacing: '0.06em', mb: 0.5 }}>
+            Linked report
+          </Typography>
+
+          {isLoading && <CircularProgress size="sm" data-testid="feedback-focused-loading" />}
+
+          {/* The read route returns the same NotFoundError whether the record is gone or simply
+              not the caller's, so this copy deliberately covers both rather than guessing. */}
+          {(isError || (!isLoading && !feedbackItem)) && (
+            <Alert color="warning" size="sm" data-testid="feedback-focused-missing">
+              This report is no longer available, or you do not have access to it.
+            </Alert>
+          )}
+
+          {feedbackItem && (
+            <Stack spacing={0.5}>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                <Chip size="sm" variant="solid">
+                  {feedbackItem.status}
+                </Chip>
+                {feedbackItem.organization && feedbackItem.organization !== 'Unknown' && (
+                  <Chip size="sm" variant="outlined">
+                    {feedbackItem.organization}
+                  </Chip>
+                )}
+                {feedbackItem.username && <Typography level="body-sm">{feedbackItem.username}</Typography>}
+                {feedbackItem.userEmail && (
+                  <Tooltip title={feedbackItem.userId}>
+                    <Typography level="body-sm">{feedbackItem.userEmail}</Typography>
+                  </Tooltip>
+                )}
+                <Typography level="body-xs">{relativeTimeFormat(new Date(feedbackItem.createdAt))}</Typography>
+              </Stack>
+              <Typography level="body-sm" sx={{ whiteSpace: 'pre-wrap' }}>
+                {getFeedbackDisplayContent(feedbackItem, 'No content')}
+              </Typography>
+            </Stack>
+          )}
+        </Box>
+
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          {/* The card is where a Slack or email link lands, so reaching the conversation it is
+              about has to be possible from here - not only from a row in the list below. */}
+          {feedbackItem && <FeedbackRowLinks feedbackItem={feedbackItem} />}
+
+          <Tooltip title="Back to all feedback">
+            <IconButton size="sm" variant="plain" onClick={onDismiss} data-testid="feedback-focused-dismiss-btn">
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+};
+
+export default FocusedFeedbackCard;

--- a/apps/client/app/components/admin/Feedback/constants.ts
+++ b/apps/client/app/components/admin/Feedback/constants.ts
@@ -1,0 +1,9 @@
+import { FEEDBACK_LIST_MAX_LIMIT } from '@bike4mind/common';
+
+/**
+ * Page sizes offered for the feedback list, passed explicitly rather than left to
+ * PaginationControls' own defaults: that component is shared with other admin tabs, and a size
+ * above FEEDBACK_LIST_MAX_LIMIT is rejected by GET /api/feedback outright. Deriving the top option
+ * from the cap means the two cannot drift into a list that 4xxs on its largest page size.
+ */
+export const FEEDBACK_PAGE_SIZE_OPTIONS = [10, 20, 50, FEEDBACK_LIST_MAX_LIMIT];

--- a/apps/client/app/components/admin/Feedback/hooks/__tests__/useFeedbackFilters.test.ts
+++ b/apps/client/app/components/admin/Feedback/hooks/__tests__/useFeedbackFilters.test.ts
@@ -1,343 +1,179 @@
-import { describe, it, expect } from 'vitest';
-import { FeedbackStatus, FeedbackType } from '@bike4mind/common';
-import { IExtendedFeedbackDocument } from '../../types';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { FeedbackStatus } from '@bike4mind/common';
+import { useFeedbackFilters } from '../useFeedbackFilters';
 
-const createMockFeedback = (overrides: Partial<IExtendedFeedbackDocument>): any => ({
-  _id: 'test-id',
-  userId: 'user-1',
-  content: 'Test feedback content',
-  status: FeedbackStatus.New,
-  tags: [],
-  username: 'testuser',
-  userEmail: 'test@example.com',
-  customerService: 'support',
-  organization: 'test-org',
-  type: FeedbackType.FEEDBACK,
-  promptMeta: {
-    promptId: 'prompt-1',
-    model: {
-      name: 'test-model',
-    },
-    session: {
-      id: 'session-1',
-      userId: 'user-1',
-    },
-  },
-  createdAt: new Date('2024-01-01'),
-  updatedAt: new Date('2024-01-01'),
-  ...overrides,
-});
+/**
+ * The hook's whole job is translating filter UI state into the GET /api/feedback query, so the
+ * assertions here are on `filterParams` rather than on any filtered array: the filtering itself
+ * now happens server-side, because the list is paginated and a client predicate can only filter
+ * the page on screen.
+ */
+describe('useFeedbackFilters', () => {
+  let onFilterChange: ReturnType<typeof vi.fn>;
 
-// Test the filtering logic directly
-const applyFilters = (
-  feedback: IExtendedFeedbackDocument[],
-  statusFilters: Record<FeedbackStatus, boolean>,
-  searchTerm: string = '',
-  selectedOrganization: string[] = []
-) => {
-  return feedback.filter(feedbackItem => {
-    const matchesStatus = statusFilters[feedbackItem.status];
-    const matchesOrganization =
-      selectedOrganization && selectedOrganization.length > 0
-        ? selectedOrganization.includes('all') || selectedOrganization.includes(feedbackItem.organization)
-        : true;
-    const matchesSearchTerm = searchTerm
-      ? feedbackItem.username.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        feedbackItem.content.toLowerCase().includes(searchTerm.toLowerCase())
-      : true;
-    return matchesStatus && matchesOrganization && matchesSearchTerm;
+  beforeEach(() => {
+    onFilterChange = vi.fn();
   });
-};
 
-// Test the sorting logic directly
-const applySorting = (feedback: IExtendedFeedbackDocument[], sortAscending: boolean = false) => {
-  const statusOrder = [FeedbackStatus.New, FeedbackStatus.InProgress, FeedbackStatus.Closed];
+  const setup = () => renderHook(() => useFeedbackFilters(onFilterChange));
 
-  return feedback.sort((a, b) => {
-    const statusComparison = statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status);
-    if (statusComparison !== 0) return statusComparison;
-    return sortAscending
-      ? new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      : new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-  });
-};
+  it('queries only New feedback by default, newest first', () => {
+    const { result } = setup();
 
-describe('useFeedbackFilters Logic', () => {
-  describe('Default State Verification', () => {
-    it('should have correct default statusFilters configuration', () => {
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: false,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      expect(defaultStatusFilters[FeedbackStatus.New]).toBe(true);
-      expect(defaultStatusFilters[FeedbackStatus.InProgress]).toBe(false);
-      expect(defaultStatusFilters[FeedbackStatus.Closed]).toBe(false);
+    expect(result.current.filters.statusFilters).toEqual({
+      [FeedbackStatus.New]: true,
+      [FeedbackStatus.InProgress]: false,
+      [FeedbackStatus.Closed]: false,
     });
-
-    it('should verify that default filters show only New feedback', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', status: FeedbackStatus.New }),
-        createMockFeedback({ _id: '2', status: FeedbackStatus.InProgress }),
-        createMockFeedback({ _id: '3', status: FeedbackStatus.Closed }),
-      ];
-
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: false,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, defaultStatusFilters);
-
-      expect(filtered).toHaveLength(1);
-      expect(filtered[0].status).toBe(FeedbackStatus.New);
-      expect(filtered[0]._id).toBe('1');
+    expect(result.current.filterParams).toEqual({
+      status: [FeedbackStatus.New],
+      sort: 'desc',
     });
   });
 
-  describe('Default Filtering Behavior', () => {
-    it('should return only New feedback entries with default filters', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', status: FeedbackStatus.New, content: 'New feedback' }),
-        createMockFeedback({ _id: '2', status: FeedbackStatus.InProgress, content: 'InProgress feedback' }),
-        createMockFeedback({ _id: '3', status: FeedbackStatus.Closed, content: 'Closed feedback' }),
-        createMockFeedback({ _id: '4', status: FeedbackStatus.New, content: 'Another new feedback' }),
-      ];
+  it('sends every checked status', () => {
+    const { result } = setup();
 
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: false,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, defaultStatusFilters);
-
-      expect(filtered).toHaveLength(2);
-      expect(filtered[0].status).toBe(FeedbackStatus.New);
-      expect(filtered[1].status).toBe(FeedbackStatus.New);
+    act(() => {
+      result.current.setStatusFilters(previous => ({ ...previous, [FeedbackStatus.InProgress]: true }));
     });
 
-    it('should return empty array when no New feedback exists', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', status: FeedbackStatus.InProgress }),
-        createMockFeedback({ _id: '2', status: FeedbackStatus.Closed }),
-      ];
-
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: false,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, defaultStatusFilters);
-
-      expect(filtered).toHaveLength(0);
-    });
-
-    it('should return empty array when feedback array is empty', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [];
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: false,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, defaultStatusFilters);
-
-      expect(filtered).toHaveLength(0);
-    });
+    expect(result.current.filterParams.status).toEqual([FeedbackStatus.New, FeedbackStatus.InProgress]);
   });
 
-  describe('Filter State Changes', () => {
-    it('should filter correctly when InProgress is also enabled', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', status: FeedbackStatus.New }),
-        createMockFeedback({ _id: '2', status: FeedbackStatus.InProgress }),
-        createMockFeedback({ _id: '3', status: FeedbackStatus.Closed }),
-      ];
+  it('sends only the checked status when New is unchecked', () => {
+    const { result } = setup();
 
-      const statusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: true,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, statusFilters);
-
-      expect(filtered).toHaveLength(2);
-      const statuses = filtered.map(f => f.status);
-      expect(statuses).toContain(FeedbackStatus.New);
-      expect(statuses).toContain(FeedbackStatus.InProgress);
-    });
-
-    it('should filter correctly when only InProgress is selected', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', status: FeedbackStatus.New }),
-        createMockFeedback({ _id: '2', status: FeedbackStatus.InProgress }),
-        createMockFeedback({ _id: '3', status: FeedbackStatus.Closed }),
-      ];
-
-      const statusFilters = {
+    act(() => {
+      result.current.setStatusFilters({
         [FeedbackStatus.New]: false,
-        [FeedbackStatus.InProgress]: true,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, statusFilters);
-
-      expect(filtered).toHaveLength(1);
-      expect(filtered[0].status).toBe(FeedbackStatus.InProgress);
-    });
-
-    it('should filter correctly when multiple statuses are selected', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', status: FeedbackStatus.New }),
-        createMockFeedback({ _id: '2', status: FeedbackStatus.InProgress }),
-        createMockFeedback({ _id: '3', status: FeedbackStatus.Closed }),
-      ];
-
-      const statusFilters = {
-        [FeedbackStatus.New]: true,
         [FeedbackStatus.InProgress]: false,
         [FeedbackStatus.Closed]: true,
-      };
-
-      const filtered = applyFilters(mockFeedback, statusFilters);
-
-      expect(filtered).toHaveLength(2);
-      const statuses = filtered.map(f => f.status);
-      expect(statuses).toContain(FeedbackStatus.New);
-      expect(statuses).toContain(FeedbackStatus.Closed);
-      expect(statuses).not.toContain(FeedbackStatus.InProgress);
+      });
     });
+
+    expect(result.current.filterParams.status).toEqual([FeedbackStatus.Closed]);
   });
 
-  describe('Search Functionality', () => {
-    it('should filter by username when search term is provided', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', username: 'john.doe', status: FeedbackStatus.New }),
-        createMockFeedback({ _id: '2', username: 'jane.smith', status: FeedbackStatus.New }),
-      ];
+  /**
+   * Load-bearing: with no status checked the key is OMITTED, and an absent `status` is the
+   * server's "any status". So this state cannot be sent as a query - it would invert the UI's
+   * "nothing checked means nothing shown" into "show everything". useFeedbackOperations is what
+   * holds that line, by disabling the list query while `status` is empty; this test pins the
+   * fact that gate exists to cover.
+   */
+  it('omits status entirely when nothing is checked', () => {
+    const { result } = setup();
 
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
+    act(() => {
+      result.current.setStatusFilters({
+        [FeedbackStatus.New]: false,
         [FeedbackStatus.InProgress]: false,
         [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, defaultStatusFilters, 'john');
-
-      expect(filtered).toHaveLength(1);
-      expect(filtered[0].username).toBe('john.doe');
+      });
     });
 
-    it('should filter by content when search term is provided', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', content: 'This is a bug report', status: FeedbackStatus.New }),
-        createMockFeedback({ _id: '2', content: 'This is general feedback', status: FeedbackStatus.New }),
-      ];
-
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: false,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filtered = applyFilters(mockFeedback, defaultStatusFilters, 'bug');
-
-      expect(filtered).toHaveLength(1);
-      expect(filtered[0].content).toBe('This is a bug report');
-    });
-
-    it('should be case insensitive when searching', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({ _id: '1', username: 'John.Doe', content: 'BUG Report', status: FeedbackStatus.New }),
-      ];
-
-      const defaultStatusFilters = {
-        [FeedbackStatus.New]: true,
-        [FeedbackStatus.InProgress]: false,
-        [FeedbackStatus.Closed]: false,
-      };
-
-      const filteredByUsername = applyFilters(mockFeedback, defaultStatusFilters, 'john');
-      expect(filteredByUsername).toHaveLength(1);
-
-      const filteredByContent = applyFilters(mockFeedback, defaultStatusFilters, 'bug');
-      expect(filteredByContent).toHaveLength(1);
-    });
+    expect(result.current.filterParams).not.toHaveProperty('status');
   });
 
-  describe('Sorting Behavior', () => {
-    it('should sort by status first, then by date descending by default', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({
-          _id: '1',
-          status: FeedbackStatus.New,
-          createdAt: new Date('2024-01-02'),
-        }),
-        createMockFeedback({
-          _id: '2',
-          status: FeedbackStatus.New,
-          createdAt: new Date('2024-01-01'),
-        }),
-      ];
+  /**
+   * Regression guard. The organization filter used to be inert end to end: the old client-side
+   * predicate read `selectedOrganization` from OrganizationContext (nothing sets it, so it was
+   * fixed at ['all'] and always passed) while the dropdown wrote to a separate
+   * `selectedOrganizations` state that nothing read. The dropdown must reach the query.
+   */
+  it('sends the organizations picked in the dropdown', () => {
+    const { result } = setup();
 
-      const sorted = applySorting([...mockFeedback], false);
-
-      // Should be sorted by date descending (newer first)
-      expect(sorted[0]._id).toBe('1');
-      expect(sorted[1]._id).toBe('2');
+    act(() => {
+      result.current.setSelectedOrganizations(['acme', 'globex']);
     });
 
-    it('should sort by date ascending when sortAscending is true', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({
-          _id: '1',
-          status: FeedbackStatus.New,
-          createdAt: new Date('2024-01-02'),
-        }),
-        createMockFeedback({
-          _id: '2',
-          status: FeedbackStatus.New,
-          createdAt: new Date('2024-01-01'),
-        }),
-      ];
+    expect(result.current.filterParams.organization).toEqual(['acme', 'globex']);
+  });
 
-      const sorted = applySorting([...mockFeedback], true);
+  it('omits organization when the dropdown is cleared', () => {
+    const { result } = setup();
 
-      // Should be sorted by date ascending (older first)
-      expect(sorted[0]._id).toBe('2');
-      expect(sorted[1]._id).toBe('1');
+    act(() => {
+      result.current.setSelectedOrganizations(['acme']);
+    });
+    act(() => {
+      result.current.setSelectedOrganizations([]);
     });
 
-    it('should prioritize status order over date sorting', () => {
-      const mockFeedback: IExtendedFeedbackDocument[] = [
-        createMockFeedback({
-          _id: '1',
-          status: FeedbackStatus.Closed,
-          createdAt: new Date('2024-01-03'),
-        }),
-        createMockFeedback({
-          _id: '2',
-          status: FeedbackStatus.New,
-          createdAt: new Date('2024-01-01'),
-        }),
-        createMockFeedback({
-          _id: '3',
-          status: FeedbackStatus.InProgress,
-          createdAt: new Date('2024-01-02'),
-        }),
-      ];
+    expect(result.current.filterParams).not.toHaveProperty('organization');
+  });
 
-      const sorted = applySorting([...mockFeedback], false);
+  it('flips the sort direction without touching the other filters', () => {
+    const { result } = setup();
 
-      // Should be sorted by status order: New, InProgress, Closed
-      expect(sorted[0].status).toBe(FeedbackStatus.New);
-      expect(sorted[1].status).toBe(FeedbackStatus.InProgress);
-      expect(sorted[2].status).toBe(FeedbackStatus.Closed);
+    act(() => {
+      result.current.toggleSortDirection();
+    });
+
+    expect(result.current.filterParams).toEqual({ status: [FeedbackStatus.New], sort: 'asc' });
+  });
+
+  // Every filter edit must reset the page cursor, or narrowing the filters can leave the caller
+  // on a page number the new, shorter result set does not reach - which renders as an empty list.
+  it('notifies the caller on every filter change so the page cursor resets', () => {
+    const { result } = setup();
+
+    act(() => result.current.setSearchTerm('a'));
+    act(() => result.current.setStatusFilters(previous => previous));
+    act(() => result.current.setSelectedOrganizations(['acme']));
+    act(() => result.current.toggleSortDirection());
+
+    expect(onFilterChange).toHaveBeenCalledTimes(4);
+  });
+
+  describe('search', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('keeps the typed term out of the query until the debounce settles', () => {
+      const { result } = setup();
+
+      act(() => {
+        result.current.setSearchTerm('crash');
+      });
+
+      // Echoed to the input immediately, but not yet a request.
+      expect(result.current.filters.searchTerm).toBe('crash');
+      expect(result.current.filterParams).not.toHaveProperty('search');
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.filterParams.search).toBe('crash');
+    });
+
+    it('trims the term and omits a whitespace-only one', () => {
+      const { result } = setup();
+
+      act(() => {
+        result.current.setSearchTerm('  crash  ');
+      });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(result.current.filterParams.search).toBe('crash');
+
+      act(() => {
+        result.current.setSearchTerm('   ');
+      });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(result.current.filterParams).not.toHaveProperty('search');
     });
   });
 });

--- a/apps/client/app/components/admin/Feedback/hooks/useFeedbackFilters.ts
+++ b/apps/client/app/components/admin/Feedback/hooks/useFeedbackFilters.ts
@@ -1,55 +1,74 @@
-import { useState, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { FeedbackStatus } from '@bike4mind/common';
-import { useOrganizationContext } from '@client/app/contexts/OrganizationContext';
-import { IExtendedFeedbackDocument, FeedbackFilters, UseFeedbackFiltersReturn } from '../types';
+import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
+import { FeedbackFilters, FeedbackListFilterParams, UseFeedbackFiltersReturn } from '../types';
 
-const statusOrder = [FeedbackStatus.New, FeedbackStatus.InProgress, FeedbackStatus.Closed];
+/**
+ * Filter state for the feedback list, and the server query it maps to.
+ *
+ * Filtering is server-side because the list is paginated: a predicate applied to the page on
+ * screen can only ever filter one page of matches, which reads as data silently going missing.
+ * Every setter also calls `onFilterChange` so the page cursor resets - otherwise narrowing the
+ * filters can leave the caller on a page number the new result set does not reach.
+ *
+ * The organization filter used to be inert: the predicate read `selectedOrganization` from
+ * OrganizationContext, which nothing in the app ever sets (it is fixed at ['all'], so the
+ * predicate always passed), while the dropdown wrote to a separate `selectedOrganizations` state
+ * that nothing read. The dropdown's selection now reaches the query.
+ */
+export const useFeedbackFilters = (onFilterChange: () => void): UseFeedbackFiltersReturn => {
+  const { value: searchTerm, debouncedValue: debouncedSearchTerm, setValue: setSearchTermValue } = useDebounceValue('');
 
-export const useFeedbackFilters = (feedback: IExtendedFeedbackDocument[]): UseFeedbackFiltersReturn => {
-  const { selectedOrganization } = useOrganizationContext();
-
-  const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilters, setStatusFilters] = useState<Record<FeedbackStatus, boolean>>({
+  const [statusFilters, setStatusFiltersState] = useState<Record<FeedbackStatus, boolean>>({
     [FeedbackStatus.New]: true,
     [FeedbackStatus.InProgress]: false,
     [FeedbackStatus.Closed]: false,
   });
-  const [selectedOrganizations, setSelectedOrganizations] = useState<string[]>([]);
-  const [sortAscending, setSortAscending] = useState<boolean>(false);
+  const [selectedOrganizations, setSelectedOrganizationsState] = useState<string[]>([]);
+  const [sortAscending, setSortAscending] = useState(false);
 
-  const filters: FeedbackFilters = {
-    searchTerm,
-    statusFilters,
-    selectedOrganizations,
-    sortAscending,
-  };
+  const setSearchTerm = useCallback(
+    (term: string) => {
+      setSearchTermValue(term);
+      onFilterChange();
+    },
+    [setSearchTermValue, onFilterChange]
+  );
 
-  const toggleSortDirection = () => {
-    setSortAscending(!sortAscending);
-  };
+  const setStatusFilters = useCallback<UseFeedbackFiltersReturn['setStatusFilters']>(
+    update => {
+      setStatusFiltersState(update);
+      onFilterChange();
+    },
+    [onFilterChange]
+  );
 
-  const filteredAndSortedFeedback = useMemo(() => {
-    return feedback
-      .filter(feedbackItem => {
-        const matchesStatus = statusFilters[feedbackItem.status];
-        const matchesOrganization =
-          selectedOrganization && selectedOrganization.length > 0
-            ? selectedOrganization.includes('all') || selectedOrganization.includes(feedbackItem.organization)
-            : true;
-        const matchesSearchTerm = searchTerm
-          ? feedbackItem.username.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            (feedbackItem.content ?? '').toLowerCase().includes(searchTerm.toLowerCase())
-          : true;
-        return matchesStatus && matchesOrganization && matchesSearchTerm;
-      })
-      .sort((a, b) => {
-        const statusComparison = statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status);
-        if (statusComparison !== 0) return statusComparison;
-        return sortAscending
-          ? new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-          : new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-      });
-  }, [feedback, statusFilters, selectedOrganization, searchTerm, sortAscending]);
+  const setSelectedOrganizations = useCallback(
+    (orgs: string[]) => {
+      setSelectedOrganizationsState(orgs);
+      onFilterChange();
+    },
+    [onFilterChange]
+  );
+
+  const toggleSortDirection = useCallback(() => {
+    setSortAscending(previous => !previous);
+    onFilterChange();
+  }, [onFilterChange]);
+
+  const filters: FeedbackFilters = { searchTerm, statusFilters, selectedOrganizations, sortAscending };
+
+  const filterParams = useMemo<FeedbackListFilterParams>(() => {
+    const statuses = Object.values(FeedbackStatus).filter(status => statusFilters[status]);
+    return {
+      // Omitted rather than sent empty: an empty array would be serialized as no filter anyway,
+      // and `status` absent is the server's "any status".
+      ...(statuses.length > 0 ? { status: statuses } : {}),
+      ...(selectedOrganizations.length > 0 ? { organization: selectedOrganizations } : {}),
+      ...(debouncedSearchTerm.trim() ? { search: debouncedSearchTerm.trim() } : {}),
+      sort: sortAscending ? 'asc' : 'desc',
+    };
+  }, [statusFilters, selectedOrganizations, debouncedSearchTerm, sortAscending]);
 
   return {
     filters,
@@ -57,6 +76,6 @@ export const useFeedbackFilters = (feedback: IExtendedFeedbackDocument[]): UseFe
     setStatusFilters,
     setSelectedOrganizations,
     toggleSortDirection,
-    filteredAndSortedFeedback,
+    filterParams,
   };
 };

--- a/apps/client/app/components/admin/Feedback/hooks/useFeedbackOperations.ts
+++ b/apps/client/app/components/admin/Feedback/hooks/useFeedbackOperations.ts
@@ -1,13 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useState } from 'react';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { FeedbackStatus } from '@bike4mind/common';
 import {
-  getFeedbackFromServer,
   deleteFeedbackFromServer,
+  getFeedbackFromServer,
   updateFeedbackOnServer,
 } from '@client/app/utils/feedbackAPICalls';
 import useToggle from '@client/app/hooks/useToggle';
-import { getFeedbackDisplayContent, IExtendedFeedbackDocument, UseFeedbackOperationsReturn } from '../types';
+import { getFeedbackDisplayContent, FeedbackListParams, IExtendedFeedbackDocument } from '../types';
+import { UseFeedbackOperationsReturn } from '../types';
+import { FEEDBACK_LIST_QUERY_KEY, FEEDBACK_ORGANIZATIONS_QUERY_KEY, FEEDBACK_RECORD_QUERY_KEY } from '../queryKeys';
 
 const formatReporter = (feedbackItem: IExtendedFeedbackDocument | undefined) => {
   if (!feedbackItem) return 'Unknown user';
@@ -23,84 +26,115 @@ const showFeedbackToast = {
   error: (message: string) => toast.error(message, { closeButton: true, position: 'bottom-left' }),
 };
 
-export const useFeedbackOperations = (): UseFeedbackOperationsReturn => {
-  const [feedback, setFeedback] = useState<IExtendedFeedbackDocument[]>([]);
-  const [organizations, setOrganizations] = useState<string[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
+const getNextStatus = (currentStatus: FeedbackStatus): FeedbackStatus => {
+  switch (currentStatus) {
+    case FeedbackStatus.New:
+      return FeedbackStatus.InProgress;
+    case FeedbackStatus.InProgress:
+      return FeedbackStatus.Closed;
+    case FeedbackStatus.Closed:
+      return FeedbackStatus.New;
+    default:
+      return currentStatus;
+  }
+};
+
+/**
+ * Reads one page of feedback from the server and owns the status/delete mutations.
+ *
+ * The org filter menu's options come from a SEPARATE query, deliberately unfiltered: folding them
+ * into the list response would make the options disappear as soon as a filter narrowed the rows -
+ * including the filter that is currently selected, which the reader then cannot clear.
+ */
+export const useFeedbackOperations = (params: FeedbackListParams): UseFeedbackOperationsReturn => {
+  const queryClient = useQueryClient();
   const [feedbackToDelete, setFeedbackToDelete] = useState<string | null>(null);
   const [openDeleteFeedbackModal, toggleDeleteFeedbackModal] = useToggle();
 
-  const getNextStatus = (currentStatus: FeedbackStatus): FeedbackStatus => {
-    switch (currentStatus) {
-      case FeedbackStatus.New:
-        return FeedbackStatus.InProgress;
-      case FeedbackStatus.InProgress:
-        return FeedbackStatus.Closed;
-      case FeedbackStatus.Closed:
-        return FeedbackStatus.New;
-      default:
-        return currentStatus;
-    }
-  };
+  // No status checked matches nothing by definition - the previous client-side predicate returned
+  // an empty list for it. Skipping the request rather than omitting the param is what preserves
+  // that: `status` absent means "any status" to the server, which would invert the filter into
+  // showing every report.
+  const hasStatusSelection = (params.status?.length ?? 0) > 0;
 
-  const refreshFeedback = async () => {
-    setLoading(true);
-    try {
-      const feedbackData = await getFeedbackFromServer();
-      const typedFeedbackData = feedbackData as IExtendedFeedbackDocument[];
-      setFeedback(typedFeedbackData);
+  const listQuery = useQuery({
+    queryKey: [...FEEDBACK_LIST_QUERY_KEY, params],
+    queryFn: () => getFeedbackFromServer(params),
+    enabled: hasStatusSelection,
+    // Keeps the previous page on screen while the next one loads, instead of flashing empty.
+    placeholderData: keepPreviousData,
+  });
 
-      const uniqueOrganizations = Array.from(new Set(typedFeedbackData.map(item => item.organization)));
-      setOrganizations(uniqueOrganizations);
-    } catch (error) {
-      console.error('Error fetching feedback:', error);
-      showFeedbackToast.error('Failed to load feedback data.');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const organizationsQuery = useQuery({
+    queryKey: FEEDBACK_ORGANIZATIONS_QUERY_KEY,
+    // limit: 1 because only the `organizations` facet is wanted here; the rows are the list
+    // query's job.
+    queryFn: () => getFeedbackFromServer({ page: 1, limit: 1, sort: 'desc' }),
+    select: response => response.organizations,
+  });
 
-  const handleStatusChange = async (feedbackItem: IExtendedFeedbackDocument, newValue: FeedbackStatus | null) => {
-    const updatedStatus = newValue ? newValue : getNextStatus(feedbackItem.status);
-    const updatedFeedback = { ...feedbackItem, status: updatedStatus };
+  const feedback = hasStatusSelection ? (listQuery.data?.items ?? []) : [];
+  const total = hasStatusSelection ? (listQuery.data?.total ?? 0) : 0;
 
-    try {
-      const response = await updateFeedbackOnServer(feedbackItem._id, updatedFeedback);
-      if (response) {
-        setFeedback(prevFeedback =>
-          prevFeedback.map(item => (item._id === feedbackItem._id ? { ...item, status: updatedStatus } : item))
-        );
-        const reporter = formatReporter(feedbackItem);
+  const refreshFeedback = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: FEEDBACK_LIST_QUERY_KEY }),
+      queryClient.invalidateQueries({ queryKey: FEEDBACK_ORGANIZATIONS_QUERY_KEY }),
+      // A deep-linked record is pinned above the list from its own query, so a delete that
+      // refreshed only the list would leave the card showing a report that no longer exists.
+      queryClient.invalidateQueries({ queryKey: FEEDBACK_RECORD_QUERY_KEY }),
+    ]);
+  }, [queryClient]);
+
+  const handleStatusChange = useCallback(
+    async (feedbackItem: IExtendedFeedbackDocument, newValue: FeedbackStatus | null) => {
+      const updatedStatus = newValue ?? getNextStatus(feedbackItem.status);
+
+      try {
+        const response = await updateFeedbackOnServer(feedbackItem._id, { ...feedbackItem, status: updatedStatus });
+        if (!response) throw new Error('Failed to update feedback status');
+
+        // Refetch rather than patch in place: the row may no longer match the active status
+        // filter, in which case it belongs off this page entirely. The focused card reads the
+        // same record from a separate query and has to move with it. The organization facet does
+        // not: a status change cannot add or remove an org from the set that has any feedback.
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: FEEDBACK_LIST_QUERY_KEY }),
+          queryClient.invalidateQueries({ queryKey: FEEDBACK_RECORD_QUERY_KEY }),
+        ]);
+
         const content = getFeedbackDisplayContent(feedbackItem, 'No content');
         const preview = content.length > 50 ? content.substring(0, 50) + '...' : content;
-
-        showFeedbackToast.success(`"${preview}" feedback from ${reporter} updated to: ${updatedStatus}`);
-      } else {
-        throw new Error('Failed to update feedback status');
+        showFeedbackToast.success(
+          `"${preview}" feedback from ${formatReporter(feedbackItem)} updated to: ${updatedStatus}`
+        );
+      } catch (error) {
+        console.error('Error updating feedback status:', error);
+        showFeedbackToast.error('Failed to update feedback status.');
       }
-    } catch (error) {
-      console.error('Error updating feedback status:', error);
-      showFeedbackToast.error('Failed to update feedback status.');
-    }
-  };
+    },
+    [queryClient]
+  );
 
-  const handleDeleteFeedbackClick = (feedback: IExtendedFeedbackDocument) => {
-    setFeedbackToDelete(feedback._id);
-    toggleDeleteFeedbackModal();
-  };
+  const handleDeleteFeedbackClick = useCallback(
+    (item: IExtendedFeedbackDocument) => {
+      setFeedbackToDelete(item._id);
+      toggleDeleteFeedbackModal();
+    },
+    [toggleDeleteFeedbackModal]
+  );
 
-  const confirmDeleteFeedback = async () => {
+  const confirmDeleteFeedback = useCallback(async () => {
     if (feedbackToDelete) {
+      const deletedItem = feedback.find(item => item._id === feedbackToDelete);
       try {
         const response = await deleteFeedbackFromServer(feedbackToDelete);
         if (response) {
-          setFeedback(prevFeedback => prevFeedback.filter(feedback => feedback._id !== feedbackToDelete));
-          const feedbackToDeleteItem = feedback.find(f => f._id === feedbackToDelete);
-          const reporter = formatReporter(feedbackToDeleteItem);
-          const deleteContent = getFeedbackDisplayContent(feedbackToDeleteItem, 'No content');
-          const preview = deleteContent.length > 50 ? deleteContent.substring(0, 50) + '...' : deleteContent;
+          await refreshFeedback();
 
-          showFeedbackToast.success(`"${preview}" feedback from ${reporter} deleted successfully`);
+          const deleteContent = getFeedbackDisplayContent(deletedItem, 'No content');
+          const preview = deleteContent.length > 50 ? deleteContent.substring(0, 50) + '...' : deleteContent;
+          showFeedbackToast.success(`"${preview}" feedback from ${formatReporter(deletedItem)} deleted successfully`);
         }
       } catch (error) {
         console.error('Error deleting feedback:', error);
@@ -110,35 +144,13 @@ export const useFeedbackOperations = (): UseFeedbackOperationsReturn => {
 
     toggleDeleteFeedbackModal();
     setFeedbackToDelete(null);
-  };
-
-  useEffect(() => {
-    const loadFeedback = async () => {
-      setLoading(true);
-      try {
-        const feedbackData = await getFeedbackFromServer();
-        const typedFeedbackData = feedbackData as IExtendedFeedbackDocument[];
-        setFeedback(typedFeedbackData);
-
-        const uniqueOrganizations = Array.from(
-          new Set(typedFeedbackData.map(item => item.organization).filter(Boolean))
-        );
-        setOrganizations(uniqueOrganizations);
-      } catch (error) {
-        console.error('Error loading feedback:', error);
-        showFeedbackToast.error('Failed to load feedback data.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadFeedback();
-  }, []);
+  }, [feedbackToDelete, feedback, refreshFeedback, toggleDeleteFeedbackModal]);
 
   return {
     feedback,
-    organizations,
-    loading,
+    organizations: organizationsQuery.data ?? [],
+    total,
+    loading: (hasStatusSelection && listQuery.isFetching) || organizationsQuery.isFetching,
     refreshFeedback,
     handleStatusChange,
     handleDeleteFeedbackClick,

--- a/apps/client/app/components/admin/Feedback/hooks/useFeedbackPagination.ts
+++ b/apps/client/app/components/admin/Feedback/hooks/useFeedbackPagination.ts
@@ -1,36 +1,32 @@
-import { useState, useMemo } from 'react';
-import { IExtendedFeedbackDocument, UseFeedbackPaginationReturn } from '../types';
+import { useCallback, useState } from 'react';
+import { FEEDBACK_LIST_DEFAULT_LIMIT } from '@bike4mind/common';
+import { UseFeedbackPaginationReturn } from '../types';
 
-export const useFeedbackPagination = (
-  filteredAndSortedFeedback: IExtendedFeedbackDocument[]
-): UseFeedbackPaginationReturn => {
+/**
+ * Page cursor for the feedback list.
+ *
+ * Holds only the page and page size: the rows themselves come back already paginated from
+ * GET /api/feedback, so there is nothing to slice here. This hook is declared BEFORE the query
+ * that consumes it, because its values are query inputs rather than results.
+ */
+export const useFeedbackPagination = (): UseFeedbackPaginationReturn => {
   const [currentPage, setCurrentPage] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(20);
+  const [itemsPerPage, setItemsPerPage] = useState(FEEDBACK_LIST_DEFAULT_LIMIT);
 
-  const totalPages = Math.ceil(filteredAndSortedFeedback.length / itemsPerPage);
-
-  const currentFeedback = useMemo(() => {
-    const indexOfLast = currentPage * itemsPerPage;
-    const indexOfFirst = indexOfLast - itemsPerPage;
-    return filteredAndSortedFeedback.slice(indexOfFirst, indexOfLast);
-  }, [filteredAndSortedFeedback, currentPage, itemsPerPage]);
-
-  const handlePageChange = (newPage: number) => {
+  const handlePageChange = useCallback((newPage: number) => {
     setCurrentPage(newPage);
-  };
+  }, []);
 
-  const handleItemsPerPageChange = (items: number) => {
+  const handleItemsPerPageChange = useCallback((items: number) => {
     setItemsPerPage(items);
     setCurrentPage(1);
-  };
+  }, []);
 
-  return {
-    currentPage,
-    setCurrentPage,
-    currentFeedback,
-    totalPages,
-    handlePageChange,
-    itemsPerPage,
-    handleItemsPerPageChange,
-  };
+  // Filters narrow the result set, so page 7 of the old set may not exist in the new one - which
+  // would otherwise show an empty table with no indication why.
+  const resetPage = useCallback(() => {
+    setCurrentPage(1);
+  }, []);
+
+  return { currentPage, handlePageChange, itemsPerPage, handleItemsPerPageChange, resetPage };
 };

--- a/apps/client/app/components/admin/Feedback/index.tsx
+++ b/apps/client/app/components/admin/Feedback/index.tsx
@@ -39,12 +39,28 @@ import { useFeedbackOperations } from './hooks/useFeedbackOperations';
 import { useFeedbackFilters } from './hooks/useFeedbackFilters';
 import { useFeedbackPagination } from './hooks/useFeedbackPagination';
 import { getFeedbackDisplayContent } from './types';
+import { FEEDBACK_EXPORT_MAX_ROWS, getAllFeedbackForExport } from '@client/app/utils/feedbackAPICalls';
+import { toast } from 'sonner';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import { FEEDBACK_ID_PARAM } from '@bike4mind/common';
+import FocusedFeedbackCard from './FocusedFeedbackCard';
+import FeedbackRowLinks from './FeedbackRowLinks';
+import { FEEDBACK_PAGE_SIZE_OPTIONS } from './constants';
 
 const FeedbackTab: React.FC = () => {
   const isMobile = useIsMobile();
+  // Declaration order is the data flow: the page cursor and the filters are INPUTS to the server
+  // query, not results of it. Filtering and paging both moved server-side, so nothing here slices
+  // a local array any more.
+  const { currentPage, handlePageChange, itemsPerPage, handleItemsPerPageChange, resetPage } = useFeedbackPagination();
+
+  const { filters, setSearchTerm, setStatusFilters, setSelectedOrganizations, toggleSortDirection, filterParams } =
+    useFeedbackFilters(resetPage);
+
   const {
-    feedback,
+    feedback: currentFeedback,
     organizations,
+    total,
     loading,
     refreshFeedback,
     handleStatusChange,
@@ -52,24 +68,46 @@ const FeedbackTab: React.FC = () => {
     confirmDeleteFeedback,
     openDeleteFeedbackModal,
     toggleDeleteFeedbackModal,
-  } = useFeedbackOperations();
+  } = useFeedbackOperations({ ...filterParams, page: currentPage, limit: itemsPerPage });
 
-  const {
-    filters,
-    setSearchTerm,
-    setStatusFilters,
-    setSelectedOrganizations,
-    toggleSortDirection,
-    filteredAndSortedFeedback,
-  } = useFeedbackFilters(feedback);
+  const totalPages = Math.max(1, Math.ceil(total / itemsPerPage));
 
-  const { currentPage, currentFeedback, totalPages, handlePageChange, itemsPerPage, handleItemsPerPageChange } =
-    useFeedbackPagination(filteredAndSortedFeedback);
+  // A deep link names one report. It is pinned above the list rather than highlighted in place:
+  // with server-side paging and filtering the linked report is usually not on the current page.
+  const { [FEEDBACK_ID_PARAM]: focusedFeedbackId } = useSearch({ strict: false }) as { feedbackId?: string };
+  const navigate = useNavigate();
+
+  const dismissFocusedFeedback = () => {
+    navigate({
+      to: '/admin',
+      search: previous => ({ ...previous, [FEEDBACK_ID_PARAM]: undefined }),
+      replace: true,
+    });
+  };
 
   const statusOptions = [FeedbackStatus.New, FeedbackStatus.InProgress, FeedbackStatus.Closed];
 
-  const handleExportToCSV = () => {
-    const csvData = filteredAndSortedFeedback.map(feedbackItem => ({
+  // Pages through every match server-side. Exporting `currentFeedback` would silently emit one
+  // page now that the list is paginated, which reads as a complete export of a much smaller
+  // dataset.
+  const handleExportToCSV = async () => {
+    let exported: Awaited<ReturnType<typeof getAllFeedbackForExport>>;
+    try {
+      exported = await getAllFeedbackForExport(filterParams);
+    } catch (error) {
+      console.error('Error exporting feedback:', error);
+      toast.error('Failed to export feedback.', { closeButton: true, position: 'bottom-left' });
+      return;
+    }
+
+    if (exported.truncated) {
+      toast.warning(`Export capped at ${FEEDBACK_EXPORT_MAX_ROWS} rows - narrow the filters for the rest.`, {
+        closeButton: true,
+        position: 'bottom-left',
+      });
+    }
+
+    const csvData = exported.items.map(feedbackItem => ({
       ID: feedbackItem._id,
       Status: feedbackItem.status,
       Username: feedbackItem.username,
@@ -209,7 +247,7 @@ const FeedbackTab: React.FC = () => {
                       </Tooltip>
                       <Tooltip title="Export CSV">
                         <IconButton
-                          disabled={loading || filteredAndSortedFeedback.length === 0}
+                          disabled={loading || total === 0}
                           onClick={handleExportToCSV}
                           color="success"
                           variant="outlined"
@@ -226,14 +264,21 @@ const FeedbackTab: React.FC = () => {
           </Stack>
         </Grid>
 
+        {focusedFeedbackId && (
+          <Grid xs={12}>
+            <FocusedFeedbackCard feedbackId={focusedFeedbackId} onDismiss={dismissFocusedFeedback} />
+          </Grid>
+        )}
+
         <Grid xs={12} mb={0.5} pb={0.7} sx={{ borderBottom: '1px solid', borderColor: 'divider' }}>
           <PaginationControls
             currentPage={currentPage}
             onPageChange={handlePageChange}
             totalPages={totalPages}
-            totalItems={filteredAndSortedFeedback.length}
+            totalItems={total}
             itemsPerPage={itemsPerPage}
             onItemsPerPageChange={handleItemsPerPageChange}
+            pageLimitOptions={FEEDBACK_PAGE_SIZE_OPTIONS}
           />
         </Grid>
 
@@ -351,6 +396,7 @@ const FeedbackTab: React.FC = () => {
                                 </Option>
                               ))}
                             </Select>
+                            <FeedbackRowLinks feedbackItem={feedbackItem} />
                             <Tooltip title="Delete" color="danger">
                               <IconButton
                                 size="sm"
@@ -534,6 +580,7 @@ const FeedbackTab: React.FC = () => {
                                 </Option>
                               ))}
                             </Select>
+                            <FeedbackRowLinks feedbackItem={feedbackItem} />
                             <Tooltip title="Delete" color="danger">
                               <IconButton
                                 size="sm"

--- a/apps/client/app/components/admin/Feedback/queryKeys.ts
+++ b/apps/client/app/components/admin/Feedback/queryKeys.ts
@@ -1,0 +1,11 @@
+/**
+ * React Query keys for the admin feedback tab, in one place because three surfaces read the same
+ * records and every mutation has to refresh all of them: the paged list, the unfiltered
+ * organization facet, and the single record a deep link pins above the list. A mutation that
+ * invalidates only the list leaves the focused card showing the pre-mutation status.
+ */
+export const FEEDBACK_LIST_QUERY_KEY = ['admin', 'feedback', 'list'] as const;
+export const FEEDBACK_ORGANIZATIONS_QUERY_KEY = ['admin', 'feedback', 'organizations'] as const;
+export const FEEDBACK_RECORD_QUERY_KEY = ['admin', 'feedback', 'record'] as const;
+
+export const feedbackRecordQueryKey = (feedbackId: string) => [...FEEDBACK_RECORD_QUERY_KEY, feedbackId];

--- a/apps/client/app/components/admin/Feedback/types.ts
+++ b/apps/client/app/components/admin/Feedback/types.ts
@@ -30,13 +30,30 @@ export interface FeedbackFilters {
   sortAscending: boolean;
 }
 
-export interface FeedbackState {
-  feedback: IExtendedFeedbackDocument[];
+/**
+ * The filter half of the server query, as GET /api/feedback understands it. Kept separate from
+ * page/limit so a CSV export can reuse the same filters while paging independently.
+ */
+export interface FeedbackListFilterParams {
+  status?: FeedbackStatus[];
+  organization?: string[];
+  search?: string;
+  sort: 'asc' | 'desc';
+}
+
+export type FeedbackListParams = FeedbackListFilterParams & {
+  page: number;
+  limit: number;
+};
+
+/** Response envelope of GET /api/feedback. */
+export interface FeedbackListResponse {
+  items: IExtendedFeedbackDocument[];
+  total: number;
+  page: number;
+  limit: number;
+  /** Distinct organization labels across the caller's whole accessible set, for the filter menu. */
   organizations: string[];
-  loading: boolean;
-  currentPage: number;
-  feedbackToDelete: string | null;
-  openDeleteFeedbackModal: boolean;
 }
 
 // Hook return types
@@ -46,22 +63,25 @@ export interface UseFeedbackFiltersReturn {
   setStatusFilters: React.Dispatch<React.SetStateAction<Record<FeedbackStatus, boolean>>>;
   setSelectedOrganizations: (orgs: string[]) => void;
   toggleSortDirection: () => void;
-  filteredAndSortedFeedback: IExtendedFeedbackDocument[];
+  /** Debounced, server-ready filter query. Feeds both the list and the CSV export. */
+  filterParams: FeedbackListFilterParams;
 }
 
 export interface UseFeedbackPaginationReturn {
   currentPage: number;
-  setCurrentPage: (page: number) => void;
-  currentFeedback: IExtendedFeedbackDocument[];
-  totalPages: number;
   handlePageChange: (newPage: number) => void;
   itemsPerPage: number;
   handleItemsPerPageChange: (items: number) => void;
+  /** Called when a filter changes: the current page number may not exist in the new result set. */
+  resetPage: () => void;
 }
 
 export interface UseFeedbackOperationsReturn {
+  /** The current page of results, already filtered and sorted by the server. */
   feedback: IExtendedFeedbackDocument[];
   organizations: string[];
+  /** Total matching the current filters across all pages - drives pagination and the CSV count. */
+  total: number;
   loading: boolean;
   refreshFeedback: () => Promise<void>;
   handleStatusChange: (feedbackItem: IExtendedFeedbackDocument, newValue: FeedbackStatus | null) => Promise<void>;

--- a/apps/client/app/components/admin/adminTabSlugs.test.ts
+++ b/apps/client/app/components/admin/adminTabSlugs.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { ADMIN_FEEDBACK_TAB_SLUG } from '@bike4mind/common';
+import { AdminTab } from './adminSidebarConfig';
+import { adminTabFromSlug } from './adminTabSlugs';
+
+describe('adminTabFromSlug', () => {
+  it('resolves the feedback slug to the feedback tab', () => {
+    expect(adminTabFromSlug(ADMIN_FEEDBACK_TAB_SLUG)).toBe(AdminTab.Feedback);
+  });
+
+  /**
+   * The whole reason slugs exist. AdminTab's values are positional, so a link carrying the
+   * number would silently retarget the first time someone inserts a tab above it - and these
+   * links live in Slack messages and emails that outlive any one deploy.
+   */
+  it('does not accept the tab enum number as a slug', () => {
+    expect(adminTabFromSlug(String(AdminTab.Feedback))).toBeUndefined();
+  });
+
+  /**
+   * AdminPage's effect guards with `!== undefined` rather than a truthiness check, because
+   * AdminTab.Users is 0. That guard is only correct if "not linkable" is exactly `undefined`,
+   * so a falsy-but-valid tab stays distinguishable from an unknown slug.
+   */
+  it('reports an unknown or absent slug as exactly undefined', () => {
+    expect(adminTabFromSlug('not-a-tab')).toBeUndefined();
+    expect(adminTabFromSlug('')).toBeUndefined();
+    expect(adminTabFromSlug(undefined)).toBeUndefined();
+  });
+
+  it('does not resolve slugs off the prototype chain', () => {
+    expect(adminTabFromSlug('toString')).toBeUndefined();
+    expect(adminTabFromSlug('constructor')).toBeUndefined();
+  });
+});

--- a/apps/client/app/components/admin/adminTabSlugs.ts
+++ b/apps/client/app/components/admin/adminTabSlugs.ts
@@ -1,0 +1,22 @@
+import { ADMIN_FEEDBACK_TAB_SLUG } from '@bike4mind/common';
+import { AdminTab } from './adminSidebarConfig';
+
+/**
+ * URL slug -> AdminTab, for the console's `?tab=` deep-link param.
+ *
+ * Only tabs something actually links to need an entry. `AdminTab`'s values are positional, so
+ * they must never reach a URL: a link built today would retarget the first time the enum is
+ * reordered, and these links live in Slack messages and emails. The slugs themselves are declared
+ * in common/utils/deepLinks alongside the builders that emit them.
+ *
+ * A Map, not an object literal: the key comes straight from the query string, and an object
+ * lookup would resolve `?tab=toString` to an inherited Object.prototype member instead of
+ * undefined - which then passes the caller's `!== undefined` guard.
+ */
+const SLUG_TO_ADMIN_TAB: ReadonlyMap<string, AdminTab> = new Map([[ADMIN_FEEDBACK_TAB_SLUG, AdminTab.Feedback]]);
+
+/** Resolves a `?tab=` slug, or undefined when it is absent or not a linkable tab. */
+export function adminTabFromSlug(slug: string | undefined): AdminTab | undefined {
+  if (!slug) return undefined;
+  return SLUG_TO_ADMIN_TAB.get(slug);
+}

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -820,7 +820,7 @@ Structured multi-step plans created by the QuestMaster agent.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | /api/feedback | List feedback |
+| GET | /api/feedback | List feedback (paginated; filters: page, limit, status, organization, organizationId, userId, sessionId, questId, subject, search, sort) |
 | POST | /api/feedback | Submit feedback |
 | GET | /api/feedback/[id]/read | Mark as read |
 | PUT | /api/feedback/[id]/update | Update feedback |

--- a/apps/client/app/generated/help-index.json
+++ b/apps/client/app/generated/help-index.json
@@ -422,6 +422,11 @@
         },
         {
           "level": 3,
+          "text": "Deep Links",
+          "anchor": "deep-links"
+        },
+        {
+          "level": 3,
           "text": "Refresh",
           "anchor": "refresh"
         },
@@ -10067,6 +10072,11 @@
             },
             {
               "level": 3,
+              "text": "Deep Links",
+              "anchor": "deep-links"
+            },
+            {
+              "level": 3,
               "text": "Refresh",
               "anchor": "refresh"
             },
@@ -19299,5 +19309,5 @@
       "accessLevel": "public"
     }
   ],
-  "version": "f869326413360b97"
+  "version": "7a529418680017c8"
 }

--- a/apps/client/app/router.tsx
+++ b/apps/client/app/router.tsx
@@ -294,9 +294,12 @@ const notebookRoute = createRoute({
       <NotebookPage />
     </Suspense>
   ),
-  validateSearch: (search: Record<string, unknown>): { projectId?: string } => {
+  // `questId` is the turn anchor a feedback deep link carries (see common/utils/deepLinks) - the
+  // session loads normally and ChatHistory scrolls to that turn once it has rendered.
+  validateSearch: (search: Record<string, unknown>): { projectId?: string; questId?: string } => {
     return {
       projectId: search.projectId ? String(search.projectId) : undefined,
+      questId: search.questId ? String(search.questId) : undefined,
     };
   },
 });
@@ -941,9 +944,16 @@ const adminRoute = createRoute({
       </ProviderBundle>
     </RestrictedPage>
   ),
-  validateSearch: (search: Record<string, unknown>): { emergency_access?: string } => {
+  // `tab` and `feedbackId` make the console addressable: a feedback deep link opens the Feedback
+  // tab focused on one record. `tab` is a stable slug, never the positional AdminTab enum value -
+  // see common/utils/deepLinks for why, and adminTabSlugs.ts for the slug <-> enum mapping.
+  validateSearch: (
+    search: Record<string, unknown>
+  ): { emergency_access?: string; tab?: string; feedbackId?: string } => {
     return {
       emergency_access: search.emergency_access ? String(search.emergency_access) : undefined,
+      tab: search.tab ? String(search.tab) : undefined,
+      feedbackId: search.feedbackId ? String(search.feedbackId) : undefined,
     };
   },
 });

--- a/apps/client/app/utils/feedbackAPICalls.test.ts
+++ b/apps/client/app/utils/feedbackAPICalls.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeedbackStatus } from '@bike4mind/common';
+
+const mocks = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: mocks.get, post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+import { FEEDBACK_LIST_MAX_LIMIT } from '@bike4mind/common';
+import { getAllFeedbackForExport, FEEDBACK_EXPORT_MAX_ROWS } from './feedbackAPICalls';
+
+const rows = (count: number, offset = 0) =>
+  Array.from({ length: count }, (_, i) => ({
+    _id: `fb-${offset + i}`,
+    status: FeedbackStatus.New,
+    content: 'x',
+  }));
+
+/** One page of the list envelope, as GET /api/feedback returns it. */
+const page = (items: unknown[], total: number) => ({ data: { items, total, page: 1, limit: 100, organizations: [] } });
+
+describe('getAllFeedbackForExport', () => {
+  beforeEach(() => {
+    mocks.get.mockReset();
+  });
+
+  /**
+   * The export must cover every row matching the filters, not the page on screen. Before this
+   * existed the CSV carried whatever the current page held, which reads as a complete export of
+   * a suspiciously small data set.
+   */
+  it('pages through every match rather than exporting one page', async () => {
+    mocks.get
+      .mockResolvedValueOnce(page(rows(100), 250))
+      .mockResolvedValueOnce(page(rows(100, 100), 250))
+      .mockResolvedValueOnce(page(rows(50, 200), 250));
+
+    const { items, truncated } = await getAllFeedbackForExport({ sort: 'desc' });
+
+    expect(items).toHaveLength(250);
+    expect(truncated).toBe(false);
+    expect(mocks.get).toHaveBeenCalledTimes(3);
+    expect(mocks.get.mock.calls.map(([, config]) => config.params.page)).toEqual([1, 2, 3]);
+  });
+
+  it('requests the largest page the server will accept', async () => {
+    mocks.get.mockResolvedValue(page(rows(1), 1));
+
+    await getAllFeedbackForExport({ sort: 'desc' });
+
+    expect(mocks.get.mock.calls[0][1].params.limit).toBe(FEEDBACK_LIST_MAX_LIMIT);
+  });
+
+  it('forwards the active filters to every page', async () => {
+    mocks.get.mockResolvedValueOnce(page(rows(100), 150)).mockResolvedValueOnce(page(rows(50, 100), 150));
+
+    await getAllFeedbackForExport({ sort: 'asc', status: [FeedbackStatus.Closed], search: 'crash' });
+
+    for (const [, config] of mocks.get.mock.calls) {
+      expect(config.params).toMatchObject({ sort: 'asc', status: [FeedbackStatus.Closed], search: 'crash' });
+    }
+  });
+
+  /**
+   * Load-bearing: past the cap the caller has to be told the file is short. A silent slice is the
+   * failure mode this flag exists for - the reader cannot tell a truncated export from a complete
+   * one by looking at it.
+   */
+  it('reports truncation when the match set exceeds the row cap', async () => {
+    const total = FEEDBACK_EXPORT_MAX_ROWS + 500;
+    mocks.get.mockResolvedValue(page(rows(100), total));
+
+    const { items, truncated } = await getAllFeedbackForExport({ sort: 'desc' });
+
+    expect(truncated).toBe(true);
+    expect(items).toHaveLength(FEEDBACK_EXPORT_MAX_ROWS);
+  });
+
+  // An empty page with a total the rows never reach would otherwise page forever.
+  it('stops on an empty page even when total disagrees', async () => {
+    mocks.get.mockResolvedValueOnce(page(rows(100), 999999)).mockResolvedValueOnce(page([], 999999));
+
+    const { items, truncated } = await getAllFeedbackForExport({ sort: 'desc' });
+
+    expect(items).toHaveLength(100);
+    expect(truncated).toBe(false);
+    expect(mocks.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns nothing for a filter that matches nothing', async () => {
+    mocks.get.mockResolvedValue(page([], 0));
+
+    const { items, truncated } = await getAllFeedbackForExport({ sort: 'desc' });
+
+    expect(items).toEqual([]);
+    expect(truncated).toBe(false);
+    expect(mocks.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/app/utils/feedbackAPICalls.ts
+++ b/apps/client/app/utils/feedbackAPICalls.ts
@@ -1,9 +1,47 @@
 import { api } from '@client/app/contexts/ApiContext';
+import { FEEDBACK_LIST_MAX_LIMIT } from '@bike4mind/common';
 import type { IFeedbackDocument, CreateFeedbackResponse } from '@bike4mind/common';
+import type {
+  FeedbackListParams,
+  FeedbackListResponse,
+  IExtendedFeedbackDocument,
+} from '@client/app/components/admin/Feedback/types';
 
-export const getFeedbackFromServer = async () => {
-  const response = await api.get<IFeedbackDocument[]>(`/api/feedback`);
+/**
+ * Hard ceiling on rows a CSV export will page through. The export has to cover every row matching
+ * the current filters, not just the page on screen, but it must not be able to walk an unbounded
+ * collection either - so it stops here and reports the truncation rather than quietly emitting a
+ * partial file.
+ */
+export const FEEDBACK_EXPORT_MAX_ROWS = 5000;
+
+export const getFeedbackFromServer = async (params: FeedbackListParams): Promise<FeedbackListResponse> => {
+  const response = await api.get<FeedbackListResponse>('/api/feedback', { params });
   return response.data;
+};
+
+/**
+ * Pages through every report matching `filters` for the CSV export, up to FEEDBACK_EXPORT_MAX_ROWS.
+ * `truncated` tells the caller the file is short so it can say so; an export that silently drops
+ * rows past the cap would read as a complete one.
+ */
+export const getAllFeedbackForExport = async (
+  filters: Omit<FeedbackListParams, 'page' | 'limit'>
+): Promise<{ items: IExtendedFeedbackDocument[]; truncated: boolean }> => {
+  const items: IExtendedFeedbackDocument[] = [];
+  let page = 1;
+
+  for (;;) {
+    const response = await getFeedbackFromServer({ ...filters, page, limit: FEEDBACK_LIST_MAX_LIMIT });
+    items.push(...response.items);
+
+    const exhausted = items.length >= response.total || response.items.length === 0;
+    if (exhausted) return { items, truncated: false };
+    if (items.length >= FEEDBACK_EXPORT_MAX_ROWS) {
+      return { items: items.slice(0, FEEDBACK_EXPORT_MAX_ROWS), truncated: true };
+    }
+    page += 1;
+  }
 };
 
 export const createFeedbackOnServer = async (
@@ -26,7 +64,7 @@ export const deleteFeedbackFromServer = async (feedbackId: string): Promise<{ ms
   return response.data;
 };
 
-export const getFeedbackByIdFromServer = async (feedbackId: string): Promise<IFeedbackDocument | null> => {
-  const response = await api.get<IFeedbackDocument | null>(`/api/feedback/${feedbackId}/read`);
+export const getFeedbackByIdFromServer = async (feedbackId: string): Promise<IExtendedFeedbackDocument | null> => {
+  const response = await api.get<IExtendedFeedbackDocument | null>(`/api/feedback/${feedbackId}/read`);
   return response.data;
 };

--- a/apps/client/pages/api/feedback/[id]/__tests__/delete.redaction.test.ts
+++ b/apps/client/pages/api/feedback/[id]/__tests__/delete.redaction.test.ts
@@ -32,8 +32,14 @@ const { deletedFeedbackDoc } = vi.hoisted(() => {
   return { deletedFeedbackDoc: { ...plain, toJSON: () => plain } };
 });
 
+// The route reads the document first so the ownership condition on the delete grant can be
+// evaluated against the instance, then deletes it - hence findById + deleteOne, not
+// findOneAndDelete.
 vi.mock('@bike4mind/database', () => ({
-  FeedbackModel: { findOneAndDelete: vi.fn().mockResolvedValue(deletedFeedbackDoc) },
+  FeedbackModel: {
+    findById: vi.fn().mockResolvedValue(deletedFeedbackDoc),
+    deleteOne: vi.fn().mockResolvedValue({ deletedCount: 1 }),
+  },
   FeedbackTextModel: { deleteOne: vi.fn().mockResolvedValue({}) },
 }));
 

--- a/apps/client/pages/api/feedback/[id]/delete.ts
+++ b/apps/client/pages/api/feedback/[id]/delete.ts
@@ -17,12 +17,21 @@ const handler = baseApi().delete(
       throw new Error('Ability not found');
     }
 
-    if (!req.ability.can('delete', FeedbackModel)) {
-      throw new Error('Permission denied');
+    // Read before deleting so the ownership condition can be evaluated. Authorizing by class
+    // (`can('delete', FeedbackModel)`) does NOT evaluate the non-admin grant's { userId }
+    // condition, so a by-class check would let any logged-in user hard-delete any reporter's
+    // record. A reporter retracting their own report and an admin deleting any report are the
+    // same route; the ability rules are what separate them.
+    const feedback = await FeedbackModel.findById(id);
+    if (!feedback) throw new NotFoundError('Feedback not found');
+
+    // Same NotFoundError as above: a probe must not be able to distinguish "not yours" from
+    // "does not exist".
+    if (!req.ability.can('delete', feedback)) {
+      throw new NotFoundError('Feedback not found');
     }
 
-    const deletedFeedbackItem = await FeedbackModel.findOneAndDelete({ _id: id });
-    if (!deletedFeedbackItem) throw new NotFoundError('Feedback not found');
+    await FeedbackModel.deleteOne({ _id: id });
 
     // Mongo has no cascade: without this, a deleted report's free text survives up to 90 days,
     // inverting the retention promise. Best-effort - the report is already gone either way.
@@ -32,7 +41,7 @@ const handler = baseApi().delete(
 
     await logEvent({ userId, type: FeedbackEvents.DELETE_FEEDBACK, metadata: { id } }, { ability: req.ability });
 
-    return res.status(200).json(toRedactedFeedback(deletedFeedbackItem));
+    return res.status(200).json(toRedactedFeedback(feedback));
   })
 );
 

--- a/apps/client/pages/api/feedback/[id]/read.ts
+++ b/apps/client/pages/api/feedback/[id]/read.ts
@@ -13,13 +13,18 @@ const handler = baseApi().get(
       throw new NotFoundError('Ability not found');
     }
 
-    if (!req.ability.can('read', FeedbackModel)) {
-      throw new NotFoundError('Permission denied');
-    }
-
     const feedback = await FeedbackModel.findById(id);
 
     if (!feedback) {
+      throw new NotFoundError('Feedback not found');
+    }
+
+    // Authorize against the document instance, not the model class: the non-admin `read` grant
+    // carries a { userId } ownership condition that a by-class check does not evaluate, so a
+    // by-class check here would hand every logged-in user any reporter's record. Same
+    // NotFoundError as the missing-document case above, so a probe cannot use the status to
+    // confirm an id exists.
+    if (!req.ability.can('read', feedback)) {
       throw new NotFoundError('Feedback not found');
     }
 

--- a/apps/client/pages/api/feedback/__tests__/list.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/list.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { AbilityBuilder, createMongoAbility } from '@casl/ability';
+import { accessibleBy } from '@casl/mongoose';
+import errorHandler from '@server/middlewares/errorHandler';
+
+/**
+ * GET /api/feedback - server-side filter/projection/pagination over FeedbackModel. The CASL
+ * ability rules ARE the scope (accessibleBy narrows to {} for an admin's unconditional read grant,
+ * or to an ownership filter for anyone else); free-text search resolves through the TTL'd
+ * FeedbackTextModel sibling, since `content` does not live on the report itself.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: unknown, res: unknown) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    get: (fn: unknown) => {
+      mockRefs.getHandler = fn as (req: unknown, res: unknown) => unknown;
+      return chain;
+    },
+    post: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+const mockListDocs = vi.fn<() => unknown[]>(() => []);
+const mockSelect = vi.fn();
+const mockSort = vi.fn();
+const mockSkip = vi.fn();
+const mockLimit = vi.fn();
+// The route chains .select().sort().skip().limit() before awaiting, so the mock has to be a
+// thenable query rather than a resolved array - mirrors redaction.test.ts's harness.
+const mockFind = vi.fn((_filter: unknown) => {
+  const query = {
+    select: (...args: unknown[]) => {
+      mockSelect(...args);
+      return query;
+    },
+    sort: (...args: unknown[]) => {
+      mockSort(...args);
+      return query;
+    },
+    skip: (...args: unknown[]) => {
+      mockSkip(...args);
+      return query;
+    },
+    limit: (...args: unknown[]) => {
+      mockLimit(...args);
+      return query;
+    },
+    then: (resolve: (docs: unknown[]) => unknown) => resolve(mockListDocs()),
+  };
+  return query;
+});
+const mockCountDocuments = vi.fn().mockResolvedValue(0);
+const mockDistinct = vi.fn().mockResolvedValue([]);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function FeedbackModelMock(this: any, data: unknown) {
+  Object.assign(this, data);
+}
+FeedbackModelMock.find = mockFind;
+FeedbackModelMock.countDocuments = mockCountDocuments;
+FeedbackModelMock.distinct = mockDistinct;
+
+// The route chains .select('_id').lean() off FeedbackTextModel.find before awaiting it.
+const mockTextFind = vi.fn().mockReturnValue({ select: () => ({ lean: vi.fn().mockResolvedValue([]) }) });
+
+vi.mock('@bike4mind/database', () => ({
+  FeedbackModel: FeedbackModelMock,
+  FeedbackTextModel: { find: (...args: unknown[]) => mockTextFind(...args) },
+  User: {},
+  adminSettingsRepository: {},
+}));
+
+vi.mock('@bike4mind/utils', () => ({
+  escapeRegex: (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  getSettingsMap: vi.fn().mockResolvedValue({}),
+  getSettingsValue: vi.fn(),
+}));
+
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn() }));
+vi.mock('@server/integrations/slack/slack', () => ({ postFeedbackToSlack: vi.fn() }));
+vi.mock('@server/utils/eventBus', () => ({ EmailEvents: { Send: { publish: vi.fn() } } }));
+vi.mock('@server/utils/config', () => ({ Config: { STAGE: 'production' } }));
+vi.mock('@bike4mind/observability', () => ({ Logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+vi.mock('@server/utils/cloudwatch', async () => {
+  const actual = await vi.importActual<typeof import('@server/utils/cloudwatch')>('@server/utils/cloudwatch');
+  return {
+    recordFeedbackDeliverySuccess: vi.fn(),
+    recordFeedbackDeliveryFailure: vi.fn(),
+    recordFeedbackDeliverySkipped: vi.fn(),
+    ALARM_WORTHY_SKIP_REASONS: actual.ALARM_WORTHY_SKIP_REASONS,
+  };
+});
+
+// The page bounds are shared with the client (the CSV export pages at exactly the maximum), so
+// they live in common; only the projection allowlist belongs to the route.
+import { FEEDBACK_LIST_DEFAULT_LIMIT, FEEDBACK_LIST_MAX_LIMIT } from '@bike4mind/common';
+import { FEEDBACK_LIST_FIELDS } from '../index';
+
+/**
+ * Built inline rather than imported from server/auth/ability.ts, which pulls an unresolvable
+ * `tldts` transitive dependency under this vitest setup. MUST STAY IN SYNC with the admin feedback
+ * rules there: an unconditional read grant is what makes accessibleBy narrow to {}.
+ */
+const adminAbility = () => {
+  const { can, build } = new AbilityBuilder(createMongoAbility);
+  can('read', FeedbackModelMock);
+  return build();
+};
+
+const ownAbility = (userId: string) => {
+  const { can, build } = new AbilityBuilder(createMongoAbility);
+  can('read', FeedbackModelMock, { userId });
+  return build();
+};
+
+const stubLogger = () => {
+  const logger: Record<string, unknown> = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  logger.withMetadata = vi.fn(() => logger);
+  return logger;
+};
+
+function buildRequest(query: Record<string, unknown>, ability: unknown) {
+  const { req, res } = createMocks({ method: 'GET', query });
+  (req as unknown as { ability: unknown }).ability = ability;
+  (req as unknown as { logger: unknown }).logger = stubLogger();
+  (req as unknown as { requestId: string }).requestId = 'test-request-id';
+  return { req, res };
+}
+
+// Mirrors the real onError wiring in baseApi's next-connect router (errorHandler is the router's
+// onError), so a thrown validation error is asserted as the actual HTTP response the app would
+// send, not just an uncaught rejection - this test bypasses baseApi's real router entirely.
+const runHandler = async (req: unknown, res: unknown) => {
+  try {
+    await mockRefs.getHandler!(req, res);
+  } catch (error) {
+    errorHandler(error, req as Parameters<typeof errorHandler>[1], res as Parameters<typeof errorHandler>[2]);
+  }
+};
+
+describe('GET /api/feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListDocs.mockReturnValue([]);
+    mockCountDocuments.mockResolvedValue(0);
+    mockDistinct.mockResolvedValue([]);
+    mockTextFind.mockReturnValue({ select: () => ({ lean: vi.fn().mockResolvedValue([]) }) });
+  });
+
+  it('maps page and limit to skip and limit on the query', async () => {
+    const { req, res } = buildRequest({ page: '3', limit: '10' }, adminAbility());
+    await runHandler(req, res);
+
+    expect(mockSkip).toHaveBeenCalledWith(20);
+    expect(mockLimit).toHaveBeenCalledWith(10);
+  });
+
+  it('defaults to page 1 and the default limit with no query params', async () => {
+    const { req, res } = buildRequest({}, adminAbility());
+    await runHandler(req, res);
+
+    expect(mockSkip).toHaveBeenCalledWith(0);
+    expect(mockLimit).toHaveBeenCalledWith(FEEDBACK_LIST_DEFAULT_LIMIT);
+    const body = res._getJSONData();
+    expect(body.page).toBe(1);
+    expect(body.limit).toBe(FEEDBACK_LIST_DEFAULT_LIMIT);
+  });
+
+  it('rejects a limit above FEEDBACK_LIST_MAX_LIMIT with a 422, not a 400', async () => {
+    const { req, res } = buildRequest({ limit: String(FEEDBACK_LIST_MAX_LIMIT + 1) }, adminAbility());
+    await runHandler(req, res);
+
+    // ListFeedbackQuerySchema.parse throws a ZodError, which errorHandler maps to
+    // UnprocessableEntityError (422) - see server/middlewares/errorHandler.ts.
+    expect(res._getStatusCode()).toBe(422);
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it('projects only the list allowlist, never promptMeta', async () => {
+    const { req, res } = buildRequest({}, adminAbility());
+    await runHandler(req, res);
+
+    expect(mockSelect).toHaveBeenCalledWith(FEEDBACK_LIST_FIELDS);
+    const selected = mockSelect.mock.calls[0][0] as string;
+    expect(selected).not.toContain('promptMeta');
+  });
+
+  it('returns exactly items/total/page/limit/organizations, sourced from countDocuments and distinct', async () => {
+    mockListDocs.mockReturnValue([]);
+    mockCountDocuments.mockResolvedValue(7);
+    mockDistinct.mockResolvedValue(['Acme', 'Beta']);
+
+    const { req, res } = buildRequest({ page: '2', limit: '5' }, adminAbility());
+    await runHandler(req, res);
+
+    const body = res._getJSONData();
+    expect(Object.keys(body).sort()).toEqual(['items', 'limit', 'organizations', 'page', 'total']);
+    expect(body.total).toBe(7);
+    expect(body.page).toBe(2);
+    expect(body.limit).toBe(5);
+    expect(body.organizations).toEqual(['Acme', 'Beta']);
+  });
+
+  it('computes the organization facet over the accessible set, not the org-filtered set', async () => {
+    const { req, res } = buildRequest({ organization: 'acme' }, adminAbility());
+    await runHandler(req, res);
+
+    // Selecting an org must not prune the dropdown that selected it: distinct() has to see every
+    // organization the caller can access, so it takes the unfiltered accessible-set query.
+    const distinctFilter = mockDistinct.mock.calls[0][1];
+    expect(JSON.stringify(distinctFilter)).not.toContain('acme');
+
+    const findFilter = mockFind.mock.calls[0][0] as { $and: unknown[] };
+    expect(JSON.stringify(findFilter.$and)).toContain('acme');
+  });
+
+  it('narrows a non-admin caller to their own records via the ability, not a hand-written filter', async () => {
+    const ability = ownAbility('user-1');
+    const { req, res } = buildRequest({}, ability);
+    await runHandler(req, res);
+
+    // Read the real shape accessibleBy produces for this ability rather than assuming one - the
+    // route's `readable` clause is exactly this value.
+    const expectedReadable = accessibleBy(ability, 'read').ofType(FeedbackModelMock);
+    const findFilter = mockFind.mock.calls[0][0] as { $and: unknown[] };
+    expect(findFilter.$and[0]).toEqual(expectedReadable);
+    expect(JSON.stringify(expectedReadable)).toContain('user-1');
+  });
+
+  it('resolves free-text search through the FeedbackText sibling and filters by matching ids', async () => {
+    mockTextFind.mockReturnValue({
+      select: () => ({ lean: vi.fn().mockResolvedValue([{ _id: 'match-1' }, { _id: 'match-2' }]) }),
+    });
+
+    const { req, res } = buildRequest({ search: 'crash' }, adminAbility());
+    await runHandler(req, res);
+
+    expect(mockTextFind).toHaveBeenCalledWith({ content: expect.any(RegExp) });
+    expect(mockTextFind.mock.calls[0][0].content.source).toContain('crash');
+
+    const findFilter = mockFind.mock.calls[0][0] as { $and: unknown[] };
+    const serialized = JSON.stringify(findFilter.$and);
+    expect(serialized).toContain('match-1');
+    expect(serialized).toContain('match-2');
+  });
+});

--- a/apps/client/pages/api/feedback/__tests__/redaction.test.ts
+++ b/apps/client/pages/api/feedback/__tests__/redaction.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
+import { AbilityBuilder, createMongoAbility } from '@casl/ability';
 
 /**
  * A bug report leaves the product entirely (a third-party Slack workspace, unencrypted email).
@@ -32,7 +33,21 @@ vi.mock('@server/middlewares/baseApi', () => {
 
 const savedFeedback = { id: 'fb1' };
 const mockSave = vi.fn().mockResolvedValue(undefined);
-const mockFind = vi.fn();
+// The list route chains .select().sort().skip().limit() before awaiting, so the mock has to be a
+// thenable query rather than a resolved array.
+const mockListDocs = vi.fn<() => unknown[]>(() => []);
+const mockFind = vi.fn(() => {
+  const query = {
+    select: () => query,
+    sort: () => query,
+    skip: () => query,
+    limit: () => query,
+    then: (resolve: (docs: unknown[]) => unknown) => resolve(mockListDocs()),
+  };
+  return query;
+});
+const mockCountDocuments = vi.fn().mockResolvedValue(1);
+const mockDistinct = vi.fn().mockResolvedValue([]);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function FeedbackModelMock(this: any, data: unknown) {
   Object.assign(this, data, {
@@ -42,6 +57,8 @@ function FeedbackModelMock(this: any, data: unknown) {
   });
 }
 FeedbackModelMock.find = mockFind;
+FeedbackModelMock.countDocuments = mockCountDocuments;
+FeedbackModelMock.distinct = mockDistinct;
 
 vi.mock('@bike4mind/database', () => ({
   FeedbackModel: FeedbackModelMock,
@@ -67,6 +84,7 @@ vi.mock('@server/utils/eventBus', () => ({
 }));
 
 vi.mock('@bike4mind/utils', () => ({
+  escapeRegex: (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
   getSettingsMap: vi.fn().mockResolvedValue({}),
   getSettingsValue: vi.fn((key: string) => {
     if (key === 'EnableFeedBackToSlack') return true;
@@ -93,6 +111,17 @@ vi.mock('@server/utils/cloudwatch', async () => {
 });
 
 import '../index';
+
+/**
+ * Built inline rather than imported from server/auth/ability.ts, which pulls an unresolvable
+ * `tldts` transitive dependency under this vitest setup. MUST STAY IN SYNC with the admin feedback
+ * rules there: an unconditional read grant is what makes accessibleBy narrow to {}.
+ */
+const adminAbility = () => {
+  const { can, build } = new AbilityBuilder(createMongoAbility);
+  can('read', FeedbackModelMock);
+  return build();
+};
 
 const PROMPT_META_WITH_TOOL_OUTPUT = {
   functionCalls: [
@@ -156,13 +185,11 @@ describe('GET /api/feedback - redacts tool output before returning it to an admi
   });
 
   it('strips returnValue from every reporters functionCalls', async () => {
-    mockFind.mockResolvedValue([
-      {
-        toJSON: () => ({ id: 'fb1', promptMeta: PROMPT_META_WITH_TOOL_OUTPUT }),
-      },
-    ]);
+    mockListDocs.mockReturnValue([{ toJSON: () => ({ id: 'fb1', promptMeta: PROMPT_META_WITH_TOOL_OUTPUT }) }]);
     const { req, res } = createMocks({ method: 'GET' });
-    (req as unknown as { ability: { can: () => boolean } }).ability = { can: () => true };
+    // A real ability, not a { can: () => true } stub: the route derives its Mongo scope from the
+    // rules via accessibleBy, which needs the actual CASL instance.
+    (req as unknown as { ability: unknown }).ability = adminAbility();
 
     await mockRefs.getHandler!(req, res);
 

--- a/apps/client/pages/api/feedback/index.ts
+++ b/apps/client/pages/api/feedback/index.ts
@@ -1,9 +1,11 @@
 import { FeedbackModel, FeedbackTextModel, User } from '@bike4mind/database';
 import {
   classifyStage,
+  FEEDBACK_SUBJECTS,
   FeedbackEvents,
   FeedbackStatus,
   IOrganizationDocument,
+  Permission,
   PromptMetaZodSchema,
   feedbackContentExpiresAt,
   redactFunctionCallsForViewer,
@@ -17,10 +19,9 @@ import type {
 } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
 import { logEvent } from '@server/utils/analyticsLog';
-import { getSettingsMap, getSettingsValue } from '@bike4mind/utils';
+import { escapeRegex, getSettingsMap, getSettingsValue } from '@bike4mind/utils';
 import { adminSettingsRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
-import { NotFoundError } from '@server/utils/errors';
 import { EmailEvents } from '@server/utils/eventBus';
 import { postFeedbackToSlack } from '@server/integrations/slack/slack';
 import { hydrateFeedbackText, toRedactedFeedback } from '@server/utils/redactedFeedback';
@@ -34,9 +35,76 @@ import {
   emitFeedbackDeliveryMetrics,
   ALARM_WORTHY_SKIP_REASONS,
 } from '@server/utils/cloudwatch';
+import { accessibleBy } from '@casl/mongoose';
 import mongoose from 'mongoose';
+import qs from 'qs';
+import type { FilterQuery } from 'mongoose';
 import sanitizeHtml from 'sanitize-html';
 import { z } from 'zod';
+
+export const FEEDBACK_LIST_DEFAULT_LIMIT = 20;
+export const FEEDBACK_LIST_MAX_LIMIT = 100;
+
+/**
+ * Fields the admin triage table and its CSV export actually read, as an allowlist.
+ *
+ * `promptMeta` is deliberately absent: it is the largest field on the document and no list row
+ * renders it (it is read one record at a time through feedback/[id]/read), so projecting it here
+ * would ship the per-report diagnostic blob with every row of every page. `contentStored` is
+ * required by hydrateFeedbackText to tell an expired report from one that never had text.
+ */
+const FEEDBACK_LIST_FIELDS = [
+  'userId',
+  'content',
+  'contentStored',
+  'status',
+  'tags',
+  'username',
+  'userEmail',
+  'organization',
+  'organizationId',
+  'type',
+  'subject',
+  'sessionId',
+  'questId',
+  'createdAt',
+  'updatedAt',
+].join(' ');
+
+/**
+ * Query contract for the feedback list. Every filter keys off a field #1864 indexed
+ * (`userId`/`sessionId`/`questId`/`organizationId`, each paired with `createdAt`) so a scoped
+ * read walks an index rather than the collection.
+ *
+ * Sort is `createdAt` only, and that is a deliberate narrowing of what the client used to do
+ * in-browser (status rank first, then date). A status-rank sort is a computed field, which no
+ * index can serve - it would force a blocking in-memory sort of every matching document on every
+ * page, defeating the four `{ key, createdAt }` indexes this endpoint exists to use. The status
+ * *filter* below covers the triage need the grouping was standing in for.
+ */
+const ListFeedbackQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).prefault(1),
+  limit: z.coerce.number().int().min(1).max(FEEDBACK_LIST_MAX_LIMIT).prefault(FEEDBACK_LIST_DEFAULT_LIMIT),
+  userId: z.string().min(1).optional(),
+  sessionId: z.string().min(1).optional(),
+  questId: z.string().min(1).optional(),
+  organizationId: z.string().min(1).optional(),
+  // Legacy free-text org label. The admin dropdown builds its options out of the documents
+  // themselves, so it still selects on this; `organizationId` is the key programmatic callers
+  // (rollups, deep links) should use.
+  organization: z.union([z.string(), z.array(z.string())]).optional(),
+  status: z.union([z.enum(FeedbackStatus), z.array(z.enum(FeedbackStatus))]).optional(),
+  subject: z.enum(FEEDBACK_SUBJECTS).optional(),
+  // Capped: the value reaches a Mongo regex, so an unbounded pattern is a CPU sink even escaped.
+  search: z.string().min(1).max(200).optional(),
+  sort: z.enum(['asc', 'desc']).prefault('desc'),
+});
+
+/** `qs.parse` hands back a lone value or an array depending on how many times a key repeats. */
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
 
 const CreateFeedbackRequestSchema = z.object({
   userId: z.string(),
@@ -113,17 +181,73 @@ const handler = baseApi()
       throw new Error('Ability not found');
     }
 
-    if (!req.ability.can('read', FeedbackModel)) {
-      throw new Error('Permission denied');
+    const query = ListFeedbackQuerySchema.parse(qs.parse(req.query as Record<string, string>));
+
+    // The ability rules ARE the scope: an admin holds an unconditional read grant, so this
+    // narrows to {} and they see every report; everyone else holds only the { userId } grant, so
+    // it narrows to their own. A caller with no read grant at all narrows to an unsatisfiable
+    // filter rather than an empty one, so this fails closed - which is why there is no separate
+    // by-class permission check here (a by-class check would ignore the ownership condition and
+    // pass for every logged-in user).
+    const readable = accessibleBy(req.ability, Permission.read).ofType(FeedbackModel);
+
+    const clauses: FilterQuery<unknown>[] = [readable];
+
+    if (query.userId) clauses.push({ userId: query.userId });
+    if (query.sessionId) clauses.push({ sessionId: query.sessionId });
+    if (query.questId) clauses.push({ questId: query.questId });
+    if (query.organizationId) clauses.push({ organizationId: query.organizationId });
+    if (query.subject) clauses.push({ subject: query.subject });
+
+    const organizations = toArray(query.organization);
+    if (organizations.length > 0) clauses.push({ organization: { $in: organizations } });
+
+    const statuses = toArray(query.status);
+    if (statuses.length > 0) clauses.push({ status: { $in: statuses } });
+
+    if (query.search) {
+      const pattern = new RegExp(escapeRegex(query.search), 'i');
+
+      // `content` lives on the TTL'd FeedbackText sibling rather than on the report, so a text
+      // search has to resolve ids over there first and cannot be expressed as one filter. The
+      // regex is unindexed, but this is an admin triage surface and the path it replaces shipped
+      // the entire collection to the browser to search it client-side. Projecting only _id keeps
+      // the intermediate small; FeedbackText is itself bounded by the 90-day content TTL.
+      const matchingText = await FeedbackTextModel.find({ content: pattern }).select('_id').lean();
+
+      const searchClauses: FilterQuery<unknown>[] = [{ username: pattern }, { userEmail: pattern }];
+      if (matchingText.length > 0) {
+        searchClauses.push({ _id: { $in: matchingText.map(text => text._id) } });
+      }
+      clauses.push({ $or: searchClauses });
     }
 
-    const feedback = await FeedbackModel.find();
+    // $and rather than a merged object literal: the CASL scope carries its own $or arm and a
+    // spread would silently drop one side of it. Same reason as pages/api/files/index.ts.
+    const filter = { $and: clauses };
 
-    if (!feedback) {
-      throw new NotFoundError('Feedback not found');
-    }
+    const [items, total, organizationFacet] = await Promise.all([
+      FeedbackModel.find(filter)
+        .select(FEEDBACK_LIST_FIELDS)
+        .sort({ createdAt: query.sort === 'asc' ? 1 : -1 })
+        .skip((query.page - 1) * query.limit)
+        .limit(query.limit),
+      FeedbackModel.countDocuments(filter),
+      // Facet options come from the caller's whole accessible set, NOT from `filter` - otherwise
+      // selecting an organization would prune every other option out of the dropdown that
+      // selected it.
+      FeedbackModel.distinct('organization', readable),
+    ]);
 
-    return res.json(await hydrateFeedbackText(feedback.map(toRedactedFeedback)));
+    return res.json({
+      items: await hydrateFeedbackText(items.map(toRedactedFeedback)),
+      total,
+      page: query.page,
+      limit: query.limit,
+      organizations: organizationFacet
+        .filter((name): name is string => typeof name === 'string' && name.length > 0)
+        .sort((a, b) => a.localeCompare(b)),
+    });
   })
   .post(async (req, res) => {
     const newFeedbackData = CreateFeedbackRequestSchema.parse(req.body);

--- a/apps/client/pages/api/feedback/index.ts
+++ b/apps/client/pages/api/feedback/index.ts
@@ -1,6 +1,8 @@
 import { FeedbackModel, FeedbackTextModel, User } from '@bike4mind/database';
 import {
   classifyStage,
+  FEEDBACK_LIST_DEFAULT_LIMIT,
+  FEEDBACK_LIST_MAX_LIMIT,
   FEEDBACK_SUBJECTS,
   FeedbackEvents,
   FeedbackStatus,
@@ -42,9 +44,6 @@ import type { FilterQuery } from 'mongoose';
 import sanitizeHtml from 'sanitize-html';
 import { z } from 'zod';
 
-export const FEEDBACK_LIST_DEFAULT_LIMIT = 20;
-export const FEEDBACK_LIST_MAX_LIMIT = 100;
-
 /**
  * Fields the admin triage table and its CSV export actually read, as an allowlist.
  *
@@ -53,7 +52,7 @@ export const FEEDBACK_LIST_MAX_LIMIT = 100;
  * would ship the per-report diagnostic blob with every row of every page. `contentStored` is
  * required by hydrateFeedbackText to tell an expired report from one that never had text.
  */
-const FEEDBACK_LIST_FIELDS = [
+export const FEEDBACK_LIST_FIELDS = [
   'userId',
   'content',
   'contentStored',

--- a/apps/client/server/auth/__tests__/ability.test.ts
+++ b/apps/client/server/auth/__tests__/ability.test.ts
@@ -31,7 +31,8 @@ vi.mock('@server/models/Subscription', () => ({
 }));
 
 import defineAbilitiesFor from '../ability';
-import { Prompt, FabFile } from '@bike4mind/database';
+import { Prompt, FabFile, FeedbackModel } from '@bike4mind/database';
+import { accessibleBy } from '@casl/mongoose';
 
 const makeUser = (overrides: Partial<IUserDocument> = {}): IUserDocument =>
   ({
@@ -145,5 +146,60 @@ describe('defineAbilitiesFor - group-shared document access', () => {
       { groupId: 'g2', permissions: ['read', 'update'] },
     ]);
     expect(ability.can('update', doc)).toBe(true);
+  });
+});
+
+describe('defineAbilitiesFor - Feedback read/delete scoping', () => {
+  // A reporter owns fb-own; someone else owns fb-other. Instances, not the class: every non-admin
+  // feedback grant carries a { userId } condition, and a by-class check does not evaluate it.
+  const ownReport = Object.assign(new FeedbackModel(), { userId: 'u1' });
+  const othersReport = Object.assign(new FeedbackModel(), { userId: 'someone-else' });
+
+  it('lets a reporter read and retract their OWN report', () => {
+    const ability = defineAbilitiesFor(makeUser());
+    expect(ability.can('read', ownReport)).toBe(true);
+    expect(ability.can('delete', ownReport)).toBe(true);
+  });
+
+  it("denies a reporter reading or deleting SOMEONE ELSE'S report", () => {
+    const ability = defineAbilitiesFor(makeUser());
+    expect(ability.can('read', othersReport)).toBe(false);
+    expect(ability.can('delete', othersReport)).toBe(false);
+  });
+
+  it('lets an admin read and delete any report', () => {
+    const ability = defineAbilitiesFor(makeUser({ isAdmin: true }));
+    expect(ability.can('read', othersReport)).toBe(true);
+    expect(ability.can('delete', othersReport)).toBe(true);
+  });
+
+  it('pins the footgun these grants create: the by-class check passes for a non-owner', () => {
+    // This is why every feedback route authorizes against the fetched instance (read/update/
+    // delete) or narrows the query with accessibleBy (list). If a route ever reverts to a
+    // by-class check, it hands every logged-in user the admin view - and this assertion is the
+    // record of why that check is not safe here.
+    const ability = defineAbilitiesFor(makeUser());
+    expect(ability.can('read', FeedbackModel)).toBe(true);
+    expect(ability.can('delete', FeedbackModel)).toBe(true);
+    expect(ability.can('read', othersReport)).toBe(false);
+    expect(ability.can('delete', othersReport)).toBe(false);
+  });
+
+  it('narrows a list query to the caller for a non-admin, and not at all for an admin', () => {
+    // accessibleBy is what pages/api/feedback/index.ts uses to scope the list; these are the two
+    // shapes it must produce.
+    const reporterScope = accessibleBy(defineAbilitiesFor(makeUser()), 'read').ofType(FeedbackModel);
+    expect(JSON.stringify(reporterScope)).toContain('u1');
+
+    const adminScope = accessibleBy(defineAbilitiesFor(makeUser({ isAdmin: true })), 'read').ofType(FeedbackModel);
+    expect(adminScope).toEqual({});
+  });
+
+  it('fails closed for a caller with no read grant at all', () => {
+    // An unsatisfiable filter, never an empty one: an empty filter would match the whole
+    // collection.
+    const scope = accessibleBy(defineAbilitiesFor(undefined), 'read').ofType(FeedbackModel);
+    expect(scope).toEqual({ $expr: { $eq: [0, 1] } });
+    expect(scope).not.toEqual({});
   });
 });

--- a/apps/client/server/auth/ability.ts
+++ b/apps/client/server/auth/ability.ts
@@ -150,6 +150,20 @@ function defineAbilitiesFor(user: IUserDocument | undefined) {
       userId: user.id,
     });
 
+    // A reporter can read back and retract their own reports. Every condition below is INVISIBLE
+    // to a by-class `can(action, FeedbackModel)` check, which reports true as soon as any rule for
+    // the action exists - so a feedback route must authorize against the fetched document instance
+    // (see feedback/[id]/read.ts, update.ts, delete.ts) or narrow the query with accessibleBy()
+    // (see feedback/index.ts). A by-class check here would grant every non-admin the admin view.
+    // MUST STAY IN SYNC with the feedback rules in packages/database/src/utils/ability.ts.
+    allow(Permission.read, FeedbackModel, {
+      userId: user.id,
+    });
+
+    allow(Permission.delete, FeedbackModel, {
+      userId: user.id,
+    });
+
     if (user.isAdmin) {
       allow(Permission.read, FeedbackModel);
       allow(Permission.delete, FeedbackModel);

--- a/b4m-core/common/src/index.ts
+++ b/b4m-core/common/src/index.ts
@@ -76,6 +76,7 @@ export * from './schemas/curation';
 export * from './schemas/imageModerationIncident';
 export * from './utils/artifactHelpers';
 export * from './utils/creditTransactionDisplay';
+export * from './utils/deepLinks';
 export * from './utils/requireEnv';
 export * from './utils/internalStaffDomains';
 export * from './utils/countCodePoints';

--- a/b4m-core/common/src/types/entities/FeedbackTypes.ts
+++ b/b4m-core/common/src/types/entities/FeedbackTypes.ts
@@ -20,6 +20,14 @@ export enum FeedbackType {
 export const FEEDBACK_SUBJECTS = ['turn', 'session', 'product'] as const;
 export type FeedbackSubject = (typeof FEEDBACK_SUBJECTS)[number];
 
+/**
+ * Page bounds for the feedback list endpoint. Shared rather than mirrored on each side: the
+ * server rejects a larger `limit`, and the CSV export pages at exactly the maximum - so a lower
+ * server cap with a stale client copy turns every export request into a validation error.
+ */
+export const FEEDBACK_LIST_DEFAULT_LIMIT = 20;
+export const FEEDBACK_LIST_MAX_LIMIT = 100;
+
 export interface IFeedback {
   userId: string;
   /** Moved to `IFeedbackText` (a TTL'd sibling document sharing this doc's `_id`) 90 days after

--- a/b4m-core/common/src/utils/deepLinks.test.ts
+++ b/b4m-core/common/src/utils/deepLinks.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADMIN_FEEDBACK_TAB_SLUG,
+  ADMIN_TAB_PARAM,
+  FEEDBACK_ID_PARAM,
+  QUEST_ID_PARAM,
+  adminFeedbackRecordPath,
+  sessionPath,
+  sessionTurnPath,
+  toAbsoluteUrl,
+} from './deepLinks';
+
+describe('deepLinks', () => {
+  it('addresses an admin feedback record by tab slug and id', () => {
+    const url = new URL(adminFeedbackRecordPath('fb-1'), 'https://app.example');
+    expect(url.pathname).toBe('/admin');
+    expect(url.searchParams.get(ADMIN_TAB_PARAM)).toBe(ADMIN_FEEDBACK_TAB_SLUG);
+    expect(url.searchParams.get(FEEDBACK_ID_PARAM)).toBe('fb-1');
+  });
+
+  it('uses a stable slug rather than the positional AdminTab enum value', () => {
+    // A link in a Slack message outlives any reordering of the enum, so the wire format must not
+    // be the enum's number.
+    expect(adminFeedbackRecordPath('fb-1')).toContain(`${ADMIN_TAB_PARAM}=feedback`);
+    expect(adminFeedbackRecordPath('fb-1')).not.toMatch(/tab=\d/);
+  });
+
+  it('addresses a session and a turn within it', () => {
+    expect(sessionPath('sess-1')).toBe('/notebooks/sess-1');
+
+    const turn = new URL(sessionTurnPath('sess-1', 'quest-1'), 'https://app.example');
+    expect(turn.pathname).toBe('/notebooks/sess-1');
+    expect(turn.searchParams.get(QUEST_ID_PARAM)).toBe('quest-1');
+  });
+
+  it('escapes ids so a crafted id cannot graft extra path or query onto the link', () => {
+    const session = new URL(sessionPath('a/../../admin'), 'https://app.example');
+    expect(session.pathname).toBe('/notebooks/a%2F..%2F..%2Fadmin');
+
+    const record = new URL(adminFeedbackRecordPath('fb-1&tab=users'), 'https://app.example');
+    expect(record.searchParams.get(FEEDBACK_ID_PARAM)).toBe('fb-1&tab=users');
+    expect(record.searchParams.get(ADMIN_TAB_PARAM)).toBe(ADMIN_FEEDBACK_TAB_SLUG);
+  });
+
+  it('joins an origin whether or not it carries a trailing slash', () => {
+    expect(toAbsoluteUrl('https://app.example', '/admin')).toBe('https://app.example/admin');
+    expect(toAbsoluteUrl('https://app.example/', '/admin')).toBe('https://app.example/admin');
+    expect(toAbsoluteUrl('https://app.example///', '/admin')).toBe('https://app.example/admin');
+  });
+});

--- a/b4m-core/common/src/utils/deepLinks.ts
+++ b/b4m-core/common/src/utils/deepLinks.ts
@@ -1,0 +1,58 @@
+/**
+ * The one definition of how a feedback report, the session it describes, and the individual turn
+ * inside that session are addressed by URL.
+ *
+ * Four independent parties have to agree on these paths, and none of them can see the others:
+ * the Slack payload builder and the email template (server-side, composing an absolute URL from
+ * APP_URL), the router's search-param contract, and the admin console that reads the params back
+ * out. Encoding the scheme once here is what stops a second, incompatible scheme appearing the
+ * next time a channel wants to link to a report.
+ *
+ * These are pure PATH builders with no environment access, so client code can import them too -
+ * a server caller prepends the origin with toAbsoluteUrl().
+ */
+
+/** Search-param names. Shared so a builder and its reader cannot drift onto different spellings. */
+export const ADMIN_TAB_PARAM = 'tab';
+export const FEEDBACK_ID_PARAM = 'feedbackId';
+export const QUEST_ID_PARAM = 'questId';
+
+/**
+ * URL-stable slug for the admin console's Feedback tab.
+ *
+ * Deliberately NOT the `AdminTab` enum's numeric value: those are positional, so a link built
+ * today would silently point at a different tab the first time someone reorders the enum. A link
+ * in a Slack message or an email outlives the enum's ordering.
+ */
+export const ADMIN_FEEDBACK_TAB_SLUG = 'feedback';
+
+/** Deep link to one feedback record in the admin console's Feedback tab. */
+export function adminFeedbackRecordPath(feedbackId: string): string {
+  const params = new URLSearchParams({
+    [ADMIN_TAB_PARAM]: ADMIN_FEEDBACK_TAB_SLUG,
+    [FEEDBACK_ID_PARAM]: feedbackId,
+  });
+  return `/admin?${params.toString()}`;
+}
+
+/** Deep link to a chat session. */
+export function sessionPath(sessionId: string): string {
+  return `/notebooks/${encodeURIComponent(sessionId)}`;
+}
+
+/**
+ * Deep link to one turn within a session. The session still loads normally; `questId` tells the
+ * thread which turn to scroll to and highlight once it has rendered.
+ */
+export function sessionTurnPath(sessionId: string, questId: string): string {
+  const params = new URLSearchParams({ [QUEST_ID_PARAM]: questId });
+  return `${sessionPath(sessionId)}?${params.toString()}`;
+}
+
+/**
+ * Join an origin and one of the paths above. Tolerates a trailing slash on the base because
+ * APP_URL is operator-configured and arrives both ways.
+ */
+export function toAbsoluteUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}${path}`;
+}

--- a/docs-site/docs/admin/feedback.md
+++ b/docs-site/docs/admin/feedback.md
@@ -15,7 +15,7 @@ The feedback control panel provides all filtering and action controls in a singl
 
 ### Search
 
-The search input filters feedback by matching against the **username** or **content** of feedback entries. Results update as you type. Report text older than 90 days is automatically deleted (see Data Retention below), so search will no longer match on the content of an expired report.
+The search input filters feedback by matching against the **username**, **email**, or **content** of feedback entries. Matching runs on the server across every report, not just the page on screen, and the request is sent shortly after you stop typing rather than on each keystroke. Report text older than 90 days is automatically deleted (see Data Retention below), so search will no longer match on the content of an expired report.
 
 ### Status Filters
 
@@ -27,20 +27,22 @@ Feedback status is managed through three checkbox filters that can be combined:
 | **In Progress** | Unchecked | Feedback that is being actively addressed |
 | **Closed** | Unchecked | Feedback that has been resolved or dismissed |
 
-By default, only **New** feedback is shown. Toggle any combination of checkboxes to view multiple statuses simultaneously. Feedback items are sorted by status order (New first, then In Progress, then Closed), with date sorting applied within each status group.
+By default, only **New** feedback is shown. Toggle any combination of checkboxes to view multiple statuses simultaneously. Unchecking every box shows nothing rather than everything.
+
+Within the selected statuses, reports are ordered purely by date -- there is no longer a New-before-In-Progress-before-Closed grouping. Ordering by a computed status rank cannot use the database's date indexes, which is what made the list slow to page; if you want to work one status at a time, filter to it.
 
 ### Organization Filter
 
 A multi-select dropdown filters feedback by the submitting user's organization:
 
-- **All** - Shows feedback from all organizations (default when no specific selection is made)
-- Individual organization names extracted from the feedback data
+- Selecting nothing shows feedback from all organizations (the default)
+- Individual organization names, taken from every report you can see
 
-Multiple organizations can be selected at the same time.
+Multiple organizations can be selected at the same time. The list of available organizations is not narrowed by the filter itself, so selecting one does not remove the others from the dropdown.
 
 ### Sorting
 
-Click the **Created At** column header to toggle between ascending and descending date order. The default sort order is descending (newest first). Sorting is applied within each status group -- New items appear first, followed by In Progress, then Closed, regardless of sort direction.
+Click the **Created At** column header to toggle between ascending and descending date order. The default sort order is descending (newest first). Sorting is by date alone and is applied across the whole filtered set on the server, so it reorders every match rather than just the rows currently on screen.
 
 ## Feedback List
 
@@ -51,7 +53,7 @@ Each feedback entry is displayed as a card row with the following columns:
 | **Created At** | ~16% | Timestamp in `Mon DD, YYYY HH:MM AM/PM` format with relative time (e.g., "2 days ago"). Tags associated with the feedback are shown as green chips below the date. |
 | **Reporter** | ~21% | Organization name (bold), username, and email with tooltip showing the user ID |
 | **Feedback** | ~46% | The feedback content, displayed with preserved whitespace and word wrapping. Scrollable if content exceeds 80px height. A **Truncated** chip appears if the original submission was cut down to the length cap, and expired content (see Data Retention below) renders as `[content expired]`. |
-| **Actions** | ~17% | Status dropdown and delete button |
+| **Actions** | ~17% | Status dropdown, deep-link buttons (see Deep Links below), and delete button |
 
 ### Header Row
 
@@ -75,13 +77,27 @@ Changing the status triggers an immediate API update. A toast notification confi
 
 The delete button (trash icon) on each feedback entry initiates deletion. A confirmation modal appears with the message "Are you sure you want to delete the feedback?" before the deletion is executed. Upon successful deletion, a toast notification confirms the action with a preview of the deleted content.
 
+### Deep Links
+
+Two buttons on each row link out of the list:
+
+| Button | What it does |
+|--------|--------------|
+| **Copy link to this report** (link icon) | Copies an absolute URL that reopens this tab with the one report pinned above the list. Safe to paste into a ticket or chat. |
+| **Open the conversation** (forum icon) | Opens the session the report came from in a new tab, scrolled to the turn it was filed against. Shown only for a report attached to a session. |
+
+A copied link pins its report in a card above the list whether or not it matches your current
+filters or page; dismiss the card to return to the plain list, or expect the "no longer available"
+notice if the report has since been deleted. In a very long conversation the jump may land on the
+newest message first and reach the highlighted turn as older history loads.
+
 ### Refresh
 
 The **Refresh** button reloads all feedback data from the server. It is disabled while data is loading.
 
 ### Export CSV
 
-The **Export** button generates a CSV file containing all currently filtered and sorted feedback entries. The exported file is named `feedback_YYYY-MM-DD.csv` with the current date. The CSV uses the `papaparse` library for generation.
+The **Export** button generates a CSV file containing every feedback entry matching the current filters -- not just the page on screen. Large result sets are capped at 5,000 rows; when the cap is hit, a toast says so explicitly rather than handing you a short file that looks complete. The exported file is named `feedback_YYYY-MM-DD.csv` with the current date. The CSV uses the `papaparse` library for generation.
 
 Exported columns:
 
@@ -102,9 +118,9 @@ Pagination controls appear above the feedback list:
 
 | Setting | Details |
 |---------|---------|
-| Items per page | 20 (fixed) |
+| Items per page | Selectable: 10, 20, 50, or 100 (defaults to 20) |
 | Navigation | Previous / Next buttons with current page and total pages |
-| Total count | Displayed as "Total Feedback: N" reflecting the filtered count |
+| Total count | Displayed as "Total Feedback: N", the server-side count of every report matching the filters |
 
 ## Data Retention
 
@@ -112,7 +128,8 @@ Feedback text is **automatically deleted 90 days after submission**. The structu
 
 ## Best Practices
 
-- Keep the **New** status filter checked to ensure incoming feedback is not missed.
+- Keep the **New** status filter checked to ensure incoming feedback is not missed. Leaving every status unchecked shows an empty list, not all reports.
+- Use the conversation link when triaging a confusing report -- reading the turn it was filed against is usually faster than asking the reporter.
 - Regularly review and triage feedback by updating statuses from New to In Progress as items are being addressed.
 - Use the organization filter when investigating feedback patterns specific to a particular customer or team.
 - Export feedback to CSV before closing out a sprint or support cycle to maintain records.

--- a/packages/database/src/utils/ability.test.ts
+++ b/packages/database/src/utils/ability.test.ts
@@ -18,7 +18,8 @@ vi.mock('../models', () => ({
 }));
 
 import { defineAbilitiesFor } from './ability';
-import { Prompt, FabFile } from '../models';
+import { Prompt, FabFile, FeedbackModel } from '../models';
+import { accessibleBy } from '@casl/mongoose';
 
 const makeUser = (overrides: Partial<IUserDocument> = {}): IUserDocument =>
   ({ id: 'u1', isAdmin: false, tags: [], groups: [], email: 'user@example.com', ...overrides }) as IUserDocument;
@@ -101,5 +102,41 @@ describe('db-core defineAbilitiesFor - group-shared document access', () => {
     const ability = defineAbilitiesFor(makeUser({ groups: [] }));
     const doc = sharedWithGroups([{ groupId: 'g1', permissions: ['read'] }]);
     expect(ability.can('read', doc)).toBe(false);
+  });
+});
+
+// Mirrors the HTTP ability's Feedback block (apps/client/server/auth/ability.ts). Both grant a
+// reporter { userId }-scoped read and delete; if one side drops the condition, that side hands
+// every logged-in user the admin view, so both are pinned separately.
+describe('db-core defineAbilitiesFor - Feedback read/delete scoping', () => {
+  const ownReport = Object.assign(new FeedbackModel(), { userId: 'u1' });
+  const othersReport = Object.assign(new FeedbackModel(), { userId: 'someone-else' });
+
+  it('lets a reporter read and retract their own report, but not anyone else\'s', () => {
+    const a = defineAbilitiesFor(makeUser());
+    expect(a.can('read', ownReport)).toBe(true);
+    expect(a.can('delete', ownReport)).toBe(true);
+    expect(a.can('read', othersReport)).toBe(false);
+    expect(a.can('delete', othersReport)).toBe(false);
+  });
+
+  it('lets an admin read and delete any report', () => {
+    const a = defineAbilitiesFor(makeUser({ isAdmin: true }));
+    expect(a.can('read', othersReport)).toBe(true);
+    expect(a.can('delete', othersReport)).toBe(true);
+  });
+
+  it('pins the footgun: a by-class check passes for a non-owner, an instance check does not', () => {
+    const a = defineAbilitiesFor(makeUser());
+    expect(a.can('read', FeedbackModel)).toBe(true);
+    expect(a.can('read', othersReport)).toBe(false);
+  });
+
+  it('narrows a list query to the caller, opens it for an admin, and fails closed with no grant', () => {
+    expect(JSON.stringify(accessibleBy(defineAbilitiesFor(makeUser()), 'read').ofType(FeedbackModel))).toContain('u1');
+    expect(accessibleBy(defineAbilitiesFor(makeUser({ isAdmin: true })), 'read').ofType(FeedbackModel)).toEqual({});
+    expect(accessibleBy(defineAbilitiesFor(undefined), 'read').ofType(FeedbackModel)).toEqual({
+      $expr: { $eq: [0, 1] },
+    });
   });
 });

--- a/packages/database/src/utils/ability.ts
+++ b/packages/database/src/utils/ability.ts
@@ -132,6 +132,19 @@ export function defineAbilitiesFor(user: IUserDocument | undefined) {
       userId: user.id,
     });
 
+    // Allow users to read back and retract their own feedback. Every condition here is INVISIBLE
+    // to a by-class `can(action, FeedbackModel)` check, which reports true as soon as any rule for
+    // the action exists - so a feedback route must authorize against the fetched document instance
+    // or narrow the query with accessibleBy(). A by-class check grants every non-admin the admin
+    // view. MUST STAY IN SYNC with the feedback rules in apps/client/server/auth/ability.ts.
+    allow(Permission.read, FeedbackModel, {
+      userId: user.id,
+    });
+
+    allow(Permission.delete, FeedbackModel, {
+      userId: user.id,
+    });
+
     // Allow admins to read and delete any feedback
     if (user.isAdmin) {
       allow(Permission.read, FeedbackModel);


### PR DESCRIPTION

## Description

The admin Feedback tab fetched **every** feedback report in the database on load and then did all
filtering, sorting and paging in the browser. This replaces that with a real server-side query,
and scopes the endpoint to what the caller is allowed to read instead of gating it with a
permission check that ignores ownership.

It also lands the URL scheme that feedback notifications need in order to link back to a report
or to the conversation turn it was filed about, plus both ends of it: the admin console is now
addressable, the chat view can be pointed at one turn, and the Feedback tab both emits and
consumes those links.

Closes #1866

### Heads-up for reviewers: the GET response shape changed

`GET /api/feedback` used to return a bare `IFeedbackDocument[]`. It now returns an envelope:

```
{ items, total, page, limit, organizations }
```

The endpoint is reachable with an API key (`baseApi()` runs the api-key chain by default and this
route declares no `requiredScopes`), and it is listed in the in-app API reference, so this is a
breaking change for any external caller. It is a wire-format change rather than a changed package
export, so no overlay implementer breaks and the title carries no `!` -- but it is the thing to
argue with me about if you are going to argue with something.

Relatedly: a non-admin caller used to get a thrown `Permission denied`. It now returns that
caller's own reports. That scoped read is the deliverable the author-facing surfaces need, and it
is why the ownership grants had to ship together with the by-instance authorization (see below).

## Changes

**Scoped reads and deletes (first commit)**

- `read` and `delete` grants on feedback, conditioned on `{ userId }`, in both mirrored ability
  files.
- Converted all three feedback routes that authorized **by class** to authorize against the
  fetched document instead. This was mandatory in the same commit: `can(action, FeedbackModel)`
  does **not** evaluate a rule's `{ userId }` condition and returns true as soon as any rule for
  the action exists. Adding the grants without converting the checks would have handed every
  logged-in user read access to all feedback and the ability to hard-delete anyone's report.
  The footgun is now pinned by tests in both ability files, so reverting a check fails the build.
- `read.ts` and `delete.ts` return the same `NotFoundError` for "not yours" as for "does not
  exist", so a probe cannot use the status to confirm an id.

**Server-side list (second commit)**

- `GET /api/feedback` takes `page`, `limit`, `status`, `organization`, `organizationId`, `userId`,
  `sessionId`, `questId`, `subject`, `search`, `sort`, and narrows the query with
  `accessibleBy(req.ability, read)` rather than a by-class check. A caller with no read grant
  narrows to an unsatisfiable filter, so it fails closed.
- Projection allowlist excludes `promptMeta`, which carries the redaction-sensitive payload.
- Free-text search resolves through the `FeedbackText` sibling (content lives there behind a
  90-day TTL) and is regex-escaped.
- `organizations` for the filter dropdown is computed over the whole accessible set, **not** the
  filtered set, so selecting an organization cannot prune the dropdown that selected it.
- Client rewritten onto React Query with server paging; the page cursor resets on every filter
  change.

**Deep links (second commit)**

- `b4m-core/common/src/utils/deepLinks.ts` -- pure path builders, the single definition of the
  scheme, so the Slack/email payloads will emit exactly what the UI copies.
- `/admin` accepts `?tab=<slug>&feedbackId=<id>`; `/notebooks/$id` accepts `?questId=<id>`.
- `?tab=` carries a stable slug, never `AdminTab`'s positional enum number -- these links live in
  chat messages and outlive a reorder of that enum.
- Linked report renders in a card above the list, fetched by id, because with server-side paging
  it is usually not on the current page and may not match the active filters at all.
- The turn scroll goes through Virtuoso's index API; the target is virtualized out on arrival and
  has no DOM node to query.

## Guide for Testers

Environment: a preview deploy of this PR, or `app.staging.bike4mind.com` once merged. You need an
**admin** account, and a **second non-admin** account that has submitted at least one feedback
report. Substitute your own host for `<HOST>` below.

### A. The list still works, and now pages on the server

1. Sign in as an admin. Navigate: **Sidebar -> Admin -> User Ops -> Feedback**.
2. Expect the list to render with only **New** reports shown and "Total Feedback: N" above it.
3. Open your browser devtools **Network** tab and filter to `feedback`. Reload.
4. Expect exactly one `GET /api/feedback?...` request carrying `page=1` and `limit=20`, and a
   response body shaped `{ items, total, page, limit, organizations }` -- **not** a bare array.
   `items` must have at most 20 entries regardless of how many reports exist.
5. Change **Items per page** to `100`. Expect a new request with `limit=100` and a 200 response.
   There must be no option above 100 in that dropdown.
6. Click **Next**. Expect `page=2` in the request and different rows on screen.

### B. Filters reach the server

7. Check the **In Progress** box as well as New. Expect a request carrying both statuses and the
   page reset to 1.
8. Uncheck **all three** status boxes. Expect an **empty list** and **no** request fired. (If you
   see every report in the database here, that is the bug this step exists to catch.)
9. Re-check New. In the search box type `test`. Expect one request roughly 300ms after you stop
   typing -- not one per keystroke -- carrying `search=test`.
10. Open the **Organization** dropdown and select one organization. Expect the rows to narrow, and
    expect **the other organizations to still be listed in the dropdown** so you can clear or
    change the selection.
11. Click the **Created At** header. Expect a request with `sort=asc` and the oldest reports first.
    Note that reports are now ordered by date alone -- New reports no longer float above
    In Progress ones. That change is intentional.

### C. Deep links

12. On any feedback row, click the **link icon** ("Copy link to this report").
13. Expect a toast confirming the copy. Paste the clipboard into a new browser tab and load it.
14. Expect the URL to look like `https://<HOST>/admin?tab=feedback&feedbackId=<id>`. It must
    contain `tab=feedback`, **not** `tab=2` or any other number.
15. Expect that page to open the Admin console on the **Feedback** tab, with a highlighted
    "Linked report" card pinned above the list showing that one report.
16. While that card is showing, change the status filters so the linked report would **not**
    match. Expect the card to stay visible -- it is deliberately independent of the filters.
17. Click the **X** on the card. Expect the card to disappear and `feedbackId` to drop out of the
    URL, with the Feedback tab still selected.
18. Find a report that came from a chat session (it will show a **forum icon** next to the link
    icon) and click that icon.
19. Expect a **new browser tab** opening `/notebooks/<sessionId>?questId=<questId>`, landing on
    that conversation with the specific turn scrolled into view and briefly highlighted. In a very
    long conversation you may land at the newest message first and arrive at the highlighted turn
    as older history loads.
20. Find a report with no session attached (a general product report). Expect **no** forum icon on
    that row.

### D. Scoped reads -- the authorization change

21. Sign in as the **non-admin** account. Do not navigate to /admin (it is role-gated and will
    refuse you; that is unchanged).
22. From that session's devtools console, run:
    `await fetch('/api/feedback?page=1&limit=20').then(r => r.json())`
23. Expect a **200** with `items` containing **only that user's own reports** -- not other users'.
    Before this PR the same call threw `Permission denied`.
24. Note the id of a report belonging to a *different* user (get it from the admin session).
    As the non-admin, run `await fetch('/api/feedback/<other-users-id>/read')`.
25. Expect a **404**, with the same response as for a completely made-up id. It must not be a 403
    and must not differ between "not yours" and "does not exist".
26. As the non-admin, run `await fetch('/api/feedback/<other-users-id>/delete', {method:'DELETE'})`.
27. Expect a **404** and, checking as the admin, expect that report to **still exist**.
28. As the admin, delete any report through the UI. Expect the confirmation modal, then a success
    toast, and the row gone.

### E. CSV export

29. As the admin, with filters set so more than 20 reports match, click **Export**.
30. Expect a `feedback_YYYY-MM-DD.csv` download containing **every matching report**, not 20 rows.
    Open it and confirm the row count is close to the "Total Feedback: N" shown on screen.
31. Confirm the CSV contains no `promptMeta` column and no raw prompt payloads.

### Regression Checks

- The Feedback tab renders, pages, filters and searches as before -- this is a rewrite of how the
  data is fetched, so the whole tab is the regression surface.
- **Status updates**: change a report from New to In Progress with only "New" checked. The row
  should leave the list (it no longer matches) and the total should drop by one.
- **Status update with a card open**: arrive via a copied deep link, then change that same
  report's status in the row below. The pinned card must show the **new** status, not the old one.
- **Delete with a card open**: arrive via a deep link, then delete that report. The card must
  switch to the "no longer available" notice rather than keep showing a deleted report.
- The **Refresh** button still reloads the list and is disabled while loading.
- Chat is unaffected when no `?questId=` is present: open any session normally and confirm it
  still opens scrolled to the newest message with no jumping.
- QuestMaster's existing "jump to the message" behavior still works (`QuestMasterReply` drives it
  through `requestScrollToMessage`). It shares the scroll helper this PR extracted out of
  ChatHistory, so it is a real regression surface: open a QuestMaster reply that references an
  earlier turn and confirm clicking through still scrolls to and highlights that turn.
- Other admin tabs still open from the sidebar, and `?tab=` does not fight the sidebar: load
  `/admin?tab=feedback`, then click **Users** in the sidebar. You must land on Users and stay
  there.
- `/admin?emergency_access=...` still behaves as before (that search param was already there).

### What NOT to test

- Slack and email feedback notifications do **not** contain these links yet. This PR defines the
  scheme and builds the targets; the notification payloads that emit them are the follow-up
  (#1863). Do not expect a clickable link in a Slack feedback message.
- There is no end-user "my reports" UI. The scoped read endpoint and the author-facing delete are
  reachable by API key and by the follow-up work (#1869), not by a screen in this PR -- see
  Additional Information.
- Feedback **content retention** is unchanged (still 90 days); nothing here alters what expires or
  when.
- No AdminSettings were added, so there is nothing to hydrate on staging or prod.

## Additional Information

**Deliberately unreachable in this PR, stated so it is not mistaken for an oversight:** the
author-facing `delete` grant and the user-scoped list have no end-user screen here. Both are
reachable today via API key, and the UI that consumes them is #1869. I have not manufactured a
"my reports" page for them -- that is that issue's scope, not this one.

**Known follow-ups I did not fix here:**

- The content search collects matching `_id`s from `FeedbackText` with no cap before building an
  `$in`. It is bounded by the 90-day content TTL and replaces a path that shipped the entire
  collection to the browser, so it is not a regression -- but a very large match set would build a
  large `$in`. I left it uncapped rather than adding a silent `.limit()` that would drop matches
  without telling anyone.
- The CSV export issues up to 50 sequential requests to cover 5,000 rows. Fine from the admin UI;
  worth revisiting if it is ever driven by an API key under rate limiting.
- `help-embeddings.json` was **not** regenerated -- it needs an `OPENAI_API_KEY` this worktree does
  not have. `help-id-resolution.test.ts` does gate this, keyed on H2 sections, so the docs
  addition is written as an **H3 under the existing `## Actions`** rather than a new H2: no new
  chunk key, gate green, and the resulting tokenCount drift only warns (deliberately -- that test
  notes the repo holds no CI `OPENAI_API_KEY`). `## Actions` lands at ~677 of the chunker's
  800-token budget, so there is ~120 tokens of headroom before it re-splits at H3 boundaries and
  the gate does go red. Consequence: the new deep-link prose renders in the help panel but is not
  retrievable by Help AI chat until someone runs
  `pnpm --filter @bike4mind/scripts help:regenerate`. `help-index.json` is regenerated and
  committed.

## Developer Notes

- `b4m-core/common/src/utils/deepLinks.ts` is the single definition of the app's shareable URL
  scheme. Pure path functions with no env access, so client and server both import them; the
  server composes `requireEnv('APP_URL') + path`. Add new deep links here rather than
  interpolating URLs at the call site.
- `adminTabSlugs.ts` is the slug-to-tab map for `?tab=`. Adding a linkable admin tab is one line.
  It is a `Map` rather than an object literal on purpose -- an object lookup resolves
  `?tab=toString` to an inherited `Object.prototype` member, which passes the caller's
  `!== undefined` guard. There is a test for that.
- `Feedback/queryKeys.ts` centralizes the three query keys because three surfaces mirror the same
  records and every mutation has to refresh all of them.
- The `accessibleBy(ability, action).ofType(Model)` pattern is the correct way to scope a **list**
  to an ownership-conditioned grant in this codebase; `can(action, Model)` is the wrong tool and
  silently over-permits. Both ability files now carry a comment saying so at the grant site.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
