### PR TITLE
feat(session): typographic rendering for chat reply markdown

### DIFF
--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -2,22 +2,13 @@ import ImageContainer from '@client/app/components/Session/ImageContainer';
 import VideoContainer from '@client/app/components/Session/VideoContainer';
 import { Box, Stack, Chip, Avatar, Tooltip, Button, Alert } from '@mui/joy';
 import Typography from '@mui/joy/Typography';
-import React, {
-  FC,
-  useCallback,
-  useState,
-  useRef,
-  useEffect,
-  HTMLAttributes,
-  DetailedHTMLProps,
-  FunctionComponent,
-  ReactNode,
-  useMemo,
-  ComponentProps,
-} from 'react';
+import React, { FC, useCallback, useState, useRef, useEffect, ReactNode, useMemo, ComponentProps } from 'react';
 import ReactMarkdown, { ExtraProps } from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter/dist/cjs';
-import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { useTheme } from '@mui/joy/styles';
+import { createMarkdownComponents } from './markdown/markdownComponents';
+import { getMarkdownSyntaxTheme, type PrismStyle } from './markdown/syntaxTheme';
+import './markdown/observatory.css';
 import { useMessageEditMode } from '@client/app/hooks/useMessageEditMode';
 import ErrorBoundary from '@client/app/components/common/ErrorBoundary';
 import { highlightTextSearch } from '@client/app/components/GenAI/highlight';
@@ -102,338 +93,334 @@ function simpleHash(str: string): string {
   return Math.abs(hash).toString(36).slice(0, 8);
 }
 
-// Markdown `code` component: handles inline artifacts in code blocks
+// Markdown `code` component: handles inline artifacts in code blocks. The
+// Prism theme is closed over rather than read from a hook here, because the
+// caller already resolves the color scheme and this function deliberately
+// stays a plain render helper.
+const createCodeComponent = (syntaxTheme: PrismStyle) => {
+  const code = ({ node, className, children, ref, ...props }: ComponentProps<'code'> & ExtraProps) => {
+    const match = /language-(\w+)/.exec(className || '');
+    const language = match ? match[1] : 'text';
+    const codeContent = String(children).replace(/\n$/, '');
+    const lineCount = codeContent.split('\n').length;
+    const inline =
+      node?.position?.start.line === node?.position?.end.line &&
+      node?.position?.start.column !== node?.position?.end.column;
 
-const code = ({ node, className, children, ref, ...props }: ComponentProps<'code'> & ExtraProps) => {
-  const match = /language-(\w+)/.exec(className || '');
-  const language = match ? match[1] : 'text';
-  const codeContent = String(children).replace(/\n$/, '');
-  const lineCount = codeContent.split('\n').length;
-  const inline =
-    node?.position?.start.line === node?.position?.end.line &&
-    node?.position?.start.column !== node?.position?.end.column;
+    // Generate a stable yet unique ID for this code block
+    const position = node?.position?.start.line || '';
+    const firstChars = codeContent.slice(0, 100).replace(/\s/g, '');
+    const baseId = `code-${language}-${position}-${firstChars}`;
+    const contentHash = simpleHash(codeContent);
 
-  // Generate a stable yet unique ID for this code block
-  const position = node?.position?.start.line || '';
-  const firstChars = codeContent.slice(0, 100).replace(/\s/g, '');
-  const baseId = `code-${language}-${position}-${firstChars}`;
-  const contentHash = simpleHash(codeContent);
-
-  let artifactId: string;
-  if (!codeBlockRegistry.has(baseId)) {
-    codeBlockRegistry.set(baseId, new Set([contentHash]));
-    artifactId = baseId;
-  } else {
-    const hashSet = codeBlockRegistry.get(baseId)!;
-    if (!hashSet.has(contentHash)) {
-      hashSet.add(contentHash);
+    let artifactId: string;
+    if (!codeBlockRegistry.has(baseId)) {
+      codeBlockRegistry.set(baseId, new Set([contentHash]));
+      artifactId = baseId;
+    } else {
+      const hashSet = codeBlockRegistry.get(baseId)!;
+      if (!hashSet.has(contentHash)) {
+        hashSet.add(contentHash);
+      }
+      artifactId = `${baseId}-${contentHash}`;
     }
-    artifactId = `${baseId}-${contentHash}`;
-  }
 
-  // Legacy blog-draft JSON detection - fallback for drafts persisted before the
-  // <artifact> path; the artifact handler is now the primary route. Kept for
-  // backward compatibility; silently no-ops on non-matching JSON.
-  if (language === 'json') {
-    try {
-      const parsed = JSON.parse(codeContent);
-      if (
-        parsed.title &&
-        parsed.content &&
-        typeof parsed.title === 'string' &&
-        typeof parsed.content === 'string' &&
-        parsed.suggestedTags &&
-        Array.isArray(parsed.suggestedTags)
-      ) {
+    // Legacy blog-draft JSON detection - fallback for drafts persisted before the
+    // <artifact> path; the artifact handler is now the primary route. Kept for
+    // backward compatibility; silently no-ops on non-matching JSON.
+    if (language === 'json') {
+      try {
+        const parsed = JSON.parse(codeContent);
+        if (
+          parsed.title &&
+          parsed.content &&
+          typeof parsed.title === 'string' &&
+          typeof parsed.content === 'string' &&
+          parsed.suggestedTags &&
+          Array.isArray(parsed.suggestedTags)
+        ) {
+          return (
+            <Box sx={{ my: 2 }}>
+              <ContentTransformPreviewCard
+                data={{
+                  title: parsed.title,
+                  content: parsed.content,
+                  summary: parsed.summary || '',
+                  suggestedTags: parsed.suggestedTags,
+                }}
+              />
+            </Box>
+          );
+        }
+      } catch {
+        // Not a blog-draft JSON block - fall through to normal code rendering.
+      }
+    }
+
+    // Recharts inline rendering
+    if (language === 'recharts') {
+      try {
+        const rechartsConfig = parseChartJSON(codeContent);
         return (
-          <Box sx={{ my: 2 }}>
-            <ContentTransformPreviewCard
-              data={{
-                title: parsed.title,
-                content: parsed.content,
-                summary: parsed.summary || '',
-                suggestedTags: parsed.suggestedTags,
+          <RechartsRenderer
+            config={rechartsConfig}
+            title={rechartsConfig.title}
+            description={rechartsConfig.description}
+            forceMode="inline"
+          />
+        );
+      } catch (error) {
+        const errorMessage =
+          error instanceof ChartParseError ? getChartErrorMessage(error) : 'Invalid chart configuration';
+        return (
+          <Box sx={{ my: 2, p: 2, border: '1px solid', borderColor: 'danger.300', borderRadius: 'sm' }}>
+            <Typography level="body-sm" color="danger">
+              Error rendering chart: {errorMessage}
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                mt: 1,
+                p: 1,
+                bgcolor: 'background.level1',
+                borderRadius: 'sm',
+                fontSize: '0.875rem',
+                fontFamily: 'monospace',
+                overflow: 'auto',
+                maxHeight: '200px',
               }}
-            />
+            >
+              {codeContent}
+            </Box>
           </Box>
         );
       }
-    } catch {
-      // Not a blog-draft JSON block - fall through to normal code rendering.
     }
-  }
 
-  // Recharts inline rendering
-  if (language === 'recharts') {
-    try {
-      const rechartsConfig = parseChartJSON(codeContent);
-      return (
-        <RechartsRenderer
-          config={rechartsConfig}
-          title={rechartsConfig.title}
-          description={rechartsConfig.description}
-          forceMode="inline"
-        />
-      );
-    } catch (error) {
-      const errorMessage =
-        error instanceof ChartParseError ? getChartErrorMessage(error) : 'Invalid chart configuration';
-      return (
-        <Box sx={{ my: 2, p: 2, border: '1px solid', borderColor: 'danger.300', borderRadius: 'sm' }}>
-          <Typography level="body-sm" color="danger">
-            Error rendering chart: {errorMessage}
-          </Typography>
-          <Box
-            component="pre"
-            sx={{
-              mt: 1,
-              p: 1,
-              bgcolor: 'background.level1',
-              borderRadius: 'sm',
-              fontSize: '0.875rem',
-              fontFamily: 'monospace',
-              overflow: 'auto',
-              maxHeight: '200px',
-            }}
-          >
-            {codeContent}
-          </Box>
-        </Box>
-      );
-    }
-  }
+    // Chess inline rendering
+    if (language === 'chess') {
+      try {
+        const jsonStr = extractChessJson(codeContent);
+        if (!jsonStr) throw new Error('No JSON in chess data');
+        const chessData = JSON.parse(jsonStr);
+        const fen = chessData.fen || chessData.resultingFen;
+        if (!fen) throw new Error('No FEN in chess data');
 
-  // Chess inline rendering
-  if (language === 'chess') {
-    try {
-      const jsonStr = extractChessJson(codeContent);
-      if (!jsonStr) throw new Error('No JSON in chess data');
-      const chessData = JSON.parse(jsonStr);
-      const fen = chessData.fen || chessData.resultingFen;
-      if (!fen) throw new Error('No FEN in chess data');
+        const turnLabel = chessData.turn === 'w' ? 'White' : 'Black';
+        let statusText = `${turnLabel} to move`;
+        if (chessData.isCheckmate) statusText = `Checkmate! ${chessData.turn === 'w' ? 'Black' : 'White'} wins`;
+        else if (chessData.isStalemate) statusText = 'Stalemate \u2014 draw';
+        else if (chessData.isDraw) statusText = 'Draw';
+        else if (chessData.isCheck) statusText = `${turnLabel} to move \u2014 Check!`;
 
-      const turnLabel = chessData.turn === 'w' ? 'White' : 'Black';
-      let statusText = `${turnLabel} to move`;
-      if (chessData.isCheckmate) statusText = `Checkmate! ${chessData.turn === 'w' ? 'Black' : 'White'} wins`;
-      else if (chessData.isStalemate) statusText = 'Stalemate — draw';
-      else if (chessData.isDraw) statusText = 'Draw';
-      else if (chessData.isCheck) statusText = `${turnLabel} to move — Check!`;
-
-      const openChessInSidePanelFromCode = () => {
-        const urlSessionId =
-          typeof window !== 'undefined' ? window.location.pathname.match(/\/notebooks\/([^/]+)/)?.[1] : undefined;
-        let latest: LatestChessState | undefined;
-        if (urlSessionId) {
-          latest = latestChessStateMap.get(urlSessionId);
-        }
-        if (!latest) {
-          for (const entry of latestChessStateMap.values()) {
-            if (!latest || (entry.moveNumber ?? 0) >= (latest.moveNumber ?? 0)) {
-              latest = entry;
+        const openChessInSidePanelFromCode = () => {
+          const urlSessionId =
+            typeof window !== 'undefined' ? window.location.pathname.match(/\/notebooks\/([^/]+)/)?.[1] : undefined;
+          let latest: LatestChessState | undefined;
+          if (urlSessionId) {
+            latest = latestChessStateMap.get(urlSessionId);
+          }
+          if (!latest) {
+            for (const entry of latestChessStateMap.values()) {
+              if (!latest || (entry.moveNumber ?? 0) >= (latest.moveNumber ?? 0)) {
+                latest = entry;
+              }
             }
           }
-        }
-        const useFen = latest?.fen || fen;
-        const useJsonStr = latest?.jsonStr || jsonStr;
-        const useData = latest || chessData;
-        const now = new Date();
-        const chessArtifact: ChessArtifact = {
-          id: `chess-${useFen.replace(/\s+/g, '-').slice(0, 20)}-${Date.now()}`,
-          type: 'chess',
-          title: 'Chess Game',
-          content: useJsonStr,
-          createdAt: now,
-          updatedAt: now,
-          metadata: {
-            fen: useFen,
-            turn: useData.turn as 'w' | 'b' | undefined,
-            lastMove: useData.move ? { from: useData.move.from, to: useData.move.to } : undefined,
-            isCheck: useData.isCheck,
-            isCheckmate: useData.isCheckmate,
-            isDraw: useData.isDraw,
-            isGameOver: useData.isGameOver,
-            moveNumber: useData.moveNumber,
-          },
-        };
-        setSessionLayout({
-          layout: 'vertical',
-          artifactData: {
+          const useFen = latest?.fen || fen;
+          const useJsonStr = latest?.jsonStr || jsonStr;
+          const useData = latest || chessData;
+          const now = new Date();
+          const chessArtifact: ChessArtifact = {
+            id: `chess-${useFen.replace(/\s+/g, '-').slice(0, 20)}-${Date.now()}`,
             type: 'chess',
-            content: chessArtifact,
-            mimeType: 'application/vnd.ant.chess',
-            id: chessArtifact.id,
-          },
-        });
-      };
-
-      return (
-        <Box
-          onClick={openChessInSidePanelFromCode}
-          sx={{
-            my: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: 1,
-            cursor: 'pointer',
-            '&:hover': { opacity: 0.85 },
-          }}
-        >
-          <ChessBoard
-            fen={fen}
-            lastMove={chessData.move ? { from: chessData.move.from, to: chessData.move.to } : undefined}
-          />
-          <Typography level="body-sm" sx={{ fontWeight: 500 }}>
-            {statusText}
-            {chessData.moveNumber ? ` — Move ${chessData.moveNumber}` : ''}
-          </Typography>
-          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-            Click to open interactive board
-          </Typography>
-        </Box>
-      );
-    } catch (err) {
-      console.warn('[Chess] Failed to parse chess data:', err, 'Content:', codeContent.slice(0, 200));
-      return (
-        <Box sx={{ my: 2, p: 2, border: '1px solid', borderColor: 'danger.300', borderRadius: 'sm' }}>
-          <Typography level="body-sm" color="danger">
-            Error rendering chess board: {err instanceof Error ? err.message : 'Invalid data'}
-          </Typography>
-          <Box
-            component="pre"
-            sx={{
-              mt: 1,
-              p: 1,
-              bgcolor: 'background.level1',
-              borderRadius: 'sm',
-              fontSize: '0.875rem',
-              fontFamily: 'monospace',
-              overflow: 'auto',
-              maxHeight: '200px',
-            }}
-          >
-            {codeContent}
-          </Box>
-        </Box>
-      );
-    }
-  }
-
-  // Mermaid preview
-  if (language === 'mermaid') {
-    const validation = validateMermaidSyntax(codeContent);
-    const displayContent = validation.cleanedContent || codeContent;
-
-    return (
-      <Box
-        sx={{
-          my: 2,
-          cursor: 'pointer',
-          border: '1px solid',
-          borderColor: 'divider',
-          borderRadius: 'sm',
-          p: 2,
-          '&:hover': {
-            bgcolor: 'background.level1',
-          },
-        }}
-        onClick={() => {
-          const mermaidArtifact: MermaidArtifact = {
-            id: `mermaid-${Math.random().toString(36).substring(2, 11)}`,
-            type: 'mermaid',
-            title: 'Mermaid Diagram',
-            content: displayContent,
+            title: 'Chess Game',
+            content: useJsonStr,
+            createdAt: now,
+            updatedAt: now,
             metadata: {
-              chartType: 'flowchart',
-              description: 'Generated Mermaid diagram',
+              fen: useFen,
+              turn: useData.turn as 'w' | 'b' | undefined,
+              lastMove: useData.move ? { from: useData.move.from, to: useData.move.to } : undefined,
+              isCheck: useData.isCheck,
+              isCheckmate: useData.isCheckmate,
+              isDraw: useData.isDraw,
+              isGameOver: useData.isGameOver,
+              moveNumber: useData.moveNumber,
             },
-            createdAt: new Date(),
-            updatedAt: new Date(),
           };
-
           setSessionLayout({
             layout: 'vertical',
             artifactData: {
-              type: 'mermaid',
-              content: mermaidArtifact,
-              mimeType: 'text/plain',
-              id: mermaidArtifact.id,
+              type: 'chess',
+              content: chessArtifact,
+              mimeType: 'application/vnd.ant.chess',
+              id: chessArtifact.id,
             },
           });
-        }}
-      >
-        <Stack direction="row" spacing={1} alignItems="center" mb={1}>
-          <MermaidIcon sx={{ color: 'neutral.300', fontSize: '1.25rem' }} />
-          <Typography level="body-sm">Click to view Mermaid diagram</Typography>
-        </Stack>
+        };
+
+        return (
+          <Box
+            onClick={openChessInSidePanelFromCode}
+            sx={{
+              my: 2,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1,
+              cursor: 'pointer',
+              '&:hover': { opacity: 0.85 },
+            }}
+          >
+            <ChessBoard
+              fen={fen}
+              lastMove={chessData.move ? { from: chessData.move.from, to: chessData.move.to } : undefined}
+            />
+            <Typography level="body-sm" sx={{ fontWeight: 500 }}>
+              {statusText}
+              {chessData.moveNumber ? ` \u2014 Move ${chessData.moveNumber}` : ''}
+            </Typography>
+            <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+              Click to open interactive board
+            </Typography>
+          </Box>
+        );
+      } catch (err) {
+        console.warn('[Chess] Failed to parse chess data:', err, 'Content:', codeContent.slice(0, 200));
+        return (
+          <Box sx={{ my: 2, p: 2, border: '1px solid', borderColor: 'danger.300', borderRadius: 'sm' }}>
+            <Typography level="body-sm" color="danger">
+              Error rendering chess board: {err instanceof Error ? err.message : 'Invalid data'}
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                mt: 1,
+                p: 1,
+                bgcolor: 'background.level1',
+                borderRadius: 'sm',
+                fontSize: '0.875rem',
+                fontFamily: 'monospace',
+                overflow: 'auto',
+                maxHeight: '200px',
+              }}
+            >
+              {codeContent}
+            </Box>
+          </Box>
+        );
+      }
+    }
+
+    // Mermaid preview
+    if (language === 'mermaid') {
+      const validation = validateMermaidSyntax(codeContent);
+      const displayContent = validation.cleanedContent || codeContent;
+
+      return (
         <Box
-          component="pre"
           sx={{
-            p: 2,
+            my: 2,
+            cursor: 'pointer',
+            border: '1px solid',
+            borderColor: 'divider',
             borderRadius: 'sm',
-            bgcolor: 'background.level1',
-            overflow: 'auto',
-            fontSize: '0.875rem',
-            fontFamily: 'monospace',
-            whiteSpace: 'pre-wrap',
-            maxHeight: '100px',
+            p: 2,
+            '&:hover': {
+              bgcolor: 'background.level1',
+            },
+          }}
+          onClick={() => {
+            const mermaidArtifact: MermaidArtifact = {
+              id: `mermaid-${Math.random().toString(36).substring(2, 11)}`,
+              type: 'mermaid',
+              title: 'Mermaid Diagram',
+              content: displayContent,
+              metadata: {
+                chartType: 'flowchart',
+                description: 'Generated Mermaid diagram',
+              },
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            };
+
+            setSessionLayout({
+              layout: 'vertical',
+              artifactData: {
+                type: 'mermaid',
+                content: mermaidArtifact,
+                mimeType: 'text/plain',
+                id: mermaidArtifact.id,
+              },
+            });
           }}
         >
-          {displayContent}
+          <Stack direction="row" spacing={1} alignItems="center" mb={1}>
+            <MermaidIcon sx={{ color: 'neutral.300', fontSize: '1.25rem' }} />
+            <Typography level="body-sm">Click to view Mermaid diagram</Typography>
+          </Stack>
+          <Box
+            component="pre"
+            sx={{
+              p: 2,
+              borderRadius: 'sm',
+              bgcolor: 'background.level1',
+              overflow: 'auto',
+              fontSize: '0.875rem',
+              fontFamily: 'monospace',
+              whiteSpace: 'pre-wrap',
+              maxHeight: '100px',
+            }}
+          >
+            {displayContent}
+          </Box>
         </Box>
+      );
+    }
+
+    // Inline code or short snippet
+    if (inline || lineCount <= 10) {
+      return !inline ? (
+        <Box sx={{ position: 'relative' }}>
+          <CopyCodeButton code={codeContent} language={language} />
+          <SyntaxHighlighter
+            // @ts-ignore - ignoring style prop type issue
+            style={syntaxTheme}
+            customStyle={{ paddingTop: '32px' }}
+            language={language}
+            PreTag="div"
+            {...props}
+          >
+            {codeContent}
+          </SyntaxHighlighter>
+        </Box>
+      ) : (
+        // Bare <code>: observatory.css owns the inline-code skin, and a hardcoded
+        // sx here would only lose to it on specificity while reading as live.
+        <code {...props}>{children}</code>
+      );
+    }
+
+    // Longer code blocks -> CodeArtifact preview card
+    const extractedTitle = extractCodeBlockTitle(codeContent, language);
+
+    const codeArtifact = {
+      title: extractedTitle,
+      description: codeContent.split('\n').slice(0, 2).join('\n') + '...',
+      language,
+      code: codeContent,
+      lineCount,
+    };
+
+    return (
+      <Box sx={{ my: 2 }}>
+        <CodeArtifactPreviewCard data={codeArtifact} artifactId={artifactId} />
       </Box>
     );
-  }
-
-  // Inline code or short snippet
-  if (inline || lineCount <= 10) {
-    return !inline ? (
-      <Box sx={{ position: 'relative' }}>
-        <CopyCodeButton code={codeContent} language={language} />
-        <SyntaxHighlighter
-          // @ts-ignore - ignoring style prop type issue
-          style={oneDark}
-          customStyle={{ paddingTop: '32px' }}
-          language={language}
-          PreTag="div"
-          {...props}
-        >
-          {codeContent}
-        </SyntaxHighlighter>
-      </Box>
-    ) : (
-      <Box
-        component="code"
-        sx={{
-          padding: '3px 6px',
-          backgroundColor: 'neutral.700',
-          borderRadius: '.235rem',
-          color: 'neutral.50',
-          textWrap: 'balance',
-        }}
-        {...props}
-      >
-        {children}
-      </Box>
-    );
-  }
-
-  // Longer code blocks -> CodeArtifact preview card
-  const extractedTitle = extractCodeBlockTitle(codeContent, language);
-
-  const codeArtifact = {
-    title: extractedTitle,
-    description: codeContent.split('\n').slice(0, 2).join('\n') + '...',
-    language,
-    code: codeContent,
-    lineCount,
   };
 
-  return (
-    <Box sx={{ my: 2 }}>
-      <CodeArtifactPreviewCard data={codeArtifact} artifactId={artifactId} />
-    </Box>
-  );
+  return code;
 };
 
 // Other markdown components
@@ -1220,132 +1207,14 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
     [search]
   );
 
-  const p: FunctionComponent<
-    Omit<DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>, 'ref'> & ExtraProps
-  > = useCallback(
-    ({ node, children, color, ...props }) => {
-      const nodeWithParent = node as typeof node & { parent?: { children?: unknown[] } };
-      const isLast =
-        node &&
-        nodeWithParent.parent &&
-        Array.isArray(nodeWithParent.parent.children) &&
-        nodeWithParent.parent.children[nodeWithParent.parent.children.length - 1] === node;
+  // The reply's react-markdown override map. Everything not listed there renders
+  // as a bare semantic tag and is styled by observatory.css.
+  const markdownComponents = useMemo(() => createMarkdownComponents({ highlightText }), [highlightText]);
 
-      const childArray = React.Children.toArray(children);
-      const hasOnlyImage =
-        childArray.length === 1 &&
-        React.isValidElement(childArray[0]) &&
-        (childArray[0].type === ImageContainer ||
-          (typeof childArray[0].type === 'function' && childArray[0].type.name === 'img'));
-
-      if (hasOnlyImage) {
-        return <Box sx={{ mb: isLast ? '0 !important' : '8px !important' }}>{children}</Box>;
-      }
-
-      const processedChildren = React.Children.map(children, child => {
-        if (typeof child === 'string') {
-          return highlightText(child);
-        }
-        return child;
-      });
-
-      return (
-        <Typography
-          level={isMobile ? 'body-sm' : 'body-md'}
-          component="p"
-          gutterBottom={false}
-          sx={{ display: 'block', color: 'text.primary', mb: isLast ? '0 !important' : '8px !important' }}
-          {...props}
-          data-testid="ai-response"
-        >
-          {processedChildren}
-        </Typography>
-      );
-    },
-    [highlightText, isMobile]
-  );
-
-  const tableComponents = {
-    // Wide tables scroll horizontally inside their own wrapper. The reply body is
-    // no longer a scroll container (that caused Android to snap text selection to
-    // whole-block boundaries), so each element that can exceed the width owns its
-    // own overflow.
-    table: ({ node, children, ref, ...props }: ComponentProps<'table'> & ExtraProps) => (
-      <Box sx={{ overflowX: 'auto', maxWidth: '100%', margin: '1rem 0' }}>
-        <Box
-          component="table"
-          sx={{
-            width: '100%',
-            borderCollapse: 'collapse',
-            border: '1px solid',
-            borderColor: 'neutral.300',
-            borderRadius: '8px',
-            overflow: 'hidden',
-            color: 'text.primary',
-            '& th, & td': {
-              padding: '0.75rem',
-              border: '1px solid',
-              borderColor: 'divider',
-              color: 'text.primary',
-            },
-            '& th': {
-              backgroundColor: 'background.level1',
-              fontWeight: 'bold',
-              borderBottom: '2px solid',
-              borderBottomColor: 'divider',
-              color: 'text.primary',
-            },
-            '& tr:nth-of-type(even)': {
-              backgroundColor: 'background.level1',
-              color: 'text.primary',
-            },
-          }}
-          {...props}
-        >
-          {children}
-        </Box>
-      </Box>
-    ),
-    thead: ({ node, children, ref, ...props }: ComponentProps<'thead'> & ExtraProps) => (
-      <Box component="thead" {...props}>
-        {children}
-      </Box>
-    ),
-    tbody: ({ node, children, ref, ...props }: ComponentProps<'tbody'> & ExtraProps) => (
-      <Box component="tbody" {...props}>
-        {children}
-      </Box>
-    ),
-    tr: ({ children }: ComponentProps<'tr'> & ExtraProps) => <Box component="tr">{children}</Box>,
-    th: ({ children }: ComponentProps<'th'> & ExtraProps) => {
-      const processedChildren = React.Children.map(children, child => {
-        if (typeof child === 'string') {
-          return highlightText(child);
-        }
-        return child;
-      });
-
-      return (
-        <Box component="th" sx={{ color: 'text.primary' }}>
-          {processedChildren}
-        </Box>
-      );
-    },
-    td: ({ children }: ComponentProps<'td'> & ExtraProps) => {
-      const processedChildren = React.Children.map(children, child => {
-        if (typeof child === 'string') {
-          return highlightText(child);
-        }
-        return child;
-      });
-
-      return (
-        <Box component="td" sx={{ color: 'text.primary' }}>
-          {processedChildren}
-        </Box>
-      );
-    },
-  };
+  // palette.mode rather than useColorScheme(), which can report 'system'.
+  const replyTheme = useTheme();
+  const syntaxTheme = useMemo(() => getMarkdownSyntaxTheme(replyTheme.palette.mode), [replyTheme.palette.mode]);
+  const codeComponent = useMemo(() => createCodeComponent(syntaxTheme), [syntaxTheme]);
 
   const cleanReply = useMemo(() => {
     return omitBetweenTags(reply || '', '<think>', '</think>');
@@ -1601,7 +1470,7 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
       )}
 
       {showSyntaxHighlight ? (
-        <SyntaxHighlighter style={oneDark}>{processedContent || cleanReply}</SyntaxHighlighter>
+        <SyntaxHighlighter style={syntaxTheme}>{processedContent || cleanReply}</SyntaxHighlighter>
       ) : (
         <>
           <ThoughtBubbles content={thought || ''} isStreaming={!completed} defaultFolded={isExpandable} />
@@ -1811,63 +1680,50 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
                         )}
 
                         {displayContent && (
-                          <ReactMarkdown
-                            components={{
-                              p,
-                              code,
-                              h1: ({ children }) => (
-                                <Typography
-                                  level="h3"
-                                  component="h1"
-                                  sx={{ color: 'text.primary', mb: 2, mt: 2, display: 'block', width: '100%' }}
-                                >
-                                  {children}
-                                </Typography>
-                              ),
-                              h2: ({ children }) => (
-                                <Typography
-                                  level="h4"
-                                  component="h2"
-                                  sx={{ color: 'text.primary', mb: 1.5, mt: 1.5, display: 'block', width: '100%' }}
-                                >
-                                  {children}
-                                </Typography>
-                              ),
-                              img: ({ alt, src, title }) => {
-                                if (!src) {
-                                  return null;
-                                }
+                          // Root scope for observatory.css. It wraps the markdown
+                          // and nothing else: the banners, media grids and artifact
+                          // chrome are siblings above, and must not inherit the
+                          // reading typography or land in the `> *` measure rules.
+                          <div className="b4m-md">
+                            <ReactMarkdown
+                              components={{
+                                ...markdownComponents,
+                                code: codeComponent,
+                                img: ({ alt, src, title }) => {
+                                  if (!src) {
+                                    return null;
+                                  }
 
-                                const srcStr = typeof src === 'string' ? src : '';
-                                if (
-                                  srcStr.startsWith('/mnt/') ||
-                                  srcStr.startsWith('/tmp/') ||
-                                  srcStr.startsWith('file://') ||
-                                  srcStr.startsWith('sandbox:') ||
-                                  srcStr.includes('/mnt/data/')
-                                ) {
-                                  return null;
-                                }
+                                  const srcStr = typeof src === 'string' ? src : '';
+                                  if (
+                                    srcStr.startsWith('/mnt/') ||
+                                    srcStr.startsWith('/tmp/') ||
+                                    srcStr.startsWith('file://') ||
+                                    srcStr.startsWith('sandbox:') ||
+                                    srcStr.includes('/mnt/data/')
+                                  ) {
+                                    return null;
+                                  }
 
-                                return (
-                                  <ImageContainer
-                                    src={srcStr}
-                                    index={0}
-                                    totalImages={1}
-                                    images={[srcStr]}
-                                    onSendMessage={onSendMessage}
-                                  />
-                                );
-                              },
-                              a: link,
-                              ...tableComponents,
-                            }}
-                            remarkPlugins={[remarkGfmNoSingleTilde, [remarkMath, { singleDollarTextMath: false }]]}
-                            rehypePlugins={[rehypeKatex]}
-                            remarkRehypeOptions={{ clobberPrefix: `fn-${messageId ?? 'reply'}-` }}
-                          >
-                            {mathReadyContent}
-                          </ReactMarkdown>
+                                  return (
+                                    <ImageContainer
+                                      src={srcStr}
+                                      index={0}
+                                      totalImages={1}
+                                      images={[srcStr]}
+                                      onSendMessage={onSendMessage}
+                                    />
+                                  );
+                                },
+                                a: link,
+                              }}
+                              remarkPlugins={[remarkGfmNoSingleTilde, [remarkMath, { singleDollarTextMath: false }]]}
+                              rehypePlugins={[rehypeKatex]}
+                              remarkRehypeOptions={{ clobberPrefix: `fn-${messageId ?? 'reply'}-` }}
+                            >
+                              {mathReadyContent}
+                            </ReactMarkdown>
+                          </div>
                         )}
                       </>
                     )}

--- a/apps/client/app/components/Session/markdown/markdownComponents.test.tsx
+++ b/apps/client/app/components/Session/markdown/markdownComponents.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { createMarkdownComponents, NUM_CELL_CLASS, NUMTEXT_CELL_CLASS } from './markdownComponents';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const components = createMarkdownComponents({ highlightText: node => node });
+
+const Body = ({ markdown }: { markdown: string }) => (
+  <CssVarsProvider theme={appTheme}>
+    <div data-testid="md-root">
+      <ReactMarkdown components={components} remarkPlugins={[remarkGfm]}>
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  </CssVarsProvider>
+);
+
+const root = () => screen.getByTestId('md-root');
+
+/** Body-row cells of the first rendered table, row-major. */
+const bodyCells = () => Array.from(root().querySelectorAll('tbody td'));
+
+/** Body cells of one zero-based column of the first rendered table. */
+const column = (index: number) => {
+  const rows = Array.from(root().querySelectorAll('tbody tr'));
+  return rows.map(row => row.querySelectorAll('td')[index]);
+};
+
+describe('numeric-column detection', () => {
+  it('marks a column whose every body cell is one number, over enough rows', () => {
+    render(
+      <Body
+        markdown={['| Option | Hours |', '| --- | --- |', '| Alpha | 91 |', '| Bravo | 118 |', '| Charlie | 46 |'].join(
+          '\n'
+        )}
+      />
+    );
+
+    const hours = column(1);
+    expect(hours.map(cell => cell.className)).toEqual([NUM_CELL_CLASS, NUM_CELL_CLASS, NUM_CELL_CLASS]);
+    // The label column stays prose.
+    expect(column(0).every(cell => cell.className === '')).toBe(true);
+  });
+
+  it('scales the magnitude bar against the column maximum', () => {
+    render(
+      <Body
+        markdown={['| Option | Hours |', '| --- | --- |', '| Alpha | 50 |', '| Bravo | 100 |', '| Charlie | 25 |'].join(
+          '\n'
+        )}
+      />
+    );
+
+    expect(column(1).map(cell => cell.style.getPropertyValue('--b4m-md-bar'))).toEqual(['0.5000', '1.0000', '0.2500']);
+  });
+
+  it('reads thousands separators and decimals as one number', () => {
+    render(
+      <Body
+        markdown={['| Rack | Draw |', '| --- | --- |', '| A | 1,200 |', '| B | 18.5 |', '| C | 940 |'].join('\n')}
+      />
+    );
+
+    expect(column(1).every(cell => cell.className === NUM_CELL_CLASS)).toBe(true);
+  });
+
+  it('marks the header cell of a numeric column so it aligns with its body', () => {
+    render(
+      <Body markdown={['| Option | Hours |', '| --- | --- |', '| A | 91 |', '| B | 118 |', '| C | 46 |'].join('\n')} />
+    );
+
+    const headers = Array.from(root().querySelectorAll('thead th'));
+    expect(headers[1].className).toBe(NUM_CELL_CLASS);
+    expect(headers[0].className).toBe('');
+  });
+
+  it('leaves a two-row table alone: two values are not a comparison', () => {
+    render(<Body markdown={['| Option | Hours |', '| --- | --- |', '| Alpha | 91 |', '| Bravo | 118 |'].join('\n')} />);
+
+    expect(bodyCells().every(cell => cell.className === '')).toBe(true);
+    expect(bodyCells().every(cell => !cell.style.getPropertyValue('--b4m-md-bar'))).toBe(true);
+  });
+
+  it('leaves a column alone when any cell holds more than one number', () => {
+    render(
+      <Body
+        markdown={[
+          '| Option | Range |',
+          '| --- | --- |',
+          '| Alpha | 91 |',
+          '| Bravo | 100 to 118 |',
+          '| Charlie | 46 |',
+        ].join('\n')}
+      />
+    );
+
+    expect(column(1).every(cell => cell.className === '')).toBe(true);
+  });
+
+  it('treats a numeric column with an over-long cell as prose, and draws no bar', () => {
+    render(
+      <Body
+        markdown={[
+          '| Option | Note |',
+          '| --- | --- |',
+          '| Alpha | 91 |',
+          '| Bravo | 118 hours of sustained draw before the rig throttles |',
+          '| Charlie | 46 |',
+        ].join('\n')}
+      />
+    );
+
+    const notes = column(1);
+    expect(notes.every(cell => cell.className === NUMTEXT_CELL_CLASS)).toBe(true);
+    expect(notes.every(cell => !cell.style.getPropertyValue('--b4m-md-bar'))).toBe(true);
+  });
+
+  it('marks a body row whose first cell is wholly bold as the total row', () => {
+    render(
+      <Body
+        markdown={[
+          '| Option | Hours |',
+          '| --- | --- |',
+          '| Alpha | 91 |',
+          '| Bravo | 118 |',
+          '| **Total** | 209 |',
+        ].join('\n')}
+      />
+    );
+
+    const rows = Array.from(root().querySelectorAll('tbody tr'));
+    expect(rows.map(row => row.hasAttribute('data-b4m-md-total'))).toEqual([false, false, true]);
+  });
+});
+
+describe('semantic tags', () => {
+  it('renders h1 through h6 as their own heading tags', () => {
+    render(<Body markdown={['# One', '## Two', '### Three', '#### Four', '##### Five', '###### Six'].join('\n\n')} />);
+
+    ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].forEach((tag, index) => {
+      const heading = screen.getByRole('heading', { level: index + 1 });
+      expect(heading.tagName.toLowerCase()).toBe(tag);
+    });
+  });
+
+  it('renders lists, list items, blockquote and rule as bare semantic tags', () => {
+    render(<Body markdown={['- one', '- two', '', '1. first', '2. second', '', '> quoted', '', '---'].join('\n')} />);
+
+    expect(root().querySelector('ul')).not.toBeNull();
+    expect(root().querySelector('ol')).not.toBeNull();
+    expect(root().querySelectorAll('li')).toHaveLength(4);
+    expect(root().querySelector('blockquote')).not.toBeNull();
+    expect(root().querySelector('hr')).not.toBeNull();
+  });
+
+  it('renders strikethrough and task-list checkboxes as bare tags', () => {
+    render(<Body markdown={['~~gone~~', '', '- [x] done', '- [ ] pending'].join('\n')} />);
+
+    expect(root().querySelector('del')).not.toBeNull();
+    expect(root().querySelectorAll('input[type="checkbox"]')).toHaveLength(2);
+  });
+
+  it('renders a paragraph as a <p> carrying the reply test id', () => {
+    render(<Body markdown="A plain sentence." />);
+
+    const paragraph = screen.getByTestId('ai-response');
+    expect(paragraph.tagName.toLowerCase()).toBe('p');
+    expect(paragraph).toHaveTextContent('A plain sentence.');
+  });
+
+  it('wraps a table in its own overflow container', () => {
+    render(<Body markdown={['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n')} />);
+
+    const table = root().querySelector('table');
+    expect(table?.parentElement?.className).toBe('b4m-md-table-wrap');
+  });
+});

--- a/apps/client/app/components/Session/markdown/markdownComponents.tsx
+++ b/apps/client/app/components/Session/markdown/markdownComponents.tsx
@@ -1,0 +1,243 @@
+import React, { ComponentProps, CSSProperties, ReactNode, createContext, useContext, useMemo } from 'react';
+import type { Components, ExtraProps } from 'react-markdown';
+import ImageContainer from '@client/app/components/Session/ImageContainer';
+
+/**
+ * The react-markdown override map for assistant replies.
+ *
+ * The governing choice: elements render as bare semantic HTML and
+ * `observatory.css` styles them by descendant selector. An override earns its
+ * place here only by doing work CSS cannot - search highlighting, invalid-
+ * nesting repair, or the cross-row analysis a table needs before a cell can
+ * know how to set itself.
+ */
+
+/* --------------------------------------------------------------------------
+ * hast helpers
+ *
+ * react-markdown hands each component the same hast node object it built the
+ * element from, which is what lets the table analyse its own rows once and
+ * have every cell find its own verdict again by identity.
+ * ------------------------------------------------------------------------ */
+
+type HastNode = NonNullable<ExtraProps['node']>;
+type HastChild = HastNode['children'][number];
+
+const isElement = (node: HastChild | undefined, tagName?: string): node is HastNode =>
+  !!node && node.type === 'element' && (tagName === undefined || node.tagName === tagName);
+
+const textOf = (node: HastChild): string => {
+  if (node.type === 'text') return node.value;
+  if (node.type === 'element') return node.children.map(textOf).join('');
+  return '';
+};
+
+const childElements = (node: HastNode, tagName?: string): HastNode[] =>
+  node.children.filter((child): child is HastNode => isElement(child, tagName));
+
+/** Returns every <tr> under the table's <tbody> elements, in document order. */
+const bodyRowsOf = (table: HastNode): HastNode[] =>
+  childElements(table, 'tbody').flatMap(tbody => childElements(tbody, 'tr'));
+
+/** Returns every <tr> under the table's <thead> elements, in document order. */
+const headRowsOf = (table: HastNode): HastNode[] =>
+  childElements(table, 'thead').flatMap(thead => childElements(thead, 'tr'));
+
+const cellsOf = (row: HastNode): HastNode[] =>
+  row.children.filter((c): c is HastNode => isElement(c, 'td') || isElement(c, 'th'));
+
+/* --------------------------------------------------------------------------
+ * numeric-column analysis
+ * ------------------------------------------------------------------------ */
+
+/** Matches a single quantity: digits, optional thousands separators, optional decimal. */
+const NUMBER_RE = /\d[\d,]*(?:\.\d+)?/g;
+
+/** A column is read as prose once any of its cells is this long, however numeric it looks. */
+const PROSE_CELL_LENGTH = 24;
+
+/** A comparison needs enough rows to be a comparison. */
+const MIN_COMPARABLE_ROWS = 3;
+
+export const NUM_CELL_CLASS = 'b4m-md-num';
+export const NUMTEXT_CELL_CLASS = 'b4m-md-numtext';
+
+interface CellMeta {
+  className?: string;
+  /** Value over column maximum, or undefined when the column draws no bar. */
+  bar?: number;
+}
+
+interface TableMeta {
+  cells: Map<HastNode, CellMeta>;
+  totalRows: Set<HastNode>;
+}
+
+const EMPTY_TABLE_META: TableMeta = { cells: new Map(), totalRows: new Set() };
+
+const TableMetaContext = createContext<TableMeta>(EMPTY_TABLE_META);
+
+/**
+ * Parses one column to numbers. Returns null unless the column is honestly
+ * comparable: every body cell must yield exactly one number, there must be
+ * enough rows to compare, and the maximum must be positive (a column of zeroes
+ * has no magnitude to draw).
+ */
+const columnValues = (rows: HastNode[][], column: number): number[] | null => {
+  if (rows.length < MIN_COMPARABLE_ROWS) return null;
+  const values: number[] = [];
+  for (const row of rows) {
+    const cell = row[column];
+    if (!cell) return null;
+    const matches = textOf(cell).trim().match(NUMBER_RE);
+    if (!matches || matches.length !== 1) return null;
+    const value = Number(matches[0].replace(/,/g, ''));
+    if (!Number.isFinite(value)) return null;
+    values.push(value);
+  }
+  return Math.max(...values) > 0 ? values : null;
+};
+
+/**
+ * Classifies every cell of a table and marks its total row, once per parse.
+ *
+ * A numeric column is right-aligned with tabular figures and gets a magnitude
+ * bar; the same column is demoted to left-aligned mono the moment one of its
+ * cells is long enough to wrap, because a laddered column of wrapped text
+ * reads worse than plain prose.
+ */
+export const analyseTable = (table: HastNode): TableMeta => {
+  const bodyRows = bodyRowsOf(table).map(cellsOf);
+  const headRows = headRowsOf(table).map(cellsOf);
+  const columnCount = Math.max(0, ...bodyRows.map(row => row.length), ...headRows.map(row => row.length));
+
+  const cells = new Map<HastNode, CellMeta>();
+
+  for (let column = 0; column < columnCount; column += 1) {
+    const values = columnValues(bodyRows, column);
+    if (!values) continue;
+
+    const longest = Math.max(...bodyRows.map(row => (row[column] ? textOf(row[column]).trim().length : 0)));
+    const isProse = longest > PROSE_CELL_LENGTH;
+    const className = isProse ? NUMTEXT_CELL_CLASS : NUM_CELL_CLASS;
+    const max = Math.max(...values);
+
+    headRows.forEach(row => {
+      if (row[column]) cells.set(row[column], { className });
+    });
+    bodyRows.forEach((row, rowIndex) => {
+      if (!row[column]) return;
+      cells.set(row[column], { className, bar: isProse ? undefined : values[rowIndex] / max });
+    });
+  }
+
+  // A body row whose first cell is wholly bold is a total: the model writes it
+  // as `**Total**`, and it wants a rule above it rather than a fill behind it.
+  const totalRows = new Set<HastNode>();
+  for (const row of bodyRowsOf(table)) {
+    const first = cellsOf(row)[0];
+    if (!first) continue;
+    const meaningful = first.children.filter(child => !(child.type === 'text' && child.value.trim() === ''));
+    if (meaningful.length === 1 && isElement(meaningful[0], 'strong')) totalRows.add(row);
+  }
+
+  return { cells, totalRows };
+};
+
+/* --------------------------------------------------------------------------
+ * component map
+ * ------------------------------------------------------------------------ */
+
+export interface MarkdownComponentsOptions {
+  /** Wraps matching runs of a search term in <mark>; identity when no search is active. */
+  highlightText: (node: ReactNode[] | string) => ReactNode;
+}
+
+const highlightStrings = (children: ReactNode, highlightText: MarkdownComponentsOptions['highlightText']): ReactNode =>
+  React.Children.map(children, child => (typeof child === 'string' ? highlightText(child) : child));
+
+/**
+ * Builds the components map for one reply. A factory rather than a constant
+ * because `highlightText` closes over the session's current search term.
+ */
+export const createMarkdownComponents = ({ highlightText }: MarkdownComponentsOptions): Components => {
+  const Paragraph: Components['p'] = ({ node, children, color, ...props }) => {
+    const childArray = React.Children.toArray(children);
+    // An image-only paragraph is unwrapped: ImageContainer renders a <div>, and
+    // a <div> inside a <p> is invalid nesting the browser silently repairs by
+    // closing the paragraph early, which breaks the reply's flow.
+    const hasOnlyImage =
+      childArray.length === 1 &&
+      React.isValidElement(childArray[0]) &&
+      (childArray[0].type === ImageContainer ||
+        (typeof childArray[0].type === 'function' && childArray[0].type.name === 'img'));
+
+    if (hasOnlyImage) {
+      return <div className="b4m-md-figure">{children}</div>;
+    }
+
+    return (
+      <p {...props} data-testid="ai-response">
+        {highlightStrings(children, highlightText)}
+      </p>
+    );
+  };
+
+  // Wide tables scroll horizontally inside their own wrapper. The reply body is
+  // not a scroll container (that made Android snap text selection to whole-block
+  // boundaries), so each element that can exceed the width owns its own overflow.
+  const Table = ({ node, children, ref, ...props }: ComponentProps<'table'> & ExtraProps) => {
+    const meta = useMemo(() => (node ? analyseTable(node) : EMPTY_TABLE_META), [node]);
+    return (
+      <TableMetaContext.Provider value={meta}>
+        <div className="b4m-md-table-wrap">
+          <table {...props}>{children}</table>
+        </div>
+      </TableMetaContext.Provider>
+    );
+  };
+
+  const Row = ({ node, children, ref, ...props }: ComponentProps<'tr'> & ExtraProps) => {
+    const { totalRows } = useContext(TableMetaContext);
+    const isTotal = !!node && totalRows.has(node);
+    return (
+      <tr {...props} {...(isTotal ? { 'data-b4m-md-total': '' } : {})}>
+        {children}
+      </tr>
+    );
+  };
+
+  const useCellMeta = (node: HastNode | undefined): CellMeta => {
+    const { cells } = useContext(TableMetaContext);
+    return (node && cells.get(node)) || {};
+  };
+
+  const HeaderCell = ({ node, children, ref, ...props }: ComponentProps<'th'> & ExtraProps) => {
+    const { className } = useCellMeta(node);
+    return (
+      <th {...props} className={className}>
+        {highlightStrings(children, highlightText)}
+      </th>
+    );
+  };
+
+  const Cell = ({ node, children, ref, ...props }: ComponentProps<'td'> & ExtraProps) => {
+    const { className, bar } = useCellMeta(node);
+    // The bar width is data, so it has to reach CSS as a value rather than a
+    // class; a custom property is the only channel for that.
+    const style = bar === undefined ? undefined : ({ '--b4m-md-bar': bar.toFixed(4) } as CSSProperties);
+    return (
+      <td {...props} className={className} style={style}>
+        {highlightStrings(children, highlightText)}
+      </td>
+    );
+  };
+
+  return {
+    p: Paragraph,
+    table: Table,
+    tr: Row,
+    th: HeaderCell,
+    td: Cell,
+  };
+};

--- a/apps/client/app/components/Session/markdown/observatory.css
+++ b/apps/client/app/components/Session/markdown/observatory.css
@@ -60,9 +60,11 @@
 }
 
 /* -- shape, fonts, measure -----------------------------------------------
-   No webfont is loaded. The body face is a system serif stack; the UI face
-   inherits whatever the app already set (Poppins today); mono defers to Joy's
-   own code family, which is what the rest of globals.css already does.
+   Three faces doing three jobs: a serif to read in, sans for chrome (headings
+   below h2, table heads, labels), mono for data. The serif and mono are
+   self-hosted by next/font in app/layout.tsx and reach this file as CSS
+   variables; the sans is deliberately the app's own UI face, so rendered
+   markdown does not introduce a fourth typeface next to the surrounding chrome.
 
    `.b4m-md` is a plain <div> that wraps the markdown and nothing else. It
    deliberately does NOT sit on the reply bubble: the bubble is a Joy
@@ -75,7 +77,12 @@
   --b4m-md-r: 10px;
   --b4m-md-r-sm: 6px;
 
-  --b4m-md-font-body: Georgia, 'Iowan Old Style', 'Source Serif 4', serif;
+  /* Self-hosted by next/font in app/layout.tsx. The fallback belongs INSIDE
+     var(): an undefined custom property makes the whole font-family invalid at
+     computed-value time, so a trailing comma-list would never be reached. The
+     variable is set on <html> server-side, but tests and any surface that
+     renders this CSS without the root layout rely on this. */
+  --b4m-md-font-body: var(--font-reading-serif, 'Source Serif 4'), Georgia, 'Iowan Old Style', serif;
 
   /* Must be a real stack, not `inherit`. This element sets font-family to the
      body serif, so an inheriting UI font would resolve to that serif and
@@ -92,16 +99,9 @@
     Arial,
     sans-serif
   );
-  --b4m-md-font-mono: var(
-    --joy-fontFamily-code,
-    ui-monospace,
-    'Monaco',
-    'Menlo',
-    'Ubuntu Mono',
-    'Consolas',
-    'source-code-pro',
-    monospace
-  );
+  --b4m-md-font-mono:
+    var(--font-reading-mono, 'JetBrains Mono'), ui-monospace, 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas',
+    'source-code-pro', monospace;
 
   /* Cap the reading measure on the flow children rather than on `.b4m-md`
      itself: the element is the reply bubble, and narrowing it would shrink its
@@ -212,19 +212,23 @@
   text-wrap: balance;
 }
 
+/* Optical sizing is left to the browser, which reads the serif's `opsz` axis
+   straight off font-size. Setting it by hand would mean font-variation-settings,
+   which resets every axis it does not name - including `wght`, silently
+   undoing the font-weight below. */
 .b4m-md h1 {
   font-family: var(--b4m-md-font-body);
+  font-optical-sizing: auto;
   font-size: 1.42em;
   font-weight: 600;
-  font-variation-settings: 'opsz' 44;
   margin: 2em 0 0.62em;
 }
 
 .b4m-md h2 {
   font-family: var(--b4m-md-font-body);
+  font-optical-sizing: auto;
   font-size: 1.2em;
   font-weight: 600;
-  font-variation-settings: 'opsz' 30;
   letter-spacing: -0.018em;
   margin: 1.85em 0 0.6em;
   padding-top: 0.72em;

--- a/apps/client/app/components/Session/markdown/observatory.css
+++ b/apps/client/app/components/Session/markdown/observatory.css
@@ -1,0 +1,559 @@
+/* =========================================================================
+   Chat markdown - "Observatory" reading treatment.
+
+   Scope: every rule below is a descendant of `.b4m-md`, the class on the
+   assistant reply body in PromptReplies.tsx. Nothing here is global.
+
+   Light/dark keys off `[data-joy-color-scheme]`, which MUI Joy's
+   InitColorSchemeScript writes on <html> before hydration. Do NOT switch this
+   to `[data-color-mode]` - that is the unrelated attribute the @uiw editor
+   packages use, and it is never set on this app's <html>.
+
+   Non-ASCII is deliberate in this file: .css is outside the repo's ASCII
+   guards (which cover .ts/.tsx/.mts/.cts only), and the typography here wants
+   real characters.
+   ========================================================================= */
+
+/* -- tokens --------------------------------------------------------------
+   The bare `.b4m-md` selector carries the light values so the body still
+   renders if the color-scheme attribute is missing (SSR, tests). Joy's own
+   default light scheme is 'light', so this is the same answer, not a guess. */
+.b4m-md,
+[data-joy-color-scheme='light'] .b4m-md {
+  --b4m-md-bg: #eceff3;
+  --b4m-md-bg-2: #ffffff;
+  --b4m-md-surface: #f6f9fb;
+  --b4m-md-surface-2: #edf2f6;
+  --b4m-md-line: rgba(16, 38, 56, 0.11);
+  --b4m-md-line-2: rgba(16, 38, 56, 0.22);
+  --b4m-md-ink: #141f28;
+  --b4m-md-ink-2: #425663;
+  --b4m-md-ink-3: #768895;
+  --b4m-md-accent: #0b6bcb;
+  --b4m-md-accent-soft: rgba(11, 107, 203, 0.07);
+  --b4m-md-accent-line: rgba(11, 107, 203, 0.32);
+  --b4m-md-warn: #9a6410;
+  --b4m-md-warn-soft: rgba(232, 163, 61, 0.14);
+  --b4m-md-danger: #c41c1c;
+  --b4m-md-ok: #167230;
+  --b4m-md-lift: rgba(255, 255, 255, 0.9);
+}
+
+[data-joy-color-scheme='dark'] .b4m-md {
+  --b4m-md-bg: #080b0e;
+  --b4m-md-bg-2: #0b1014;
+  --b4m-md-surface: #0f161d;
+  --b4m-md-surface-2: #0c1218;
+  --b4m-md-line: rgba(190, 215, 235, 0.085);
+  --b4m-md-line-2: rgba(190, 215, 235, 0.17);
+  --b4m-md-ink: #e8edf2;
+  --b4m-md-ink-2: #a6b5c1;
+  --b4m-md-ink-3: #6c7d8b;
+  --b4m-md-accent: #5aaaea;
+  --b4m-md-accent-soft: rgba(90, 170, 234, 0.11);
+  --b4m-md-accent-line: rgba(90, 170, 234, 0.34);
+  --b4m-md-warn: #e8a33d;
+  --b4m-md-warn-soft: rgba(232, 163, 61, 0.1);
+  --b4m-md-danger: #e5555a;
+  --b4m-md-ok: #43d08c;
+  --b4m-md-lift: rgba(255, 255, 255, 0.055);
+}
+
+/* -- shape, fonts, measure -----------------------------------------------
+   No webfont is loaded. The body face is a system serif stack; the UI face
+   inherits whatever the app already set (Poppins today); mono defers to Joy's
+   own code family, which is what the rest of globals.css already does.
+
+   `.b4m-md` is a plain <div> that wraps the markdown and nothing else. It
+   deliberately does NOT sit on the reply bubble: the bubble is a Joy
+   <Typography>, whose emitted class would tie this one on specificity and win
+   on injection order, and its children include banners and media grids that
+   must not inherit reading typography or match the `> *` measure rules below.
+   Because of that placement this file needs no specificity bumps and no
+   !important anywhere. */
+.b4m-md {
+  --b4m-md-r: 10px;
+  --b4m-md-r-sm: 6px;
+
+  --b4m-md-font-body: Georgia, 'Iowan Old Style', 'Source Serif 4', serif;
+
+  /* Must be a real stack, not `inherit`. This element sets font-family to the
+     body serif, so an inheriting UI font would resolve to that serif and
+     collapse the whole point: serif for reading, sans for chrome (headings
+     below h2, table heads, labels), mono for data. */
+  --b4m-md-font-ui: var(
+    --joy-fontFamily-body,
+    'Poppins',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif
+  );
+  --b4m-md-font-mono: var(
+    --joy-fontFamily-code,
+    ui-monospace,
+    'Monaco',
+    'Menlo',
+    'Ubuntu Mono',
+    'Consolas',
+    'source-code-pro',
+    monospace
+  );
+
+  /* Cap the reading measure on the flow children rather than on `.b4m-md`
+     itself: the element is the reply bubble, and narrowing it would shrink its
+     background and padding along with the text. */
+  --b4m-md-measure: min(100%, 68ch);
+  --b4m-md-measure-wide: min(100%, 76ch);
+
+  /* Container plumbing for the later rail work. The only thing that reads it
+     today is the measure widening at the bottom of this file. */
+  container-type: inline-size;
+  container-name: b4m-md;
+
+  font-family: var(--b4m-md-font-body);
+  line-height: 1.68;
+  color: var(--b4m-md-ink-2);
+  hanging-punctuation: first last;
+  text-wrap: pretty;
+}
+
+.b4m-md > :where(p, ul, ol, dl, blockquote, h1, h2, h3, h4, h5, h6) {
+  max-width: var(--b4m-md-measure);
+}
+
+.b4m-md > :first-child {
+  margin-top: 0;
+}
+
+.b4m-md > :last-child {
+  margin-bottom: 0;
+}
+
+/* -- prose ---------------------------------------------------------------- */
+.b4m-md p {
+  margin: 0 0 1.05em;
+  text-wrap: pretty;
+}
+
+/* An image-only paragraph, unwrapped to a <div> by markdownComponents.tsx
+   because <div> inside <p> is invalid nesting. It keeps the paragraph rhythm. */
+.b4m-md .b4m-md-figure {
+  margin: 0 0 1.05em;
+}
+
+.b4m-md strong {
+  color: var(--b4m-md-ink);
+  font-weight: 620;
+}
+
+.b4m-md em {
+  font-style: italic;
+}
+
+.b4m-md a {
+  color: var(--b4m-md-accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--b4m-md-accent-line);
+}
+
+.b4m-md a:hover {
+  border-bottom-color: var(--b4m-md-accent);
+}
+
+.b4m-md del {
+  color: var(--b4m-md-ink-3);
+  text-decoration: line-through;
+  text-decoration-color: var(--b4m-md-line-2);
+  text-decoration-thickness: 1px;
+}
+
+.b4m-md mark {
+  background: var(--b4m-md-warn-soft);
+  color: inherit;
+  border-radius: var(--b4m-md-r-sm);
+  padding: 0 0.15em;
+}
+
+.b4m-md sup,
+.b4m-md sub {
+  font-size: 0.72em;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+  font-family: var(--b4m-md-font-ui);
+}
+
+.b4m-md sup {
+  top: -0.5em;
+}
+
+.b4m-md sub {
+  bottom: -0.25em;
+}
+
+.b4m-md hr {
+  border: 0;
+  border-top: 1px solid var(--b4m-md-line);
+  margin: 2em 0;
+}
+
+/* -- headings -------------------------------------------------------------
+   h1-h3 come straight from the comp. h4-h6 extend the same idea: the scale
+   stops growing and starts receding, so a deep outline reads as structure
+   rather than as ever-smaller shouting. */
+.b4m-md :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--b4m-md-ink);
+  letter-spacing: -0.015em;
+  line-height: 1.22;
+  text-wrap: balance;
+}
+
+.b4m-md h1 {
+  font-family: var(--b4m-md-font-body);
+  font-size: 1.42em;
+  font-weight: 600;
+  font-variation-settings: 'opsz' 44;
+  margin: 2em 0 0.62em;
+}
+
+.b4m-md h2 {
+  font-family: var(--b4m-md-font-body);
+  font-size: 1.2em;
+  font-weight: 600;
+  font-variation-settings: 'opsz' 30;
+  letter-spacing: -0.018em;
+  margin: 1.85em 0 0.6em;
+  padding-top: 0.72em;
+  border-top: 1px solid var(--b4m-md-line);
+}
+
+.b4m-md h3 {
+  font-family: var(--b4m-md-font-ui);
+  font-size: 0.86em;
+  font-weight: 660;
+  letter-spacing: 0.02em;
+  margin: 1.5em 0 0.5em;
+}
+
+.b4m-md h4 {
+  font-family: var(--b4m-md-font-ui);
+  font-size: 0.8em;
+  font-weight: 640;
+  letter-spacing: 0.03em;
+  margin: 1.35em 0 0.45em;
+}
+
+.b4m-md h5 {
+  font-family: var(--b4m-md-font-ui);
+  font-size: 0.72em;
+  font-weight: 640;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--b4m-md-ink-2);
+  margin: 1.25em 0 0.4em;
+}
+
+.b4m-md h6 {
+  font-family: var(--b4m-md-font-ui);
+  font-size: 0.68em;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--b4m-md-ink-3);
+  margin: 1.2em 0 0.4em;
+}
+
+/* -- lists ----------------------------------------------------------------
+   Unordered markers are a hairline dash, not a bullet: at reading size a dot
+   is a blob and a dash is a rule, which is the language the rest of this
+   treatment speaks. Ordered markers recede to tertiary ink, because the
+   number is an index, not a claim. */
+.b4m-md ul,
+.b4m-md ol {
+  margin: 0 0 1.1em;
+  padding-left: 1.1em;
+}
+
+.b4m-md ul {
+  list-style: none;
+  padding-left: 1.25em;
+}
+
+.b4m-md ul > li {
+  position: relative;
+  margin-bottom: 0.5em;
+  text-wrap: pretty;
+}
+
+.b4m-md ul > li::before {
+  content: '';
+  position: absolute;
+  left: -1.05em;
+  top: 0.66em;
+  width: 5px;
+  height: 1px;
+  background: var(--b4m-md-ink-3);
+}
+
+.b4m-md ol > li {
+  margin-bottom: 0.5em;
+  padding-left: 0.25em;
+  text-wrap: pretty;
+}
+
+.b4m-md ol > li::marker {
+  color: var(--b4m-md-ink-3);
+  font-family: var(--b4m-md-font-mono);
+  font-size: 0.85em;
+}
+
+.b4m-md li > :last-child {
+  margin-bottom: 0;
+}
+
+.b4m-md li > ul,
+.b4m-md li > ol {
+  margin-top: 0.5em;
+}
+
+/* Task lists: GFM renders `- [x] done` as a checkbox inside the <li>. The
+   checkbox replaces the dash, so suppress the marker on exactly those rows. */
+.b4m-md li:has(> input[type='checkbox']) {
+  list-style: none;
+  padding-left: 0.1em;
+}
+
+.b4m-md li:has(> input[type='checkbox'])::before {
+  content: none;
+}
+
+.b4m-md li > input[type='checkbox'] {
+  appearance: none;
+  position: absolute;
+  left: -1.35em;
+  top: 0.42em;
+  width: 11px;
+  height: 11px;
+  margin: 0;
+  border: 1px solid var(--b4m-md-line-2);
+  border-radius: 3px;
+  background: transparent;
+}
+
+.b4m-md li > input[type='checkbox']:checked {
+  border-color: var(--b4m-md-accent-line);
+  background: var(--b4m-md-accent-soft);
+}
+
+.b4m-md li > input[type='checkbox']:checked::after {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 0;
+  width: 3px;
+  height: 7px;
+  border: solid var(--b4m-md-accent);
+  border-width: 0 1.5px 1.5px 0;
+  transform: rotate(42deg);
+}
+
+.b4m-md li:has(> input[type='checkbox']:checked) {
+  color: var(--b4m-md-ink-3);
+}
+
+/* -- blockquote -----------------------------------------------------------
+   A rule and a shift of register, not a tinted box: the quote is a different
+   voice, not a different importance. */
+.b4m-md blockquote {
+  margin: 0 0 1.3em;
+  padding: 0.1em 0 0.1em 1.15em;
+  border-left: 1px solid var(--b4m-md-line-2);
+  color: var(--b4m-md-ink-3);
+  font-style: italic;
+}
+
+.b4m-md blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.b4m-md blockquote strong {
+  color: var(--b4m-md-ink-2);
+}
+
+/* -- inline code ---------------------------------------------------------- */
+.b4m-md :not(pre) > code {
+  font-family: var(--b4m-md-font-mono);
+  font-size: 0.83em;
+  color: var(--b4m-md-ink);
+  background: var(--b4m-md-surface-2);
+  border: 1px solid var(--b4m-md-line);
+  padding: 0.08em 0.38em;
+  border-radius: var(--b4m-md-r-sm);
+  font-style: normal;
+}
+
+/* -- tables ---------------------------------------------------------------
+   Ruled above and below, never boxed: verticals fight the eye's left-to-right
+   scan, and a horizontal rule per row is all the separation a reader needs.
+   The per-column classes are set in markdownComponents.tsx, which is where the
+   numeric analysis has to live (CSS cannot look across rows). */
+.b4m-md .b4m-md-table-wrap {
+  margin: 0 0 1.5em;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.b4m-md table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 0;
+  font-family: var(--b4m-md-font-ui);
+  font-size: 0.84em;
+  line-height: 1.45;
+}
+
+.b4m-md thead th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.68em;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  color: var(--b4m-md-ink-3);
+  padding: 0 14px 9px;
+  border: 0;
+  border-bottom: 1px solid var(--b4m-md-line-2);
+  white-space: nowrap;
+}
+
+.b4m-md tbody td {
+  padding: 10px 14px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--b4m-md-line);
+  color: var(--b4m-md-ink-2);
+  vertical-align: top;
+}
+
+.b4m-md tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.b4m-md tbody tr:hover td {
+  background: var(--b4m-md-surface-2);
+}
+
+/* A column every body cell of which parses to exactly one number: right-align,
+   tabular figures, and a magnitude bar under the value. */
+.b4m-md .b4m-md-num {
+  font-family: var(--b4m-md-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1;
+  text-align: right;
+  white-space: nowrap;
+  color: var(--b4m-md-ink);
+}
+
+.b4m-md tbody td.b4m-md-num {
+  position: relative;
+}
+
+.b4m-md tbody td.b4m-md-num[style*='--b4m-md-bar']::after {
+  content: '';
+  position: absolute;
+  right: 14px;
+  bottom: 5px;
+  width: calc(var(--b4m-md-bar) * 62px);
+  height: 2px;
+  border-radius: 2px;
+  background: var(--b4m-md-accent);
+  opacity: 0.42;
+}
+
+/* Numeric but long enough to be read as prose (the >24-character guard): keep
+   the mono face and the tabular figures, drop the right-alignment and the bar
+   so a wrapped cell does not ladder away from its neighbours. */
+.b4m-md .b4m-md-numtext {
+  font-family: var(--b4m-md-font-mono);
+  font-size: 0.93em;
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+  white-space: normal;
+  color: var(--b4m-md-ink-2);
+}
+
+/* The total row is ruled, not filled: a fill reads as a highlight, and a total
+   is a boundary. */
+.b4m-md tbody tr[data-b4m-md-total] td {
+  background: transparent;
+  border-top: 1px solid var(--b4m-md-line-2);
+  color: var(--b4m-md-ink);
+}
+
+.b4m-md tbody tr[data-b4m-md-total] strong {
+  color: var(--b4m-md-ink);
+}
+
+.b4m-md tbody tr[data-b4m-md-total] td.b4m-md-num {
+  color: var(--b4m-md-accent);
+}
+
+/* -- footnotes ------------------------------------------------------------
+   remark-gfm emits <section data-footnotes> with an <ol> of definitions and an
+   <hr> just above it. The whole block is apparatus, so it drops a size and a
+   step of ink rather than carrying body weight. */
+.b4m-md section[data-footnotes] {
+  margin-top: 2em;
+  padding-top: 1.1em;
+  border-top: 1px solid var(--b4m-md-line);
+  font-size: 0.86em;
+  color: var(--b4m-md-ink-3);
+}
+
+.b4m-md section[data-footnotes] > h2 {
+  font-family: var(--b4m-md-font-ui);
+  font-size: 0.72em;
+  font-weight: 640;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--b4m-md-ink-3);
+  border-top: 0;
+  padding-top: 0;
+  margin: 0 0 0.8em;
+}
+
+.b4m-md section[data-footnotes] ol {
+  padding-left: 1.4em;
+}
+
+.b4m-md section[data-footnotes] li {
+  margin-bottom: 0.35em;
+}
+
+.b4m-md section[data-footnotes] p {
+  margin-bottom: 0.4em;
+}
+
+/* The <hr> remark-gfm inserts immediately before the footnote section would
+   double the section's own top rule. */
+.b4m-md hr + section[data-footnotes] {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.b4m-md .data-footnote-backref {
+  border-bottom: 0;
+}
+
+/* -- container plumbing ---------------------------------------------------
+   One query, one effect: when the reply column itself (not the viewport) is
+   wide, the measure relaxes. This exists to prove the container is wired so a
+   later branch can hang the margin rail off the same context. */
+@container b4m-md (min-width: 720px) {
+  .b4m-md > :where(p, ul, ol, dl, blockquote, h1, h2, h3, h4, h5, h6) {
+    max-width: var(--b4m-md-measure-wide);
+  }
+}

--- a/apps/client/app/components/Session/markdown/syntaxTheme.ts
+++ b/apps/client/app/components/Session/markdown/syntaxTheme.ts
@@ -1,0 +1,171 @@
+import type { CSSProperties } from 'react';
+
+/**
+ * Prism themes for chat-reply code blocks, derived from the Observatory
+ * palette in `observatory.css` so a fenced block sits in the same room as the
+ * prose around it instead of importing a second design language.
+ *
+ * Three rules carry the whole thing:
+ *   - comments recede to tertiary ink, because a comment is apparatus;
+ *   - strings and numbers are the only warm notes, so literal data is the one
+ *     thing that reads as content rather than as structure;
+ *   - keywords sit a step off the accent, near enough to belong to it and far
+ *     enough that an actual link or action still wins the eye.
+ *
+ * Shape matches react-syntax-highlighter's other Prism styles: a flat map of
+ * selector to inline-style object, passed as the `style` prop. The Prism
+ * plugin selectors oneDark also ships (rainbow-braces, previewers, diff and
+ * line-number chrome) are omitted - none of those plugins are loaded here.
+ */
+export type PrismStyle = Record<string, CSSProperties>;
+
+interface Palette {
+  bg: string;
+  fg: string;
+  ink: string;
+  ink3: string;
+  keyword: string;
+  string: string;
+  number: string;
+  danger: string;
+  ok: string;
+  selection: string;
+}
+
+const DARK: Palette = {
+  bg: '#0C1218',
+  fg: '#A6B5C1',
+  ink: '#E8EDF2',
+  ink3: '#6C7D8B',
+  keyword: '#8FC1F0',
+  string: '#D9A45E',
+  number: '#E8A33D',
+  danger: '#E5555A',
+  ok: '#43D08C',
+  selection: 'rgba(90, 170, 234, 0.18)',
+};
+
+const LIGHT: Palette = {
+  bg: '#EDF2F6',
+  fg: '#425663',
+  ink: '#141F28',
+  ink3: '#768895',
+  keyword: '#2364A8',
+  string: '#8A5A12',
+  number: '#9A6410',
+  danger: '#C41C1C',
+  ok: '#167230',
+  selection: 'rgba(11, 107, 203, 0.14)',
+};
+
+const FONT_STACK =
+  "var(--joy-fontFamily-code, ui-monospace, 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace)";
+
+/**
+ * Builds the full Prism style map for one palette.
+ */
+const build = (p: Palette): PrismStyle => {
+  const base: CSSProperties = {
+    background: p.bg,
+    color: p.fg,
+    fontFamily: FONT_STACK,
+    direction: 'ltr',
+    textAlign: 'left',
+    whiteSpace: 'pre',
+    wordSpacing: 'normal',
+    wordBreak: 'normal',
+    lineHeight: '1.55',
+    MozTabSize: '2',
+    OTabSize: '2',
+    tabSize: '2',
+    WebkitHyphens: 'none',
+    MozHyphens: 'none',
+    msHyphens: 'none',
+    hyphens: 'none',
+  };
+
+  const selection: CSSProperties = { background: p.selection, color: 'inherit', textShadow: 'none' };
+  const recessive: CSSProperties = { color: p.ink3 };
+  const comment: CSSProperties = { color: p.ink3, fontStyle: 'italic' };
+  const literal: CSSProperties = { color: p.string };
+  const numeric: CSSProperties = { color: p.number };
+  const keyword: CSSProperties = { color: p.keyword };
+  const structure: CSSProperties = { color: p.ink };
+  const body: CSSProperties = { color: p.fg };
+
+  return {
+    'code[class*="language-"]': base,
+    'pre[class*="language-"]': {
+      ...base,
+      padding: '1em',
+      margin: '0.5em 0',
+      overflow: 'auto',
+      borderRadius: '8px',
+      border: '1px solid rgba(128, 150, 170, 0.16)',
+    },
+    ':not(pre) > code[class*="language-"]': {
+      background: p.bg,
+      padding: '0.1em 0.3em',
+      borderRadius: '0.3em',
+      whiteSpace: 'normal',
+    },
+
+    'code[class*="language-"]::-moz-selection': selection,
+    'code[class*="language-"] *::-moz-selection': selection,
+    'pre[class*="language-"] *::-moz-selection': selection,
+    'code[class*="language-"]::selection': selection,
+    'code[class*="language-"] *::selection': selection,
+    'pre[class*="language-"] *::selection': selection,
+
+    comment,
+    prolog: comment,
+    cdata: comment,
+    doctype: comment,
+
+    punctuation: recessive,
+    operator: recessive,
+    entity: { ...recessive, cursor: 'help' },
+
+    keyword,
+    atrule: keyword,
+    important: { ...keyword, fontWeight: 'bold' },
+    selector: keyword,
+    'attr-name': keyword,
+
+    tag: structure,
+    'class-name': structure,
+    function: structure,
+    builtin: structure,
+    symbol: structure,
+    namespace: { ...structure, opacity: 0.7 },
+
+    string: literal,
+    char: literal,
+    regex: literal,
+    url: literal,
+    'attr-value': literal,
+    inserted: { color: p.ok },
+
+    number: numeric,
+    boolean: numeric,
+    constant: numeric,
+
+    variable: body,
+    property: body,
+
+    deleted: { color: p.danger },
+
+    bold: { fontWeight: 'bold' },
+    italic: { fontStyle: 'italic' },
+  };
+};
+
+/** Prism theme for chat-reply code blocks in dark mode. */
+export const observatoryDark: PrismStyle = build(DARK);
+
+/** Prism theme for chat-reply code blocks in light mode. */
+export const observatoryLight: PrismStyle = build(LIGHT);
+
+/** Returns the reply code-block Prism theme matching the resolved color scheme. */
+export const getMarkdownSyntaxTheme = (mode: 'light' | 'dark' | undefined): PrismStyle =>
+  mode === 'light' ? observatoryLight : observatoryDark;

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,7 +1,7 @@
 import '@/app/globals.css';
 import Script from 'next/script';
 import { ReactNode } from 'react';
-import { Poppins } from 'next/font/google';
+import { Poppins, Source_Serif_4, JetBrains_Mono } from 'next/font/google';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import { ClientProviders } from './providers';
 import { ColorSchemeScript } from './ColorSchemeScript';
@@ -19,6 +19,29 @@ const poppins = Poppins({
   preload: true,
 });
 
+// Reading faces for long-form rendered markdown. Exposed as CSS variables
+// rather than applied to <html>, so they reach only the surfaces that opt in
+// and the app's own chrome stays Poppins. Both are variable fonts: omitting
+// `weight` ships the whole range in one file, and the serif carries an optical
+// size axis that the browser applies automatically from font-size.
+const sourceSerif = Source_Serif_4({
+  subsets: ['latin'],
+  style: ['normal', 'italic'],
+  axes: ['opsz'],
+  display: 'swap',
+  preload: true,
+  variable: '--font-reading-serif',
+});
+
+// Not preloaded: mono only appears once a reply contains code, a table or a
+// figure, so it should not compete with the serif on first paint.
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  preload: false,
+  variable: '--font-reading-mono',
+});
+
 export const viewport = {
   width: 'device-width',
   initialScale: 1,
@@ -34,7 +57,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={poppins.className} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${poppins.className} ${sourceSerif.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
       <body>
         <ColorSchemeScript />
         {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (


### PR DESCRIPTION
## Description

Assistant replies render through `react-markdown` with a `components` override map of twelve keys: `p`, `code`, `h1`, `h2`, `img`, `a`, and the five table parts. Everything else falls through to bare HTML with **no styling at all** - `h3`-`h6`, `ul`/`ol`/`li`, `blockquote`, `hr`, `del`, task-list checkboxes, `sup`/`sub` and footnotes. A reply containing an `h3` renders it at the browser default, indistinguishable from bold body text, which is part of why models fake hierarchy with bold paragraphs instead of using the heading levels.

This gives rendered markdown a real type system, on its own scoped stylesheet, without changing what any of it parses to.

## Changes

- **`markdown/observatory.css`** (new) - every rule is a descendant of a single `.b4m-md` root; nothing is global. Token blocks key off `[data-joy-color-scheme]`, which Joy's `InitColorSchemeScript` writes on `<html>` before hydration. Covers the full heading scale, lists, blockquote, `hr`, inline code, `del`, `sup`/`sub`, task items, footnotes and tables. No `!important` anywhere.
- **`markdown/markdownComponents.tsx`** (new) - the override map, now mostly absent on purpose. Elements render as bare semantic tags and the stylesheet owns them, so `h3`-`h6` are covered without six more component overrides. What remains does real work: search highlighting, the image-only `<p>` unwrap, the per-table overflow wrapper, and numeric-column analysis that marks cells for tabular alignment and magnitude bars.
- **`markdown/syntaxTheme.ts`** (new) - replaces Prism's `oneDark` for reply code blocks with a palette derived from the same tokens, selected from `theme.palette.mode`. `oneDark` rendered dark regardless of the app's colour scheme.
- **`PromptReplies.tsx`** - wires the above in. Large diff, but roughly 320 lines of it are a pure reindent; **review with `git diff -w`**.
- **`layout.tsx`** - self-hosts Source Serif 4 and JetBrains Mono via `next/font/google`, following the existing Poppins setup. Both are exposed as CSS variables rather than applied to `<html>`, so they reach only surfaces that opt in.

### Notes for the reviewer

Three decisions worth a second opinion:

1. **`.b4m-md` wraps the markdown only, not the reply bubble.** The bubble's other children are banners and media grids, which must not inherit reading typography or match the `> *` measure rules. Putting the class on the bubble also meant fighting the Joy `Typography` emotion class on the same element; this placement removes the need for any specificity bump.
2. **`container-type: inline-size`** is set on that wrapper. Today it only widens the measure, but it is the plumbing for width-responsive treatments later: there is currently no width signal for the reply column at all, only a viewport media query (`useIsMobile`). **This is the riskiest line in the PR** - containment can perturb sticky positioning and absolutely-positioned descendants.
3. **The sans face is deliberately the app's own UI font, not a third webfont**, so a reply does not introduce a typeface the surrounding interface never uses.

`oneDark` is intentionally left in place in `CodeArtifactPreviewCard` and `OptimizeHistoryScriptModal` - converting those touches artifact rendering and belongs in its own PR.

## Guide for Testers

1. Open a notebook that already contains assistant replies with rich markdown (headings, lists, a table, a fenced code block). Expected: the reply body renders in a serif face, with headings, list markers and rules that are visibly styled.
2. In that reply, compare an `h1`, `h2` and `h3`. Expected: `h1` and `h2` are serif and get progressively smaller, `h2` has a hairline rule above it, and `h3` is a small uppercase-weight sans label - not bold body text.
3. Find a reply containing a bulleted list and a numbered list. Expected: bullets are a thin dash rule, numbers are mono and recessive. Neither uses the browser default disc/decimal.
4. Find a reply containing a markdown table with a numeric column of at least 3 rows. Expected: the numeric column is right-aligned in a mono face with aligned digits. Text columns stay left-aligned in the body face.
5. Find or generate a reply with a fenced code block of 10 lines or fewer. Expected: it renders with syntax highlighting and a copy button, in a palette that matches the app rather than the old purple-on-`#282c34`.
6. Click that copy button. Expected: the code copies and the button gives its normal confirmation.
7. Toggle the app between dark and light mode. Expected: the reply typography re-themes with the app in both directions, including the code block palette. Nothing stays stuck dark.
8. Narrow the browser window until the layout is mobile-width, then widen it again. Expected: reply text reflows and stays readable; no horizontal scrollbar appears on the reply body itself.
9. Select text spanning several paragraphs of a reply and copy it. Expected: the copied text has correct spacing and no doubled or missing whitespace.
10. Send a new message and watch the reply stream in. Expected: text appears progressively without code blocks flickering or remounting, and the final render matches step 1.

### Regression Checks

11. Confirm a reply containing only an image still renders the image (not an empty paragraph).
12. Confirm the search-highlight still works: run a notebook search for a word you know appears in a reply, and check it is highlighted in the reply body.
13. Confirm a wide table still scrolls horizontally inside its own wrapper rather than making the whole reply scroll.
14. Confirm a code block longer than 10 lines still renders as the artifact preview card, not an inline highlighted block.
15. Confirm the prompt-enhancement banner, file/image grids and the "Generating artifact..." indicator are unchanged - they sit outside the markdown wrapper and should not have picked up the serif face.

### What NOT to test

- Artifact rendering internals and the artifact viewer: `oneDark` is deliberately unchanged there.
- The other six `ReactMarkdown` call sites in `apps/client` (knowledge viewer, help centre, admin tabs, research tasks). They are untouched by this PR.

## Additional Information

**Verification performed**

- Client typecheck: clean on all tracked files.
- `apps/client` Session suite: 92 files / 656 tests passing.
- Both ASCII guards (`check-no-smart-punctuation.sh`, `check-no-control-bytes.sh`): pass. Non-ASCII in the `.css` is intentional and outside those guards, which cover `.ts`/`.tsx`/`.mts`/`.cts` only.
- Stylesheet validated in Chrome against the exact DOM `react-markdown` emits, in both colour schemes, including the font-variable-absent fallback path.

**Not yet verified, and worth a reviewer's eyes:** the change has not been exercised against a live reply in a running app - the local dev environment had no messages to render. Steps 5, 6, 10 and 13 above are the ones that would catch a problem with `container-type` containment.

**Pre-existing on `main`, not introduced here** (each confirmed by running it on `main`): the `premiumMigrationsWiring` test failure, and one `react-hooks/set-state-in-effect` warning in `PromptReplies.tsx`.

**Follow-ups**, deliberately out of scope: a semantic layer over recurring markdown shapes, built on the container plumbing added here; and migrating the remaining `oneDark` call sites.

## Developer Notes

- **New extension point**: `createMarkdownComponents({ highlightText })` is a factory, so the override map can be composed per surface. The other markdown call sites in `apps/client` can adopt it without duplicating the type system.
- **Reusable pattern**: tokens live in CSS custom properties under one root class rather than in the Joy palette, so an alternate visual treatment is a swap of one token block over the same DOM rather than a component rewrite.
- **Gotcha worth knowing**: `font-variation-settings: 'opsz' N` resets every axis it does not name, including `wght`. Two headings carried it, which would have silently voided their `font-weight` once a real variable font loaded. Use `font-optical-sizing: auto` instead.
- **Gotcha worth knowing**: a font fallback must go *inside* `var()`. An undefined custom property invalidates the whole `font-family` at computed-value time, so a trailing comma-separated list is never reached.
