### PR TITLE
feat(retrieval): sweep the forced-retrieval relevance floors offline

### DIFF
--- a/b4m-core/common/src/constants/forcedRetrieval.ts
+++ b/b4m-core/common/src/constants/forcedRetrieval.ts
@@ -54,3 +54,22 @@ export const FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT = 75;
  * the distribution any value chosen today would have been fitted to.
  */
 export const FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT = 85;
+
+/**
+ * Candidates above the ABSOLUTE floor retained for the char-budget walk, so resident chunk text
+ * stays bounded. The relative floor narrows this pool further, after the scan (it needs the turn's
+ * final top score), so this cap bounds memory on its own and does not depend on either floor.
+ *
+ * The budget can only fit this many sections while the mean retained chunk exceeds
+ * (configured char budget)/256 chars - ~47 at the 12,000-char default, which real chunking always
+ * clears. Since the char budget became a setting (`forcedRetrievalCharBudget`, defaulted by
+ * `FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT` above), a very large configured value could in principle
+ * admit more sections than this caps; a corpus of very short chunks could inject fewer than expected
+ * regardless of budget.
+ *
+ * Lives here rather than beside the scan it bounds because the offline floor sweep
+ * (`packages/scripts/retrieval/forcedFloorSweep.ts`) has to apply the same cap: the floors are
+ * measured over the pool that survives it, so a harness using a different ceiling would measure a
+ * cut the served path does not make.
+ */
+export const FORCED_RETRIEVAL_MAX_SCORED_CHUNKS = 256;

--- a/b4m-core/common/src/index.ts
+++ b/b4m-core/common/src/index.ts
@@ -79,6 +79,7 @@ export * from './utils/creditTransactionDisplay';
 export * from './utils/requireEnv';
 export * from './utils/internalStaffDomains';
 export * from './utils/countCodePoints';
+export * from './utils/forcedRetrievalFloors';
 export * from './utils/modelHelpers';
 export * from './utils/activity';
 export * from './utils/sseEvents';

--- a/b4m-core/common/src/utils/forcedRetrievalFloors.test.ts
+++ b/b4m-core/common/src/utils/forcedRetrievalFloors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareForcedRetrievalRank,
+  forcedRetrievalRelativeCutoff,
+  type ForcedRetrievalRankable,
+} from './forcedRetrievalFloors';
+
+describe('forcedRetrievalRelativeCutoff', () => {
+  it('is the requested fraction of the turn top score', () => {
+    expect(forcedRetrievalRelativeCutoff(0.914, 0.85)).toBeCloseTo(0.7769, 4);
+  });
+
+  it('returns 0 when the floor is off, so the caller takes its unfiltered branch', () => {
+    expect(forcedRetrievalRelativeCutoff(0.914, 0)).toBe(0);
+  });
+
+  it('never cuts the head of the ranking, at any floor up to 100%', () => {
+    // The setting caps at 100, so the fraction is at most 1 and the cutoff is at most `topScore`.
+    // With the `>=` comparison at the call sites, the best candidate always survives its own
+    // cutoff - the floor cannot starve a turn that had anything to serve.
+    const topScore = 0.83;
+    expect(topScore).toBeGreaterThanOrEqual(forcedRetrievalRelativeCutoff(topScore, 1));
+  });
+
+  it('disarms on a non-positive top score rather than inverting across zero', () => {
+    // 0.85 * -0.2 = -0.17, which is ABOVE the score it came from: a naive multiply would put the
+    // cutoff over every candidate and empty the pool. Unreachable on the served path (its absolute
+    // floor is positive) but reachable from the sweep, which takes arbitrary floor pairs.
+    expect(forcedRetrievalRelativeCutoff(-0.2, 0.85)).toBe(0);
+    expect(forcedRetrievalRelativeCutoff(0, 0.85)).toBe(0);
+  });
+});
+
+describe('compareForcedRetrievalRank', () => {
+  const c = (score: number, fileId: string, chunkId: string): ForcedRetrievalRankable => ({
+    score,
+    fileId,
+    chunkId,
+  });
+
+  it('orders by score descending', () => {
+    expect(compareForcedRetrievalRank(c(0.9, 'f', 'a'), c(0.8, 'f', 'b'))).toBeLessThan(0);
+  });
+
+  it('breaks a score tie on fileId, then chunkId', () => {
+    expect(compareForcedRetrievalRank(c(0.9, 'f1', 'z'), c(0.9, 'f2', 'a'))).toBeLessThan(0);
+    expect(compareForcedRetrievalRank(c(0.9, 'f1', 'a'), c(0.9, 'f1', 'b'))).toBeLessThan(0);
+  });
+
+  it('returns 0 only for the same ranking identity', () => {
+    expect(compareForcedRetrievalRank(c(0.9, 'f1', 'a'), c(0.9, 'f1', 'a'))).toBe(0);
+  });
+
+  it('is a total order, so a sort cannot depend on arrival order', () => {
+    // This is the property both callers rely on: the served path for stable citation numbering
+    // across two identical turns, the sweep for which candidates survive the pool cap.
+    const candidates = [c(0.9, 'f2', 'b'), c(0.9, 'f1', 'b'), c(0.95, 'f9', 'z'), c(0.9, 'f1', 'a')];
+    const forward = [...candidates].sort(compareForcedRetrievalRank);
+    const reversed = [...candidates].reverse().sort(compareForcedRetrievalRank);
+    expect(forward).toEqual(reversed);
+    expect(forward.map(x => `${x.fileId}/${x.chunkId}`)).toEqual(['f9/z', 'f1/a', 'f1/b', 'f2/b']);
+  });
+});

--- a/b4m-core/common/src/utils/forcedRetrievalFloors.test.ts
+++ b/b4m-core/common/src/utils/forcedRetrievalFloors.test.ts
@@ -61,3 +61,88 @@ describe('compareForcedRetrievalRank', () => {
     expect(forward.map(x => `${x.fileId}/${x.chunkId}`)).toEqual(['f9/z', 'f1/a', 'f1/b', 'f2/b']);
   });
 });
+
+/**
+ * Parity against the code these helpers were extracted from.
+ *
+ * The extraction was meant to be behavior-preserving, and `ChatCompletionFeatures.test.ts` passing
+ * both before and after cannot show that - it passes either way. The reference implementations below
+ * are the pre-extraction expressions VERBATIM (the cutoff from the forced-retrieval scan, the
+ * comparator from `compareForcedRetrievalCandidates`), so any future change to the shared helpers
+ * that would move the served path fails here and says so.
+ */
+describe('parity with the pre-extraction served path', () => {
+  const legacyCutoff = (topScore: number, relativeFloor: number): number =>
+    relativeFloor > 0 && topScore > 0 ? topScore * relativeFloor : 0;
+
+  type LegacyCandidate = { score: number; fabFileId: string; id: string };
+  const legacyCompare = (a: LegacyCandidate, b: LegacyCandidate): number => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.fabFileId !== b.fabFileId) return a.fabFileId < b.fabFileId ? -1 : 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  };
+
+  /** Deterministic PRNG, so a parity failure reproduces exactly instead of on one unlucky run. */
+  const nextRandom = (seed: number): (() => number) => {
+    let state = seed;
+    return () => {
+      state = (state * 1103515245 + 12345) % 2147483648;
+      return state / 2147483648;
+    };
+  };
+
+  it('computes the same relative cutoff over the whole input domain', () => {
+    const random = nextRandom(7);
+    // Deliberately includes negative and zero top scores and a 0 floor: those are the branches the
+    // extraction moved, so they are the ones parity has to cover.
+    const topScores = [-1, -0.2, 0, 0.0001, 0.75, 0.914, 1, ...Array.from({ length: 40 }, () => random() * 2 - 1)];
+    const floors = [0, 0.01, 0.5, 0.85, 0.95, 1, ...Array.from({ length: 20 }, () => random())];
+    for (const topScore of topScores) {
+      for (const floor of floors) {
+        expect(forcedRetrievalRelativeCutoff(topScore, floor)).toBe(legacyCutoff(topScore, floor));
+      }
+    }
+  });
+
+  it('produces the same total order, including ties on every tiebreak level', () => {
+    const random = nextRandom(11);
+    // A small id/score alphabet on purpose: it forces collisions on score alone, on score+file, and
+    // on all three, which is where a comparator rewrite actually goes wrong.
+    const candidates = Array.from({ length: 200 }, () => ({
+      score: Math.round(random() * 4) / 4,
+      fabFileId: `f${Math.floor(random() * 3)}`,
+      id: `c${Math.floor(random() * 5)}`,
+    }));
+
+    const legacyOrder = [...candidates].sort(legacyCompare).map(c => `${c.score}|${c.fabFileId}|${c.id}`);
+    const sharedOrder = [...candidates]
+      .sort((a, b) =>
+        compareForcedRetrievalRank(
+          { score: a.score, fileId: a.fabFileId, chunkId: a.id },
+          { score: b.score, fileId: b.fabFileId, chunkId: b.id }
+        )
+      )
+      .map(c => `${c.score}|${c.fabFileId}|${c.id}`);
+
+    expect(sharedOrder).toEqual(legacyOrder);
+  });
+
+  it('agrees on the sign of every pairwise comparison, not just the sorted result', () => {
+    // A sort can agree while the comparator disagrees on individual pairs, and it is the pairwise
+    // contract the in-scan trim depends on.
+    const random = nextRandom(13);
+    for (let i = 0; i < 500; i++) {
+      const pair = Array.from({ length: 2 }, () => ({
+        score: Math.round(random() * 3) / 3,
+        fabFileId: `f${Math.floor(random() * 2)}`,
+        id: `c${Math.floor(random() * 3)}`,
+      })) as [LegacyCandidate, LegacyCandidate];
+      const legacy = legacyCompare(pair[0], pair[1]);
+      const shared = compareForcedRetrievalRank(
+        { score: pair[0].score, fileId: pair[0].fabFileId, chunkId: pair[0].id },
+        { score: pair[1].score, fileId: pair[1].fabFileId, chunkId: pair[1].id }
+      );
+      expect(Math.sign(shared)).toBe(Math.sign(legacy));
+    }
+  });
+});

--- a/b4m-core/common/src/utils/forcedRetrievalFloors.ts
+++ b/b4m-core/common/src/utils/forcedRetrievalFloors.ts
@@ -1,0 +1,57 @@
+/**
+ * The arithmetic of the two forced-retrieval relevance floors, shared by the served path
+ * (`ChatCompletionFeatures.ts`, `KnowledgeRetrievalFeature`) and the offline sweep that exists to
+ * pick their values (`packages/scripts/retrieval/forcedFloorSweep.ts`).
+ *
+ * It lives here for the same reason `retrieval/scoreDistribution.ts` routes its scoring through the
+ * shipped `computeCosineSimilarity` rather than a local copy: a harness that reimplements the gate
+ * it is measuring can drift from it, and a sweep fitted to a drifted gate recommends a value for a
+ * filter that does not exist. Both callers multiplying the same way makes that impossible by
+ * construction, which a cross-reference comment cannot promise.
+ *
+ * UNITS. Every number here is a 0..1 cosine fraction. The two admin settings store whole-number
+ * percents, and `ChatCompletionFeatures`' `forcedRetrievalFloorFraction` divides by 100 exactly
+ * once before anything reaches this module - see `FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT` for
+ * why the stored unit is a percent. A caller passing 85 where 0.85 belongs gets a cutoff above every
+ * possible cosine and an empty result, so the fraction contract is stated rather than inferred.
+ */
+
+/**
+ * The absolute score a candidate must reach to clear the relative floor, or 0 when the floor is off.
+ *
+ * `topScore` is the turn's best score across the WHOLE scanned pool - every reachable lake, one
+ * pool, one top score - not a per-lake or per-file maximum. A per-lake rung would need per-lake
+ * top-score semantics defined first (see issue #2572, item 3).
+ *
+ * The `topScore > 0` guard is what makes this safe to share rather than inline. A multiplicative
+ * floor inverts across zero (0.85 * -0.2 = -0.17, ABOVE the score it came from), so on a negative
+ * top score the cutoff would sit above every candidate and empty the turn. The served path cannot
+ * reach that today because its absolute floor is positive, but the sweep can: it is handed arbitrary
+ * floor pairs by an operator, including `minSimilarity` 0 over a corpus with negative cosines.
+ */
+export function forcedRetrievalRelativeCutoff(topScore: number, relativeFloor: number): number {
+  return relativeFloor > 0 && topScore > 0 ? topScore * relativeFloor : 0;
+}
+
+/** The ranking identity of a scored chunk: enough to reproduce the served path's total order. */
+export type ForcedRetrievalRankable = {
+  score: number;
+  /** The parent file. `fabFileId` on the served path, `docId` in the offline fixtures. */
+  fileId: string;
+  chunkId: string;
+};
+
+/**
+ * Total order: score desc, then fileId, then chunkId.
+ *
+ * The explicit tiebreaker is load-bearing on both sides. On the served path chunks arrive in
+ * batches, so equal scores would otherwise be ordered by fetch order and the citation numbering
+ * could differ between two identical turns. In the sweep the same ties decide which candidates
+ * survive the `FORCED_RETRIEVAL_MAX_SCORED_CHUNKS` cap, and therefore what a floor is measured
+ * against - so a harness with its own tiebreak could report a cut the served path would not make.
+ */
+export function compareForcedRetrievalRank(a: ForcedRetrievalRankable, b: ForcedRetrievalRankable): number {
+  if (b.score !== a.score) return b.score - a.score;
+  if (a.fileId !== b.fileId) return a.fileId < b.fileId ? -1 : 1;
+  return a.chunkId < b.chunkId ? -1 : a.chunkId > b.chunkId ? 1 : 0;
+}

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -56,8 +56,11 @@ import {
   buildLakeMemoryContext,
   lakeMemoryFacts,
   FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+  FORCED_RETRIEVAL_MAX_SCORED_CHUNKS,
   FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
   FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+  compareForcedRetrievalRank,
+  forcedRetrievalRelativeCutoff,
   LAKE_RECALL_K_DEFAULT,
   DATALAKE_TAG_PREFIX,
   PROMPT_TEXT_MAX,
@@ -1704,15 +1707,6 @@ const FORCED_RETRIEVAL_FILE_BATCH_SIZE = 10;
 const FORCED_RETRIEVAL_BATCH_CHUNK_CAP = 1000;
 // Hard ceiling on chunks scored in one turn, so a few huge documents cannot stall a turn.
 const FORCED_RETRIEVAL_MAX_SCANNED_CHUNKS = 4000;
-// Candidates above the ABSOLUTE floor retained for the char-budget walk, so resident chunk text
-// stays bounded. The relative floor narrows this pool further, after the scan (it needs the turn's
-// final top score), so this cap bounds memory on its own and does not depend on either floor.
-// The budget can only fit this many sections while the mean retained chunk exceeds
-// (configured char budget)/256 chars - ~47 at the 12,000-char default, which real chunking always
-// clears. Since the char budget became a setting (see `forcedRetrievalCharBudget` below), a very
-// large configured value could in principle admit more sections than this caps; a corpus of very
-// short chunks could inject fewer than expected regardless of budget.
-const FORCED_RETRIEVAL_MAX_SCORED_CHUNKS = 256;
 // The char budget and both relevance floors are levers now (all three resolved once per turn by
 // resolveForcedRetrievalConfig below), so none is a module constant - every former
 // FORCED_RETRIEVAL_CHAR_BUDGET and FORCED_RETRIEVAL_MIN_SIMILARITY reference is a resolved local
@@ -1820,11 +1814,15 @@ interface ForcedRetrievalCoverage {
  * Total order: score desc, then fabFileId, then chunk id. The explicit tiebreaker matters now
  * that chunks arrive in batches - otherwise equal scores would be ordered by fetch order and the
  * citation numbering could differ between two identical turns.
+ *
+ * Delegates so the offline floor sweep can rank by the same order; see `compareForcedRetrievalRank`
+ * for why an independent tiebreak there would measure a cut this path does not make.
  */
 function compareForcedRetrievalCandidates(a: ForcedRetrievalCandidate, b: ForcedRetrievalCandidate): number {
-  if (b.score !== a.score) return b.score - a.score;
-  if (a.fabFileId !== b.fabFileId) return a.fabFileId < b.fabFileId ? -1 : 1;
-  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  return compareForcedRetrievalRank(
+    { score: a.score, fileId: a.fabFileId, chunkId: a.id },
+    { score: b.score, fileId: b.fabFileId, chunkId: b.id }
+  );
 }
 
 /**
@@ -2655,20 +2653,19 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       // corpus or an embedding model lands the scores in, where a fixed absolute line either admits
       // everything or nothing.
       //
-      // Skipped when the top score is not positive. `topScore` is not derived from `pool` - it is
-      // updated one line BEFORE the absolute-floor `continue`, so it tracks every finite scored
-      // candidate while `pool` holds only those that cleared the floor, and can therefore be
-      // negative here. The guard is inert either way: a non-positive `topScore` makes the product
-      // non-positive, so the `> 0` test below takes the unfiltered branch with or without it. Kept
-      // as documentation that a multiplicative floor inverts across zero (0.85 * -0.2 = -0.17,
-      // ABOVE the score it came from), which would matter if a future absolute floor admitted
-      // negatives.
+      // Skipped when the top score is not positive - that guard now lives in
+      // `forcedRetrievalRelativeCutoff`, along with the inversion-across-zero reasoning behind it.
+      // `topScore` is not derived from `pool`: it is updated one line BEFORE the absolute-floor
+      // `continue`, so it tracks every finite scored candidate while `pool` holds only those that
+      // cleared the floor, and can therefore be negative here. The guard is inert on THIS path (a
+      // non-positive `topScore` makes the product non-positive, so the unfiltered branch is taken
+      // either way) and load-bearing on the sweep's, which is handed arbitrary floor pairs.
       //
       // Cannot starve a turn: the fraction is at most 1 (the setting caps at 100) and `topScore`
       // equals the head of `ranked` whenever it is non-empty - the global maximum always clears the
       // absolute floor if anything does, and the in-scan trim retains the highest scores - so the
       // best candidate always survives its own cutoff. No new empty-handed exit is introduced.
-      const relativeCutoff = floors.relativeFloor > 0 && topScore > 0 ? topScore * floors.relativeFloor : 0;
+      const relativeCutoff = forcedRetrievalRelativeCutoff(topScore, floors.relativeFloor);
       const scored = relativeCutoff > 0 ? ranked.filter(c => c.score >= relativeCutoff) : ranked;
       if (scored.length < ranked.length) {
         this.logger.log(

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -59,7 +59,8 @@
     "retrieval:supersession-probe": "tsx retrieval/supersession-probe.ts",
     "retrieval:capture-embeddings": "tsx retrieval/capture-embeddings.ts",
     "retrieval:answerability-replay": "tsx retrieval/answerability-replay.ts",
-    "retrieval:model-comparison": "tsx retrieval/model-comparison.ts"
+    "retrieval:model-comparison": "tsx retrieval/model-comparison.ts",
+    "retrieval:forced-floor-sweep": "tsx retrieval/forced-floor-sweep.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.111.0",

--- a/packages/scripts/retrieval/MODEL-COMPARISON.md
+++ b/packages/scripts/retrieval/MODEL-COMPARISON.md
@@ -309,9 +309,79 @@ pnpm --filter @bike4mind/scripts retrieval:forced-floor-sweep \
   --floors 0:0,85:75,85:0,90:0,95:0
 ```
 
+### MEASURED: the first sweep off a real capture
+
+Run on the `system-help` lake (51 articles, 452 chunks, 30 `PROBE_QUESTIONS`) captured under both
+arms, 12000-char budget. Read the caveats at the end of this subsection before quoting any number.
+
+Shipped defaults are `forcedRetrievalRelativeFloorPct` 85 and `forcedRetrievalMinSimilarityPct` 75.
+
+| arm | floors | accepted/q | served/q | relative bound | emptied | recall | precision |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| ada-002 | 0:0 (baseline) | 256.0 | 15.7 | 0.0% | 0/30 | 100.0% | 3.8% |
+| ada-002 | 0:74 | 13.1 | 9.4 | 0.0% | 0/30 | 90.7% | 36.6% |
+| ada-002 | **85:75** (shipped) | 6.3 | 5.9 | **0.0%** | 2/30 | 65.3% | 39.6% |
+| ada-002 | 0:76 | 2.7 | 2.7 | 0.0% | 9/30 | 39.7% | 56.1% |
+| 3-small | **85:75** (shipped) | **0.0** | **0.0** | 0.0% | **30/30** | **0.0%** | n/a |
+| 3-small | 0:30 | 19.2 | 9.9 | 0.0% | 0/30 | 92.7% | 32.1% |
+| 3-small | 0:35 | 6.8 | 5.9 | 0.0% | 4/30 | 70.0% | 53.5% |
+| 3-small | 85:35 | 3.3 | 3.3 | 40.0% | 4/30 | 62.0% | 71.7% |
+
+`recall` and `precision` are over `accepted/q`, the population the floors gate. `served/q` is what
+the char budget then injects. The baseline row is the reason both columns are printed: its 100.0%
+recall is over 256 accepted chunks of which 15.7 reached the model, so a floor's apparent cost
+between the baseline and a live value is partly a cost the budget was already imposing.
+
+The hand-derivation held up: it predicted 85 rejecting nothing under ada-002 and cutting "around
+rank 5-6" under 3-small, and the sweep measures 0.0% bound and a mean cut rank of 5.2. Three things
+the measurement adds to it.
+
+**1. Where the absolute floor lands inside the band decides everything, and one point is a lot.**
+This corpus's ada-002 band is 0.0918 wide, so one point of the setting moves the gate by ~11% of the
+band. Measured, 74 -> 75 -> 76 is 90.7% -> 65.3% -> 39.7% recall, and 75 is the first value that
+empties a query outright. Here 74 dominates the shipped 75 - 25 points of recall, 0 emptied queries
+instead of 2, for 3 points of precision - though `served/q` says the model-visible difference is the
+narrower 9.4 vs 5.9, since the budget was already trimming 74's wider accepted set. That does NOT make 74 the value to ship: on the production
+lake in `FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT`'s comment the band sat at 0.8025-0.9140 and
+0.75 was below all of it, rejecting nothing. Same setting, same model, one corpus where it is a
+cliff and one where it is a no-op. A single global percent cannot be correct for both, which is the
+case for per-lake floors (#2572, item 3) rather than for a new global number.
+
+**2. The relative floor at 85 is inert on THIS corpus by arithmetic, not by luck.** A candidate
+reaching the relative cutoff has already cleared the absolute one, so the relative floor can only cut
+when `topScore * relativeFloor > minSimilarity`, i.e. when `topScore > minSimilarity /
+relativeFloor`. At 85:75 that is 0.882, and this corpus's ada-002 band max is 0.8110 - no query here
+can reach it. Sweeping 80/85/88/90/92 at absolute 75 changes not one column; the first value that
+binds is 95 (10% of queries). Note this is a statement about the corpus, not the vector space: the
+production lake behind `FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT`'s comment measured a band
+topping out at 0.9140, comfortably past 0.882, so the same default would bind there. Which is the
+point of measuring rather than deriving - "is this gate live" has a per-corpus answer, and a help
+corpus of short articles answers it differently from a lake of long documents.
+
+**3. The relative floor transfers across vector spaces and the absolute floor does not.** On this
+corpus the same 85 is inert under ada-002 and binds on 40% of queries under 3-small, because its
+threshold `0.35/0.85 = 0.412` lands mid-distribution against a measured `posTop` of 0.4269. Holding
+the absolute floor at 35 and adding it is what that buys: 0:35 -> 85:35 is 6.8 -> 3.3 chunks/q, mean
+cut rank 5.2, precision 53.5% -> 71.7% for 8 points of recall. The absolute floor meanwhile goes from "one point past the knee" to "above the entire
+band" - 0.75 exceeds 3-small's band max of 0.5588, so the shipped pair returns nothing on every
+query. That is the silent outage the band paragraph predicts, now measured: not a tuning nicety, a
+total blackout on the forced path. A raw cosine threshold is not comparable across embedding models;
+a fraction of the turn's top score is.
+
+Caveats, all of which bound how far these numbers travel:
+
+- **Not the long-document regime.** Median chunk 638 chars against a prod reference of 2182. Floor
+  values fitted on short help prose are not fitted for a production lake. Recapture before adopting
+  any specific number.
+- **Exact kNN, not the served ANN path.** The 256-chunk pool cap truncated all 30 queries at the low
+  floors, so every `cut @` is a rank within a truncated pool, and prod gates a top-K hit set rather
+  than this full scan (#2526).
+- 30 hand-authored questions, 5 of them negatives. Enough to separate a dead gate from a live one;
+  not enough to pick between two adjacent live values.
+
 Read `bound` before recall. A relative floor showing 0.0% there is the dormant case this section
-describes under ada-002; `cut @` against `budget-bound` is what separates a floor that cuts from one
-cutting past where the char budget already stopped. It shares the served path's arithmetic (see
+describes under ada-002; `cut @` against `budget-bound`, and `accepted/q` against `served/q`, are
+what separate a floor that cuts from one cutting past where the char budget already stopped. It shares the served path's arithmetic (see
 `forcedRetrievalRelativeCutoff`), so the gate it reports is the gate production applies - over a
 deeper candidate pool, since this harness is exact kNN and prod now serves through ANN.
 

--- a/packages/scripts/retrieval/MODEL-COMPARISON.md
+++ b/packages/scripts/retrieval/MODEL-COMPARISON.md
@@ -299,6 +299,22 @@ around rank 5-6. Given precision of 0.35 that may well be an improvement, but it
 switching on rather than a no-op, and it is the opposite direction from the "tune it UPWARD" note at its
 definition.
 
+Both paragraphs above were derived by hand from the band and the spread. `forced-floor-sweep.ts` now
+measures them directly off the same fixtures, so the re-tune after the embedding flip does not have to
+repeat the derivation:
+
+```bash
+pnpm --filter @bike4mind/scripts retrieval:forced-floor-sweep \
+  --fixture out/text-embedding-3-small.system-help.fixture.json \
+  --floors 0:0,85:75,85:0,90:0,95:0
+```
+
+Read `bound` before recall. A relative floor showing 0.0% there is the dormant case this section
+describes under ada-002; `cut @` against `budget-bound` is what separates a floor that cuts from one
+cutting past where the char budget already stopped. It shares the served path's arithmetic (see
+`forcedRetrievalRelativeCutoff`), so the gate it reports is the gate production applies - over a
+deeper candidate pool, since this harness is exact kNN and prod now serves through ANN.
+
 ## Out of scope
 
 This harness measures. It does not change anything. Flipping `defaultEmbeddingModel`, re-embedding the
@@ -312,6 +328,8 @@ pnpm --filter @bike4mind/scripts test retrieval/
 pnpm --filter @bike4mind/scripts typecheck
 pnpm --filter @bike4mind/scripts retrieval:model-comparison \
   --fixtures retrieval/fixtures/tiny-comparison.fixture.json --widths 16,8
+pnpm --filter @bike4mind/scripts retrieval:forced-floor-sweep \
+  --fixture retrieval/fixtures/tiny-comparison.fixture.json --floors 0:0,85:75
 ```
 
 `fixtures/tiny-comparison.fixture.json` is a 16-dim **synthetic** capture with a planted topical

--- a/packages/scripts/retrieval/MODEL-COMPARISON.md
+++ b/packages/scripts/retrieval/MODEL-COMPARISON.md
@@ -304,10 +304,24 @@ measures them directly off the same fixtures, so the re-tune after the embedding
 repeat the derivation:
 
 ```bash
+# ada-002 arm
+pnpm --filter @bike4mind/scripts retrieval:forced-floor-sweep \
+  --fixture out/text-embedding-ada-002.system-help.fixture.json \
+  --floors 0:0,0:74,85:75,0:76
+
+# 3-small arm
 pnpm --filter @bike4mind/scripts retrieval:forced-floor-sweep \
   --fixture out/text-embedding-3-small.system-help.fixture.json \
-  --floors 0:0,85:75,85:0,90:0,95:0
+  --floors 85:75,0:30,0:35,85:35
 ```
+
+**These two runs are what produced the MEASURED table below, and neither is reproducible from a
+clean clone.** `packages/scripts/out/` is gitignored, so the captures are not committed - 452 chunks
+of vectors per arm is not something to put in git. Re-making them means a staged capture against a
+provider key with real spend (see "Price the candidates, then run them" above). The only committed
+fixture is the synthetic `retrieval/fixtures/tiny-comparison.fixture.json`, which exercises the tool
+but measures no embedding model. `--fixture` is singular, one arm per run, so the table below is a
+hand-merge of these two runs with an `arm` column the tool does not print.
 
 ### MEASURED: the first sweep off a real capture
 
@@ -373,17 +387,42 @@ Caveats, all of which bound how far these numbers travel:
 - **Not the long-document regime.** Median chunk 638 chars against a prod reference of 2182. Floor
   values fitted on short help prose are not fitted for a production lake. Recapture before adopting
   any specific number.
-- **Exact kNN, not the served ANN path.** The 256-chunk pool cap truncated all 30 queries at the low
-  floors, so every `cut @` is a rank within a truncated pool, and prod gates a top-K hit set rather
-  than this full scan (#2526).
+- **A full scan, over a differently-composed pool than prod gates.** The 256-chunk pool cap
+  truncated all 30 queries at the low floors, so every `cut @` is a rank within a truncated pool;
+  that cap is genuinely shared with the served path. The rest is not: forced retrieval does not go
+  through Atlas `$vectorSearch` at all, so the divergence is not ANN vs exact kNN. It is the three
+  narrowings this harness does not model - a 100-file candidate cap ordered `fileName` ASC, a
+  4000-chunk per-turn scan budget, and supersession collapse before scoring. None binds on this
+  51-article fixture; all three bind on a production lake, and they make the served pool differently
+  composed rather than simply shallower.
+- **The budget is charged pre-defang, so `served/q` is optimistic.** This harness spends
+  `countCodePoints(text)`; the served walk spends `defangRetrievedContent(text).length`, which adds
+  one character per line starting `[`, `---`, `###`, `N. **` or `NOTE:`, and counts UTF-16 units
+  rather than code points. Both errors run the same direction, so the real `served/q` and
+  budget-bound rank are slightly below what is printed here - small on prose, systematic on markdown
+  headings and lists. Correcting it means re-capturing: `charLength` is fixture data, the fixture
+  schema carries no version field, and a capture taken under the old definition would load clean and
+  be swept under the new one.
 - 30 hand-authored questions, 5 of them negatives. Enough to separate a dead gate from a live one;
   not enough to pick between two adjacent live values.
 
 Read `bound` before recall. A relative floor showing 0.0% there is the dormant case this section
 describes under ada-002; `cut @` against `budget-bound`, and `accepted/q` against `served/q`, are
-what separate a floor that cuts from one cutting past where the char budget already stopped. It shares the served path's arithmetic (see
-`forcedRetrievalRelativeCutoff`), so the gate it reports is the gate production applies - over a
-deeper candidate pool, since this harness is exact kNN and prod now serves through ANN.
+what separate a floor that cuts from one cutting past where the char budget already stopped.
+
+**The table above is an abridged transcription of the tool's output.** The tool prints
+`relative | absolute | accepted/q | served/q | pre-rel | bound | cut @ | budget-bound | emptied |
+recall | precision | MRR`; the table drops `pre-rel`, `cut @`, `budget-bound` and `MRR`, and strips
+the denominator the tool prints beside precision (`n=`), which matters because that denominator
+moves with the configuration. So the two comparisons the paragraph above tells you to make have to
+be read off a fresh run, not off this table - as does the mean cut rank of 5.2 quoted earlier.
+
+What cannot drift is **the arithmetic**: `compareForcedRetrievalRank` and
+`forcedRetrievalRelativeCutoff` are one implementation with one definition site each, shared with
+the served path. The rest of the gate - the absolute-floor comparison, the `topScore` read, the cap
+application, and the budget walk - is hand-mirrored here and pinned only by comments. It agrees with
+the served scan today, and the budget walk is the one place it knowingly does not (see the
+pre-defang caveat above).
 
 ## Out of scope
 

--- a/packages/scripts/retrieval/forced-floor-sweep.ts
+++ b/packages/scripts/retrieval/forced-floor-sweep.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env tsx
+/**
+ * Sweep the two forced-retrieval relevance floors over captured embedding fixtures (#2572, item 2).
+ *
+ * Pure: no database, no provider key, no network, no stage. Everything it needs was already paid
+ * for by `capture-embeddings.ts`, so a floor pair costs nothing to try and the whole sweep can be
+ * re-run after the embedding migration (#471) re-captures the corpus - which is the point. Both
+ * floors ship at behavior-preserving defaults fitted to the ada-002 band, and that band moves on
+ * the migration; #2572 item 4 is the re-tune this instrument exists to inform.
+ *
+ * Paths are resolved from `packages/scripts/`, the cwd `pnpm --filter` runs in and where
+ * `capture-embeddings.ts` writes its `out/` by default, so the two halves agree without an absolute
+ * path in either.
+ *
+ *   pnpm --filter @bike4mind/scripts retrieval:forced-floor-sweep \
+ *     --fixture out/text-embedding-3-small.system-help.fixture.json \
+ *     --floors 0:0,85:75,85:0,90:0,95:0
+ *
+ * READ THE TABLE IN THIS ORDER. `bound` first: a relative floor with 0.0% there is inert on this
+ * corpus, which is the failure the relative floor was introduced to fix in the absolute one and is
+ * just as possible for the relative one at the wrong value. Then `cut @` against `budget-bound` - a
+ * floor cutting past where the char budget already stopped changes nothing that reaches the model.
+ * Only then recall and precision, which are the cost of a floor that does bind.
+ *
+ * ONE CAVEAT THE WRITE-UP MUST CARRY, inherited from `scoreDistribution.ts`: this is exact kNN over
+ * every captured chunk, where prod now serves through Atlas `$vectorSearch` (ANN, #2526). The
+ * served pool is a top-K hit set rather than a full scan, so a floor's cut rank measured here is
+ * measured over a deeper pool than production gates. The floor arithmetic is shared with the served
+ * path and cannot drift from it; the candidate set it runs over is the instrument's own.
+ */
+
+import { readFileSync } from 'node:fs';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT, FORCED_RETRIEVAL_MAX_SCORED_CHUNKS } from '@bike4mind/common';
+import { PROBE_QUESTIONS } from './corpus';
+import { loadEmbeddingFixture } from './embeddingFixture';
+import {
+  buildFloorSweepRow,
+  formatFloorSweepTable,
+  parseFloorConfigs,
+  type FloorScorableChunk,
+} from './forcedFloorSweep';
+
+const argv = await yargs(hideBin(process.argv))
+  .option('fixture', {
+    type: 'string',
+    demandOption: true,
+    describe: 'A capture fixture path (one model arm - floors are swept within one vector space)',
+  })
+  .option('floors', {
+    type: 'string',
+    default: '0:0,85:75',
+    describe:
+      'Comma-separated "relativeFloorPct:minSimilarityPct" pairs. 0 turns the relative floor off; ' +
+      '0 on the absolute floor is a floor AT zero, which still rejects negative cosines',
+  })
+  .option('char-budget', {
+    type: 'number',
+    default: FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+    describe: 'forcedRetrievalCharBudget to measure the floors against',
+  })
+  .strict()
+  .parse();
+
+if (!Number.isInteger(argv['char-budget']) || argv['char-budget'] < 0) {
+  throw new Error(`--char-budget must be a non-negative integer, got "${argv['char-budget']}"`);
+}
+
+// `loadEmbeddingFixture` also checks each query's `questionHash`, which matters here: a floor
+// measured against a reworded question is measured against ground truth that no longer describes
+// it, and the id alone cannot say which text was embedded under it.
+const fixture = loadEmbeddingFixture(JSON.parse(readFileSync(argv.fixture, 'utf8')) as unknown);
+
+const supportingById = new Map(PROBE_QUESTIONS.map(q => [q.id, q.supporting]));
+const queries = fixture.queries.map(q => ({
+  id: q.id,
+  vector: q.vector,
+  supporting: supportingById.get(q.id) ?? [],
+}));
+
+const chunks: FloorScorableChunk[] = fixture.chunks.map(c => ({
+  chunkId: c.chunkId,
+  docId: c.docId,
+  vector: c.vector,
+  charLength: c.charLength,
+}));
+
+const rows = parseFloorConfigs(argv.floors).map(config =>
+  buildFloorSweepRow({ config, chunks, queries, charBudget: argv['char-budget'] })
+);
+
+console.log(
+  `${fixture.model}@${fixture.dims} on ${fixture.corpus}: ` +
+    `${chunks.length} chunks, ${queries.length} queries, budget ${argv['char-budget']} chars\n`
+);
+console.log(formatFloorSweepTable(rows));
+
+// Loud rather than a column, because it is a caveat on how to read `cut @` and not a property of
+// either floor: past the cap the ranks are ranks within a truncated pool.
+const capped = rows.filter(r => r.cappedQueries > 0);
+if (capped.length > 0) {
+  console.log(
+    `
+NOTE: the ${FORCED_RETRIEVAL_MAX_SCORED_CHUNKS}-chunk pool cap truncated the candidate set on ` +
+      `${Math.max(...capped.map(r => r.cappedQueries))} of ${queries.length} queries. ` +
+      'Every "cut @" rank below is a rank within that truncated pool.'
+  );
+}

--- a/packages/scripts/retrieval/forced-floor-sweep.ts
+++ b/packages/scripts/retrieval/forced-floor-sweep.ts
@@ -20,7 +20,11 @@
  * corpus, which is the failure the relative floor was introduced to fix in the absolute one and is
  * just as possible for the relative one at the wrong value. Then `cut @` against `budget-bound` - a
  * floor cutting past where the char budget already stopped changes nothing that reaches the model.
- * Only then recall and precision, which are the cost of a floor that does bind.
+ * Only then recall and precision, which are the cost of a floor that does bind - and read those
+ * against `accepted/q` vs `served/q`, because they score the accepted set and only `served/q`
+ * reached the model. At a floor low enough to leave hundreds accepted on a corpus of short chunks
+ * the two differ by an order of magnitude, and the baseline row's flattering recall is mostly
+ * chunks no turn ever saw.
  *
  * ONE CAVEAT THE WRITE-UP MUST CARRY, inherited from `scoreDistribution.ts`: this is exact kNN over
  * every captured chunk, where prod now serves through Atlas `$vectorSearch` (ANN, #2526). The

--- a/packages/scripts/retrieval/forced-floor-sweep.ts
+++ b/packages/scripts/retrieval/forced-floor-sweep.ts
@@ -26,11 +26,21 @@
  * the two differ by an order of magnitude, and the baseline row's flattering recall is mostly
  * chunks no turn ever saw.
  *
- * ONE CAVEAT THE WRITE-UP MUST CARRY, inherited from `scoreDistribution.ts`: this is exact kNN over
- * every captured chunk, where prod now serves through Atlas `$vectorSearch` (ANN, #2526). The
- * served pool is a top-K hit set rather than a full scan, so a floor's cut rank measured here is
- * measured over a deeper pool than production gates. The floor arithmetic is shared with the served
- * path and cannot drift from it; the candidate set it runs over is the instrument's own.
+ * ONE CAVEAT THE WRITE-UP MUST CARRY: this is a full scan over every captured chunk, and the served
+ * forced path is not. The divergence is NOT ANN vs exact kNN - forced retrieval never touches Atlas
+ * `$vectorSearch` at all, it keyset-pages `findVectorsByFabFileIds` and scores in JS. That caveat
+ * belongs to `scoreDistribution.ts`, which measures the knowledge-tool path, and carrying it here
+ * contradicts the separation this harness exists to make.
+ *
+ * The real divergence is three narrowings the served path applies and this harness does not model:
+ * the candidate list is capped at FORCED_RETRIEVAL_MAX_CANDIDATE_FILES (100) ordered `fileName`
+ * ASC, so past the cap prod scores the alphabetically-first files rather than the most relevant;
+ * the scan stops at FORCED_RETRIEVAL_MAX_SCANNED_CHUNKS (4000) per turn; and superseded generations
+ * are dropped before scoring. So the served candidate set is not deeper or shallower than this one,
+ * it is differently composed - a floor fitted here is fitted to a pool prod may never assemble.
+ * None of the three binds on the 51-article `system-help` capture; all three bind on a production lake.
+ * The floor arithmetic is shared with the served path and cannot drift from it; the candidate set
+ * it runs over is the instrument's own.
  */
 
 import { readFileSync } from 'node:fs';
@@ -67,8 +77,11 @@ const argv = await yargs(hideBin(process.argv))
   .strict()
   .parse();
 
-if (!Number.isInteger(argv['char-budget']) || argv['char-budget'] < 0) {
-  throw new Error(`--char-budget must be a non-negative integer, got "${argv['char-budget']}"`);
+// Rejects 0, not just negatives: the served resolver's `positiveIntOr` can only yield >= 1, and at
+// 0 the budget walk below records one chunk served where the served walk breaks at the loop top and
+// emits nothing.
+if (!Number.isInteger(argv['char-budget']) || argv['char-budget'] < 1) {
+  throw new Error(`--char-budget must be a positive integer, got "${argv['char-budget']}"`);
 }
 
 // `loadEmbeddingFixture` also checks each query's `questionHash`, which matters here: a floor

--- a/packages/scripts/retrieval/forced-floor-sweep.ts
+++ b/packages/scripts/retrieval/forced-floor-sweep.ts
@@ -33,8 +33,8 @@ import { readFileSync } from 'node:fs';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT, FORCED_RETRIEVAL_MAX_SCORED_CHUNKS } from '@bike4mind/common';
-import { PROBE_QUESTIONS } from './corpus';
 import { loadEmbeddingFixture } from './embeddingFixture';
+import { resolveQueries } from './modelComparison';
 import {
   buildFloorSweepRow,
   formatFloorSweepTable,
@@ -72,12 +72,11 @@ if (!Number.isInteger(argv['char-budget']) || argv['char-budget'] < 0) {
 // it, and the id alone cannot say which text was embedded under it.
 const fixture = loadEmbeddingFixture(JSON.parse(readFileSync(argv.fixture, 'utf8')) as unknown);
 
-const supportingById = new Map(PROBE_QUESTIONS.map(q => [q.id, q.supporting]));
-const queries = fixture.queries.map(q => ({
-  id: q.id,
-  vector: q.vector,
-  supporting: supportingById.get(q.id) ?? [],
-}));
+// Reuses the model comparison's resolver rather than looking the ground truth up here, because it
+// makes an id `corpus.ts` does not know an ERROR. Defaulting such an id to an empty supporting set
+// would score it as a deliberate NEGATIVE, quietly inflating the false-positive rate and moving
+// precision's denominator - a complete, confident, wrong table.
+const queries = resolveQueries(fixture);
 
 const chunks: FloorScorableChunk[] = fixture.chunks.map(c => ({
   chunkId: c.chunkId,

--- a/packages/scripts/retrieval/forcedFloorSweep.test.ts
+++ b/packages/scripts/retrieval/forcedFloorSweep.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+import { FORCED_RETRIEVAL_MAX_SCORED_CHUNKS } from '@bike4mind/common';
+import {
+  applyFloors,
+  buildFloorSweepRow,
+  formatFloorConfig,
+  formatFloorSweepTable,
+  parseFloorConfigs,
+  SHIPPED_CONFIG,
+  ZERO_FLOOR_CONFIG,
+  type FloorScorableChunk,
+} from './forcedFloorSweep';
+
+/**
+ * A 2-dim unit-circle chunk at the requested cosine against the query `[1, 0]`, so every score in
+ * these tests is the number written at the call site rather than something to be re-derived.
+ */
+const chunkAt = (cosine: number, chunkId: string, docId = chunkId, charLength = 100): FloorScorableChunk => ({
+  chunkId,
+  docId,
+  vector: [cosine, Math.sqrt(Math.max(0, 1 - cosine * cosine))],
+  charLength,
+});
+
+const QUERY = { id: 'q01', vector: [1, 0] };
+
+describe('parseFloorConfigs', () => {
+  it('parses a sweep of relativeFloorPct:minSimilarityPct points', () => {
+    expect(parseFloorConfigs('0:0,85:75,95:0')).toEqual([
+      { relativeFloorPct: 0, minSimilarityPct: 0 },
+      { relativeFloorPct: 85, minSimilarityPct: 75 },
+      { relativeFloorPct: 95, minSimilarityPct: 0 },
+    ]);
+  });
+
+  it('tolerates whitespace and trailing separators', () => {
+    expect(parseFloorConfigs(' 0:0 , 90:75 ,')).toEqual([
+      { relativeFloorPct: 0, minSimilarityPct: 0 },
+      { relativeFloorPct: 90, minSimilarityPct: 75 },
+    ]);
+  });
+
+  it('requires exactly two components, since a missing one parses as a silent 0', () => {
+    // Number('') is 0 and Number.isInteger(0) is true, so "85:" would otherwise run an ungated
+    // absolute floor under the name of the 75 that was asked for.
+    expect(() => parseFloorConfigs('85:')).toThrow(/absolute floor/i);
+    expect(() => parseFloorConfigs(':75')).toThrow(/relative floor/i);
+    expect(() => parseFloorConfigs('85:75:60')).toThrow(/exactly/i);
+    expect(() => parseFloorConfigs('85')).toThrow(/exactly/i);
+  });
+
+  it('rejects a floor outside 0-100, the unit both settings store', () => {
+    expect(() => parseFloorConfigs('101:75')).toThrow(/relative floor/i);
+    expect(() => parseFloorConfigs('85:101')).toThrow(/absolute floor/i);
+    expect(() => parseFloorConfigs('-5:75')).toThrow(/relative floor/i);
+    expect(() => parseFloorConfigs('85:0.75')).toThrow(/absolute floor/i);
+  });
+
+  it('rejects an empty spec and a duplicated point', () => {
+    expect(() => parseFloorConfigs('')).toThrow(/no configurations/i);
+    expect(() => parseFloorConfigs('85:75,85:75')).toThrow(/duplicate/i);
+  });
+
+  it('accepts the shipped defaults and the zero-floor baseline', () => {
+    expect(parseFloorConfigs('0:0')).toEqual([ZERO_FLOOR_CONFIG]);
+    expect(parseFloorConfigs('85:75')).toEqual([SHIPPED_CONFIG]);
+  });
+});
+
+describe('formatFloorConfig', () => {
+  it('labels a point with both floors named', () => {
+    expect(formatFloorConfig({ relativeFloorPct: 90, minSimilarityPct: 75 })).toBe('relative=90% absolute=75%');
+  });
+});
+
+describe('applyFloors', () => {
+  it('admits every non-negative candidate at the zero-floor baseline', () => {
+    const outcome = applyFloors(QUERY, [chunkAt(0.9, 'a'), chunkAt(0.4, 'b')], ZERO_FLOOR_CONFIG);
+    expect(outcome.accepted).toBe(2);
+    expect(outcome.binding).toBe('none');
+    expect(outcome.cutRank).toBeNull();
+  });
+
+  it('still rejects a negative cosine at a zero absolute floor, as the served path does', () => {
+    // `score >= minSimilarity` with minSimilarity 0 is a real comparison, so "0" is a floor at zero
+    // and not an absent floor. Getting this wrong would inflate every baseline row in the table.
+    const outcome = applyFloors(QUERY, [chunkAt(0.9, 'a'), chunkAt(-0.3, 'b')], ZERO_FLOOR_CONFIG);
+    expect(outcome.scoredCount).toBe(2);
+    expect(outcome.accepted).toBe(1);
+    expect(outcome.binding).toBe('absolute');
+  });
+
+  it('cuts at a fraction of the turn top score, not at an absolute line', () => {
+    // top 0.90, relative 85% -> cutoff 0.765: 0.80 survives, 0.70 does not.
+    const outcome = applyFloors(QUERY, [chunkAt(0.9, 'a'), chunkAt(0.8, 'b'), chunkAt(0.7, 'c')], {
+      relativeFloorPct: 85,
+      minSimilarityPct: 0,
+    });
+    expect(outcome.relativeCutoff).toBeCloseTo(0.765, 4);
+    expect(outcome.accepted).toBe(2);
+    expect(outcome.cutRank).toBe(3);
+    expect(outcome.binding).toBe('relative');
+  });
+
+  it('is inert when the whole band sits inside the floor, which is what the sweep exists to show', () => {
+    // The measured ada-002 case: band 0.8025-0.9140, weakest/top ~= 0.878, so 85% rejects nothing.
+    const outcome = applyFloors(QUERY, [chunkAt(0.914, 'a'), chunkAt(0.8025, 'b')], SHIPPED_CONFIG);
+    expect(outcome.accepted).toBe(2);
+    expect(outcome.cutRank).toBeNull();
+    expect(outcome.binding).toBe('none');
+  });
+
+  it('applies the absolute floor before the relative one, so the top score can outrank the pool', () => {
+    // 0.9 clears the absolute floor; 0.5 does not, so it is gone before the relative floor is
+    // computed and cannot widen the pool the relative cutoff is measured against.
+    const outcome = applyFloors(QUERY, [chunkAt(0.9, 'a'), chunkAt(0.5, 'b')], {
+      relativeFloorPct: 85,
+      minSimilarityPct: 75,
+    });
+    expect(outcome.topScore).toBeCloseTo(0.9, 4);
+    expect(outcome.aboveAbsolute).toBe(1);
+    expect(outcome.accepted).toBe(1);
+    expect(outcome.binding).toBe('absolute');
+  });
+
+  it('reads topScore across every scored candidate, including ones the absolute floor rejected', () => {
+    // Mirrors the served path, where topScore is updated one line before the absolute-floor
+    // `continue`. Only observable when nothing clears that floor, as here.
+    const outcome = applyFloors(QUERY, [chunkAt(0.6, 'a'), chunkAt(0.5, 'b')], {
+      relativeFloorPct: 85,
+      minSimilarityPct: 75,
+    });
+    expect(outcome.topScore).toBeCloseTo(0.6, 4);
+    expect(outcome.accepted).toBe(0);
+  });
+
+  it('never empties a pool the absolute floor let through', () => {
+    // The fraction is at most 1 and the comparison is `>=`, so the head always survives its own
+    // cutoff. A floor that starved a turn with candidates in hand would be a defect, not a setting.
+    for (const relativeFloorPct of [1, 50, 85, 99, 100]) {
+      const outcome = applyFloors(QUERY, [chunkAt(0.9, 'a'), chunkAt(0.8, 'b')], {
+        relativeFloorPct,
+        minSimilarityPct: 0,
+      });
+      expect(outcome.accepted).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('drops a NaN cosine rather than letting it sort ahead of real hits', () => {
+    const zeroMagnitude: FloorScorableChunk = { chunkId: 'z', docId: 'z', vector: [0, 0], charLength: 10 };
+    const outcome = applyFloors(QUERY, [chunkAt(0.9, 'a'), zeroMagnitude], ZERO_FLOOR_CONFIG);
+    expect(outcome.scoredCount).toBe(1);
+    expect(outcome.acceptedDocIds).toEqual(['a']);
+  });
+
+  it('leaves the -1 top-score sentinel when nothing scored', () => {
+    const outcome = applyFloors(QUERY, [], SHIPPED_CONFIG);
+    expect(outcome.topScore).toBe(-1);
+    expect(outcome.relativeCutoff).toBe(0);
+    expect(outcome.accepted).toBe(0);
+  });
+
+  it('dedupes parent documents best-first, which is the order reciprocalRank reads', () => {
+    const outcome = applyFloors(
+      QUERY,
+      [chunkAt(0.7, 'c1', 'docA'), chunkAt(0.9, 'c2', 'docB'), chunkAt(0.8, 'c3', 'docA')],
+      ZERO_FLOOR_CONFIG
+    );
+    expect(outcome.acceptedDocIds).toEqual(['docB', 'docA']);
+  });
+
+  it('reports the rank the char budget binds at, so a later cut rank reads as dormant', () => {
+    const outcome = applyFloors(
+      QUERY,
+      [chunkAt(0.9, 'a', 'a', 60), chunkAt(0.85, 'b', 'b', 60), chunkAt(0.8, 'c', 'c', 60)],
+      ZERO_FLOOR_CONFIG,
+      100
+    );
+    expect(outcome.charsAdmitted).toBe(100);
+    expect(outcome.budgetStopRank).toBe(2);
+  });
+
+  it('leaves budgetStopRank null when the accepted set fits inside the budget', () => {
+    const outcome = applyFloors(QUERY, [chunkAt(0.9, 'a', 'a', 10)], ZERO_FLOOR_CONFIG, 10_000);
+    expect(outcome.budgetStopRank).toBeNull();
+    expect(outcome.charsAdmitted).toBe(10);
+  });
+});
+
+describe('buildFloorSweepRow', () => {
+  // 0.76 sits in the narrow window where BOTH floors bite: above the 75% absolute line, below 85%
+  // of the 0.90 top score. That window is the whole subject of the sweep - it is where a relative
+  // floor stops being a no-op over an absolute one.
+  const chunks = [chunkAt(0.9, 'a', 'docA'), chunkAt(0.76, 'b', 'docB'), chunkAt(0.6, 'c', 'docC')];
+  const queries = [{ id: 'q01', vector: [1, 0], supporting: ['docA'] }];
+
+  it('reports the relative floor as unbound when it cuts nothing', () => {
+    const row = buildFloorSweepRow({ config: ZERO_FLOOR_CONFIG, chunks, queries });
+    expect(row.relativeBoundShare).toBe(0);
+    expect(row.meanCutRank).toBeNull();
+    expect(row.meanAccepted).toBe(3);
+  });
+
+  it('separates the relative floor cost from the absolute floor cost', () => {
+    // absolute 75% removes 0.60; relative 85% of 0.90 = 0.765 then removes 0.76.
+    const row = buildFloorSweepRow({ config: { relativeFloorPct: 85, minSimilarityPct: 75 }, chunks, queries });
+    expect(row.meanAboveAbsolute).toBe(2);
+    expect(row.meanAccepted).toBe(1);
+    expect(row.relativeBoundShare).toBe(1);
+    expect(row.meanCutRank).toBe(2);
+  });
+
+  it('blames the pool cap on the cap, not on the absolute floor', () => {
+    // Every candidate clears the absolute floor, so the only thing removing any of them is
+    // FORCED_RETRIEVAL_MAX_SCORED_CHUNKS. Attributing that to a floor would name the wrong gate and
+    // read as a floor doing work it never did.
+    const many = Array.from({ length: FORCED_RETRIEVAL_MAX_SCORED_CHUNKS + 4 }, (_, i) =>
+      chunkAt(0.9, `c${String(i).padStart(4, '0')}`)
+    );
+    const row = buildFloorSweepRow({ config: { relativeFloorPct: 0, minSimilarityPct: 75 }, chunks: many, queries });
+    expect(row.cappedQueries).toBe(1);
+    expect(row.meanAboveAbsolute).toBe(FORCED_RETRIEVAL_MAX_SCORED_CHUNKS);
+    expect(row.relativeBoundShare).toBe(0);
+  });
+
+  it('counts a query the floors emptied, which only the absolute floor can do', () => {
+    const row = buildFloorSweepRow({
+      config: { relativeFloorPct: 85, minSimilarityPct: 95 },
+      chunks,
+      queries,
+    });
+    expect(row.emptiedQueries).toBe(1);
+  });
+
+  it('scores the accepted set against the committed ground truth', () => {
+    const row = buildFloorSweepRow({ config: ZERO_FLOOR_CONFIG, chunks, queries });
+    expect(row.quality.recall).toBe(1);
+    expect(row.queries).toBe(1);
+  });
+
+  it('holds up with no queries rather than dividing by zero', () => {
+    const row = buildFloorSweepRow({ config: SHIPPED_CONFIG, chunks, queries: [] });
+    expect(row.queries).toBe(0);
+    expect(row.relativeBoundShare).toBe(0);
+    expect(row.budgetBoundShare).toBe(0);
+    expect(row.meanCutRank).toBeNull();
+  });
+});
+
+describe('formatFloorSweepTable', () => {
+  const chunks = [chunkAt(0.9, 'a', 'docA'), chunkAt(0.8, 'b', 'docB')];
+  const queries = [{ id: 'q01', vector: [1, 0], supporting: ['docA'] }];
+  const row = (config: { relativeFloorPct: number; minSimilarityPct: number }) =>
+    buildFloorSweepRow({ config, chunks, queries });
+
+  it('renders one row per floor pair under a Markdown header', () => {
+    const lines = formatFloorSweepTable([row(ZERO_FLOOR_CONFIG), row(SHIPPED_CONFIG)]).split('\n');
+    expect(lines).toHaveLength(4); // header + separator + 2 rows
+    expect(lines[0]).toContain('budget-bound');
+  });
+
+  it('prints the relative floor as "off" at 0, but never the absolute one', () => {
+    // A 0 relative floor skips the filter entirely. A 0 ABSOLUTE floor is a real line - it rejects
+    // negative cosines - so labelling it "off" would claim the baseline row is the whole scored
+    // pool when it is not.
+    expect(formatFloorSweepTable([row(ZERO_FLOOR_CONFIG)]).split('\n')[2]).toContain('| off | 0% |');
+  });
+
+  it('prints "never" rather than a rank when the floor cuts nothing', () => {
+    // A 0 here would read as "cuts at rank 0", i.e. rejects everything - the opposite of inert.
+    expect(formatFloorSweepTable([row(ZERO_FLOOR_CONFIG)]).split('\n')[2]).toContain('never');
+  });
+
+  it('shows both floors with their units', () => {
+    expect(formatFloorSweepTable([row({ relativeFloorPct: 90, minSimilarityPct: 75 })]).split('\n')[2]).toContain(
+      '| 90% | 75% |'
+    );
+  });
+
+  it('renders a header even with no rows, so an empty run is visibly empty', () => {
+    expect(formatFloorSweepTable([]).split('\n')).toHaveLength(2);
+  });
+});

--- a/packages/scripts/retrieval/forcedFloorSweep.test.ts
+++ b/packages/scripts/retrieval/forcedFloorSweep.test.ts
@@ -210,6 +210,23 @@ describe('buildFloorSweepRow', () => {
     expect(row.meanCutRank).toBe(2);
   });
 
+  // The column exists because these two diverge, and the divergence is what stops a reader taking
+  // the baseline row's recall as recall of what the model saw.
+  it('reports served below accepted when the char budget stops the walk short', () => {
+    const wide = [chunkAt(0.9, 'a', 'docA', 400), chunkAt(0.88, 'b', 'docB', 400), chunkAt(0.86, 'c', 'docC', 400)];
+    const row = buildFloorSweepRow({ config: ZERO_FLOOR_CONFIG, chunks: wide, queries, charBudget: 600 });
+    expect(row.meanAccepted).toBe(3);
+    // 400 fits in 600; the second FILLS the remaining 200 (truncated) and is the last injected.
+    expect(row.meanServed).toBe(2);
+    expect(row.budgetBoundShare).toBe(1);
+  });
+
+  it('reports served equal to accepted when the budget never binds', () => {
+    const row = buildFloorSweepRow({ config: ZERO_FLOOR_CONFIG, chunks, queries, charBudget: 100_000 });
+    expect(row.meanServed).toBe(row.meanAccepted);
+    expect(row.budgetBoundShare).toBe(0);
+  });
+
   it('blames the pool cap on the cap, not on the absolute floor', () => {
     // Every candidate clears the absolute floor, so the only thing removing any of them is
     // FORCED_RETRIEVAL_MAX_SCORED_CHUNKS. Attributing that to a floor would name the wrong gate and
@@ -257,6 +274,15 @@ describe('formatFloorSweepTable', () => {
     const lines = formatFloorSweepTable([row(ZERO_FLOOR_CONFIG), row(SHIPPED_CONFIG)]).split('\n');
     expect(lines).toHaveLength(4); // header + separator + 2 rows
     expect(lines[0]).toContain('budget-bound');
+  });
+
+  it('prints accepted and served as separate columns', () => {
+    // Recall and precision score the ACCEPTED set, so collapsing these two back into one column
+    // would let the baseline row's recall read as recall of what reached the model.
+    const lines = formatFloorSweepTable([row(ZERO_FLOOR_CONFIG)]).split('\n');
+    expect(lines[0]).toContain('accepted/q');
+    expect(lines[0]).toContain('served/q');
+    expect(lines[0]).not.toContain('chunks/q');
   });
 
   it('prints the relative floor as "off" at 0, but never the absolute one', () => {

--- a/packages/scripts/retrieval/forcedFloorSweep.ts
+++ b/packages/scripts/retrieval/forcedFloorSweep.ts
@@ -272,6 +272,13 @@ export type FloorSweepRow = FloorConfig & {
   queries: number;
   /** Mean chunks surviving both floors. The pool the char-budget walk then spends. */
   meanAccepted: number;
+  /**
+   * Mean chunks the budget walk actually injects, which is what reaches the model. Reported beside
+   * `meanAccepted` because the two diverge hard at a low floor: on a corpus of short chunks the
+   * budget can stop at a small fraction of an accepted set of hundreds, and reading the accepted
+   * count as the served count overstates a floor's cost by that whole factor.
+   */
+  meanServed: number;
   /** Mean chunks surviving the absolute floor alone, so the relative floor's own cost is visible. */
   meanAboveAbsolute: number;
   /**
@@ -298,7 +305,13 @@ export type FloorSweepRow = FloorConfig & {
    * corpus, so `cut @` is a rank within that pool. The driver warns when it is non-zero.
    */
   cappedQueries: number;
-  /** Recall, precision and MRR of the accepted set against the committed ground truth. */
+  /**
+   * Recall, precision and MRR of the ACCEPTED set against the committed ground truth - the
+   * population the floors gate, deliberately not the shorter prefix the char budget then injects.
+   * A floor has to be judged on what it admits, or lowering the budget would read as a better
+   * floor. The consequence is that a row with a high `budget-bound` share reports quality over a
+   * candidate set wider than the model saw, which is what `budget-bound` is in the table to say.
+   */
   quality: Aggregate;
 };
 
@@ -322,6 +335,9 @@ export function buildFloorSweepRow(args: {
     ...args.config,
     queries: outcomes.length,
     meanAccepted: mean(outcomes.map(o => o.accepted)),
+    // `budgetStopRank` is the rank of the LAST injected candidate (the one that fills or overruns
+    // the remaining budget), so it is the served count itself - not one past it.
+    meanServed: mean(outcomes.map(o => o.budgetStopRank ?? o.accepted)),
     meanAboveAbsolute: mean(outcomes.map(o => o.aboveAbsolute)),
     relativeBoundShare: outcomes.length === 0 ? 0 : outcomes.filter(o => o.cutRank !== null).length / outcomes.length,
     meanCutRank: cutRanks.length === 0 ? null : mean(cutRanks),
@@ -346,12 +362,14 @@ const precisionCell = (a: Aggregate): string =>
  * derivable from recall: a floor can leave recall untouched because it is cutting nothing (inert)
  * or because it is cutting only noise (working), and only the binding columns separate those.
  * `budget-bound` is here because it can make a cut rank irrelevant - the char budget having already
- * stopped shorter than the floor does.
+ * stopped shorter than the floor does. `accepted/q` against `served/q` is the same warning as a
+ * ratio rather than a share: recall and precision are over `accepted`, so the wider that gap, the
+ * more of the measured set never reached the model.
  */
 export function formatFloorSweepTable(rows: readonly FloorSweepRow[]): string {
   const header = [
-    '| relative | absolute | chunks/q | pre-rel | bound | cut @ | budget-bound | emptied | recall | precision | MRR |',
-    '|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
+    '| relative | absolute | accepted/q | served/q | pre-rel | bound | cut @ | budget-bound | emptied | recall | precision | MRR |',
+    '|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
   ];
   const body = rows.map(r =>
     [
@@ -361,6 +379,7 @@ export function formatFloorSweepTable(rows: readonly FloorSweepRow[]): string {
       r.relativeFloorPct === 0 ? 'off' : `${r.relativeFloorPct}%`,
       `${r.minSimilarityPct}%`,
       r.meanAccepted.toFixed(1),
+      r.meanServed.toFixed(1),
       r.meanAboveAbsolute.toFixed(1),
       pct(r.relativeBoundShare),
       r.meanCutRank === null ? 'never' : r.meanCutRank.toFixed(1),

--- a/packages/scripts/retrieval/forcedFloorSweep.ts
+++ b/packages/scripts/retrieval/forcedFloorSweep.ts
@@ -1,0 +1,373 @@
+/**
+ * The configuration sweep for the two FORCED-retrieval relevance floors (#2572, item 2).
+ *
+ * WHY THIS IS NOT `sweep.ts`. That module sweeps `kbSearchResultTokenBudget` and
+ * `kbSearchMinRelevancePct`, the two knobs the `search_knowledge_base` TOOL reads, and
+ * `recall-probe.ts` measures them by invoking that tool. Forced retrieval is a different code path
+ * that reads neither (`ChatCompletionFeatures.ts`: "it is NOT routed through
+ * semanticDataLakeSearch"); it reads `forcedRetrievalRelativeFloorPct` and
+ * `forcedRetrievalMinSimilarityPct` instead. Adding those two to `SweepConfig` would have written
+ * settings the probed path never reads and printed a table whose rows differ only by noise - the
+ * mirror image of the reason `recall-probe.ts` drives the tool rather than a chat turn.
+ *
+ * WHAT IT MEASURES INSTEAD. Both floors are pure arithmetic over one turn's ranked score pool, so
+ * they can be swept offline over captured embedding fixtures - no database, no provider key, no
+ * stage, and re-runnable at a new floor pair for free. This is the instrument
+ * `MODEL-COMPARISON.md`'s "what the measured bands do to the live cosine floors" section derived by
+ * hand: at a given floor, does the gate reject anything at all, at which rank does it start
+ * cutting, what does that cost recall, and does it bind before the char budget already did.
+ *
+ * That last question is the one that makes a floor dormant rather than wrong. A floor cutting at
+ * rank 9 when the char budget already stopped at rank 6 changes nothing, and reads like a quality
+ * gate regardless.
+ *
+ * Pure: scoring, filtering and formatting only, so the shape of a sweep and the shape of its report
+ * are testable without a fixture. The live driver is `forced-floor-sweep.ts`.
+ */
+
+import {
+  FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT,
+  FORCED_RETRIEVAL_MAX_SCORED_CHUNKS,
+  FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+  FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+  compareForcedRetrievalRank,
+  forcedRetrievalRelativeCutoff,
+} from '@bike4mind/common';
+import { computeCosineSimilarity } from '@bike4mind/utils';
+import { aggregate, scoreQuestion, type Aggregate } from './metrics';
+import type { ScorableChunk } from './scoreDistribution';
+
+/**
+ * One point in the sweep, in the whole-number percents the two admin settings store - NOT the 0..1
+ * fractions the comparison uses. The conversion happens once, in `applyFloors`, mirroring the single
+ * division in `ChatCompletionFeatures`' resolver.
+ *
+ * THE TWO ZEROES ARE NOT THE SAME. Zero on the RELATIVE floor is genuinely off: the cutoff is 0 and
+ * the filter branch is skipped. Zero on the ABSOLUTE floor is a floor AT zero - the served path
+ * still compares `score >= minSimilarity`, so it rejects every negative cosine, which on a
+ * 16-dimension or otherwise wide space is a large share of the corpus. `0:0` is therefore the right
+ * baseline row to state a cost against, but it is not the whole scored pool and the table must not
+ * label it as though it were.
+ */
+export type FloorConfig = {
+  relativeFloorPct: number;
+  minSimilarityPct: number;
+};
+
+/**
+ * Both floors at zero: the baseline a floor's cost is measured against. Not named "ungated" because
+ * it is not - a zero absolute floor still rejects negative cosines. See `FloorConfig`.
+ */
+export const ZERO_FLOOR_CONFIG: FloorConfig = { relativeFloorPct: 0, minSimilarityPct: 0 };
+
+/** Today's shipped defaults, deliberately behavior-preserving rather than tuned (see #2572 item 4). */
+export const SHIPPED_CONFIG: FloorConfig = {
+  relativeFloorPct: FORCED_RETRIEVAL_RELATIVE_FLOOR_PCT_DEFAULT,
+  minSimilarityPct: FORCED_RETRIEVAL_MIN_SIMILARITY_PCT_DEFAULT,
+};
+
+export const formatFloorConfig = (c: FloorConfig): string =>
+  `relative=${c.relativeFloorPct}% absolute=${c.minSimilarityPct}%`;
+
+/**
+ * Parse `--floors=0:0,85:75,90:75` into sweep points ("relativeFloorPct:minSimilarityPct").
+ *
+ * Throws rather than skipping a malformed entry, for the reason `parseConfigs` does: a silently
+ * dropped point leaves a results table that looks complete and is missing the row someone asked
+ * for. The arity and emptiness checks are load-bearing for the same reason there - `Number('')` is
+ * 0 and `Number.isInteger(0)` is true, so "85:" would otherwise run an ungated absolute floor under
+ * the name of the 75 that was asked for.
+ */
+export function parseFloorConfigs(spec: string): FloorConfig[] {
+  const configs = spec
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(part => {
+      const components = part.split(':');
+      if (components.length !== 2) {
+        throw new Error(
+          `Bad floor pair "${part}": expected exactly "relativeFloorPct:minSimilarityPct", ` +
+            `got ${components.length} component(s)`
+        );
+      }
+      const [relative, absolute] = components;
+      const relativeFloorPct = Number(relative);
+      const minSimilarityPct = Number(absolute);
+      if (
+        relative.trim() === '' ||
+        !Number.isInteger(relativeFloorPct) ||
+        relativeFloorPct < 0 ||
+        relativeFloorPct > 100
+      ) {
+        throw new Error(`Bad relative floor in "${part}": expected an integer percent 0-100, got "${relative}"`);
+      }
+      if (
+        absolute.trim() === '' ||
+        !Number.isInteger(minSimilarityPct) ||
+        minSimilarityPct < 0 ||
+        minSimilarityPct > 100
+      ) {
+        throw new Error(`Bad absolute floor in "${part}": expected an integer percent 0-100, got "${absolute}"`);
+      }
+      return { relativeFloorPct, minSimilarityPct };
+    });
+  if (configs.length === 0) throw new Error('--floors listed no configurations');
+
+  const seen = new Set<string>();
+  for (const c of configs) {
+    const key = formatFloorConfig(c);
+    // A repeated point runs the whole query set twice for two rows that can only differ by noise,
+    // which reads as instability in the measurement rather than a duplicated input.
+    if (seen.has(key)) throw new Error(`Duplicate floor pair in --floors: ${key}`);
+    seen.add(key);
+  }
+  return configs;
+}
+
+/** A chunk to gate. `charLength` is carried so the sweep can say whether the budget bound first. */
+export type FloorScorableChunk = ScorableChunk & { charLength: number };
+
+/** Which gate actually removed something on one query. `budget` means neither floor was reached. */
+export type BindingGate = 'none' | 'absolute' | 'relative' | 'both';
+
+/** One query's pass through both floors, with the diagnostics a tuning decision reads. */
+export type FloorOutcome = {
+  queryId: string;
+  /** Finite-scored chunks, before either floor. NaN cosines are dropped as the served path drops them. */
+  scoredCount: number;
+  /** The turn's best score across the whole pool. -1 when nothing scored, matching the served sentinel. */
+  topScore: number;
+  relativeCutoff: number;
+  /** Survivors of the absolute floor and the pool cap: the served path's `preRelativeFloorCandidates`. */
+  aboveAbsolute: number;
+  /**
+   * Candidates the absolute floor admitted and `FORCED_RETRIEVAL_MAX_SCORED_CHUNKS` then discarded.
+   * Reported rather than absorbed into `aboveAbsolute`: once this is non-zero the floors are being
+   * measured over a truncated pool, which is a caveat on the row and not a property of either floor.
+   */
+  cappedOut: number;
+  /** Survivors of both floors: the served path's `postRelativeFloorCandidates`. */
+  accepted: number;
+  /** Distinct parent documents of the accepted set, best-first - what `metrics.ts` scores. */
+  acceptedDocIds: string[];
+  /**
+   * 1-based rank at which the relative floor starts cutting, or null when it cuts nothing. THE
+   * number this sweep exists for: a floor whose cut rank sits past where the char budget already
+   * stopped is dormant, however strict it looks.
+   */
+  cutRank: number | null;
+  /** Chars the budget walk would admit from the accepted set, in rank order. */
+  charsAdmitted: number;
+  /** Rank the char budget stops at, or null when the accepted set fits inside it. */
+  budgetStopRank: number | null;
+  binding: BindingGate;
+};
+
+/**
+ * Gate one query's chunks through both floors, in the served path's order.
+ *
+ * MIRRORS `KnowledgeRetrievalFeature`'s scan step for step, and shares its arithmetic rather than
+ * restating it: `computeCosineSimilarity` for the scores, `compareForcedRetrievalRank` for the tie
+ * order that decides who survives the cap, `forcedRetrievalRelativeCutoff` for the multiply. What
+ * remains local is the absolute floor's single `>=` comparison and the cap's `slice`.
+ *
+ * The order is not interchangeable. The absolute floor runs DURING the scan, so the pool is capped
+ * to the top `FORCED_RETRIEVAL_MAX_SCORED_CHUNKS` of what cleared it; the relative floor runs after,
+ * because it needs the turn's final top score. `topScore` therefore tracks every finite scored
+ * candidate, including ones the absolute floor rejected - it is read one line before that
+ * `continue`. That only matters when nothing clears the absolute floor at all, since the global
+ * maximum is itself in the pool whenever the pool is non-empty.
+ */
+export function applyFloors(
+  query: { id: string; vector: number[] },
+  chunks: readonly FloorScorableChunk[],
+  config: FloorConfig,
+  charBudget: number = FORCED_RETRIEVAL_CHAR_BUDGET_DEFAULT
+): FloorOutcome {
+  const minSimilarity = config.minSimilarityPct / 100;
+  const relativeFloor = config.relativeFloorPct / 100;
+
+  const scored = chunks
+    .map(chunk => ({ chunk, score: computeCosineSimilarity(query.vector, chunk.vector) }))
+    // A zero-magnitude vector makes cosine NaN, and NaN fails every comparison below - it would
+    // slip past the floors and sort ahead of real hits.
+    .filter(c => Number.isFinite(c.score));
+
+  // -1 rather than 0 when nothing scored, matching the served path's sentinel so a starved turn
+  // reads the same in both places.
+  const topScore = scored.reduce((best, c) => (c.score > best ? c.score : best), -1);
+
+  // Kept separate from `ranked` because the cap also removes candidates, and attributing its cut to
+  // the absolute floor would name the wrong gate in `binding` on any corpus larger than the cap.
+  const aboveAbsolute = scored
+    .filter(c => c.score >= minSimilarity)
+    .sort((a, b) =>
+      compareForcedRetrievalRank(
+        { score: a.score, fileId: a.chunk.docId, chunkId: a.chunk.chunkId },
+        { score: b.score, fileId: b.chunk.docId, chunkId: b.chunk.chunkId }
+      )
+    );
+  // The served path trims mid-scan whenever the pool exceeds the cap, which retains the same global
+  // top-N a single sort-then-slice does: a candidate is dropped only once N strictly better ones
+  // exist, and those are never themselves all dropped.
+  const ranked = aboveAbsolute.slice(0, FORCED_RETRIEVAL_MAX_SCORED_CHUNKS);
+
+  const relativeCutoff = forcedRetrievalRelativeCutoff(topScore, relativeFloor);
+  const accepted = relativeCutoff > 0 ? ranked.filter(c => c.score >= relativeCutoff) : ranked;
+
+  const seen = new Set<string>();
+  const acceptedDocIds = accepted
+    .map(c => c.chunk.docId)
+    // Forward dedupe (keep the best-scoring occurrence), because reciprocalRank reads this order.
+    .filter(id => (seen.has(id) ? false : (seen.add(id), true)));
+
+  // The served path's budget walk, with one shortcut. It breaks when `used >= budget` and otherwise
+  // slices the chunk to whatever remains, so the first candidate that FILLS OR OVERRUNS the
+  // remaining budget is the last one injected - it exhausts the budget (truncated, if it overran)
+  // and every later candidate meets the break immediately. Stopping there is the same character
+  // count, and its rank is the honest answer to "where did the budget bind".
+  let charsAdmitted = 0;
+  let budgetStopRank: number | null = null;
+  for (const [index, candidate] of accepted.entries()) {
+    const remaining = charBudget - charsAdmitted;
+    if (candidate.chunk.charLength >= remaining) {
+      budgetStopRank = index + 1;
+      charsAdmitted += remaining;
+      break;
+    }
+    charsAdmitted += candidate.chunk.charLength;
+  }
+
+  const absoluteCut = scored.length - aboveAbsolute.length;
+  const relativeCut = ranked.length - accepted.length;
+  return {
+    queryId: query.id,
+    scoredCount: scored.length,
+    topScore,
+    relativeCutoff,
+    aboveAbsolute: ranked.length,
+    cappedOut: aboveAbsolute.length - ranked.length,
+    accepted: accepted.length,
+    acceptedDocIds,
+    cutRank: relativeCut > 0 ? accepted.length + 1 : null,
+    charsAdmitted,
+    budgetStopRank,
+    binding:
+      absoluteCut > 0 && relativeCut > 0
+        ? 'both'
+        : absoluteCut > 0
+          ? 'absolute'
+          : relativeCut > 0
+            ? 'relative'
+            : 'none',
+  };
+}
+
+/** One floor pair's row: what the gate admitted, what it cost, and whether it bound at all. */
+export type FloorSweepRow = FloorConfig & {
+  queries: number;
+  /** Mean chunks surviving both floors. The pool the char-budget walk then spends. */
+  meanAccepted: number;
+  /** Mean chunks surviving the absolute floor alone, so the relative floor's own cost is visible. */
+  meanAboveAbsolute: number;
+  /**
+   * Share of queries where the RELATIVE floor removed at least one candidate. A floor at 0.0% here
+   * is inert on this corpus - it provides no protection while reading like a quality gate, which is
+   * the exact failure the relative floor was introduced to fix in the absolute one.
+   */
+  relativeBoundShare: number;
+  /** Mean 1-based rank the relative floor cuts at, over the queries where it cut anything. */
+  meanCutRank: number | null;
+  /**
+   * Share of queries whose accepted set the char budget truncates. Read against `meanCutRank`: a
+   * floor cutting past where the budget already stopped changes nothing that reaches the model.
+   */
+  budgetBoundShare: number;
+  /**
+   * Queries the floors emptied outright. A floor cannot starve a turn that scored anything (see
+   * `forcedRetrievalRelativeCutoff`), so a non-zero count here is the absolute floor's doing.
+   */
+  emptiedQueries: number;
+  /**
+   * Queries whose pool the cap truncated before either floor ran. Non-zero invalidates nothing, but
+   * the floors were measured over the top `FORCED_RETRIEVAL_MAX_SCORED_CHUNKS` rather than the whole
+   * corpus, so `cut @` is a rank within that pool. The driver warns when it is non-zero.
+   */
+  cappedQueries: number;
+  /** Recall, precision and MRR of the accepted set against the committed ground truth. */
+  quality: Aggregate;
+};
+
+const mean = (xs: readonly number[]): number => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length);
+
+/**
+ * Gate every query at one floor pair and roll it up.
+ *
+ * `supporting` is the hand-authored ground truth keyed by query id (`corpus.ts`); a query with an
+ * empty supporting set is a deliberate negative, and `metrics.ts` scores it as one.
+ */
+export function buildFloorSweepRow(args: {
+  config: FloorConfig;
+  chunks: readonly FloorScorableChunk[];
+  queries: readonly { id: string; vector: number[]; supporting: readonly string[] }[];
+  charBudget?: number;
+}): FloorSweepRow {
+  const outcomes = args.queries.map(q => applyFloors(q, args.chunks, args.config, args.charBudget));
+  const cutRanks = outcomes.map(o => o.cutRank).filter((r): r is number => r !== null);
+  return {
+    ...args.config,
+    queries: outcomes.length,
+    meanAccepted: mean(outcomes.map(o => o.accepted)),
+    meanAboveAbsolute: mean(outcomes.map(o => o.aboveAbsolute)),
+    relativeBoundShare: outcomes.length === 0 ? 0 : outcomes.filter(o => o.cutRank !== null).length / outcomes.length,
+    meanCutRank: cutRanks.length === 0 ? null : mean(cutRanks),
+    budgetBoundShare:
+      outcomes.length === 0 ? 0 : outcomes.filter(o => o.budgetStopRank !== null).length / outcomes.length,
+    emptiedQueries: outcomes.filter(o => o.scoredCount > 0 && o.accepted === 0).length,
+    cappedQueries: outcomes.filter(o => o.cappedOut > 0).length,
+    quality: aggregate(outcomes.map((o, i) => scoreQuestion(o.acceptedDocIds, new Set(args.queries[i].supporting)))),
+  };
+}
+
+const pct = (n: number): string => `${(n * 100).toFixed(1)}%`;
+
+/** See `sweep.ts`' `precisionCell`: precision's denominator moves with the configuration. */
+const precisionCell = (a: Aggregate): string =>
+  a.precisionScored === 0 ? 'n/a (n=0)' : `${pct(a.precision)} (n=${a.precisionScored})`;
+
+/**
+ * Render the sweep as a Markdown table for pasting into the ticket.
+ *
+ * `bound` and `cut @` are the two columns a floor decision actually turns on, and neither is
+ * derivable from recall: a floor can leave recall untouched because it is cutting nothing (inert)
+ * or because it is cutting only noise (working), and only the binding columns separate those.
+ * `budget-bound` is here because it can make a cut rank irrelevant - the char budget having already
+ * stopped shorter than the floor does.
+ */
+export function formatFloorSweepTable(rows: readonly FloorSweepRow[]): string {
+  const header = [
+    '| relative | absolute | chunks/q | pre-rel | bound | cut @ | budget-bound | emptied | recall | precision | MRR |',
+    '|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
+  ];
+  const body = rows.map(r =>
+    [
+      '',
+      // Only the relative floor can be genuinely off. A 0 absolute floor is a real line in cosine
+      // space - it rejects negatives - so printing it as "off" would overstate the baseline row.
+      r.relativeFloorPct === 0 ? 'off' : `${r.relativeFloorPct}%`,
+      `${r.minSimilarityPct}%`,
+      r.meanAccepted.toFixed(1),
+      r.meanAboveAbsolute.toFixed(1),
+      pct(r.relativeBoundShare),
+      r.meanCutRank === null ? 'never' : r.meanCutRank.toFixed(1),
+      pct(r.budgetBoundShare),
+      String(r.emptiedQueries),
+      pct(r.quality.recall),
+      precisionCell(r.quality),
+      r.quality.mrr.toFixed(3),
+      '',
+    ].join(' | ')
+  );
+  return [...header, ...body].join('\n');
+}

--- a/packages/scripts/retrieval/forcedFloorSweep.ts
+++ b/packages/scripts/retrieval/forcedFloorSweep.ts
@@ -240,7 +240,10 @@ export function applyFloors(
   }
 
   const absoluteCut = scored.length - aboveAbsolute.length;
-  const relativeCut = ranked.length - accepted.length;
+  // The single definition of "the relative floor bound on this query". `buildFloorSweepRow` reads it
+  // back off `cutRank` rather than recomputing, so the row's `relativeBoundShare` and the outcome's
+  // `binding` cannot disagree about whether the floor did anything.
+  const cutRank = accepted.length < ranked.length ? accepted.length + 1 : null;
   return {
     queryId: query.id,
     scoredCount: scored.length,
@@ -250,15 +253,15 @@ export function applyFloors(
     cappedOut: aboveAbsolute.length - ranked.length,
     accepted: accepted.length,
     acceptedDocIds,
-    cutRank: relativeCut > 0 ? accepted.length + 1 : null,
+    cutRank,
     charsAdmitted,
     budgetStopRank,
     binding:
-      absoluteCut > 0 && relativeCut > 0
+      absoluteCut > 0 && cutRank !== null
         ? 'both'
         : absoluteCut > 0
           ? 'absolute'
-          : relativeCut > 0
+          : cutRank !== null
             ? 'relative'
             : 'none',
   };

--- a/packages/scripts/retrieval/recall-probe.ts
+++ b/packages/scripts/retrieval/recall-probe.ts
@@ -10,13 +10,17 @@
  * ticket inherited that wording - but forced retrieval is a different code path with different
  * budgets (`ChatCompletionFeatures.ts` states it is NOT routed through semanticDataLakeSearch; it
  * uses `forcedRetrievalCharBudget` plus its own two relevance floors,
- * `forcedRetrievalRelativeFloorPct` and `forcedRetrievalMinSimilarityPct`, which this probe does not
- * sweep). The three kb* knobs
- * are consumed in exactly one file, `knowledgeBaseSearch/index.ts`. A forced-retrieval probe would
- * have returned identical numbers at every configuration. Invoking the tool directly also removes
- * model tool-choice variance entirely, which is the variable forced retrieval was chosen to control,
+ * `forcedRetrievalRelativeFloorPct` and `forcedRetrievalMinSimilarityPct`). The three kb* knobs are
+ * consumed in exactly one file, `knowledgeBaseSearch/index.ts`. A forced-retrieval probe would have
+ * returned identical numbers at every configuration. Invoking the tool directly also removes model
+ * tool-choice variance entirely, which is the variable forced retrieval was chosen to control,
  * while still exercising the shipped ranking, ceiling, floor and token-budget code rather than a
  * reimplementation that could drift from it.
+ *
+ * WHICH IS WHY IT DOES NOT SWEEP THE TWO FORCED FLOORS. Doing so here would write settings the
+ * probed path never reads and print rows that differ only by noise. They are swept offline instead,
+ * over captured embedding fixtures, by `forced-floor-sweep.ts`: both floors are pure arithmetic over
+ * one turn's ranked pool, so measuring them needs neither a tool call nor a stage.
  *
  * HOW IT SEES WHAT WAS SERVED. The tool already reports every read to the lake audit trail
  * (`recordLakeAccessEvent`, `knowledgeBaseSearch/index.ts:974`) carrying the deduped file ids, chunk

--- a/packages/scripts/retrieval/sweep.ts
+++ b/packages/scripts/retrieval/sweep.ts
@@ -8,7 +8,10 @@
 import type { Aggregate } from './metrics';
 
 /**
- * One point in the sweep. Both knobs are admin settings introduced by #1955 (PR #2009).
+ * One point in the sweep. Both knobs are admin settings introduced by #1955 (PR #2009), and both
+ * belong to the `search_knowledge_base` TOOL path - forced retrieval reads neither. Its own two
+ * floors are swept by `forcedFloorSweep.ts`; see `recall-probe.ts`' header for why the two
+ * instruments are separate rather than four columns of one table.
  *
  * `tokenBudget` is `kbSearchResultTokenBudget`: approximate tokens of served passage text one call
  * may emit. `minRelevancePct` is `kbSearchMinRelevancePct`: a whole-number percent, converted to the


### PR DESCRIPTION
## Description

Offline instrument for the two forced-retrieval relevance floors added in PR #2567 (issue #2572,
item 2), plus the first real measurements out of it. The forced path (`KnowledgeRetrievalFeature`
in `ChatCompletionFeatures.ts`) reads `forcedRetrievalRelativeFloorPct` /
`forcedRetrievalMinSimilarityPct` and is a separate code path from the `search_knowledge_base` TOOL
that the existing `recall-probe.ts` / `sweep.ts` harness drives - that tooling can't see these two
settings by design, so a new instrument was needed rather than new columns on the old one.

Ran it against a real 452-chunk capture of the `system-help` lake (51 articles) under today's
default (`text-embedding-ada-002`) and the migration target (`text-embedding-3-small`, #471). The
headline finding: the shipped floor pair (relative 85% / absolute 75%) returns **nothing at all** in
the target vector space - 0.75 is a raw cosine threshold sitting above that model's entire measured
band, so all 30 probe questions come back empty with no error. That turns #471 from "revisit the
floors after migrating" into "the floors must move with the migration or it ships a silent
blackout" - filed as a new sub-item and a native `blocked_by` dependency from #471 to #2572.

## Changes

- **`b4m-core/common/src/utils/forcedRetrievalFloors.ts`** (new) - the floor arithmetic
  (`forcedRetrievalRelativeCutoff`, `compareForcedRetrievalRank`) extracted from
  `ChatCompletionFeatures.ts` into `@bike4mind/common`, shared by the served path and the offline
  sweep so the two cannot drift. `forcedRetrievalFloors.test.ts` pins the extraction against the
  pre-refactor expressions verbatim across ~1,500 randomized inputs.
- **`ChatCompletionFeatures.ts`** - behavior-preserving: delegates to the shared functions instead
  of its own inline comparator/cutoff. `FORCED_RETRIEVAL_MAX_SCORED_CHUNKS` moved to
  `b4m-core/common/src/constants/forcedRetrieval.ts` so the harness can mirror the same pool cap.
- **`packages/scripts/retrieval/forcedFloorSweep.ts`** + **`forced-floor-sweep.ts`** (new) - the
  pure sweep (parsing, gating, table formatting) and its CLI driver. No DB, no provider key, no
  stage - everything it needs was already paid for by `capture-embeddings.ts`, so a floor pair
  costs nothing to try and the whole sweep re-runs after #471 recaptures the corpus.
- **`recall-probe.ts`** / **`sweep.ts`** - doc-only: point at the new instrument and explain why the
  two forced floors don't belong on the existing tool-path sweep.
- **`MODEL-COMPARISON.md`** - runnable command plus a new "MEASURED" section with the real numbers,
  three findings, and the caveats that bound them (not the long-document regime, a served candidate
  pool that is differently composed than this one, 30 questions).
- **`packages/scripts/package.json`** - `retrieval:forced-floor-sweep` script.

Issue-tracker updates (not in this diff): #2572 body updated (items 1/2 marked done, item 4 split
into a migration-blocking part and a still-P3 tuning part); #471 now has a native `blocked_by`
dependency on #2572 with the measured numbers and, in a follow-up comment, two more hardcoded `0.75`
cosine floors found on the memento recall path that will need the same treatment.

## Guide for Testers

This PR ships an offline analysis tool with no user-facing surface - nothing to click through.

1. `cd packages/scripts && pnpm test forcedFloorSweep` - unit tests for the sweep's gating logic
   (parity with the pre-extraction production code, the never-starve invariant, pool-cap
   attribution, accepted-vs-served divergence).
2. `pnpm --filter @bike4mind/common test src/utils/forcedRetrievalFloors` - the shared arithmetic's
   parity tests.
3. `pnpm --filter @bike4mind/services test ChatCompletionFeatures` - confirms the extraction didn't
   change `KnowledgeRetrievalFeature`'s served behavior (163 tests, unchanged from before this PR).
4. Optional, to see it run against real data: capture a fixture with
   `pnpm --filter @bike4mind/scripts retrieval:capture-embeddings --lake <slug> --userId <id>
   --models text-embedding-ada-002` against a stage with an embedding key, then
   `pnpm --filter @bike4mind/scripts retrieval:forced-floor-sweep --fixture out/<file>.json`.

**What NOT to test:** no admin-settings UI, API contract, or chat behavior changed. The
`ChatCompletionFeatures.ts` edit is a pure refactor (delegate to shared functions) verified by its
existing test suite passing unchanged; it does not need a live chat-turn regression pass.

## Additional Information

- All commits are on `feat/2572-sweep-forced-retrieval-floors`, four commits: the feature, a
  self-review pass with three fixes (ground-truth resolution, one definition of "the relative floor
  bound", the parity test), and the measured-capture follow-up (plus two instrument fixes the real
  run exposed: `accepted/q` vs `served/q` as separate columns, since the baseline row's "100%
  recall" was over 256 accepted chunks of which only 15.7 reached the model), and an adjudication
  fold-in correcting the fidelity caveat and rejecting a zero `--char-budget`.
- Correction, folded in as the fourth commit: an earlier revision of this description and of the
  harness header carried a fidelity caveat inherited from `scoreDistribution.ts` - "exact kNN here
  vs the served ANN path". That is wrong for this instrument. The forced path never touches Atlas
  `$vectorSearch` at all; it keyset-pages `findVectorsByFabFileIds` and scores in JS, so the
  divergence is not ANN vs exact kNN. It is three narrowings the served path applies and this
  harness does not model: the candidate list is capped at `FORCED_RETRIEVAL_MAX_CANDIDATE_FILES`
  (100) ordered `fileName` ASC, the scan stops at `FORCED_RETRIEVAL_MAX_SCANNED_CHUNKS` (4000) per
  turn, and superseded generations are dropped before scoring. The served pool is therefore
  differently composed rather than shallower, and a floor fitted here is fitted to a pool
  production may never assemble.
- Gates green: `turbo:core:build`, `lint:check`, ASCII guards, and 285 + 11 + 163 + 255 tests across
  `common`, `services`, and `scripts`, plus three typechecks.
- The measured numbers come from short help-article prose (median chunk 638 chars vs a production
  reference of ~2182), which the harness itself flags as not the long-document regime - right shape,
  wrong magnitudes. A production-lake capture is the natural follow-up before tuning any specific
  value (#2572 item 4b).

## Developer Notes (Optional)

- **New Extension Points**: `forcedRetrievalRelativeCutoff` / `compareForcedRetrievalRank` in
  `@bike4mind/common` are the load-bearing floor arithmetic - any future harness measuring forced
  retrieval should import them rather than reimplementing, the same way `scoreDistribution.ts`
  routes through the shipped `computeCosineSimilarity`.
- **Reusable Pattern**: the accepted-vs-served column split in a sweep table (`FloorSweepRow`) is a
  pattern worth reusing anywhere a gate's "population it scores" and "population that reaches the
  model" can diverge under a downstream budget.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`MODEL-COMPARISON.md`)
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI surface
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A
