### PR TITLE
chore(ci): probe the help-docs core-build fallback (do not merge)

### DIFF
--- a/.github/actions/changes-filter/README.md
+++ b/.github/actions/changes-filter/README.md
@@ -17,7 +17,7 @@ docs live in `docs-site/` (not `docs/`), `.changeset/` is excluded, and a second
 | Output | Meaning |
 |---|---|
 | `deployable` | `'true'` to run test + deploy, `'false'` to skip. Fails **open** (`true`) when the diff range can't be resolved. |
-| `docs-changed` | `'true'` when the changeset touches `docs-site/`. Fails **open** (`true`) on an unresolved range. Gates the `help-docs` job. |
+| `docs-changed` | `'true'` when the changeset touches `docs-site/` or the help tooling in `packages/scripts/help/`. Fails **open** (`true`) on an unresolved range. Gates the `help-docs` job. |
 
 The two are orthogonal: a docs-only PR is `deployable=false, docs-changed=true`;
 a code+docs PR is `true, true`; a `.changeset` or root-`README` change is
@@ -80,7 +80,7 @@ jobs:
 | Input | Default | Notes |
 |---|---|---|
 | `exclude-paths` | curated docs/config list | Newline-separated **git pathspecs**. If every changed file matches one, `deployable=false`. Blank lines and `#` comments ignored. |
-| `docs-paths` | `docs-site/**` | INCLUDE-form pathspecs defining the docs site for `docs-changed`. |
+| `docs-paths` | `docs-site/**`, `packages/scripts/help/**` | INCLUDE-form pathspecs defining the docs site for `docs-changed`. Includes the help tooling, so a change to those scripts runs the `help-docs` guard that covers them. |
 
 ## Gotchas baked into the default list
 

--- a/.github/actions/changes-filter/action.yml
+++ b/.github/actions/changes-filter/action.yml
@@ -62,9 +62,16 @@ inputs:
       Newline-separated git pathspecs (INCLUDE form) defining the docs site.
       docs-changed=true when the run's changeset touches any of these. Used to
       gate the help-docs job independently of the deploy gate.
+
+      Covers the help TOOLING as well as the corpus: help-docs is the only job
+      that runs packages/scripts/help/**, so listing docs-site alone let a change
+      to those scripts skip the very guard that covers them. A test there then
+      came to import a package the job never built, and the break surfaced on an
+      unrelated docs-site PR rather than on the change that caused it.
     required: false
     default: |
       docs-site/**
+      packages/scripts/help/**
 
 outputs:
   deployable:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,13 +837,21 @@ jobs:
   # holds regardless of deployability. On a deployable docs PR the suites also run in
   # the shards; the duplicate is ~1 min and worth the unconditional guarantee.
   #
-  # Deliberately does NOT need core-build: the help tooling imports only glob/gray-matter
-  # (see loadHelpArticles.ts), so this stays a light, standalone leg that a non-deployable
-  # run can satisfy on its own.
+  # This leg used to need no core build - the help tooling imported only glob/gray-matter.
+  # `ingestHelpDatalake.ts` now pulls in @bike4mind/common, whose package entries all point
+  # at dist/, so the suite fails to LOAD without it (not an assertion failure - a resolve
+  # error). `needs: core-build` alone would be a regression: core-build is gated on
+  # `deployable`, and a docs-only PR is non-deployable, so this job would inherit that skip
+  # and go quiet on exactly the changes it exists to guard. Hence the explicit `if` that
+  # keeps the `docs-changed` gate and tolerates core-build having been skipped, plus the
+  # artifact download with a local build as fallback.
   help-docs:
     name: Help Docs Guards
-    needs: changes
-    if: needs.changes.outputs.docs-changed == 'true'
+    needs: [changes, core-build]
+    if: |
+      always() &&
+      needs.changes.outputs.docs-changed == 'true' &&
+      (needs.core-build.result == 'success' || needs.core-build.result == 'skipped')
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
     timeout-minutes: 10
     permissions:
@@ -877,6 +885,22 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --recursive
+
+      - name: Download core build artifacts
+        id: download-core
+        uses: actions/download-artifact@v7
+        with:
+          name: core-build-${{ needs.core-build.outputs.core-content-hash }}
+          # Artifact paths are relative to the repo root (the common ancestor of
+          # b4m-core/*/dist and packages/database/dist).
+          path: .
+        continue-on-error: true
+
+      # Covers both misses: core-build skipped (docs-only run, so no artifact and an empty
+      # name above) and a genuine download failure.
+      - name: Build bike4mind core packages (fallback)
+        if: steps.download-core.outcome == 'failure'
+        run: pnpm core:build
 
       - name: Run help corpus and help-id suites
         run: pnpm --filter @bike4mind/scripts exec vitest run help/__tests__

--- a/packages/scripts/src/checkHelpContentGuardWired.test.ts
+++ b/packages/scripts/src/checkHelpContentGuardWired.test.ts
@@ -7,7 +7,8 @@ import path from 'node:path';
  * Guards the CI-wiring gap in #2210: .husky/check-help-content.sh enforces the Help AI chat's
  * "every indexed article has a vector" invariant, but a diff that touches ONLY that file is
  * `deployable=false` (`.husky/**` is on changes-filter's exclude list) AND `docs-changed=false`
- * (docs-paths only covers docs-site/**), so every job gated on either flag skips - and a skipped
+ * (docs-paths covers docs-site/** and packages/scripts/help/**, neither of which matches a
+ * .husky-only diff), so every job gated on either flag skips - and a skipped
  * required check counts as passing. Nothing in CI would ever run the script on a diff shaped
  * exactly like an edit to itself.
  *


### PR DESCRIPTION
**Throwaway. Do not merge; close after the run.**

This exists only to execute the `pnpm core:build` fallback added in #2734, which cannot run on #2734 itself: that PR touches `.github/**`, which is deployable, so `core-build` always runs and the artifact always downloads. Basing a non-deployable change on that branch forces the other path: `deployable=false` -> `core-build` skipped -> empty `core-content-hash` -> `download-artifact` fails -> fallback builds.

The probe file sits directly under `docs-site/` rather than `docs-site/docs/` on purpose. `selfhost-image.yml` triggers on `docs-site/docs/**` with no branch restriction, so touching that path would fire both Docker image builds for nothing, and a new article there could trip the index-vs-embeddings invariant that `Check help artifacts agree` enforces, reddening this run for an unrelated reason.

**Pass criteria:** `Core Build` reports `skipped` (this is the discriminator proving the empty-hash path was taken), `Help Docs Guards` runs and its log shows the `Build bike4mind core packages (fallback)` step actually executing, and the job is green.